### PR TITLE
Add After=graphical.target into service

### DIFF
--- a/services/systemd/scx.service
+++ b/services/systemd/scx.service
@@ -3,6 +3,7 @@ Description=Start scx_scheduler
 ConditionPathIsDirectory=/sys/kernel/sched_ext
 StartLimitIntervalSec=30
 StartLimitBurst=2
+After=graphical.target
 
 [Service]
 Type=simple
@@ -13,4 +14,4 @@ StandardError=journal
 LogNamespace=sched-ext
 
 [Install]
-WantedBy=graphical.target
+WantedBy=multi-user.target


### PR DESCRIPTION
In systemd, the After=graphical.target directive specifies that a unit should start after the graphical environment (such as the desktop) has been fully loaded. Users complain that the service's launch is too early and this sometimes causes various unwanted side effects. This should solve the problem. You might still consider adding something like this: 

```
[Unit]
Description=Run scx schedulers

[Timer]
OnBootSec=30sec
Unit=scx.service

[Install]
WantedBy=graphical.target
```

however, the PR solution should be sufficient