### PR TITLE
scx_rustland: mitigate sub-optimal performance with offline CPUs

### DIFF
--- a/rust/scx_rustland_core/src/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/src/bpf/main.bpf.c
@@ -441,7 +441,7 @@ s32 BPF_STRUCT_OPS(rustland_select_cpu, struct task_struct *p, s32 prev_cpu,
 	s32 cpu;
 
 	cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
-	if (is_idle && !full_user) {
+	if (is_idle && cpu < num_possible_cpus && !full_user) {
 		/*
 		 * Using SCX_DSQ_LOCAL ensures that the task will be executed
 		 * directly on the CPU returned by this function.


### PR DESCRIPTION
Most of the schedulers assume that the amount of possible CPUs in the system represents the actual number of CPUs available.

This is not always true: some CPUs may be offline or certain CPU models (AMD CPUs for example) may include unavailable CPUs in this number.

This can lead to sub-optimal performance or even errors in the scheduler (see for example [1][2]).

Ideally, we need to attack this issue in a more generic way, such as having a proper API provided by a C library, that can be used by all schedulers and the topology Rust module (scx_utils crate).

But for now, let's try to mitigate most of the common sub-optimal cases separately inside each scheduler.

For rustland we can apply some mitigations both in select_cpu() (for the BPF part) and in the user-space part:

 - the former is fixed in the sched-ext kernel by commit 94dc0c01b957 ("scx: Use cpu_online_mask when resetting idle masks"). However, adding an extra check `cpu < num_possible_cpus` in select_cpu(), allows to properly support AMD CPUs, even with kernels that don't have the cpu_online_mask fix yet (this doesn't always guarantee the validity of cpu, but it should be enough to mitigate the majority of the potential sub-optimal cases, without introducing any significant overhead)

 - the latter can be fixed relying on topology.span(), instead of topology.nr_cpus(), to count the amount of available CPUs in the system.

[1] https://github.com/sched-ext/sched_ext/issues/69
[2] https://github.com/sched-ext/scx/issues/147

Link: https://github.com/sched-ext/sched_ext/commit/94dc0c01b95709316fa590c862ca6ed221e2d6c4