### PR TITLE
ci: detect errors only from stderr

### DIFF
--- a/meson-scripts/test_sched
+++ b/meson-scripts/test_sched
@@ -41,7 +41,7 @@ for sched in ${SCHEDULERS}; do
     timeout --preserve-status ${GUEST_TIMEOUT} \
         vng --force-9p --disable-microvm -v -r ${kernel} -- \
             "timeout --foreground --preserve-status ${TEST_TIMEOUT} ${sched_path}" \
-	        2>&1 </dev/null | tee /tmp/output
+                2> >(tee /tmp/output) </dev/null
         sed -n -e '/\bBUG:/q1' \
 	       -e '/\bWARNING:/q1' \
 	       -e '/\berror\b/Iq1' \


### PR DESCRIPTION
Search for potential errors only in the kernel logs and the scheduler stderr.

In this way we can use "error keywords" in the scheduler's output without triggering false positives in the CI (see for example #127).

NOTE: this works, because virtme-ng, when executed in verbose mode, sends the kernel messages to stderr (together with the command's stderr) and it channels the command's stdout to the stdout of the host.