### PR TITLE
scx_lavd: support yield-based preemption

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -56,8 +56,8 @@ enum consts {
 	LAVD_MAX_CAS_RETRY		= 8,
 
 	LAVD_TARGETED_LATENCY_NS	= (15 * NSEC_PER_MSEC),
-	LAVD_SLICE_MIN_NS		= (300 * NSEC_PER_USEC),/* min time slice */
-	LAVD_SLICE_MAX_NS		= (3 * NSEC_PER_MSEC),	/* max time slice */
+	LAVD_SLICE_MIN_NS		= ( 1 * NSEC_PER_MSEC), /* min time slice */
+	LAVD_SLICE_MAX_NS		= (15 * NSEC_PER_MSEC), /* max time slice */
 	LAVD_SLICE_UNDECIDED		= SCX_SLICE_INF,
 	LAVD_SLICE_GREEDY_FT		= 3,
 	LAVD_LOAD_FACTOR_ADJ		= 6,
@@ -73,18 +73,17 @@ enum consts {
 	LAVD_GREEDY_RATIO_MAX		= USHRT_MAX,
 	LAVD_LAT_PRIO_IDLE		= USHRT_MAX,
 
-	LAVD_ELIGIBLE_TIME_LAT_FT	= 2,
-	LAVD_ELIGIBLE_TIME_MAX		= LAVD_TARGETED_LATENCY_NS,
+	LAVD_ELIGIBLE_TIME_LAT_FT	= 16,
+	LAVD_ELIGIBLE_TIME_MAX		= (LAVD_SLICE_MIN_NS >> 8),
 
 	LAVD_CPU_UTIL_MAX		= 1000, /* 100.0% */
 	LAVD_CPU_UTIL_INTERVAL_NS	= (100 * NSEC_PER_MSEC), /* 100 msec */
-	LAVD_CPU_ID_HERE		= ((u16)-2),
-	LAVD_CPU_ID_NONE		= ((u16)-1),
+	LAVD_CPU_ID_HERE		= ((u32)-2),
+	LAVD_CPU_ID_NONE		= ((u32)-1),
 
-	LAVD_FREQ_CPU_UTIL_THRES	= 950, /* 95.0% */
-
-	LAVD_PREEMPT_KICK_LAT_PRIO	= 18,
-	LAVD_PREEMPT_KICK_MARGIN	= (LAVD_SLICE_MIN_NS >> 1),
+	LAVD_PREEMPT_KICK_LAT_PRIO	= 15,
+	LAVD_PREEMPT_KICK_MARGIN	= (LAVD_SLICE_MIN_NS >> 3),
+	LAVD_PREEMPT_TICK_MARGIN	= (LAVD_SLICE_MIN_NS >> 8),
 
 	LAVD_GLOBAL_DSQ			= 0,
 };
@@ -180,10 +179,10 @@ struct task_ctx {
 	u64	slice_ns;		/* time slice */
 	u64	greedy_ratio;		/* task's overscheduling ratio compared to its nice priority */
 	u64	lat_cri;		/* calculated latency criticality */
+	volatile s32 victim_cpu;
 	u16	slice_boost_prio;	/* how many times a task fully consumed the slice */
 	u16	lat_prio;		/* latency priority */
 	s16	lat_boost_prio;		/* DEBUG */
-	s16	victim_cpu;		/* DEBUG */
 
 	/*
 	 * Task's performance criticality
@@ -195,11 +194,9 @@ struct task_ctx_x {
 	pid_t	pid;
 	char	comm[TASK_COMM_LEN + 1];
 	u16	static_prio;	/* nice priority */
-	u16	cpu_id;		/* where a task ran */
+	u32	cpu_id;		/* where a task ran */
 	u64	cpu_util;	/* cpu utilization in [0..100] */
 	u64	sys_load_factor; /* system load factor in [0..100..] */
-	u64	max_lat_cri;	/* maximum latency criticality */
-	u64	min_lat_cri;	/* minimum latency criticality */
 	u64	avg_lat_cri;	/* average latency criticality */
 	u64	avg_perf_cri;	/* average performance criticality */
 };

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1440,21 +1440,13 @@ static int get_random_directional_inc(u32 nuance)
 static  bool can_task1_kick_task2(struct preemption_info *prm_task1,
 				  struct preemption_info *prm_task2)
 {
-	int ret;
-
-	ret = comp_preemption_info(prm_task1, prm_task2);
-	if (ret < 0)
-		return true;
-
-	return false;
+	return comp_preemption_info(prm_task1, prm_task2) < 0;
 }
 
 static  bool can_cpu1_kick_cpu2(struct preemption_info *prm_cpu1,
 				struct preemption_info *prm_cpu2,
 				struct cpu_ctx *cpuc2)
 {
-	int ret;
-
 	/*
 	 * Set a CPU information
 	 */
@@ -1467,11 +1459,7 @@ static  bool can_cpu1_kick_cpu2(struct preemption_info *prm_cpu1,
 	 * If that CPU runs a lower priority task, that's a victim
 	 * candidate.
 	 */
-	ret = comp_preemption_info(prm_cpu1, prm_cpu2);
-	if (ret < 0)
-		return true;
-
-	return false;
+	return comp_preemption_info(prm_cpu1, prm_cpu2) < 0;
 }
 
 static bool is_worth_kick_other_task(struct task_ctx *taskc)

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -172,8 +172,7 @@ impl<'a> Scheduler<'a> {
                 "| {:9} | {:8} | {:17} \
                    | {:4} | {:4} | {:9} \
                    | {:9} | {:10} | {:9} \
-                   | {:8} | {:7} | {:7} \
-                   | {:7} | {:7} | {:12} \
+                   | {:8} | {:7} | {:12} \
                    | {:7} | {:9} | {:9} \
                    | {:9} | {:9} | {:9} \
                    | {:8} | {:8} | {:8} \
@@ -188,10 +187,7 @@ impl<'a> Scheduler<'a> {
                 "slice_ns",
                 "grdy_rt",
                 "lat_prio",
-                "lat_cri",
-                "min_lc",
                 "avg_lc",
-                "max_lc",
                 "static_prio",
                 "lat_bst",
                 "slice_bst",
@@ -214,8 +210,7 @@ impl<'a> Scheduler<'a> {
             "| {:9} | {:8} | {:17} \
                | {:4} | {:4} | {:9} \
                | {:9} | {:10} | {:9} \
-               | {:8} | {:7} | {:7} \
-               | {:7} | {:7} | {:12} \
+               | {:8} | {:7} | {:12} \
                | {:7} | {:9} | {:9} \
                | {:9} | {:9} | {:9} \
                | {:8} | {:8} | {:8} \
@@ -230,10 +225,7 @@ impl<'a> Scheduler<'a> {
             tc.slice_ns,
             tc.greedy_ratio,
             tc.lat_prio,
-            tc.lat_cri,
-            tx.min_lat_cri,
             tx.avg_lat_cri,
-            tx.max_lat_cri,
             tx.static_prio,
             tc.lat_boost_prio,
             tc.slice_boost_prio,


### PR DESCRIPTION
If there is a higher priority task when running ops.tick(), ops.select_cpu(), and ops.enqueue() callbacks, the current running tasks yields its CPU by shrinking time slice to zero and a higher priority task can run on the current CPU.

As low-cost, fine-grained preemption becomes available, default parameters are adjusted as follows:
  - Raise the bar for remote CPU preemption to avoid IPIs.
  - Increase the maximum time slice.
  - Gradually enforce the fair use of CPU time (i.e., ineligible duration)

Lastly, using CAS, we ensure that a remote CPU is preempted by only one CPU. This removes unnecessary remote preemptions (and IPIs).