### PR TITLE
rust: Update libbpf-rs & libbpf-cargo to 0.22

### DIFF
--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_utils"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0-only"
@@ -12,7 +12,7 @@ anyhow = "1.0"
 bindgen = "0.69"
 glob = "0.3"
 lazy_static = "1.4"
-libbpf-cargo = "0.21"
+libbpf-cargo = "0.22"
 regex = "1.10"
 sscanf = "0.4"
 tar = "0.4"

--- a/scheds/rust-user/scx_layered/Cargo.toml
+++ b/scheds/rust-user/scx_layered/Cargo.toml
@@ -13,16 +13,16 @@ clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7"
 lazy_static = "1.4"
-libbpf-rs = "0.21"
+libbpf-rs = "0.22"
 libc = "0.2"
 log = "0.4"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.3" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.4" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.3" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.4" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust-user/scx_rusty/Cargo.toml
+++ b/scheds/rust-user/scx_rusty/Cargo.toml
@@ -13,15 +13,15 @@ clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7.0"
 hex = "0.4.3"
-libbpf-rs = "0.21.0"
+libbpf-rs = "0.22.0"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.3" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.4" }
 simplelog = "0.12.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.3" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.4" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION
This is a follow on to #32, which got reverted. I wrongly assumed that scx_rusty resides in the sched_ext tree and consumes published version of scx_utils.
With this change we update the other in-tree dependencies. I built scx_layered & scx_rusty. I bumped scx-utils to 0.4, because the libbpf-cargo seems to be part of the public API surface and libbpf-cargo 0.21 and 0.22 are not compatible with each other.