### PR TITLE
scx_rusty: Refactor ridx assignment in populate_tasks_by_load

### DIFF
--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -686,9 +686,7 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
         let mut pids = vec![];
 
         let (mut ridx, widx) = (active_pids.read_idx, active_pids.write_idx);
-        if widx - ridx > MAX_PIDS {
-            ridx = widx - MAX_PIDS;
-        }
+        ridx = ridx.max(widx - MAX_PIDS);
 
         for idx in ridx..widx {
             let pid = active_pids.pids[(idx % MAX_PIDS) as usize];


### PR DESCRIPTION
## Summary
Origin assignment of the variable `ridx` is equivalent to comparing between "ridx" and "wids - MAX_PIDS". It's confusing using `if` statement and compare "wids - ridx" with "MAX_PIDS".

Using u64 max library helper function to perform the comparison and provide better readability.