### PR TITLE
build: introduce enable_rust build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ options can be used in such cases.
 - `cargo`: `cargo` to use when building rust sub-projects
 - 'cargo_home': 'CARGO_HOME env to use when invoking cargo'
 - `offline`: 'Compilation step should not access the internet'
+- `enable_rust`: 'Enable the build of rust sub-projects'
 
 For example, let's say you want to use `bpftool` and `libbpf` shipped in the
 kernel tree located at `$KERNEL`. We need to build `bpftool` in the kernel

--- a/meson.build
+++ b/meson.build
@@ -140,9 +140,13 @@ if get_option('cargo_home') != ''
   cargo_env.set('CARGO_HOME', get_option('cargo_home'))
 endif
 
-meson.add_install_script('meson-scripts/install_rust_user_scheds')
+if get_option('enable_rust')
+  meson.add_install_script('meson-scripts/install_rust_user_scheds')
+endif
 
 run_target('fetch', command: [cargo_fetch, cargo], env: cargo_env)
 
-subdir('rust')
+if get_option('enable_rust')
+  subdir('rust')
+endif
 subdir('scheds')

--- a/meson.options
+++ b/meson.options
@@ -12,3 +12,5 @@ option('cargo_home', type: 'string',
        description: 'CARGO_HOME env to use when invoking cargo')
 option('offline', type: 'boolean', value: 'false',
        description: 'Compilation step should not access the internet')
+option('enable_rust', type: 'boolean', value: 'true',
+       description: 'Enable rust sub-projects')

--- a/scheds/meson.build
+++ b/scheds/meson.build
@@ -9,5 +9,7 @@ bpf_includes = ['-I', join_paths(meson.current_source_dir(), 'include'),
 user_c_includes = include_directories('include')
 
 subdir('kernel-examples')
-subdir('rust-user')
+if get_option('enable_rust')
+  subdir('rust-user')
+endif
 subdir('c-user')


### PR DESCRIPTION
Introduce an option to enable/disable the build of all the Rust sub-projects (default is enabled).

This can be useful to build scx on those systems where Rust is not fully supported (e.g., armhf).