### PR TITLE
scx.service: start service after graphical target

### DIFF
--- a/services/systemd/scx.service
+++ b/services/systemd/scx.service
@@ -13,4 +13,4 @@ StandardError=journal
 LogNamespace=sched-ext
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=graphical.target


### PR DESCRIPTION
In conversation with @Byte-Lab , we determined that it is preferable to launch the service at a later stage of the system's startup.