### PR TITLE
scx: update /etc/default/scx sample flags

### DIFF
--- a/services/scx
+++ b/services/scx
@@ -2,4 +2,4 @@
 SCX_SCHEDULER=scx_rusty
 
 # Set custom flags for each scheduler, below is an example of how to use
-#SCX_FLAGS='-s 3000 -i 0.5 -I 0.025 -l 0.5 -b -k'
+#SCX_FLAGS='-u 3000 -i 0.5 -I 0.025 -l 0.5 -b -k'


### PR DESCRIPTION
Commit https://github.com/sched-ext/scx/commit/2403f606312123ada197d174aa1aa4158791d8b7 made changes to the naming of flags and thus one of the example flags no longer exists. Therefore, let's use the existing one so as not to cause unnecessary confusion. 