### PR TITLE
scx_rustland: performance improvements

### DIFF
--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -15,6 +15,7 @@ fb_procfs = "0.7.0"
 hex = "0.4.3"
 libbpf-rs = "0.22.0"
 libc = "0.2.137"
+buddy-alloc = "0.5.1"
 log = "0.4.17"
 ordered-float = "3.4.0"
 scx_utils = { path = "../../../rust/scx_utils", version = "0.6" }

--- a/scheds/rust/scx_rustland/src/bpf.rs
+++ b/scheds/rust/scx_rustland/src/bpf.rs
@@ -130,18 +130,6 @@ pub const NO_CPU: i32 = -1;
 /// }
 ///
 
-// Override default memory allocator.
-//
-// To prevent potential deadlock conditions under heavy loads, any scheduler that delegates
-// scheduling decisions to user-space should avoid triggering page faults.
-//
-// To address this issue, replace the global allocator with a custom one (RustLandAllocator),
-// designed to operate on a pre-allocated buffer. This, coupled with the memory locking achieved
-// through mlockall(), prevents page faults from occurring during the execution of the user-space
-// scheduler.
-#[global_allocator]
-static ALLOCATOR: RustLandAllocator = RustLandAllocator;
-
 // Task queued for scheduling from the BPF component (see bpf_intf::queued_task_ctx).
 #[derive(Debug)]
 pub struct QueuedTask {


### PR DESCRIPTION
Reduce custom memory allocator overhead by switching to buddy-alloc and use a HashMap to speed up search by PID in tasks BTreeSet.