### PR TITLE
scx_layered: Add MATCH_NICE_EQUALS match kind

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -62,6 +62,7 @@ enum layer_match_kind {
 	MATCH_COMM_PREFIX,
 	MATCH_NICE_ABOVE,
 	MATCH_NICE_BELOW,
+	MATCH_NICE_EQUALS,
 
 	NR_LAYER_MATCH_KINDS,
 };
@@ -70,7 +71,7 @@ struct layer_match {
 	int		kind;
 	char		cgroup_prefix[MAX_PATH];
 	char		comm_prefix[MAX_COMM];
-	int		nice_above_or_below;
+	int		nice;
 };
 
 struct layer_match_ands {

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -114,6 +114,9 @@ lazy_static::lazy_static! {
 /// * NiceBelow: Matches if the task's nice value is smaller than the
 ///   pattern.
 ///
+/// * NiceEquals: Matches if the task's nice value is exactly equal to
+///   the pattern.
+///
 /// While there are complexity limitations as the matches are performed in
 /// BPF, it is straightforward to add more types of matches.
 ///
@@ -280,6 +283,7 @@ enum LayerMatch {
     CommPrefix(String),
     NiceAbove(i32),
     NiceBelow(i32),
+    NiceEquals(i32),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1170,11 +1174,15 @@ impl<'a> Scheduler<'a> {
                         }
                         LayerMatch::NiceAbove(nice) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_NICE_ABOVE as i32;
-                            mt.nice_above_or_below = *nice;
+                            mt.nice = *nice;
                         }
                         LayerMatch::NiceBelow(nice) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_NICE_BELOW as i32;
-                            mt.nice_above_or_below = *nice;
+                            mt.nice = *nice;
+                        }
+                        LayerMatch::NiceEquals(nice) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_NICE_EQUALS as i32;
+                            mt.nice = *nice;
                         }
                     }
                 }


### PR DESCRIPTION
I have a usecase where specific nice values are used to bucket tasks into groups that are handled separately by different `scx_layered` policies, with no implications of relative priority between niceness X, X + 1, X - 1, etc. In other words, nicevals are used as simple tags in this scenario.

If we wanted to treat a specific niceness this way e.g. `11`, we could do so with AND'd MATCH_NICE_{ABOVE,BELOW} like so:

```json
  "matches" : [
    [
      {
        "NiceAbove": 10
      },
      {
        "NiceBelow": 12
      },
    ],
  ],
```

But this is unnecessarily verbose and doesn't communicate the intent of the match very well. Adding a `NiceEquals` matcher simplifies the config and makes intent obvious:

```json
  "matches" : [
    [
      {
        "NiceEquals": 11
      },
    ],
  ],
```

This PR adds support for such a matcher.

Also, rename `layer_match.nice_above_or_below` to just `layer_match.nice`, as the former doesn't describe the newly-added matcher's use of the field. It's still obvious that `layer_match.nice` is relevant to MATCH_NICE_{ABOVE, BELOW, EQUALS}.