### PR TITLE
Bump to 0.1.7

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('sched_ext schedulers', 'c',
-        version: '0.1.6',
+        version: '0.1.7',
         license: 'GPL-2.0')
 
 if meson.version().version_compare('<1.2')


### PR DESCRIPTION
There is an old version in the meson.build file: https://github.com/sched-ext/scx/blob/main/meson.build#L2  