### PR TITLE
scx.service: allow overriding scx variables

### DIFF
--- a/services/systemd/scx.service
+++ b/services/systemd/scx.service
@@ -7,7 +7,7 @@ StartLimitBurst=2
 [Service]
 Type=simple
 EnvironmentFile=/etc/default/scx
-ExecStart=/bin/bash -c 'exec $SCX_SCHEDULER $SCX_FLAGS '
+ExecStart=/bin/bash -c 'exec ${SCX_SCHEDULER_OVERRIDE:-$SCX_SCHEDULER} ${SCX_FLAGS_OVERRIDE:-$SCX_FLAGS} '
 Restart=on-failure
 StandardError=journal
 LogNamespace=sched-ext


### PR DESCRIPTION
Switching the scheduler requires changing SCX_SCHEDULER (and potentially also SCX_FLAGS) in /etc/default/scx.

This patch allows overriding these settings using systemd environment variables SCX_SCHEDULER_OVERRIDE and SCX_FLAGS_OVERRIDE, without changing the default configuration.

Example:

 > grep SCX_SCHEDULER /etc/default/scx
 SCX_SCHEDULER=scx_rusty

 > sudo systemctl status scx
 ...
   Main PID: 8021 (scx_rusty)
 ...

 > sudo systemctl set-environment SCX_SCHEDULER_OVERRIDE=scx_rustland
 > sudo systemctl restart scx
 > sudo systemctl status scx
...
   Main PID: 4021 (scx_rustland)
...

This feature can be useful for quickly testing different schedulers and settings, without altering the global system configuration.