### PR TITLE
scx_rustland: introduce update_idle callback

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rustland/src/bpf/main.bpf.c
@@ -297,12 +297,12 @@ static bool is_task_cpu_available(struct task_struct *p)
 	struct task_ctx *tctx;
 
 	/*
-	 * Always dispatch kthread on the same CPU, bypassing the user-space
-	 * scheduler (in this way we can to prioritize critical kernel threads
-	 * that may potentially slow down the entire system if they are blocked
-	 * for too long).
+	 * Always dispatch per-CPU kthread on the same CPU, bypassing the
+	 * user-space scheduler (in this way we can to prioritize critical
+	 * kernel threads that may potentially slow down the entire system if
+	 * they are blocked for too long).
 	 */
-	if (is_kthread(p))
+	if (is_kthread(p) && p->nr_cpus_allowed == 1)
 		return true;
 
 	/*


### PR DESCRIPTION
- move the logic to activate the user-space scheduler to an `update_idle()` callback
- restore the logic to prioritize only per-cpu kthreads (not all kthreads)