### PR TITLE
Revert "scx_rustland_core: use new consume_raw() libbpf-rs API"

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -15,7 +15,7 @@ include = [
 
 [dependencies]
 anyhow = "1.0"
-libbpf-rs = { git = "https://github.com/libbpf/libbpf-rs.git#af3296c00d74fd50b311adc7f931563be137cd8b" }
+libbpf-rs = "0.22.0"
 libc = "0.2.137"
 buddy-alloc = "0.5.1"
 scx_utils = { path = "../scx_utils", version = "0.6" }

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-2.0-only"
 [dependencies]
 anyhow = "1.0.65"
 ctrlc = { version = "3.1", features = ["termination"] }
-libbpf-rs = { git = "https://github.com/libbpf/libbpf-rs.git#af3296c00d74fd50b311adc7f931563be137cd8b" }
+libbpf-rs = "0.22.0"
 libc = "0.2.137"
 scx_utils = { path = "../../../rust/scx_utils", version = "0.6" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.1" }

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.65"
 clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7.0"
-libbpf-rs = { git = "https://github.com/libbpf/libbpf-rs.git#af3296c00d74fd50b311adc7f931563be137cd8b" }
+libbpf-rs = "0.22.0"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"


### PR DESCRIPTION
In order to use the new consume_raw() API we need to depend on a version of libbpf-rs that is not released yet.

Apparently adding such dependency may introduce a potential dependency conflict with libbpf-sys.

Therefore, revert this change and go back to the previous consume() API. One a new version of libbpf-rs will be out we can update all our dependencies to use the new libbpf-rs and re-apply this patch to scx_rustland_core.

Fixes: 7c8c5fd ("scx_rustland_core: use new consume_raw() libbpf-rs API")