### PR TITLE
scx_layered: Improve affn_viol handling and implement dump method

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -31,6 +31,9 @@ enum consts {
 	MAX_LAYERS		= 16,
 	USAGE_HALF_LIFE		= 100000000,	/* 100ms */
 
+	HI_FALLBACK_DSQ		= MAX_LAYERS,
+	LO_FALLBACK_DSQ		= MAX_LAYERS + 1,
+
 	/* XXX remove */
 	MAX_CGRP_PREFIXES = 32
 };

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -589,7 +589,8 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 		if (layers[idx].preempt && scx_bpf_consume(idx))
 			return;
 
-	scx_bpf_consume(HI_FALLBACK_DSQ);
+	if (scx_bpf_consume(HI_FALLBACK_DSQ))
+		return;
 
 	/* consume !open layers second */
 	bpf_for(idx, 0, nr_layers) {


### PR DESCRIPTION
- Any tasks with custom affinity which are enqueued outside of wakeup path were considered to be `affn_viol` and queued on the global DSQ. This is unnecessary. The per-layer DSQs and preemption path can handle tasks with custom affinities just fine for tasks in open or grouped layers. Update enqueue to better handle tasks with custom affinities.
- `affn_viol` tasks were queued onto `SCX_DSQ_GLOBAL` which has precedence over all user and thus per-layer DSQs. It doesn't make sense to boost tasks which are in violation. Let's create user fallback DSQs and use them to handle affinity violations.
- Add dump method to aid debugging.