### PR TITLE
scx_lavd: tweaks to avoid fork starvation

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -61,8 +61,9 @@ enum consts {
 	LAVD_SLICE_MAX_NS		= ( 3 * NSEC_PER_MSEC), /* max time slice */
 	LAVD_SLICE_UNDECIDED		= SCX_SLICE_INF,
 	LAVD_SLICE_GREEDY_FT		= 3,
-	LAVD_LOAD_FACTOR_ADJ		= 6,
+	LAVD_LOAD_FACTOR_ADJ		= 6, /* adjustment for better estimation */
 	LAVD_LOAD_FACTOR_MAX		= (10 * 1000),
+	LAVD_LOAD_FACTOR_FT		= 4, /* factor to stretch the time line */
 
 	LAVD_LC_FREQ_MAX		= 1000000,
 	LAVD_LC_RUNTIME_MAX		= LAVD_TARGETED_LATENCY_NS,

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1482,7 +1482,8 @@ static u64 calc_virtual_deadline_delta(struct task_struct *p,
 	 * tick slower to give room to execute the overloaded tasks.
 	 */
 	if (load_factor > 1000)
-		vdeadline_delta_ns = (vdeadline_delta_ns * load_factor) / 1000;
+		vdeadline_delta_ns = (vdeadline_delta_ns *load_factor *
+				      LAVD_LOAD_FACTOR_FT) / 1000;
 
 	taskc->vdeadline_delta_ns = vdeadline_delta_ns;
 	return vdeadline_delta_ns;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -27,6 +27,7 @@ use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::Skel;
 use libbpf_rs::skel::SkelBuilder;
 use log::info;
+use scx_utils::build_id;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
@@ -362,7 +363,7 @@ fn main() -> Result<()> {
 
     loop {
 	let mut sched = Scheduler::init(&opts)?;
-	info!("scx_lavd scheduler is initialized");
+	info!("scx_lavd scheduler is initialized (build ID: {})", *build_id::SCX_FULL_VERSION);
 	info!("    Note that scx_lavd currently is not optimized for multi-CCX/NUMA architectures.");
 	info!("    Stay tuned for future improvements!");
 


### PR DESCRIPTION
This PR addresses the fork starvation observed when they compete against CPU-intensive workloads. CPU-intensive workloads are likely to be slice-boosted, but a newly forked task will be penalized anyway until their traits are known to the scheduler. The old initial values were too conservative, causing the fork starvation problem. Now a newly forked task will inherit its parent's tarits. 