### PR TITLE
scx: Add CI action that builds schedulers for PRs

### DIFF
--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -1,0 +1,49 @@
+name: build-scheds
+run-name: ${{ github.actor }} PR run
+on: [pull_request]
+jobs:
+  build-schedulers:
+    runs-on: ubuntu-20.04
+    steps:
+
+      ### DOWNLOAD AND INSTALL DEPENDENCIES ###
+
+      # Download dependencies packaged by Ubuntu
+      - run: sudo apt update
+      - run: sudo apt -y install cmake cargo elfutils libelf-dev linux-headers-generic linux-tools-common ninja-build
+
+      # clang 17
+      - run: wget https://apt.llvm.org/llvm.sh
+      - run: chmod +x llvm.sh
+      - run: sudo ./llvm.sh all
+      - run: sudo ln -sf /usr/bin/clang-17 /usr/bin/clang
+      - run: sudo ln -sf /usr/bin/llvm-strip-17 /usr/bin/llvm-strip
+
+      # bpftool
+      - run: git clone --recurse-submodules --branch v7.3.0 https://github.com/libbpf/bpftool.git
+      - run: make -j -C bpftool/src
+      - run: sudo make -j -C bpftool/src install
+
+      # zstd
+      - run: git clone --branch zstd-0.4.2 https://github.com/facebook/zstd.git
+      - run: make -j -C zstd
+      - run: sudo make -j -C zstd install
+
+      # asm headers
+      - run: sudo ln -s /usr/include/asm-generic /usr/include/asm
+
+      - uses: actions/checkout@v4
+
+      # libbpf
+      - run: git clone --recurse-submodules --branch v1.3.0 https://github.com/libbpf/libbpf.git
+      - run: make -j -C libbpf/src
+      - run: sudo make -j -C libbpf/src install
+
+      # meson
+      - run: pip install meson
+
+      ### END DEPENDENCIES ###
+
+      # The actual build:
+      - run: meson setup build -Dlibbpf_a=`pwd`/libbpf/src/libbpf.a --prefix ~
+      - run: meson compile -C build

--- a/scheds/c/meson.build
+++ b/scheds/c/meson.build
@@ -1,10 +1,11 @@
 c_scheds = ['scx_simple', 'scx_qmap', 'scx_central', 'scx_pair', 'scx_flatcg', 'scx_userland', 'scx_nest']
 
 foreach sched: c_scheds
+  thread_dep = dependency('threads')
   bpf_o = gen_bpf_o.process(sched + '.bpf.c', extra_args: bpf_includes)
   bpf_skel = gen_bpf_skel.process(bpf_o)
   executable(sched, [bpf_skel, sched + '.c'],
              include_directories: [user_c_includes],
-             dependencies: libbpf_dep,
+             dependencies: [libbpf_dep, thread_dep],
              install: true)
 endforeach


### PR DESCRIPTION
When Ubuntu ships with sched_ext, we can also maybe test loading the schedulers (not sure if the runners can run as root though). For now, we should at least have a CI job that lets us verify that the schedulers can _build_. To that end, this patch adds a basic CI action that builds the schedulers.

As is, this is a bit brittle in that we're having to manually download and install a few dependencies. I don't see a better way for now without hosting our own runners with our own containers, but that's a bigger investment. For now, hopefully this will get us _some_ coverage.