### PR TITLE
layered: Use TLS map instead of hash map

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -37,7 +37,6 @@ enum consts {
 
 /* Statistics */
 enum global_stat_idx {
-	GSTAT_TASK_CTX_FREE_FAILED,
 	GSTAT_EXCL_IDLE,
 	GSTAT_EXCL_WAKEUP,
 	NR_GSTATS,


### PR DESCRIPTION
In scx_layered, we're using a BPF_MAP_TYPE_HASH map (indexed by pid) rather than a BPF_MAP_TYPE_TASK_STORAGE, to track local storage for a task. As far as I can tell, there's no reason we need to be doing this. We never access the map from user space, and we're even passing a struct task_struct * to a helper subprog to look up the task context rather than only doing it by pid.

Using a hashmap is error prone for this because we end up having to manually track lifecycles for entries in the map rather than relying on BPF to do it for us. For example, BPF will automatically free a task's entry from the map when it exits. Let's just use TLS here rather than a hashmap to avoid issues from this (e.g. we've observed the scheduler getting evicted because we're accessing a stale map entry after a task has been destroyed).

Reported-by: Valentin Andrei <vandrei@meta.com>