### PR TITLE
rusty: Support CPU hotplug onlining

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -261,6 +261,10 @@ static inline u32 bpf_log2l(u64 v)
                 return bpf_log2(v) + 1;
 }
 
+/* useful compiler attributes */
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+
 void *bpf_obj_new_impl(__u64 local_type_id, void *meta) __ksym;
 void bpf_obj_drop_impl(void *kptr, void *meta) __ksym;
 

--- a/scheds/rust/scx_rusty/src/bpf/intf.h
+++ b/scheds/rust/scx_rusty/src/bpf/intf.h
@@ -127,12 +127,6 @@ struct task_ctx {
 	/* select_cpu() telling enqueue() to queue directly on the DSQ */
 	bool dispatch_local;
 
-	/*
-	 * Task couldn't find a domain to run on. Is likely affinitized to an
-	 * offline core
-	 */
-	bool offline;
-
 	struct ravg_data dcyc_rd;
 };
 

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -748,7 +748,6 @@ static bool task_set_domain(struct task_ctx *taskc, struct task_struct *p,
 	new_domc = try_lookup_dom_ctx(new_dom_id);
 	if (!new_domc) {
 		if (new_dom_id == NO_DOM_FOUND) {
-			taskc->offline = true;
 			bpf_cpumask_clear(t_cpumask);
 			return !(p->scx.flags & SCX_TASK_QUEUED);
 		} else {
@@ -1248,12 +1247,6 @@ void BPF_STRUCT_OPS(rusty_runnable, struct task_struct *p, u64 enq_flags)
 
 	if (!(wakee_ctx = lookup_task_ctx(p)))
 		return;
-
-	if (wakee_ctx->offline) {
-		scx_bpf_error("Offline task [%s](%d) is becoming runnable",
-			      p->comm, p->pid);
-		return;
-	}
 
 	wakee_ctx->is_kworker = p->flags & PF_WQ_WORKER;
 

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -304,9 +304,9 @@ impl<'a> Scheduler<'a> {
             }
         }
 
-	if opts.partial {
+        if opts.partial {
             skel.struct_ops.rusty_mut().flags |= *compat::SCX_OPS_SWITCH_PARTIAL;
-	}
+        }
         skel.struct_ops.rusty_mut().exit_dump_len = opts.exit_dump_len;
 
         skel.rodata_mut().load_half_life = (opts.load_half_life * 1000000000.0) as u32;


### PR DESCRIPTION
There's currently a slight issue on existing kernels on the hotplug
path wherein we can start to receive scheduling callbacks on a CPU
before that CPU has received hotplug events. For CPUs going online, this
can possibly confuse a scheduler because it may not be expecting
anything to ever happen on that CPU, and therefore may do things that
could cause the scheduler to crash. For example, without this PR,
scx_rusty will try to consume from a bogus DSQ that doesn't exist on the
hotplug online path, which causes ext.c to boot out the scheduler.
    
Though this issue will soon be fixed in ext.c, let's explicitly add the
necessary logic to scx_rusty so that it supports hotplug onlining.