### PR TITLE
scx_lavd: add non-functional misc updates

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -340,7 +340,8 @@ fn main() -> Result<()> {
 
     let mut sched = Scheduler::init(&opts)?;
     info!("scx_lavd scheduler is initialized");
-
+    info!("    Note that scx_lavd currently is not optimized for multi-CCX/NUMA architectures.");
+    info!("    Stay tuned for future improvements!");
     init_signal_handlers();
 
     info!("scx_lavd scheduler starts running.");


### PR DESCRIPTION
This PR contains two non-functional changes:

1) Added the comments describing the preemption design in scx_lavd.
2) Added the log message saying the scx_lavd is not optimized for multi-CCX/NUMA architectures. The message will be printed out when the scx_lavd is initialized.