### PR TITLE
scx_utils: Utilize Entry API for BTreeMap insertion

### DIFF
--- a/rust/scx_utils/src/infeasible.rs
+++ b/rust/scx_utils/src/infeasible.rs
@@ -313,25 +313,18 @@ impl LoadAggregator {
             bail!("weight {} is less than minimum weight {}", weight, MIN_WEIGHT);
         }
 
-        if !self.doms.contains_key(&dom_id) {
-            self.doms.insert(dom_id, Domain {
-                loads: BTreeMap::new(),
-                dcycle_sum: 0.0f64,
-                load_sum: 0.0f64,
-            });
-        }
+        let domain = self.doms.entry(dom_id).or_insert(Domain{
+            loads: BTreeMap::new(),
+            dcycle_sum: 0.0f64,
+            load_sum: 0.0f64,
+        });
 
-        let domain = self.doms.get_mut(&dom_id).unwrap();
         if let Some(_) = domain.loads.insert(weight, dcycle) {
             bail!("Domain {} already had load for weight {}", dom_id, weight);
         }
 
-        if !self.global_loads.contains_key(&weight) {
-            self.global_loads.insert(weight, 0.0f64);
-        }
-        let mut weight_dcycle = self.global_loads.get(&weight).unwrap().clone();
-        weight_dcycle += dcycle;
-        self.global_loads.insert(weight, weight_dcycle);
+        let weight_dcycle = self.global_loads.entry(weight).or_insert(0.0f64);
+        *weight_dcycle += dcycle;
 
         let load = weight as f64 * dcycle;
 

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -395,25 +395,17 @@ fn create_insert_cpu(cpu_id: usize, node: &mut Node, online_mask: &Cpumask) -> R
     let max_freq = read_file_usize(&freq_path.join("scaling_max_freq")).unwrap_or(0);
     let trans_lat_ns = read_file_usize(&freq_path.join("cpuinfo_transition_latency")).unwrap_or(0);
 
-    if !node.llcs.contains_key(&llc_id) {
-        let cache = Cache {
-            id: llc_id,
-            cores: BTreeMap::new(),
-            span: Cpumask::new()?,
-        };
-        node.llcs.insert(llc_id, cache);
-    }
-    let cache = node.llcs.get_mut(&llc_id).unwrap();
+    let cache = node.llcs.entry(llc_id).or_insert(Cache{
+        id: llc_id,
+        cores: BTreeMap::new(),
+        span: Cpumask::new()?,
+    });
 
-    if !cache.cores.contains_key(&core_id) {
-        let core = Core {
-            id: core_id,
-            cpus: BTreeMap::new(),
-            span: Cpumask::new()?,
-        };
-        cache.cores.insert(core_id, core);
-    }
-    let core = cache.cores.get_mut(&core_id).unwrap();
+    let core = cache.cores.entry(core_id).or_insert(Core{
+        id: core_id,
+        cpus: BTreeMap::new(),
+        span: Cpumask::new()?,
+    });
 
     core.cpus.insert(
         cpu_id,


### PR DESCRIPTION
## Summary
Take advantages of BTreeMap's Entry API working with or_insert() to do the conditional insertion. Insert only when the entry doesn't exist. Doing so can reduce the amount of code and provide better readability and perform in-place manipulation.
## Reference
* [BTreeMap example](https://doc.rust-lang.org/nightly/std/collections/struct.BTreeMap.html#examples)
* [BTreeMap Entry API](https://doc.rust-lang.org/nightly/std/collections/struct.BTreeMap.html#method.entry)