### PR TITLE
scx_bpfland: mitigations and additional statistics

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -641,7 +641,8 @@ void BPF_STRUCT_OPS(bpfland_stopping, struct task_struct *p, bool runnable)
 	 * opportunities to be classified as interactive and dispatched to the
 	 * high priority DSQ (PRIO_DSQ).
 	 */
-	p->scx.dsq_vtime += (slice_ns - p->scx.slice) * 100 / p->scx.weight;
+	if (slice_ns > p->scx.slice)
+		p->scx.dsq_vtime += (slice_ns - p->scx.slice) * 100 / p->scx.weight;
 
 	/*
 	 * Refresh voluntary context switch metrics.

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -34,7 +34,7 @@ const volatile bool debug;
 /*
  * Default task time slice.
  */
-const volatile u64 slice_ns = 5ULL * NSEC_PER_SEC;
+const volatile u64 slice_ns = 5ULL * NSEC_PER_MSEC;
 
 /*
  * Time slice used when system is over commissioned.

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -72,6 +72,15 @@ struct Opts {
     #[clap(short = 'l', long, default_value = "0")]
     slice_us_lag: u64,
 
+    /// Enable per-CPU kthreads prioritization.
+    ///
+    /// Enabling this can enhance the performance of interrupt-driven workloads (e.g., networking
+    /// throughput) over regular system/user workloads. However, it may also introduce
+    /// interactivity issues or unfairness under heavy interrupt-driven loads, such as high RX
+    /// network traffic.
+    #[clap(short = 'k', long, action = clap::ArgAction::SetTrue)]
+    local_kthreads: bool,
+
     /// Threshold of voluntary context switch per second, used to classify interactive tasks
     /// (0 = disable interactive tasks classification).
     #[clap(short = 'c', long, default_value = "10")]
@@ -179,6 +188,7 @@ impl<'a> Scheduler<'a> {
         // Override default BPF scheduling parameters.
         skel.rodata_mut().debug = opts.debug;
         skel.rodata_mut().smt_enabled = smt_enabled;
+        skel.rodata_mut().local_kthreads = opts.local_kthreads;
         skel.rodata_mut().slice_ns = opts.slice_us * 1000;
         skel.rodata_mut().slice_ns_min = opts.slice_us_min * 1000;
         skel.rodata_mut().slice_ns_lag = opts.slice_us_lag * 1000;

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -205,7 +205,7 @@ impl<'a> Scheduler<'a> {
     }
 
     fn update_stats(&mut self) {
-        let nr_cpus = libbpf_rs::num_possible_cpus().unwrap();
+        let nr_cpus = self.skel.bss().nr_online_cpus;
         let nr_running = self.skel.bss().nr_running;
         let nr_interactive = self.skel.bss().nr_interactive;
         let nr_kthread_dispatches = self.skel.bss().nr_kthread_dispatches;


### PR DESCRIPTION
Set of changes extensively tested by the CachyOS community with positive results:
 - all kthreads are now following the same scheduling path of regular tasks by default: this allows to prevent interactivity issues or unfairness in presence of too many softirqs (i.e., high RX network traffic)
 - mitigate spam of "fake" interactive tasks: workloads that create large amount of tasks doing sync wake events (e.g.., `hackbench -l N`) can make the system almost unresponsive, because all these tasks ae classified as "interactive"; the mitigation puts a limit (= 4x the online cpus) on the amount of tasks that can be queued to the priority DSQ, preventing the flood of too many interactive tasks, all scheduled before regular tasks.

Moreover, report additional statistics to stdout:
 - interactive tasks running
 - real amount of online CPUs (updated on cpu hotplugging events)