### PR TITLE
Add build-id to build process

### DIFF
--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -31,4 +31,5 @@ metrics-util = "0.17.0"
 [build-dependencies]
 bindgen = ">=0.68, <0.70"
 tar = "0.4"
+vergen = { version = "8.0.0", features = ["cargo", "git", "gitcl"] }
 walkdir = "2.4"

--- a/rust/scx_utils/build.rs
+++ b/rust/scx_utils/build.rs
@@ -3,8 +3,14 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
+use vergen::EmitBuilder;
 include!("src/builder.rs");
 
 fn main() {
-    Builder::new().build()
+    Builder::new().build();
+    EmitBuilder::builder()
+        .all_git()
+        .cargo_target_triple()
+        .emit()
+        .unwrap();
 }

--- a/rust/scx_utils/src/build_id.rs
+++ b/rust/scx_utils/src/build_id.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use std::fmt::Write;
+
+lazy_static::lazy_static! {
+    static ref GIT_VERSION: String = {
+        let mut ver = String::new();
+        match option_env!("VERGEN_GIT_SHA") {
+            Some(v) if v != "VERGEN_IDEMPOTENT_OUTPUT" => {
+                ver += "g";
+                ver += v;
+                if let Some("true") = option_env!("VERGEN_GIT_DIRTY") {
+                    ver += "-dirty";
+                }
+            }
+            _ => {}
+        }
+        ver
+    };
+    static ref BUILD_TAG: String = {
+        let mut tag = env!("VERGEN_CARGO_TARGET_TRIPLE").to_string();
+        if cfg!(debug_assertions) {
+            write!(tag, "/debug").unwrap();
+        }
+        tag
+    };
+}
+
+fn full_version(semver: &str) -> String {
+    let mut ver = semver.to_string();
+    if GIT_VERSION.len() > 0 {
+        write!(ver, "-{}", &*GIT_VERSION).unwrap();
+    }
+    if BUILD_TAG.len() > 0 {
+        write!(ver, " {}", &*BUILD_TAG).unwrap();
+    }
+    ver
+}
+
+lazy_static::lazy_static! {
+    pub static ref SCX_CARGO_VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    pub static ref SCX_FULL_VERSION: String = full_version(*SCX_CARGO_VERSION);
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_cargo_ver() {
+        //assert_eq!(super::*SCX_CARGO_VERSION, 1);
+        println!("{}", super::*SCX_CARGO_VERSION);
+    }
+
+    #[test]
+    fn test_full_ver() {
+        //assert_eq!(super::*SCX_CARGO_VERSION, 1);
+        println!("{}", super::*SCX_FULL_VERSION);
+    }
+}

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -50,6 +50,7 @@ pub use user_exit_info::UeiDumpPtr;
 pub use user_exit_info::UserExitInfo;
 pub use user_exit_info::UEI_DUMP_PTR_MUTEX;
 
+pub mod build_id;
 pub mod compat;
 
 mod libbpf_logger;

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -43,6 +43,7 @@ use metrics::Histogram;
 use metrics::gauge;
 use metrics::Gauge;
 use scx_utils::LogRecorderBuilder;
+use scx_utils::build_id;
 use scx_utils::compat;
 use scx_utils::init_libbpf_logging;
 use scx_utils::scx_ops_attach;
@@ -304,6 +305,7 @@ impl<'a> Scheduler<'a> {
         let mut skel_builder = BpfSkelBuilder::default();
         skel_builder.obj_builder.debug(opts.verbose > 0);
         init_libbpf_logging(None);
+        info!("Running scx_rusty (build ID: {})", *build_id::SCX_FULL_VERSION);
         let mut skel = scx_ops_open!(skel_builder, rusty).unwrap();
 
         // Initialize skel according to @opts.
@@ -390,7 +392,7 @@ impl<'a> Scheduler<'a> {
         // Attach.
         let mut skel = scx_ops_load!(skel, rusty, uei)?;
         let struct_ops = Some(scx_ops_attach!(skel, rusty)?);
-        info!("Rusty Scheduler Attached");
+        info!("Rusty scheduler started!");
 
         // Other stuff.
         let proc_reader = procfs::ProcReader::new();


### PR DESCRIPTION
We want schedulers to be able to print, log, etc the build ID of the
repository.
    
These patches update scx_utils accordingly to use vergen to generate the output of
`git describe`, and then updates scx_rusty to print that build ID when it's loaded.
In the future, we could further update scx_utils to include all of the various features
available in [0]. A subsequent patch will update scx_rusty to print this build ID value.

[0]: https://docs.rs/vergen/8.3.1/vergen/index.html