### PR TITLE
[scx_rusty] select_cpu to kick lower pri tasks

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/intf.h
+++ b/scheds/rust/scx_rusty/src/bpf/intf.h
@@ -17,6 +17,7 @@
 typedef unsigned char u8;
 typedef unsigned int u32;
 typedef unsigned long long u64;
+typedef int s32;
 #endif
 
 #include <scx/ravg.bpf.h>

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -137,6 +137,11 @@ struct Opts {
     #[clap(short = 'f', long, action = clap::ArgAction::SetTrue)]
     fifo_sched: bool,
 
+    /// Disable preemption to prioritize lower vtime waking tasks.
+    /// fifo_sched needs to be set to false for preemption to work.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    no_preemption: bool,
+
     /// Idle CPUs with utilization lower than this will get remote tasks
     /// directly pushed on them. 0 disables, 100 enables always.
     #[clap(short = 'D', long, default_value = "90.0")]
@@ -1109,6 +1114,7 @@ impl<'a> Scheduler<'a> {
         skel.rodata_mut().kthreads_local = opts.kthreads_local;
         skel.rodata_mut().fifo_sched = opts.fifo_sched;
         skel.rodata_mut().switch_partial = opts.partial;
+        skel.rodata_mut().enable_preemption = !(opts.no_preemption || opts.fifo_sched);
         skel.rodata_mut().greedy_threshold = opts.greedy_threshold;
         skel.rodata_mut().debug = opts.verbose as u32;
 


### PR DESCRIPTION
If we get to the end of select_cpu:
if no idle cpu, waking, and no other tasks are in the domain queue then see if any cpu in the domain is running a task with lower priority. Pick the one with the lowest priority, whose runtime is also lower than the task we want to select the cpu for, and kick it.