### PR TITLE
scx_rustland: voluntary context switch boost

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf.rs
+++ b/scheds/rust/scx_rustland/src/bpf.rs
@@ -127,8 +127,9 @@ const SCHED_EXT: i32 = 7;
 pub struct QueuedTask {
     pub pid: i32,              // pid that uniquely identifies a task
     pub cpu: i32,              // CPU where the task is running (-1 = exiting)
-    pub sum_exec_runtime: u64, // Total cpu time */
-    pub weight: u64,           // Task static priority */
+    pub sum_exec_runtime: u64, // Total cpu time
+    pub nvcsw: u64,            // Voluntary context switches
+    pub weight: u64,           // Task static priority
 }
 
 // Task queued for dispatching to the BPF component (see bpf_intf::dispatched_task_ctx).
@@ -159,6 +160,7 @@ impl EnqueuedMessage {
             pid: self.inner.pid,
             cpu: self.inner.cpu,
             sum_exec_runtime: self.inner.sum_exec_runtime,
+            nvcsw: self.inner.nvcsw,
             weight: self.inner.weight,
         }
     }

--- a/scheds/rust/scx_rustland/src/bpf/intf.h
+++ b/scheds/rust/scx_rustland/src/bpf/intf.h
@@ -35,6 +35,7 @@ struct queued_task_ctx {
 	s32 pid;
 	s32 cpu; /* CPU where the task is running (-1 = exiting) */
 	u64 sum_exec_runtime; /* Total cpu time */
+	u64 nvcsw; /* Voluntary context switches */
 	u64 weight; /* Task static priority */
 };
 

--- a/scheds/rust/scx_rustland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rustland/src/bpf/main.bpf.c
@@ -386,6 +386,7 @@ static void get_task_info(struct queued_task_ctx *task,
 		return;
 	}
 	task->sum_exec_runtime = p->se.sum_exec_runtime;
+	task->nvcsw = p->nvcsw;
 	task->weight = p->scx.weight;
 	task->cpu = scx_bpf_task_cpu(p);
 }

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -61,6 +61,21 @@ const SCHEDULER_NAME: &'static str = "RustLand";
 /// scheduling policies should be able to simply modify the Rust component, without having to deal
 /// with any internal kernel / BPF details.
 ///
+/// === Troubleshooting ===
+///
+/// - Disable HyperThreading / SMT if you notice poor performance: this scheduler lacks support for
+///   any type of core scheduling and lacks NUMA awareness, assuming uniform performance and
+///   migration costs across all CPUs.
+///
+/// - Adjust the time slice boost parameter (option `-b`) to enhance the responsiveness of
+///   low-latency applications (i.e., online gaming, live streaming, video conferencing etc.).
+///
+/// - Reduce the time slice boost parameter (option `-b`) if you notice poor performance in your
+///   CPU-intensive applications or if you experience any stall during your typical workload.
+///
+/// - Reduce the time slice (option `-s`) if you experience audio issues (i.e., cracking audio or
+///   audio packet loss).
+///
 #[derive(Debug, Parser)]
 struct Opts {
     /// Scheduling slice duration in microseconds.


### PR DESCRIPTION
A significant improvement in scheduler responsiveness for low-latency application: in short, the idea is to take into account the amount of voluntary context switches to identify interactive tasks vs CPU-intensive background tasks, and use this criteria to reduce the accounted time slice of interactive tasks (implicitly boosting their priority).

This simple heuristic is much better than the previous approach that was de-prioritizing newly created tasks, as it allows to classify CPU-intensive workloads that are not spawning too many tasks vs the actual interactive low-latency applications. And it also allows avoids to de-prioritize interactive applications that need to fork short-lived tasks, e.g., interactive shell sessions, that receive a big responsiveness improvement with this change.

In conclusion:
 - I can now play Terraria at 60 fps even with a `stress-ng -c 32` running in background
 - I can run shell commands faster while the kernel is building in background `make -j 32` (faster than the default linux scheduler)
 - For my typical personal workload (reading emails, browsing internet, using git, vim, and running shell commands while I recompile kernels in the background) this scheduler now seems to perform nearly as well as the default Linux scheduler, and in some cases even better!