### PR TITLE
scx_lavd: Enforce memory barrier in flip_sys_cpu_util

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -520,7 +520,7 @@ static struct sys_cpu_util *get_sys_cpu_util_next(void)
 
 static void flip_sys_cpu_util(void)
 {
-	__sys_cpu_util_idx ^= 0x1;
+	__sync_fetch_and_xor(&__sys_cpu_util_idx, 0x1);
 }
 
 static __attribute__((always_inline))


### PR DESCRIPTION
Use the GNU built-in __sync_fetch_and_xor() to perform the XOR operation on global variable "__sys_cpu_util_idx" to ensure the operations visibility.

The built-in function "__sync_fetch_and_xor()" can provide both atomic operation and full memory barrier which is needed by every operation (especially store operation) on global variables.