### PR TITLE
scx_lavd: properly calculate task's runtime after suspend/resume

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -142,6 +142,12 @@ struct cpu_ctx {
 	volatile u64	last_kick_clk;	/* when the CPU was kicked */
 
 	/*
+	 * Information for cpu hotplug
+	 */
+	u64		online_clk;	/* when a CPU becomes online */
+	u64		offline_clk;	/* when a CPU becomes offline */
+
+	/*
 	 * Information used to keep track of latency criticality
 	 */
 	volatile u64	max_lat_cri;	/* maximum latency criticality */
@@ -165,7 +171,6 @@ struct cpu_ctx {
 	/*
 	 * Fields for core compaction
 	 *
-	 * NOTE: The followings MUST be placed at the end of this struct.
 	 */
 	struct bpf_cpumask __kptr *tmp_a_mask;	/* temporary cpu mask */
 	struct bpf_cpumask __kptr *tmp_o_mask;	/* temporary cpu mask */


### PR DESCRIPTION
When a device is suspended and resumed, the suspended duration is added up to a task's runtime if the task was running on the CPU. After the resume, the task's runtime is incorrectly long and the scheduler starts to recognize the system is under heavy load. To avoid such problem, the suspended duration is measured and substracted from the task's runtime.