### PR TITLE
Fix issue when CDPATH contains libbpf directory

### DIFF
--- a/meson-scripts/fetch_libbpf
+++ b/meson-scripts/fetch_libbpf
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+unset CDPATH
 cd $1
 rm -rf libbpf
 git clone --depth=1 https://github.com/libbpf/libbpf


### PR DESCRIPTION
When CDPATH is set the fetch_libbpf build script will cd into the preferred CDPATH directory. This change removes the CDPATH environment variable so any preferred CDPATH paths are ignored. The issue can be reproduced with the following steps:

```
$ mkdir -p /tmp/libbpf
$ CDPATH=/tmp/ meson setup build --prefix /tmp
```

The build should fail at the fetch_libbpf step.