### PR TITLE
scx_rustland: notify user-space scheduler about exiting tasks

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf/intf.h
+++ b/scheds/rust/scx_rustland/src/bpf/intf.h
@@ -33,7 +33,7 @@ typedef long long s64;
  */
 struct queued_task_ctx {
 	s32 pid;
-	s32 cpu; /* CPU where the task is running */
+	s32 cpu; /* CPU where the task is running (-1 = exiting) */
 	u64 sum_exec_runtime; /* Total cpu time */
 	u64 weight; /* Task static priority */
 };


### PR DESCRIPTION
Instead of implementing a garbage collector to periodically free up exiting tasks' resources, implement a proper synchronous mechanism to notify the user-space scheduler about the exiting tasks from the BPF component, using the .disable() callback.

When the user-space scheduler receives a queued task with a negative CPU number, it can then release all the resources associated with that task (which currently includes only the entry in the TaskInfoMap for now).

This allows to get rid of the TaskInfoMap periodic garbage collector routine, save a lot of syscalls in procfs (used to check if the pids were still alive), and improve the overall scheduler performance.