### PR TITLE
scx_rustland: time slice boost

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rustland/src/bpf/main.bpf.c
@@ -461,7 +461,7 @@ static void dispatch_user_scheduler(s32 cpu)
 		scx_bpf_error("Failed to find usersched task %d", usersched_pid);
 		return;
 	}
-	dispatch_task(p, cpu, SCX_ENQ_PREEMPT);
+	dispatch_task(p, cpu, 0);
 	__sync_fetch_and_add(&nr_kernel_dispatches, 1);
 	bpf_task_release(p);
 }


### PR DESCRIPTION
This PR includes the "time slice boost"  option (that should be called "time slice penalty", but boost sounds more cool :wink:), that is the extra patch that I've used for live demo video (https://www.youtube.com/watch?v=oCfVbz9jvVQ), cleaned up a little bit.

I was a bit skeptical to send this one, because it can make the scheduler more unpredictable / unstable if used improperly, but at the end the worst case scenario would be a 5s stall, before the sched-ext watchdog kicks out the scheduler and the benefit can be that people may actually want to test and play around with this. 

Moreover, without using `-b NUM`, no boosting is applied, so the default behavior remains unchanged.

In addition to that there's also a small patch to dispatch the user-space scheduler without SCX_ENQ_PREEMPT, that is not really needed anymore at this point.