### PR TITLE
scx_rustland: clarify and improve BPF / userspace interlocking

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rustland/src/bpf/main.bpf.c
@@ -297,12 +297,12 @@ static bool is_task_cpu_available(struct task_struct *p)
 	struct task_ctx *tctx;
 
 	/*
-	 * Always dispatch per-CPU kthread on the same CPU, bypassing the
-	 * user-space scheduler (in this way we can to prioritize critical
-	 * kernel threads that may potentially slow down the entire system if
-	 * they are blocked for too long).
+	 * Always dispatch kthread on the same CPU, bypassing the user-space
+	 * scheduler (in this way we can to prioritize critical kernel threads
+	 * that may potentially slow down the entire system if they are blocked
+	 * for too long).
 	 */
-	if (is_kthread(p) && p->nr_cpus_allowed == 1)
+	if (is_kthread(p))
 		return true;
 
 	/*

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -443,14 +443,14 @@ impl<'a> Scheduler<'a> {
 
     // Print internal scheduler statistics (fetched from the BPF part)
     fn print_stats(&mut self) {
-        let nr_enqueues = self.skel.bss().nr_enqueues as u64;
+        let nr_queued = self.skel.bss().nr_queued as u64;
         let nr_user_dispatches = self.skel.bss().nr_user_dispatches as u64;
         let nr_kernel_dispatches = self.skel.bss().nr_kernel_dispatches as u64;
         let nr_sched_congested = self.skel.bss().nr_sched_congested as u64;
 
         info!(
-            "min_vtime={} nr_enqueues={} nr_user_dispatched={} nr_kernel_dispatches={} nr_sched_congested={}",
-            self.min_vruntime, nr_enqueues, nr_user_dispatches, nr_kernel_dispatches, nr_sched_congested
+            "min_vtime={} nr_queued={} nr_user_dispatched={} nr_kernel_dispatches={} nr_sched_congested={}",
+            self.min_vruntime, nr_queued, nr_user_dispatches, nr_kernel_dispatches, nr_sched_congested
         );
         for cpu in 0..self.nr_cpus_online {
             let pid = self.get_cpu_pid(cpu as u32);


### PR DESCRIPTION
A set of interlocking improvements for scx_rustland:
 - clarify interlocking between the BPF dispatcher and the user-space scheduler
 - introduce get/set_cpu_owner() primitives as a baseline to implement a better idle tracking in the future
 - move user-space scheduler activation from `.enqueue()` to `.stopping()` (and activate only when needed) to reduce unnecessary user-space activations
 - always bypass user-space scheduling for kthreads

I have also explored the possibility to move the user-space scheduler activation from `.stopping()` to `.update_idle()`, but the scheduler performs quite poorly with this change: it seems that CPUs are not fully used even in presence of CPU intensive workloads, as if the user-space scheduler isn't feeding the dispatcher fast enough. My guess is that activating the user-space scheduler in `.update_idle()` is a bit too late and we get bubbles in the whole scheduling pipeline, compared to do the activation in `.stopping`. But this is something that I'd like to explore more for the next set of improvements for scx_rustland.