### PR TITLE
scx_layered: Fix exit_task task_ctx lookup failed

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1170,7 +1170,8 @@ void BPF_STRUCT_OPS(layered_exit_task, struct task_struct *p,
 	struct cpu_ctx *cctx;
 	struct task_ctx *tctx;
 
-	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)))
+	tctx = lookup_task_ctx_may_fail(p);
+	if (!(cctx = lookup_cpu_ctx(-1)) || !tctx)
 		return;
 
 	if (tctx->layer >= 0 && tctx->layer < nr_layers)


### PR DESCRIPTION
When forking one task, init_task will save task_ctx into bpf storage, then bpf_task_storage_get can get it later, refer to [1].

However, if task creation fails before sched_cgroup_fork, so no task_ctx is created. then final run cgroup_cancel_fork, exit_task finds no task_ctx and runs scx_bpf_error("task_ctx lookup failed"), scx_layered exits, refer to [2].

[1] Successfully fork one task
    copy_process
	sched_fork
	sched_cgroup_fork -> init_task
	sched_post_fork
	return p

[2] Failed to create task
    copy_process
	sched_fork
	xxx // failed then skip sched_cgroup_fork
      goto bad_fork_cancel_cgroup:
    	cgroup_cancel_fork -> exit_task