### PR TITLE
scx_rusty: fix stats map initialization

### DIFF
--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -485,7 +485,7 @@ impl<'a> Scheduler<'a> {
         let stats_map = maps.stats();
         let mut stats: Vec<u64> = Vec::new();
         let zero_vec =
-            vec![vec![0u8; stats_map.value_size() as usize]; self.top.nr_cpu_ids()];
+            vec![vec![0u8; stats_map.value_size() as usize]; self.top.nr_cpus_possible()];
 
         for stat in 0..bpf_intf::stat_idx_RUSTY_NR_STATS {
             let cpu_stat_vec = stats_map


### PR DESCRIPTION
The stats map in scx_rusty is a BPF_MAP_TYPE_PERCPU_ARRAY, with its size determined by num_possible_cpus(). Initializing it with nr_cpu_ids() can result in errors such as:

 Error: Failed to zero stat

 Caused by:
     number of values 6 != number of cpus 8

Fix by using num_possible_cpus() to initialize it.

Fixes: 263e02f6 ("rusty: Use nr_cpu_ids instead of nr_cpus_possible")