### PR TITLE
scx_rustland: maximize CPU utilization

### DIFF
--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -522,7 +522,7 @@ impl<'a> Scheduler<'a> {
         // This allows to have more tasks sitting in the task pool, reducing the pressure on the
         // dispatcher queues and giving a chance to higher priority tasks to come in and get
         // dispatched earlier, mitigating potential priority inversion issues.
-        for _ in 0..self.nr_idle_cpus() {
+        for _ in 0..self.nr_idle_cpus().max(1) {
             match self.task_pool.pop() {
                 Some(task) => {
                     // Update global minimum vruntime.


### PR DESCRIPTION
Always dispatch at least one task, even if all the CPUs are busy.

This small overcommitment allows to maximize the CPU utilization without introducing bubbles in the scheduling and also without introducing regressions in terms of resposiveness.

Before this change the average CPU utilization of a `stress-ng -c 8` on an 8-cores system is around 95%. With this change applied the CPU utilization goes up to a consistent 100%.