### PR TITLE
rusty: Use cpumask kfuncs in cpumask_intersects_domain()

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -1144,17 +1144,18 @@ dom_queue:
 
 static bool cpumask_intersects_domain(const struct cpumask *cpumask, u32 dom_id)
 {
-	s32 cpu;
+	struct dom_ctx *domc;
+	struct bpf_cpumask *dmask;
 
-	if (dom_id >= MAX_DOMS)
+	domc = lookup_dom_ctx(dom_id);
+	if (!domc)
 		return false;
 
-	bpf_for(cpu, 0, nr_cpus_possible) {
-		if (bpf_cpumask_test_cpu(cpu, cpumask) &&
-		    (dom_cpumasks[dom_id][cpu / 64] & (1LLU << (cpu % 64))))
-			return true;
-	}
-	return false;
+	dmask = domc->cpumask;
+	if (!dmask)
+		return false;
+
+	return bpf_cpumask_intersects(cpumask, (const struct cpumask *)dmask);
 }
 
 u32 dom_node_id(u32 dom_id)


### PR DESCRIPTION
In cpumask_intersects_domain(), we check whether a given cpumask has any CPUs in common with the specified domain by looking at the const, static dom_cpumasks map. This map is only really necessary when creating the domain struct bpf_cpumask objects at scheduler load time. After that, we can just use the actual struct bpf_cpumask object embedded in the domain context. Let's use that and cpumask kfuncs instead.

This allows rusty to load with
https://github.com/sched-ext/sched_ext/pull/216.