### PR TITLE
Bring rust scheduler's compat support to parity with C

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -118,7 +118,7 @@ if should_build_libbpf
   endforeach
 
   message('Fetching libbpf repo')
-  libbpf_commit = '6d3595d215b014d3eddb88038d686e1c20781534'
+  libbpf_commit = '42065ea6627ff6e1ab4c65e51042a70fbf30ff7c'
   run_command(fetch_libbpf, meson.current_build_dir(), libbpf_commit, check: true)
 
   make_jobs = 1
@@ -174,7 +174,7 @@ endif
 
 if should_build_bpftool
   message('Fetching bpftool repo')
-  bpftool_commit = '20ce6933869b70bacfdd0dd1a8399199290bf8ff'
+  bpftool_commit = '42065ea6627ff6e1ab4c65e51042a70fbf30ff7c'
   run_command(fetch_bpftool, meson.current_build_dir(), bpftool_commit, check: true)
 
   bpftool_target = custom_target('bpftool_target',

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -127,11 +127,11 @@ pub fn struct_has_field(type_name: &str, field: &str) -> Result<bool> {
     return Ok(false);
 }
 
-pub fn kfunc_exists(kfunc: &str) -> Result<bool> {
+pub fn ksym_exists(ksym: &str) -> Result<bool> {
     let btf: &btf = *VMLINUX_BTF;
 
-    let kfunc_name = CString::new(kfunc).unwrap();
-    let tid = unsafe { btf__find_by_name_kind(btf, kfunc_name.as_ptr(), BTF_KIND_FUNC) };
+    let ksym_name = CString::new(ksym).unwrap();
+    let tid = unsafe { btf__find_by_name(btf, ksym_name.as_ptr()) };
     Ok(tid >= 0)
 }
 
@@ -252,8 +252,8 @@ mod tests {
     }
 
     #[test]
-    fn test_kfunc_exists() {
-        assert!(super::kfunc_exists("scx_bpf_consume").unwrap());
-        assert!(!super::kfunc_exists("NO_SUCH_KFUNC").unwrap());
+    fn test_ksym_exists() {
+        assert!(super::ksym_exists("scx_bpf_consume").unwrap());
+        assert!(!super::ksym_exists("NO_SUCH_KFUNC").unwrap());
     }
 }

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -204,10 +204,27 @@ macro_rules! scx_ops_load {
             scx_utils::uei_set_size!($skel, $ops, $uei);
 
             let ops = $skel.struct_ops.[<$ops _mut>]();
-            let has_field = scx_utils::compat::struct_has_field("sched_ext_ops", "exit_dump_len")?;
-            if !has_field && ops.exit_dump_len != 0 {
+
+            if !scx_utils::compat::struct_has_field("sched_ext_ops", "exit_dump_len")?
+                && ops.exit_dump_len != 0 {
                 scx_utils::warn!("Kernel doesn't support setting exit dump len");
                 ops.exit_dump_len = 0;
+            }
+
+            if !scx_utils::compat::struct_has_field("sched_ext_ops", "tick")?
+                && ops.tick != std::ptr::null_mut() {
+                scx_utils::warn!("Kernel doesn't support ops.tick()");
+                ops.tick = std::ptr::null_mut();
+            }
+
+            if !scx_utils::compat::struct_has_field("sched_ext_ops", "dump")?
+                && (ops.dump != std::ptr::null_mut() ||
+                    ops.dump_cpu != std::ptr::null_mut() ||
+                    ops.dump_task != std::ptr::null_mut()) {
+                scx_utils::warn!("Kernel doesn't support ops.dump*()");
+                ops.dump = std::ptr::null_mut();
+                ops.dump_cpu = std::ptr::null_mut();
+                ops.dump_task = std::ptr::null_mut();
             }
 
             $skel.load().context("Failed to load BPF program")

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -214,8 +214,8 @@ static void refresh_cpumasks(int idx)
 	trace("LAYER[%d] now has %d cpus, seq=%llu", idx, layer->nr_cpus, layer->cpus_seq);
 }
 
-SEC("fentry/scheduler_tick")
-int scheduler_tick_fentry(const void *ctx)
+SEC("fentry")
+int BPF_PROG(sched_tick_fentry)
 {
 	int idx;
 


### PR DESCRIPTION
With these updates, `scx_layered` can be loaded on v6.10-rc kernels as well as kernel which don't support `ops.dump*()`.