### PR TITLE
install_user_scheds: Skip packaging of scx_mitosis

### DIFF
--- a/meson-scripts/install_rust_user_scheds
+++ b/meson-scripts/install_rust_user_scheds
@@ -7,6 +7,12 @@ for manifest in "$MESON_SOURCE_ROOT"/scheds/rust/*/Cargo.toml; do
     target_dir="${MESON_BUILD_ROOT}${source_dir#${MESON_SOURCE_ROOT}}"
     name="${target_dir##*/}"
 
+    # Skip scx_mitosis
+    if [ "$name" = "scx_mitosis" ]; then
+        echo "Skipping installation of $name"
+        continue
+    fi
+
     bins=($(ls -t "${target_dir}/"*"/${name}"))
     if [ ${#bins[@]} -lt 1 ]; then
 	echo "Cannot find a binary for $name under $target_dir" 1>&2


### PR DESCRIPTION
Since scx_mitosis got disabled, but still gets read out by the install_user_scheds script, lets skip it to avoid packaging issues.

Can be enabled, as soon scx_mitosis got enabled again.