### PR TITLE
scx_lavd: optimization for communicaiton-intensive workloads and heavily-overloaded cases

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -62,8 +62,8 @@ enum consts {
 	LAVD_SLICE_UNDECIDED		= SCX_SLICE_INF,
 	LAVD_SLICE_GREEDY_FT		= 3,
 	LAVD_LOAD_FACTOR_ADJ		= 6, /* adjustment for better estimation */
-	LAVD_LOAD_FACTOR_MAX		= (10 * 1000),
-	LAVD_LOAD_FACTOR_FT		= 4, /* factor to stretch the time line */
+	LAVD_LOAD_FACTOR_MAX		= (20 * 1000),
+	LAVD_LOAD_FACTOR_FT		= 80, /* factor to stretch the time line */
 
 	LAVD_LC_FREQ_MAX		= 1000000,
 	LAVD_LC_RUNTIME_MAX		= LAVD_TARGETED_LATENCY_NS,
@@ -75,6 +75,7 @@ enum consts {
 	LAVD_SLICE_BOOST_MAX_STEP	= 8, /* 8 slice exhausitions in a row */
 	LAVD_GREEDY_RATIO_MAX		= USHRT_MAX,
 	LAVD_LAT_PRIO_IDLE		= USHRT_MAX,
+	LAVD_LAT_WEIGHT_SHIFT		= 3,
 
 	LAVD_ELIGIBLE_TIME_LAT_FT	= 16,
 	LAVD_ELIGIBLE_TIME_MAX		= (100 * NSEC_PER_USEC),

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -370,19 +370,20 @@ static const u64 sched_prio_to_slice_weight[NICE_WIDTH] = {
  * It is used to determine the virtual deadline. Each step increases by 10%.
  * The idea behind the virtual deadline is to limit the competition window
  * among concurrent tasks. For example, in the case of a normal priority task
- * with nice 0, its corresponding value is 7.5 msec. This guarantees that any
- * tasks enqueued in 7.5 msec after the task is enqueued will not compete for
- * CPU time with the task. This array is the inverse of
- * sched_prio_to_latency_weight with some normalization. Suppose the maximum
- * time slice per schedule (LAVD_SLICE_MAX_NS) is 3 msec. We normalized the
- * values so that the normal priority (nice 0) has a deadline of 7.5 msec, a
- * center of the targeted latency (i.e., when LAVD_TARGETED_LATENCY_NS is 15
+ * with nice 0, its corresponding value is 7.5 msec (when LAVD_LAT_WEIGHT_SHIFT
+ * is 0). This guarantees that any tasks enqueued in 7.5 msec after the task is
+ * enqueued will not compete for CPU time with the task. This array is the
+ * inverse of sched_prio_to_latency_weight with some normalization. Suppose the
+ * maximum time slice per schedule (LAVD_SLICE_MAX_NS) is 3 msec. We normalized
+ * the values so that the normal priority (nice 0) has a deadline of 7.5 msec,
+ * a center of the targeted latency (i.e., when LAVD_TARGETED_LATENCY_NS is 15
  * msec). The virtual deadline ranges from 87 usec to 512 msec. As the maximum
  * time slice becomes shorter, the deadlines become tighter.
  */
 static const u64 sched_prio_to_latency_weight[NICE_WIDTH] = {
 	/* weight	nice priority	sched priority	vdeadline (usec)    */
 	/*						(max slice == 3 ms) */
+	/*                                              (LAVD_LAT_WEIGHT_SHIFT == 0) */
 	/* ------	-------------	--------------	------------------- */
 	    29,		/* -20		 0		    87 */
 	    36,		/* -19		 1		   108 */
@@ -1448,7 +1449,12 @@ static u64 calc_latency_weight(struct task_struct *p, struct task_ctx *taskc,
 			       struct cpu_ctx *cpuc, bool is_wakeup)
 {
 	boost_lat(p, taskc, cpuc, is_wakeup);
-	return sched_prio_to_latency_weight[taskc->lat_prio];
+
+	/*
+	 * Tighten the competition window according to LAVD_LAT_WEIGHT_SHIFT.
+	 */
+	return sched_prio_to_latency_weight[taskc->lat_prio] >>
+	       LAVD_LAT_WEIGHT_SHIFT;
 }
 
 static u64 calc_virtual_deadline_delta(struct task_struct *p,
@@ -1479,11 +1485,17 @@ static u64 calc_virtual_deadline_delta(struct task_struct *p,
 
 	/*
 	 * When a system is overloaded (>1000), stretch time space so make time
-	 * tick slower to give room to execute the overloaded tasks.
+	 * tick logically slower to give room to execute the overloaded tasks.
 	 */
-	if (load_factor > 1000)
-		vdeadline_delta_ns = (vdeadline_delta_ns *load_factor *
-				      LAVD_LOAD_FACTOR_FT) / 1000;
+	if (load_factor > 1000) {
+		/*
+		 * The time space is stretched more if task's latency priority
+		 * is lower (i.e., higher value) and the load is higher.
+		 */
+		vdeadline_delta_ns = (vdeadline_delta_ns * load_factor *
+				      taskc->lat_prio * taskc->lat_prio) /
+				     (LAVD_LOAD_FACTOR_FT * 1000);
+	}
 
 	taskc->vdeadline_delta_ns = vdeadline_delta_ns;
 	return vdeadline_delta_ns;


### PR DESCRIPTION
This PR contains three tunings for 
1. When a system is heavily overloaded
2. When a workload is very communication-intensive.

It changes three things:
1. Stretch the time-space more aggressively (lat_prio^2) if the task's latency priority is low (i.e., high value). This prioritizes latency-critical tasks more and gives bounded delay to throughput-oriented tasks.
2. Avoid the active/overflow CPU mask check when all CPUs are using.
3. Tighten the competition window to avoid unnecessary tasks that are competing with each other in the timeline.

In result, it improves:
1. The communication-intensive benchmark (e.g., `perf bench sched messaging`)
2. Interactive tasks when heavy compilation + `stress-ng -c`
