### PR TITLE
scx_utils: Add CPU freq transition latency

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -82,6 +82,7 @@ pub struct Cpu {
     id: usize,
     min_freq: usize,
     max_freq: usize,
+    trans_lat_ns: usize,
 }
 
 impl Cpu {
@@ -98,6 +99,11 @@ impl Cpu {
     /// Get the maximum scaling frequency of this CPU
     pub fn max_freq(&self) -> usize {
         self.max_freq
+    }
+
+    /// Get the transition latency of the CPU in nanoseconds
+    pub fn trans_lat_ns(&self) -> usize {
+        self.trans_lat_ns
     }
 }
 
@@ -387,6 +393,7 @@ fn create_insert_cpu(cpu_id: usize, node: &mut Node, online_mask: &Cpumask) -> R
     let freq_path = cpu_path.join("cpufreq");
     let min_freq = read_file_usize(&freq_path.join("scaling_min_freq")).unwrap_or(0);
     let max_freq = read_file_usize(&freq_path.join("scaling_max_freq")).unwrap_or(0);
+    let trans_lat_ns = read_file_usize(&freq_path.join("cpuinfo_transition_latency")).unwrap_or(0);
 
     if !node.llcs.contains_key(&llc_id) {
         let cache = Cache {
@@ -414,6 +421,7 @@ fn create_insert_cpu(cpu_id: usize, node: &mut Node, online_mask: &Cpumask) -> R
             id: cpu_id,
             min_freq: min_freq,
             max_freq: max_freq,
+            trans_lat_ns: trans_lat_ns,
         },
     );
 


### PR DESCRIPTION
This change adds the CPU frequency transition latency from the `cpuinfo_transition_latency` from sysfs. The value of this field is described [cpufreq
docs](https://www.kernel.org/doc/Documentation/cpu-freq/user-guide.txt). On supported systems it returns the CPU frequency transition latency in nanoseconds. The goal of this change is so that in the future schedulers can use this data to make better frequency scaling decisions.