### PR TITLE
scx_rustland: improve interactive workloads

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rustland/src/bpf/main.bpf.c
@@ -339,13 +339,17 @@ static void get_task_info(struct queued_task_ctx *task,
 			  const struct task_struct *p, bool exiting)
 {
 	task->pid = p->pid;
-	task->sum_exec_runtime = p->se.sum_exec_runtime;
-	task->weight = p->scx.weight;
 	/*
 	 * Use a negative CPU number to notify that the task is exiting, so
 	 * that we can free up its resources in the user-space scheduler.
 	 */
-	task->cpu = exiting ? -1 : scx_bpf_task_cpu(p);
+	if (exiting) {
+		task->cpu = -1;
+		return;
+	}
+	task->sum_exec_runtime = p->se.sum_exec_runtime;
+	task->weight = p->scx.weight;
+	task->cpu = scx_bpf_task_cpu(p);
 }
 
 /*
@@ -555,7 +559,7 @@ s32 BPF_STRUCT_OPS(rustland_prep_enable, struct task_struct *p,
  */
 void BPF_STRUCT_OPS(rustland_disable, struct task_struct *p)
 {
-        struct queued_task_ctx task;
+        struct queued_task_ctx task = {};
 
 	dbg_msg("exiting: pid=%d", task.pid);
 	get_task_info(&task, p, true);

--- a/scheds/rust/scx_rustland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rustland/src/bpf/main.bpf.c
@@ -320,19 +320,6 @@ static bool is_task_cpu_available(struct task_struct *p, u64 enq_flags)
 		return true;
 
 	/*
-	 * Moreover, immediately dispatch kthreads that still have more than
-	 * half of their runtime budget. As they are likely to release the CPU
-	 * soon, granting them a substantial priority boost can enhance the
-	 * overall system performance.
-	 *
-	 * In the event that one of these kthreads turns into a CPU hog, it
-	 * will deplete its runtime budget and therefore it will be scheduled
-	 * like any other normal task.
-	 */
-	if (is_kthread(p) && p->scx.slice > slice_ns / 2)
-		return true;
-
-	/*
 	 * For regular tasks always rely on force_local to determine if we can
 	 * bypass the scheduler.
 	 */


### PR DESCRIPTION
Big logical change:
- scx_rustland: prioritize interactive workloads

Small "cleanup" changes:
- scx_rustland: do not update exiting tasks statistics
- scx_rustland: schedule non-cpu intensive kthreads normally

The big change can actually make scx_rustland relevant under certain conditions. As I mentioned in the commit message:
```
  For example, with a parallel kernel build (make -j32) running in the
  background, I can play Terraria with a constant rate of ~30-40 fps,
  while the default Linux scheduler can handle only ~20-30 fps under the
  same conditions.
```
While the scheduler isn't quite production-ready, I think we're approaching a state where it can be considered "usable" (under certain conditions) and someone might even find it beneficial in a few real-world scenarios (also considering how easy it is to extend its functionality, by simply modifying the Rust part).