### PR TITLE
scx_rustland: add documentation to scheds/rust/README.md

### DIFF
--- a/scheds/rust/README.md
+++ b/scheds/rust/README.md
@@ -82,3 +82,35 @@ task with a very high weight may cause the scheduler to incorrectly leave cores
 idle because it thinks they're necessary to accommodate the compute for a
 single task. This can also happen in CFS, and should soon be addressed for
 scx_rusty.
+
+## scx_rustland
+
+### Overview
+
+scx_rustland is made of a BPF component (dispatcher) that implements the low
+level sched-ext functionalities and a user-space counterpart (scheduler),
+written in Rust, that implements the actual scheduling policy.
+
+The BPF dispatcher is completely agnostic of the particular scheduling policy
+implemented in user-space. For this reason developers that are willing to use
+this scheduler to experiment scheduling policies should be able to simply
+modify the Rust component, without having to deal with any internal kernel /
+BPF details.
+
+### Typical Use Case
+
+scx_rustland is designed to be "easy to read" template that can be used by any
+developer to quickly experiment more complex scheduling policies, that can be
+fully implemented in Rust.
+
+### Production Ready?
+
+Not quite. For production scenarios, other schedulers are likely to exhibit
+better performance, as offloading all scheduling decisions to user-space comes
+with a certain cost.
+
+However, a scheduler entirely implemented in user-space holds the potential for
+seamless integration with sophisticated libraries, tracing tools, external
+services (e.g., AI), etc. Hence, there might be situations where the benefits
+outweigh the overhead, justifying the use of this scheduler in a production
+environment.


### PR DESCRIPTION
Add documentation for scx_rustland to the README.md files of the Rust schedulers.