### PR TITLE
scheds: Add scx_mitosis scheduler to /etc/default/scx

### DIFF
--- a/services/scx
+++ b/services/scx
@@ -1,4 +1,4 @@
-# List of scx_schedulers: scx_central scx_flatcg scx_lavd scx_layered scx_nest scx_pair scx_qmap scx_rlfifo scx_rustland scx_rusty scx_simple scx_userland
+# List of scx_schedulers: scx_central scx_flatcg scx_lavd scx_layered scx_mitosis scx_nest scx_pair scx_qmap scx_rlfifo scx_rustland scx_rusty scx_simple scx_userland
 SCX_SCHEDULER=scx_rusty
 
 # Set custom flags for each scheduler, below is an example of how to use


### PR DESCRIPTION
Synchronize the scheduler list with the actual state. Even if scx_mitosis is in the early stages of development, let's show in the config that it exists. 