### PR TITLE
scx_rusty: load balancing fixes

### DIFF
--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -311,7 +311,7 @@ impl LoadEntity {
     }
 
     fn xfer_between(&self, other: &LoadEntity) -> f64 {
-        self.imbal().min(other.imbal()).abs() * self.xfer_ratio
+        self.imbal().abs().min(other.imbal().abs()) * self.xfer_ratio
     }
 }
 

--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -714,11 +714,8 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
                     continue;
                 }
 
-                let weight = (task_ctx.weight as f64).min(self.infeas_threshold);
-
                 let rd = &task_ctx.dcyc_rd;
-                let load = weight
-                    * ravg_read(
+                let mut load = ravg_read(
                         rd.val,
                         rd.val_at,
                         rd.old,
@@ -727,6 +724,11 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
                         load_half_life,
                         RAVG_FRAC_BITS,
                     );
+
+                if self.lb_apply_weight {
+                    let weight = (task_ctx.weight as f64).min(self.infeas_threshold);
+                    load *= weight;
+                }
 
                 dom.tasks.insert(
                     TaskInfo {


### PR DESCRIPTION
Fix 1:

scx_rusty: make per-task loads sensitive to lb_apply_weight

Rusty's load balancer calculates load differently based on average system CPU utilization in create_domain_hierarchy().  At >= 99.999% utilization, load is the product of a task's weight and duty cycle; below that, load is the same as the task's duty cycle.

populate_tasks_by_load(), however, always uses the product when calculating per-task load so that in the sub-99.999% util case, load is inflated, typically by a factor of 100 with a normal priority task.  Tasks look too heavy to migrate as a result because a single task would transfer more load than the domain imbalance allows, leading to significant imbalance in some cases.

Make populate_tasks_by_load() calculate task load the same way as domain load, checking lb_apply_weight.

Here's a CPU utilization heatmap from an EPYC server before the fix.  Each pair of CPU rows are SMT siblings, every 16 CPUs are an LLC, and the top and bottom halves are nodes 0 and 1.  The total time is 2 minutes, and each square is a 1 second sample.

[![64users_iter1_240430_210719 mpstat %busy_small](https://github.com/sched-ext/scx/assets/1816081/b68735fe-4011-440c-8103-2cca1aa0f36c)](https://raw.githubusercontent.com/danieljordan10/scx/rusty-lb-fixes-hmap/64users_iter1_240430_210719.mpstat.%25busy.png)

Here's the same workload after the fix:

[![64users_iter1_240501_115702 mpstat %busy_small](https://github.com/sched-ext/scx/assets/1816081/5acd9915-1051-4f6f-b3ab-91b3d9332dd6)](https://raw.githubusercontent.com/danieljordan10/scx/rusty-lb-fixes-hmap/64users_iter1_240501_115702.mpstat.%25busy.png)

Fix 2:

scx_rusty: compare abs values in xfer_between()

A LoadEntity gets the load to transfer between two entities by taking the minimum of their imbalances and reducing its abs value by xfer_ratio.

In practice self.imbal(), the push node or domain, always has positive imbalance and other.imbal(), the pull node or domain, always has negative imbalance, so other.imbal() is always the minimum even though the abs value of its imbalance might be greater than the abs value of self.imbal().  It seems like the intent is to take the minimum of the two absolute values instead to avoid overbalancing at the puller, so make both values abs.