### PR TITLE
common: Add css iter forward declares

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -366,6 +366,16 @@ struct cgroup *bpf_cgroup_ancestor(struct cgroup *cgrp, int level) __ksym;
 void bpf_cgroup_release(struct cgroup *cgrp) __ksym;
 struct cgroup *bpf_cgroup_from_id(u64 cgid) __ksym;
 
+/* css iteration is experimental, forward declare the necessary functions */
+struct bpf_iter_css;
+struct cgroup_subsys_state;
+extern int bpf_iter_css_new(struct bpf_iter_css *it,
+			    struct cgroup_subsys_state *start,
+			    unsigned int flags) __weak __ksym;
+extern struct cgroup_subsys_state *
+bpf_iter_css_next(struct bpf_iter_css *it) __weak __ksym;
+extern void bpf_iter_css_destroy(struct bpf_iter_css *it) __weak __ksym;
+
 /* cpumask */
 struct bpf_cpumask *bpf_cpumask_create(void) __ksym;
 struct bpf_cpumask *bpf_cpumask_acquire(struct bpf_cpumask *cpumask) __ksym;

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -228,16 +228,6 @@ static inline const struct cpumask *lookup_cell_cpumask(int idx)
 	return (const struct cpumask *)cpumaskw->cpumask;
 }
 
-/* css iteration is experimental, forward declare the necessary functions */
-struct bpf_iter_css;
-struct cgroup_subsys_state;
-extern int bpf_iter_css_new(struct bpf_iter_css *it,
-			    struct cgroup_subsys_state *start,
-			    unsigned int flags) __weak __ksym;
-extern struct cgroup_subsys_state *
-bpf_iter_css_next(struct bpf_iter_css *it) __weak __ksym;
-extern void bpf_iter_css_destroy(struct bpf_iter_css *it) __weak __ksym;
-
 /*
 * Along with a user_global_seq bump, indicates that cgroup->cell assignment
 * changed


### PR DESCRIPTION
These are used in mitosis, but they belong in common code so other schedulers can do css iteration.