### PR TITLE
Set the correct value for sched-ext journald namespace

### DIFF
--- a/services/journald@sched-ext.conf
+++ b/services/journald@sched-ext.conf
@@ -1,7 +1,9 @@
 [Journal]
 # Sets the maximum journal size to 10M for each namespace.
-NamespaceMaxUse=10M
+SystemMaxUse=10M
 # Sets the maximum log age to 7 days.
 MaxRetentionSec=7day
 # Sets the priority level for messages to be stored to info.
 MaxLevelStore=info
+# Sets the maximum number of log files that can be stored for each namespace.
+SystemMaxFiles=5


### PR DESCRIPTION
This pull request fixes an erroneous entry fixing the size of the sched-ext log in journald namespace.

However the logs were saved correctly in a separate space, so the mistake in the name of the directive made it impossible to limit its size. 