### PR TITLE
Update libbpf commit hash

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -124,7 +124,7 @@ if should_build_libbpf
   endforeach
 
   message('Fetching libbpf repo')
-  libbpf_commit = '42065ea6627ff6e1ab4c65e51042a70fbf30ff7c'
+  libbpf_commit = 'c1a6c770c46c6e78ad6755bf596c23a4e6f6b216'
   run_command(fetch_libbpf, meson.current_build_dir(), libbpf_commit, check: true)
 
   make_jobs = 1


### PR DESCRIPTION
libbpf has added a member `link` in the struct `bpf_map_skeleton`, which causes a build failure in SCX. This commit updates the libbpf commit hash to the latest version to avoid this error.

Please refer to commit be998aa in libbpf repo.

Error message:
ninja: Entering directory `/home/otteryc/linux2024/scx/build'
[3/25] Compiling C object scheds/c/scx_simple.p/scx_simple.c.o
FAILED: scheds/c/scx_simple.p/scx_simple.c.o
cc -Ischeds/c/scx_simple.p -Ischeds/c -I../scheds/c -I../scheds/include -I../build/libbpf/src/usr/include -I../build/libbpf/include/uapi -fdiagnostics-color=alway
s -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g -pthread -MD -MQ scheds/c/scx_simple.p/scx_simple.c.o -MF scheds/c/scx_simple.p/scx_simple.c.o.d -o scheds/c/s
cx_simple.p/scx_simple.c.o -c ../scheds/c/scx_simple.c                                                                                                            In file included from ../scheds/c/scx_simple.c:13:                                                                                                                scheds/c/scx_simple.p/scx_simple.bpf.skel.h: In function ‘scx_simple__create_skeleton’:
scheds/c/scx_simple.p/scx_simple.bpf.skel.h:243:19: error: ‘struct bpf_map_skeleton’ has no member named ‘link’
  243 |         s->maps[5].link = &obj->links.simple_ops;
      |                   ^