### PR TITLE
scx_bpfland: additional stats and output improvements

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -34,6 +34,7 @@ use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::Skel;
 use libbpf_rs::skel::SkelBuilder;
 
+use scx_utils::build_id;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
@@ -42,8 +43,6 @@ use scx_utils::uei_report;
 use scx_utils::UserExitInfo;
 
 const SCHEDULER_NAME: &'static str = "scx_bpfland";
-
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 /// scx_bpfland: a vruntime-based sched_ext scheduler that prioritizes interactive workloads.
 ///
@@ -159,7 +158,12 @@ impl<'a> Scheduler<'a> {
             Ok(value) => value == 1,
             Err(e) => bail!("Failed to read SMT status: {}", e),
         };
-        info!("SMT scheduling {}", if smt_enabled { "on" } else { "off" });
+        info!(
+            "{} {} {}",
+            SCHEDULER_NAME,
+            *build_id::SCX_FULL_VERSION,
+            if smt_enabled { "SMT on" } else { "SMT off" }
+        );
 
         // Initialize BPF connector.
         let mut skel_builder = BpfSkelBuilder::default();
@@ -256,7 +260,7 @@ fn main() -> Result<()> {
     let opts = Opts::parse();
 
     if opts.version {
-        println!("{} version {}", SCHEDULER_NAME, VERSION);
+        println!("{} {}", SCHEDULER_NAME, *build_id::SCX_FULL_VERSION);
         return Ok(());
     }
 

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -221,7 +221,7 @@ impl<'a> Scheduler<'a> {
             .set(nr_shared_dispatches as f64);
 
         // Log scheduling statistics.
-        info!("running={}/{} kthread_dispatches={} direct_dispatches={} prio_dispatches={} shared_dispatches={}",
+        info!("running: {:>4}/{:<4} | kthread: {:<6} | direct: {:<6} | prio: {:<6} | shared: {:<6}",
             nr_running,
             nr_cpus,
             nr_kthread_dispatches,

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -102,6 +102,7 @@ struct Opts {
 
 struct Metrics {
     nr_running: Gauge,
+    nr_kthread_dispatches: Gauge,
     nr_direct_dispatches: Gauge,
     nr_prio_dispatches: Gauge,
     nr_shared_dispatches: Gauge,
@@ -113,8 +114,11 @@ impl Metrics {
             nr_running: gauge!(
                 "nr_running", "info" => "Number of running tasks"
             ),
+            nr_kthread_dispatches: gauge!(
+                "nr_kthread_dispatches", "info" => "Number of kthread direct dispatches"
+            ),
             nr_direct_dispatches: gauge!(
-                "nr_direct_dispatches", "info" => "Number of direct dispatches"
+                "nr_direct_dispatches", "info" => "Number of task direct dispatches"
             ),
             nr_prio_dispatches: gauge!(
                 "nr_prio_dispatches", "info" => "Number of interactive task dispatches"
@@ -195,12 +199,17 @@ impl<'a> Scheduler<'a> {
     fn update_stats(&mut self) {
         let nr_cpus = libbpf_rs::num_possible_cpus().unwrap();
         let nr_running = self.skel.bss().nr_running;
+        let nr_kthread_dispatches = self.skel.bss().nr_kthread_dispatches;
         let nr_direct_dispatches = self.skel.bss().nr_direct_dispatches;
         let nr_prio_dispatches = self.skel.bss().nr_prio_dispatches;
         let nr_shared_dispatches = self.skel.bss().nr_shared_dispatches;
 
         // Update Prometheus statistics.
         self.metrics.nr_running.set(nr_running as f64);
+
+        self.metrics
+            .nr_kthread_dispatches
+            .set(nr_kthread_dispatches as f64);
         self.metrics
             .nr_direct_dispatches
             .set(nr_direct_dispatches as f64);
@@ -212,9 +221,10 @@ impl<'a> Scheduler<'a> {
             .set(nr_shared_dispatches as f64);
 
         // Log scheduling statistics.
-        info!("running={}/{} direct_dispatches={} prio_dispatches={} shared_dispatches={}",
+        info!("running={}/{} kthread_dispatches={} direct_dispatches={} prio_dispatches={} shared_dispatches={}",
             nr_running,
             nr_cpus,
+            nr_kthread_dispatches,
             nr_direct_dispatches,
             nr_prio_dispatches,
             nr_shared_dispatches);


### PR DESCRIPTION
No functional changes, only cosmetics: report additional statistics (split kthread / direct dipatches), report the build id version (using `scx_utils::build_id`) and print statistics in a more human-readable format.