### PR TITLE
scx_rustland: introduce low power mode

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -293,6 +293,12 @@ impl<'cb> BpfScheduler<'cb> {
         }
     }
 
+    // Counter of currently running tasks.
+    #[allow(dead_code)]
+    pub fn nr_running_mut(&mut self) -> &mut u64 {
+        &mut self.skel.bss_mut().nr_running
+    }
+
     // Counter of queued tasks.
     #[allow(dead_code)]
     pub fn nr_queued_mut(&mut self) -> &mut u64 {

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -181,6 +181,7 @@ impl<'cb> BpfScheduler<'cb> {
         partial: bool,
         exit_dump_len: u32,
         full_user: bool,
+        low_power: bool,
         debug: bool,
     ) -> Result<Self> {
         // Open the BPF prog first for verification.
@@ -244,6 +245,7 @@ impl<'cb> BpfScheduler<'cb> {
         skel.rodata_mut().switch_partial = partial;
         skel.rodata_mut().debug = debug;
         skel.rodata_mut().full_user = full_user;
+        skel.rodata_mut().low_power = low_power;
 
         // Attach BPF scheduler.
         let mut skel = scx_ops_load!(skel, rustland, uei)?;

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -26,7 +26,7 @@ struct Scheduler<'a> {
 impl<'a> Scheduler<'a> {
     fn init() -> Result<Self> {
         let topo = Topology::new().expect("Failed to build host topology");
-        let bpf = BpfScheduler::init(5000, topo.nr_cpus_possible() as i32, false, 0, false, false)?;
+        let bpf = BpfScheduler::init(5000, topo.nr_cpus_possible() as i32, false, 0, false, false, false)?;
         Ok(Self { bpf })
     }
 

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -129,6 +129,14 @@ struct Opts {
     #[clap(short = 'u', long, action = clap::ArgAction::SetTrue)]
     full_user: bool,
 
+    /// When low-power mode is enabled, the scheduler behaves in a more non-work conserving way:
+    /// the CPUs operate at reduced capacity, which slows down CPU-bound tasks, enhancing the
+    /// prioritization of interactive workloads.  In summary, enabling low-power mode will limit
+    /// the performance of CPU-intensive tasks, reducing power consumption, while maintaining
+    /// effective prioritization of interactive tasks.
+    #[clap(short = 'l', long, action = clap::ArgAction::SetTrue)]
+    low_power: bool,
+
     /// If specified, only tasks which have their scheduling policy set to
     /// SCHED_EXT using sched_setscheduler(2) are switched. Otherwise, all
     /// tasks are switched.
@@ -297,6 +305,7 @@ impl<'a> Scheduler<'a> {
             opts.partial,
 	    opts.exit_dump_len,
             opts.full_user,
+            opts.low_power,
             opts.debug,
         )?;
         info!("{} scheduler attached - {} CPUs", SCHEDULER_NAME, nr_cpus);


### PR DESCRIPTION
Introduce a "low power" mode in `scx_rustland` (provided by `scx_rustland_core`) that can be used to reduce power consumption with a minimal impact on the performance of latency-critical tasks.

The idea is to prevent CPUs from immediately waking up when they enter the idle state, if there are other CPUs active. Having other CPUs active still allows to dispatch latency-critical tasks, so system is still responsiveness, while the background CPU-intensive tasks receive an additional throttling.

This has the consequence of reducing the overall system throughput by intentionally creating bubbles in the scheduling and exploiting the additional time spent by the CPUs in idle state to save power.

The following test case summarizes the benefit of the "low power" mode:
- play a video game (Terraria) while recompiling the kernel
- measure game performance (fps) and core power consumption (W)
- compare the result of normal mode vs low-power mode
    
Result:
```
                      Game performance | Power consumption |
         ------------+-----------------+-------------------+
         normal mode |          60 fps |               6W  |
      low-power mode |          60 fps |               3W  |
```

Considering that the CPU intensive tasks are massively throttled the "low power" mode should be used only in emergency conditions (for example when a mobile system is close to run out of power), or simply to extend the battery life of mobile/portable devices.