### PR TITLE
scx_rustland: fix cpumask stall and prevent stuttery behavior

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf.rs
+++ b/scheds/rust/scx_rustland/src/bpf.rs
@@ -300,6 +300,12 @@ impl<'a> BpfScheduler<'a> {
         &mut self.skel.bss_mut().nr_kernel_dispatches
     }
 
+    // Counter of cancel dispatch events.
+    #[allow(dead_code)]
+    pub fn nr_cancel_dispatches_mut(&mut self) -> &mut u64 {
+        &mut self.skel.bss_mut().nr_cancel_dispatches
+    }
+
     // Counter of failed dispatch events.
     #[allow(dead_code)]
     pub fn nr_failed_dispatches_mut(&mut self) -> &mut u64 {

--- a/scheds/rust/scx_rustland/src/bpf.rs
+++ b/scheds/rust/scx_rustland/src/bpf.rs
@@ -366,13 +366,13 @@ impl<'a> BpfScheduler<'a> {
 
     // Read exit code from the BPF part.
     pub fn exited(&mut self) -> bool {
-	uei_exited!(&self.skel.bss().uei)
+        uei_exited!(&self.skel.bss().uei)
     }
 
     // Called on exit to shutdown and report exit message from the BPF part.
     pub fn shutdown_and_report(&mut self) -> Result<()> {
-	self.struct_ops.take();
-	uei_report!(self.skel.bss().uei)
+        self.struct_ops.take();
+        uei_report!(self.skel.bss().uei)
     }
 }
 

--- a/scheds/rust/scx_rustland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rustland/src/bpf/main.bpf.c
@@ -571,8 +571,15 @@ void BPF_STRUCT_OPS(rustland_stopping, struct task_struct *p, bool runnable)
 	/*
 	 * Mark the CPU as idle by setting the owner to 0.
 	 */
-	if (!is_usersched_task(p))
+	if (!is_usersched_task(p)) {
 		set_cpu_owner(scx_bpf_task_cpu(p), 0);
+		/*
+		 * Kick the user-space scheduler immediately when a task
+		 * releases a CPU and speculate on the fact that most of the
+		 * time there is another task ready to run.
+		 */
+		set_usersched_needed();
+	}
 }
 
 /*

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -497,9 +497,11 @@ impl<'a> Scheduler<'a> {
                     // Update global minimum vruntime.
                     self.min_vruntime = task.vruntime;
 
-                    // Do not pin the task to any specific CPU, simply dispatch on the first idle
-                    // CPU available.
-                    task.cpu = NO_CPU;
+                    // If the CPU assigned to the task is not idle anymore, dispatch to the first
+                    // CPU that becomes available.
+                    if !idle_cpus.contains(&task.cpu) {
+                        task.cpu = NO_CPU;
+                    }
 
                     // Send task to the BPF dispatcher.
                     match self.bpf.dispatch_task(&task.to_dispatched_task()) {

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -632,9 +632,10 @@ impl<'a> Scheduler<'a> {
         // Show general statistics.
         let nr_user_dispatches = *self.bpf.nr_user_dispatches_mut();
         let nr_kernel_dispatches = *self.bpf.nr_kernel_dispatches_mut();
+        let nr_cancel_dispatches = *self.bpf.nr_cancel_dispatches_mut();
         info!(
-            "  nr_user_dispatches={} nr_kernel_dispatches={}",
-            nr_user_dispatches, nr_kernel_dispatches
+            "  nr_user_dispatches={} nr_kernel_dispatches={} nr_cancel_dispatches={}",
+            nr_user_dispatches, nr_kernel_dispatches, nr_cancel_dispatches
         );
 
         // Show tasks that are waiting to be dispatched.

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -694,8 +694,10 @@ impl<'a> Scheduler<'a> {
                 prev_ts = curr_ts;
             }
         }
+        // Dump scheduler statistics before exiting
+        self.print_stats();
 
-	self.bpf.shutdown_and_report()
+        self.bpf.shutdown_and_report()
     }
 }
 


### PR DESCRIPTION
A set of improvements/fixes for rustland.

In particular:

`scx_rustland: use scx_bpf_dispatch_cancel()`

This uses the new `scx_bpf_dispatch_cancel()` API that prevents the cpumask-related stall conditions. I still can't completely ignore the task when the cpumask is not valid anymore, because there are cases where a task is never dispatched to any DSQ. But I can use the cancel operation to redirect the task to the CPU assigned during select_cpu or to the shared DSQ (if the prev cpu is also not available) in a reliable way. With this logic applied I haven't been able to stall the scheduler using `stress-ng --race-sched`, so in any case it is definitely an improved and a reasonable fix IMHO.

And this also allows to enable the following:

`scx_rustland: keep default CPU selection when idle`

This uses a more reasonable CPU assignment logic in the user-space scheduler, that redirects to tasks to the shared DSQ only when the CPU assigned by the BPF part is not idle anymore.

I've also included a fix that prevents stuttery behaviors (I can systematically reproduce this problem playing Team Fortress 2):

`scx_rustland: kick user-space scheduler when a CPU is released`

The idea is to kick the user-space scheduler immediately in the `.stopping()` callback and speculate on the fact that most of the time there's always another task ready to run. This prevents evident lag issues with Team Fortress 2 and also sporadic lags with Counter-Strike 2. The extra overhead added due to potential unnecessary wake-up events seems to be negligible compared to the benefits.

Last but not least, a small change that can be really useful for debugging:

`scx_rustland: dump scheduler statistics before exiting`