### PR TITLE
scx_rustland_core: relax compact unevictable memory constraint

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland_core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Andrea Righi <andrea.righi@canonical.com>"]
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -12,11 +12,11 @@ ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "0.23"
 libc = "0.2.137"
 scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.3" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.4" }
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.3" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.4" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -16,12 +16,12 @@ libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
 scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.3" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.4" }
 simplelog = "0.12.0"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.3" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.4" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION
In order to prevent deadlock conditions user-space schedulers need to perform memory allocations from a pool of pre-allocated memory that will never be unmapped/reclaimed by the kernel (unevictable memory).

However, there is a special kernel sysctl setting
(vm.compact_unevictable_allowed) that allows kcompactd to reclaim unevictable memory. This behavior should be prevented by setting vm.compact_unevictable_allowed = 0, that is what scx_rustland_core does transparently when a scheduler is started, restoring the previous value when the scheduler is stopped.

Unfortunately, this is not always doable, especially when running a scheduler inside a containerized environment or under certain security/privilege restrictions (e.g., AppArmor confinement).

Therefore, just report a WARNING if we are unable to change this parameter, instead of considering it a hard-failure, to allow running scx_rustland_core schedulers also inside such limited environments.