### PR TITLE
build: add Debian arch name mapping for s390

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,7 @@ endif
 arch_dict = {
   'x86': 'x86',
   'x86_64': 'x86',
-  's390': 's390',
+  's390x': 's390',
   'arm': 'arm',
   'aarch64': 'arm64',
   'mips': 'mips',


### PR DESCRIPTION
Add the proper mapping from Debian architecture "s390x" to the kernel architecture name "s390".