### PR TITLE
Strip compat support

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -246,7 +246,6 @@ impl<'cb> BpfScheduler<'cb> {
 
         skel.bss_mut().usersched_pid = std::process::id();
         skel.rodata_mut().slice_ns = slice_us * 1000;
-        skel.rodata_mut().switch_partial = partial;
         skel.rodata_mut().debug = debug;
         skel.rodata_mut().full_user = full_user;
         skel.rodata_mut().low_power = low_power;

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -1010,8 +1010,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rustland_init)
 	err = usersched_timer_init();
 	if (err)
 		return err;
-        if (!switch_partial)
-		__COMPAT_scx_bpf_switch_all();
 
 	return 0;
 }

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -432,7 +432,7 @@ dispatch_task(struct task_struct *p, u64 dsq_id,
 			p->pid, p->comm, dsq_id, enq_flags, slice);
 
 		/* Wake up the target CPU (only if idle) */
-		scx_bpf_kick_cpu(cpu, __COMPAT_SCX_KICK_IDLE);
+		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 		break;
 	}
 }
@@ -467,7 +467,7 @@ static void
 dispatch_direct_cpu(struct task_struct *p, s32 cpu, u64 slice_ns, u64 enq_flags)
 {
 	scx_bpf_dispatch(p, cpu_to_dsq(cpu), slice_ns, enq_flags);
-	scx_bpf_kick_cpu(cpu, __COMPAT_SCX_KICK_IDLE);
+	scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 
 	__sync_fetch_and_add(&nr_kernel_dispatches, 1);
 }

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -163,34 +163,34 @@ macro_rules! unwrap_or_break {
 
 pub fn check_min_requirements() -> Result<()> {
     if let Ok(false) | Err(_) = struct_has_field("sched_ext_ops", "dump") {
-	bail!("sched_ext_ops.dump() missing, kernel too old?");
+        bail!("sched_ext_ops.dump() missing, kernel too old?");
     }
     if let Ok(false) | Err(_) = struct_has_field("sched_ext_ops", "tick") {
-	bail!("sched_ext_ops.tick() missing, kernel too old?");
+        bail!("sched_ext_ops.tick() missing, kernel too old?");
     }
     if let Ok(false) | Err(_) = struct_has_field("sched_ext_ops", "exit_dump_len") {
-	bail!("sched_ext_ops.exit_dump_len missing, kernel too old?");
+        bail!("sched_ext_ops.exit_dump_len missing, kernel too old?");
     }
     if let Ok(false) | Err(_) = struct_has_field("sched_ext_ops", "hotplug_seq") {
-	bail!("sched_ext_ops.hotplug_seq missing, kernel too old?");
+        bail!("sched_ext_ops.hotplug_seq missing, kernel too old?");
     }
     if let Ok(false) | Err(_) = ksym_exists("scx_bpf_cpuperf_cap") {
-	bail!("scx_bpf_cpuperf_*() missing, kernel too old?");
+        bail!("scx_bpf_cpuperf_*() missing, kernel too old?");
     }
     if let Ok(false) | Err(_) = ksym_exists("scx_bpf_nr_cpu_ids") {
-	bail!("scx_bpf_nr_cpu_ids() missing, kernel too old?");
+        bail!("scx_bpf_nr_cpu_ids() missing, kernel too old?");
     }
     if let Ok(false) | Err(_) = ksym_exists("scx_bpf_dump_bstr") {
-	bail!("scx_bpf_dump() missing, kernel too old?");
+        bail!("scx_bpf_dump() missing, kernel too old?");
     }
     if let Ok(false) | Err(_) = ksym_exists("scx_bpf_exit_bstr") {
-	bail!("scx_bpf_exit() missing, kernel too old?");
+        bail!("scx_bpf_exit() missing, kernel too old?");
     }
     if let Err(_) = read_enum("scx_kick_flags", "SCX_KICK_IDLE") {
-	bail!("SCX_KICK_IDLE missing, kernel too old?");
+        bail!("SCX_KICK_IDLE missing, kernel too old?");
     }
     if *SCX_OPS_SWITCH_PARTIAL == 0 {
-	bail!("SCX_OPS_SWITCH_PARTIAL missing, kernel too old?");
+        bail!("SCX_OPS_SWITCH_PARTIAL missing, kernel too old?");
     }
     Ok(())
 }
@@ -199,10 +199,6 @@ pub fn check_min_requirements() -> Result<()> {
 /// is used to define ops, and scx_ops_open!(), scx_ops_load!(), and
 /// scx_ops_attach!() are used to open, load and attach it, backward
 /// compatibility is automatically maintained where reasonable.
-///
-/// - sched_ext_ops.hotplug_seq was added later. On kernels which support it,
-/// set the value to a nonzero value to trigger an exit in the scheduler when
-/// a hotplug event occurs between opening and attaching the scheduler.
 #[rustfmt::skip]
 #[macro_export]
 macro_rules! scx_ops_open {

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -162,14 +162,17 @@ macro_rules! unwrap_or_break {
 }
 
 pub fn check_min_requirements() -> Result<()> {
-    if *SCX_OPS_SWITCH_PARTIAL == 0 {
-	bail!("SCX_OPS_SWITCH_PARTIAL missing, kernel too old?");
+    if let Ok(false) | Err(_) = ksym_exists("scx_bpf_dump_bstr") {
+	bail!("scx_bpf_dump() missing, kernel too old?");
+    }
+    if let Ok(false) | Err(_) = ksym_exists("scx_bpf_exit_bstr") {
+	bail!("scx_bpf_exit() missing, kernel too old?");
     }
     if let Err(_) = read_enum("scx_kick_flags", "SCX_KICK_IDLE") {
 	bail!("SCX_KICK_IDLE missing, kernel too old?");
     }
-    if let Ok(false) | Err(_) = ksym_exists("scx_bpf_exit_bstr") {
-	bail!("scx_bpf_exit() missing, kernel too old?");
+    if *SCX_OPS_SWITCH_PARTIAL == 0 {
+	bail!("SCX_OPS_SWITCH_PARTIAL missing, kernel too old?");
     }
     Ok(())
 }

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -162,6 +162,9 @@ macro_rules! unwrap_or_break {
 }
 
 pub fn check_min_requirements() -> Result<()> {
+    if let Ok(false) | Err(_) = struct_has_field("sched_ext_ops", "tick") {
+	bail!("sched_ext_ops.tick() missing, kernel too old?");
+    }
     if let Ok(false) | Err(_) = struct_has_field("sched_ext_ops", "exit_dump_len") {
 	bail!("sched_ext_ops.exit_dump_len missing, kernel too old?");
     }
@@ -244,13 +247,6 @@ macro_rules! scx_ops_load {
             scx_utils::uei_set_size!($skel, $ops, $uei);
 
             let ops = $skel.struct_ops.[<$ops _mut>]();
-
-            let has_field = scx_utils::unwrap_or_break!(
-                scx_utils::compat::struct_has_field("sched_ext_ops", "tick"), 'block);
-            if !has_field && ops.tick != std::ptr::null_mut() {
-                scx_utils::warn!("Kernel doesn't support ops.tick()");
-                ops.tick = std::ptr::null_mut();
-            }
 
             let has_field = scx_utils::unwrap_or_break!(
                 scx_utils::compat::struct_has_field("sched_ext_ops", "dump"), 'block);

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -162,35 +162,10 @@ macro_rules! unwrap_or_break {
 }
 
 pub fn check_min_requirements() -> Result<()> {
+    // ec7e3b0463e1 ("implement-ops") in https://github.com/sched-ext/sched_ext
+    // is the current minimum required kernel version.
     if let Ok(false) | Err(_) = struct_has_field("sched_ext_ops", "dump") {
         bail!("sched_ext_ops.dump() missing, kernel too old?");
-    }
-    if let Ok(false) | Err(_) = struct_has_field("sched_ext_ops", "tick") {
-        bail!("sched_ext_ops.tick() missing, kernel too old?");
-    }
-    if let Ok(false) | Err(_) = struct_has_field("sched_ext_ops", "exit_dump_len") {
-        bail!("sched_ext_ops.exit_dump_len missing, kernel too old?");
-    }
-    if let Ok(false) | Err(_) = struct_has_field("sched_ext_ops", "hotplug_seq") {
-        bail!("sched_ext_ops.hotplug_seq missing, kernel too old?");
-    }
-    if let Ok(false) | Err(_) = ksym_exists("scx_bpf_cpuperf_cap") {
-        bail!("scx_bpf_cpuperf_*() missing, kernel too old?");
-    }
-    if let Ok(false) | Err(_) = ksym_exists("scx_bpf_nr_cpu_ids") {
-        bail!("scx_bpf_nr_cpu_ids() missing, kernel too old?");
-    }
-    if let Ok(false) | Err(_) = ksym_exists("scx_bpf_dump_bstr") {
-        bail!("scx_bpf_dump() missing, kernel too old?");
-    }
-    if let Ok(false) | Err(_) = ksym_exists("scx_bpf_exit_bstr") {
-        bail!("scx_bpf_exit() missing, kernel too old?");
-    }
-    if let Err(_) = read_enum("scx_kick_flags", "SCX_KICK_IDLE") {
-        bail!("SCX_KICK_IDLE missing, kernel too old?");
-    }
-    if *SCX_OPS_SWITCH_PARTIAL == 0 {
-        bail!("SCX_OPS_SWITCH_PARTIAL missing, kernel too old?");
     }
     Ok(())
 }

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -165,6 +165,9 @@ pub fn check_min_requirements() -> Result<()> {
     if *SCX_OPS_SWITCH_PARTIAL == 0 {
 	bail!("SCX_OPS_SWITCH_PARTIAL missing, kernel too old?");
     }
+    if let Err(_) = read_enum("scx_kick_flags", "SCX_KICK_IDLE") {
+	bail!("SCX_KICK_IDLE missing, kernel too old?");
+    }
     Ok(())
 }
 

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -162,6 +162,9 @@ macro_rules! unwrap_or_break {
 }
 
 pub fn check_min_requirements() -> Result<()> {
+    if let Ok(false) | Err(_) = ksym_exists("scx_bpf_cpuperf_cap") {
+	bail!("scx_bpf_cpuperf_*() missing, kernel too old?");
+    }
     if let Ok(false) | Err(_) = ksym_exists("scx_bpf_nr_cpu_ids") {
 	bail!("scx_bpf_nr_cpu_ids() missing, kernel too old?");
     }

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -168,6 +168,9 @@ pub fn check_min_requirements() -> Result<()> {
     if let Err(_) = read_enum("scx_kick_flags", "SCX_KICK_IDLE") {
 	bail!("SCX_KICK_IDLE missing, kernel too old?");
     }
+    if let Ok(false) | Err(_) = ksym_exists("scx_bpf_exit_bstr") {
+	bail!("scx_bpf_exit() missing, kernel too old?");
+    }
     Ok(())
 }
 

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -162,6 +162,9 @@ macro_rules! unwrap_or_break {
 }
 
 pub fn check_min_requirements() -> Result<()> {
+    if let Ok(false) | Err(_) = ksym_exists("scx_bpf_nr_cpu_ids") {
+	bail!("scx_bpf_nr_cpu_ids() missing, kernel too old?");
+    }
     if let Ok(false) | Err(_) = ksym_exists("scx_bpf_dump_bstr") {
 	bail!("scx_bpf_dump() missing, kernel too old?");
     }

--- a/scheds/c/scx_central.bpf.c
+++ b/scheds/c/scx_central.bpf.c
@@ -175,7 +175,7 @@ static bool dispatch_to_cpu(s32 cpu)
 		scx_bpf_dispatch(p, SCX_DSQ_LOCAL_ON | cpu, SCX_SLICE_INF, 0);
 
 		if (cpu != central_cpu)
-			scx_bpf_kick_cpu(cpu, __COMPAT_SCX_KICK_IDLE);
+			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 
 		bpf_task_release(p);
 		return true;

--- a/scheds/c/scx_central.bpf.c
+++ b/scheds/c/scx_central.bpf.c
@@ -305,7 +305,6 @@ int BPF_STRUCT_OPS_SLEEPABLE(central_init)
 	struct bpf_timer *timer;
 	int ret;
 
-	__COMPAT_scx_bpf_switch_all();
 	ret = scx_bpf_create_dsq(FALLBACK_DSQ_ID, -1);
 	if (ret)
 		return ret;

--- a/scheds/c/scx_nest.bpf.c
+++ b/scheds/c/scx_nest.bpf.c
@@ -582,8 +582,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(nest_init)
 	struct bpf_timer *timer;
 	u32 key = 0;
 
-	__COMPAT_scx_bpf_switch_all();
-
 	err = scx_bpf_create_dsq(FALLBACK_DSQ_ID, NUMA_NO_NODE);
 	if (err) {
 		scx_bpf_error("Failed to create fallback DSQ");

--- a/scheds/c/scx_qmap.bpf.c
+++ b/scheds/c/scx_qmap.bpf.c
@@ -221,7 +221,7 @@ void BPF_STRUCT_OPS(qmap_enqueue, struct task_struct *p, u64 enq_flags)
 		scx_bpf_dispatch(p, SHARED_DSQ, 0, enq_flags);
 		cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
 		if (cpu >= 0)
-			scx_bpf_kick_cpu(cpu, __COMPAT_SCX_KICK_IDLE);
+			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 		return;
 	}
 

--- a/scheds/c/scx_qmap.bpf.c
+++ b/scheds/c/scx_qmap.bpf.c
@@ -524,9 +524,6 @@ static void print_cpus(void)
 	char buf[128] = "", *p;
 	int idx;
 
-	if (!__COMPAT_HAS_CPUMASKS)
-		return;
-
 	possible = scx_bpf_get_possible_cpumask();
 	online = scx_bpf_get_online_cpumask();
 
@@ -591,9 +588,6 @@ static void monitor_cpuperf(void)
 	u64 target_sum = 0, target_min = SCX_CPUPERF_ONE, target_max = 0;
 	const struct cpumask *online;
 	int i, nr_online_cpus = 0;
-
-	if (!__COMPAT_HAS_CPUMASKS)
-		return;
 
 	nr_cpu_ids = scx_bpf_nr_cpu_ids();
 	online = scx_bpf_get_online_cpumask();

--- a/scheds/c/scx_qmap.bpf.c
+++ b/scheds/c/scx_qmap.bpf.c
@@ -41,7 +41,6 @@ const volatile bool print_shared_dsq;
 const volatile char exp_prefix[17];
 const volatile s32 disallow_tgid;
 const volatile bool suppress_dump;
-const volatile bool switch_partial;
 
 u32 test_error_cnt;
 
@@ -682,9 +681,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(qmap_init)
 	u32 key = 0;
 	struct bpf_timer *timer;
 	s32 ret;
-
-	if (!switch_partial)
-		__COMPAT_scx_bpf_switch_all();
 
 	print_cpus();
 

--- a/scheds/c/scx_qmap.bpf.c
+++ b/scheds/c/scx_qmap.bpf.c
@@ -475,13 +475,13 @@ void BPF_STRUCT_OPS(qmap_dump, struct scx_dump_ctx *dctx)
 		if (!(fifo = bpf_map_lookup_elem(&queue_arr, &i)))
 			return;
 
-		__COMPAT_scx_bpf_dump("QMAP FIFO[%d]:", i);
+		scx_bpf_dump("QMAP FIFO[%d]:", i);
 		bpf_repeat(4096) {
 			if (bpf_map_pop_elem(fifo, &pid))
 				break;
-			__COMPAT_scx_bpf_dump(" %d", pid);
+			scx_bpf_dump(" %d", pid);
 		}
-		__COMPAT_scx_bpf_dump("\n");
+		scx_bpf_dump("\n");
 	}
 }
 
@@ -495,9 +495,9 @@ void BPF_STRUCT_OPS(qmap_dump_cpu, struct scx_dump_ctx *dctx, s32 cpu, bool idle
 	if (!(cpuc = bpf_map_lookup_percpu_elem(&cpu_ctx_stor, &zero, cpu)))
 		return;
 
-	__COMPAT_scx_bpf_dump("QMAP: dsp_idx=%llu dsp_cnt=%llu avg_weight=%u cpuperf_target=%u",
-			      cpuc->dsp_idx, cpuc->dsp_cnt, cpuc->avg_weight,
-			      cpuc->cpuperf_target);
+	scx_bpf_dump("QMAP: dsp_idx=%llu dsp_cnt=%llu avg_weight=%u cpuperf_target=%u",
+		     cpuc->dsp_idx, cpuc->dsp_cnt, cpuc->avg_weight,
+		     cpuc->cpuperf_target);
 }
 
 void BPF_STRUCT_OPS(qmap_dump_task, struct scx_dump_ctx *dctx, struct task_struct *p)
@@ -509,8 +509,8 @@ void BPF_STRUCT_OPS(qmap_dump_task, struct scx_dump_ctx *dctx, struct task_struc
 	if (!(taskc = bpf_task_storage_get(&task_ctx_stor, p, 0, 0)))
 		return;
 
-	__COMPAT_scx_bpf_dump("QMAP: force_local=%d core_sched_seq=%llu",
-			      taskc->force_local, taskc->core_sched_seq);
+	scx_bpf_dump("QMAP: force_local=%d core_sched_seq=%llu",
+		     taskc->force_local, taskc->core_sched_seq);
 }
 
 /*

--- a/scheds/c/scx_qmap.c
+++ b/scheds/c/scx_qmap.c
@@ -104,8 +104,7 @@ int main(int argc, char **argv)
 			skel->rodata->suppress_dump = true;
 			break;
 		case 'p':
-			skel->rodata->switch_partial = true;
-			skel->struct_ops.qmap_ops->flags |= __COMPAT_SCX_OPS_SWITCH_PARTIAL;
+			skel->struct_ops.qmap_ops->flags |= SCX_OPS_SWITCH_PARTIAL;
 			break;
 		case 'v':
 			verbose = true;

--- a/scheds/c/scx_simple.bpf.c
+++ b/scheds/c/scx_simple.bpf.c
@@ -136,7 +136,6 @@ void BPF_STRUCT_OPS(simple_enable, struct task_struct *p)
 
 s32 BPF_STRUCT_OPS_SLEEPABLE(simple_init)
 {
-	__COMPAT_scx_bpf_switch_all();
 	return scx_bpf_create_dsq(SHARED_DSQ, -1);
 }
 

--- a/scheds/include/scx/common.h
+++ b/scheds/include/scx/common.h
@@ -28,8 +28,11 @@ typedef int64_t s64;
 
 #define SCX_BUG(__fmt, ...)							\
 	do {									\
-		fprintf(stderr, "%s:%d [scx panic]: %s\n", __FILE__, __LINE__,	\
-			strerror(errno));					\
+		fprintf(stderr, "[SCX_BUG] %s:%d", __FILE__, __LINE__);		\
+		if (errno)							\
+			fprintf(stderr, " (%s)\n", strerror(errno));		\
+		else								\
+			fprintf(stderr, "\n");					\
 		fprintf(stderr, __fmt __VA_OPT__(,) __VA_ARGS__);		\
 		fprintf(stderr, "\n");						\
 										\

--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -16,32 +16,6 @@
 })
 
 /*
- * cpuperf is new. The followings become noop on older kernels. Callers can be
- * updated to call cpuperf kfuncs directly in the future.
- */
-static inline u32 __COMPAT_scx_bpf_cpuperf_cap(s32 cpu)
-{
-	if (bpf_ksym_exists(scx_bpf_cpuperf_cap))
-		return scx_bpf_cpuperf_cap(cpu);
-	else
-		return 1024;
-}
-
-static inline u32 __COMPAT_scx_bpf_cpuperf_cur(s32 cpu)
-{
-	if (bpf_ksym_exists(scx_bpf_cpuperf_cur))
-		return scx_bpf_cpuperf_cur(cpu);
-	else
-		return 1024;
-}
-
-static inline void __COMPAT_scx_bpf_cpuperf_set(s32 cpu, u32 perf)
-{
-	if (bpf_ksym_exists(scx_bpf_cpuperf_set))
-		return scx_bpf_cpuperf_set(cpu, perf);
-}
-
-/*
  * Iteration and scx_bpf_consume_task() are new. The following become noop on
  * older kernels. The users can switch to bpf_for_each(scx_dsq) and directly
  * call scx_bpf_consume_task() in the future.

--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -16,18 +16,6 @@
 })
 
 /*
- * scx_bpf_exit() is a new addition. Fall back to scx_bpf_error() if
- * unavailable. Users can use scx_bpf_exit() directly in the future.
- */
-#define __COMPAT_scx_bpf_exit(code, fmt, args...)				\
-({										\
-	if (bpf_ksym_exists(scx_bpf_exit_bstr))					\
-		scx_bpf_exit((code), fmt, ##args);				\
-	else									\
-		scx_bpf_error(fmt, ##args);					\
-})
-
-/*
  * scx_bpf_dump() is a new addition. Ignore if unavailable. Users can use
  * scx_bpf_dump() directly in the future.
  */

--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -24,19 +24,6 @@
 	__COMPAT_ENUM_OR_ZERO(enum scx_kick_flags, SCX_KICK_IDLE)
 
 /*
- * scx_switch_all() was replaced by %SCX_OPS_SWITCH_PARTIAL. See
- * %__COMPAT_SCX_OPS_SWITCH_PARTIAL in compat.h. This can be dropped in the
- * future.
- */
-void scx_bpf_switch_all(void) __ksym __weak;
-
-static inline void __COMPAT_scx_bpf_switch_all(void)
-{
-	if (!bpf_core_enum_value_exists(enum scx_ops_flags, SCX_OPS_SWITCH_PARTIAL))
-		scx_bpf_switch_all();
-}
-
-/*
  * scx_bpf_exit() is a new addition. Fall back to scx_bpf_error() if
  * unavailable. Users can use scx_bpf_exit() directly in the future.
  */

--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -16,16 +16,6 @@
 })
 
 /*
- * scx_bpf_dump() is a new addition. Ignore if unavailable. Users can use
- * scx_bpf_dump() directly in the future.
- */
-#define __COMPAT_scx_bpf_dump(fmt, args...)					\
-({										\
-	if (bpf_ksym_exists(scx_bpf_dump_bstr))					\
-		scx_bpf_dump(fmt, ##args);					\
-})
-
-/*
  * scx_bpf_nr_cpu_ids(), scx_bpf_get_possible/online_cpumask() are new. No good
  * way to noop these kfuncs. Provide a test macro. Users can assume existence in
  * the future.

--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -16,14 +16,6 @@
 })
 
 /*
- * %SCX_KICK_IDLE is a later addition. To support both before and after, use
- * %__COMPAT_SCX_KICK_IDLE which becomes 0 on kernels which don't support it.
- * Users can use %SCX_KICK_IDLE directly in the future.
- */
-#define __COMPAT_SCX_KICK_IDLE							\
-	__COMPAT_ENUM_OR_ZERO(enum scx_kick_flags, SCX_KICK_IDLE)
-
-/*
  * scx_bpf_exit() is a new addition. Fall back to scx_bpf_error() if
  * unavailable. Users can use scx_bpf_exit() directly in the future.
  */

--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -16,14 +16,6 @@
 })
 
 /*
- * scx_bpf_nr_cpu_ids(), scx_bpf_get_possible/online_cpumask() are new. No good
- * way to noop these kfuncs. Provide a test macro. Users can assume existence in
- * the future.
- */
-#define __COMPAT_HAS_CPUMASKS							\
-	bpf_ksym_exists(scx_bpf_nr_cpu_ids)
-
-/*
  * cpuperf is new. The followings become noop on older kernels. Callers can be
  * updated to call cpuperf kfuncs directly in the future.
  */

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -160,6 +160,8 @@ static inline long scx_hotplug_seq(void)
 										\
 	SCX_BUG_ON(!SCX_OPS_SWITCH_PARTIAL,					\
 		   "SCX_OPS_SWITCH_PARTIAL missing, kernel too old?");		\
+	SCX_BUG_ON(!__COMPAT_ENUM_OR_ZERO("scx_kick_flags", "SCX_KICK_IDLE"),	\
+		   "SCX_KICK_IDLE missing, kernel too old?");			\
 										\
 	__skel = __scx_name##__open();						\
 	SCX_BUG_ON(!__skel, "Could not open " #__scx_name);			\

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -158,12 +158,14 @@ static inline long scx_hotplug_seq(void)
 #define SCX_OPS_OPEN(__ops_name, __scx_name) ({					\
 	struct __scx_name *__skel;						\
 										\
-	SCX_BUG_ON(!SCX_OPS_SWITCH_PARTIAL,					\
-		   "SCX_OPS_SWITCH_PARTIAL missing, kernel too old?");		\
-	SCX_BUG_ON(!__COMPAT_ENUM_OR_ZERO("scx_kick_flags", "SCX_KICK_IDLE"),	\
-		   "SCX_KICK_IDLE missing, kernel too old?");			\
+	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_dump_bstr"),			\
+		   "scx_bpf_dump() missing, kernel too old?");			\
 	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_exit_bstr"),			\
 		   "scx_bpf_exit() missing, kernel too old?");			\
+	SCX_BUG_ON(!__COMPAT_ENUM_OR_ZERO("scx_kick_flags", "SCX_KICK_IDLE"),	\
+		   "SCX_KICK_IDLE missing, kernel too old?");			\
+	SCX_BUG_ON(!SCX_OPS_SWITCH_PARTIAL,					\
+		   "SCX_OPS_SWITCH_PARTIAL missing, kernel too old?");		\
 										\
 	__skel = __scx_name##__open();						\
 	SCX_BUG_ON(!__skel, "Could not open " #__scx_name);			\

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -146,11 +146,12 @@ static inline long scx_hotplug_seq(void)
  * - ops.tick(): Ignored on older kernels with a warning.
  * - ops.dump*(): Ignored on older kernels with a warning.
  * - ops.exit_dump_len: Cleared to zero on older kernels with a warning.
- * - ops.hotplug_seq: Ignored on older kernels.
  */
 #define SCX_OPS_OPEN(__ops_name, __scx_name) ({					\
 	struct __scx_name *__skel;						\
 										\
+	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "hotplug_seq"),	\
+		   "sched_ext_ops.hotplug_seq missing, kernel too old?");	\
 	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_cpuperf_cap"),			\
 		   "scx_bpf_cpuperf_*() missing, kernel too old?");		\
 	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_nr_cpu_ids"),			\
@@ -166,9 +167,7 @@ static inline long scx_hotplug_seq(void)
 										\
 	__skel = __scx_name##__open();						\
 	SCX_BUG_ON(!__skel, "Could not open " #__scx_name);			\
-										\
-	if (__COMPAT_struct_has_field("sched_ext_ops", "hotplug_seq"))		\
-		__skel->struct_ops.__ops_name->hotplug_seq = scx_hotplug_seq();	\
+	__skel->struct_ops.__ops_name->hotplug_seq = scx_hotplug_seq();		\
 	__skel; 								\
 })
 

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -162,6 +162,8 @@ static inline long scx_hotplug_seq(void)
 		   "SCX_OPS_SWITCH_PARTIAL missing, kernel too old?");		\
 	SCX_BUG_ON(!__COMPAT_ENUM_OR_ZERO("scx_kick_flags", "SCX_KICK_IDLE"),	\
 		   "SCX_KICK_IDLE missing, kernel too old?");			\
+	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_exit_bstr"),			\
+		   "scx_bpf_exit() missing, kernel too old?");			\
 										\
 	__skel = __scx_name##__open();						\
 	SCX_BUG_ON(!__skel, "Could not open " #__scx_name);			\

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -110,13 +110,6 @@ static inline bool __COMPAT_struct_has_field(const char *type, const char *field
 	__COMPAT_ENUM_OR_ZERO("scx_ops_flags", "SCX_OPS_SWITCH_PARTIAL")
 
 /*
- * scx_bpf_nr_cpu_ids(), scx_bpf_get_possible/online_cpumask() are new. Users
- * will be able to assume existence in the future.
- */
-#define __COMPAT_HAS_CPUMASKS							\
-	__COMPAT_has_ksym("scx_bpf_nr_cpu_ids")
-
-/*
  * DSQ iterator is new. Users will be able to assume existence in the future.
  */
 #define __COMPAT_HAS_DSQ_ITER							\
@@ -158,6 +151,8 @@ static inline long scx_hotplug_seq(void)
 #define SCX_OPS_OPEN(__ops_name, __scx_name) ({					\
 	struct __scx_name *__skel;						\
 										\
+	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_nr_cpu_ids"),			\
+		   "scx_bpf_nr_cpu_ids() missing, kernel too old?");		\
 	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_dump_bstr"),			\
 		   "scx_bpf_dump() missing, kernel too old?");			\
 	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_exit_bstr"),			\

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -151,6 +151,8 @@ static inline long scx_hotplug_seq(void)
 #define SCX_OPS_OPEN(__ops_name, __scx_name) ({					\
 	struct __scx_name *__skel;						\
 										\
+	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_cpuperf_cap"),			\
+		   "scx_bpf_cpuperf_*() missing, kernel too old?");		\
 	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_nr_cpu_ids"),			\
 		   "scx_bpf_nr_cpu_ids() missing, kernel too old?");		\
 	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_dump_bstr"),			\

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -143,12 +143,13 @@ static inline long scx_hotplug_seq(void)
  * and attach it, backward compatibility is automatically maintained where
  * reasonable.
  *
- * - ops.tick(): Ignored on older kernels with a warning.
  * - ops.dump*(): Ignored on older kernels with a warning.
  */
 #define SCX_OPS_OPEN(__ops_name, __scx_name) ({					\
 	struct __scx_name *__skel;						\
 										\
+	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "tick"),		\
+		   "sched_ext_ops.tick() missing, kernel too old?");		\
 	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "exit_dump_len"),\
 		   "sched_ext_ops.exit_dump_len missing, kernel too old?");	\
 	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "hotplug_seq"),	\
@@ -174,11 +175,6 @@ static inline long scx_hotplug_seq(void)
 
 #define SCX_OPS_LOAD(__skel, __ops_name, __scx_name, __uei_name) ({		\
 	UEI_SET_SIZE(__skel, __ops_name, __uei_name);				\
-	if (!__COMPAT_struct_has_field("sched_ext_ops", "tick") &&		\
-	    (__skel)->struct_ops.__ops_name->tick) {				\
-		fprintf(stderr, "WARNING: kernel doesn't support ops.tick()\n"); \
-		(__skel)->struct_ops.__ops_name->tick = NULL;			\
-	}									\
 	if (!__COMPAT_struct_has_field("sched_ext_ops", "dump") &&		\
 	    ((__skel)->struct_ops.__ops_name->dump ||				\
 	     (__skel)->struct_ops.__ops_name->dump_cpu ||			\

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -143,31 +143,14 @@ static inline long scx_hotplug_seq(void)
  * and attach it, backward compatibility is automatically maintained where
  * reasonable.
  *
- * - ops.dump*(): Ignored on older kernels with a warning.
+ * ec7e3b0463e1 ("implement-ops") in https://github.com/sched-ext/sched_ext is
+ * the current minimum required kernel version.
  */
 #define SCX_OPS_OPEN(__ops_name, __scx_name) ({					\
 	struct __scx_name *__skel;						\
 										\
 	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "dump"),		\
 		   "sched_ext_ops.dump() missing, kernel too old?");		\
-	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "tick"),		\
-		   "sched_ext_ops.tick() missing, kernel too old?");		\
-	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "exit_dump_len"),\
-		   "sched_ext_ops.exit_dump_len missing, kernel too old?");	\
-	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "hotplug_seq"),	\
-		   "sched_ext_ops.hotplug_seq missing, kernel too old?");	\
-	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_cpuperf_cap"),			\
-		   "scx_bpf_cpuperf_*() missing, kernel too old?");		\
-	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_nr_cpu_ids"),			\
-		   "scx_bpf_nr_cpu_ids() missing, kernel too old?");		\
-	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_dump_bstr"),			\
-		   "scx_bpf_dump() missing, kernel too old?");			\
-	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_exit_bstr"),			\
-		   "scx_bpf_exit() missing, kernel too old?");			\
-	SCX_BUG_ON(!__COMPAT_ENUM_OR_ZERO("scx_kick_flags", "SCX_KICK_IDLE"),	\
-		   "SCX_KICK_IDLE missing, kernel too old?");			\
-	SCX_BUG_ON(!SCX_OPS_SWITCH_PARTIAL,					\
-		   "SCX_OPS_SWITCH_PARTIAL missing, kernel too old?");		\
 										\
 	__skel = __scx_name##__open();						\
 	SCX_BUG_ON(!__skel, "Could not open " #__scx_name);			\

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -148,6 +148,8 @@ static inline long scx_hotplug_seq(void)
 #define SCX_OPS_OPEN(__ops_name, __scx_name) ({					\
 	struct __scx_name *__skel;						\
 										\
+	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "dump"),		\
+		   "sched_ext_ops.dump() missing, kernel too old?");		\
 	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "tick"),		\
 		   "sched_ext_ops.tick() missing, kernel too old?");		\
 	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "exit_dump_len"),\
@@ -175,15 +177,6 @@ static inline long scx_hotplug_seq(void)
 
 #define SCX_OPS_LOAD(__skel, __ops_name, __scx_name, __uei_name) ({		\
 	UEI_SET_SIZE(__skel, __ops_name, __uei_name);				\
-	if (!__COMPAT_struct_has_field("sched_ext_ops", "dump") &&		\
-	    ((__skel)->struct_ops.__ops_name->dump ||				\
-	     (__skel)->struct_ops.__ops_name->dump_cpu ||			\
-	     (__skel)->struct_ops.__ops_name->dump_task)) {			\
-		fprintf(stderr, "WARNING: kernel doesn't support ops.dump*()\n"); \
-		(__skel)->struct_ops.__ops_name->dump = NULL;			\
-		(__skel)->struct_ops.__ops_name->dump_cpu = NULL;		\
-		(__skel)->struct_ops.__ops_name->dump_task = NULL;		\
-	}									\
 	SCX_BUG_ON(__scx_name##__load((__skel)), "Failed to load skel");	\
 })
 

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -106,14 +106,7 @@ static inline bool __COMPAT_struct_has_field(const char *type, const char *field
 	return false;
 }
 
-/*
- * An ops flag, %SCX_OPS_SWITCH_PARTIAL, replaced scx_bpf_switch_all() which had
- * to be called from ops.init(). To support both before and after, use both
- * %__COMPAT_SCX_OPS_SWITCH_PARTIAL and %__COMPAT_scx_bpf_switch_all() defined
- * in compat.bpf.h. Users can switch to directly using %SCX_OPS_SWITCH_PARTIAL
- * in the future.
- */
-#define __COMPAT_SCX_OPS_SWITCH_PARTIAL						\
+#define SCX_OPS_SWITCH_PARTIAL							\
 	__COMPAT_ENUM_OR_ZERO("scx_ops_flags", "SCX_OPS_SWITCH_PARTIAL")
 
 /*
@@ -164,6 +157,9 @@ static inline long scx_hotplug_seq(void)
  */
 #define SCX_OPS_OPEN(__ops_name, __scx_name) ({					\
 	struct __scx_name *__skel;						\
+										\
+	SCX_BUG_ON(!SCX_OPS_SWITCH_PARTIAL,					\
+		   "SCX_OPS_SWITCH_PARTIAL missing, kernel too old?");		\
 										\
 	__skel = __scx_name##__open();						\
 	SCX_BUG_ON(!__skel, "Could not open " #__scx_name);			\

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -145,11 +145,12 @@ static inline long scx_hotplug_seq(void)
  *
  * - ops.tick(): Ignored on older kernels with a warning.
  * - ops.dump*(): Ignored on older kernels with a warning.
- * - ops.exit_dump_len: Cleared to zero on older kernels with a warning.
  */
 #define SCX_OPS_OPEN(__ops_name, __scx_name) ({					\
 	struct __scx_name *__skel;						\
 										\
+	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "exit_dump_len"),\
+		   "sched_ext_ops.exit_dump_len missing, kernel too old?");	\
 	SCX_BUG_ON(!__COMPAT_struct_has_field("sched_ext_ops", "hotplug_seq"),	\
 		   "sched_ext_ops.hotplug_seq missing, kernel too old?");	\
 	SCX_BUG_ON(!__COMPAT_has_ksym("scx_bpf_cpuperf_cap"),			\
@@ -173,11 +174,6 @@ static inline long scx_hotplug_seq(void)
 
 #define SCX_OPS_LOAD(__skel, __ops_name, __scx_name, __uei_name) ({		\
 	UEI_SET_SIZE(__skel, __ops_name, __uei_name);				\
-	if (!__COMPAT_struct_has_field("sched_ext_ops", "exit_dump_len") &&	\
-	    (__skel)->struct_ops.__ops_name->exit_dump_len) {			\
-		fprintf(stderr, "WARNING: kernel doesn't support setting exit dump len\n"); \
-		(__skel)->struct_ops.__ops_name->exit_dump_len = 0;		\
-	}									\
 	if (!__COMPAT_struct_has_field("sched_ext_ops", "tick") &&		\
 	    (__skel)->struct_ops.__ops_name->tick) {				\
 		fprintf(stderr, "WARNING: kernel doesn't support ops.tick()\n"); \

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -3027,11 +3027,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init)
 	if (err)
 		return err;
 
-	/*
-	 * Switch all tasks to scx tasks.
-	 */
-	__COMPAT_scx_bpf_switch_all();
-
 	return err;
 }
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1074,7 +1074,7 @@ static void do_core_compaction(void)
 				bpf_cpumask_set_cpu(cpu, ovrflw);
 				bpf_cpumask_clear_cpu(cpu, active);
 			}
-			scx_bpf_kick_cpu(cpu, __COMPAT_SCX_KICK_IDLE);
+			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 		}
 		else {
 			if (i < nr_active_old) {

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1248,8 +1248,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(layered_init)
 	struct bpf_cpumask *cpumask;
 	int i, j, k, nr_online_cpus, ret;
 
-	__COMPAT_scx_bpf_switch_all();
-
 	ret = scx_bpf_create_dsq(HI_FALLBACK_DSQ, -1);
 	if (ret < 0)
 		return ret;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -508,7 +508,7 @@ bool pick_idle_cpu_and_kick(struct task_struct *p, s32 task_cpu,
 
 	if (cpu >= 0) {
 		lstat_inc(LSTAT_KICK, layer, cctx);
-		scx_bpf_kick_cpu(cpu, __COMPAT_SCX_KICK_IDLE);
+		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 		return true;
 	} else {
 		return false;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1006,7 +1006,7 @@ void BPF_STRUCT_OPS(layered_running, struct task_struct *p)
 	}
 
 	if (layer->perf > 0)
-		__COMPAT_scx_bpf_cpuperf_set(task_cpu, layer->perf);
+		scx_bpf_cpuperf_set(task_cpu, layer->perf);
 
 	cctx->maybe_idle = false;
 }

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1197,9 +1197,6 @@ static void dump_layer_cpumask(int idx)
 	s32 cpu;
 	char buf[128] = "", *p;
 
-	if (!__COMPAT_HAS_CPUMASKS)
-		return;
-
 	if (!(layer_cpumask = lookup_layer_cpumask(idx)))
 		return;
 

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -877,8 +877,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 	u32 i;
 	s32 ret;
 
-	__COMPAT_scx_bpf_switch_all();
-
 	cpumask = bpf_cpumask_create();
 	if (!cpumask)
 		return -ENOMEM;

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -69,7 +69,6 @@ const volatile u32 load_half_life = 1000000000	/* 1s */;
 
 const volatile bool kthreads_local;
 const volatile bool fifo_sched;
-const volatile bool switch_partial;
 const volatile bool direct_greedy_numa;
 const volatile u32 greedy_threshold;
 const volatile u32 greedy_threshold_x_numa;
@@ -1750,9 +1749,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rusty_init)
 	ret = create_save_cpumask(&kick_greedy_cpumask);
 	if (ret)
 		return ret;
-
-	if (!switch_partial)
-		__COMPAT_scx_bpf_switch_all();
 
 	bpf_for(i, 0, nr_nodes) {
 		ret = create_node(i);

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -314,7 +314,6 @@ impl<'a> Scheduler<'a> {
         skel.rodata_mut().load_half_life = (opts.load_half_life * 1000000000.0) as u32;
         skel.rodata_mut().kthreads_local = opts.kthreads_local;
         skel.rodata_mut().fifo_sched = opts.fifo_sched;
-        skel.rodata_mut().switch_partial = opts.partial;
         skel.rodata_mut().greedy_threshold = opts.greedy_threshold;
         skel.rodata_mut().greedy_threshold_x_numa = opts.greedy_threshold_x_numa;
         skel.rodata_mut().direct_greedy_numa = opts.direct_greedy_numa;


### PR DESCRIPTION
In preparation of upstreaming, set the currently released v6.9 kernels as the minimum requirement and strip the compat features. The only remaining one is for dsq iters. This needs updates from BPF side and will be handled later.