### PR TITLE
scx_rustland_core: use a BPF_MAP_TYPE_USER_RINGBUF to dispatch tasks

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -9,7 +9,8 @@ description = "Framework to implement sched_ext schedulers running in user space
 
 [dependencies]
 anyhow = "1.0"
-libbpf-rs = "0.23"
+plain = "0.2.3"
+libbpf-rs = "0.23.1"
 libc = "0.2.137"
 buddy-alloc = "0.5.1"
 scx_utils = { path = "../scx_utils", version = "0.8" }

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -8,8 +8,9 @@ license = "GPL-2.0-only"
 
 [dependencies]
 anyhow = "1.0.65"
+plain = "0.2.3"
 ctrlc = { version = "3.1", features = ["termination"] }
-libbpf-rs = "0.23"
+libbpf-rs = "0.23.1"
 libc = "0.2.137"
 scx_utils = { path = "../../../rust/scx_utils", version = "0.8" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "0.4" }

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -8,10 +8,11 @@ license = "GPL-2.0-only"
 
 [dependencies]
 anyhow = "1.0.65"
+plain = "0.2.3"
 clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7.0"
-libbpf-rs = "0.23"
+libbpf-rs = "0.23.1"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"


### PR DESCRIPTION
Replace the BPF_MAP_TYPE_QUEUE with a BPF_MAP_TYPE_USER_RINGBUF to store the tasks dispatched from the user-space scheduler to the BPF component.

This eliminates the need of the bpf() syscalls, significantly reducing the overhead of the user-space->kernel communication and delivering a notable performance boost in the overall system throughput.

Based on experimental results, this change allows to reduces the scheduling overhead by approximately 30-35% when the system is overcommitted.

This improvement has the potential to make user-space schedulers based on scx_rustland_core viable options for real production systems.

Link: https://github.com/libbpf/libbpf-rs/pull/776