### PR TITLE
build: limit the maximum amount of parallel cargo build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,6 +130,11 @@ endif
 cargo_env = environment()
 cargo_env.set('BPF_CLANG', bpf_clang.full_path())
 
+#
+# Limit the maximum amount of parallel builds for the Rust schedulers.
+#
+cargo_env.set('CARGO_BUILD_JOBS', '1')
+
 foreach flag: bpf_base_cflags
   cargo_env.append('BPF_BASE_CFLAGS', flag, separator: ' ')
 endforeach


### PR DESCRIPTION
Each cargo build is already parallelized, spreading multiple rustc across all the available CPUs by default.

Allowing to run multiple instances of cargo at the same time doesn't provide any benefit and it can only increase the risk of triggering OOM conditions or overloading the build system.

Therefore, limit the amount of parallel cargo build instances to 1.