### PR TITLE
uei: Pass skel to RESIZE_ARRAY()

### DIFF
--- a/scheds/c/scx_central.c
+++ b/scheds/c/scx_central.c
@@ -77,8 +77,8 @@ restart:
 	}
 
 	/* Resize arrays so their element count is equal to cpu count. */
-	RESIZE_ARRAY(data, cpu_gimme_task, skel->rodata->nr_cpu_ids);
-	RESIZE_ARRAY(data, cpu_started_at, skel->rodata->nr_cpu_ids);
+	RESIZE_ARRAY(skel, data, cpu_gimme_task, skel->rodata->nr_cpu_ids);
+	RESIZE_ARRAY(skel, data, cpu_started_at, skel->rodata->nr_cpu_ids);
 
 	SCX_OPS_LOAD(skel, central_ops, scx_central, uei);
 

--- a/scheds/c/scx_pair.c
+++ b/scheds/c/scx_pair.c
@@ -76,9 +76,9 @@ restart:
 	bpf_map__set_max_entries(skel->maps.pair_ctx, skel->rodata->nr_cpu_ids / 2);
 
 	/* Resize arrays so their element count is equal to cpu count. */
-	RESIZE_ARRAY(rodata, pair_cpu, skel->rodata->nr_cpu_ids);
-	RESIZE_ARRAY(rodata, pair_id, skel->rodata->nr_cpu_ids);
-	RESIZE_ARRAY(rodata, in_pair_idx, skel->rodata->nr_cpu_ids);
+	RESIZE_ARRAY(skel, rodata, pair_cpu, skel->rodata->nr_cpu_ids);
+	RESIZE_ARRAY(skel, rodata, pair_id, skel->rodata->nr_cpu_ids);
+	RESIZE_ARRAY(skel, rodata, in_pair_idx, skel->rodata->nr_cpu_ids);
 
 	for (i = 0; i < skel->rodata->nr_cpu_ids; i++)
 		skel->rodata_pair_cpu->pair_cpu[i] = -1;

--- a/scheds/include/scx/common.h
+++ b/scheds/include/scx/common.h
@@ -44,7 +44,8 @@ typedef int64_t s64;
 
 /**
  * RESIZE_ARRAY - Convenience macro for resizing a BPF array
- * @elfsec: the data section of the BPF program in which to the array exists
+ * @__skel: the skeleton containing the array
+ * @elfsec: the data section of the BPF program in which the array exists
  * @arr: the name of the array
  * @n: the desired array element count
  *
@@ -56,13 +57,13 @@ typedef int64_t s64;
  * for that custom data section so that it points to the newly memory mapped
  * region.
  */
-#define RESIZE_ARRAY(elfsec, arr, n)						  \
-	do {									  \
-		size_t __sz;							  \
-		bpf_map__set_value_size(skel->maps.elfsec##_##arr,		  \
-				sizeof(skel->elfsec##_##arr->arr[0]) * (n));	  \
-		skel->elfsec##_##arr =						  \
-			bpf_map__initial_value(skel->maps.elfsec##_##arr, &__sz); \
+#define RESIZE_ARRAY(__skel, elfsec, arr, n)						\
+	do {										\
+		size_t __sz;								\
+		bpf_map__set_value_size((__skel)->maps.elfsec##_##arr,			\
+				sizeof((__skel)->elfsec##_##arr->arr[0]) * (n));	\
+		(__skel)->elfsec##_##arr =						\
+			bpf_map__initial_value((__skel)->maps.elfsec##_##arr, &__sz);	\
 	} while (0)
 
 #include "user_exit_info.h"

--- a/scheds/include/scx/user_exit_info.h
+++ b/scheds/include/scx/user_exit_info.h
@@ -53,10 +53,10 @@ struct user_exit_info {
 #include <stdbool.h>
 
 /* no need to call the following explicitly if SCX_OPS_LOAD() is used */
-#define UEI_SET_SIZE(__skel, __ops_name, __uei_name) ({				\
-	u32 __len = (__skel)->struct_ops.__ops_name->exit_dump_len ?: UEI_DUMP_DFL_LEN; \
-	(__skel)->rodata->__uei_name##_dump_len = __len;			\
-	RESIZE_ARRAY(data, __uei_name##_dump, __len);				\
+#define UEI_SET_SIZE(__skel, __ops_name, __uei_name) ({					\
+	u32 __len = (__skel)->struct_ops.__ops_name->exit_dump_len ?: UEI_DUMP_DFL_LEN;	\
+	(__skel)->rodata->__uei_name##_dump_len = __len;				\
+	RESIZE_ARRAY((__skel), data, __uei_name##_dump, __len);				\
 })
 
 #define UEI_EXITED(__skel, __uei_name) ({					\


### PR DESCRIPTION
The RESIZE_ARRAY() macro assumes the presence of an in-scope "skel" variable. This is bad practice and can cause issues in other macros that use it. Let's update it to explicitly take a skel argument.