### PR TITLE
Support LLVM_VERSION_SUFFIX in clang version parsing regex

### DIFF
--- a/meson-scripts/get_clang_ver
+++ b/meson-scripts/get_clang_ver
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-"$1" --version | sed -nr 's/^.*clang version ([\.0-9]*)(git)?( .*)?$/\1/p'
+"$1" --version | sed -nr 's/^.*clang version ([\.0-9]*)(git)?(\+.*)?( .*)?$/\1/p'


### PR DESCRIPTION
If LLVM is compiled with the LLVM_VERSION_SUFFIX cmake option, then the version may have an additional suffix, for example "18.1.7+libcxx". Gentoo for example uses this to fend off ABI issues between libstdc++ and libc++.