### PR TITLE
mitosis: Update synchronization

### DIFF
--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -347,6 +347,7 @@ impl<'a> Scheduler<'a> {
             let mut reconfigured = false;
             if self.skel.bss().user_global_seq != self.skel.bss().global_seq {
                 trace!("BPF reconfiguration still in progress, skipping further changes");
+                continue;
             } else if self.last_reconfiguration.elapsed() >= self.reconfiguration_interval {
                 trace!("Reconfiguring");
                 reconfigured = true;


### PR DESCRIPTION
The synchronization for mitosis is a bit ad-hoc, working around lack of atomics in BPF. This commit updates the logic to use READ/WRITE_ONCE and compiler barriers to get the behaviors we want.