### PR TITLE
scx_rustland: introduce fifo mode

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -183,6 +183,7 @@ impl<'cb> BpfScheduler<'cb> {
         exit_dump_len: u32,
         full_user: bool,
         low_power: bool,
+        fifo_sched: bool,
         debug: bool,
     ) -> Result<Self> {
         // Open the BPF prog first for verification.
@@ -247,6 +248,7 @@ impl<'cb> BpfScheduler<'cb> {
         skel.rodata_mut().debug = debug;
         skel.rodata_mut().full_user = full_user;
         skel.rodata_mut().low_power = low_power;
+        skel.rodata_mut().fifo_sched = fifo_sched;
 
         // Attach BPF scheduler.
         let mut skel = scx_ops_load!(skel, rustland, uei)?;

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -172,6 +172,11 @@ struct task_ctx {
 	 * current task's cpumask.
 	 */
 	u64 cpumask_cnt;
+
+	/*
+	 * Dispatch immediately to the local DSQ.
+	 */
+	bool dispatch_local;
 };
 
 /* Map that contains task-local storage. */
@@ -468,21 +473,45 @@ static void dispatch_user_scheduler(void)
 s32 BPF_STRUCT_OPS(rustland_select_cpu, struct task_struct *p, s32 prev_cpu,
 		   u64 wake_flags)
 {
+	struct task_ctx *tctx;
 	bool is_idle = false;
 	s32 cpu;
 
+	tctx = lookup_task_ctx(p);
+	if (!tctx)
+		return prev_cpu;
+
 	/*
-	 * Try to find the best CPU relying on the built-in idle selection
-	 * logic, eventually migrating the task and dispatching directly from
-	 * here if a CPU is available, unless full_user mode is enabled.
+	 * If the previously used CPU is still available, keep using it to take
+	 * advantage of the cached working set.
 	 */
-	cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
-	if (is_idle && !full_user) {
-		dispatch_task(p, SCX_DSQ_LOCAL, 0, 0, 0);
-		__sync_fetch_and_add(&nr_kernel_dispatches, 1);
+	if (scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
+		tctx->dispatch_local = true;
+		return prev_cpu;
 	}
 
-	return cpu;
+	/*
+	 * If the task was directly dispatched give it a second chance to
+	 * remain on the current CPU, instead of immediately migrating it.
+	 */
+	if (tctx->dispatch_local) {
+		tctx->dispatch_local = false;
+		return prev_cpu;
+	}
+
+	/*
+	 * Find the best CPU relying on the built-in idle selection logic,
+	 * eventually migrating the task and dispatching directly from here if
+	 * a CPU is available.
+	 */
+	cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
+	if (is_idle) {
+		tctx->dispatch_local = true;
+		return cpu;
+	}
+	tctx->dispatch_local = false;
+
+	return prev_cpu;
 }
 
 /*
@@ -531,6 +560,7 @@ static void sched_congested(struct task_struct *p)
 void BPF_STRUCT_OPS(rustland_enqueue, struct task_struct *p, u64 enq_flags)
 {
 	struct queued_task_ctx *task;
+	struct task_ctx *tctx;
 
 	/*
 	 * Scheduler is dispatched directly in .dispatch() when needed, so
@@ -548,7 +578,21 @@ void BPF_STRUCT_OPS(rustland_enqueue, struct task_struct *p, u64 enq_flags)
 	 * long (i.e., ksoftirqd/N, rcuop/N, etc.).
 	 */
 	if (is_kthread(p) && p->nr_cpus_allowed == 1) {
-		dispatch_task(p, SCX_DSQ_LOCAL, 0, 0, enq_flags);
+		dispatch_task(p, SCX_DSQ_LOCAL, 0, slice_ns, enq_flags);
+		__sync_fetch_and_add(&nr_kernel_dispatches, 1);
+		return;
+	}
+
+	/*
+	 * Dispatch immediately on the local DSQ if .select_cpu() has found an
+	 * idle CPU.
+	 *
+	 * NOTE: assign a shorter time slice (slice_ns / 4) to task directly
+	 * dispatched to prevent them from gaining excessive CPU bandwidth.
+	 */
+	tctx = lookup_task_ctx(p);
+	if (!full_user && tctx && tctx->dispatch_local) {
+		dispatch_task(p, SCX_DSQ_LOCAL, 0, slice_ns / 4, enq_flags);
 		__sync_fetch_and_add(&nr_kernel_dispatches, 1);
 		return;
 	}
@@ -557,7 +601,7 @@ void BPF_STRUCT_OPS(rustland_enqueue, struct task_struct *p, u64 enq_flags)
 	 * Dispatch directly to the target CPU DSQ if the scheduler is set to
 	 * FIFO mode.
 	 */
-	if (is_fifo_enabled) {
+	if (!full_user && is_fifo_enabled) {
 		s32 cpu = scx_bpf_task_cpu(p);
 
 		scx_bpf_dispatch(p, cpu_to_dsq(cpu), slice_ns, enq_flags);

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -434,14 +434,6 @@ static void dispatch_user_scheduler(void)
 }
 
 /*
- * Return true if we are waking up from a wait event, false otherwise.
- */
-static bool is_waking_up(u64 wake_flags)
-{
-	return !!(wake_flags & SCX_WAKE_TTWU);
-}
-
-/*
  * Select the target CPU where a task can be executed.
  *
  * The idea here is to try to find an idle CPU in the system, and preferably
@@ -460,41 +452,12 @@ s32 BPF_STRUCT_OPS(rustland_select_cpu, struct task_struct *p, s32 prev_cpu,
 	s32 cpu;
 
 	/*
-	 * In full-user mode simply assign the previously used CPU and let the
-	 * user-space scheduler decide where it should be dispatched.
-	 */
-	if (full_user)
-		return prev_cpu;
-
-	/*
-	 * Always try to stick on the same CPU if it's available, to better
-	 * exploit the cached working set.
-	 */
-	if (scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
-		/*
-		 * Using SCX_DSQ_LOCAL ensures that the task will be executed
-		 * directly on the CPU returned by this function.
-		 */
-		dispatch_task(p, SCX_DSQ_LOCAL, 0, 0, 0);
-		__sync_fetch_and_add(&nr_kernel_dispatches, 1);
-		return prev_cpu;
-	}
-
-	/*
-	 * If the previously used CPU is not available, check whether the task
-	 * is coming from a wait state. If not, enqueue it on the same CPU
-	 * regardless, without directly dispatching it.
-	 */
-	if (!is_waking_up(wake_flags))
-		return prev_cpu;
-
-	/*
-	 * If we are coming from a wait state, try to find the best CPU relying
-	 * on the built-in idle selection logic (eventually migrating the
-	 * task).
+	 * Try to find the best CPU relying on the built-in idle selection
+	 * logic, eventually migrating the task and dispatching directly from
+	 * here if a CPU is available, unless full_user mode is enabled.
 	 */
 	cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
-	if (is_idle) {
+	if (is_idle && !full_user) {
 		dispatch_task(p, SCX_DSQ_LOCAL, 0, 0, 0);
 		__sync_fetch_and_add(&nr_kernel_dispatches, 1);
 	}

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -662,15 +662,15 @@ void BPF_STRUCT_OPS(rustland_dispatch, s32 cpu, struct task_struct *prev)
 	 */
 	bpf_user_ringbuf_drain(&dispatched, handle_dispatched_task, NULL, 0);
 
-	/* Consume all tasks enqueued in the current CPU's DSQ first */
-	bpf_repeat(MAX_ENQUEUED_TASKS) {
-		if (!scx_bpf_consume(cpu_to_dsq(cpu)))
-			break;
-	}
-
 	/* Consume all tasks enqueued in the shared DSQ */
 	bpf_repeat(MAX_ENQUEUED_TASKS) {
 		if (!scx_bpf_consume(SHARED_DSQ))
+			break;
+	}
+
+	/* Consume all tasks enqueued in the current CPU's DSQ first */
+	bpf_repeat(MAX_ENQUEUED_TASKS) {
+		if (!scx_bpf_consume(cpu_to_dsq(cpu)))
 			break;
 	}
 }

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -105,6 +105,19 @@ const volatile bool full_user;
   */
 const volatile bool low_power;
 
+/*
+ * Automatically switch to simple FIFO scheduling during periods of system
+ * underutilization to minimize unnecessary scheduling overhead.
+ *
+ * 'fifo_sched' can be used by the user-space scheduler to enable/disable this
+ * behavior.
+ *
+ * 'is_fifo_enabled' indicates whether the scheduling has switched to FIFO mode
+ * or regular scheduling mode.
+ */
+const volatile bool fifo_sched;
+static bool is_fifo_enabled;
+
 /* Allow to use bpf_printk() only when @debug is set */
 #define dbg_msg(_fmt, ...) do {						\
 	if (debug)							\
@@ -199,6 +212,13 @@ struct {
 	__type(key, u32);
 	__type(value, struct usersched_timer);
 } usersched_timer SEC(".maps");
+
+/*
+ * Time period of the scheduler heartbeat, used to periodically kick the the
+ * scheduler and check if we need to switch to FIFO mode or regular
+ * scheduling (default 100ms).
+ */
+#define USERSCHED_TIMER_NS (NSEC_PER_SEC / 10)
 
 /*
  * Map of allocated CPUs.
@@ -534,6 +554,20 @@ void BPF_STRUCT_OPS(rustland_enqueue, struct task_struct *p, u64 enq_flags)
 	}
 
 	/*
+	 * Dispatch directly to the target CPU DSQ if the scheduler is set to
+	 * FIFO mode.
+	 */
+	if (is_fifo_enabled) {
+		s32 cpu = scx_bpf_task_cpu(p);
+
+		scx_bpf_dispatch(p, cpu_to_dsq(cpu), slice_ns, enq_flags);
+		scx_bpf_kick_cpu(cpu, __COMPAT_SCX_KICK_IDLE);
+
+		__sync_fetch_and_add(&nr_kernel_dispatches, 1);
+		return;
+	}
+
+	/*
 	 * Add tasks to the @queued list, they will be processed by the
 	 * user-space scheduler.
 	 *
@@ -739,7 +773,6 @@ void BPF_STRUCT_OPS(rustland_cpu_release, s32 cpu,
 		set_usersched_needed();
 }
 
-
 /*
  * A new task @p is being created.
  *
@@ -792,6 +825,43 @@ void BPF_STRUCT_OPS(rustland_exit_task, struct task_struct *p,
 }
 
 /*
+ * Check whether we can switch to FIFO mode if the system is underutilized.
+ */
+static bool should_enable_fifo(void)
+{
+	/* Moving average of the tasks that are waiting to be scheduled */
+	static u64 nr_waiting_avg;
+	/* Current amount of tasks waiting to be scheduled */
+	u64 nr_waiting = nr_queued + nr_scheduled;
+
+	if (!fifo_sched)
+		return false;
+
+	/*
+	 * Exiting from FIFO mode requires to have almost all the CPUs busy.
+	 */
+	if (is_fifo_enabled)
+		return nr_running < num_possible_cpus - 1;
+
+	/*
+	 * We are not in FIFO mode, check for the task waiting to be processed
+	 * by the user-space scheduler.
+	 *
+	 * We want to evaluate a moving average of the waiting tasks to prevent
+	 * bouncing too often between FIFO mode and user-space mode.
+	 */
+	nr_waiting_avg = (nr_waiting_avg + nr_waiting) / 2;
+
+	/*
+	 * The condition to enter in FIFO mode is to have no tasks (in average)
+	 * that are waiting to be scheduled.
+	 *
+	 * Exiting from FIFO mode requires to have almost all the CPUs busy.
+	 */
+	return nr_waiting_avg == 0;
+}
+
+/*
  * Heartbeat scheduler timer callback.
  *
  * If the system is completely idle the sched-ext watchdog may incorrectly
@@ -807,8 +877,11 @@ static int usersched_timer_fn(void *map, int *key, struct bpf_timer *timer)
 	/* Kick the scheduler */
 	set_usersched_needed();
 
+	/* Update flag that determines if FIFO scheduling needs to be enabled */
+	is_fifo_enabled = should_enable_fifo();
+
 	/* Re-arm the timer */
-	err = bpf_timer_start(timer, NSEC_PER_SEC, 0);
+	err = bpf_timer_start(timer, USERSCHED_TIMER_NS, 0);
 	if (err)
 		scx_bpf_error("Failed to arm stats timer");
 
@@ -831,7 +904,7 @@ static int usersched_timer_init(void)
 	}
 	bpf_timer_init(timer, &usersched_timer, CLOCK_BOOTTIME);
 	bpf_timer_set_callback(timer, usersched_timer_fn);
-	err = bpf_timer_start(timer, NSEC_PER_SEC, 0);
+	err = bpf_timer_start(timer, USERSCHED_TIMER_NS, 0);
 	if (err)
 		scx_bpf_error("Failed to arm scheduler timer");
 

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -26,7 +26,7 @@ struct Scheduler<'a> {
 impl<'a> Scheduler<'a> {
     fn init() -> Result<Self> {
         let topo = Topology::new().expect("Failed to build host topology");
-        let bpf = BpfScheduler::init(5000, topo.nr_cpus_possible() as i32, false, 0, false, false, false)?;
+        let bpf = BpfScheduler::init(5000, topo.nr_cpus_possible() as i32, false, 0, false, false, true, false)?;
         Ok(Self { bpf })
     }
 

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -543,17 +543,9 @@ impl<'a> Scheduler<'a> {
                         dispatched_task.set_flag(RL_CPU_ANY);
                     }
                     if task.is_interactive && !self.no_preemption {
-                        // Assign the maximum time slice to this task and allow to preempt others.
-                        //
-                        // NOTE: considering that, with preemption enabled, interactive tasks can
-                        // preempt each other (for now) and they are also more likely to release
-                        // the CPU before its assigned time slice expires, always give them the
-                        // maximum static time slice allowed.
-                        dispatched_task.set_slice_ns(self.slice_ns);
                         dispatched_task.set_flag(RL_PREEMPT_CPU);
-                    } else {
-                        dispatched_task.set_slice_ns(self.effective_slice_ns(nr_scheduled));
                     }
+                    dispatched_task.set_slice_ns(self.effective_slice_ns(nr_scheduled));
 
                     // Send task to the BPF dispatcher.
                     match self.bpf.dispatch_task(&dispatched_task) {

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -137,6 +137,19 @@ struct Opts {
     #[clap(short = 'l', long, action = clap::ArgAction::SetTrue)]
     low_power: bool,
 
+    /// By default the scheduler automatically transitions to FIFO mode when the system is
+    /// underutilized. This allows to reduce unnecessary scheduling overhead and boost performance
+    /// when the system is not running at full capacity.
+    ///
+    /// Be aware that FIFO mode can lead to less predictable performance. Therefore, use this
+    /// option if performance predictability is important, such as when running real-time audio
+    /// applications or during live streaming. Conversely, avoid using this option when you care
+    /// about maximizing performance, such as gaming.
+    ///
+    /// Set this option to disable this automatic transition.
+    #[clap(short = 'f', long, action = clap::ArgAction::SetTrue)]
+    disable_fifo: bool,
+
     /// If specified, only tasks which have their scheduling policy set to
     /// SCHED_EXT using sched_setscheduler(2) are switched. Otherwise, all
     /// tasks are switched.
@@ -304,6 +317,7 @@ impl<'a> Scheduler<'a> {
             opts.exit_dump_len,
             opts.full_user,
             opts.low_power,
+            !opts.disable_fifo,
             opts.debug,
         )?;
         info!("{} scheduler attached - {} CPUs", SCHEDULER_NAME, nr_cpus);


### PR DESCRIPTION
This is a v2 of the FIFO mode feature, more tested and tuned, based on additional experimental results (specifically to determine the optimal USERSCHED_TIMER_NS and the conditions to automatically enter and exit to/from FIFO mode).

The idea is to give an option to automatically transition to a FIFO scheduler when the system is underutilized and switch to the user-space scheduler only when the system is over commissioned.

This allows to maximize performance during regular system use, for example gaming without additional stress tests running, while also ensuring responsiveness if a CPU-intensive workload is suddenly started.

FIFO mode can lead to less predictable performance (due to the potential transitions between the scheduling policies), therefore it is provided as an optional feature that can be disabled when performance predictability is crucial, such as in real-time audio applications or during live streaming.