### PR TITLE
scx/compat.bpf.h: Fix __COMPAT_scx_bpf_consume_task() and improve scx_qmap example

### DIFF
--- a/scheds/c/scx_qmap.c
+++ b/scheds/c/scx_qmap.c
@@ -29,8 +29,7 @@ const char help_fmt[] =
 "  -l COUNT      Trigger dispatch infinite looping after COUNT dispatches\n"
 "  -b COUNT      Dispatch upto COUNT tasks together\n"
 "  -P            Print out DSQ content to trace_pipe every second, use with -b\n"
-"  -E PREFIX     Expedite consumption of threads w/ matching comm, use with -b\n"
-"                (e.g. match shell on a loaded system)\n"
+"  -E CGID       Expedite consumption of threads in a cgroup, use with -b\n"
 "  -d PID        Disallow a process from switching into SCHED_EXT (-1 for self)\n"
 "  -D LEN        Set scx_exit_info.dump buffer length\n"
 "  -S            Suppress qmap-specific debug dump\n"
@@ -89,8 +88,7 @@ int main(int argc, char **argv)
 			skel->rodata->print_shared_dsq = true;
 			break;
 		case 'E':
-			strncpy(skel->rodata->exp_prefix, optarg,
-				sizeof(skel->rodata->exp_prefix) - 1);
+			skel->rodata->exp_cgid = strtoull(optarg, NULL, 0);
 			break;
 		case 'd':
 			skel->rodata->disallow_tgid = strtol(optarg, NULL, 0);
@@ -116,7 +114,7 @@ int main(int argc, char **argv)
 	}
 
 	if (!__COMPAT_HAS_DSQ_ITER &&
-	    (skel->rodata->print_shared_dsq || strlen(skel->rodata->exp_prefix)))
+	    (skel->rodata->print_shared_dsq || skel->rodata->exp_cgid))
 		fprintf(stderr, "kernel doesn't support DSQ iteration\n");
 
 	SCX_OPS_LOAD(skel, qmap_ops, scx_qmap, uei);

--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -27,7 +27,10 @@
 static inline bool __COMPAT_scx_bpf_consume_task(struct bpf_iter_scx_dsq *it,
 						 struct task_struct *p)
 {
-	return false;
+	if (bpf_ksym_exists(__scx_bpf_consume_task))
+		return scx_bpf_consume_task(it, p);
+	else
+		return false;
 }
 
 /*


### PR DESCRIPTION
__COMPAT_scx_bpf_consume_task() wasn't calling scx_bpf_consume_task() at all and was always returning false. Fix it.

Also, update scx_qmap usage example so that it matches cgroup ID rather than comm prefix. This should make testing with multiple processes a bit easier.