### PR TITLE
meson: restore previous libbpf version and update bpftool

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -124,7 +124,7 @@ if should_build_libbpf
   endforeach
 
   message('Fetching libbpf repo')
-  libbpf_commit = 'c1a6c770c46c6e78ad6755bf596c23a4e6f6b216'
+  libbpf_commit = '42065ea6627ff6e1ab4c65e51042a70fbf30ff7c'
   run_command(fetch_libbpf, meson.current_build_dir(), libbpf_commit, check: true)
 
   make_jobs = 1
@@ -180,7 +180,7 @@ endif
 
 if should_build_bpftool
   message('Fetching bpftool repo')
-  bpftool_commit = '42065ea6627ff6e1ab4c65e51042a70fbf30ff7c'
+  bpftool_commit = '20ce6933869b70bacfdd0dd1a8399199290bf8ff'
   run_command(fetch_bpftool, meson.current_build_dir(), bpftool_commit, check: true)
 
   bpftool_target = custom_target('bpftool_target',


### PR DESCRIPTION
The upstrem bpftool git repo (https://github.com/libbpf/bpftool.git) is periodically force pushed and the specific commit that we needed is not available anymore.

Instead of failing we are actually fetching the latest bpftool (HEAD) that introduced some breakage initially fixed by commit e59c48a6 ("Update libbpf commit hash").

However, updating libbpf seems to introduce a run-time problem and all the schedulers are failing to start:

 libbpf: failed to find skeleton map ''
 libbpf: failed to populate skeleton maps for 'bpf_bpf': -3

So, revert libbpf to the previous version and update the commit for bpftool to use a version that still allows to generate a compatible BPF skel.

Fixes: e59c48a6 ("Update libbpf commit hash")