### PR TITLE
scx-utils: bump up version to 0.8.0

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -12,12 +12,12 @@ anyhow = "1.0"
 libbpf-rs = "0.23"
 libc = "0.2.137"
 buddy-alloc = "0.5.1"
-scx_utils = { path = "../scx_utils", version = "0.7" }
+scx_utils = { path = "../scx_utils", version = "0.8" }
 
 [build-dependencies]
 tar = "0.4"
 walkdir = "2.4"
-scx_utils = { path = "../scx_utils", version = "0.7" }
+scx_utils = { path = "../scx_utils", version = "0.8" }
 
 [lib]
 name = "scx_rustland_core"

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_utils"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -17,7 +17,7 @@ libbpf-rs = "0.23"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
 simplelog = "0.12.0"
 static_assertions = "1.1.0"
 rlimit = "0.10.1"
@@ -25,7 +25,7 @@ plain = "0.2.3"
 nix = "0.28.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -17,13 +17,13 @@ libbpf-rs = "0.23"
 libc = "0.2"
 log = "0.4"
 prometheus-client = "0.19"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -11,11 +11,11 @@ anyhow = "1.0.65"
 ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "0.23"
 libc = "0.2.137"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.3" }
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.3" }
 
 [features]

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -15,12 +15,12 @@ libbpf-rs = "0.23"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.3" }
 simplelog = "0.12.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.3" }
 
 [features]

--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -15,13 +15,13 @@ libbpf-rs = "0.23"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
-scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
 simplelog = "0.12.0"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "0.7" }
+scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION
Bump up scx-utils version to provide the new `scx_utils::TopologyMap` (and allow to publish a new `scx_rustland` crate).