### PR TITLE
rusty: Account for disabled but offline CPUs

### DIFF
--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -44,6 +44,12 @@ use anyhow::Context;
 use anyhow::Result;
 use bitvec::prelude::*;
 use std::fmt;
+use std::ops::BitAnd;
+use std::ops::BitAndAssign;
+use std::ops::BitOr;
+use std::ops::BitOrAssign;
+use std::ops::BitXor;
+use std::ops::BitXorAssign;
 
 #[derive(Debug, Clone)]
 pub struct Cpumask {
@@ -183,25 +189,25 @@ impl Cpumask {
         self.nr_cpus
     }
 
-    /// Create a Cpumask that is the OR of the current Cpumask and another.
-    pub fn or(&self, other: &Cpumask) -> Result<Cpumask> {
-        let mut new = self.clone();
-        new.mask |= other.mask.clone();
-        Ok(new)
-    }
-
     /// Create a Cpumask that is the AND of the current Cpumask and another.
-    pub fn and(&self, other: &Cpumask) -> Result<Cpumask> {
+    pub fn and(&self, other: &Cpumask) -> Cpumask {
         let mut new = self.clone();
         new.mask &= other.mask.clone();
-        Ok(new)
+        new
+    }
+
+    /// Create a Cpumask that is the OR of the current Cpumask and another.
+    pub fn or(&self, other: &Cpumask) -> Cpumask {
+        let mut new = self.clone();
+        new.mask |= other.mask.clone();
+        new
     }
 
     /// Create a Cpumask that is the XOR of the current Cpumask and another.
-    pub fn xor(&self, other: &Cpumask) -> Result<Cpumask> {
+    pub fn xor(&self, other: &Cpumask) -> Cpumask {
         let mut new = self.clone();
         new.mask ^= other.mask.clone();
-        Ok(new)
+        new
     }
 }
 
@@ -215,6 +221,45 @@ impl fmt::Display for Cpumask {
             write!(f, "{:0width$b}", submask, width = remaining_width.min(64))?;
         }
         Ok(())
+    }
+}
+
+impl BitAnd for Cpumask {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self {
+        self.and(&rhs)
+    }
+}
+
+impl BitAndAssign for Cpumask {
+    fn bitand_assign(&mut self, rhs: Cpumask) {
+        self.mask &= &rhs.mask;
+    }
+}
+
+impl BitOr for Cpumask {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        self.or(&rhs)
+    }
+}
+
+impl BitOrAssign for Cpumask {
+    fn bitor_assign(&mut self, rhs: Cpumask) {
+        self.mask |= &rhs.mask;
+    }
+}
+
+impl BitXor for Cpumask {
+    type Output = Self;
+    fn bitxor(self, rhs: Self) -> Self {
+        self.xor(&rhs)
+    }
+}
+
+impl BitXorAssign for Cpumask {
+    fn bitxor_assign(&mut self, rhs: Cpumask) {
+        self.mask ^= &rhs.mask;
     }
 }
 

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -278,7 +278,7 @@ fn cpus_online() -> Result<Cpumask> {
                 bail!("Failed to parse online cpus {}", group.trim());
             }
         };
-        for i in min..max {
+        for i in min..(max + 1) {
             mask.set_cpu(i)?;
         }
     }

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -26,7 +26,7 @@ struct Scheduler<'a> {
 impl<'a> Scheduler<'a> {
     fn init() -> Result<Self> {
         let topo = Topology::new().expect("Failed to build host topology");
-        let bpf = BpfScheduler::init(5000, topo.nr_cpus() as i32, false, false, false)?;
+        let bpf = BpfScheduler::init(5000, topo.nr_cpus_possible() as i32, false, false, false)?;
         Ok(Self { bpf })
     }
 

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -264,7 +264,7 @@ impl<'a> Scheduler<'a> {
         let init_page_faults: u64 = 0;
 
         // Low-level BPF connector.
-        let nr_online_cpus = topo.span().weight() + 1;
+        let nr_online_cpus = topo.span().weight();
         let bpf = BpfScheduler::init(
             opts.slice_us,
             nr_online_cpus as i32,

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -359,7 +359,7 @@ impl<'a> Scheduler<'a> {
         //
         // This allows to survive stress tests that are spawning a massive amount of
         // tasks.
-        self.eff_slice_boost = (self.slice_boost * self.topo.nr_cpus() as u64
+        self.eff_slice_boost = (self.slice_boost * self.topo.nr_cpus_possible() as u64
             / self.task_pool.tasks.len().max(1) as u64)
             .max(1);
 

--- a/scheds/rust/scx_rusty/src/bpf/intf.h
+++ b/scheds/rust/scx_rusty/src/bpf/intf.h
@@ -26,6 +26,7 @@ enum consts {
 	MAX_DOMS		= 64,	/* limited to avoid complex bitmask ops */
 	MAX_NUMA_NODES		= MAX_DOMS,	/* Assume at least 1 domain per NUMA node */
 	CACHELINE_SIZE		= 64,
+	NO_DOM_FOUND		= MAX_DOMS + 1,
 
 	LB_DEFAULT_WEIGHT	= 100,
 	LB_MIN_WEIGHT		= 1,
@@ -89,6 +90,12 @@ struct task_ctx {
 
 	/* select_cpu() telling enqueue() to queue directly on the DSQ */
 	bool dispatch_local;
+
+	/*
+	 * Task couldn't find a domain to run on. Is likely affinitized to an
+	 * offline core
+	 */
+	bool offline;
 
 	struct ravg_data dcyc_rd;
 };

--- a/scheds/rust/scx_rusty/src/domain.rs
+++ b/scheds/rust/scx_rusty/src/domain.rs
@@ -35,7 +35,7 @@ impl Domain {
 
     /// The number of CPUs in the domain.
     pub fn weight(&self) -> usize {
-        self.mask.len()
+        self.mask.weight()
     }
 }
 

--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -612,7 +612,8 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
 
         let mut aggregator = LoadAggregator::new(self.top.nr_cpus(), !self.lb_apply_weight.clone());
 
-        for dom in 0..self.dom_group.nr_doms() {
+        for dom_id in self.dom_group.doms().keys() {
+            let dom = *dom_id;
             let dom_key = unsafe { std::mem::transmute::<u32, [u8; 4]>(dom as u32) };
 
             if let Some(dom_ctx_map_elem) = dom_data

--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -147,7 +147,6 @@ use log::debug;
 use log::warn;
 use ordered_float::OrderedFloat;
 use scx_utils::ravg::ravg_read;
-use scx_utils::Topology;
 use scx_utils::LoadLedger;
 use scx_utils::LoadAggregator;
 use sorted_vec::SortedVec;
@@ -501,7 +500,6 @@ impl fmt::Display for NumaStat {
 
 pub struct LoadBalancer<'a, 'b> {
     skel: &'a mut BpfSkel<'b>,
-    top: Arc<Topology>,
     dom_group: Arc<DomainGroup>,
     skip_kworkers: bool,
 
@@ -520,7 +518,6 @@ const_assert_eq!(bpf_intf::consts_LB_MAX_WEIGHT % bpf_intf::consts_LB_LOAD_BUCKE
 impl<'a, 'b> LoadBalancer<'a, 'b> {
     pub fn new(
         skel: &'a mut BpfSkel<'b>,
-        top: Arc<Topology>,
         dom_group: Arc<DomainGroup>,
         skip_kworkers: bool,
         lb_apply_weight: bool,
@@ -537,7 +534,6 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
             lb_apply_weight: lb_apply_weight.clone(),
             balance_load,
 
-            top,
             dom_group,
         }
     }
@@ -610,7 +606,7 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
         let maps = self.skel.maps();
         let dom_data = maps.dom_data();
 
-        let mut aggregator = LoadAggregator::new(self.top.nr_cpus(), !self.lb_apply_weight.clone());
+        let mut aggregator = LoadAggregator::new(self.dom_group.weight(), !self.lb_apply_weight.clone());
 
         for dom_id in self.dom_group.doms().keys() {
             let dom = *dom_id;

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -273,7 +273,7 @@ impl<'a> Scheduler<'a> {
             let node_domains = domains.numa_doms(&numa);
             for dom in node_domains.iter() {
                 let dom_mask = dom.mask();
-                numa_mask = numa_mask.or(&dom_mask)?;
+                numa_mask = numa_mask.or(&dom_mask);
             }
 
             let raw_numa_slice = numa_mask.as_raw_slice();

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -71,10 +71,6 @@ const MAX_CPUS: usize = bpf_intf::consts_MAX_CPUS as usize;
 /// domains, each representing a chiplet in a six-chiplet AMD processor, and
 /// could match the performance of production setup using CFS.
 ///
-/// WARNING: Very high weight (low nice value) tasks can throw off load
-/// balancing due to infeasible weight problem. This problem will be solved
-/// in the near future.
-///
 /// WARNING: scx_rusty currently assumes that all domains have equal
 /// processing power and at similar distances from each other. This
 /// limitation will be removed in the future.
@@ -125,8 +121,8 @@ struct Opts {
     greedy_threshold: u32,
 
     /// When non-zero, enable greedy task stealing across NUMA nodes. The order
-    /// of greedy task stealing follows greedy_threshold as described above, and
-    /// greedy_threshold must be nonzero to enable task stealing across NUMA
+    /// of greedy task stealing follows greedy-threshold as described above, and
+    /// greedy-threshold must be nonzero to enable task stealing across NUMA
     /// nodes.
     #[clap(long, default_value = "0")]
     greedy_threshold_x_numa: u32,
@@ -163,7 +159,7 @@ struct Opts {
     kick_greedy_under: f64,
 
     /// Whether tasks can be pushed directly to idle CPUs on NUMA nodes
-    /// different than its domain's node. If direct_greedy_under is disabled,
+    /// different than its domain's node. If direct-greedy-under is disabled,
     /// this option is a no-op. Otherwise, if this option is set to false
     /// (default), tasks will only be directly pushed to idle CPUs if they
     /// reside on the same NUMA node as the task's domain.


### PR DESCRIPTION
As described in https://bugzilla.kernel.org/show_bug.cgi?id=218109,
https://github.com/sched-ext/scx/issues/147 and https://github.com/sched-ext/sched_ext/issues/69, AMD chips can
sometimes report fully disabled CPUs as offline, which causes us to
count them when looking at /sys/devices/system/cpu/possible.
                                                                                      
Additionally, systems can have holes in their active CPU maps. For
example, a system with CPUs 0, 1, 2, 3 possible, may have only 0 and 2
active. To address this, we need to do a few things:   
                                                                                      
1. Update topology.rs to be clear that it's returning the number of
    _possible_ CPUs in the system. Also update Topology to only record
    online CPUs when creating its span and iterating over sysfs when
    creating domains. It was previously trying to record when a CPU was
    online, but this was actually broken as the topology directory isn't
    present in sysfs when the CPU is offline.
                                           
2. Schedulers should not be relying on nr_possible_cpus for anything
    other than interacting with per-CPU data (e.g. for stats extraction),
    or e.g. verifying maximum sizes of statically sized arrays in BPF. It
    should _not_ be used for e.g. performing load calculations, etc. With
    that said, we'll also need to update schedulers to not rely on the
    nr_possible_cpus figure being exported by the topology crate. We do
    that for rusty in this patch, but don't fix any of the others other
    than updating how they call topology.rs. 

3. Account for the fact that LLC IDs may be non-contiguous. For example,
    if there is a single core in an LLC, then if we assign LLC IDs to
    domains, then the domain IDs won't be contiguous. This doesn't fit
    our current model which is used by e.g. infeasible_weights.rs. We'll
    update some of the code in rusty to accomodate this, but we'll need
    to do more.

4. Update schedulers to properly reset themselves in the event of a
    hotplug event. We'll take care of that in a follow-on change.