### PR TITLE
systemd-service: Don't restart always

### DIFF
--- a/services/systemd/scx.service
+++ b/services/systemd/scx.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=Start scx_scheduler
 ConditionPathIsDirectory=/sys/kernel/sched_ext
+StartLimitIntervalSec=30
+StartLimitBurst=2
 
 [Service]
 Type=simple
 EnvironmentFile=/etc/default/scx
 ExecStart=/bin/bash -c 'exec $SCX_SCHEDULER $SCX_FLAGS '
-Restart=always
+Restart=on-failure
 StandardError=journal
 LogNamespace=sched-ext
 


### PR DESCRIPTION
Currently if the scx.service is failing to launch due issues, systemd will try to start the scheduler all the time. This results into a massive flood to the kernel and does not bring the service up again.

explanation of the changes:
The StartLimitBurst=2 and StartLimitIntervalSec=30 settings tell systemd that if the service unsuccessfully tries to restart itself twice within 30 seconds, it should enter a failed state and no longer try to restart. This ensures that if the service is truly broken, systemd won't continuously try to restart it.