### PR TITLE
layered: Add ability to match by process name

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -69,6 +69,7 @@ struct cpu_ctx {
 enum layer_match_kind {
 	MATCH_CGROUP_PREFIX,
 	MATCH_COMM_PREFIX,
+	MATCH_PCOMM_PREFIX,
 	MATCH_NICE_ABOVE,
 	MATCH_NICE_BELOW,
 	MATCH_NICE_EQUALS,
@@ -80,6 +81,7 @@ struct layer_match {
 	int		kind;
 	char		cgroup_prefix[MAX_PATH];
 	char		comm_prefix[MAX_COMM];
+	char		pcomm_prefix[MAX_COMM];
 	int		nice;
 };
 

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -598,6 +598,12 @@ static bool match_one(struct layer_match *match, struct task_struct *p, const ch
 		memcpy(comm, p->comm, MAX_COMM);
 		return match_prefix(match->comm_prefix, comm, MAX_COMM);
 	}
+	case MATCH_PCOMM_PREFIX: {
+		char pcomm[MAX_COMM];
+
+		memcpy(pcomm, p->group_leader->comm, MAX_COMM);
+		return match_prefix(match->pcomm_prefix, pcomm, MAX_COMM);
+	}
 	case MATCH_NICE_ABOVE:
 		return prio_to_nice((s32)p->static_prio) > match->nice;
 	case MATCH_NICE_BELOW:
@@ -964,6 +970,9 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(layered_init)
 					break;
 				case MATCH_COMM_PREFIX:
 					dbg("%s COMM_PREFIX \"%s\"", header, match->comm_prefix);
+					break;
+				case MATCH_PCOMM_PREFIX:
+					dbg("%s PCOMM_PREFIX \"%s\"", header, match->pcomm_prefix);
 					break;
 				case MATCH_NICE_ABOVE:
 					dbg("%s NICE_ABOVE %d", header, match->nice);

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -189,10 +189,15 @@ lazy_static::lazy_static! {
 ///
 /// The configuration can be specified in multiple json files and command
 /// line arguments. Each must contain valid layer configurations and they're
-/// concatenated in the specified order. In most cases, something like the
-/// following should do.
+/// concatenated in the specified order.
+///
+/// By default, an argument to scx_layered is interpreted as a JSON string. If
+/// the argument is a pointer to a JSON file, it should be prefixed with file:
+/// or f: as follows:
 ///
 ///   $ scx_layered file:example.json
+///   ...
+///   $ scx_layered f:example.json
 ///
 /// Statistics
 /// ==========


### PR DESCRIPTION
If a library creates threads, those threads will often have the same
name. If two different processes of different priority both use a
library, it may be that we want the library's threads in each process to
be put into different layers.

To support this, let's add the ability to filter not only by task name,
but also by process name via the task thread group leader's comm.

Tested by creating two executables named "foo" and "bar", which both
spawn a bunch of tasks named "exp_worker" that spin until being
interrupted. With this config: https://pastebin.com/QSGwnkDF, the tasks
were correctly matched to the expected layers.