### PR TITLE
Better parsing for clang version

### DIFF
--- a/meson-scripts/get_clang_ver
+++ b/meson-scripts/get_clang_ver
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-"$1" --version | sed -nr 's/^.*clang version ([\.0-9]*)( .*)?$/\1/p'
+"$1" --version | sed -nr 's/^.*clang version ([\.0-9]*)(git)?( .*)?$/\1/p'

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,10 @@ if enable_rust
 endif
 
 bpf_clang_ver = run_command(get_clang_ver, bpf_clang, check: true).stdout().strip()
+if bpf_clang_ver == ''
+  error('Unable to find clang version')
+endif
+
 bpf_clang_maj = bpf_clang_ver.split('.')[0].to_int()
 
 if bpf_clang_maj < 16


### PR DESCRIPTION
My development environment uses clang from git, and meson fails with the following error:

```
meson setup build --prefix ~
The Meson build system
Version: 1.4.0

<snip>


meson.build:44:44: ERROR: String '' cannot be converted to int
```

Fix this problem by expanding how `get_clang_ver`  parses of clang version