### PR TITLE
[scx_layered] downgrade prometheus-client

### DIFF
--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_layered"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Tejun Heo <htejun@meta.com>", "Meta"]
 edition = "2021"
 description = "A highly configurable multi-layer BPF / user space hybrid scheduler used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
@@ -16,7 +16,7 @@ lazy_static = "1.4"
 libbpf-rs = "0.22"
 libc = "0.2"
 log = "0.4"
-prometheus-client = "0.22.0"
+prometheus-client = "0.19"
 scx_utils = { path = "../../../rust/scx_utils", version = "0.6" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
This library at version 22 is not available in fedora: https://src.fedoraproject.org/rpms/rust-prometheus-client

Rather than bothering the maintainer, let's just downgrade here.

I tested locally. The output still looks sane:
```
[root@fedora debug]# sudo ./scx_layered file:example.json -o
12:33:51 [INFO] CPUs: online/possible=1/1 nr_cores=1
12:33:51 [INFO] Layered Scheduler Attached
# HELP total Total scheduling events in the period.
# TYPE total gauge
total 250
# HELP local % that got scheduled directly into an idle CPU.
# TYPE local gauge
local 0.0
# HELP open_idle % of open layer tasks scheduled into occupied idle CPUs.
# TYPE open_idle gauge
open_idle 0.0
# HELP affn_viol % which violated configured policies due to CPU affinity restrictions.
# TYPE affn_viol gauge
affn_viol 0.0
# HELP tctx_err Failures to free task contexts.
# TYPE tctx_err gauge
tctx_err 0
# HELP proc_ms CPU time this binary has consumed during the period.
# TYPE proc_ms gauge
proc_ms 5
# HELP busy CPU busy % (100% means all CPUs were fully occupied).
# TYPE busy gauge
busy 0.0
# HELP util CPU utilization % (100% means one CPU was fully occupied).
# TYPE util gauge
util 0.5660943994986982
# HELP load Sum of weight * duty_cycle for all tasks.
# TYPE load gauge
load 0.3895238176528804
# HELP l_util CPU utilization of the layer (100% means one CPU was fully occupied).
# TYPE l_util gauge
l_util{layer_name="batch"} 0.187327642437604
l_util{layer_name="immediate"} 0.0
l_util{layer_name="normal"} 0.37876675706109427
# HELP l_util_frac Fraction of total CPU utilization consumed by the layer.
# TYPE l_util_frac gauge
l_util_frac{layer_name="immediate"} 0.0
l_util_frac{layer_name="normal"} 66.90876246020258
l_util_frac{layer_name="batch"} 33.09123753979742
# HELP l_load Sum of weight * duty_cycle for tasks in the layer.
# TYPE l_load gauge
l_load{layer_name="immediate"} 0.0
l_load{layer_name="batch"} 0.00009382883879342116
l_load{layer_name="normal"} 0.38942998881408699
# HELP l_load_frac Fraction of total load consumed by the layer.
# TYPE l_load_frac gauge
l_load_frac{layer_name="immediate"} 0.0
l_load_frac{layer_name="batch"} 0.02408808769609966
l_load_frac{layer_name="normal"} 99.9759119123039
# HELP l_tasks Number of tasks in the layer.
# TYPE l_tasks gauge
l_tasks{layer_name="normal"} 16
l_tasks{layer_name="batch"} 4
l_tasks{layer_name="immediate"} 0
# HELP l_total Number of scheduling events in the layer.
# TYPE l_total gauge
l_total{layer_name="batch"} 95
l_total{layer_name="immediate"} 0
l_total{layer_name="normal"} 155
# HELP l_local % of scheduling events directly into an idle CPU.
# TYPE l_local gauge
l_local{layer_name="normal"} 0.0
l_local{layer_name="batch"} 0.0
l_local{layer_name="immediate"} 0.0
```