### PR TITLE
Make meson.build more readable

### DIFF
--- a/services/meson.build
+++ b/services/meson.build
@@ -1,22 +1,11 @@
+# Get the directory for systemd system unit files
 systemd_system_unit_dir = systemd.get_variable(pkgconfig : 'systemdsystemunitdir')
 
-  install_data(
-    [
-      'scx.service',
-    ],
-    install_dir: systemd_system_unit_dir
-  )
+# Install the 'scx.service' file to the systemd system unit directory
+install_data('scx.service', install_dir: systemd_system_unit_dir)
 
-  install_data(
-    [
-      'journald@sched-ext.conf',
-    ],
-    install_dir: '/etc/systemd'
-  )
+# Install the 'journald@sched-ext.conf' file to the '/etc/systemd' directory
+install_data('journald@sched-ext.conf', install_dir: '/etc/systemd')
 
-  install_data(
-    [
-      'scx',
-    ],
-    install_dir: '/etc/default'
-  )
+# Install the 'scx' file to the '/etc/default' directory
+install_data('scx', install_dir: '/etc/default')


### PR DESCRIPTION
I’ve removed the unnecessary array declarations for single files and also I’ve added comments to each line to explain what it does. This can be helpful for others (or even yourself in the future) to understand what each line of code is doing.