### PR TITLE
scx_flatcg: Make good use of __sync_fetch_and_sub()

### DIFF
--- a/scheds/c/scx_flatcg.bpf.c
+++ b/scheds/c/scx_flatcg.bpf.c
@@ -258,8 +258,7 @@ static void cgrp_cap_budget(struct cgv_node *cgv_node, struct fcg_cgrp_ctx *cgc)
 	 * and thus can't be updated and repositioned. Instead, we collect the
 	 * vtime deltas separately and apply it asynchronously here.
 	 */
-	delta = cgc->cvtime_delta;
-	__sync_fetch_and_sub(&cgc->cvtime_delta, delta);
+	delta = __sync_fetch_and_sub(&cgc->cvtime_delta, cgc->cvtime_delta);
 	cvtime = cgv_node->cvtime + delta;
 
 	/*


### PR DESCRIPTION
## Summary
Fetch the value of `delta` directly from the returned value from `__sync_fetch_and_sub`, as it returns the origin value of `cgc->cvtime_delta`.

Additional fetching instruction of `cgc->cvtime_delta` would be redundant here.