### PR TITLE
ci: Also include gcc-multilib to fix CI

### DIFF
--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -16,7 +16,7 @@ jobs:
       ### DOWNLOAD AND INSTALL DEPENDENCIES ###
 
       # Download dependencies packaged by Ubuntu
-      - run: sudo apt -y install bison busybox-static cargo cmake coreutils cpio elfutils file flex gcc git iproute2 jq kbd kmod libcap-dev libelf-dev libunwind-dev libvirt-clients libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic make ninja-build pahole pkg-config python3-dev python3-pip python3-requests qemu-kvm rsync rustc udev zstd
+      - run: sudo apt -y install bison busybox-static cargo cmake coreutils cpio elfutils file flex gcc gcc-multilib git iproute2 jq kbd kmod libcap-dev libelf-dev libunwind-dev libvirt-clients libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic make ninja-build pahole pkg-config python3-dev python3-pip python3-requests qemu-kvm rsync rustc udev zstd
 
       # clang 17
       # Use a custom llvm.sh script which includes the -y flag for


### PR DESCRIPTION
We're failing in CI with:

/usr/include/string.h:26:10: fatal error: 'bits/libc-header-start.h' file not found
   26 | #include <bits/libc-header-start.h>

This header is apparently shipped with the gcc-multilib Ubuntu package, according to a Stack Overflow post. Let's see if this fixes CI.