### PR TITLE
rustland: reduce scheduling overhead

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -293,24 +293,6 @@ impl<'cb> BpfScheduler<'cb> {
         }
     }
 
-    // Override the default scheduler time slice (in us).
-    #[allow(dead_code)]
-    pub fn set_effective_slice_us(&mut self, slice_us: u64) {
-        self.skel.bss_mut().effective_slice_ns = slice_us * 1000;
-    }
-
-    // Get current value of time slice (slice_ns).
-    #[allow(dead_code)]
-    pub fn get_effective_slice_us(&mut self) -> u64 {
-        let slice_ns = self.skel.bss().effective_slice_ns;
-
-        if slice_ns > 0 {
-            slice_ns / 1000
-        } else {
-            self.skel.rodata().slice_ns / 1000
-        }
-    }
-
     // Counter of queued tasks.
     #[allow(dead_code)]
     pub fn nr_queued_mut(&mut self) -> &mut u64 {

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -700,14 +700,6 @@ void BPF_STRUCT_OPS(rustland_stopping, struct task_struct *p, bool runnable)
 
 /*
  * A CPU is about to change its idle state.
- *
- * NOTE: implementing an update_idle() callback automatically disables the
- * built-in idle tracking. This is fine because we want to rely on the internal
- * CPU ownership map (get_cpu_owner() / set_cpu_owner()) to determine if a CPU
- * is available or not.
- *
- * This information can easily be shared with the user-space scheduler via
- * cpu_map.
  */
 void BPF_STRUCT_OPS(rustland_update_idle, s32 cpu, bool idle)
 {

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -53,12 +53,6 @@ const volatile bool switch_partial; /* Switch all tasks or SCHED_EXT tasks */
 const volatile u64 slice_ns = SCX_SLICE_DFL; /* Base time slice duration */
 
 /*
- * Effective time slice: allow the scheduler to override the default time slice
- * (slice_ns) if this one is set.
- */
-volatile u64 effective_slice_ns;
-
-/*
  * Number of tasks that are queued for scheduling.
  *
  * This number is incremented by the BPF component when a task is queued to the
@@ -321,8 +315,7 @@ dispatch_task(struct task_struct *p, u64 dsq_id,
 	      u64 cpumask_cnt, u64 task_slice_ns, u64 enq_flags)
 {
 	struct task_ctx *tctx;
-	u64 slice = task_slice_ns ? :
-		__sync_fetch_and_add(&effective_slice_ns, 0) ? : slice_ns;
+	u64 slice = task_slice_ns ? : slice_ns;
 	u64 curr_cpumask_cnt;
 	bool force_shared = false;
 	s32 cpu;

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -271,26 +271,33 @@ impl Topology {
 pub struct TopologyMap {
     map: Vec<Vec<usize>>,
     nr_cpus_possible: usize,
+    nr_cpus_online: usize,
 }
 
 impl TopologyMap {
     pub fn new(topo: Topology) -> Result<TopologyMap> {
         let mut map: Vec<Vec<usize>> = Vec::new();
+        let mut nr_cpus_online = 0;
 
         for core in topo.cores().into_iter() {
             let mut cpu_ids: Vec<usize> = Vec::new();
             for cpu_id in core.span().clone().into_iter() {
                 cpu_ids.push(cpu_id);
+                nr_cpus_online += 1;
             }
             map.push(cpu_ids);
         }
         let nr_cpus_possible = topo.nr_cpus_possible;
 
-        Ok(TopologyMap { map, nr_cpus_possible, })
+        Ok(TopologyMap { map, nr_cpus_possible, nr_cpus_online })
     }
 
     pub fn nr_cpus_possible(&self) -> usize {
         self.nr_cpus_possible
+    }
+
+    pub fn nr_cpus_online(&self) -> usize {
+        self.nr_cpus_online
     }
 
     pub fn iter(&self) -> Iter<Vec<usize>> {

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -290,7 +290,7 @@ impl<'a> Scheduler<'a> {
         let init_page_faults: u64 = 0;
 
         // Low-level BPF connector.
-        let nr_online_cpus = topo_map.nr_cpus_possible();
+        let nr_online_cpus = topo_map.nr_cpus_online();
         let bpf = BpfScheduler::init(
             opts.slice_us,
             nr_online_cpus as i32,
@@ -385,7 +385,7 @@ impl<'a> Scheduler<'a> {
         //
         // This allows to survive stress tests that are spawning a massive amount of
         // tasks.
-        self.eff_slice_boost = (self.slice_boost * self.topo_map.nr_cpus_possible() as u64
+        self.eff_slice_boost = (self.slice_boost * self.topo_map.nr_cpus_online() as u64
             / self.task_pool.tasks.len().max(1) as u64)
             .max(1);
 


### PR DESCRIPTION
This PR contains a set of changes that I've been experimenting with for some time.

Given the optimized communication between user-space -> kernel (#270), it seems like a good time now to apply also these changes and potentially elevate scx_rustland to a more production-ready scheduler.

With these changes in place we can reduce the CPU time used by the scheduler and improve the level of responsiveness whether the system is under or over commissioned.

In terms of numbers the improvement can be quantified around a +4-5% boost in fps in games, such as Baldur's Gate 3, Counter-Strike 2 and Cyberpunk 2077, when the system is over commissioned. <s>The same results can be obtained both in the under-commissioned and over-commissioned scenarios.</s>

Here is a short summary of the changes:
 - `scx_rustland_core: implement effective time slice on a per-task basis`: remove the global dynamic slice_ns and set a time slice on a per-task basis
 - <s>`scx_rustland_core: switch to FIFO when system is underutilized`: automatically switch to a simple FIFO when the scheduler is not really needed (under commissioned system)</s>
 - `scx_rustland_core: refine built-in CPU idle selection logic`:  improve the BPF `select_cpu()` logic differentiating tasks waking up from a wait state vs tasks not coming from a wait state
<s>- `scx_rustland_core: optimize update_idle()`: do not re-kick the current CPU when entering an idle state (since it seems to introduce more overhead than benefits with all the recent changes applied)</s>

Edit: do not merge yet, because I would like to do more tests with the last change (the one about `update_idle()`), since it could regress some workloads.

Edit: dropped the `update_idle()` that actually seems to introduce big regressions with CPU-intensive workloads (making a kernel build too much slower, for example).

Edit: update description with fps results.

Edit: temporarily dropped the FIFO mode change from this PR, since it requires more testing. The switch to FIFO mode makes the system quite unresponsive if all of a sudden a bunch of tasks are spawned and the scheduler doesn't react fast enough at exiting from FIFO mode. Even if it can provide a slightly boost when the system is under commissioned, it's still preferable for now to maintain the reliability of the scheduler to provide system responsiveness in all the possible scenarios. I'll re-introduce the FIFO mode in a separate PR after more tweaking and testing.