### PR TITLE
scx_utils: Bump version to 0.3.2

### DIFF
--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_utils"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0"


### PR DESCRIPTION
- Build fix for ubuntu clang.