### PR TITLE
Downgrade bindgen to 0.68

### DIFF
--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -9,7 +9,7 @@ description = "Utilities for sched_ext schedulers"
 
 [dependencies]
 anyhow = "1.0"
-bindgen = "0.69"
+bindgen = ">=0.68, <0.70"
 glob = "0.3"
 lazy_static = "1.4"
 libbpf-cargo = "0.22"

--- a/rust/scx_utils/src/bpf_builder.rs
+++ b/rust/scx_utils/src/bpf_builder.rs
@@ -506,7 +506,7 @@ impl BpfBuilder {
             .header(input)
             // Tell cargo to invalidate the built crate whenever any of the
             // included header files changed.
-            .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks))
             .generate()
             .context("Unable to generate bindings")?;
 


### PR DESCRIPTION
This is so we can package scx_utils into fedora without having to upgrade rust-bindgen
(https://bodhi.fedoraproject.org/updates/FEDORA-2023-18e7f124e1).

To make this happen we need to stop using the `CargoCallbacks::new` constructor which was added in 0.69. Old way seems legit according to the docs:
https://rust-lang.github.io/rust-bindgen/non-system-libraries.html