### PR TITLE
simple: Invoke __COMPAT_scx_bpf_switch_all();

### DIFF
--- a/scheds/c/scx_simple.bpf.c
+++ b/scheds/c/scx_simple.bpf.c
@@ -129,6 +129,7 @@ void BPF_STRUCT_OPS(simple_enable, struct task_struct *p)
 
 s32 BPF_STRUCT_OPS_SLEEPABLE(simple_init)
 {
+	__COMPAT_scx_bpf_switch_all();
 	return scx_bpf_create_dsq(SHARED_DSQ, -1);
 }
 


### PR DESCRIPTION
scx_simple no longer supports running in "partial" mode, with only certain tasks usig scx_simple. When this option was removed, we also removed the call to scx_bpf_switch_all();

While switching-all is the default behavior for newer kernels, let's add __COMPAT_scx_bpf_switch_all() so that scx_simple can work on older kernels as well.