### PR TITLE
rusty: Integrate stats with the metrics framework

### DIFF
--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -19,6 +19,8 @@ scx_utils = { path = "../../../rust/scx_utils", version = "0.8.1" }
 simplelog = "0.12.0"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
+metrics = "0.23.0"
+metrics-exporter-prometheus = "0.15.0"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "0.8.1" }


### PR DESCRIPTION
We need a layer of indirection between the stats collection and their output destinations. Currently, stats are only printed to stdout. Our goal is to integrate with various telemetry systems such as Prometheus, StatsD, and custom metric backends like those used by Meta and Netflix. Importantly, adding a new backend should not require changes to the existing stats code.

This patch introduces the `metrics` [1] crate, which provides a framework for defining metrics and publishing them to different backends.

The initial implementation includes the `dispatched_tasks_count` metric, tagged with `type`. This metric increments every time a task is dispatched, emitting the raw count instead of a percentage. A monotonic counter is the most suitable metric type for this use case, as percentages can be calculated at query time if needed. Existing logged metrics continue to print percentages and remain unchanged.

A new flag, `--enable-prometheus`, has been added. When enabled, it starts a Prometheus endpoint on port 9000 (default is false). This endpoint allows metrics to be charted in Prometheus or Grafana dashboards.

Example of charting 1s rate of dispatched tasks by type:
![image](https://github.com/sched-ext/scx/assets/3172/bc4aa03f-fe8e-4062-86ac-b2ca95f74a8b)

Future changes will migrate additional stats to this framework and add support for other backends.

[1] https://metrics.rs/