### PR TITLE
scx_rustland: dynamic time slice

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf.rs
+++ b/scheds/rust/scx_rustland/src/bpf.rs
@@ -226,6 +226,24 @@ impl<'a> BpfScheduler<'a> {
         }
     }
 
+    // Override the default scheduler time slice (in us).
+    #[allow(dead_code)]
+    pub fn set_effective_slice_us(&mut self, slice_us: u64) {
+        self.skel.bss_mut().effective_slice_ns = slice_us * 1000;
+    }
+
+    // Get current value of time slice (slice_ns).
+    #[allow(dead_code)]
+    pub fn get_effective_slice_us(&mut self) -> u64 {
+        let slice_ns = self.skel.bss().effective_slice_ns;
+
+        if slice_ns > 0 {
+            slice_ns / 1000
+        } else {
+            self.skel.rodata().slice_ns / 1000
+        }
+    }
+
     // Counter of queued tasks.
     pub fn nr_queued_mut(&mut self) -> &mut u64 {
         &mut self.skel.bss_mut().nr_queued


### PR DESCRIPTION
Provide a new abstraction for the user-space scheduler to dynamically adjust the time slice used to dispatch tasks. Moreover, implement a mechanism in the user-space scheduler to dynamically scale the time slice as a function of the waiting tasks and the available CPUs in the system.

Apart for the benefits of having an additional scheduling abstraction (that can be beneficial for potential developers interested in expanding RustLand), this change also significantly improves the interactive performance of the scheduler, especially when the system is overloaded by a massive amount of CPU hogs (e.g., `stress-ng -c 256`).

Before this change the stress-ng command above could make my system pretty much unresponsive (triggering the sched-ext watchdog / stall detector). With this change applied the scheduler survives and I'm still able to run commands.