### PR TITLE
topology: Don't allocate on calls to span()

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -119,8 +119,8 @@ impl Core {
     }
 
     /// Get a Cpumask of all SMT siblings in this Core
-    pub fn span(&self) -> Cpumask {
-        self.span.clone()
+    pub fn span(&self) -> &Cpumask {
+        &self.span
     }
 }
 
@@ -143,8 +143,8 @@ impl Cache {
     }
 
     /// Get a Cpumask of all CPUs in this LLC
-    pub fn span(&self) -> Cpumask {
-        self.span.clone()
+    pub fn span(&self) -> &Cpumask {
+        &self.span
     }
 }
 
@@ -167,8 +167,8 @@ impl Node {
     }
 
     /// Get a Cpumask of all CPUs in this NUMA node
-    pub fn span(&self) -> Cpumask {
-        self.span.clone()
+    pub fn span(&self) -> &Cpumask {
+        &self.span
     }
 }
 
@@ -227,8 +227,8 @@ impl Topology {
     }
 
     /// Get a cpumask of all the online CPUs on the host
-    pub fn span(&self) -> Cpumask {
-        self.span.clone()
+    pub fn span(&self) -> &Cpumask {
+        &self.span
     }
 
     /// Get the maximum possible number of CPUs. Note that this number is likely

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -320,7 +320,7 @@ impl<'a> Scheduler<'a> {
         // Count the number of cores where all the CPUs are idle.
         for core in self.topo.cores().iter() {
             let mut all_idle = true;
-            for cpu_id in core.span().into_iter() {
+            for cpu_id in core.span().clone().into_iter() {
                 if self.bpf.get_cpu_pid(cpu_id as i32) != 0 {
                     all_idle = false;
                     break;

--- a/scheds/rust/scx_rusty/src/domain.rs
+++ b/scheds/rust/scx_rusty/src/domain.rs
@@ -71,7 +71,7 @@ impl DomainGroup {
             let mut doms: BTreeMap<usize, Domain> = BTreeMap::new();
             for (node_id, node) in top.nodes().iter().enumerate() {
                 for (_, llc) in node.llcs().iter() {
-                    let mask = llc.span();
+                    let mask = llc.span().clone();
                     span |= mask.clone();
                     doms.insert(dom_id, Domain { id: dom_id, mask, });
                     dom_numa_map.insert(dom_id, node_id.clone());


### PR DESCRIPTION
We're currently cloning cpumasks returned by calls to {Core, Cache, Node, Topology}::span(). If a caller needs to clone it, they can. Let's not penalize the callers that just want to query the underlying cpumask.

We might be able to further optimize -- the trait implementations for bitwise operations on Cpumasks don't take references on the rhs, so we're doing extra clones where we shouldn't need to. I also wasn't able to figure out how to iterate over the bits set in the underlying cpumask without using `.into_iter()`, which requires cloning as well.