### PR TITLE
scx_bpfland: properly integrate with meson build

### DIFF
--- a/scheds/rust/scx_bpfland/meson.build
+++ b/scheds/rust/scx_bpfland/meson.build
@@ -1,8 +1,14 @@
+if serialize
+  sched_deps = [libbpf, bpftool_target, sched]
+else
+  sched_deps = [libbpf, bpftool_target]
+endif
+
 sched = custom_target('scx_bpfland',
               output: '@PLAINNAME@.__PHONY__',
               input: 'Cargo.toml',
               command: [cargo, 'build', '--manifest-path=@INPUT@', '--target-dir=@OUTDIR@',
                         cargo_build_args],
               env: cargo_env,
-              depends: [sched],
+              depends: sched_deps,
               build_always_stale: true)


### PR DESCRIPTION
Properly honor the meson build `serialize` option.