### PR TITLE
scx_layered: Make config json assume default vaules for unspecified fields

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -302,20 +302,29 @@ enum LayerMatch {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 enum LayerKind {
     Confined {
-        cpus_range: Option<(usize, usize)>,
         util_range: (f64, f64),
+	#[serde(default)]
+        cpus_range: Option<(usize, usize)>,
+	#[serde(default)]
         min_exec_us: u64,
     },
     Grouped {
-        cpus_range: Option<(usize, usize)>,
         util_range: (f64, f64),
+	#[serde(default)]
+        cpus_range: Option<(usize, usize)>,
+	#[serde(default)]
         min_exec_us: u64,
+	#[serde(default)]
         preempt: bool,
+	#[serde(default)]
         exclusive: bool,
     },
     Open {
+	#[serde(default)]
         min_exec_us: u64,
+	#[serde(default)]
         preempt: bool,
+	#[serde(default)]
         exclusive: bool,
     },
 }


### PR DESCRIPTION
This makes writing configs and allows introducing new fields without breaking existing configs.