### PR TITLE
bpfland: small improvements

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -234,12 +234,12 @@ static inline u64 task_vtime(struct task_struct *p)
 }
 
 /*
- * Return the task's unused portion of its previously assigned time slice (with
- * a minimum of slice_ns_min).
+ * Return the task's unused portion of its previously assigned time slice in
+ * the range a [slice_ns_min..slice_ns].
  */
 static inline u64 task_slice(struct task_struct *p)
 {
-	return MAX(p->scx.slice, slice_ns_min);
+	return CLAMP((p->scx.slice + slice_ns_min) / 2, slice_ns_min, slice_ns);
 }
 
 /*


### PR DESCRIPTION
Small improvements / cleanups in bpfland to slightly improve fairness and responsiveness:
 - scx_bpfland: refill task time slice (re-evaluate task time slice based on the unused quota and min time slice, to improve fairness and avoid excessive amount of context switches)
 - scx_bpfland: always classify interactive tasks (classify interactive tasks also when they're directly dispatched in select_cpu)
 - scx_bpfland: pass enqueue flags when dispatching kthread (just for consistency)