### PR TITLE
simple: Add comment explaining use of SHARED_DSQ

### DIFF
--- a/scheds/c/scx_simple.bpf.c
+++ b/scheds/c/scx_simple.bpf.c
@@ -29,6 +29,13 @@ const volatile bool fifo_sched;
 static u64 vtime_now;
 UEI_DEFINE(uei);
 
+/*
+ * Built-in DSQs such as SCX_DSQ_GLOBAL cannot be used as priority queues
+ * (meaning, cannot be dispatched to with scx_bpf_dispatch_vtime()). We
+ * therefore create a separate DSQ with ID 0 that we dispatch to and consume
+ * from. If scx_simple only supported global FIFO scheduling, then we could
+ * just use SCX_DSQ_GLOBAL.
+ */
 #define SHARED_DSQ 0
 
 struct {


### PR DESCRIPTION
scx_simple is a basic scheduler that does either basic vtime, or global FIFO, scheduling. At first glance, it may be confusing why we create a separate DSQ rather than just using SCX_DSQ_GLOBAL. Let's add a comment explaining the reason for this, so that users that are going over scx_simple as an example scheduler don't get confused.