### PR TITLE
topology: support single CPU systems

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -275,8 +275,13 @@ fn cpus_online() -> Result<Cpumask> {
         let (min, max) = match sscanf!(group.trim(), "{usize}-{usize}") {
             Ok((x, y)) => (x, y),
             Err(_) => {
-                bail!("Failed to parse online cpus {}", group.trim());
-            }
+                match sscanf!(group.trim(), "{usize}") {
+                    Ok(x) => (x, x),
+                    Err(_) => {
+                        bail!("Failed to parse online cpus {}", group.trim());
+                    }
+                }
+            },
         };
         for i in min..max {
             mask.set_cpu(i)?;


### PR DESCRIPTION
We are failing to parse /sys/devices/system/cpu/online in systems with just one CPU, for example:

 $ vng -r --cpus 1 -- scx_rusty
 Error: Failed to parse online cpus 0

Correctly handle strings containing only a single CPU during parsing.

Fixes: c5a3b83b ("topology: Add new topology crate")