### PR TITLE
mitosis: Fix build

### DIFF
--- a/scheds/rust/scx_mitosis/meson.build
+++ b/scheds/rust/scx_mitosis/meson.build
@@ -1,4 +1,4 @@
-custom_target('scx_mitosis',
+sched = custom_target('scx_mitosis',
               output: '@PLAINNAME@.__PHONY__',
               input: 'Cargo.toml',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',


### PR DESCRIPTION
The target wasn't dependent on the previous sched so building all schedulers ended up not building scx_mitosis which broke the install script.