### PR TITLE
ci: enable kvm support in the github workflow

### DIFF
--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -61,5 +61,11 @@ jobs:
       # debugging purposes)
       - run: grep 'model name' /proc/cpuinfo | head -1
 
+      # Setup KVM support
+      - run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       # Test schedulers
       - run: meson compile -C build test_sched

--- a/meson-scripts/test_sched
+++ b/meson-scripts/test_sched
@@ -39,14 +39,15 @@ for sched in ${SCHEDULERS}; do
 
     rm -f /tmp/output
     timeout --preserve-status ${GUEST_TIMEOUT} \
-        vng --force-9p --disable-microvm -v -r ${kernel} -- \
+        vng --force-9p -v -r ${kernel} -- \
             "timeout --foreground --preserve-status ${TEST_TIMEOUT} ${sched_path}" \
                 2> >(tee /tmp/output) </dev/null
-        sed -n -e '/\bBUG:/q1' \
-	       -e '/\bWARNING:/q1' \
-	       -e '/\berror\b/Iq1' \
-	       -e '/\bstall/Iq1' \
-	       -e '/\btimeout\b/Iq1' /tmp/output
+        grep -v " Speculative Return Stack Overflow" /tmp/output | \
+            sed -n -e '/\bBUG:/q1' \
+                   -e '/\bWARNING:/q1' \
+                   -e '/\berror\b/Iq1' \
+                   -e '/\bstall/Iq1' \
+                   -e '/\btimeout\b/Iq1'
     res=$?
     if [ ${res} -ne 0 ]; then
         echo "FAIL: ${sched}"


### PR DESCRIPTION
Enable kvm acceleration and qemu microvm to speed up CI tests inside virtme-ng.

Also adjust the regex to catch potential errors excluding a false positive triggered by the new configuration.

Link: https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
Link: https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/