### PR TITLE
scx_flatcg: introduce CGROUP_MAX_RETRIES

### DIFF
--- a/scheds/c/scx_flatcg.bpf.c
+++ b/scheds/c/scx_flatcg.bpf.c
@@ -46,6 +46,11 @@
 #include <scx/common.bpf.h>
 #include "scx_flatcg.h"
 
+/*
+ * Maximum amount of retries to find a valid cgroup.
+ */
+#define CGROUP_MAX_RETRIES 1024
+
 char _license[] SEC("license") = "GPL";
 
 const volatile u32 nr_cpus = 32;	/* !0 for veristat, set during init */
@@ -766,7 +771,7 @@ pick_next_cgroup:
 		return;
 	}
 
-	bpf_repeat(BPF_MAX_LOOPS) {
+	bpf_repeat(CGROUP_MAX_RETRIES) {
 		if (try_pick_next_cgroup(&cpuc->cur_cgid))
 			break;
 	}


### PR DESCRIPTION
We may end up stalling for too long in fcg_dispatch() if try_pick_next_cgroup() doesn't find another valid cgroup to pick. This can be quite risky, considering that we are holding the rq lock in dispatch().

This condition can be reproduced easily in our CI, where we can trigger stalling softirq works:

[    4.972926] NOHZ tick-stop error: local softirq work is pending, handler #200!!!

Or rcu stalls:

[   47.731900] rcu: INFO: rcu_preempt detected stalls on CPUs/tasks:
[   47.731900] rcu:     1-...!: (0 ticks this GP) idle=b29c/1/0x4000000000000000 softirq=2204/2204 fqs=0
[   47.731900] rcu:     3-...!: (0 ticks this GP) idle=db74/1/0x4000000000000000 softirq=2286/2286 fqs=0
[   47.731900] rcu:     (detected by 0, t=26002 jiffies, g=6029, q=54 ncpus=4)
[   47.731900] Sending NMI from CPU 0 to CPUs 1:

To mitigate this issue reduce the amount of try_pick_next_cgroup() retries from BPF_MAX_LOOPS (8M) to CGROUP_MAX_RETRIES (1024).