### PR TITLE
Build: Make -Werror non-default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,6 @@
 project('sched_ext schedulers', 'c',
         version: '0.1.9',
-        license: 'GPL-2.0',
-        default_options: 'werror=true',)
+        license: 'GPL-2.0',)
 
 if meson.version().version_compare('<1.2')
   error('meson >= 1.2 required')


### PR DESCRIPTION
It seems that libbpf and bpftool have some places where -Werror triggers when compiled with gcc. Let's make it non-default. Users can always enable it locally if they want to by invoking `meson setup` with the --werror flag.