### PR TITLE
ci: test the shedulers with the latest sched-ext kernel

### DIFF
--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -10,17 +10,13 @@ jobs:
       # Hard turn-off interactive mode
       - run: echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
 
-      # Add sched-ext external ppa to get the latest sched-ext kernel
-      - run: sudo add-apt-repository -n -y ppa:arighi/sched-ext-unstable
-      - run: sudo sed -i s/jammy/noble/ /etc/apt/sources.list.d/arighi-ubuntu-sched-ext-unstable-jammy.list
-
       # Refresh packages list
       - run: sudo apt update
 
       ### DOWNLOAD AND INSTALL DEPENDENCIES ###
 
       # Download dependencies packaged by Ubuntu
-      - run: sudo apt -y install coreutils cmake cargo elfutils libelf-dev libunwind-dev libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic ninja-build python3-pip python3-requests qemu-kvm udev iproute2 busybox-static libvirt-clients kbd kmod file rsync zstd
+      - run: sudo apt -y install bison busybox-static cargo cmake coreutils cpio elfutils file flex gcc git iproute2 kbd kmod libcap-dev libelf-dev libunwind-dev libvirt-clients libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic make ninja-build pahole python3-dev python3-pip python3-requests qemu-kvm rsync rustc udev zstd
 
       # clang 17
       # Use a custom llvm.sh script which includes the -y flag for
@@ -51,16 +47,23 @@ jobs:
       # Install virtme-ng
       - run: pip install virtme-ng
 
-      # Download a sched-ext enabled kernel
-      - run: apt download linux-image-unsigned-6.7.0-4-generic linux-modules-6.7.0-4-generic
-      - run: mkdir -p kernel
-      - run: for f in *.deb; do dpkg -x $f kernel; done
+      # Get the latest sched-ext enabled kernel directly from the git
+      # repository (try the sched_ext-ci branch first, if it doesn't exist use
+      # sched_ext)
+      - run: git clone --single-branch -b sched_ext-ci --depth 1 https://github.com/sched-ext/sched_ext.git linux || git clone --single-branch -b sched_ext --depth 1 https://github.com/sched-ext/sched_ext.git linux
+
+      # Build a minimal kernel (with sched-ext enabled) using virtme-ng
+      - run: cd linux && vng -v --build --config .github/workflows/sched-ext.config
 
       ### END DEPENDENCIES ###
 
       # The actual build:
-      - run: meson setup build -Dlibbpf_a=`pwd`/libbpf/src/libbpf.a -Dkernel=$(pwd)/$(ls -c1 kernel/boot/vmlinuz* | tail -1)
+      - run: meson setup build -Dlibbpf_a=`pwd`/libbpf/src/libbpf.a -Dkernel=$(pwd)/linux
       - run: meson compile -C build
+
+      # Print CPU model before running the tests (this can be useful for
+      # debugging purposes)
+      - run: grep 'model name' /proc/cpuinfo | head -1
 
       # Test schedulers
       - run: meson compile -C build test_sched


### PR DESCRIPTION
Instead of downloading a precompiled sched-ext enabled kernel from the Ubuntu ppa, fetch the latest kernel directly from the sched-ext git repository and recompile it on-the-fly using virtme-ng.

This allows to get rid of the Ubuntu ppa dependency, take out from the equation potential Ubuntu-specific patches, and ensures testing all the schedulers with the most up-to-date sched-ext kernel (that should also help to detect potential kernel-related issues in advance).

The downside is that the CI runs will take a bit longer now, because we are recompiling the kernel from scratch. However, the kernel built with virtme-ng is relatively quick to compile and includes all the sched-ext features required for testing.

It's worth noting that this method aligns with the current sched-ext kernel CI, where we test only the in-kernel schedulers (as intended).

This change allows to extend the test coverage, using the same kernel to test also the schedulers included in this repository.