### PR TITLE
Reduce MAX_ENQUEUED_TASKS to fit percpu allocator

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -131,7 +131,7 @@ static bool is_fifo_enabled;
  * The @queued and @dispatched lists are used in a producer/consumer fashion
  * between the BPF part and the user-space part.
  */
-#define MAX_ENQUEUED_TASKS 8192
+#define MAX_ENQUEUED_TASKS 4096
 
 /*
  * Maximum amount of slots reserved to the tasks dispatched via shared queue.


### PR DESCRIPTION
The setting of `ops->dispatch_max_batch` leads to a too large allocated size for percpu allocator, and it will be unhappy if we want a size larger than `PCPU_MIN_UNIT_SIZE`. Reduce `MAX_ENQUEUED_TASKS` for fix.

The details for the issue can be found at #308.

