### PR TITLE
scx_rustland: per-task cpumask generation counter

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf/intf.h
+++ b/scheds/rust/scx_rustland/src/bpf/intf.h
@@ -34,6 +34,7 @@ typedef long long s64;
 struct queued_task_ctx {
 	s32 pid;
 	s32 cpu; /* CPU where the task is running (-1 = exiting) */
+	u64 cpumask_cnt; /* cpumask generation counter */
 	u64 sum_exec_runtime; /* Total cpu time */
 	u64 nvcsw; /* Voluntary context switches */
 	u64 weight; /* Task static priority */
@@ -52,6 +53,7 @@ struct queued_task_ctx {
 struct dispatched_task_ctx {
 	s32 pid;
 	s32 cpu; /* CPU where the task should be dispatched */
+	u64 cpumask_cnt; /* cpumask generation counter */
 	u64 payload; /* Task payload */
 };
 


### PR DESCRIPTION
Introduce a per-task generation counter to check the validity of the cpumask at dispatch time.

The logic is the following:

 - the cpumask generation number is incremented every time a task calls .set_cpumask()

 - when a task is enqueued the current generation number is stored in the queued_task_ctx and relayed to the user-space scheduler

 - the user-space scheduler can decide to dispatch the task on the CPU determined by the BPF layer in .select_cpu(), redirect the task to any other specific CPU, or redirect to the first CPU available (using NO_CPU)

 - task is then dispatched back to the BPF code along with its cpumask generation counter

 - at dispatch time the BPF code checks if the generation number is the same and it discards the dispatch attempt if the cpumask is not valid anymore (the task will be automatically re-enqueued by the sched-ext core code, potentially selecting another CPU / cpumask)

 - if the cpumask is valid, but the CPU selected by the user-space scheduler is invalid (according to the cpumask), the task will be transparently bounced by the BPF code to the shared DSQ (in this way the user-space code can be completely abstracted and dispatches that target invalid CPUs can be automatically fixed by the BPF layer)

This solution can prevent stalls due to dispatches targeting invalid CPUs and it can also avoid redundant dispatch events, making the code more efficient and the cpumask interlocking more reliable.