### PR TITLE
scx_simple: re-add __COMPAT_scx_bpf_switch_all()

### DIFF
--- a/scheds/c/scx_simple.bpf.c
+++ b/scheds/c/scx_simple.bpf.c
@@ -129,6 +129,7 @@ void BPF_STRUCT_OPS(simple_enable, struct task_struct *p)
 
 s32 BPF_STRUCT_OPS_SLEEPABLE(simple_init)
 {
+	__COMPAT_scx_bpf_switch_all();
 	return scx_bpf_create_dsq(SHARED_DSQ, -1);
 }
 


### PR DESCRIPTION
Although newer kernels default to switching-all, some users might still be using the scheduler with older kernels.

Therefore, ensure all tasks are moved to the SCHED_EXT class by calling __COMPAT_scx_bpf_switch_all() during init, so that scx_simple can still operate on these older kernels as well.

Fixes: cf66e58 ("Sync from kernel (670bdab6073)")