### PR TITLE
build scx on 32-bit architectures

### DIFF
--- a/scheds/kernel-examples/scx_central.c
+++ b/scheds/kernel-examples/scx_central.c
@@ -103,17 +103,17 @@ int main(int argc, char **argv)
 
 	while (!exit_req && !uei_exited(&skel->bss->uei)) {
 		printf("[SEQ %llu]\n", seq++);
-		printf("total   :%10lu    local:%10lu   queued:%10lu  lost:%10lu\n",
+		printf("total   :%10llu    local:%10llu   queued:%10llu  lost:%10llu\n",
 		       skel->bss->nr_total,
 		       skel->bss->nr_locals,
 		       skel->bss->nr_queued,
 		       skel->bss->nr_lost_pids);
-		printf("timer   :%10lu dispatch:%10lu mismatch:%10lu retry:%10lu\n",
+		printf("timer   :%10llu dispatch:%10llu mismatch:%10llu retry:%10llu\n",
 		       skel->bss->nr_timers,
 		       skel->bss->nr_dispatches,
 		       skel->bss->nr_mismatches,
 		       skel->bss->nr_retries);
-		printf("overflow:%10lu\n",
+		printf("overflow:%10llu\n",
 		       skel->bss->nr_overflows);
 		fflush(stdout);
 		sleep(1);

--- a/scheds/kernel-examples/scx_userland.bpf.c
+++ b/scheds/kernel-examples/scx_userland.bpf.c
@@ -20,7 +20,6 @@
  * Copyright (c) 2022 Tejun Heo <tj@kernel.org>
  * Copyright (c) 2022 David Vernet <dvernet@meta.com>
  */
-#include <string.h>
 #include <scx/common.bpf.h>
 #include "scx_userland.h"
 
@@ -146,9 +145,8 @@ static void dispatch_user_scheduler(void)
 
 static void enqueue_task_in_user_space(struct task_struct *p, u64 enq_flags)
 {
-	struct scx_userland_enqueued_task task;
+	struct scx_userland_enqueued_task task = {};
 
-	memset(&task, 0, sizeof(task));
 	task.pid = p->pid;
 	task.sum_exec_runtime = p->se.sum_exec_runtime;
 	task.weight = p->scx.weight;


### PR DESCRIPTION
A couple of small fixes that allow to build the scx schedulers also on 32-bit architectures (e.g., armhf).