### PR TITLE
scx-scheds: Add After=graphical.target into service (third attempt)

### DIFF
--- a/libalpm/systemd/scx-systemd-restart
+++ b/libalpm/systemd/scx-systemd-restart
@@ -4,7 +4,7 @@
 # Check the status of the service
 if systemctl is-active --quiet scx.service; then
     echo "The service is active. Restarting..."
-    systemctl daemon-reload
+    systemctl reenable scx.service
     systemctl restart scx.service
     echo "Service has been restarted."
 else

--- a/services/systemd/scx.service
+++ b/services/systemd/scx.service
@@ -3,6 +3,7 @@ Description=Start scx_scheduler
 ConditionPathIsDirectory=/sys/kernel/sched_ext
 StartLimitIntervalSec=30
 StartLimitBurst=2
+After=graphical.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
**The second approach to change the policy of launching the systemd service.** 

The first approach was not successful, but nevertheless the problem with too early loading of the service remained. This time we managed to achieve a working result. 

```
lucjan at cachyos ~ 18:08:30    
❯ systemctl status scx
● scx.service - Start scx_scheduler
     Loaded: loaded (/usr/lib/systemd/system/scx.service; enabled; preset: disabled)
     Active: active (running) since Wed 2024-06-26 18:01:39 CEST; 6min ago
 Invocation: a3d1f5a0843c41cb93acec4578eaa1ea
   Main PID: 683 (scx_rusty)
      Tasks: 13 (limit: 37758)
     Memory: 235.4M (peak: 246M)
        CPU: 627ms
     CGroup: /system.slice/scx.service
             └─683 scx_rusty

cze 26 18:08:33 cachyos bash[683]: 16:08:33 [INFO]   repatriate_total: 0 [0.0/s]
cze 26 18:08:33 cachyos bash[683]: 16:08:33 [INFO]   task_errors_total: 0 [0.0/s]
cze 26 18:08:33 cachyos bash[683]: 16:08:33 [INFO] Gauges:
cze 26 18:08:33 cachyos bash[683]: 16:08:33 [INFO]   slice_length_us: 1000.00
cze 26 18:08:33 cachyos bash[683]: 16:08:33 [INFO] Histograms:
cze 26 18:08:33 cachyos bash[683]: 16:08:33 [INFO]   cpu_busy_pct: avg=98.31 min=96.62 max=100.00
cze 26 18:08:33 cachyos bash[683]: 16:08:33 [INFO]   load_avg node=0: avg=1340.44 min=1262.99 max=1417.88
cze 26 18:08:33 cachyos bash[683]: 16:08:33 [INFO]   load_avg node=0 dom=0: avg=1340.44 min=1262.99 max=1417.88
cze 26 18:08:33 cachyos bash[683]: 16:08:33 [INFO]   processing_duration_us: avg=148.50 min=148.00 max=149.00
cze 26 18:08:33 cachyos bash[683]: 16:08:33 [INFO] ---
lucjan at cachyos ~ 18:08:34    
❯ cat /usr/lib/systemd/system/scx.service
[Unit]
Description=Start scx_scheduler
ConditionPathIsDirectory=/sys/kernel/sched_ext
StartLimitIntervalSec=30
StartLimitBurst=2
After=graphical.target

[Service]
Type=simple
EnvironmentFile=/etc/default/scx
ExecStart=/bin/bash -c 'exec ${SCX_SCHEDULER_OVERRIDE:-$SCX_SCHEDULER} ${SCX_FLAGS_OVERRIDE:-$SCX_FLAGS} '
Restart=on-failure
StandardError=journal
LogNamespace=sched-ext

[Install]
WantedBy=graphical.target
lucjan at cachyos ~ 18:08:38    
❯ systemctl show -p Requires,Wants,Requisite,BindsTo,PartOf,Before,After scx.service
Requires=systemd-journald@sched-ext.socket systemd-journald-sync@sched-ext.service system.slice systemd-journald-varlink@sched-ext.socket sysinit.target
Requisite=
Wants=
BindsTo=
PartOf=
Before=shutdown.target
After=systemd-journald@sched-ext.socket graphical.target systemd-journald-sync@sched-ext.service system.slice sysinit.target systemd-journald-varlink@sched-ext.socket basic.target
```
**Potential issues**

This solution has drawbacks. Simply reloading the service with `systemctl daemon-reload` or even reboot **MAY** be not enough. For some users it is required to execute `systemctl disable --now scx.service` and `systemctl enable --now scx.service`. 

I realize that this is not a good solution, but at the moment I am unable to think of anything else. Feel free to discuss 