### PR TITLE
scx_rustland_core: use new consume_raw() libbpf-rs API

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -15,7 +15,7 @@ include = [
 
 [dependencies]
 anyhow = "1.0"
-libbpf-rs = "0.22.0"
+libbpf-rs = { git = "https://github.com/libbpf/libbpf-rs.git#af3296c00d74fd50b311adc7f931563be137cd8b" }
 libc = "0.2.137"
 buddy-alloc = "0.5.1"
 scx_utils = { path = "../scx_utils", version = "0.6" }

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-2.0-only"
 [dependencies]
 anyhow = "1.0.65"
 ctrlc = { version = "3.1", features = ["termination"] }
-libbpf-rs = "0.22.0"
+libbpf-rs = { git = "https://github.com/libbpf/libbpf-rs.git#af3296c00d74fd50b311adc7f931563be137cd8b" }
 libc = "0.2.137"
 scx_utils = { path = "../../../rust/scx_utils", version = "0.6" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.1" }

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.65"
 clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7.0"
-libbpf-rs = "0.22.0"
+libbpf-rs = { git = "https://github.com/libbpf/libbpf-rs.git#af3296c00d74fd50b311adc7f931563be137cd8b" }
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"


### PR DESCRIPTION
Use the new consume_raw() API provided by libbpf-rs with https://github.com/libbpf/libbpf-rs/pull/680.

This allows to be more precise and efficient at processing tasks consumed from the BPF ring buffer.

NOTE: the new consume_raw() API is not available yet in any official release of the libbpf-rs crate, but cargo allows to pick versions directly from git. This slightly increases the build time of scx_rustland_core and the schedulers based on this crate (since we need to recompile libbpf-rs from source), but we can re-add a proper versioned dependency once the libbpf-rs is out.

TODO: this new API also offers the possibility to consume multiple items from the BPF ring buffer with a single call to consume_raw(). This could be investigated and implemented as a potential future enhancement.