### PR TITLE
Add CPU frequency related helpers and extend scx_layered

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -98,6 +98,9 @@ bool scx_bpf_task_running(const struct task_struct *p) __ksym;
 s32 scx_bpf_task_cpu(const struct task_struct *p) __ksym;
 struct cgroup *scx_bpf_task_cgroup(struct task_struct *p) __ksym;
 u32 scx_bpf_reenqueue_local(void) __ksym;
+u32 scx_bpf_cpuperf_cap(s32 cpu) __ksym;
+u32 scx_bpf_cpuperf_cur(s32 cpu) __ksym;
+void scx_bpf_cpuperf_set(u32 cpu, u32 perf) __ksym;
 
 #define BPF_STRUCT_OPS(name, args...)						\
 SEC("struct_ops/"#name)								\

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -107,6 +107,7 @@ struct layer {
 	unsigned int		refresh_cpus;
 	unsigned char		cpus[MAX_CPUS_U8];
 	unsigned int		nr_cpus;	// managed from BPF side
+	unsigned int		perf;
 };
 
 #endif /* __INTF_H */


### PR DESCRIPTION
This change adds `scx_bpf_cpuperf_cap`, `scx_bpf_cpuperf_cur` and `scx_bpf_cpuperf_set` definitions that were recently introduced into [`sched_ext`](https://github.com/sched-ext/sched_ext/pull/180). It adds a `perf` field to `scx_layered` to allow for controlling performance per layer.