### PR TITLE
scx_rustland: prevent starvation and improve responsiveness

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rustland/src/bpf/main.bpf.c
@@ -336,12 +336,6 @@ static bool is_task_cpu_available(struct task_struct *p, u64 enq_flags)
 		return true;
 
 	/*
-	 * No scheduling required if it's the last task running.
-	 */
-        if (enq_flags & SCX_ENQ_LAST)
-		return true;
-
-	/*
 	 * For regular tasks always rely on force_local to determine if we can
 	 * bypass the scheduler.
 	 */

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -410,10 +410,10 @@ impl<'a> Scheduler<'a> {
                     //
                     // Use the previously used CPU if idle, that is always the best choice (to
                     // mitigate migration overhead), otherwise pick the next idle CPU available.
-                    if let Some(id) = idle_cpus.iter().position(|&x| x == task.cpu) {
+                    if let Some(pos) = idle_cpus.iter().position(|&x| x == task.cpu) {
                         // The CPU assigned to the task is in idle_cpus, keep the assignment and
                         // remove the CPU from idle_cpus.
-                        idle_cpus.remove(id);
+                        idle_cpus.remove(pos);
                     } else {
                         // The CPU assigned to the task is not in idle_cpus, pop the first CPU from
                         // idle_cpus and assign it to the task.

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -355,11 +355,10 @@ impl<'a> Scheduler<'a> {
     ) {
         // Add cputime delta normalized by weight to the vruntime (if delta > 0).
         if sum_exec_runtime > task_info.sum_exec_runtime {
-            let mut delta = sum_exec_runtime - task_info.sum_exec_runtime;
+            let delta = (sum_exec_runtime - task_info.sum_exec_runtime) * 100 / weight;
             // Never account more than max_slice_ns. This helps to prevent starving a task for too
             // long in the scheduler task pool.
-            delta = delta.min(max_slice_ns);
-            task_info.vruntime += delta / weight;
+            task_info.vruntime += delta.min(max_slice_ns);
         }
         // Make sure vruntime is moving forward (> current minimum).
         task_info.vruntime = task_info.vruntime.max(min_vruntime);

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -159,22 +159,6 @@ impl TaskInfoMap {
         }
     }
 
-    // Get an item (as mutable) from the HashMap (by pid).
-    fn get_mut(&mut self, pid: i32) -> Option<&mut TaskInfo> {
-        self.tasks.get_mut(&pid)
-    }
-
-    // Add or update an item in the HashMap (by pid), if the pid is already present the item will
-    // be replaced (updated).
-    fn insert(&mut self, pid: i32, task: TaskInfo) {
-        self.tasks.insert(pid, task);
-    }
-
-    // Return the amount of tasks stored in the TaskInfoMap.
-    fn len(&self) -> usize {
-        self.tasks.len()
-    }
-
     // Clean up old entries (pids that don't exist anymore).
     fn gc(&mut self) {
         fn is_pid_running(pid: i32) -> bool {
@@ -376,36 +360,36 @@ impl<'a> Scheduler<'a> {
         loop {
             match queued.lookup_and_delete(&[]) {
                 Ok(Some(msg)) => {
-                    // Schedule the task and update task information.
+                    // Extract the task object from the message.
                     let task = EnqueuedMessage::from_bytes(msg.as_slice()).as_queued_task_ctx();
-                    if let Some(task_info) = self.task_map.get_mut(task.pid) {
-                        // Taks is already mapped in self.task_map: update its information.
-                        Self::update_enqueued(
-                            task_info,
-                            task.sum_exec_runtime,
-                            task.weight,
-                            // Make sure the global vruntime is always progressing during each
-                            // scheduler run.
-                            self.min_vruntime + 1,
-                            self.skel.rodata().slice_ns,
-                        );
-                        self.task_pool.push(task.pid, task.cpu, task_info.vruntime);
-                    } else {
-                        // A new task has been scheduled.
-                        //
-                        // Initialize task information in self.task_map and set an initial vruntime
-                        // of (self.min_vruntime + 1): this ensures a progressing global vruntime
+
+                    // Get task information if the task is already stored in the task map,
+                    // otherwise create a new entry for it.
+                    let task_info =
+                        self.task_map
+                            .tasks
+                            .entry(task.pid)
+                            .or_insert_with_key(|&_pid| TaskInfo {
+                                sum_exec_runtime: task.sum_exec_runtime,
+                                vruntime: self.min_vruntime,
+                            });
+
+                    // Update task information.
+                    Self::update_enqueued(
+                        task_info,
+                        task.sum_exec_runtime,
+                        task.weight,
+                        // Make sure the global vruntime is always progressing (at least by +1)
                         // during each scheduler run, providing a priority boost to newer tasks
                         // (that is still beneficial for potential short-lived tasks), while also
                         // preventing excessive starvation of the other tasks sitting in the
                         // self.task_pool tree, waiting to be dispatched.
-                        let task_info = TaskInfo {
-                            sum_exec_runtime: task.sum_exec_runtime,
-                            vruntime: self.min_vruntime + 1,
-                        };
-                        self.task_map.insert(task.pid, task_info);
-                        self.task_pool.push(task.pid, task.cpu, self.min_vruntime + 1);
-                    }
+                        self.min_vruntime + 1,
+                        self.skel.rodata().slice_ns,
+                    );
+
+                    // Insert task in the task pool (ordered by vruntime).
+                    self.task_pool.push(task.pid, task.cpu, task_info.vruntime);
                 }
                 Ok(None) => {
                     // Reset nr_queued and update nr_scheduled, to notify the dispatcher that
@@ -521,7 +505,11 @@ impl<'a> Scheduler<'a> {
     // Print internal scheduler statistics (fetched from the BPF part).
     fn print_stats(&mut self) {
         // Show minimum vruntime (this should be constantly incrementing).
-        info!("vruntime={} tasks={}", self.min_vruntime, self.task_map.len());
+        info!(
+            "vruntime={} tasks={}",
+            self.min_vruntime,
+            self.task_map.tasks.len()
+        );
 
         // Show general statistics.
         let nr_user_dispatches = self.skel.bss().nr_user_dispatches as u64;


### PR DESCRIPTION
Improvements and fixes to scx_rustland to prevent some cases of starvation and enhance responsiveness:
 - scx_rustland: evaluate the proper vruntime delta
 - scx_rustland: prevent starvation handling short-lived tasks properly
 - bpf_rustland: do not dispatch the scheduler to the global DSQ
 - scx_rustland: remove SCX_ENQ_LAST check in is_task_cpu_available()
 - scx_rustland: never account more than slice_ns to vruntime
 - scx_rustland: clean up old entries in the task map

Small code readability improvement:
- scx_rustland: small code refactoring
- scx_rustland: rename variable id -> pos for better clarity

With all these changes in place the scheduler can properly handle, on my 8-cores laptop, a parallel kernel build (`make -j32`), a stress test (`stress-ng --cpu 32 --iomix 4 --vm 2 --vm-bytes 128M --fork 4`), a YouTube music video playing in the background, all while reading emails and writing the text of this PR.