### PR TITLE
scx_rustland: interactive tuning

### DIFF
--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -391,10 +391,13 @@ impl<'a> Scheduler<'a> {
         // NOTE: we should make this threshold a tunable, but for now let's assume that a moving
         // average of 10 voluntary context switch per second is enough to classify the task as
         // interactive.
+        //
+        // NOTE: some tasks may have a very high weight, that can potentially disrupt our slice
+        // boost optimizations, therefore always limit the task priority to a max of 1000.
         let weight = if task_info.avg_nvcsw >= 10 {
-            task.weight * self.slice_boost.max(1)
+            task.weight.min(1000) * self.slice_boost.max(1)
         } else {
-            task.weight
+            task.weight.min(1000)
         };
 
         // Scale the time slice by the task's priority (weight).

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -79,8 +79,8 @@ const SCHEDULER_NAME: &'static str = "RustLand";
 ///
 #[derive(Debug, Parser)]
 struct Opts {
-    /// Scheduling slice duration in microseconds.
-    #[clap(short = 's', long, default_value = "20000")]
+    /// Scheduling slice duration in microseconds (default is 5ms).
+    #[clap(short = 's', long, default_value = "5000")]
     slice_us: u64,
 
     /// Time slice boost: increasing this value enhances performance of interactive applications


### PR DESCRIPTION
A couple of adjustments that have been empirically proven to be highly effective in improving system responsiveness, particularly in the context of gaming and live conferencing / live streaming workloads.

Reducing the base time slice from 20ms to 5ms helps prevent potential audio cracking issues and sporadic lags under average load conditions. Additionally, setting a cap on the maximum task weight helps prevent similar issues when tasks with very high priority are running within the same SCHED_EXT scheduling class.