### PR TITLE
scx_rustland: properly support offline CPUs

### DIFF
--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -290,16 +290,16 @@ impl<'a> Scheduler<'a> {
         let init_page_faults: u64 = 0;
 
         // Low-level BPF connector.
-        let nr_online_cpus = topo_map.nr_cpus_online();
+        let nr_cpus = topo_map.nr_cpus_possible();
         let bpf = BpfScheduler::init(
             opts.slice_us,
-            nr_online_cpus as i32,
+            nr_cpus as i32,
             opts.partial,
 	    opts.exit_dump_len,
             opts.full_user,
             opts.debug,
         )?;
-        info!("{} scheduler attached - {} online CPUs", SCHEDULER_NAME, nr_online_cpus);
+        info!("{} scheduler attached - {} CPUs", SCHEDULER_NAME, nr_cpus);
 
         // Return scheduler object.
         Ok(Self {


### PR DESCRIPTION
During the initialization phase the scheduler needs to be aware of all the available CPUs in the system (also those that are offline), in order to create a proper per-CPU DSQ for all of them.

Otherwise, if some cores are offline, we may get errors like the following:

  swapper/7[0] triggered exit kind 1024:
    runtime error (invalid DSQ ID 0x0000000000000007)

  Backtrace:
    scx_bpf_consume+0xaa/0xd0
    bpf_prog_42ff1b9d1ac5b184_rustland_dispatch+0x12b/0x187

Change the code to configure the BpfScheduler object with the total amount of CPUs available in the system and prevent such failure.

This fixes #280.