### PR TITLE
scx_lavd: addressed comments from PR #192

### DIFF
--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -20,7 +20,6 @@ ordered-float = "3.4.0"
 scx_utils = { path = "../../../rust/scx_utils", version = "0.6" }
 simplelog = "0.12.0"
 static_assertions = "1.1.0"
-num_cpus = "1.16.0"
 rlimit = "0.10.1"
 plain = "0.2.3"
 nix = "0.28.0"

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -796,7 +796,7 @@ static u64 calc_greedy_factor(struct task_ctx *taskc)
 		gr_ft *= LAVD_SLICE_GREEDY_FT;
 
 	return gr_ft;
-	}
+}
 
 static bool is_eligible(struct task_ctx *taskc)
 {

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1482,6 +1482,14 @@ static bool slice_fully_consumed(struct cpu_ctx *cpuc, struct task_ctx *taskc)
 {
 	u64 run_time_ns;
 
+	/*
+	 * Sanity check just to make sure the runtime is positive.
+	 */
+	if (taskc->last_stop_clk < taskc->last_start_clk) {
+		scx_bpf_error("run_time_ns is negative: 0x%llu - 0x%llu",
+			      taskc->last_stop_clk, taskc->last_start_clk);
+	}
+
 	run_time_ns = taskc->last_stop_clk - taskc->last_start_clk;
 
 	return run_time_ns >= taskc->slice_ns;

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -858,7 +858,7 @@ static u64 calc_eligible_delta(struct task_struct *p, struct task_ctx *taskc)
 	 * We calculate how long a task should be ineligible for execution. To
 	 * this end, the scheduler stretches the ineligible duration of a task
 	 * so it can control the frequency of the task's running to let the
-	 * task pay its debut. Reducing the time slice of a task would be
+	 * task pay its debt. Reducing the time slice of a task would be
 	 * another approach. However, adjusting the time slice for fairness
 	 * does not work well since many latency-critical tasks voluntarily
 	 * yield CPU waiting for an event before expiring its time slice. 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -389,7 +389,7 @@ static u16 get_nice_prio(struct task_struct *p);
 static u64 get_task_load_ideal(struct task_struct *p);
 
 static bool put_local_rq(struct task_struct *p, struct task_ctx *taskc,
-			 s32 cpu_id, u64 enq_flags);
+			 u64 enq_flags);
 static bool put_global_rq(struct task_struct *p, struct task_ctx *taskc,
 			  u64 enq_flags);
 
@@ -1250,7 +1250,7 @@ static void calc_when_to_run(struct task_struct *p, struct task_ctx *taskc,
 }
 
 static bool put_local_rq(struct task_struct *p, struct task_ctx *taskc,
-			 s32 cpu_id, u64 enq_flags)
+			 u64 enq_flags)
 {
 	/*
 	 * Calculate when a tack can be scheduled. If a task is cannot be
@@ -1352,7 +1352,7 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 			return prev_cpu;
 		}
 
-		if (!put_local_rq(p, taskc, cpu_id, 0)) {
+		if (!put_local_rq(p, taskc, 0)) {
 			/*
 			 * If a task is overscheduled (greedy_ratio > 1000), we
 			 * do not select a CPU, so that later the enqueue

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1248,13 +1248,7 @@ static void update_stat_for_stop(struct task_struct *p, struct task_ctx *taskc,
 {
 	u64 now, run_time_ns;
 
-	/*
-	 * If the task was runnable before governed by this scheduler, ignore
-	 * this run.
-	 */
 	now = bpf_ktime_get_ns();
-	if (now < taskc->last_start_clk)
-		return;
 
 	/*
 	 * When stopped, reduce the per-CPU task load. Per-CPU task load will

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1482,10 +1482,9 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 
 static bool slice_fully_consumed(struct cpu_ctx *cpuc, struct task_ctx *taskc)
 {
-	u64 run_time_ns = 0;
+	u64 run_time_ns;
 
-	if (taskc->last_stop_clk > taskc->last_start_clk)
-		run_time_ns = taskc->last_stop_clk - taskc->last_start_clk;
+	run_time_ns = taskc->last_stop_clk - taskc->last_start_clk;
 
 	return run_time_ns >= taskc->slice_ns;
 }

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -820,7 +820,11 @@ static bool is_eligible(struct task_ctx *taskc)
 
 static bool is_wakeup_wf(u64 wake_flags)
 {
-	return wake_flags & (SCX_WAKE_TTWU | SCX_WAKE_SYNC);
+	/*
+	 * We don't need to test SCX_WAKE_SYNC because SCX_WAKE_SYNC should
+	 * only be set when SCX_WAKE_TTWU is set.
+	 */
+	return wake_flags & SCX_WAKE_TTWU;
 }
 
 static bool is_wakeup_ef(u64 enq_flags)

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -268,13 +268,18 @@ static const u64 sched_prio_to_slice_weight[NICE_WIDTH] = {
  * MuQSS scheduler. We choose a different distribution for
  * sched_prio_to_latency_weight on purpose instead of inversing
  * sched_prio_to_slice_weight. That is because sched_prio_to_slice_weight is
- * too steep to use for latency. We normalized the values so that the normal
+ * too steep to use for latency. Suppose the maximum time slice per schedule
+ * (LAVD_SLICE_MAX_NS) is 4 msec. We normalized the values so that the normal
  * priority (nice 0) has a deadline of 10 msec. The virtual deadline ranges
- * from 1.5 msec to 60.9 msec.
+ * from 1.5 msec to 60.9 msec. As the maximum time slice becomes shorter, the
+ * deadlines become tighter.Taking an example of 3 msec, the virtual deadline
+ * ranges from 1.15 msec (for nice -20) to 7.5 msec (for nice 0) and 45.65 msec
+ * (for nice 19).
  */
 static const u64 sched_prio_to_latency_weight[NICE_WIDTH] = {
-	/* weight	nice priority	sched priority	vdeadline (usec)  */
-	/* ------	-------------	--------------	----------------  */
+	/* weight	nice priority	sched priority	vdeadline (usec)    */
+	/*						(max slice == 4 ms) */
+	/* ------	-------------	--------------	------------------- */
 	  383,		/* -20		 0		 1532 */
 	  419,		/* -19		 1 		 1676 */
 	  461,		/* -18		 2 		 1844 */

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1437,7 +1437,7 @@ void BPF_STRUCT_OPS(lavd_runnable, struct task_struct *p, u64 enq_flags)
 	 * is updated. The @current task is a waker and @p is a waiter, which
 	 * is being wakened up now.
 	 */
-	if (!(enq_flags & SCX_ENQ_WAKEUP))
+	if (!is_wakeup_ef(enq_flags))
 		return;
 
 	waker = bpf_get_current_task_btf();

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -94,12 +94,12 @@
  * fair use of CPU time. It defers choosing over-scheduled tasks to reduce the
  * frequency of task execution. The deferring time- ineligible duration- is
  * proportional to how much time is over-spent and added to the task's
- * deadline. Additionally, suppose a task is compute-intensive and not
- * latency-critical tasks. In that case, so its runtime per schedule is long
- * enough without voluntarily yielding CPU time, the scheduler reduces the time
- * slice, too. Note that reducing the time slice of a latency-critical task for
- * fairness is not very effective because the scheduling overhead might be
- * detrimental.
+ * deadline. Additionally, if a task is compute-intensive and not
+ * latency-critical, the scheduler automatically reduces its time slice, since
+ * its runtime per schedule is sufficiently long enough without voluntarily
+ * yielding the CPU. Note that reducing the time slice of a latency-critical
+ * task for fairness is not very effective because the scheduling overhead
+ * might be detrimental.
  *
  *
  * Copyright (c) 2023, 2024 Changwoo Min <changwoo@igalia.com>

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1042,19 +1042,8 @@ out:
 static u64 calc_latency_weight(struct task_struct *p, struct task_ctx *taskc,
 			       bool is_wakeup)
 {
-	int nice_prio, lat_boost_prio, prio;
-	u64 weight;
-
-	/*
-	 * Aggregate nice priority and latency boost priority, then convert the
-	 * final priority to weight.
-	 */
-	nice_prio = get_nice_prio(p);
-	lat_boost_prio = boost_lat(p, taskc, is_wakeup);
-	prio = sum_prios_for_lat(p, nice_prio, lat_boost_prio);
-
-	weight = sched_prio_to_latency_weight[prio];
-	return weight;
+	boost_lat(p, taskc, is_wakeup);
+	return sched_prio_to_latency_weight[taskc->lat_prio];
 }
 
 static u64 calc_virtual_dealine_delta(struct task_struct *p,

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -47,8 +47,8 @@ static RUNNING: AtomicBool = AtomicBool::new(true);
 /// See the more detailed overview of the LAVD design at main.bpf.c.
 #[derive(Debug, Parser)]
 struct Opts {
-    /// The number of scheduling samples to be reported every second (default: 0)
-    #[clap(short = 's', long, default_value = "0")]
+    /// The number of scheduling samples to be reported every second (default: 1)
+    #[clap(short = 's', long, default_value = "1")]
     nr_sched_samples: u64,
 
     /// PID to be tracked all its scheduling activities if specified

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -10,14 +10,14 @@ pub use bpf_skel::*;
 pub mod bpf_intf;
 pub use bpf_intf::*;
 
-extern crate static_assertions;
-extern crate plain;
 extern crate libc;
+extern crate plain;
+extern crate static_assertions;
 
+use std::mem;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
-use std::mem;
 
 use libc::c_char;
 use std::ffi::CStr;
@@ -33,9 +33,9 @@ use log::info;
 use scx_utils::uei_exited;
 use scx_utils::uei_report;
 
-use rlimit::{setrlimit, getrlimit, Resource};
-use plain::Plain;
 use nix::sys::signal;
+use plain::Plain;
+use rlimit::{getrlimit, setrlimit, Resource};
 
 static RUNNING: AtomicBool = AtomicBool::new(true);
 
@@ -63,17 +63,14 @@ struct Opts {
 unsafe impl Plain for msg_task_ctx {}
 
 impl msg_task_ctx {
-    fn from_bytes(buf: &[u8]) -> & msg_task_ctx {
-        plain::from_bytes(buf)
-            .expect("The buffer is either too short or not aligned!")
+    fn from_bytes(buf: &[u8]) -> &msg_task_ctx {
+        plain::from_bytes(buf).expect("The buffer is either too short or not aligned!")
     }
 }
 
 impl introspec {
     fn new() -> Self {
-        let intrspc = unsafe {
-            mem::MaybeUninit::<introspec>::zeroed().assume_init()
-        };
+        let intrspc = unsafe { mem::MaybeUninit::<introspec>::zeroed().assume_init() };
         intrspc
     }
 
@@ -82,12 +79,10 @@ impl introspec {
         if opts.nr_sched_samples > 0 {
             intrspc.cmd = LAVD_CMD_SCHED_N;
             intrspc.arg = opts.nr_sched_samples;
-        }
-        else if opts.pid_traced > 0 {
+        } else if opts.pid_traced > 0 {
             intrspc.cmd = LAVD_CMD_PID;
             intrspc.arg = opts.pid_traced;
-        }
-        else {
+        } else {
             intrspc.cmd = LAVD_CMD_NOP;
         }
         intrspc.requested = false as u8;
@@ -113,13 +108,12 @@ impl<'a> Scheduler<'a> {
         // Open the BPF prog first for verification.
         let mut skel_builder = BpfSkelBuilder::default();
         skel_builder.obj_builder.debug(opts.verbose > 0);
-        let mut skel = skel_builder.open()
-                                   .context("Failed to open BPF program")?;
+        let mut skel = skel_builder.open().context("Failed to open BPF program")?;
 
         // Initialize skel according to @opts.
-	let nr_cpus_onln = num_cpus::get() as u64;
-	skel.bss_mut().nr_cpus_onln = nr_cpus_onln;
-	skel.rodata_mut(). verbose = opts.verbose;
+        let nr_cpus_onln = num_cpus::get() as u64;
+        skel.bss_mut().nr_cpus_onln = nr_cpus_onln;
+        skel.rodata_mut().verbose = opts.verbose;
         let intrspc = introspec::init(opts);
 
         // Attach.
@@ -170,36 +164,62 @@ impl<'a> Scheduler<'a> {
         let mseq = Scheduler::get_msg_seq_id();
 
         if mseq % 32 == 1 {
-            info!("| {:9} | {:8} | {:17} \
+            info!(
+                "| {:9} | {:8} | {:17} \
                    | {:4} | {:9} | {:9} \
                    | {:10} | {:9} | {:8} \
                    | {:12} | {:7} | {:9} \
                    | {:9} | {:9} | {:9} \
                    | {:9} | {:8} |",
-                  "mseq", "pid", "comm",
-                  "cpu", "vddln_ns", "elglty_ns",
-                  "slice_ns", "grdy_rt", "lat_prio",
-                  "static_prio", "lat_bst", "slice_bst",
-                  "run_freq", "run_tm_ns", "wait_freq",
-                  "wake_freq", "cpu_util");
+                "mseq",
+                "pid",
+                "comm",
+                "cpu",
+                "vddln_ns",
+                "elglty_ns",
+                "slice_ns",
+                "grdy_rt",
+                "lat_prio",
+                "static_prio",
+                "lat_bst",
+                "slice_bst",
+                "run_freq",
+                "run_tm_ns",
+                "wait_freq",
+                "wake_freq",
+                "cpu_util"
+            );
         }
 
-        let c_tx_cm: *const c_char = (&tx.comm as *const [i8;17]) as *const i8;
+        let c_tx_cm: *const c_char = (&tx.comm as *const [i8; 17]) as *const i8;
         let c_tx_cm_str: &CStr = unsafe { CStr::from_ptr(c_tx_cm) };
-        let tx_comm : &str = c_tx_cm_str.to_str().unwrap();
+        let tx_comm: &str = c_tx_cm_str.to_str().unwrap();
 
-        info!("| {:9} | {:8} | {:17} \
+        info!(
+            "| {:9} | {:8} | {:17} \
                | {:4} | {:9} | {:9} \
                | {:10} | {:9} | {:8} \
                | {:12} | {:7} | {:9} \
                | {:9} | {:9} | {:9} \
                | {:9} | {:8} | ",
-              mseq, tx.pid, tx_comm,
-              tx.cpu_id, tc.vdeadline_delta_ns, tc.eligible_delta_ns,
-              tc.slice_ns, tc.greedy_ratio, tc.lat_prio,
-              tx.static_prio, tc.lat_boost_prio, tc.slice_boost_prio,
-              tc.run_freq, tc.run_time_ns, tc.wait_freq,
-              tc.wake_freq, tx.cpu_util);
+            mseq,
+            tx.pid,
+            tx_comm,
+            tx.cpu_id,
+            tc.vdeadline_delta_ns,
+            tc.eligible_delta_ns,
+            tc.slice_ns,
+            tc.greedy_ratio,
+            tc.lat_prio,
+            tx.static_prio,
+            tc.lat_boost_prio,
+            tc.slice_boost_prio,
+            tc.run_freq,
+            tc.run_time_ns,
+            tc.wait_freq,
+            tc.wake_freq,
+            tx.cpu_util
+        );
 
         0
     }
@@ -207,17 +227,16 @@ impl<'a> Scheduler<'a> {
     fn prep_introspec(&mut self) -> u64 {
         let mut interval_ms = 1000;
 
-        if self.intrspc.cmd == LAVD_CMD_SCHED_N && 
-            self.intrspc.arg > self.nr_cpus_onln {
-		// More samples, shorter sampling interval.
-                let f = self.intrspc.arg / self.nr_cpus_onln * 2;
-                interval_ms /= f;
+        if self.intrspc.cmd == LAVD_CMD_SCHED_N && self.intrspc.arg > self.nr_cpus_onln {
+            // More samples, shorter sampling interval.
+            let f = self.intrspc.arg / self.nr_cpus_onln * 2;
+            interval_ms /= f;
         }
-	self.intrspc.requested = true as u8;
+        self.intrspc.requested = true as u8;
 
-	self.skel.bss_mut().intrspc.cmd = self.intrspc.cmd;
-	self.skel.bss_mut().intrspc.arg = self.intrspc.arg;
-	self.skel.bss_mut().intrspc.requested = self.intrspc.requested;
+        self.skel.bss_mut().intrspc.cmd = self.intrspc.cmd;
+        self.skel.bss_mut().intrspc.arg = self.intrspc.arg;
+        self.skel.bss_mut().intrspc.requested = self.intrspc.requested;
 
         interval_ms
     }
@@ -231,7 +250,7 @@ impl<'a> Scheduler<'a> {
         // Once dumped, it is done.
         if self.intrspc.cmd == LAVD_CMD_DUMP {
             self.intrspc.cmd = LAVD_CMD_NOP;
-	}
+        }
     }
 
     fn running(&mut self) -> bool {
@@ -247,8 +266,8 @@ impl<'a> Scheduler<'a> {
         }
         self.rb_mgr.consume().unwrap();
 
-	self.struct_ops.take();
-	uei_report!(&self.skel.bss().uei)
+        self.struct_ops.take();
+        uei_report!(&self.skel.bss().uei)
     }
 }
 
@@ -260,7 +279,7 @@ impl<'a> Drop for Scheduler<'a> {
     }
 }
 
-fn init_log(opts: & Opts) {
+fn init_log(opts: &Opts) {
     let llv = match opts.verbose {
         0 => simplelog::LevelFilter::Info,
         1 => simplelog::LevelFilter::Debug,
@@ -276,7 +295,8 @@ fn init_log(opts: & Opts) {
         lcfg.build(),
         simplelog::TerminalMode::Stderr,
         simplelog::ColorChoice::Auto,
-    ).unwrap();
+    )
+    .unwrap();
 }
 
 extern "C" fn handle_sigint(_: libc::c_int, _: *mut libc::siginfo_t, _: *mut libc::c_void) {
@@ -288,7 +308,9 @@ fn init_signal_handlers() {
     unsafe {
         let sigint_action = signal::SigAction::new(
             signal::SigHandler::SigAction(handle_sigint),
-            signal::SaFlags::empty(), signal::SigSet::empty());
+            signal::SaFlags::empty(),
+            signal::SigSet::empty(),
+        );
         signal::sigaction(signal::SIGINT, &sigint_action).unwrap();
     }
 }

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -32,6 +32,7 @@ use libbpf_rs::skel::SkelBuilder as _;
 use log::info;
 use scx_utils::uei_exited;
 use scx_utils::uei_report;
+use scx_utils::Topology;
 
 use nix::sys::signal;
 use plain::Plain;
@@ -111,7 +112,8 @@ impl<'a> Scheduler<'a> {
         let mut skel = skel_builder.open().context("Failed to open BPF program")?;
 
         // Initialize skel according to @opts.
-        let nr_cpus_onln = num_cpus::get() as u64;
+        let topo = Topology::new().expect("Failed to build host topology");
+        let nr_cpus_onln = topo.span().weight() as u64;
         skel.bss_mut().nr_cpus_onln = nr_cpus_onln;
         skel.rodata_mut().verbose = opts.verbose;
         let intrspc = introspec::init(opts);


### PR DESCRIPTION
This PR contains all the fixes for the suggested changes in PR #192. It includes the following changes:

- scx_lavd: fix formatting issues in main.rs and main.bpf.c
- scx_lavd: replace num_cpus to scx_utils::Topology
- scx_lavd: remove unnecessary arg from put_local_rq()
- scx_lavd: print one scheduling decision by default
- scs_lavd: improve the description of fairness
- scx_lavd: remove unnecessary condition check in is_wakeup_wf()
- scx_lavd: add a utility func, {try_}get_task_ctx()
- scx_lavd: move scx_bpf_error() calls to get_cpu_ctx{_id}()
- scx_lavd: improve the clarity of the task state transition
- scx_lavd: use is_wakeup_ef() in checking wait flag
- scx_lavd: remove unnecessary condition check at update_stat_for_stop()
- scx_lavd: remove unnecessary condition check at slice_fully_consumed()
- scx_lavd: remove redundant latency calculcation at calc_latency_weight()
- scx_lavd: fix potential CPU stall in lavd_select_cpu()