### PR TITLE
Bump versions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('sched_ext schedulers', 'c',
-        version: '0.1.4',
+        version: '0.1.5',
         license: 'GPL-2.0')
 
 if meson.version().version_compare('<1.2')

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_utils"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_layered"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Tejun Heo <htejun@meta.com>", "Meta"]
 edition = "2021"
 description = "Userspace scheduling with BPF for Ads"
@@ -16,13 +16,13 @@ lazy_static = "1.4"
 libbpf-rs = "0.22"
 libc = "0.2"
 log = "0.4"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.4" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.5" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.4" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.5" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Andrea Righi <andrea.righi@canonical.com>", "Canonical"]
 edition = "2021"
 description = "Userspace scheduling with BPF"
@@ -17,11 +17,11 @@ libbpf-rs = "0.22.0"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.4" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.5" }
 simplelog = "0.12.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.4" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.5" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rusty"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Dan Schatzberg <dschatzberg@meta.com>", "Meta"]
 edition = "2021"
 description = "Userspace scheduling with BPF"
@@ -17,11 +17,11 @@ libbpf-rs = "0.22.0"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.4" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.5" }
 simplelog = "0.12.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.4" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.5" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION
After updates to reflect the updated init and direct dispatch API, the schedulers aren't compatible with older kernels. Bump versions and publish releases.