### PR TITLE
scx_rustland_core: bump up version to 0.2

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland_core"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Andrea Righi <andrea.righi@canonical.com>"]
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -12,11 +12,11 @@ ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "0.23"
 libc = "0.2.137"
 scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.1" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.2" }
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.1" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.2" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -16,12 +16,12 @@ libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
 scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.1" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.2" }
 simplelog = "0.12.0"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.1" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.2" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION
Bump up the version of the crate and update dependencies.