### PR TITLE
scx_bpfland: enhance performance consistency and predictability

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/intf.h
+++ b/scheds/rust/scx_bpfland/src/bpf/intf.h
@@ -15,7 +15,9 @@
 #define CLAMP(val, lo, hi) MIN(MAX(val, lo), hi)
 
 enum consts {
-	NSEC_PER_SEC = 1000000000ULL,
+        NSEC_PER_USEC = 1000ULL,
+        NSEC_PER_MSEC = (1000ULL * NSEC_PER_USEC),
+        NSEC_PER_SEC = (1000ULL * NSEC_PER_MSEC),
 };
 
 #ifndef __VMLINUX_H__

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -34,7 +34,7 @@ const volatile bool debug;
 /*
  * Default task time slice.
  */
-const volatile u64 slice_ns = SCX_SLICE_DFL;
+const volatile u64 slice_ns = 5000000;
 
 /*
  * Time slice used when system is over commissioned.

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -97,7 +97,6 @@ struct Opts {
 
 struct Metrics {
     nr_running: Gauge,
-    nr_kthread_dispatches: Gauge,
     nr_direct_dispatches: Gauge,
     nr_prio_dispatches: Gauge,
     nr_shared_dispatches: Gauge,
@@ -108,9 +107,6 @@ impl Metrics {
         Metrics {
             nr_running: gauge!(
                 "nr_running", "info" => "Number of running tasks"
-            ),
-            nr_kthread_dispatches: gauge!(
-                "nr_kthread_dispatches", "info" => "Number of kthread dispatches"
             ),
             nr_direct_dispatches: gauge!(
                 "nr_direct_dispatches", "info" => "Number of direct dispatches"
@@ -191,18 +187,14 @@ impl<'a> Scheduler<'a> {
     }
 
     fn update_stats(&mut self) {
-        let nr_running = self.skel.bss().nr_running;
         let nr_cpus = libbpf_rs::num_possible_cpus().unwrap();
-        let nr_kthread_dispatches = self.skel.bss().nr_kthread_dispatches;
+        let nr_running = self.skel.bss().nr_running;
         let nr_direct_dispatches = self.skel.bss().nr_direct_dispatches;
         let nr_prio_dispatches = self.skel.bss().nr_prio_dispatches;
         let nr_shared_dispatches = self.skel.bss().nr_shared_dispatches;
 
         // Update Prometheus statistics.
         self.metrics.nr_running.set(nr_running as f64);
-        self.metrics
-            .nr_kthread_dispatches
-            .set(nr_kthread_dispatches as f64);
         self.metrics
             .nr_direct_dispatches
             .set(nr_direct_dispatches as f64);
@@ -214,10 +206,9 @@ impl<'a> Scheduler<'a> {
             .set(nr_shared_dispatches as f64);
 
         // Log scheduling statistics.
-        info!("running={}/{} nr_kthread_dispatches={} nr_direct_dispatches={} nr_prio_dispatches={} nr_shared_dispatches={}",
+        info!("running={}/{} direct_dispatches={} prio_dispatches={} shared_dispatches={}",
             nr_running,
             nr_cpus,
-            nr_kthread_dispatches,
             nr_direct_dispatches,
             nr_prio_dispatches,
             nr_shared_dispatches);

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -59,7 +59,7 @@ struct Opts {
     exit_dump_len: u32,
 
     /// Maximum scheduling slice duration in microseconds.
-    #[clap(short = 's', long, default_value = "20000")]
+    #[clap(short = 's', long, default_value = "5000")]
     slice_us: u64,
 
     /// Minimum scheduling slice duration in microseconds.

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -78,10 +78,6 @@ struct Opts {
     #[clap(short = 'c', long, default_value = "10")]
     nvcsw_thresh: u64,
 
-    /// Enable direct dispatch via sched_ext built-in idle selection logic.
-    #[clap(short = 'i', long, action = clap::ArgAction::SetTrue)]
-    builtin_idle: bool,
-
     /// Enable the Prometheus endpoint for metrics on port 9000.
     #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
     enable_prometheus: bool,
@@ -174,7 +170,6 @@ impl<'a> Scheduler<'a> {
         skel.rodata_mut().slice_ns_min = opts.slice_us_min * 1000;
         skel.rodata_mut().slice_ns_lag = opts.slice_us_lag * 1000;
         skel.rodata_mut().nvcsw_thresh = opts.nvcsw_thresh;
-        skel.rodata_mut().builtin_idle = opts.builtin_idle;
 
         // Attach the scheduler.
         let mut skel = scx_ops_load!(skel, bpfland_ops, uei)?;

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -78,6 +78,11 @@ struct Opts {
     #[clap(short = 'c', long, default_value = "10")]
     nvcsw_thresh: u64,
 
+    /// Prevent the starvation making sure that at least one lower priority task is scheduled every
+    /// starvation_thresh_us (0 = disable starvation prevention).
+    #[clap(short = 't', long, default_value = "5000")]
+    starvation_thresh_us: u64,
+
     /// Enable the Prometheus endpoint for metrics on port 9000.
     #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
     enable_prometheus: bool,
@@ -165,6 +170,7 @@ impl<'a> Scheduler<'a> {
         skel.rodata_mut().slice_ns = opts.slice_us * 1000;
         skel.rodata_mut().slice_ns_min = opts.slice_us_min * 1000;
         skel.rodata_mut().slice_ns_lag = opts.slice_us_lag * 1000;
+        skel.rodata_mut().starvation_thresh_ns = opts.starvation_thresh_us * 1000;
         skel.rodata_mut().nvcsw_thresh = opts.nvcsw_thresh;
 
         // Attach the scheduler.


### PR DESCRIPTION
A set of changes to make performance more consistent and prevent spikes:
 - scx_bpfland: adjust default time slice to 5ms (default tuning for latency)
 - scx_bpfland: ensure task time slice never exceeds the slice_ns limit (latency improvement)
 - scx_bpfland: prevent starvation of regular tasks (prevent interactive tasks from monopolizing the CPUs)
 - scx_bpfland: unify dispatching kthreads with direct CPU dispatches (dispatch kthreads using per-CPU DSQs instead of `SCX_DSQ_LOCAL`)
 - scx_bpfland: drop built-in idle CPU selection logic (drop unused option / cleanup)

Thanks to the CachyOS community that provided an extensive amount of test results and feedback about these changes.