### PR TITLE
Revert "scx_rusty: Refactor ridx assignment in populate_tasks_by_load"

### DIFF
--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -686,7 +686,9 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
         let mut pids = vec![];
 
         let (mut ridx, widx) = (active_pids.read_idx, active_pids.write_idx);
-        ridx = ridx.max(widx - MAX_PIDS);
+        if widx - ridx > MAX_PIDS {
+            ridx = widx - MAX_PIDS;
+        }
 
         for idx in ridx..widx {
             let pid = active_pids.pids[(idx % MAX_PIDS) as usize];


### PR DESCRIPTION
Reverts sched-ext/scx#382

Causes the following issue:

```
21:32:36 [INFO] Running scx_rusty (build ID: 0.8.1-g41d60aef04d2a7fc0da738bf50391ea5f232ddd3 x86_64-unknown-linux-gnu/debug)                                
21:32:36 [INFO] ---                                                           
21:32:36 [INFO] NUMA[00] mask= 0b11111111111111111111111111111111             
21:32:36 [INFO]   DOM[00] mask= 0b00000000111111110000000011111111            
21:32:36 [INFO]   DOM[01] mask= 0b11111111000000001111111100000000            
21:32:36 [INFO] Rusty scheduler started!                                                                                                                    
thread 'main' panicked at src/load_balance.rs:689:25:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

We can instead add a comment explaining the weird logic, or figure out another way to do it.