### PR TITLE
scx_central: Provide backward compability

### DIFF
--- a/scheds/c/scx_central.bpf.c
+++ b/scheds/c/scx_central.bpf.c
@@ -305,6 +305,7 @@ int BPF_STRUCT_OPS_SLEEPABLE(central_init)
 	struct bpf_timer *timer;
 	int ret;
 
+	__COMPAT_scx_bpf_switch_all();
 	ret = scx_bpf_create_dsq(FALLBACK_DSQ_ID, -1);
 	if (ret)
 		return ret;


### PR DESCRIPTION
## Summary
Newer sched_ext kernel versions sets the scheduler to schedule all tasks within the system by default. However, some users are using the old versions of kernel.

Therefore we call "__COMPAT_scx_bpf_switch_all()" to move all tasks to "SCHED_EXT" class so scx_central would schedule all tasks by default in older kernels.

## Fix issue
fix #313 