### PR TITLE
rusty: Rework deadline as a signed sum

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/intf.h
+++ b/scheds/rust/scx_rusty/src/bpf/intf.h
@@ -17,6 +17,7 @@
 typedef unsigned char u8;
 typedef unsigned int u32;
 typedef unsigned long long u64;
+typedef long long s64;
 #endif
 
 #include <scx/ravg.bpf.h>
@@ -43,12 +44,29 @@ enum consts {
 	NSEC_PER_SEC            = NSEC_PER_USEC * USEC_PER_SEC,
 
 	/* Constants used for determining a task's deadline */
-	DL_RUNTIME_SCALE	= 2, /* roughly scales average runtime to */
-				     /* same order of magnitude as waker  */
-				     /* and blocked frequencies */
-	DL_MAX_LATENCY_NS	= (50 * NSEC_PER_MSEC),
+	DL_RUNTIME_FACTOR	= 100,
 	DL_FREQ_FT_MAX		= 100000,
 	DL_MAX_LAT_PRIO		= 39,
+	/*
+	 * Duty cycle is the proportion of time in some interval during which a
+	 * task could have used CPU. In other words, for some time interval
+	 * [t_0, t_1], a task's duty cycle is the value between [0, 1]
+	 * corresponding to how much time in the interval it _could_ have used.
+	 * For example, if it could have run the entire time its duty cycle
+	 * would be 1, and if it could only have run for half of the interval
+	 * its duty cycle would be .5. Note that a task that's runnable for the
+	 * first half of the interval, and running for the second half at which
+	 * point it blocks, would still have a duty cycle of .5.
+	 *
+	 * We track duty cycle in BPF using the running average helpers. The
+	 * value below is approximately the value that is observed in the
+	 * kernel when a task has duty cycle ~= 1. In user space we can do
+	 * floating point arithmetic in e.g. the rust implementation of
+	 * ravg_read(), but here in the kernel we're stuck with fixed-point
+	 * integer arithmetic and must therefore use values like this when
+	 * determining a task's latency priority when calculating its deadline.
+	 */
+	DL_FULL_DCYCLE		= 650000,
 
 	/*
 	 * When userspace load balancer is trying to determine the tasks to push
@@ -115,6 +133,12 @@ struct task_ctx {
 	/* frequency with which a task wakes other tasks (producer) */
 	u64 waker_freq;
 	u64 last_woke_at;
+
+	/*
+	 * vruntime tracked by the scheduler. Separate from p->scx.dsq_vtime as
+	 * this is set by the scheduler.
+	 */
+	u64 vruntime;
 
 	/* The task is a workqueue worker thread */
 	bool is_kworker;

--- a/scheds/rust/scx_rusty/src/bpf/intf.h
+++ b/scheds/rust/scx_rusty/src/bpf/intf.h
@@ -134,6 +134,8 @@ struct task_ctx {
 	u64 waker_freq;
 	u64 last_woke_at;
 
+	s64 lat_prio;
+
 	/*
 	 * vruntime tracked by the scheduler. Separate from p->scx.dsq_vtime as
 	 * this is set by the scheduler.

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -531,65 +531,36 @@ static u64 min(u64 a, u64 b)
 	return a <= b ? a : b;
 }
 
-/*
- * ** Taken directly from fair.c in the Linux kernel **
- *
- * We use this table to inversely scale deadline according to a task's
- * calculated latency factor. We preserve the comment directly from the table
- * in fair.c:
- *
- * "Nice levels are multiplicative, with a gentle 10% change for every
- * nice level changed. I.e. when a CPU-bound task goes from nice 0 to
- * nice 1, it will get ~10% less CPU time than another CPU-bound task
- * that remained on nice 0.
- *
- * The "10% effect" is relative and cumulative: from _any_ nice level,
- * if you go up 1 level, it's -10% CPU usage, if you go down 1 level
- * it's +10% CPU usage. (to achieve that we use a multiplier of 1.25.
- * If a task goes up by ~10% and another task goes down by ~10% then
- * the relative distance between them is ~25%.)"
- */
-const int sched_prio_to_weight[DL_MAX_LAT_PRIO + 1] = {
- /* -20 */     88761,     71755,     56483,     46273,     36291,
- /* -15 */     29154,     23254,     18705,     14949,     11916,
- /* -10 */      9548,      7620,      6100,      4904,      3906,
- /*  -5 */      3121,      2501,      1991,      1586,      1277,
- /*   0 */      1024,       820,       655,       526,       423,
- /*   5 */       335,       272,       215,       172,       137,
- /*  10 */       110,        87,        70,        56,        45,
- /*  15 */        36,        29,        23,        18,        15,
-};
+static u64 max(u64 a, u64 b)
+{
+	return a >= b ? a : b;
+}
+
+static u64 abs(s64 a)
+{
+	return (u64)(a >= 0 ? a : -a);
+}
 
 static u64 sched_prio_to_latency_weight(u64 prio)
 {
-	if (prio >= DL_MAX_LAT_PRIO) {
-		scx_bpf_error("Invalid prio index");
-		return 0;
-	}
-
-	return sched_prio_to_weight[DL_MAX_LAT_PRIO - prio - 1];
+	return prio * 1000;
 }
 
-static u64 task_compute_dl(struct task_struct *p, struct task_ctx *taskc,
+static s64 task_compute_dl(struct task_struct *p, struct task_ctx *taskc,
 			   u64 enq_flags)
 {
-	u64 waker_freq, blocked_freq;
-	u64 lat_prio, lat_scale, avg_run_raw, avg_run;
-	u64 freq_factor;
+	u64 waker_freq, blocked_freq, worker_chain_product;
+	u64 task_dcycle;
+	u64 avg_run_raw;
+	s64 work_chain_linear, avg_run_linear, inv_dcycle_linear, lat_prio, dl;
+	u64 lat_prio_abs, lat_scale;
+	struct ravg_data task_dcyc_rd;
 
 	/*
-	 * Determine the latency criticality of a task, and scale a task's
-	 * deadline accordingly. Much of this is inspired by the logic in
-	 * scx_lavd that was originally conceived and implemented by Changwoo
-	 * Min. Though the implementations for determining latency criticality
-	 * are quite different in many ways, individuals familiar with both
-	 * schedulers will feel an eerie sense of deja-vu. The details of
-	 * interactivity boosting for rusty are described below.
-	 */
-
-	/*
-	 * We begin by calculating the following interactivity factors for a
-	 * task:
+	 * We begin by calculating the following work-chain interactivity
+	 * factors for a task. This was inspired by the workchain-detection
+	 * logic in scx_lavd that was originally conceived and implemented by
+	 * Changwoo Min:
 	 *
 	 * - waker_freq: The frequency with which a task wakes up other tasks.
 	 *		 A high waker frequency generally implies a producer
@@ -642,79 +613,105 @@ static u64 task_compute_dl(struct task_struct *p, struct task_ctx *taskc,
 	 * We multiply the frequencies of wait_freq and waker_freq somewhat
 	 * arbitrarily, based on observed performance for audio and gaming
 	 * interactive workloads.
+	 *
+	 * We take the logarithm of this exponential product to get a linear
+	 * value that we can use to compute a final latency criticality factor.
 	 */
 	waker_freq = min(taskc->waker_freq, DL_FREQ_FT_MAX);
 	blocked_freq = min(taskc->blocked_freq, DL_FREQ_FT_MAX);
-	freq_factor = blocked_freq * waker_freq * waker_freq;
+	worker_chain_product = max(blocked_freq, 1) * max(waker_freq, 1);
+	work_chain_linear = log2_u64(max(worker_chain_product, 1));
 
 	/*
-	 * Scale the frequency factor according to the task's weight. A task
-	 * with higher weight is given a higher frequency factor than a task
-	 * with a lower weight.
+	 * Next, take into account a task's duty cycle. A task with a low duty
+	 * cycle should also get boosted, as it's rarely using the CPU. In
+	 * addition, it's necessary to take duty cycle into account because a
+	 * task that rarely runs would be penalized relative to worker-chain
+	 * tasks that have very frequent waker / blocker frequencies, even
+	 * though it's arguably more interactive as it uses less CPU.
+	 *
+	 * We want tasks with a _low_ duty cycle to have a positive
+	 * interactivity boost, so we set the linear form of dcycle to be the
+	 * logarithm of the inverse of a task's duty cycle, and the numerical
+	 * representation of max duty cycle when using moving averages.
 	 */
-	freq_factor = scale_up_fair(freq_factor, p->scx.weight);
+	task_dcyc_rd = taskc->dcyc_rd;
+	task_dcycle = ravg_read(&task_dcyc_rd, bpf_ktime_get_ns(), load_half_life);
+	if (task_dcycle > DL_FULL_DCYCLE)
+		task_dcycle = 0;
+	else
+		task_dcycle = DL_FULL_DCYCLE - task_dcycle;
+	inv_dcycle_linear = log2_u64(max(task_dcycle, 1));
 
 	/*
-	 * The above frequencies roughly follow an exponential distribution, so
-	 * use log2_u64() to linearize it to a boost priority that we can then
-	 * scale to a weight factor below.
-	 */
-	lat_prio = log2_u64(freq_factor + 1);
-	lat_prio = min(lat_prio, DL_MAX_LAT_PRIO);
-
-	/*
-	 * Next calculate a task's average runtime, and apply it to deadline
-	 * accordingly. A task with a large runtime is penalized from an
-	 * interactivity standpoint, for obvious reasons.
+	 * Finally, take into account a task's average runtime. A task with a
+	 * large runtime is penalized from an interactivity standpoint, for
+	 * obvious reasons.
 	 *
 	 * As with waker and blocked frequencies above, this follows an
 	 * exponential distribution. We inversely scale to account for
 	 * empirical observations which seem to bring it roughly to the same
-	 * order of magnitude as the blocker and waker frequencies above.
+	 * order of magnitude as the work-chain and dcycle factors above.
 	 *
-	 * We inversely scale the task's averge_runtime to cause tasks with
-	 * lower weight to receive a harsher penalty for long runtimes, and
-	 * vice versa for tasks with lower weight.
+	 * XXX: This has all so far been done anecdotally. We should
+	 * mathematically determine the correct values for these scaling
+	 * factors to represent a well-defined scaling function.
 	 */
-	avg_run_raw = taskc->avg_runtime / DL_RUNTIME_SCALE;
-	avg_run_raw = min(avg_run_raw, DL_MAX_LATENCY_NS);
+	avg_run_raw = taskc->avg_runtime / DL_RUNTIME_FACTOR;
 	avg_run_raw = scale_inverse_fair(avg_run_raw, p->scx.weight);
-	avg_run = log2_u64(avg_run_raw + 1);
-
-	if (avg_run < lat_prio) {
-		/* Equivalent to lat_prio = log(freq_factor / avg_run_raw) */
-		lat_prio -= avg_run;
-	} else {
-		lat_prio = 0;
-	}
+	avg_run_linear = log2_u64(max(avg_run_raw, 1));
 
 	/*
 	 * Ultimately, what we're trying to arrive at is a single value
-	 * 'lat_prio' that we can use to compute the weight that we use to
-	 * scale a task's average runtime as below.
+	 * 'lat_prio' that we can use to either positively or negatively adjust
+	 * a task's deadline according to its perceived interactivity.
 	 *
-	 * To summarize what we've done above, we compute this lat_prio as the
-	 * sum of a task's frequency factor, minus an average runtime factor.
-	 * Both factors are scaled according to a task's weight.
+	 * We have three linear factors computed above:
+	 * 1. Work-chain factor: To what degree a task functions as a producer,
+	 *    consumer, or both in a work chain. Higher means more interactive.
 	 *
-	 * Today, we're just interpreting lat_prio as a niceness value, but
-	 * this can and almost certainly will likely change to something more
-	 * generic and/or continuous and flexible so that it can also
-	 * accommodate cgroups.
+	 * 2. Inverse duty cycle factor: How infrequently (recall that it's
+	 *    really the inverse of a task's duty cycle) does a task use the
+	 *    CPU.  Higher again means more interactive.
+	 *
+	 * 3. Average runtime factor: How long does a task typically run on the
+	 *    CPU? Tasks that run for longer periods of time will of course be
+	 *    considered less interactive. Note that a task that runs
+	 *    infrequently, but typically uses the CPU for a long time, will be
+	 *    penalized less than a CPU hogging task, but more than a truly
+	 *    interactive task.
+	 *
+	 * We then finally compute a signed latency priority value of:
+	 *
+	 * Average runtime factor - (work-chain factor + duty cycle factor)
+	 *
+	 * Thus, a _lower_ (more negative) value means _more_ interactivity.
+	 * With this, we determine the deadline as follows:
+	 *
+	 * 1. Compute the scaling weight as the absolute value of the latency
+	 *    priority sum
+	 * 2. Calculate an intermediate value of slice_ns scaled by the above
+	 *    weight
+	 * 3. Compute a task's deadline as either the negative or positive
+	 *    value for this adjusted intermediate value, depending on whether
+	 *    the latency priority was negative or positive respectively.
+	 *
+	 * This ends up working out quite well because tasks with higher
+	 * interactivity will scale their deadlines further back in time (the
+	 * absolute value of the latency priority will be higher, thus giving a
+	 * larger weight to scale slice_ns), and tasks with less interactivity
+	 * / more CPU-hogging behavior will scale their deadlines further
+	 * forward in time due to weight being higher from having lower
+	 * interactivity scores and a higher average runtime.
 	 */
-	lat_scale = sched_prio_to_latency_weight(lat_prio);
+	lat_prio = avg_run_linear - inv_dcycle_linear - work_chain_linear;
+	lat_prio_abs = abs(lat_prio);
+	lat_prio_abs = min(lat_prio_abs, DL_MAX_LAT_PRIO);
+	lat_scale = sched_prio_to_latency_weight(lat_prio_abs);
 	lat_scale = min(lat_scale, LB_MAX_WEIGHT);
+	dl = scale_up_fair(slice_ns, lat_scale);
 
-	/*
-	 * Finally, with our 'lat_scale' weight, we compute the length of the
-	 * task's request as:
-	 *
-	 * r_i = avg_runtime * 100 / lat_scale
-	 *
-	 * In other words, the "CPU request length" which is used to determine
-	 * the actual absolute vtime that the task is dispatched with.
-	 */
-	return scale_inverse_fair(taskc->avg_runtime, lat_scale);
+	return lat_prio >= 0 ? dl : -dl;
 }
 
 static void clamp_task_vtime(struct task_struct *p, struct task_ctx *taskc, u64 enq_flags)
@@ -733,9 +730,9 @@ static void clamp_task_vtime(struct task_struct *p, struct task_ctx *taskc, u64 
 	 * and then coming back and having essentially full use of the CPU for
 	 * an entire day until it's caught up to the other tasks' vtimes.
 	 */
-	if (vtime_before(p->scx.dsq_vtime, min_vruntime)) {
-		p->scx.dsq_vtime = min_vruntime;
-		taskc->deadline = p->scx.dsq_vtime + task_compute_dl(p, taskc, enq_flags);
+	if (vtime_before(taskc->vruntime, min_vruntime)) {
+		taskc->vruntime = min_vruntime;
+		taskc->deadline = taskc->vruntime + task_compute_dl(p, taskc, enq_flags);
 		stat_add(RUSTY_STAT_DL_CLAMP, 1);
 	} else {
 		stat_add(RUSTY_STAT_DL_PRESET, 1);
@@ -787,8 +784,8 @@ static bool task_set_domain(struct task_ctx *taskc, struct task_struct *p,
 		if (!init_dsq_vtime)
 			dom_xfer_task(p->pid, new_dom_id, now);
 		taskc->dom_id = new_dom_id;
-		p->scx.dsq_vtime = dom_min_vruntime(new_domc);
-		taskc->deadline = p->scx.dsq_vtime +
+		taskc->vruntime = dom_min_vruntime(new_domc);
+		taskc->deadline = taskc->vruntime +
 				  scale_inverse_fair(taskc->avg_runtime, taskc->weight);
 		bpf_cpumask_and(t_cpumask, (const struct cpumask *)d_cpumask,
 				p->cpus_ptr);
@@ -1444,8 +1441,8 @@ static void stopping_update_vtime(struct task_struct *p,
 	taskc->sum_runtime += delta;
 	taskc->avg_runtime = calc_avg(taskc->avg_runtime, taskc->sum_runtime);
 
-	p->scx.dsq_vtime += scale_inverse_fair(delta, p->scx.weight);
-	taskc->deadline = p->scx.dsq_vtime + task_compute_dl(p, taskc, 0);
+	taskc->vruntime += scale_inverse_fair(delta, p->scx.weight);
+	taskc->deadline = taskc->vruntime + task_compute_dl(p, taskc, 0);
 }
 
 void BPF_STRUCT_OPS(rusty_stopping, struct task_struct *p, bool runnable)


### PR DESCRIPTION
Currently, a task's deadline is computed as its vtime + a scaled function of its average runtime (with its deadline being scaled down if it's more interactive). This makes sense intuitively, as we do want an interactive task to have an earlier deadline, but it also has some flaws.

For one thing, we're currently ignoring duty cycle when determining a task's deadline. This has a few implications. Firstly, because we reward tasks with higher waker and blocked frequencies due to considering them to be part of a work chain, we implicitly penalize tasks that rarely ever use the CPU because those frequencies are low. While those tasks are likely not part of a work chain, they also should get an interactivity boost just by pure virtue of not using the CPU very often. This should in theory be addressed by vruntime, but because we cap the amount of vtime that a task can accumulate to one slice, it may not be adequately reflected after a task runs for the first time.

Another problem is that we're minimizing a task's deadline if it's interactive, but we're also not really penalizing a task that's a super CPU hog by increasing its deadline. We sort of do a bit by applying a higher niceness which gives it a higher deadline for a lower weight, but its somewhat minimal considering that we're using niceness, and that the best an interactive task can do is minimize its deadline to near zero relative to its vtime.

What we really want to do is "negatively" scale an interactive task's deadline with the same magnitude as we "positively" scale a CPU-hogging task's deadline. To do this, we make two major changes to how we compute deadline:

1. Instead of using niceness, we now instead use our own straightforward scaling factor. This was chosen arbitrarily (by experimentation with some games) to be a scaling by 1000, but we can and should improve this in the future.

2. We now create a _signed_ linear latency priority factor as a sum of the three following inputs:
   - Work-chain factor (log_2 of product of blocked freq and waker freq)
   - Inverse duty cycle factor (log_2 of the inverse of a task's duty cycle -- higher duty cycle means lower factor)
   - Average runtime factor (Higher avg runtime means higher average runtime factor)

We then compute the latency priority as:

	lat_prio := Average runtime factor - (work-chain factor + duty cycle factor)

This gives us a signed value that can be negative. With this, we can compute a non-negative weight value by calculating a weight from the absolute value of lat_prio, and use this to scale slice_ns. If lat_prio is negative we calculate a task's deadline as its vtime MINUS its scaled slice_ns, and if it's positive, it's the task's vtime PLUS scaled slice_ns.

This ends up working well because you get a higher weight both for highly interactive tasks, and highly CPU-hogging / non-interactive tasks, which lets you scale a task's deadline "more negatively" for interactive tasks, and "more positively" for the CPU hogs.

With this change, we get a significant improvement in FPS. On a 7950X, if I run the following workload:

	$ stress-ng -c $((8 * $(nproc)))

1. I get 60 FPS when playing Stellaris (while time is progressing at max speed), whereas EEVDF gets 6-7 FPS.

2. I get ~15-40 FPS while playing Civ6, whereas EEVDF seems to get < 1 FPS. The Civ6 benchmark doesn't even start after over 4 minutes in the initial frame with EEVDF, but gets us 13s / turn with rusty.

3. It seems that EEVDF has improved with Terraria in v6.9. It was able to maintain ~30-55 FPS, as opposed to the ~5-10FPS we've seen in the past. rusty is still able to maintain a solid 60-62FPS consistently with no problem, however.