### PR TITLE
Always build libbpf as a PIE

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -80,7 +80,7 @@ if should_build_libbpf
   run_command('git', 'submodule', 'foreach', '--recursive', 'git', 'clean', '-xfd', check: true)
 
   # setup the build target
-  executable('cc_cflags_probe', 'meson-scripts/cc_cflags_probe.c', install: false)
+  executable('cc_cflags_probe', 'meson-scripts/cc_cflags_probe.c', install: false, pie: true)
 
   make_jobs = 1
   if nproc.found()
@@ -199,7 +199,7 @@ if libbpf_a != ''
   endforeach
 
   cargo_env.append('RUSTFLAGS',
-                   '-C link-args=-lelf -C link-args=-lz -C link-args=-lzstd -L '
+                   '-C relocation-model=pic -C link-args=-lelf -C link-args=-lz -C link-args=-lzstd -L '
                    + fs.parent(libbpf_a))
 
   #


### PR DESCRIPTION
This is to fix an error sometimes seen when compiling with gcc,
whereby the position independent sched ext rust libraries
don't play nicely with the libbpf library if it's not also built
as position independent.

This also explicitly sets the rustc relocation-mode to "pic",
which is the default (just so this doesn't accidentally change
out from under us).