### PR TITLE
bump scx_rusty and scx_layered

### DIFF
--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_layered"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Tejun Heo <htejun@meta.com>", "Meta"]
 edition = "2021"
 description = "Userspace scheduling with BPF for Ads"

--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rusty"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Dan Schatzberg <dschatzberg@meta.com>", "Meta"]
 edition = "2021"
 description = "Userspace scheduling with BPF"


### PR DESCRIPTION
These were supposed to be bumped in this commit:
https://github.com/sched-ext/scx/commit/fed1dae9da71926772248996e9007370f348a2f0