### PR TITLE
build: properly detect clang version in Ubuntu

### DIFF
--- a/meson-scripts/get_clang_ver
+++ b/meson-scripts/get_clang_ver
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-"$1" --version | sed -nr 's/^clang version ([\.0-9]*)( .*)?$/\1/p'
+"$1" --version | sed -nr 's/^.*clang version ([\.0-9]*)( .*)?$/\1/p'


### PR DESCRIPTION
Some distro may add their own prefix to the version string of clang, for example in Ubuntu:

 $ clang --version
 Ubuntu clang version 17.0.5 (1ubuntu1)
 ...

That triggers the following meson error during the setup phase:

 meson.build:25:44: ERROR: String '' cannot be converted to int

Change the regexp used to evaluate the clang version to avoid this build failure.