### PR TITLE
Revert "Merge pull request #165 from sched-ext/reduce-rust-build-load"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,11 +130,6 @@ endif
 cargo_env = environment()
 cargo_env.set('BPF_CLANG', bpf_clang.full_path())
 
-#
-# Limit the maximum amount of parallel builds for the Rust schedulers.
-#
-cargo_env.set('CARGO_BUILD_JOBS', '1')
-
 foreach flag: bpf_base_cflags
   cargo_env.append('BPF_BASE_CFLAGS', flag, separator: ' ')
 endforeach


### PR DESCRIPTION
This reverts commit a7b39f24e2fa17297cdbef9a95f60bc54c6ddada, reversing changes made to cf7404fb03afc9a4c839825fb6692f31fac08cde.

The PR doesn't do what the description says. It instead limits the number of rustc instances to 1 for each cargo build making rust builds extremely slow. Let's revert and try again.