### PR TITLE
meson: check if commit exists in remote git repos

### DIFF
--- a/meson-scripts/fetch_bpftool
+++ b/meson-scripts/fetch_bpftool
@@ -1,9 +1,14 @@
 #!/bin/bash
 
+URL=https://github.com/libbpf/bpftool.git
+
 cd $1
 rm -rf bpftool
-git clone --depth=1 https://github.com/libbpf/bpftool.git
+git clone --depth=1 ${URL}
 cd bpftool
-git fetch --depth=1 origin $2
+git fetch --depth=1 origin $2 || {
+    echo "commit $2 does not exists in ${URL}"
+    exit 1
+}
 git checkout $2
 git submodule update --init --recursive

--- a/meson-scripts/fetch_libbpf
+++ b/meson-scripts/fetch_libbpf
@@ -1,11 +1,16 @@
 #!/bin/bash
 
+URL=https://github.com/libbpf/libbpf.git
+
 unset CDPATH
 cd $1
 rm -rf libbpf
-git clone --depth=1 https://github.com/libbpf/libbpf
+git clone --depth=1 ${URL}
 cd libbpf
-git fetch --depth=1 origin $2
+git fetch --depth=1 origin $2 || {
+    echo "commit $2 does not exists in ${URL}"
+    exit 1
+}
 git checkout $2
 
 # This is needed because we haven't built libbpf yet


### PR DESCRIPTION
When fetching external git repositories (libbpf and bpftool) we don't check if the target commit exists.

This can leads to issues such as #400, because we may silently use HEAD, instead of the specified commit.

Prevent this by returning an error when the target SHA1 cannot be found.