### PR TITLE
scx_rustland: additional comand line options 

### DIFF
--- a/scheds/rust/scx_rustland/src/bpf.rs
+++ b/scheds/rust/scx_rustland/src/bpf.rs
@@ -223,7 +223,13 @@ struct AlignedBuffer([u8; BUFSIZE]);
 static mut BUF: AlignedBuffer = AlignedBuffer([0; BUFSIZE]);
 
 impl<'cb> BpfScheduler<'cb> {
-    pub fn init(slice_us: u64, nr_cpus_online: i32, partial: bool, debug: bool) -> Result<Self> {
+    pub fn init(
+        slice_us: u64,
+        nr_cpus_online: i32,
+        partial: bool,
+        full_user: bool,
+        debug: bool,
+    ) -> Result<Self> {
         // Open the BPF prog first for verification.
         let skel_builder = BpfSkelBuilder::default();
         let mut skel = skel_builder.open().context("Failed to open BPF program")?;
@@ -263,6 +269,7 @@ impl<'cb> BpfScheduler<'cb> {
         skel.rodata_mut().slice_ns = slice_us * 1000;
         skel.rodata_mut().switch_partial = partial;
         skel.rodata_mut().debug = debug;
+        skel.rodata_mut().full_user = full_user;
 
         // Attach BPF scheduler.
         let mut skel = skel.load().context("Failed to load BPF program")?;

--- a/scheds/rust/scx_rustland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rustland/src/bpf/main.bpf.c
@@ -97,6 +97,14 @@ volatile u64 nr_failed_dispatches, nr_sched_congested;
  /* Report additional debugging information */
 const volatile bool debug;
 
+ /*
+  * Enable/disable full user-space mode.
+  *
+  * In full user-space mode all events and actions will be sent to user-space,
+  * basically disabling any optimization to bypass the user-space scheduler.
+  */
+const volatile bool full_user;
+
 /* Allow to use bpf_printk() only when @debug is set */
 #define dbg_msg(_fmt, ...) do {						\
 	if (debug)							\
@@ -437,7 +445,7 @@ s32 BPF_STRUCT_OPS(rustland_select_cpu, struct task_struct *p, s32 prev_cpu,
 	s32 cpu;
 
 	cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
-	if (is_idle) {
+	if (is_idle && !full_user) {
 		/*
 		 * Using SCX_DSQ_LOCAL ensures that the task will be executed
 		 * directly on the CPU returned by this function.

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -99,6 +99,14 @@ struct Opts {
     #[clap(short = 'b', long, default_value = "100")]
     slice_boost: u64,
 
+    /// If specified, all the scheduling events and actions will be processed in user-space,
+    /// disabling any form of in-kernel optimization.
+    ///
+    /// This mode will likely make the system less responsive, but more predictable in terms of
+    /// performance.
+    #[clap(short = 'u', long, action = clap::ArgAction::SetTrue)]
+    full_user: bool,
+
     /// If specified, only tasks which have their scheduling policy set to
     /// SCHED_EXT using sched_setscheduler(2) are switched. Otherwise, all
     /// tasks are switched.
@@ -261,6 +269,7 @@ impl<'a> Scheduler<'a> {
             opts.slice_us,
             cores.nr_cpus_online,
             opts.partial,
+            opts.full_user,
             opts.debug,
         )?;
         info!("{} scheduler attached", SCHEDULER_NAME);


### PR DESCRIPTION
Add two command line options to adjust rustland behavior without recompiling the code. These are the usual changes that I apply manually in the code to test the "generic layer" of the scheduler.

Having them available as command line options can help for testing and debugging, in particular for users that may need to evaluate how the scheduler works under specific scenarios.

New options:
 - `--full-user`: disable all the in-kernel optimizations and sends all the scheduling events and actions to the user-space scheduler
 - `--builtin-idle`: apply the built-in idle selection logic in the user-space scheduler (scheduler will dispatch tasks in the CPU selected in the `.select_cpu()` callback, using the built-in idle selection logic); also change the default behavior to dispatch tasks on the first CPU available (that helps to improve system responsiveness - e.g., gaming)