### PR TITLE
Add user_exit_info support to scx_utils and convert the rust scheds accordingly

### DIFF
--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -21,5 +21,6 @@ tar = "0.4"
 version-compare = "0.1"
 
 [build-dependencies]
+bindgen = ">=0.68, <0.70"
 tar = "0.4"
 walkdir = "2.4"

--- a/rust/scx_utils/bindings.h
+++ b/rust/scx_utils/bindings.h
@@ -1,0 +1,1 @@
+#include "bpf_h/vmlinux/vmlinux.h"

--- a/rust/scx_utils/build.rs
+++ b/rust/scx_utils/build.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 const BPF_H: &str = "bpf_h";
 
-fn main() {
+fn gen_bpf_h() {
     let file =
         File::create(PathBuf::from(env::var("OUT_DIR").unwrap()).join(format!("{}.tar", BPF_H)))
             .unwrap();
@@ -25,4 +25,29 @@ fn main() {
             println!("cargo:rerun-if-changed={}", ent.path().to_string_lossy());
         }
     }
+}
+
+fn gen_bindings() {
+    // FIXME - bindgen's API changed between 0.68 and 0.69 so that
+    // `bindgen::CargoCallbacks::new()` should be used instead of
+    // `bindgen::CargoCallbacks`. Unfortunately, as of Dec 2023, fedora is
+    // shipping 0.68. To accommodate fedora, allow both 0.68 and 0.69 of
+    // bindgen and suppress deprecation warning. Remove the following once
+    // fedora can be updated to bindgen >= 0.69.
+    #[allow(deprecated)]
+    let bindings = bindgen::Builder::default()
+        .header("bindings.h")
+	.allowlist_type("scx_exit_kind")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .generate()
+        .expect("Unable to generate bindings");
+
+    bindings
+        .write_to_file(PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs"))
+        .expect("Couldn't write bindings");
+}
+
+fn main() {
+    gen_bpf_h();
+    gen_bindings();
 }

--- a/rust/scx_utils/src/bindings.rs
+++ b/rust/scx_utils/src/bindings.rs
@@ -1,0 +1,6 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -30,7 +30,13 @@
 //! Utility modules which can be useful for userspace component of sched_ext
 //! schedulers.
 
+mod bindings;
+
 mod bpf_builder;
 pub use bpf_builder::BpfBuilder;
 
 pub mod ravg;
+
+mod user_exit_info;
+pub use user_exit_info::UserExitInfo;
+pub use user_exit_info::ScxExitKind;

--- a/rust/scx_utils/src/user_exit_info.rs
+++ b/rust/scx_utils/src/user_exit_info.rs
@@ -1,0 +1,140 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+use crate::bindings;
+use anyhow::bail;
+use anyhow::Result;
+use std::ffi::CStr;
+
+pub enum ScxExitKind {
+    None = bindings::scx_exit_kind_SCX_EXIT_NONE as isize,
+    Done = bindings::scx_exit_kind_SCX_EXIT_DONE as isize,
+    Unreg = bindings::scx_exit_kind_SCX_EXIT_UNREG as isize,
+    SysRq = bindings::scx_exit_kind_SCX_EXIT_SYSRQ as isize,
+    Error = bindings::scx_exit_kind_SCX_EXIT_ERROR as isize,
+    ErrorBPF = bindings::scx_exit_kind_SCX_EXIT_ERROR_BPF as isize,
+    ErrorStall = bindings::scx_exit_kind_SCX_EXIT_ERROR_STALL as isize,
+}
+
+/// Takes a reference to C struct user_exit_info and reads it into
+/// UserExitInfo. See UserExitInfo.
+#[macro_export]
+macro_rules! uei_read {
+    ($bpf_uei:expr) => {{
+        {
+            let bpf_uei = $bpf_uei;
+            scx_utils::UserExitInfo::new(
+                &bpf_uei.kind as *const _,
+                bpf_uei.reason.as_ptr() as *const _,
+                bpf_uei.msg.as_ptr() as *const _,
+                bpf_uei.dump.as_ptr() as *const _,
+            )
+        }
+    }};
+}
+
+/// Takes a reference to C struct user_exit_info and test whether the BPF
+/// scheduler has exited. See UserExitInfo.
+#[macro_export]
+macro_rules! uei_exited {
+    ($bpf_uei:expr) => {{
+        (unsafe { std::ptr::read_volatile(&$bpf_uei.kind as *const _) } != 0)
+    }};
+}
+
+/// Takes a reference to C struct user_exit_info, reads it and invokes
+/// UserExitInfo::report() on it. See UserExitInfo.
+#[macro_export]
+macro_rules! uei_report {
+    ($bpf_uei:expr) => {{
+        scx_utils::uei_read!($bpf_uei).report()
+    }};
+}
+
+/// Rust counterpart of C struct user_exit_info.
+#[derive(Debug, Default)]
+pub struct UserExitInfo {
+    /// The C enum scx_exit_kind value. Test against ScxExitKind. None-zero
+    /// value indicates that the BPF scheduler has exited.
+    kind: i32,
+    reason: Option<String>,
+    msg: Option<String>,
+    dump: Option<String>,
+}
+
+impl UserExitInfo {
+    /// Create UserExitInfo from C struct user_exit_info. Each scheduler
+    /// implementation creates its own Rust binding for the C struct
+    /// user_exit_info, so we can't take the type directly. Instead, this
+    /// method takes each member field. Use the macro uei_read!() on the C
+    /// type which then calls this method with the individual fields.
+    pub fn new(
+        kind_ptr: *const i32,
+        reason_ptr: *const i8,
+        msg_ptr: *const i8,
+        dump_ptr: *const i8,
+    ) -> Self {
+        let kind = unsafe { std::ptr::read_volatile(kind_ptr) };
+
+        let (reason, msg, dump) = (
+            Some(
+                unsafe { CStr::from_ptr(reason_ptr) }
+                    .to_str()
+                    .expect("Failed to convert reason to string")
+                    .to_string(),
+            )
+            .filter(|s| !s.is_empty()),
+            Some(
+                unsafe { CStr::from_ptr(msg_ptr) }
+                    .to_str()
+                    .expect("Failed to convert msg to string")
+                    .to_string(),
+            )
+            .filter(|s| !s.is_empty()),
+            Some(
+                unsafe { CStr::from_ptr(dump_ptr) }
+                    .to_str()
+                    .expect("Failed to convert msg to string")
+                    .to_string(),
+            )
+            .filter(|s| !s.is_empty()),
+        );
+
+        Self {
+            kind,
+            reason,
+            msg,
+            dump,
+        }
+    }
+
+    /// Print out the exit message to stderr if the exit was normal. After
+    /// an error exit, it throws an error containing the exit message
+    /// instead. If debug dump exists, it's always printed to stderr.
+    pub fn report(&self) -> Result<()> {
+        if self.kind == 0 {
+            return Ok(());
+        }
+
+	if let Some(dump) = &self.dump {
+	    eprintln!("\nDEBUG DUMP");
+	    eprintln!("================================================================================\n");
+	    eprintln!("{}", dump);
+	    eprintln!("================================================================================\n");
+	}
+
+        let why = match (&self.reason, &self.msg) {
+            (Some(reason), None) => format!("EXIT: {}", reason),
+            (Some(reason), Some(msg)) => format!("EXIT: {} ({})", reason, msg),
+            _ => "<UNKNOWN>".into(),
+        };
+
+        if self.kind <= ScxExitKind::Unreg as i32 {
+            eprintln!("{}", why);
+            Ok(())
+        } else {
+            bail!("{}", why)
+        }
+    }
+}

--- a/scheds/include/scx/user_exit_info.h
+++ b/scheds/include/scx/user_exit_info.h
@@ -10,11 +10,17 @@
 #ifndef __USER_EXIT_INFO_H
 #define __USER_EXIT_INFO_H
 
+enum uei_sizes {
+	UEI_REASON_SIZE	= 128,
+	UEI_MSG_SIZE	= 1024,
+	UEI_DUMP_SIZE	= 32768,
+};
+
 struct user_exit_info {
 	int		kind;
-	char		reason[128];
-	char		msg[1024];
-	char		dump[32768];
+	char		reason[UEI_REASON_SIZE];
+	char		msg[UEI_MSG_SIZE];
+	char		dump[UEI_DUMP_SIZE];
 };
 
 #ifdef __bpf__
@@ -33,6 +39,9 @@ static inline void uei_record(struct user_exit_info *uei,
 }
 
 #else	/* !__bpf__ */
+
+#include <stdio.h>
+#include <stdbool.h>
 
 static inline bool uei_exited(struct user_exit_info *uei)
 {

--- a/scheds/rust/scx_rustland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rustland/src/bpf/main.bpf.c
@@ -37,6 +37,8 @@
 
 char _license[] SEC("license") = "GPL";
 
+struct user_exit_info uei;
+
 /*
  * Maximum amount of CPUs supported by this scheduler (this defines the size of
  * cpu_map that is used to store the idle state and CPU ownership).
@@ -45,12 +47,6 @@ char _license[] SEC("license") = "GPL";
 
 /* !0 for veristat, set during init */
 const volatile s32 num_possible_cpus = 8;
-
-/*
- * Exit info (passed to the user-space counterpart).
- */
-int exit_kind = SCX_EXIT_NONE;
-char exit_msg[SCX_EXIT_MSG_LEN];
 
 /*
  * Scheduler attributes and statistics.
@@ -644,8 +640,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rustland_init)
  */
 void BPF_STRUCT_OPS(rustland_exit, struct scx_exit_info *ei)
 {
-	bpf_probe_read_kernel_str(exit_msg, sizeof(exit_msg), ei->msg);
-	exit_kind = ei->kind;
+	uei_record(&uei, ei);
 }
 
 /*

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -48,6 +48,8 @@
 
 char _license[] SEC("license") = "GPL";
 
+struct user_exit_info uei;
+
 /*
  * const volatiles are set during initialization and treated as consts by the
  * jit compiler.
@@ -70,12 +72,6 @@ const volatile u32 debug;
 
 /* base slice duration */
 const volatile u64 slice_ns = SCX_SLICE_DFL;
-
-/*
- * Exit info
- */
-int exit_kind = SCX_EXIT_NONE;
-char exit_msg[SCX_EXIT_MSG_LEN];
 
 /*
  * Per-CPU context
@@ -1141,8 +1137,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rusty_init)
 
 void BPF_STRUCT_OPS(rusty_exit, struct scx_exit_info *ei)
 {
-	bpf_probe_read_kernel_str(exit_msg, sizeof(exit_msg), ei->msg);
-	exit_kind = ei->kind;
+	uei_record(&uei, ei);
 }
 
 SEC(".struct_ops.link")


### PR DESCRIPTION
This unifies exit handling across rust scheds and also adds debug dump printing to them.