### PR TITLE
Gracefully handle hotplug in scx_rusty

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -30,7 +30,7 @@ static inline void ___vmlinux_h_sanity_check___(void)
 
 void scx_bpf_error_bstr(char *fmt, unsigned long long *data, u32 data_len) __ksym;
 void scx_bpf_exit_bstr(s64 exit_code, char *fmt,
-		       unsigned long long *data, u32 data__sz) __ksym;
+		       unsigned long long *data, u32 data__sz) __ksym __weak;
 
 static inline __attribute__((format(printf, 1, 2)))
 void ___scx_bpf_exit_format_checker(const char *fmt, ...) {}

--- a/scheds/rust/scx_rusty/src/bpf/intf.h
+++ b/scheds/rust/scx_rusty/src/bpf/intf.h
@@ -45,6 +45,10 @@ enum consts {
 	MAX_DOM_ACTIVE_PIDS	= 1024,
 };
 
+enum rusty_exit_codes {
+	RUSTY_EXIT_HOTPLUG,
+};
+
 /* Statistics */
 enum stat_idx {
 	/* The following fields add up to all dispatched tasks */

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -1428,6 +1428,22 @@ static s32 initialize_cpu(s32 cpu)
 	return 0;
 }
 
+void BPF_STRUCT_OPS(rusty_cpu_online, s32 cpu)
+{
+	if (bpf_ksym_exists(scx_bpf_exit_bstr))
+		scx_bpf_exit(RUSTY_EXIT_HOTPLUG, "CPU %d went online", cpu);
+	else
+		scx_bpf_error("CPU %d went online", cpu);
+}
+
+void BPF_STRUCT_OPS(rusty_cpu_offline, s32 cpu)
+{
+	if (bpf_ksym_exists(scx_bpf_exit_bstr))
+		scx_bpf_exit(RUSTY_EXIT_HOTPLUG, "CPU %d went offline", cpu);
+	else
+		scx_bpf_error("CPU %d went offline", cpu);
+}
+
 s32 BPF_STRUCT_OPS_SLEEPABLE(rusty_init)
 {
 	struct bpf_cpumask *cpumask;
@@ -1497,6 +1513,8 @@ SCX_OPS_DEFINE(rusty,
 	       .set_cpumask		= (void *)rusty_set_cpumask,
 	       .init_task		= (void *)rusty_init_task,
 	       .exit_task		= (void *)rusty_exit_task,
+	       .cpu_online		= (void *)rusty_cpu_online,
+	       .cpu_offline		= (void *)rusty_cpu_offline,
 	       .init			= (void *)rusty_init,
 	       .exit			= (void *)rusty_exit,
 	       .name			= "rusty");


### PR DESCRIPTION
The scx_rusty scheduler does not support hotplug, and expects a static
host topology throughout its runtime. Though the kernel does have
support for detecting hotplug events, we currently don't detect this in
the kernel, nor surface it to user space when it happens. Now that we
have scx_bpf_exit(), we can gracefully exit the kernel in the event of a
hotplug, and communicate to user space that it should restart the
scheduler.
    
This patch adds that support to scx_rusty. Note that this assumes that
we're running on a recent enough kernel that has scx_bpf_exit(). If it
doesn't, then we instead just error out of the kernel scheduler and exit
the application.