### PR TITLE
topology: Check if NUMA sysfs directory not present

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -441,5 +441,10 @@ fn create_numa_nodes(online_mask: &Cpumask) -> Result<Vec<Node>> {
 
         nodes.push(node);
     }
+
+    if nodes.is_empty() {
+        bail!("No node found, does sysfs directory /sys/devices/system/node exist?");
+    }
+
     Ok(nodes)
 }


### PR DESCRIPTION
We've gotten bug reports of people trying to use scx_rusty, but having it exit immediately due to not having a domain. This can happen if running in an environment where for some reason, there are no NUMA nodes in the sysfs hierarchy. For example, this was observed when someone was running scx_rusty on wsl2.

We could assume by default that there's a single NUMA node, but it'd require us to rewrite some of the parsing logic. Let's just explicitly handle the case for now.