### PR TITLE
scx_rustland_core: re-introduce consume_raw() libbpf-rs API

### DIFF
--- a/rust/scx_rustland_core/src/bpf.rs
+++ b/rust/scx_rustland_core/src/bpf.rs
@@ -174,6 +174,10 @@ struct AlignedBuffer([u8; BUFSIZE]);
 
 static mut BUF: AlignedBuffer = AlignedBuffer([0; BUFSIZE]);
 
+// Special negative error code for libbpf to stop after consuming just one item from a BPF
+// ring buffer.
+const LIBBPF_STOP: i32 = -255;
+
 impl<'cb> BpfScheduler<'cb> {
     pub fn init(
         slice_us: u64,
@@ -224,7 +228,7 @@ impl<'cb> BpfScheduler<'cb> {
             // Maybe we should fix this to stop processing items from the ring buffer also when a
             // value > 0 is returned.
             //
-            -255
+            LIBBPF_STOP
         }
 
         // Initialize online CPUs counter.
@@ -374,15 +378,16 @@ impl<'cb> BpfScheduler<'cb> {
     // Receive a task to be scheduled from the BPF dispatcher.
     //
     // NOTE: if task.cpu is negative the task is exiting and it does not require to be scheduled.
-    pub fn dequeue_task(&mut self) -> Result<Option<QueuedTask>, libbpf_rs::Error> {
-        match self.queued.consume() {
-            Ok(()) => Ok(None),
-            Err(error) if error.kind() == libbpf_rs::ErrorKind::Other => {
+    pub fn dequeue_task(&mut self) -> Result<Option<QueuedTask>, i32> {
+        match self.queued.consume_raw() {
+            0 => Ok(None),
+            LIBBPF_STOP => {
                 // A valid task is received, convert data to a proper task struct.
                 let task = unsafe { EnqueuedMessage::from_bytes(&BUF.0).to_queued_task() };
                 Ok(Some(task))
             }
-            Err(error) => Err(error),
+            res if res < 0 => Err(res),
+            res => panic!("Unexpected return value from libbpf-rs::consume_raw(): {}", res),
         }
     }
 


### PR DESCRIPTION
Now that libbpf-rs 0.23 has been officially released with the new consume_raw() API (https://github.com/libbpf/libbpf-rs/pull/680) we can re-introduce the change in rustland-core that allows to use this API to improve the quality of the code and make it slightly more efficient when consuming tasks from BPF to user-space.

Fixes: bd2c18a ("Revert "scx_rustland_core: use new consume_raw() libbpf-rs API"")