### PR TITLE
Avoid redundant substraction in rsigmoid_u64

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -461,7 +461,7 @@ static u64 rsigmoid_u64(u64 v, u64 max)
 	 *	|   \
 	 *	+----+-------->
 	 */
-	return (v > max) ? 0 : max - v;
+	return (v >= max) ? 0 : max - v;
 }
 
 static struct task_ctx *try_get_task_ctx(struct task_struct *p)


### PR DESCRIPTION
## Summary
Originally the implementation of function rsigmoid_u64 will perform substraction even when the value of "v" equals to the value of "max" , in which the result is certainly zero.

We can avoid this redundant substration by changing the condition from ">" to ">=" since we know when the value of "v" and "max" are equal we can return 0 without any substract operation.