### PR TITLE
scx_rustland: improve audio workload and performance predictability

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -670,15 +670,15 @@ void BPF_STRUCT_OPS(rustland_dispatch, s32 cpu, struct task_struct *prev)
 	 */
 	bpf_user_ringbuf_drain(&dispatched, handle_dispatched_task, NULL, 0);
 
-	/* Consume all tasks enqueued in the current CPU's DSQ first */
-	bpf_repeat(MAX_ENQUEUED_TASKS) {
-		if (!scx_bpf_consume(cpu_to_dsq(cpu)))
-			break;
-	}
-
 	/* Consume all tasks enqueued in the shared DSQ */
 	bpf_repeat(MAX_ENQUEUED_TASKS) {
 		if (!scx_bpf_consume(SHARED_DSQ))
+			break;
+	}
+
+	/* Consume all tasks enqueued in the current CPU's DSQ first */
+	bpf_repeat(MAX_ENQUEUED_TASKS) {
+		if (!scx_bpf_consume(cpu_to_dsq(cpu)))
 			break;
 	}
 }

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -556,17 +556,9 @@ impl<'a> Scheduler<'a> {
                         dispatched_task.set_flag(RL_CPU_ANY);
                     }
                     if task.is_interactive && !self.no_preemption {
-                        // Assign the maximum time slice to this task and allow to preempt others.
-                        //
-                        // NOTE: considering that, with preemption enabled, interactive tasks can
-                        // preempt each other (for now) and they are also more likely to release
-                        // the CPU before its assigned time slice expires, always give them the
-                        // maximum static time slice allowed.
-                        dispatched_task.set_slice_ns(self.slice_ns);
                         dispatched_task.set_flag(RL_PREEMPT_CPU);
-                    } else {
-                        dispatched_task.set_slice_ns(self.effective_slice_ns(nr_scheduled));
                     }
+                    dispatched_task.set_slice_ns(self.effective_slice_ns(nr_scheduled));
 
                     // Send task to the BPF dispatcher.
                     match self.bpf.dispatch_task(&dispatched_task) {


### PR DESCRIPTION
A set of changes that seems to mitigate the audio cracking issues that I was experiencing when the system is massively over-commissioned.

Here's a summary of these changes:
 - dispatch interactive tasks on the first CPU available and non-interactive tasks on the CPU selected by the idle selection logic
 - assign the same time slice both to interactive and non-interactive tasks
 - implement a second-chance migration in `select_cpu()`: after a task has been directly dispatched prevent to immediately migrate it on a different CPU, but force it to stay on `prev_cpu` for another round

Tested both on an Intel Core i7 and AMD Ryzen 7 5800X 8-Core with multiple games / audio workloads. On both systems these changes seem to improve the responsiveness both in terms of fps and audio quality.