### PR TITLE
Fix error typo

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -997,7 +997,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(layered_init)
 			return ret;
 
 		if (!(cpumaskw = bpf_map_lookup_elem(&layer_cpumasks, &i)))
-			return -ENONET;
+			return -ENOENT;
 
 		cpumask = bpf_cpumask_create();
 		if (!cpumask)


### PR DESCRIPTION
ENONET means "Machine is not on the network" - this was supposed to be ENOENT "No such file or directory"