### PR TITLE
scx_lavd: use c_char consistently

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -198,7 +198,7 @@ impl<'a> Scheduler<'a> {
             );
         }
 
-        let c_tx_cm: *const c_char = (&tx.comm as *const [i8; 17]) as *const i8;
+        let c_tx_cm: *const c_char = (&tx.comm as *const [c_char; 17]) as *const c_char;
         let c_tx_cm_str: &CStr = unsafe { CStr::from_ptr(c_tx_cm) };
         let tx_comm: &str = c_tx_cm_str.to_str().unwrap();
 


### PR DESCRIPTION
In Rust c_char can be aliased to i8 or u8, depending on the particular target architecture.

For example, trying to build scx_lavd on ppc64 triggers the following error:

error[E0308]: mismatched types
   --> src/main.rs:200:38
    |
200 |         let c_tx_cm: *const c_char = (&tx.comm as *const [i8; 17]) as *const i8;
    |                      -------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
    |                      |
    |                      expected due to this
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`

To fix this, consistently use c_char instead of assuming it corresponds to i8.