### PR TITLE
meson-scripts/build_libbpf: Accommodate meson setting CC to "ccache $COMPILER"

### DIFF
--- a/meson-scripts/build_libbpf
+++ b/meson-scripts/build_libbpf
@@ -7,10 +7,16 @@ out=${out#\"}
 out=${out%\"}
 args=($out)
 
-cc=${args[0]}
+idx=0
+cc=${args[idx]}
+if [ "$cc" = "ccache" ]; then
+    idx=$((idx+1))
+    cc="$cc ${args[idx]}"
+fi
+
 declare -a cflags=()
 
-for arg in ${args[@]:1}; do
+for arg in ${args[@]:(idx+1)}; do
     case $arg in
 	-I*|-M*|-o|-c) ;;
 	-*) cflags+="$arg ";;


### PR DESCRIPTION
Otherwise, we end up passing CC=ccache to libbpf's Makefile which triggers an error as ccache invoked on its own can't act as a stand-in for the compiler.