### PR TITLE
Update README with Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ We aim to build a friendly and approachable community around sched_ext. You
 can reach us through the following channels:
 
 - github: https://github.com/sched-ext/scx
-- Slack: https://schedextworkspace.slack.com
+- Slack: [https://schedextworkspace.slack.com](https://join.slack.com/t/schedextworkspace/shared_invite/zt-24c4on3sk-sHlozdLfCZBODfwU6t6dbw)
 - Reddit: https://reddit.com/r/sched_ext
 
 We also hold weekly office hours every monday. Please see the #office-hours


### PR DESCRIPTION
The current Slack URL gives a link to the Slack workspace, but doesn't include the invite. Update the URL to include the invite URL to make it easier for people to join the Slack workspace.