### PR TITLE
Add remaining hotplug pieces

### DIFF
--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -44,6 +44,8 @@ pub use builder::Builder;
 mod user_exit_info;
 pub use user_exit_info::ScxExitKind;
 pub use user_exit_info::ScxConsts;
+pub use user_exit_info::SCX_ECODE_RSN_HOTPLUG;
+pub use user_exit_info::SCX_ECODE_ACT_RESTART;
 pub use user_exit_info::UeiDumpPtr;
 pub use user_exit_info::UserExitInfo;
 pub use user_exit_info::UEI_DUMP_PTR_MUTEX;

--- a/rust/scx_utils/src/user_exit_info.rs
+++ b/rust/scx_utils/src/user_exit_info.rs
@@ -34,6 +34,7 @@ pub enum ScxExitKind {
     Done = bindings::scx_exit_kind_SCX_EXIT_DONE as isize,
     Unreg = bindings::scx_exit_kind_SCX_EXIT_UNREG as isize,
     UnregBPF = bindings::scx_exit_kind_SCX_EXIT_UNREG_BPF as isize,
+    UnregKern = bindings::scx_exit_kind_SCX_EXIT_UNREG_KERN as isize,
     SysRq = bindings::scx_exit_kind_SCX_EXIT_SYSRQ as isize,
     Error = bindings::scx_exit_kind_SCX_EXIT_ERROR as isize,
     ErrorBPF = bindings::scx_exit_kind_SCX_EXIT_ERROR_BPF as isize,
@@ -205,7 +206,7 @@ impl UserExitInfo {
             _ => "<UNKNOWN>".into(),
         };
 
-        if self.kind <= ScxExitKind::UnregBPF as i32 {
+        if self.kind <= ScxExitKind::UnregKern as i32 {
             eprintln!("{}", why);
             Ok(())
         } else {
@@ -217,7 +218,7 @@ impl UserExitInfo {
     /// only applies when the BPF scheduler exits with scx_bpf_exit(), i.e. kind
     /// ScxExitKind::UnregBPF.
     pub fn exit_code(&self) -> Option<i64> {
-        if self.kind == ScxExitKind::UnregBPF as i32 {
+        if self.kind == ScxExitKind::UnregBPF as i32 || self.kind == ScxExitKind::UnregKern as i32 {
             Some(self.exit_code)
         } else {
             None

--- a/rust/scx_utils/src/user_exit_info.rs
+++ b/rust/scx_utils/src/user_exit_info.rs
@@ -3,6 +3,7 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 use crate::bindings;
+use crate::compat;
 use anyhow::bail;
 use anyhow::Result;
 use std::ffi::CStr;
@@ -17,6 +18,16 @@ unsafe impl Send for UeiDumpPtr {}
 pub static UEI_DUMP_PTR_MUTEX: Mutex<UeiDumpPtr> = Mutex::new(UeiDumpPtr {
     ptr: std::ptr::null(),
 });
+
+lazy_static::lazy_static! {
+    pub static ref SCX_ECODE_RSN_HOTPLUG: u64 =
+    compat::read_enum("scx_exit_code", "SCX_ECODE_RSN_HOTPLUG").unwrap_or(0);
+}
+
+lazy_static::lazy_static! {
+    pub static ref SCX_ECODE_ACT_RESTART: u64 =
+    compat::read_enum("scx_exit_code", "SCX_ECODE_ACT_RESTART").unwrap_or(0);
+}
 
 pub enum ScxExitKind {
     None = bindings::scx_exit_kind_SCX_EXIT_NONE as isize,

--- a/scheds/rust/scx_rusty/src/bpf/intf.h
+++ b/scheds/rust/scx_rusty/src/bpf/intf.h
@@ -61,10 +61,6 @@ enum consts {
 	MAX_DOM_ACTIVE_PIDS	= 1024,
 };
 
-enum rusty_exit_codes {
-	RUSTY_EXIT_HOTPLUG,
-};
-
 /* Statistics */
 enum stat_idx {
 	/* The following fields add up to all dispatched tasks */

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -1743,16 +1743,6 @@ static s32 initialize_cpu(s32 cpu)
 	return 0;
 }
 
-void BPF_STRUCT_OPS(rusty_cpu_online, s32 cpu)
-{
-	__COMPAT_scx_bpf_exit(RUSTY_EXIT_HOTPLUG, "CPU %d went online", cpu);
-}
-
-void BPF_STRUCT_OPS(rusty_cpu_offline, s32 cpu)
-{
-	__COMPAT_scx_bpf_exit(RUSTY_EXIT_HOTPLUG, "CPU %d went offline", cpu);
-}
-
 s32 BPF_STRUCT_OPS_SLEEPABLE(rusty_init)
 {
 	s32 i, ret;
@@ -1812,8 +1802,6 @@ SCX_OPS_DEFINE(rusty,
 	       .set_cpumask		= (void *)rusty_set_cpumask,
 	       .init_task		= (void *)rusty_init_task,
 	       .exit_task		= (void *)rusty_exit_task,
-	       .cpu_online		= (void *)rusty_cpu_online,
-	       .cpu_offline		= (void *)rusty_cpu_offline,
 	       .init			= (void *)rusty_init,
 	       .exit			= (void *)rusty_exit,
 	       .timeout_ms		= 10000,

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -38,6 +38,7 @@ use scx_utils::compat;
 use scx_utils::init_libbpf_logging;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
+use scx_utils::scx_ops_open;
 use scx_utils::uei_exited;
 use scx_utils::uei_read;
 use scx_utils::SCX_ECODE_ACT_RESTART;
@@ -235,7 +236,7 @@ impl<'a> Scheduler<'a> {
         let mut skel_builder = BpfSkelBuilder::default();
         skel_builder.obj_builder.debug(opts.verbose > 0);
         init_libbpf_logging(None);
-        let mut skel = skel_builder.open().context("Failed to open BPF program")?;
+        let mut skel = scx_ops_open!(skel_builder, rusty).unwrap();
 
         // Initialize skel according to @opts.
         let top = Arc::new(Topology::new()?);

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -40,6 +40,7 @@ use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
 use scx_utils::uei_exited;
 use scx_utils::uei_read;
+use scx_utils::SCX_ECODE_ACT_RESTART;
 use scx_utils::Cpumask;
 use scx_utils::Topology;
 use scx_utils::UserExitInfo;
@@ -620,7 +621,7 @@ fn main() -> Result<()> {
 
         let uei = sched.run(shutdown.clone())?;
         if let Some(exit_code) = uei.exit_code() {
-            if exit_code == bpf_intf::rusty_exit_codes_RUSTY_EXIT_HOTPLUG as i64 {
+            if (exit_code & *SCX_ECODE_ACT_RESTART as i64) != 0 {
                 continue;
             }
         }


### PR DESCRIPTION
The kernel now has the notion of `hotplug_seq`, wherein a scheduler can specify the current hotplug sequence number in its struct sched_ext_ops, and if that value has changed by the time the scheduler is attached, the scheduler is exited from the kernel with exit code `SCX_ECODE_ACT_RESTART | SCX_ECODE_RSN_HOTPLUG`.

This set does a couple of things:

1. Updates scx_utils to support these semantics
2. Update `scx_rusty` to use this built-in hotplug logic rather than spinning its own

`scx_lavd` and `scx_layered` are not updated to use `scx_ops_open!()`, as they don't have the requisite logic to detect and restart in the event of a hotplug.