### PR TITLE
Add libbpf as a submodule (take 2)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libbpf"]
+	path = libbpf
+	url = https://github.com/libbpf/libbpf

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ repo](https://mesonbuild.com/Quick-guide.html#installation-from-source) and call
   standard utilities including `awk`.
 - `clang`: >=16 required, >=17 recommended
 - `libbpf`: >=1.2.2 required, >=1.3 recommended (`RESIZE_ARRAY` support is
-  new in 1.3)
+  new in 1.3). It's preferred to link statically against the source from the libbpf git submodule.
 - Rust toolchain: >=1.72
 - `libelf`, `libz`, `libzstd` if linking against staic `libbpf.a`
 - `bpftool` (usually available in `linux-tools-common`)
@@ -210,9 +210,21 @@ repo](https://mesonbuild.com/Quick-guide.html#installation-from-source) and call
 commands in the root of the tree builds and installs all schedulers under
 `~/bin`.
 
-```
+#### Static linking against libbpf submodule (preferred)
+
+ ```
 $ cd $SCX
 $ meson setup build --prefix ~
+$ meson compile -C build
+$ meson install -C build
+```
+
+Note: `meson setup` will also fetch the libbpf submodule and `meson compile` will build it.
+
+#### Dynamic linking against libbpf
+```
+$ cd $SCX
+$ meson setup build --prefix ~ -D libbpf_a=disabled
 $ meson compile -C build
 $ meson install -C build
 ```
@@ -276,7 +288,7 @@ options can be used in such cases.
 
 - `bpf_clang`: `clang` to use when compiling `.bpf.c`
 - `bpftool`: `bpftool` to use when generating `.bpf.skel.h`
-- `libbpf_a`: Static `libbpf.a` to use
+- `libbpf_a`: Static `libbpf.a` to use. Set this to "disabled" to link libbpf dynamically
 - `libbpf_h`: `libbpf` header directories, only meaningful with `libbpf_a` option
 - `cargo`: `cargo` to use when building rust sub-projects
 - 'cargo_home': 'CARGO_HOME env to use when invoking cargo'

--- a/meson-scripts/build_libbpf
+++ b/meson-scripts/build_libbpf
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+out=$("$1" 'map(select(.["file"] | contains ("cc_cflags_probe.c"))) | first | .["command"]' < compile_commands.json)
+out=${out#\"}
+out=${out%\"}
+args=($out)
+
+cc=${args[0]}
+declare -a cflags=()
+
+for arg in ${args[@]:1}; do
+    case $arg in
+	-I*|-M*|-o|-c) ;;
+	-*) cflags+="$arg ";;
+    esac
+done
+
+make_out=$(env CC="$cc" CFLAGS="$cflags" "$2" -C "$3" -j"$4")
+exit $?

--- a/meson-scripts/cc_cflags_probe.c
+++ b/meson-scripts/cc_cflags_probe.c
@@ -1,0 +1,5 @@
+// This exists only to get the same compiler and flags meson uses.
+// See build_libbpf script for more info
+int main(void) {
+    return 0;
+}

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,8 @@ get_sys_incls = find_program(join_paths(meson.current_source_dir(),
                                         'meson-scripts/get_sys_incls'))
 test_sched  = find_program(join_paths(meson.current_source_dir(),
                                       'meson-scripts/test_sched'))
+build_libbpf = find_program(join_paths(meson.current_source_dir(),
+                                      'meson-scripts/build_libbpf'))
 if enable_rust
   cargo_fetch = find_program(join_paths(meson.current_source_dir(),
                                       'meson-scripts/cargo_fetch'))
@@ -44,9 +46,64 @@ elif bpf_clang_maj < 17
           .format(bpf_clang.full_path(), bpf_clang_ver))
 endif
 
-if get_option('libbpf_a') != ''
+libbpf_path = '@0@/libbpf/src'.format(meson.current_source_dir())
+libbpf_a = '@0@/libbpf.a'.format(libbpf_path)
+should_build_libbpf = true
+
+if get_option('libbpf_a') == 'disabled'
+  libbpf_a = ''
+  should_build_libbpf = false
+elif get_option('libbpf_a') != ''
+  libbpf_a = get_option('libbpf_a')
+  if not fs.exists(libbpf_a)
+    error('@0@ does not exist.'.format(libbpf_a))
+  endif
+  should_build_libbpf = false
+endif
+
+# WARNING! To build libbpf with the same compiler(CC) and CFLAGS
+# as the schedulers we need to do this hack whereby we create a dummy exe
+# then read the compiler and args from meson's compile_commands.json
+# and re-set them when we build libbpf with make
+if should_build_libbpf
+  jq = find_program('jq')
+  make = find_program('make')
+  nproc = find_program('nproc')
+
+  if not jq.found() or not make.found()
+    error('To build the libbpf library "make" and "jq" are required')
+  endif
+
+  message('Updating libbpf submodule')
+  run_command('git', 'submodule', 'update', '--init', '--recursive', check: true)
+  # make sure it's clean
+  run_command('git', 'submodule', 'foreach', '--recursive', 'git', 'clean', '-xfd', check: true)
+
+  # setup the build target
+  executable('cc_cflags_probe', 'meson-scripts/cc_cflags_probe.c', install: false)
+
+  make_jobs = 1
+  if nproc.found()
+    make_jobs = run_command(nproc, check: true).stdout().to_int()
+  endif
+
+  libbpf = custom_target('libbpf',
+              output: '@PLAINNAME@.__PHONY__',
+              input: 'meson-scripts/cc_cflags_probe.c',
+              command: [build_libbpf, jq, make, libbpf_path, '@0@'.format(make_jobs)],
+              build_by_default: true)
+else
+  # this is a noop when we're not building libbpf ourselves
+  libbpf = custom_target('libbpf',
+              output: '@PLAINNAME@.__PHONY__',
+              input: 'meson-scripts/cc_cflags_probe.c',
+              command: ['echo'],
+              build_by_default: true)
+endif
+
+if libbpf_a != ''
   libbpf_dep = [declare_dependency(
-    link_args: get_option('libbpf_a'),
+    link_args: libbpf_a,
     include_directories: get_option('libbpf_h')),
     cc.find_library('elf'),
     cc.find_library('z'),
@@ -98,7 +155,7 @@ message('cpu=@0@ bpf_base_cflags=@1@'.format(cpu, bpf_base_cflags))
 
 libbpf_c_headers = []
 
-if get_option('libbpf_a') != ''
+if libbpf_a != ''
   foreach header: get_option('libbpf_h')
     libbpf_c_headers += ['-I', header]
   endforeach
@@ -109,10 +166,12 @@ endif
 #
 gen_bpf_o = generator(bpf_clang,
                       output: '@BASENAME@.o',
+                      depends: [libbpf],
                       arguments: [bpf_base_cflags, '-target', 'bpf', libbpf_c_headers, '@EXTRA_ARGS@',
                                   '-c', '@INPUT@', '-o', '@OUTPUT@'])
 gen_bpf_skel = generator(bpftool_build_skel,
-                         output: ['@BASENAME@.skel.h', '@BASENAME@.subskel.h' ],
+                         output: ['@BASENAME@.skel.h','@BASENAME@.subskel.h' ],
+                         depends: [libbpf],
                          arguments: [bpftool.full_path(), '@INPUT@', '@OUTPUT0@', '@OUTPUT1@'])
 
 #
@@ -134,14 +193,14 @@ foreach flag: bpf_base_cflags
   cargo_env.append('BPF_BASE_CFLAGS', flag, separator: ' ')
 endforeach
 
-if get_option('libbpf_a') != ''
+if libbpf_a != ''
   foreach header: get_option('libbpf_h')
     cargo_env.append('BPF_EXTRA_CFLAGS_PRE_INCL', '-I' + header, separator: ' ')
   endforeach
 
   cargo_env.append('RUSTFLAGS',
                    '-C link-args=-lelf -C link-args=-lz -C link-args=-lzstd -L '
-                   + fs.parent(get_option('libbpf_a')))
+                   + fs.parent(libbpf_a))
 
   #
   # XXX - scx_rusty's original Cargo.toml contained a dependency matching

--- a/meson.options
+++ b/meson.options
@@ -3,7 +3,7 @@ option('bpf_clang', type: 'string', value: 'clang',
 option('bpftool', type: 'string', value: 'bpftool',
        description: 'bpftool to use when generating .bpf.skel.h')
 option('libbpf_a', type: 'string',
-       description: 'Static libbpf.a to use')
+       description: 'By default, libbpf is automatically downloaded and built during setup. To use an existing static library, point this to the libbpf.a file or set it to "disabled" to use dynamic linking')
 option('libbpf_h', type: 'array',
        description: 'libbpf header directories, only meaningful with libbpf_a option')
 option('cargo', type: 'string', value: 'cargo',

--- a/rust/scx_rustland_core/meson.build
+++ b/rust/scx_rustland_core/meson.build
@@ -4,4 +4,5 @@ custom_target('scx_rustland_core',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
+              depends: [libbpf],
               build_by_default: true)

--- a/rust/scx_utils/meson.build
+++ b/rust/scx_utils/meson.build
@@ -4,4 +4,5 @@ custom_target('scx_utils',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
+              depends: [libbpf],
               build_by_default: true)

--- a/scheds/rust/scx_layered/meson.build
+++ b/scheds/rust/scx_layered/meson.build
@@ -4,4 +4,5 @@ custom_target('scx_layered',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
+              depends: [libbpf],
               build_by_default: true)

--- a/scheds/rust/scx_rlfifo/meson.build
+++ b/scheds/rust/scx_rlfifo/meson.build
@@ -4,4 +4,5 @@ custom_target('scx_rlfifo',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
+              depends: [libbpf],
               build_by_default: true)

--- a/scheds/rust/scx_rustland/meson.build
+++ b/scheds/rust/scx_rustland/meson.build
@@ -4,4 +4,5 @@ custom_target('scx_rustland',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
+              depends: [libbpf],
               build_by_default: true)

--- a/scheds/rust/scx_rusty/meson.build
+++ b/scheds/rust/scx_rusty/meson.build
@@ -4,4 +4,5 @@ custom_target('scx_rusty',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
+              depends: [libbpf],
               build_by_default: true)


### PR DESCRIPTION
This is to potentinally reduce issues with folks
using different versions of libbpf at runtime.

This also:
- makes static linking of libbpf the default
- adds steps in `meson setup` to fetch libbpf and make it