### PR TITLE
topology: Fall back to cache 0

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -340,8 +340,11 @@ fn create_numa_nodes(online_mask: &Cpumask) -> Result<Vec<Node>> {
 
             // L3 cache ID
             let cache_path = cpu_path.join("cache");
+            // Use LLC 0 if we fail to detect the cache hierarchy. This seems to
+            // happen on certain SKUs, so if there's no cache information then
+            // we have no option but to assume a single unified cache per node.
             let llc_id =
-                read_file_usize(&cache_path.join(format!("index{}", CACHE_LEVEL)).join("id"))?;
+                read_file_usize(&cache_path.join(format!("index{}", CACHE_LEVEL)).join("id")).unwrap_or(0);
 
             // Min and max frequencies. If the kernel is not compiled with
             // CONFIG_CPU_FREQ, just assume 0 for both frequencies.


### PR DESCRIPTION
As described in https://github.com/sched-ext/scx/issues/195, apparently some chips don't export information about their cache topology. There's not much we can do if we don't have that information, so let's just assume a unified cache per node if that happens.

Andrea suggested this patch -- I'm applying exactly what he proposed, with a slightly modified comment.

Suggested-by: Andrea Righi <andrea.righi@canonical.com>