### PR TITLE
rustland: bump up version

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland_core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Andrea Righi <andrea.righi@canonical.com>"]
 license = "GPL-2.0-only"

--- a/rust/scx_rustland_core/src/lib.rs
+++ b/rust/scx_rustland_core/src/lib.rs
@@ -1,5 +1,7 @@
 mod bindings;
 
+pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
 mod alloc;
 pub use alloc::ALLOCATOR;
 

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -12,11 +12,11 @@ ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "0.23"
 libc = "0.2.137"
 scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.2" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.3" }
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.2" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.3" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Andrea Righi <andrea.righi@canonical.com>", "Canonical"]
 edition = "2021"
 description = "A BPF component (dispatcher) that implements the low level sched-ext functionalities and a user-space counterpart (scheduler), written in Rust, that implements the actual scheduling policy. This is used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -16,12 +16,12 @@ libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
 scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.2" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.3" }
 simplelog = "0.12.0"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.2" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.3" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -34,6 +34,8 @@ use log::warn;
 
 const SCHEDULER_NAME: &'static str = "RustLand";
 
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
 /// scx_rustland: user-space scheduler written in Rust
 ///
 /// scx_rustland is designed to prioritize interactive workloads over background CPU-intensive
@@ -141,6 +143,10 @@ struct Opts {
     /// debugfs (e.g., /sys/kernel/debug/tracing/trace_pipe).
     #[clap(short = 'd', long, action = clap::ArgAction::SetTrue)]
     debug: bool,
+
+    /// Print scheduler version and exit.
+    #[clap(short = 'v', long, action = clap::ArgAction::SetTrue)]
+    version: bool,
 }
 
 // Time constants.
@@ -753,6 +759,16 @@ impl<'a> Drop for Scheduler<'a> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if opts.version {
+        println!(
+            "{} version {} - scx_rustland_core {}",
+            SCHEDULER_NAME,
+            VERSION,
+            scx_rustland_core::VERSION
+        );
+        return Ok(());
+    }
 
     let loglevel = simplelog::LevelFilter::Info;
 


### PR DESCRIPTION
Given that rustland now supports task preemption and it has been tested successfully, it's worhtwhile to cut a new version of the `scx_rustland_core` and `scx_rustland` crates.

Edit: also provide a `--version` command to print the version of `scx_rustland` and the version of the `scx_rustland_core` crate.