### PR TITLE
Revert "Merge pull request #163 from jordalgo/libbpf-submodule"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libbpf"]
-	path = libbpf
-	url = https://github.com/libbpf/libbpf

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ repo](https://mesonbuild.com/Quick-guide.html#installation-from-source) and call
   standard utilities including `awk`.
 - `clang`: >=16 required, >=17 recommended
 - `libbpf`: >=1.2.2 required, >=1.3 recommended (`RESIZE_ARRAY` support is
-  new in 1.3). It's preferred to link statically against the source from the libbpf git submodule.
+  new in 1.3)
 - Rust toolchain: >=1.72
 - `libelf`, `libz`, `libzstd` if linking against staic `libbpf.a`
 - `bpftool` (usually available in `linux-tools-common`)
@@ -210,21 +210,9 @@ repo](https://mesonbuild.com/Quick-guide.html#installation-from-source) and call
 commands in the root of the tree builds and installs all schedulers under
 `~/bin`.
 
-#### Static linking against libbpf submodule (preferred)
-
- ```
+```
 $ cd $SCX
-$ git submodule init
-$ make -C libbpf/src
 $ meson setup build --prefix ~
-$ meson compile -C build
-$ meson install -C build
-```
-
-#### Dynamic linking against libbpf
-```
-$ cd $SCX
-$ meson setup build --prefix ~ -D libbpf_a=disabled
 $ meson compile -C build
 $ meson install -C build
 ```

--- a/meson.build
+++ b/meson.build
@@ -44,21 +44,9 @@ elif bpf_clang_maj < 17
           .format(bpf_clang.full_path(), bpf_clang_ver))
 endif
 
-libbpf_a = '@0@/libbpf/src/libbpf.a'.format(meson.current_source_dir())
-
-if get_option('libbpf_a') == 'disabled'
-  libbpf_a = ''
-elif get_option('libbpf_a') != ''
-  libbpf_a = get_option('libbpf_a')
-endif
-
-if libbpf_a != ''
-  if not fs.exists(libbpf_a)
-    error('@0@ does not exist. You need to build/make libbpf.'.format(libbpf_a))
-  endif
-
+if get_option('libbpf_a') != ''
   libbpf_dep = [declare_dependency(
-    link_args: libbpf_a,
+    link_args: get_option('libbpf_a'),
     include_directories: get_option('libbpf_h')),
     cc.find_library('elf'),
     cc.find_library('z'),
@@ -110,7 +98,7 @@ message('cpu=@0@ bpf_base_cflags=@1@'.format(cpu, bpf_base_cflags))
 
 libbpf_c_headers = []
 
-if libbpf_a != ''
+if get_option('libbpf_a') != ''
   foreach header: get_option('libbpf_h')
     libbpf_c_headers += ['-I', header]
   endforeach
@@ -151,14 +139,14 @@ foreach flag: bpf_base_cflags
   cargo_env.append('BPF_BASE_CFLAGS', flag, separator: ' ')
 endforeach
 
-if libbpf_a != ''
+if get_option('libbpf_a') != ''
   foreach header: get_option('libbpf_h')
     cargo_env.append('BPF_EXTRA_CFLAGS_PRE_INCL', '-I' + header, separator: ' ')
   endforeach
 
   cargo_env.append('RUSTFLAGS',
                    '-C link-args=-lelf -C link-args=-lz -C link-args=-lzstd -L '
-                   + fs.parent(libbpf_a))
+                   + fs.parent(get_option('libbpf_a')))
 
   #
   # XXX - scx_rusty's original Cargo.toml contained a dependency matching

--- a/meson.options
+++ b/meson.options
@@ -3,7 +3,7 @@ option('bpf_clang', type: 'string', value: 'clang',
 option('bpftool', type: 'string', value: 'bpftool',
        description: 'bpftool to use when generating .bpf.skel.h')
 option('libbpf_a', type: 'string',
-       description: 'Static libbpf.a to use. Default is to use the one inside the libbpf submodule. Set this option to "disabled" to link libbpf dynamically.')
+       description: 'Static libbpf.a to use')
 option('libbpf_h', type: 'array',
        description: 'libbpf header directories, only meaningful with libbpf_a option')
 option('cargo', type: 'string', value: 'cargo',


### PR DESCRIPTION
This reverts commit 5b9b953e3c185c2789e43239e853a49a067ec517, reversing changes made to a7b39f24e2fa17297cdbef9a95f60bc54c6ddada.

The current git submodule approach is a bit cumbersome and doesn't provide a unified build environment for both libbpf and scx scheds. Also, the build instruction doesn't seem to work. Let's revert it for now.