### PR TITLE
Make scx_rusty interactive

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -76,7 +76,7 @@ const volatile u32 greedy_threshold_x_numa;
 const volatile u32 debug;
 
 /* base slice duration */
-const volatile u64 slice_ns = SCX_SLICE_DFL;
+static u64 slice_ns = SCX_SLICE_DFL;
 
 /*
  * Per-CPU context
@@ -441,6 +441,7 @@ struct {
  */
 struct tune_input{
 	u64 gen;
+	u64 slice_ns;
 	u64 direct_greedy_cpumask[MAX_CPUS / 64];
 	u64 kick_greedy_cpumask[MAX_CPUS / 64];
 } tune_input;
@@ -477,6 +478,7 @@ static void refresh_tune_params(void)
 		return;
 
 	tune_params_gen = tune_input.gen;
+	slice_ns = tune_input.slice_ns;
 
 	bpf_for(cpu, 0, nr_cpus_possible) {
 		u32 dom_id = cpu_to_dom_id(cpu);

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -489,6 +489,12 @@ impl<'a> Scheduler<'a> {
             stat_pct(bpf_intf::stat_idx_RUSTY_STAT_KICK_GREEDY),
             stat_pct(bpf_intf::stat_idx_RUSTY_STAT_REPATRIATE),
         );
+        info!(
+            "dl_clamped={:5.2} dl_preset={:5.2}",
+            stat_pct(bpf_intf::stat_idx_RUSTY_STAT_DL_CLAMP),
+            stat_pct(bpf_intf::stat_idx_RUSTY_STAT_DL_PRESET),
+
+        );
 
         info!("direct_greedy_cpumask={}", self.tuner.direct_greedy_mask);
         info!("  kick_greedy_cpumask={}", self.tuner.kick_greedy_mask);

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -79,9 +79,13 @@ const MAX_CPUS: usize = bpf_intf::consts_MAX_CPUS as usize;
 /// limitation will be removed in the future.
 #[derive(Debug, Parser)]
 struct Opts {
-    /// Scheduling slice duration in microseconds.
-    #[clap(short = 's', long, default_value = "20000")]
-    slice_us: u64,
+    /// Scheduling slice duration for under-utilized hosts, in microseconds.
+    #[clap(short = 'u', long, default_value = "20000")]
+    slice_us_underutil: u64,
+
+    /// Scheduling slice duration for over-utilized hosts, in microseconds.
+    #[clap(short = 'o', long, default_value = "1000")]
+    slice_us_overutil: u64,
 
     /// Monitoring and load balance interval in seconds.
     #[clap(short = 'i', long, default_value = "2.0")]
@@ -305,7 +309,6 @@ impl<'a> Scheduler<'a> {
 	}
         skel.struct_ops.rusty_mut().exit_dump_len = opts.exit_dump_len;
 
-        skel.rodata_mut().slice_ns = opts.slice_us * 1000;
         skel.rodata_mut().load_half_life = (opts.load_half_life * 1000000000.0) as u32;
         skel.rodata_mut().kthreads_local = opts.kthreads_local;
         skel.rodata_mut().fifo_sched = opts.fifo_sched;
@@ -342,7 +345,11 @@ impl<'a> Scheduler<'a> {
 
             nr_lb_data_errors: 0,
 
-            tuner: Tuner::new(domains, opts.direct_greedy_under, opts.kick_greedy_under)?,
+            tuner: Tuner::new(domains,
+                              opts.direct_greedy_under,
+                              opts.kick_greedy_under,
+                              opts.slice_us_underutil * 1000,
+                              opts.slice_us_overutil * 1000,)?,
         })
     }
 
@@ -496,6 +503,7 @@ impl<'a> Scheduler<'a> {
 
         );
 
+        info!("slice_length={}us", self.tuner.slice_ns / 1000);
         info!("direct_greedy_cpumask={}", self.tuner.direct_greedy_mask);
         info!("  kick_greedy_cpumask={}", self.tuner.kick_greedy_mask);
 


### PR DESCRIPTION
## Overview

This is the first iteration that attempts to make `scx_rusty` more accommodating to interactive workloads. The patch set does the following:

- Makes `scx_rusty` a deadline scheduler, rather than a simple vtime scheduler. The deadline is calculated according to a number of factors:
    - First and foremost, the deadline is determined by a task's average runtime. Unlike with EEVDF, which sets a task's deadline based on its slice length, `scx_rusty` tracks a task's average runtime, and scales its deadline inversely according to its weight.
    - `scx_rusty` also tracks the frequency with which a task is blocked, and the frequency with which a task wakes other tasks. In the former case, the task is likely to be a consumer, and in the latter case, a producer (or both if the frequency is high for both). We calculate a `lat_prio` value for tasks when setting a deadline, which is inversely scaled by a task's block and waker frequency, and positively scaled by a task's average runtime.

While we could almost certainly go a lot further with calculating tasks' lat_prio values, this already performs quite well. More on this below.

- Updates `scx_rusty` to have a dynamic slice length. A longer slice length is used for under-utilized hosts, and a much shorter slice length is used for over-utilized hosts. These under/over util slice length values can be set when the scheduler is loaded, but are static thereafter. The scheduler will track utilization, and will adjust to use one or the other slice length depending on that util.

This is another example where we could almost certainly go further. For example, we could track slice length as a per-task construct, and e.g. throttle a task's slice when we determine that its average runtime is too high. For now, this also gives us very good results.

## Results

`scx_rusty` seems to perform remarkably well on common interactive workloads. I'll describe some of the benchmarks I ran below.

All benchmarks were run on a Ryzen 9 7950X. Each benchmark (unless stated otherwise) was run concurrently with an active Spotify session, as well as severe CPU contention via `$ stress-ng -c $((4 * $(nproc)))`:

### Terraria
Running terraria with `scx_rusty` under the above conditions results in roughly a 60-70% FPS improvement compared to EEVDF (on v6.8). See  the following video for a demonstration: https://drive.google.com/file/d/1fyHt9BYGha6apl7HAkibwpy52UTi8-AQ/view?usp=sharing

### Civilization 6
Running the standard, CPU-bound AI benchmark on Civilization 6 resulted in roughly a 2.5x improvement with `scx_rusty` over EEVDF:

#### EEVDF:
![civ_6_eevdf](https://github.com/sched-ext/scx/assets/4442853/66902e91-300d-4583-9665-8637db7403c5)


#### `scx_rusty`:
![civ_6_rusty](https://github.com/sched-ext/scx/assets/4442853/f3ddf4b2-478d-4dd4-a216-0ca46107a050)

If run without overcommitting the host, both schedulers appeared to perform equally.


### kcompile
Finally, I also tested doing a kcompile while the system is severely overutilized:

```
$ make CC=clang -j allyesconfig
$ /usr/bin/time make CC=clang -j $(nproc) # <-- testing this
```

#### EEVDF:
```
35:37.42elapsed
```

#### `scx_rusty`:
```
35:19.05elapsed
```

Only a sample size of one so not statistically significant, but at least indicative that this doesn't cause a regression.

# Future work

Here are some ideas for how this patch set could be expanded upon in the future:
1. Being more intentional and mathematical with how we're calculating lat_prio from waker/block frequencies and avg_runtime. The values chosen were fairly arbitrary and anecdotal. We should probably be more intentional and mathematically sound with how we're applying these.
2. Dynamically setting per-task slice, and be more fine-grained than just two global values
3. Make `scx_rusty` preempting to even further help interactive tasks