### PR TITLE
ci: make test build more robust

### DIFF
--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -16,7 +16,7 @@ jobs:
       ### DOWNLOAD AND INSTALL DEPENDENCIES ###
 
       # Download dependencies packaged by Ubuntu
-      - run: sudo apt -y install bison busybox-static cargo cmake coreutils cpio elfutils file flex gcc git iproute2 kbd kmod libcap-dev libelf-dev libunwind-dev libvirt-clients libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic make ninja-build pahole python3-dev python3-pip python3-requests qemu-kvm rsync rustc udev zstd
+      - run: sudo apt -y install bison busybox-static cargo cmake coreutils cpio elfutils file flex gcc git iproute2 jq kbd kmod libcap-dev libelf-dev libunwind-dev libvirt-clients libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic make ninja-build pahole pkg-config python3-dev python3-pip python3-requests qemu-kvm rsync rustc udev zstd
 
       # clang 17
       # Use a custom llvm.sh script which includes the -y flag for

--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -55,7 +55,7 @@ jobs:
 
       # The actual build:
       - run: meson setup build -Dkernel=$(pwd)/linux -Dkernel_headers=./linux/usr/include
-      - run: meson compile -C build
+      - run: meson compile -C build --jobs=1
 
       # Print CPU model before running the tests (this can be useful for
       # debugging purposes)

--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -48,10 +48,13 @@ jobs:
       # Build a minimal kernel (with sched-ext enabled) using virtme-ng
       - run: cd linux && vng -v --build --config .github/workflows/sched-ext.config
 
+      # Generate kernel headers
+      - run: cd linux && make headers
+
       ### END DEPENDENCIES ###
 
       # The actual build:
-      - run: meson setup build -Dkernel=$(pwd)/linux
+      - run: meson setup build -Dkernel=$(pwd)/linux -Dkernel_headers=./linux/usr/include
       - run: meson compile -C build
 
       # Print CPU model before running the tests (this can be useful for

--- a/meson.build
+++ b/meson.build
@@ -140,6 +140,13 @@ else
   endif
 endif
 
+if get_option('kernel_headers') != ''
+  kernel_headers = get_option('kernel_headers')
+  kernel_dep = [declare_dependency(include_directories: kernel_headers)]
+else
+  kernel_dep = []
+endif
+
 bpftool_path = '@0@/bpftool/src'.format(meson.current_build_dir())
 should_build_bpftool = true
 bpftool_exe_path = '@0@/bpftool'.format(bpftool_path)

--- a/meson.options
+++ b/meson.options
@@ -16,6 +16,8 @@ option('enable_rust', type: 'boolean', value: 'true',
        description: 'Enable rust sub-projects')
 option('kernel', type: 'string', value: 'vmlinuz',
        description: 'kernel image used to test schedulers')
+option('kernel_headers', type: 'string', value: '',
+       description: 'kernel headers to build the schedulers')
 option(
   'systemd',
   type: 'feature',

--- a/scheds/c/meson.build
+++ b/scheds/c/meson.build
@@ -6,6 +6,6 @@ foreach sched: c_scheds
   bpf_skel = gen_bpf_skel.process(bpf_o)
   executable(sched, [bpf_skel, sched + '.c'],
              include_directories: [user_c_includes],
-             dependencies: [libbpf_dep, thread_dep],
+             dependencies: [kernel_dep, libbpf_dep, thread_dep],
              install: true)
 endforeach


### PR DESCRIPTION
Always use custom linux headers to prevent potential build failures and also use `--jobs=1` during the build to prevent overloading the system during the CI run.