### PR TITLE
Fix warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('sched_ext schedulers', 'c',
         version: '0.1.9',
-        license: 'GPL-2.0')
+        license: 'GPL-2.0',
+        default_options: 'werror=true',)
 
 if meson.version().version_compare('<1.2')
   error('meson >= 1.2 required')
@@ -233,6 +234,10 @@ sys_incls = run_command(get_sys_incls, bpf_clang, check: true).stdout().splitlin
 bpf_base_cflags = ['-g', '-O2', '-Wall', '-Wno-compare-distinct-pointer-types',
                    '-D__TARGET_ARCH_' + arch_dict[cpu], '-mcpu=v3',
                    '-m@0@-endian'.format(host_machine.endian())] + sys_incls
+
+if get_option('werror')
+  bpf_base_cflags += '-Werror'
+endif
 
 message('cpu=@0@ bpf_base_cflags=@1@'.format(cpu, bpf_base_cflags))
 

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -224,7 +224,7 @@ static void set_cpu_owner(u32 cpu, u32 pid)
  *
  * Return 0 if the CPU is idle.
  */
-static u32 get_cpu_owner(u32 cpu)
+static __maybe_unused u32 get_cpu_owner(u32 cpu)
 {
 	if (cpu >= MAX_CPUS) {
 		scx_bpf_error("Invalid cpu: %d", cpu);

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -276,6 +276,8 @@ static inline u32 bpf_log2l(u64 v)
 /* useful compiler attributes */
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
+#define __maybe_unused __attribute__((__unused__))
+
 
 void *bpf_obj_new_impl(__u64 local_type_id, void *meta) __ksym;
 void bpf_obj_drop_impl(void *kptr, void *meta) __ksym;

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1966,9 +1966,7 @@ void BPF_STRUCT_OPS(lavd_tick, struct task_struct *p_run)
 	struct sys_cpu_util *cutil_cur = get_sys_cpu_util_cur();
 	s32 cpu_id = scx_bpf_task_cpu(p_run);
 	struct cpu_ctx *cpuc_run;
-	struct task_ctx *taskc_run, *taskc_wait;
-	struct preemption_info prm_run, prm_wait;
-	struct task_struct *p_wait;
+	struct task_ctx *taskc_run;
 	bool preempted = false;
 
 

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -888,8 +888,6 @@ void BPF_STRUCT_OPS(layered_exit_task, struct task_struct *p,
 {
 	struct cpu_ctx *cctx;
 	struct task_ctx *tctx;
-	s32 pid = p->pid;
-	int ret;
 
 	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)))
 		return;


### PR DESCRIPTION
When compiling with warnings enabled, I noticed some bugs in scx_rusty, and stray warnings in scx_layered. To make it easier to catch such issues in the future, we:

1. Extend the build system to apply -Werror if the built-in meson --werror `meson setup` flag is specified (option is `true` by default)
2. Fix the issues in `scx_layered`, `scx_rusty`, `scx_rustland`, `scx_rlfifo`, and `scx_lavd`

The issues in `scx_rusty` are correctness issues, not just benign build issues. They seem to marginally improve interactivity, but it seems somewhat clear that rusty is really in need of preemption support to cut down on rq delays. The other fixes are all benign, but we make them anyways as otherwise the build will break for anyone using the default options.