### PR TITLE
scx_rustland_core: smooth performance

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -476,8 +476,13 @@ static void dispatch_user_scheduler(void)
 static void
 dispatch_direct_cpu(struct task_struct *p, s32 cpu, u64 slice_ns, u64 enq_flags)
 {
-	scx_bpf_dispatch(p, cpu_to_dsq(cpu), slice_ns, enq_flags);
+	u64 dsq_id = cpu_to_dsq(cpu);
+
+	scx_bpf_dispatch(p, dsq_id, slice_ns, enq_flags);
 	scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+
+	dbg_msg("dispatch: pid=%d (%s) dsq=%llu enq_flags=%llx slice=%llu direct",
+		p->pid, p->comm, dsq_id, enq_flags, slice_ns);
 
 	__sync_fetch_and_add(&nr_kernel_dispatches, 1);
 }

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -916,10 +916,8 @@ static bool should_enable_fifo(void)
 	nr_waiting_avg = (nr_waiting_avg + nr_waiting) / 2;
 
 	/*
-	 * The condition to enter in FIFO mode is to have no tasks (in average)
-	 * that are waiting to be scheduled.
-	 *
-	 * Exiting from FIFO mode requires to have almost all the CPUs busy.
+	 * The condition to go back to FIFO mode is to have no tasks (in
+	 * average) that are waiting to be scheduled.
 	 */
 	return nr_waiting_avg == 0;
 }


### PR DESCRIPTION
Slight reduction of dispatch overhead and small refactoring of the direct dispatch in `select_cpu`, that is now performed only when the scheduler is operating in FIFO mode (under-commissioned system).

This helps to smooth performance in the over-commissioned scenario: in this case bouncing all the tasks to the user-space scheduler can provide better performance stability (smoothing both high and low performance peaks).

Big thanks to SoulHarsh007 <harsh.peshwani@outlook.com> for the multiple extensive testing sessions.