### PR TITLE
test the schedulers in the github workflow using virtme-ng

### DIFF
--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -7,18 +7,20 @@ jobs:
     steps:
       ### OTHER REPOS ####
 
-      # virtme-ng isn't used yet, but let's incorporate installing it in our environment
-      # as we have plans to use it in the future.
-      - run: sudo add-apt-repository -y ppa:arighi/virtme-ng
-      - run: sudo apt update
-
       # Hard turn-off interactive mode
       - run: echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+
+      # Add sched-ext external ppa to get the latest sched-ext kernel
+      - run: sudo add-apt-repository -n -y ppa:arighi/sched-ext
+      - run: sudo sed -i s/jammy/noble/ /etc/apt/sources.list.d/arighi-ubuntu-sched-ext-jammy.list
+
+      # Refresh packages list
+      - run: sudo apt update
 
       ### DOWNLOAD AND INSTALL DEPENDENCIES ###
 
       # Download dependencies packaged by Ubuntu
-      - run: sudo apt -y install cmake cargo elfutils libelf-dev libunwind-dev libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic ninja-build virtme-ng
+      - run: sudo apt -y install coreutils cmake cargo elfutils libelf-dev libunwind-dev libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic ninja-build python3-pip python3-requests qemu-kvm udev iproute2 busybox-static libvirt-clients kbd kmod file rsync zstd
 
       # clang 17
       # Use a custom llvm.sh script which includes the -y flag for
@@ -49,11 +51,19 @@ jobs:
       # meson
       - run: pip install meson
 
+      # Install virtme-ng
+      - run: pip install virtme-ng
+
+      # Download a sched-ext enabled kernel
+      - run: apt download linux-image-unsigned-6.7.0-3-generic linux-modules-6.7.0-3-generic
+      - run: mkdir -p kernel
+      - run: for f in *.deb; do dpkg -x $f kernel; done
+
       ### END DEPENDENCIES ###
 
       # The actual build:
-      - run: meson setup build -Dlibbpf_a=`pwd`/libbpf/src/libbpf.a
+      - run: meson setup build -Dlibbpf_a=`pwd`/libbpf/src/libbpf.a -Dkernel=$(pwd)/$(ls -c1 kernel/boot/vmlinuz* | tail -1)
       - run: meson compile -C build
 
-      # TODO: Run the schedulers using virtme-ng (currently blocked on being able
-      #       to use virtme-ng in a Docker container).
+      # Test schedulers
+      - run: meson compile -C build test_sched

--- a/meson-scripts/test_sched
+++ b/meson-scripts/test_sched
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Run a scheduler for TIMEOUT seconds inside virtme-ng and catch potential
+# errors, then unload the scheduler and return the exit status.
+
+# Maximum time for each scheduler run.
+TEST_TIMEOUT=30
+
+# Maximum timeout for the guest used for each scheduler run (this is used to
+# hard-shutdown the guest in case of system hangs).
+GUEST_TIMEOUT=60
+
+# List of schedulers to test
+#
+# TODO:
+#   - scx_layered: temporarily excluded because it
+#     cannot run with a default configuration
+#
+SCHEDULERS="scx_simple scx_central scx_flatcg scx_nest scx_pair scx_qmap scx_userland scx_rusty scx_rustland"
+
+if [ ! -x `which vng` ]; then
+    echo "vng not found, please install virtme-ng to enable testing"
+    exit 1
+fi
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 VMLINUZ"
+    exit 1
+fi
+kernel=$1
+
+for sched in ${SCHEDULERS}; do
+    sched_path=$(find -type f -executable -name ${sched})
+    if [ ! -n "${sched_path}" ]; then
+        echo "${sched}: binary not found"
+        echo "FAIL: ${sched}"
+        exit 1
+    fi
+    echo "testing ${sched_path}"
+
+    rm -f /tmp/output
+    timeout --preserve-status ${GUEST_TIMEOUT} \
+        vng --force-9p --disable-microvm -v -r ${kernel} -- \
+            "timeout --foreground --preserve-status ${TEST_TIMEOUT} ${sched_path}" \
+	        2>&1 </dev/null | tee /tmp/output
+        sed -n -e '/\bBUG:/q1' \
+	       -e '/\bWARNING:/q1' \
+	       -e '/\berror\b/Iq1' \
+	       -e '/\bstall/Iq1' \
+	       -e '/\btimeout\b/Iq1' /tmp/output
+    res=$?
+    if [ ${res} -ne 0 ]; then
+        echo "FAIL: ${sched}"
+        exit 1
+    else
+        echo "OK: ${sched}"
+    fi
+done

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,8 @@ get_sys_incls = find_program(join_paths(meson.current_source_dir(),
                                         'meson-scripts/get_sys_incls'))
 cargo_fetch = find_program(join_paths(meson.current_source_dir(),
                                       'meson-scripts/cargo_fetch'))
+test_sched  = find_program(join_paths(meson.current_source_dir(),
+                                      'meson-scripts/test_sched'))
 
 bpf_clang_ver = run_command(get_clang_ver, bpf_clang, check: true).stdout().strip()
 bpf_clang_maj = bpf_clang_ver.split('.')[0].to_int()
@@ -145,6 +147,12 @@ if get_option('enable_rust')
 endif
 
 run_target('fetch', command: [cargo_fetch, cargo], env: cargo_env)
+
+if get_option('kernel') != ''
+  kernel = get_option('kernel')
+endif
+
+run_target('test_sched', command: [test_sched, kernel])
 
 if get_option('enable_rust')
   subdir('rust')

--- a/meson.options
+++ b/meson.options
@@ -14,3 +14,5 @@ option('offline', type: 'boolean', value: 'false',
        description: 'Compilation step should not access the internet')
 option('enable_rust', type: 'boolean', value: 'true',
        description: 'Enable rust sub-projects')
+option('kernel', type: 'string', value: 'vmlinuz',
+       description: 'kernel image used to test schedulers')

--- a/scheds/c/scx_flatcg.c
+++ b/scheds/c/scx_flatcg.c
@@ -211,6 +211,7 @@ int main(int argc, char **argv)
 		       stats[FCG_STAT_PNC_GONE]);
 		printf("BAD remove:%6llu\n",
 		       acc_stats[FCG_STAT_BAD_REMOVAL]);
+		fflush(stdout);
 
 		nanosleep(&intv_ts, NULL);
 	}

--- a/scheds/c/scx_userland.c
+++ b/scheds/c/scx_userland.c
@@ -293,6 +293,7 @@ static void *run_stats_printer(void *arg)
 		printf("|  failed:   %10llu |\n", nr_vruntime_failed);
 		printf("o-----------------------o\n");
 		printf("\n\n");
+		fflush(stdout);
 		sleep(1);
 	}
 


### PR DESCRIPTION
Use virtme-ng to test the schedulers in the github workflow.

Keep in mind that I've only tested this locally (using `gh act`), so in the actual github workflow it may behave differently and it probably requires more testing / planning.

I've opened the PR to start some discussions / suggestions / ideas for now.

Overall, I think it can be really useful, I've already triggered a few bugs with this (see https://github.com/sched-ext/scx/issues/49, https://github.com/sched-ext/sched_ext/pull/101 and https://github.com/sched-ext/sched_ext/issues/74#issuecomment-1870958545).