### PR TITLE
systemd-services: replace ConditionPathExists with ConditionPathIsDirectory

### DIFF
--- a/services/scx_central.service
+++ b/services/scx_central.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start scx_central
-ConditionPathExists=/sys/kernel/debug/sched/ext
+ConditionPathIsDirectory=/sys/kernel/sched_ext
 
 [Service]
 Type=simple

--- a/services/scx_flatcg.service
+++ b/services/scx_flatcg.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start scx_flatcg
-ConditionPathExists=/sys/kernel/debug/sched/ext
+ConditionPathIsDirectory=/sys/kernel/sched_ext
 
 [Service]
 Type=simple

--- a/services/scx_nest.service
+++ b/services/scx_nest.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start scx_nest
-ConditionPathExists=/sys/kernel/debug/sched/ext
+ConditionPathIsDirectory=/sys/kernel/sched_ext
 
 [Service]
 Type=simple

--- a/services/scx_pair.service
+++ b/services/scx_pair.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start scx_pair
-ConditionPathExists=/sys/kernel/debug/sched/ext
+ConditionPathIsDirectory=/sys/kernel/sched_ext
 
 [Service]
 Type=simple

--- a/services/scx_qmap.service
+++ b/services/scx_qmap.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start scx_qmap
-ConditionPathExists=/sys/kernel/debug/sched/ext
+ConditionPathIsDirectory=/sys/kernel/sched_ext
 
 [Service]
 Type=simple

--- a/services/scx_rustland.service
+++ b/services/scx_rustland.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start scx_rustland
-ConditionPathExists=/sys/kernel/debug/sched/ext
+ConditionPathIsDirectory=/sys/kernel/sched_ext
 
 [Service]
 Type=simple

--- a/services/scx_rusty.service
+++ b/services/scx_rusty.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start scx_rusty
-ConditionPathExists=/sys/kernel/debug/sched/ext
+ConditionPathIsDirectory=/sys/kernel/sched_ext
 
 [Service]
 Type=simple

--- a/services/scx_simple.service
+++ b/services/scx_simple.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start scx_simple
-ConditionPathExists=/sys/kernel/debug/sched/ext
+ConditionPathIsDirectory=/sys/kernel/sched_ext
 
 [Service]
 Type=simple

--- a/services/scx_userland.service
+++ b/services/scx_userland.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start scx_userland
-ConditionPathExists=/sys/kernel/debug/sched/ext
+ConditionPathIsDirectory=/sys/kernel/sched_ext
 
 [Service]
 Type=simple


### PR DESCRIPTION
Commit https://github.com/sched-ext/sched_ext/pull/122 has caused systemd services to no longer be able to run because the startup conditions cannot be met. A simple change to ConditionPathIsDirectory and pointing to the correct path gets everything working properly again. 

Source: https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html

```
ConditionPathIsDirectory=
ConditionPathIsDirectory= is similar to ConditionPathExists= but verifies that a certain path exists and is a directory.

Added in version 244.
```