### PR TITLE
scx_rustland_core: API improvements

### DIFF
--- a/rust/scx_rustland_core/README.md
+++ b/rust/scx_rustland_core/README.md
@@ -46,7 +46,7 @@ impl<'a> Scheduler<'a> {
                         pid: task.pid,
                         cpu: task.cpu,
                         cpumask_cnt: task.cpumask_cnt,
-                        payload: 0,
+                        slice_ns: 0,
                     });
                 }
             }

--- a/rust/scx_rustland_core/src/bpf.rs
+++ b/rust/scx_rustland_core/src/bpf.rs
@@ -70,7 +70,7 @@ pub struct DispatchedTask {
     pub pid: i32,         // pid that uniquely identifies a task
     pub cpu: i32,         // target CPU selected by the scheduler
     pub cpumask_cnt: u64, // cpumask generation counter
-    pub payload: u64,     // task payload (used for debugging)
+    pub slice_ns: u64,    // time slice assigned to the task (0 = default)
 }
 
 // Message received from the dispatcher (see bpf_intf::queued_task_ctx for details).
@@ -113,7 +113,7 @@ impl DispatchedMessage {
             pid: task.pid,
             cpu: task.cpu,
             cpumask_cnt: task.cpumask_cnt,
-            payload: task.payload,
+            slice_ns: task.slice_ns,
         };
         DispatchedMessage {
             inner: dispatched_task_struct,

--- a/rust/scx_rustland_core/src/bpf/intf.h
+++ b/rust/scx_rustland_core/src/bpf/intf.h
@@ -43,10 +43,6 @@ struct queued_task_ctx {
 /*
  * Task sent to the BPF dispatcher by the user-space scheduler.
  *
- * This structure has a payload that can be used by the user-space scheduler to
- * send debugging information to the BPF dispatcher (i.e., vruntime, etc.),
- * depending on the particular scheduler implementation.
- *
  * This struct can be easily extended to send more information to the
  * dispatcher (i.e., a target CPU, a variable time slice, etc.).
  */
@@ -54,7 +50,7 @@ struct dispatched_task_ctx {
 	s32 pid;
 	s32 cpu; /* CPU where the task should be dispatched */
 	u64 cpumask_cnt; /* cpumask generation counter */
-	u64 payload; /* Task payload */
+	u64 slice_ns; /* time slice assigned to the task (0=default) */
 };
 
 #endif /* __INTF_H */

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -45,12 +45,7 @@ impl<'a> Scheduler<'a> {
                     // task.cpu < 0 is used to to notify an exiting task, in this
                     // case we can simply ignore the task.
                     if task.cpu >= 0 {
-                        let _ = self.bpf.dispatch_task(&DispatchedTask {
-                            pid: task.pid,
-                            cpu: task.cpu,
-                            cpumask_cnt: task.cpumask_cnt,
-                            slice_ns: 0,
-                        });
+                        let _ = self.bpf.dispatch_task(&DispatchedTask::new(&task));
                     }
                     // Give the task a chance to run and prevent overflowing the dispatch queue.
                     std::thread::yield_now();

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -49,7 +49,7 @@ impl<'a> Scheduler<'a> {
                             pid: task.pid,
                             cpu: task.cpu,
                             cpumask_cnt: task.cpumask_cnt,
-                            payload: 0,
+                            slice_ns: 0,
                         });
                     }
                     // Give the task a chance to run and prevent overflowing the dispatch queue.

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -191,7 +191,7 @@ impl Task {
             pid: self.pid,
             cpu: self.cpu,
             cpumask_cnt: self.cpumask_cnt,
-            payload: self.vruntime,
+            slice_ns: 0 /* always use default time slice */,
         }
     }
 }


### PR DESCRIPTION
Improve `scx_rustland_core` API:
 - add a method to assign a specific CPU to a task: `DispatchedTask.set_cpu()`
 - add a method to assing a specific time slice to a task (overriding the default global time slice): `DispatchedTask.set_slice_ns()`
 - provide a constructor that allows to create a `DispatchedTask` from a `QueuedTask`
 - drop unused `payload` attribute (in the future we will provide a better API to attach a custom payload to a dispatched task, if needed)

This is all purely code refactoring, no functional change to `scx_rustland` or `scx_rlfifo`.