### PR TITLE
layered: Make layered backwards compat with cpufreq

### DIFF
--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -126,6 +126,14 @@ pub fn struct_has_field(type_name: &str, field: &str) -> Result<bool> {
     return Ok(false);
 }
 
+pub fn kfunc_exists(kfunc: &str) -> Result<bool> {
+    let btf: &btf = *VMLINUX_BTF;
+
+    let kfunc_name = CString::new(kfunc).unwrap();
+    let tid = unsafe { btf__find_by_name_kind(btf, kfunc_name.as_ptr(), BTF_KIND_FUNC) };
+    Ok(tid >= 0)
+}
+
 /// struct sched_ext_ops can change over time. If
 /// compat.bpf.h::SCX_OPS_DEFINE() is used to define ops and scx_ops_load!()
 /// and scx_ops_attach!() are used to load and attach it, backward
@@ -176,5 +184,11 @@ mod tests {
         assert!(super::struct_has_field("task_struct", "flags").unwrap());
         assert!(!super::struct_has_field("task_struct", "NO_SUCH_FIELD").unwrap());
         assert!(super::struct_has_field("NO_SUCH_STRUCT", "NO_SUCH_FIELD").is_err());
+    }
+
+    #[test]
+    fn test_kfunc_exists() {
+        assert!(super::kfunc_exists("scx_bpf_consume").unwrap());
+        assert!(!super::kfunc_exists("NO_SUCH_KFUNC").unwrap());
     }
 }

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -100,7 +100,7 @@ struct cgroup *scx_bpf_task_cgroup(struct task_struct *p) __ksym;
 u32 scx_bpf_reenqueue_local(void) __ksym;
 u32 scx_bpf_cpuperf_cap(s32 cpu) __ksym;
 u32 scx_bpf_cpuperf_cur(s32 cpu) __ksym;
-void scx_bpf_cpuperf_set(u32 cpu, u32 perf) __ksym;
+void scx_bpf_cpuperf_set(u32 cpu, u32 perf) __ksym __weak;
 
 #define BPF_STRUCT_OPS(name, args...)						\
 SEC("struct_ops/"#name)								\

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -763,7 +763,7 @@ void BPF_STRUCT_OPS(layered_running, struct task_struct *p)
 		}
 	}
 
-	if (layer->perf > 0)
+	if (bpf_ksym_exists(scx_bpf_cpuperf_set) && layer->perf > 0)
 		scx_bpf_cpuperf_set(cpu, layer->perf);
 
 	cctx->maybe_idle = false;


### PR DESCRIPTION
Only the very newest kernels support scx_bpf_cpuperf_set(). Let's update
scx_layered to accommodate older kernels as well.