### PR TITLE
journal.conf: increase the size of the logs and drop unneeded options

### DIFF
--- a/services/systemd/journald@sched-ext.conf
+++ b/services/systemd/journald@sched-ext.conf
@@ -1,9 +1,5 @@
 [Journal]
-# Sets the maximum journal size to 25M for each namespace.
-SystemMaxUse=25M
-# Sets the maximum log age to 7 days.
-MaxRetentionSec=7day
+# Sets the maximum journal size to 50M for sched-ext namespace.
+SystemMaxUse=50M
 # Sets the priority level for messages to be stored to info.
 MaxLevelStore=info
-# Sets the maximum number of log files that can be stored for each namespace.
-SystemMaxFiles=5


### PR DESCRIPTION
It seems that the original journald settings were a bit too restrictive. 

- Let's increase the journal limit to 50MB (the default value for regular journald in CachyOS)

- let's abolish unnecessary cleaning limits

The changes made will make it easier to catch potential anomalies in the system. 