### PR TITLE
meson: fix RUSTFLAGS being appended incorrectly

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -295,7 +295,7 @@ if libbpf_a != ''
 
   cargo_env.append('RUSTFLAGS',
                    '-C relocation-model=pic -C link-args=-lelf -C link-args=-lz -C link-args=-lzstd -L '
-                   + fs.parent(libbpf_a))
+                   + fs.parent(libbpf_a), separator: ' ')
 
   #
   # XXX - scx_rusty's original Cargo.toml contained a dependency matching


### PR DESCRIPTION
the value to env variable RUSTFLAGS is getting appended with ':'(like in the PATH variable to list binary folders to search in) instead of ' ' in the flags env variables

resulting in
```
 ':-C' relocation-model=pic -C link-args=-lelf -C link-args=-lz -C link-args=-lzstd -L /home/smol/.cache/paru/clone/scx-scheds-git/src/scx/build/libbpf/src --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg` (exit status: 1)
 ```