### PR TITLE
scx_rustland: never use a time slice that exceeds the default value

### DIFF
--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -534,7 +534,8 @@ impl<'a> Scheduler<'a> {
                     // Moreover, ensure that the time slice is never less than 0.25 ms to prevent
                     // excessive penalty from assigning time slices that are too short and reduce
                     // context switch overhead.
-                    let slice_ns = (task.vruntime - self.min_vruntime).max(NSEC_PER_MSEC / 4);
+                    let slice_ns =
+                        (task.vruntime - self.min_vruntime).clamp(NSEC_PER_MSEC / 4, self.slice_ns);
 
                     // Update global minimum vruntime.
                     self.min_vruntime = task.vruntime;


### PR DESCRIPTION
Make sure to never assign a time slice longer than the default time slice, that can be used as an upper limit.

This seems to prevent potential stall conditions (reported by the CachyOS community) when running CPU-intensive workloads, such as:

 [   68.062813] sched_ext: BPF scheduler "rustland" errored, disabling
 [   68.062831] sched_ext: runnable task stall (ollama_llama_se[3312] failed to run for 5.180s)
 [   68.062832]    scx_watchdog_workfn+0x154/0x1e0
 [   68.062837]    process_one_work+0x18e/0x350
 [   68.062839]    worker_thread+0x2fa/0x490
 [   68.062841]    kthread+0xd2/0x100
 [   68.062842]    ret_from_fork+0x34/0x50
 [   68.062844]    ret_from_fork_asm+0x1a/0x30

Fixes: 6f4cd853 ("scx_rustland: introduce virtual time slice")
Tested-by: SoulHarsh007 <harsh.peshwani@outlook.com>
Tested-by: Piotr Gorski <piotrgorski@cachyos.org>