### PR TITLE
Revert "scx_lavd: Enforce memory barrier in flip_sys_cpu_util"

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -520,7 +520,7 @@ static struct sys_cpu_util *get_sys_cpu_util_next(void)
 
 static void flip_sys_cpu_util(void)
 {
-	__sync_fetch_and_xor(&__sys_cpu_util_idx, 0x1);
+	__sys_cpu_util_idx ^= 0x1;
 }
 
 static __attribute__((always_inline))


### PR DESCRIPTION
Reverts sched-ext/scx#318

Since the write is done in the interrupt context, we don't need atomic write here. So I revert it. 