### PR TITLE
scx_utils: clarify error about missing CONFIG_DEBUG_INFO_BTF

### DIFF
--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -20,7 +20,7 @@ lazy_static::lazy_static! {
 fn load_vmlinux_btf() -> &'static mut btf {
     let btf = unsafe { btf__load_vmlinux_btf() };
     if btf.is_null() {
-        panic!("btf__load_vmlinux_btf() returned NULL");
+        panic!("btf__load_vmlinux_btf() returned NULL, was CONFIG_DEBUG_INFO_BTF enabled?")
     }
     unsafe { &mut *btf }
 }


### PR DESCRIPTION
If CONFIG_DEBUG_INFO_BTF is not enabled in the kernel, the C schedulers report the following error via libbpf, clearly indicating the missing kernel config:

 libbpf: kernel BTF is missing at '/sys/kernel/btf/vmlinux', was CONFIG_DEBUG_INFO_BTF enabled?

In contrast, the Rust schedulers report a less clear error:

 thread 'main' panicked at /home/arighi/src/scx/rust/scx_utils/src/compat.rs:23:9:
 btf__load_vmlinux_btf() returned NULL
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Make sure to report a similar error, so that users have a better clue about the missing kernel config. After this change the error looks like the following:

 thread 'main' panicked at /home/arighi/src/scx/rust/scx_utils/src/compat.rs:23:9:
 btf__load_vmlinux_btf() returned NULL, was CONFIG_DEBUG_INFO_BTF enabled?