### PR TITLE
scx_lavd: revising tunables to reduce micro-stutters

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -68,9 +68,10 @@ enum consts {
 	LAVD_LC_RUNTIME_MAX		= LAVD_TARGETED_LATENCY_NS,
 	LAVD_LC_RUNTIME_SHIFT		= 10,
 
-	LAVD_BOOST_RANGE		= 14, /* 35% of nice range */
+	LAVD_BOOST_RANGE		= 40, /* 100% of nice range */
 	LAVD_BOOST_WAKEUP_LAT		= 1,
-	LAVD_SLICE_BOOST_MAX_STEP	= 3,
+	LAVD_SLICE_BOOST_MAX_FT		= 2, /* maximum additional 2x of slice */
+	LAVD_SLICE_BOOST_MAX_STEP	= 8, /* 8 slice exhausitions in a row */
 	LAVD_GREEDY_RATIO_MAX		= USHRT_MAX,
 	LAVD_LAT_PRIO_IDLE		= USHRT_MAX,
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1528,7 +1528,8 @@ static u64 calc_slice_share(struct task_struct *p, struct task_ctx *taskc)
 	 * scheduler tries to allocate a longer time slice.
 	 */
 	u64 share = get_task_load_ideal(p);
-	share += (share * taskc->slice_boost_prio) / LAVD_SLICE_BOOST_MAX_STEP;
+	share += (LAVD_SLICE_BOOST_MAX_FT * share * taskc->slice_boost_prio) /
+		 LAVD_SLICE_BOOST_MAX_STEP;
 
 	return share;
 }


### PR DESCRIPTION
This is a second attempt to optimize tunables for a wider range of games.

1) LAVD_BOOST_RANGE increased from 14 (35%) to 40 (100% of nice range).
   Now the latency priority (biased by nice value) will decide which
   task should run first . The nice value will decide the time slice.

2) The first change will give higher priority to latency-critical task
   compared to before. For compensation, the slice boost also increased
   (2x -> 3x).