### PR TITLE
rustland: enable preemption

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -32,6 +32,10 @@ const SCHED_EXT: i32 = 7;
 #[allow(dead_code)]
 pub const RL_CPU_ANY: i32 = bpf_intf::RL_CPU_ANY as i32;
 
+// Allow to preempt the target CPU when dispatching the task.
+#[allow(dead_code)]
+pub const RL_PREEMPT_CPU: i32 = bpf_intf::RL_PREEMPT_CPU as i32;
+
 /// High-level Rust abstraction to interact with a generic sched-ext BPF component.
 ///
 /// Overview

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -26,11 +26,11 @@ use scx_rustland_core::ALLOCATOR;
 // Defined in UAPI
 const SCHED_EXT: i32 = 7;
 
-// Do not assign any specific CPU to the task.
+// Allow to dispatch the task on any CPU.
 //
 // The task will be dispatched to the global shared DSQ and it will run on the first CPU available.
 #[allow(dead_code)]
-pub const NO_CPU: i32 = -1;
+pub const RL_CPU_ANY: i32 = bpf_intf::RL_CPU_ANY as i32;
 
 /// High-level Rust abstraction to interact with a generic sched-ext BPF component.
 ///
@@ -93,6 +93,12 @@ impl DispatchedTask {
     #[allow(dead_code)]
     pub fn set_cpu(&mut self, cpu: i32) {
         self.cpu = cpu;
+    }
+
+    // Assign a specific dispatch flag to a task.
+    #[allow(dead_code)]
+    pub fn set_flag(&mut self, flag: i32) {
+        self.cpu |= flag;
     }
 
     // Assign a specific time slice to a task.

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -39,16 +39,7 @@ typedef long long s64;
  */
 #define MAX_CPUS 1024
 
-/* Isolate target CPU from dispatch flags. */
-#define CPU_MASK	(MAX_CPUS - 1)
-
-/* Use extra bits in the CPU attribute to store dispatch flags. */
-#define RL_BASE_FLAG	__builtin_ctz(MAX_CPUS)
-
-/* Define dispatch flags using macros. */
-#define RL_FLAG(flag) (1U << (RL_BASE_FLAG + flag))
-
-/* Dispatch flags */
+/* Special dispatch flags */
 enum {
 	/*
 	 * Do not assign any specific CPU to the task.
@@ -56,12 +47,12 @@ enum {
 	 * The task will be dispatched to the global shared DSQ and it will run
 	 * on the first CPU available.
 	 */
-	RL_CPU_ANY = RL_FLAG(0),
+	RL_CPU_ANY = 1 << 0,
 
 	/*
 	 * Allow to preempt the target CPU when dispatching the task.
 	 */
-	RL_PREEMPT_CPU = RL_FLAG(1),
+	RL_PREEMPT_CPU = 1 << 1,
 };
 
 /*
@@ -87,6 +78,7 @@ struct queued_task_ctx {
 struct dispatched_task_ctx {
 	s32 pid;
 	s32 cpu; /* CPU where the task should be dispatched */
+	u64 flags; /* special dispatch flags */
 	u64 cpumask_cnt; /* cpumask generation counter */
 	u64 slice_ns; /* time slice assigned to the task (0=default) */
 };

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -57,6 +57,11 @@ enum {
 	 * on the first CPU available.
 	 */
 	RL_CPU_ANY = RL_FLAG(0),
+
+	/*
+	 * Allow to preempt the target CPU when dispatching the task.
+	 */
+	RL_PREEMPT_CPU = RL_FLAG(1),
 };
 
 /*

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -26,6 +26,39 @@ typedef unsigned long long u64;
 typedef long long s64;
 #endif
 
+/* Check a condition at build time */
+#define BUILD_BUG_ON(expr) \
+	do { \
+		extern char __build_assert__[(expr) ? -1 : 1] \
+			__attribute__((unused)); \
+	} while(0)
+
+/*
+ * Maximum amount of CPUs supported by this scheduler (this defines the size of
+ * cpu_map that is used to store the idle state and CPU ownership).
+ */
+#define MAX_CPUS 1024
+
+/* Isolate target CPU from dispatch flags. */
+#define CPU_MASK	(MAX_CPUS - 1)
+
+/* Use extra bits in the CPU attribute to store dispatch flags. */
+#define RL_BASE_FLAG	__builtin_ctz(MAX_CPUS)
+
+/* Define dispatch flags using macros. */
+#define RL_FLAG(flag) (1U << (RL_BASE_FLAG + flag))
+
+/* Dispatch flags */
+enum {
+	/*
+	 * Do not assign any specific CPU to the task.
+	 *
+	 * The task will be dispatched to the global shared DSQ and it will run
+	 * on the first CPU available.
+	 */
+	RL_CPU_ANY = RL_FLAG(0),
+};
+
 /*
  * Task sent to the user-space scheduler by the BPF dispatcher.
  *

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -173,8 +173,8 @@ impl TaskInfoMap {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone)]
 struct Task {
-    qtask: QueuedTask, // queued task
-    vruntime: u64,     // total vruntime (that determines the order how tasks are dispatched)
+    qtask: QueuedTask,      // queued task
+    vruntime: u64,          // total vruntime (that determines the order how tasks are dispatched)
 }
 
 // Make sure tasks are ordered by vruntime, if multiple tasks have the same vruntime order by pid.
@@ -505,8 +505,10 @@ impl<'a> Scheduler<'a> {
                     // If built-in idle selection logic is disabled, dispatch on the first CPU
                     // available.
                     let mut dispatched_task = DispatchedTask::new(&task.qtask);
+
+                    // Set special dispatch flags.
                     if !self.builtin_idle {
-                        dispatched_task.set_cpu(NO_CPU);
+                        dispatched_task.set_flag(RL_CPU_ANY);
                     }
 
                     // Send task to the BPF dispatcher.


### PR DESCRIPTION
### Overview

Provide preemption capability in `scx_rustland_core` and use this feature in `scx_rustland` to improve the the responsiveness of interactive tasks.

### Design

For now the design is pretty simple:
 - `scx_rustland_core` provides a new dispatch flag `RL_PREEMPT_CPU` that is mapped to `SCX_ENQ_PREEMPT`
 - `scx_rustland` uses this flag when dispatching tasks that are classified as "interactive", so that they can preempt other tasks before their assigned time slice expires

This implies that interactive tasks can also preempt each other, potentially causing an excessive amount of preemption events if a consistent amount of tasks is classified as "interactive". This can be improved in the future by limiting the the amount of preemption events per sec., similar to what `scx_lavd` is doing.

### Results

Measuring the performance of the usual benchmark "playing a video game while running a parallel kernel build in background" seems to give around 2-10% boost in the fps with preemption enabled, depending on the
particular video game.

Results were obtained running a `make -j32` kernel build on a AMD Ryzen 7 5800X 8-Cores 16GB RAM, while testing video games such as Baldur's Gate 3 (with a solid +10% fps), Counter Strike 2 (around +5%) and Team
Fortress 2 (+2% boost).

Moreover, some WebGL applications (such as https://webglsamples.org/aquarium/aquarium.html) seem to benefit even more with preemption enabled, providing up to a +15% fps boost.