### PR TITLE
Bump versions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('sched_ext schedulers', 'c',
-        version: '0.1.5',
+        version: '0.1.6',
         license: 'GPL-2.0')
 
 if meson.version().version_compare('<1.2')

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_utils"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_layered"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Tejun Heo <htejun@meta.com>", "Meta"]
 edition = "2021"
 description = "A highly configurable multi-layer BPF / user space hybrid scheduler used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
@@ -17,13 +17,13 @@ libbpf-rs = "0.22"
 libc = "0.2"
 log = "0.4"
 prometheus-client = "0.22.0"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.5" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.6" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.5" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.6" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Andrea Righi <andrea.righi@canonical.com>", "Canonical"]
 edition = "2021"
 description = "A BPF component (dispatcher) that implements the low level sched-ext functionalities and a user-space counterpart (scheduler), written in Rust, that implements the actual scheduling policy. This is used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
@@ -17,11 +17,11 @@ libbpf-rs = "0.22.0"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.5" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.6" }
 simplelog = "0.12.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.5" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.6" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rusty"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Dan Schatzberg <dschatzberg@meta.com>", "Meta"]
 edition = "2021"
 description = "A multi-domain, BPF / user space hybrid scheduler used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
@@ -17,11 +17,11 @@ libbpf-rs = "0.22.0"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.5" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.6" }
 simplelog = "0.12.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.5" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.6" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION
scx_exit_info change doesn't require code to be updated but breaks binary compatbility. Bump versions and cut a new release.