### PR TITLE
scx_rusty: Pull domain status check

### DIFF
--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -869,6 +869,10 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
 
             while pull_node.domains.len() > 0 {
                 let mut pull_dom = pull_node.domains.remove_index(0);
+                if pull_dom.load.state() != BalanceState::NeedsPull {
+                    pull_node.domains.insert(pull_dom);
+                    break;
+                }
                 let transferred = self.try_find_move_task((&mut push_dom, push_imbal),
                                                           (&mut pull_dom, pull_imbal),
                                                           xfer)?;


### PR DESCRIPTION
## Summary
Check whether the BalanceState of `pull_dom.load` inside function `try_find_move_task` is actually the variant `NeedsPull`. It'll perform task migration in a bit more conservative manner when the system is under high loading situation.

Experiments are performed when the system is compiling linux kernel and undergoing a large amount of I/O operation at the same time using fio.

## Experiment
The experiments are done when compiling linux kernel and using `fio` tool to generate large amount of I/O operation to create large load imbalance by the following commands
```
// In terminal 1
$ make -j $(nproc)

// In terminal 2
$ fio io_test.fio
```
Using `perf` to observe the number of times of task migration.
```
// In terminal 3
$ sudo perf stat -e sched:sched_migrate_task -a sleep 60
```
The result shows that before the modification, there're 12,6617 times of task migrations system wide. After the modification, there're only 11,5419 times of task migrations system wide.
The experiment are done on kernel version `6.9.3-scx1` and Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz processors.
The fio testing script :
```
[global]
ioengine=libaio            # Use Linux native asynchronous I/O
direct=1                   # Use direct I/O (bypass page cache)
rw=randrw                  # Perform random read/write operations
bs=4k                      # Block size of 4 kilobytes
size=4G                    # Each job file will handle 4GB of data
numjobs=12                 # Number of jobs (simultaneous threads) to run
runtime=600                # Run the test for 600 seconds (10 minutes)
time_based=1               # Run the test for a specified time duration
group_reporting            # Report results for the group of jobs
iodepth=64                 # Number of I/O operations to keep in flight per job

[write_test]
filename=/tmp/fio_test_file_write
rw=write                   # Sequential write operations

[read_test]
filename=/tmp/fio_test_file_read
rw=read                    # Sequential read operations
```