### PR TITLE
scx_rustland: lowlatency improvements

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rustland/src/bpf/main.bpf.c
@@ -450,11 +450,9 @@ void BPF_STRUCT_OPS(rustland_dispatch, s32 cpu, struct task_struct *prev)
 		 * task and migrate (if possible); otherwise, dispatch on the
 		 * global DSQ.
 		 */
-		prev_cpu = scx_bpf_task_cpu(p);
-		dbg_msg("usersched: pid=%d prev_cpu=%d cpu=%d payload=%llu",
+		dbg_msg("usersched: pid=%d cpu=%d payload=%llu",
 			task.pid, task.cpu, task.payload);
-		if ((task.cpu != prev_cpu) &&
-		   bpf_cpumask_test_cpu(task.cpu, p->cpus_ptr))
+		if (bpf_cpumask_test_cpu(task.cpu, p->cpus_ptr))
 			dispatch_on_cpu(p, task.cpu, 0);
 		else
 			dispatch_global(p, 0);


### PR DESCRIPTION
Low-latency improvements:
 - scx_rustland: always use dispatch_on_cpu() when possible
 - scx_rustland: bypass user-space scheduler for short-lived kthreads 

Reduce user-space overhead:
 - scx_rustland: enable SCX_OPS_ENQ_LAST

UI improvement:
 - scx_rustland: show the CPU where the scheduler is running