### PR TITLE
scx_userland: allocate tasks array based on kernel.pid_max

### DIFF
--- a/scheds/kernel-examples/scx_userland.bpf.c
+++ b/scheds/kernel-examples/scx_userland.bpf.c
@@ -23,6 +23,11 @@
 #include <scx/common.bpf.h>
 #include "scx_userland.h"
 
+/*
+ * Maximum amount of tasks enqueued/dispatched between kernel and user-space.
+ */
+#define MAX_ENQUEUED_TASKS 8192
+
 char _license[] SEC("license") = "GPL";
 
 const volatile bool switch_partial;
@@ -49,7 +54,7 @@ static bool usersched_needed;
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_QUEUE);
-	__uint(max_entries, USERLAND_MAX_TASKS);
+	__uint(max_entries, MAX_ENQUEUED_TASKS);
 	__type(value, struct scx_userland_enqueued_task);
 } enqueued SEC(".maps");
 
@@ -60,7 +65,7 @@ struct {
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_QUEUE);
-	__uint(max_entries, USERLAND_MAX_TASKS);
+	__uint(max_entries, MAX_ENQUEUED_TASKS);
 	__type(value, s32);
 } dispatched SEC(".maps");
 

--- a/scheds/kernel-examples/scx_userland.h
+++ b/scheds/kernel-examples/scx_userland.h
@@ -4,8 +4,6 @@
 #ifndef __SCX_USERLAND_COMMON_H
 #define __SCX_USERLAND_COMMON_H
 
-#define USERLAND_MAX_TASKS 8192
-
 /*
  * An instance of a task that has been enqueued by the kernel for consumption
  * by a user space global scheduler thread.


### PR DESCRIPTION
Currently the array of enqueued tasks is statically allocated to a fixed size of USERLAND_MAX_TASKS to avoid potential deadlocks that could be introduced by performing dynamic allocations in the enqueue path.

However, this also adds a limit on the maximum pid that the scheduler can handle, since the pid is used as the index to access the array.

In fact, it is quite easy to trigger the following failure on an average desktop system (making this scheduler pretty much unusable in such scenario):

 $ sudo scx_userland
 ...
 Failed to enqueue task 33258: No such file or directory
 EXIT: BPF scheduler unregistered

Prevent this by using sysctl's kernel.pid_max as the size of the tasks array (and still allocate it all at once during initialization).

The downside of this change is that scx_userland may require additional memory to start and in small systems it could even trigger OOMs. For this reason add an explicit message to the command help, suggesting to reduce kernel.pid_max in case of OOM conditions.