### PR TITLE
scx_userland: use a custom memory allocator to prevent page faults

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf/alloc.rs
+++ b/scheds/rust/scx_rustland/src/bpf/alloc.rs
@@ -1,0 +1,134 @@
+// Copyright (c) Andrea Righi <andrea.righi@canonical.com>
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use std::alloc::{GlobalAlloc, Layout};
+use std::cell::UnsafeCell;
+use std::sync::{Mutex, MutexGuard};
+
+/// scx_rustland: memory allocator.
+///
+/// RustLandAllocator is a very simple block-based memory allocator that relies on a pre-allocated
+/// buffer and an array to manage the status of allocated and free blocks.
+///
+/// The purpose of this allocator is to prevent the user-space scheduler from triggering page
+/// faults, which could lead to potential deadlocks under heavy system load conditions.
+///
+/// Despite its simplicity, this allocator exhibits reasonable speed and efficiency in meeting
+/// memory requests from the user-space scheduler, particularly when dealing with small, uniformly
+/// sized allocations.
+
+// Pre-allocate an area of 64MB, with a block size of 64 bytes, that should be reasonable enough to
+// handle small uniform allocations performed by the user-space scheduler without introducing too
+// much fragmentation and overhead.
+const ARENA_SIZE: usize = 64 * 1024 * 1024;
+const BLOCK_SIZE: usize = 64;
+const NUM_BLOCKS: usize = ARENA_SIZE / BLOCK_SIZE;
+
+#[repr(C, align(4096))]
+struct RustLandMemory {
+    // Pre-allocated buffer.
+    arena: UnsafeCell<[u8; ARENA_SIZE]>,
+    // Allocation map.
+    //
+    // Each slot represents the status of a memory block (true = allocated, false = free).
+    allocation_map: Mutex<[bool; NUM_BLOCKS]>,
+}
+
+unsafe impl Sync for RustLandMemory {}
+
+// Memory pool for the allocator.
+static MEMORY: RustLandMemory = RustLandMemory {
+    arena: UnsafeCell::new([0; ARENA_SIZE]),
+    allocation_map: Mutex::new([false; NUM_BLOCKS]),
+};
+
+// Main allocator class.
+pub struct RustLandAllocator;
+
+impl RustLandAllocator {
+    pub fn lock_memory(&self) {
+        unsafe {
+            // Call setrlimit to set the locked-in-memory limit to unlimited.
+            let new_rlimit = libc::rlimit {
+                rlim_cur: libc::RLIM_INFINITY,
+                rlim_max: libc::RLIM_INFINITY,
+            };
+            let res = libc::setrlimit(libc::RLIMIT_MEMLOCK, &new_rlimit);
+            if res != 0 {
+                panic!("setrlimit failed with error code: {}", res);
+            }
+
+            // Lock all memory to prevent being paged out.
+            let res = libc::mlockall(libc::MCL_CURRENT | libc::MCL_FUTURE);
+            if res != 0 {
+                panic!("mlockall failed with error code: {}", res);
+            }
+        };
+    }
+}
+
+// Override global allocator methods.
+unsafe impl GlobalAlloc for RustLandAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let align = layout.align();
+        if align > BLOCK_SIZE {
+            panic!("unsupported alignment: {}", align);
+        }
+        let size = layout.size();
+
+        // Find the first sequence of free blocks that can accommodate the requested size.
+        let mut map_guard: MutexGuard<[bool; NUM_BLOCKS]> = MEMORY.allocation_map.lock().unwrap();
+        let mut contiguous_blocks = 0;
+        let mut start_block = None;
+
+        for (index, &is_allocated) in map_guard.iter().enumerate() {
+            if is_allocated {
+                // Reset consecutive blocks count if an allocated block is encountered.
+                contiguous_blocks = 0;
+            } else {
+                contiguous_blocks += 1;
+                if contiguous_blocks * BLOCK_SIZE >= size {
+                    // Found a sequence of free blocks that can accommodate the size.
+                    start_block = Some(index + 1 - contiguous_blocks);
+                    break;
+                }
+            }
+        }
+
+        match start_block {
+            Some(start) => {
+                // Mark the corresponding blocks as allocated.
+                for i in start..start + contiguous_blocks {
+                    map_guard[i] = true;
+                }
+                // Return a pointer to the aligned allocated block.
+                MEMORY.arena.get().cast::<u8>().add(start * BLOCK_SIZE)
+            }
+            None => {
+                // No contiguous block sequence found, just panic.
+                //
+                // NOTE: we want to panic here so that we can better detect when we run out of
+                // memory, instead of returning a null_ptr that could potentially hide the real
+                // problem.
+                panic!("Out of memory");
+            }
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        let size = layout.size();
+
+        // Calculate the block index from the released pointer.
+        let offset = ptr as usize - MEMORY.arena.get() as usize;
+        let start_block = offset / BLOCK_SIZE;
+        let end_block = (offset + size - 1) / BLOCK_SIZE + 1;
+
+        // Update the allocation map for all blocks in the released range.
+        let mut map_guard: MutexGuard<[bool; NUM_BLOCKS]> = MEMORY.allocation_map.lock().unwrap();
+        for index in start_block..end_block {
+            map_guard[index] = false;
+        }
+    }
+}


### PR DESCRIPTION
To prevent potential deadlock conditions under heavy loads, any scheduler that delegates scheduling decisions to user-space should avoid triggering page faults.

To address this issue, replace the default Rust allocator with a custom one (RustLandAllocator), designed to operate on a pre-allocated buffer.

This, coupled with the memory locking (via mlockall), prevents page faults from happening during the execution of the user-space scheduler, avoiding the deadlock condition.

This memory allocator is completely transparent to the user-space scheduler code and it is applied automatically when the bpf module is imported.

In the future we may decide to move this allocator to a more generic place (scx_utils crate), so that also other user-space Rust schedulers can use it.

This initial implementation of the RustLandAllocator is very simple: a basic block-based allocator that uses an array to track the status of each memory block (allocated or free).

This allocator can be improved in the future, but right now, despite its simplicity, it shows a reasonable speed and efficiency in meeting memory requests from the user-space scheduler, having to deal mostly with small and uniformly sized allocations.

With this change in place scx_rustland survived more than 10hrs on a heavily stressed system (with stress-ng and kernel builds running in a loop):

 $ ps -o pid,rss,etime,cmd -p `pidof scx_rustland`
     PID   RSS     ELAPSED CMD
   34966 75840    10:00:44 ./build/scheds/rust/scx_rustland/debug/scx_rustland

Without this change it is possible to trigger the sched-ext watchdog timeout in less than 5min, under the same system load conditions.