### PR TITLE
scx_lavd: support CPU frequency scaling

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -124,6 +124,7 @@ volatile u64			nr_cpus_onln;
 static struct sys_cpu_util	__sys_cpu_util[2];
 static volatile int		__sys_cpu_util_idx;
 
+const volatile bool		no_freq_scaling;
 const volatile u8		verbose;
 
 UEI_DEFINE(uei);
@@ -518,7 +519,12 @@ static __attribute__((always_inline))
 int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc, u16 cpu_id)
 {
 	struct sys_cpu_util *cutil_cur = get_sys_cpu_util_cur();
+	struct cpu_ctx *cpuc;
 	struct msg_task_ctx *m;
+
+	cpuc = get_cpu_ctx_id(cpu_id);
+	if (!cpuc)
+		return -EINVAL;
 
 	m = bpf_ringbuf_reserve(&introspec_msg, sizeof(*m), 0);
 	if (!m)
@@ -528,12 +534,13 @@ int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc, u16 cpu_id)
 	m->taskc_x.pid = p->pid;
 	memcpy(m->taskc_x.comm, p->comm, TASK_COMM_LEN);
 	m->taskc_x.static_prio = get_nice_prio(p);
-	m->taskc_x.cpu_util = cutil_cur->util / 10;
+	m->taskc_x.cpu_util = cpuc->util / 10;
 	m->taskc_x.sys_load_factor = cutil_cur->load_factor / 10;
 	m->taskc_x.cpu_id = cpu_id;
 	m->taskc_x.max_lat_cri = cutil_cur->max_lat_cri;
 	m->taskc_x.min_lat_cri = cutil_cur->min_lat_cri;
 	m->taskc_x.avg_lat_cri = cutil_cur->avg_lat_cri;
+	m->taskc_x.avg_perf_cri = cutil_cur->avg_perf_cri;
 
 	memcpy(&m->taskc, taskc, sizeof(m->taskc));
 
@@ -666,11 +673,12 @@ static void update_sys_cpu_load(void)
 {
 	struct sys_cpu_util *cutil_cur = get_sys_cpu_util_cur();
 	struct sys_cpu_util *cutil_next = get_sys_cpu_util_next();
-	u64 now, duration, duration_total;
+	u64 now, duration, duration_total, compute, idle;
 	u64 idle_total = 0, compute_total = 0;
 	u64 load_actual = 0, load_ideal = 0, load_run_time_ns = 0;
 	s64 max_lat_cri = 0, min_lat_cri = UINT_MAX, avg_lat_cri = 0;
 	u64 sum_lat_cri = 0, sched_nr = 0;
+	u64 sum_perf_cri = 0, avg_perf_cri = 0;
 	u64 new_util, new_load_factor;
 	int cpu;
 
@@ -713,6 +721,12 @@ static void update_sys_cpu_load(void)
 		cpuc->min_lat_cri = UINT_MAX;
 
 		/*
+		 * Accumulate task's performance criticlity information.
+		 */
+		sum_perf_cri += cpuc->sum_perf_cri;
+		cpuc->sum_perf_cri = 0;
+
+		/*
 		 * If the CPU is in an idle state (i.e., idle_start_clk is
 		 * non-zero), accumulate the current idle peirod so far.
 		 */
@@ -729,6 +743,18 @@ static void update_sys_cpu_load(void)
 			}
 		}
 
+		/*
+		 * Calculcate per-CPU utilization
+		 */
+		compute = 0;
+		if (duration > cpuc->idle_total)
+			compute = duration - cpuc->idle_total;
+		new_util = (compute * LAVD_CPU_UTIL_MAX) / duration;
+		cpuc->util = calc_avg(cpuc->util, new_util);
+
+		/*
+		 * Accmulate system-wide idle time
+		 */
 		idle_total += cpuc->idle_total;
 		cpuc->idle_total = 0;
 	}
@@ -752,9 +778,12 @@ static void update_sys_cpu_load(void)
 		min_lat_cri = cutil_cur->min_lat_cri;
 		max_lat_cri = cutil_cur->max_lat_cri;
 		avg_lat_cri = cutil_cur->avg_lat_cri;
+		avg_perf_cri = cutil_cur->avg_perf_cri;
 	}
-	else
+	else {
 		avg_lat_cri = sum_lat_cri / sched_nr;
+		avg_perf_cri = sum_perf_cri / sched_nr;
+	}
 
 	/*
 	 * Update the CPU utilization to the next version.
@@ -770,6 +799,7 @@ static void update_sys_cpu_load(void)
 	cutil_next->thr_lat_cri = cutil_next->avg_lat_cri +
 				  ((cutil_next->max_lat_cri -
 				    cutil_next->avg_lat_cri) >> 1);
+	cutil_next->avg_perf_cri = calc_avg(cutil_cur->avg_perf_cri, avg_perf_cri);
 
 	/*
 	 * Calculate the increment for latency criticality to priority mapping
@@ -1044,7 +1074,7 @@ static int boost_lat(struct task_struct *p, struct task_ctx *taskc,
 		     struct cpu_ctx *cpuc, bool is_wakeup)
 {
 	u64 run_time_ft = 0, wait_freq_ft = 0, wake_freq_ft = 0;
-	u64 lat_cri_raw = 0;
+	u64 lat_cri_raw, perf_cri_raw;
 	u16 static_prio;
 	int boost;
 
@@ -1285,6 +1315,8 @@ static void update_stat_for_running(struct task_struct *p,
 {
 	u64 wait_period, interval;
 	u64 now = bpf_ktime_get_ns();
+	u64 load_actual_ft, load_ideal_ft, wait_freq_ft, wake_freq_ft;
+	u64 perf_cri_raw;
 
 	/*
 	 * Since this is the start of a new schedule for @p, we update run
@@ -1306,6 +1338,29 @@ static void update_stat_for_running(struct task_struct *p,
 		cpuc->min_lat_cri = taskc->lat_cri;
 	cpuc->sum_lat_cri += taskc->lat_cri;
 	cpuc->sched_nr++;
+
+	/*
+	 * Update task's performance criticality
+	 *
+	 * A task is more CPU-performance sensitive when it meets the following
+	 * conditions:
+	 *
+	 * - Its actual load (runtime * run_freq) is high;
+	 * - Its nice priority is high;
+	 * - It is in the middle of the task graph (high wait and wake
+	 *   frequencies).
+	 *
+	 * We use the log-ed value since the raw value follows the highly
+	 * skewed distribution.
+	 */
+	load_actual_ft = calc_runtime_factor(taskc->load_actual);
+	load_ideal_ft = get_task_load_ideal(p);
+	wait_freq_ft = calc_freq_factor(taskc->wait_freq);
+	wake_freq_ft = calc_freq_factor(taskc->wake_freq);
+	perf_cri_raw = load_actual_ft * load_ideal_ft *
+		       wait_freq_ft * wake_freq_ft;
+	taskc->perf_cri = bpf_log2l(perf_cri_raw + 1);
+	cpuc->sum_perf_cri += taskc->perf_cri;
 
 	/*
 	 * Update task state when starts running.
@@ -1761,6 +1816,44 @@ void BPF_STRUCT_OPS(lavd_dispatch, s32 cpu, struct task_struct *prev)
 	scx_bpf_consume(LAVD_GLOBAL_DSQ);
 }
 
+static u32 calc_cpuperf_target(struct sys_cpu_util *cutil_cur,
+			       struct task_ctx *taskc, struct cpu_ctx *cpuc)
+{
+	u64 max_load, cpu_load;
+	u32 cpuperf_target;
+
+	/*
+	 * If a task with an average performance criticality of the current CPU
+	 * consumes 100% of CPU time, we set the CPU performance to the
+	 * maximum.
+	 */
+	max_load = cutil_cur->avg_perf_cri * 1000 /* max cpu util */;
+	cpu_load = taskc->perf_cri * cpuc->util;
+	cpuperf_target = (cpu_load * SCX_CPUPERF_ONE) / max_load;
+	return min(cpuperf_target, SCX_CPUPERF_ONE);
+}
+
+void BPF_STRUCT_OPS(lavd_tick, struct task_struct *p)
+{
+	struct sys_cpu_util *cutil_cur = get_sys_cpu_util_cur();
+	struct cpu_ctx *cpuc;
+	struct task_ctx *taskc;
+	u32 cpuperf_target;
+
+	cpuc = get_cpu_ctx();
+	taskc = get_task_ctx(p);
+	if (!cpuc || !taskc)
+		return;
+
+	/*
+	 * Update performance target of the current CPU
+	 */
+	if (!no_freq_scaling) {
+		cpuperf_target = calc_cpuperf_target(cutil_cur, taskc, cpuc);
+		scx_bpf_cpuperf_set(scx_bpf_task_cpu(p), cpuperf_target);
+	}
+}
+
 void BPF_STRUCT_OPS(lavd_runnable, struct task_struct *p, u64 enq_flags)
 {
 	struct cpu_ctx *cpuc;
@@ -2169,6 +2262,7 @@ SCX_OPS_DEFINE(lavd_ops,
 	       .select_cpu		= (void *)lavd_select_cpu,
 	       .enqueue			= (void *)lavd_enqueue,
 	       .dispatch		= (void *)lavd_dispatch,
+	       .tick			= (void *)lavd_tick,
 	       .runnable		= (void *)lavd_runnable,
 	       .running			= (void *)lavd_running,
 	       .stopping		= (void *)lavd_stopping,


### PR DESCRIPTION
This PR supports CPU frequency scaling in scx_lavd in a minimal form. 

We keep track of 1) utilization of each CPU and 2) _performance criticality_ of each task to know the required CPU performance (e.g., frequency) demand. The performance criticality of a task denotes how critical it is to CPU performance (frequency). Like the notion of latency criticality, we use three factors: the task's average runtime, wake-up frequency, and waken-up frequency. A task's runtime is longer, and its two frequencies are higher; the task is more performance-critical because it would be a bottleneck in the middle of the task chain.