### PR TITLE
ci: Only do CI runs for pull requests

### DIFF
--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -1,6 +1,6 @@
 name: build-scheds
 run-name: ${{ github.actor }} PR run
-on: [pull_request, push]
+on: [pull_request]
 jobs:
   build-schedulers:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
We're basically always runnin two CI jobs: one for a remote push, and another for when a PR is opened. These are essentially measuring the same thing, so let's save CI bandwidth and just do a PR run. This will hopefully make things a bit less noisy as well.