### PR TITLE
rusty: Remove explicit padding

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -86,9 +86,6 @@ struct pcpu_ctx {
 	u32 dom_id;
 	u32 nr_node_doms;
 	u32 node_doms[MAX_DOMS];
-
-	/* libbpf-rs does not respect the alignment, so pad out the struct explicitly */
-	u8 _padding[CACHELINE_SIZE - ((3 + MAX_DOMS) * sizeof(u32) % CACHELINE_SIZE)];
 } __attribute__((aligned(CACHELINE_SIZE)));
 
 struct pcpu_ctx pcpu_ctx[MAX_CPUS];


### PR DESCRIPTION
As of libbpf-rs 0.23.0 (which contains commit
https://github.com/libbpf/libbpf-rs/commit/9d9e979fcfb99dfee80bb81e534b5e17df941a85), libbpf-rs now generates rust structs that honor padding. We can therefore remove the custom padding in scx_rusty's struct pcpu_ctx.

For example, here is the generated pub struct pcpu_ctx:

```
pub struct pcpu_ctx {
    pub dom_rr_cur: u32,
    pub dom_id: u32,
    pub nr_node_doms: u32,
    pub node_doms: [u32; 64],
    pub __pad_268: [u8; 52],
}
```

And here is the matching struct in the BPF object file:

```
struct pcpu_ctx {
        u32                        dom_rr_cur;           /*     0     4 */
        u32                        dom_id;               /*     4     4 */
        u32                        nr_node_doms;         /*     8     4 */
        u32                        node_doms[64];        /*    12   256 */

        /* size: 320, cachelines: 5, members: 4 */
        /* padding: 52 */
} __attribute__((__aligned__(64)));
```