### PR TITLE
scx_rustland improvements

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf/intf.h
+++ b/scheds/rust/scx_rustland/src/bpf/intf.h
@@ -33,6 +33,7 @@ typedef long long s64;
  */
 struct queued_task_ctx {
 	s32 pid;
+	s32 cpu; /* CPU where the task is running */
 	u64 sum_exec_runtime; /* Total cpu time */
 	u64 weight; /* Task static priority */
 };
@@ -49,6 +50,7 @@ struct queued_task_ctx {
  */
 struct dispatched_task_ctx {
 	s32 pid;
+	s32 cpu; /* CPU where the task should be dispatched */
 	u64 payload; /* Task payload */
 };
 


### PR DESCRIPTION
Set of changes for scx_rustland that allow to massively improve the user-space scheduler effectiveness, especially for low latency tasks:
 - provide CPU usage awareness to the user-space scheduler
 - dispatch tasks from the user-space scheduler to the BPF dispatcher in batch, instead of draining the entire task pool all at once
 - distinguish between graceful exit vs non-graceful exit