### PR TITLE
Simplifying pacman-hooks

### DIFF
--- a/libalpm/openrc/90-scx-scheds-upgrade.hook
+++ b/libalpm/openrc/90-scx-scheds-upgrade.hook
@@ -9,8 +9,7 @@ Target = usr/bin/scx_*
 [Trigger]
 Type = Package
 Operation = Upgrade
-Target = scx-scheds
-Target = scx-scheds-git
+Target = scx-scheds*
 
 [Action]
 Description = Checking scx_scheduler...

--- a/libalpm/systemd/90-scx-scheds-upgrade.hook
+++ b/libalpm/systemd/90-scx-scheds-upgrade.hook
@@ -9,8 +9,7 @@ Target = usr/lib/systemd/system/scx.service
 [Trigger]
 Type = Package
 Operation = Upgrade
-Target = scx-scheds
-Target = scx-scheds-git
+Target = scx-scheds*
 
 [Action]
 Description = Checking scx_scheduler...


### PR DESCRIPTION
This change will also allow users to create their own packages with a different name than "scx-scheds" and "scx-scheds-git" and the pacman hook will continue to be able to work properly. 