### PR TITLE
scx_rustland: per-CPU DSQs + global shared DSQ

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf.rs
+++ b/scheds/rust/scx_rustland/src/bpf.rs
@@ -24,6 +24,12 @@ use scx_utils::uei_report;
 // Defined in UAPI
 const SCHED_EXT: i32 = 7;
 
+// Do not assign any specific CPU to the task.
+//
+// The task will be dispatched to the global shared DSQ and it will run on the first CPU available.
+#[allow(dead_code)]
+pub const NO_CPU: i32 = -1;
+
 /// scx_rustland: provide high-level abstractions to interact with the BPF component.
 ///
 /// Overview

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -462,9 +462,9 @@ impl<'a> Scheduler<'a> {
         let nr_scheduled = self.task_pool.tasks.len() as u64;
         let slice_us_max = self.slice_ns / MSEC_PER_SEC;
 
-        // Scale time slice as a function of nr_scheduled, but never scale below 1 ms.
-        let scaling = (nr_scheduled / 2).max(1);
-        let slice_us = (slice_us_max / scaling).max(USEC_PER_NSEC);
+        // Scale time slice as a function of nr_scheduled, but never scale below 250 us.
+        let scaling = ((nr_scheduled + 1) / 2).max(1);
+        let slice_us = (slice_us_max / scaling).max(USEC_PER_NSEC / 4);
 
         // Apply new scaling.
         self.bpf.set_effective_slice_us(slice_us);

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -475,23 +475,16 @@ impl<'a> Scheduler<'a> {
         // This allows to have more tasks sitting in the task pool, reducing the pressure on the
         // dispatcher queues and giving a chance to higher priority tasks to come in and get
         // dispatched earlier, mitigating potential priority inversion issues.
-        let mut idle_cpus = self.get_idle_cpus();
-        while !idle_cpus.is_empty() {
+        let idle_cpus = self.get_idle_cpus();
+        for _ in &idle_cpus {
             match self.task_pool.pop() {
                 Some(mut task) => {
                     // Update global minimum vruntime.
                     self.min_vruntime = task.vruntime;
 
-                    // Pick an ideal idle CPU for the task.
-                    if let Some(pos) = idle_cpus.iter().position(|&x| x == task.cpu) {
-                        // The CPU assigned to the task is in idle_cpus, keep the assignment and
-                        // remove the CPU from idle_cpus.
-                        idle_cpus.remove(pos);
-                    } else {
-                        // The CPU assigned to the task is not in idle_cpus, remove the first idle
-                        // CPU and dispatch the task to the shared DSQ.
-                        task.cpu = idle_cpus.pop().unwrap();
-                    }
+                    // Do not pin the task to any specific CPU, simply dispatch on the first idle
+                    // CPU available.
+                    task.cpu = NO_CPU;
 
                     // Send task to the BPF dispatcher.
                     match self.bpf.dispatch_task(&task.to_dispatched_task()) {


### PR DESCRIPTION
Opening this PR mostly as an open discussion.

**Main topic**
Designing a universal BPF layer that allows to implement totally generic schedulers in user-space.

**Specific goal addressed by this PR**
The BPF part should provide an interface that allows the user-space scheduler to select a specific CPU to dispatch a task and it should also allow to not specify any CPU at all (in this case the task can be dispatched in any CPU, like the first one that becomes available).

**Implementation**
The idea is to adapt @Decave's suggestion of introducing per-CPU DSQs, the user-space scheduler sends to the BPF dispatcher a PID with an optional target CPU; the BPF part dispatches the task to the DSQ associated to the target CPU, if specified, otherwise the task is dispatched to a global shared DSQ. Per-CPU DSQs are consumed from the `dispatch()` callback of their corresponding CPU. Shared DSQ is consumed from the `dispatch()` callback of any CPU.

In this way we can provide a totally generic interface that any user-space scheduler can use to implement any type of CPU selection logic.

**Problem**
A task is dispatched to a specific per-CPU DSQ, the `dispatch()` callback is never called on that CPU => starvation.

I haven't been able to find a nice way to enforce the call of the `dispatch()` event on a specific CPU, so that tasks queued there can be consumed. I was assuming that `scx_bpf_kick_cpu()` could be used for this, but it doesn't seem to be the case.

Apparently all this logic works (no starvation) if the target CPU of a task is always the same as the one determined in the `select_cpu` callback. Basically the user-space scheduler can only "acknowledge" `select_cpu`. What I would like to do, instead, is give the ability to the user-space scheduler to potentially override the choice made in `select_cpu`.

So, at the moment, as a workaround, when the user-space scheduler tries to dispatch a task on a CPU that is different than the one selected in `select_cpu`, I simply redirect the task to the shared DSQ (that is consumed from all the CPUs) => no starvation. But I would definitely prefer if we could honor the decision made by the user-space scheduler.

Does all of this make sense? Any suggestion? Thanks!