### PR TITLE
scx_nest: Set timer callback after cancelling

### DIFF
--- a/scheds/c/scx_nest.c
+++ b/scheds/c/scx_nest.c
@@ -28,7 +28,6 @@ const char help_fmt[] =
 "  -m R_MAX      Maximum number of cores in the reserve nest (default 5)\n"
 "  -i ITERS      Number of successive placement failures tolerated before trying to aggressively expand primary nest (default 2), or 0 to disable\n"
 "  -s SLICE_US   Override slice duration in us (default 20000us / 20ms)\n"
-"  -D R_SCHED    Override the number of times that a core may be scheduled for compaction before having compaction happen immediately (default 5)\n"
 "  -I            First try to find a fully idle core, and then any idle core, when searching nests. Default behavior is to ignore hypertwins and check for any idle core.\n"
 "  -h            Display this help and exit\n";
 
@@ -165,13 +164,10 @@ int main(int argc, char **argv)
 	skel->rodata->nr_cpus = libbpf_num_possible_cpus();
 	skel->rodata->sampling_cadence_ns = SAMPLING_CADENCE_S * 1000 * 1000 * 1000;
 
-	while ((opt = getopt(argc, argv, "hId:D:m:i:s:")) != -1) {
+	while ((opt = getopt(argc, argv, "hId:m:i:s:")) != -1) {
 		switch (opt) {
 		case 'd':
 			skel->rodata->p_remove_ns = strtoull(optarg, NULL, 0) * 1000;
-			break;
-		case 'D':
-			skel->rodata->r_depth = strtoull(optarg, NULL, 0);
 			break;
 		case 'm':
 			skel->rodata->r_max = strtoull(optarg, NULL, 0);


### PR DESCRIPTION
scx_nest: Set timer callback after cancelling

In scx_nest, we use a per-cpu BPF timer to schedule compaction for a
primary core before it goes idle. If a task comes along that could use
that core, we cancel the callback with bpf_timer_cancel().
bpf_timer_cancel() drops a refcnt on the prog and nullifies the
callback, so if we want to schedule the callback again, we must use
bpf_timer_set_callback() to reset the prog. This patch does that.

Reported-by: Julia Lawall <julia.lawall@inria.fr>
Signed-off-by: David Vernet <void@manifault.com>