### PR TITLE
scx_rustland: prevent starvation

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -456,7 +456,7 @@ static void dispatch_user_scheduler(void)
 	 * Dispatch the scheduler on the first CPU available, likely the
 	 * current one.
 	 */
-	dispatch_task(p, SHARED_DSQ, 0, 0, 0);
+	dispatch_task(p, SHARED_DSQ, 0, 0, SCX_ENQ_PREEMPT);
 	bpf_task_release(p);
 }
 


### PR DESCRIPTION
A set of changes that helps prevent potential starvation conditions.

This also seems to improve system responsiveness (~4-5% fps during the typical "gaming while building the kernel" benchmark) and it also helps to prevent potential audio cracking issues.

This patch has been produced thanks to the extensive iteration tests performed by SoulHarsh007 <harsh.peshwani@outlook.com> from the CachyOS community. Big kudos to him for all his valuable feedback.