### PR TITLE
scheds: c: improve build portability

### DIFF
--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -38,9 +38,6 @@ jobs:
       - run: make -j -C bpftool/src
       - run: sudo make -j -C bpftool/src install
 
-      # asm headers
-      - run: sudo ln -s /usr/include/asm-generic /usr/include/asm
-
       - uses: actions/checkout@v4
 
       # libbpf

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -10,7 +10,7 @@
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
-#include <linux/errno.h>
+#include <asm-generic/errno.h>
 #include "user_exit_info.h"
 
 #define PF_WQ_WORKER			0x00000020	/* I'm a workqueue worker */


### PR DESCRIPTION
Improve build portability by including asm-generic/errno.h, instead of linux/errno.h.

The difference between these two headers can be summarized as following:

  - asm-generic/errno.h contains generic error code definitions that are intended to be common across different architectures,

  - linux/errno.h includes architecture-specific error codes and provides additional (or overrides) error code definitions based on the specific architecture where the code is compiled.

Considering the architecture-independent nature of scx, the advantages of being able to use architecture-specific error codes are marginal or negligible (and we should probably discourage using them).

Moving towards asm-generic/errno.h, however, allows the removal of cross-compilation dependencies (such as the gcc-multilib package in Debian/Ubuntu) and improves the code portability across various architectures and distributions.

This also allows to remove a symlink hack from the github workflow.