### PR TITLE
ci: eclude scx_qmap and scx_userland from testing

### DIFF
--- a/meson-scripts/test_sched
+++ b/meson-scripts/test_sched
@@ -16,7 +16,7 @@ GUEST_TIMEOUT=60
 #   - scx_layered: temporarily excluded because it
 #     cannot run with a default configuration
 #
-SCHEDULERS="scx_simple scx_central scx_flatcg scx_nest scx_pair scx_qmap scx_userland scx_rusty scx_rustland"
+SCHEDULERS="scx_simple scx_central scx_flatcg scx_nest scx_pair scx_rusty scx_rustland"
 
 if [ ! -x `which vng` ]; then
     echo "vng not found, please install virtme-ng to enable testing"


### PR DESCRIPTION
These two schedulers are provided mostly as examples / PoC, so we should exclude them from our periodic testing, to prevent triggering false positives in our CI.