### PR TITLE
scx_lavd: always inline submit_task_ctx to make the verifier happy

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -513,8 +513,8 @@ static void flip_sys_cpu_util(void)
 	__sys_cpu_util_idx ^= 0x1;
 }
 
-static int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc,
-			   u16 cpu_id)
+static __attribute__((always_inline))
+int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc, u16 cpu_id)
 {
 	struct sys_cpu_util *cutil_cur = get_sys_cpu_util_cur();
 	struct msg_task_ctx *m;


### PR DESCRIPTION
In _some_ kernel versions, loading scx_lavd fails with an error of "bpf_rcu_read_unlock is missing". The usage of
bpf_rcu_read_lock/unlock() in proc_dump_all_tasks() is correct but the bpf verifier still think bpf_rcu_read_unlock() is missing. The most plausible reason so far is that the problematic kernel does not have a commit 6fceea0fa59f ("bpf: Transfer RCU lock state between subprog calls"), failing inter-procedural analysis between proc_dump_all_tasks() and 
submit_task_ctx(). Thus, we force inline submit_task_ctx() (no inter-procedural analysis by the verifier is necessary) for the time being.

Suggested-by: Tejun Heo <tj@kernel.org>