### PR TITLE
scx-rustland: SMT improvements

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rustland/src/bpf/main.bpf.c
@@ -572,14 +572,8 @@ void BPF_STRUCT_OPS(rustland_update_idle, s32 cpu, bool idle)
 	 * A CPU is now available, notify the user-space scheduler that tasks
 	 * can be dispatched.
 	 */
-	if (is_usersched_needed()) {
-		/*
-		 * Kick the CPU to make it immediately ready to accept
-		 * dispatched tasks.
-		 */
-		scx_bpf_kick_cpu(cpu, 0);
+	if (is_usersched_needed())
 		set_usersched_needed();
-	}
 }
 
 /*


### PR DESCRIPTION
This PR contains an improvement in the SMT logic, it's actually a simplification and, performance-wise, it seem to deliver better results, so it's a win-win IMHO.

As mentioned in the git commit:
```
    Some preliminary results on an AMD Ryzen 7 5800X 8-Cores (SMT enabled):
    running my usual benchmark of measuring the fps of a videogame
    (Counter-Strike 2) during a parallel kernel build-induced system
    overload, shows an improvement of approximately 2x (from 8-10fps to
    15-25fps vs 1-2fps with EEVDF).
```

The other commit is more like a clean-up, apparently now we can drop the `scx_bpf_kick_cpu()` from `update_idle()` without any noticeable performance drop, so let's just get rid of it.