### PR TITLE
rusty: Make dom_xfer_task() a global prog

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -380,18 +380,32 @@ static u64 dom_min_vruntime(struct dom_ctx *domc)
 	return READ_ONCE(domc->min_vruntime);
 }
 
-static void dom_xfer_task(struct task_struct *p, struct task_ctx *taskc,
-			  u32 from_dom_id, u32 to_dom_id, u64 now)
+int dom_xfer_task(pid_t pid, u32 new_dom_id, u64 now)
 {
 	struct dom_ctx *from_domc, *to_domc;
+	struct task_ctx *taskc;
+	struct task_struct *p;
 
-	from_domc = lookup_dom_ctx(from_dom_id);
-	to_domc = lookup_dom_ctx(to_dom_id);
+	p = bpf_task_from_pid(pid);
+	if (!p) {
+		scx_bpf_error("Failed to lookup task %d", pid);
+		return 0;
+	}
 
-	if (!from_domc || !to_domc)
-		return;
+	taskc = lookup_task_ctx(p);
+	if (!taskc)
+		goto free_task;
+
+	from_domc = lookup_dom_ctx(taskc->dom_id);
+	to_domc = lookup_dom_ctx(new_dom_id);
+
+	if (!from_domc || !to_domc || !taskc)
+		goto free_task;
 
 	dom_dcycle_xfer_task(p, taskc, from_domc, to_domc, now);
+free_task:
+	bpf_task_release(p);
+	return 0;
 }
 
 /*
@@ -770,7 +784,7 @@ static bool task_set_domain(struct task_ctx *taskc, struct task_struct *p,
 		u64 now = bpf_ktime_get_ns();
 
 		if (!init_dsq_vtime)
-			dom_xfer_task(p, taskc, taskc->dom_id, new_dom_id, now);
+			dom_xfer_task(p->pid, new_dom_id, now);
 		taskc->dom_id = new_dom_id;
 		p->scx.dsq_vtime = dom_min_vruntime(new_domc);
 		taskc->deadline = p->scx.dsq_vtime +


### PR DESCRIPTION
It seems that task_set_domain() is nearly at the point where it can cause the verifier to get confused and think that it's exceeding the number of available instructions per program. I've seen this a number of times when making small changes to task_set_domain(), and it's once again happened @vax-r (I-Hsin Cheng) made a small cleanup change to rusty in https://github.com/sched-ext/scx/pull/362.

To avoid this, let's just make dom_xfer_task() a separate global program so that the verifier doens't have to worry about branch pruning, etc depending on what the caller does. This should hopefully make task_set_domain() (and its callers) much less brittle.