### PR TITLE
meson: introduce serialize build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ options can be used in such cases.
 - 'cargo_home': 'CARGO_HOME env to use when invoking cargo'
 - `offline`: 'Compilation step should not access the internet'
 - `enable_rust`: 'Enable the build of rust sub-projects'
+- `serialize`: 'Enable/disable the sequential build of the schedulers. Set this to false if you need to build just one scheduler.'
 
 For example, let's say you want to use `bpftool` and `libbpf` shipped in the
 kernel tree located at `$KERNEL`. We need to build `bpftool` in the kernel

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,8 @@ cc = meson.get_compiler('c')
 
 enable_rust = get_option('enable_rust')
 
+serialize = get_option('serialize')
+
 bpf_clang = find_program(get_option('bpf_clang'))
 
 enable_stress = get_option('enable_stress')

--- a/meson.options
+++ b/meson.options
@@ -14,6 +14,8 @@ option('offline', type: 'boolean', value: 'false',
        description: 'Compilation step should not access the internet')
 option('enable_rust', type: 'boolean', value: 'true',
        description: 'Enable rust sub-projects')
+option('serialize', type: 'boolean', value: 'true',
+       description: 'Serialize the build of all schedulers')
 option('enable_stress', type: 'boolean', value: 'true',
        description: 'Enable stress tests')
 option('kernel', type: 'string', value: 'vmlinuz',

--- a/scheds/rust/scx_lavd/meson.build
+++ b/scheds/rust/scx_lavd/meson.build
@@ -1,8 +1,14 @@
+if serialize
+  sched_deps = [libbpf, bpftool_target, sched]
+else
+  sched_deps = [libbpf, bpftool_target]
+endif
+
 sched = custom_target('scx_lavd',
               output: '@PLAINNAME@.__PHONY__',
               input: 'Cargo.toml',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
-              depends: [sched],
+              depends: sched_deps,
               build_always_stale: true)

--- a/scheds/rust/scx_layered/meson.build
+++ b/scheds/rust/scx_layered/meson.build
@@ -1,8 +1,14 @@
+if serialize
+  sched_deps = [libbpf, bpftool_target, sched]
+else
+  sched_deps = [libbpf, bpftool_target]
+endif
+
 sched = custom_target('scx_layered',
               output: '@PLAINNAME@.__PHONY__',
               input: 'Cargo.toml',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
-              depends: [libbpf, bpftool_target, sched],
+              depends: sched_deps,
               build_always_stale: true)

--- a/scheds/rust/scx_mitosis/meson.build
+++ b/scheds/rust/scx_mitosis/meson.build
@@ -1,8 +1,14 @@
+if serialize
+  sched_deps = [libbpf, bpftool_target, sched]
+else
+  sched_deps = [libbpf, bpftool_target]
+endif
+
 sched = custom_target('scx_mitosis',
               output: '@PLAINNAME@.__PHONY__',
               input: 'Cargo.toml',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
-              depends: [libbpf, bpftool_target, sched],
+              depends: sched_deps,
               build_always_stale: true)

--- a/scheds/rust/scx_rlfifo/meson.build
+++ b/scheds/rust/scx_rlfifo/meson.build
@@ -1,8 +1,14 @@
+if serialize
+  sched_deps = [libbpf, bpftool_target, sched]
+else
+  sched_deps = [libbpf, bpftool_target]
+endif
+
 sched = custom_target('scx_rlfifo',
               output: '@PLAINNAME@.__PHONY__',
               input: 'Cargo.toml',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
-              depends: [libbpf, bpftool_target, sched],
+              depends: sched_deps,
               build_always_stale: true)

--- a/scheds/rust/scx_rustland/meson.build
+++ b/scheds/rust/scx_rustland/meson.build
@@ -1,8 +1,14 @@
+if serialize
+  sched_deps = [libbpf, bpftool_target, sched]
+else
+  sched_deps = [libbpf, bpftool_target]
+endif
+
 sched = custom_target('scx_rustland',
               output: '@PLAINNAME@.__PHONY__',
               input: 'Cargo.toml',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
-              depends: [libbpf, bpftool_target, sched],
+              depends: sched_deps,
               build_always_stale: true)

--- a/scheds/rust/scx_rusty/meson.build
+++ b/scheds/rust/scx_rusty/meson.build
@@ -1,8 +1,14 @@
+if serialize
+  sched_deps = [libbpf, bpftool_target, sched]
+else
+  sched_deps = [libbpf, bpftool_target]
+endif
+
 sched = custom_target('scx_rusty',
               output: '@PLAINNAME@.__PHONY__',
               input: 'Cargo.toml',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
-              depends: [libbpf, bpftool_target, sched],
+              depends: sched_deps,
               build_always_stale: true)


### PR DESCRIPTION
With commit 5d20f89a ("scheds-rust: build rust schedulers in sequence"), schedulers are now built serially one after the other to prevent meson and cargo from forking NxN parallel tasks.

However, this change has made building a single scheduler much more cumbersome, due to the chain of dependencies.

For example, building scx_rusty using the specific meson target would still result in all schedulers being built, because they all depend on each other.

To address this issue, introduce the new meson build option `serialize=true|false` (default is false).

This option allows to disable the schedulers' build chain, restoring the old behavior.

With this option enabled, it is now possible to build just a single scheduler, parallelizing the cargo build properly, without triggering the build of the others. Example:

  $ meson setup build -Dbuildtype=release -Dserialize=false
  $ meson compile -C build scx_rusty