### PR TITLE
Doc & build: Warn about sccache

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,8 +71,9 @@ Include = /etc/pacman.d/cachyos-mirrorlist
 $ sudo pacman -Sy cachyos/linux-sched-ext cachyos/linux-sched-ext-headers cachyos/scx-scheds
 ```
 
-Note that the kernel installs as `/boot/vmlinuz-linux-sched-ext` along with the matching initramfs.
-Update the bootloader configuration to add the boot entry for the new kernel.
+:warning: The kernel installs as `/boot/vmlinuz-linux-sched-ext` along with
+the matching initramfs. Update the bootloader configuration to add the boot
+entry for the new kernel.
 
 #### Setting Up Dev Environment
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ $ meson setup build -Dbuildtype=release
 $ meson compile -C build scx_simple scx_rusty
 ```
 
+:warning: **If your system has `sccache` installed**: `meson` automatically
+uses `sccache` if available. However, `sccache` fails in one of the build
+steps. If you encounter this issue, disable `sccache` by specifying `CC`
+directly - `$ CC=clang meson setup build -Dbuildtype=release`.
+
 You can also specify `-v` if you want to see the commands being used:
 
 ```

--- a/meson-scripts/build_bpftool
+++ b/meson-scripts/build_bpftool
@@ -9,7 +9,7 @@ args=($out)
 
 idx=0
 cc=${args[idx]}
-if [ "$cc" = "ccache" ]; then
+if [ "$cc" = "ccache" -o "$cc" = "sccache" ]; then
     idx=$((idx+1))
     cc="$cc ${args[idx]}"
 fi


### PR DESCRIPTION
Build fails with sccache.

- Update meson-scripts/build_bpftool to support sccache. Unfortunately, this isn't enough.

- Update README to warn about sccache and add the instruction to disable it for buliding scx.

- Also add :warning: to make boot loader update step more prominent in arch installation instruction.