### PR TITLE
ci: Use latest upstream kernel and exclude scx_flatcg and scx_pair from testing

### DIFF
--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -45,7 +45,7 @@ jobs:
       - run: cd linux && git log -1 --pretty=format:"%h %ad %s" --date=short
 
       # Build a minimal kernel (with sched-ext enabled) using virtme-ng
-      - run: cd linux && vng -v --build --config .github/workflows/sched-ext.config
+      - run: cd linux && vng -v --build --config ../.github/workflows/sched-ext.config
 
       # Generate kernel headers
       - run: cd linux && make headers

--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -37,10 +37,9 @@ jobs:
       # Install virtme-ng
       - run: pip install virtme-ng
 
-      # Get the latest sched-ext enabled kernel directly from the git
-      # repository (try the sched_ext-ci branch first, if it doesn't exist use
-      # sched_ext)
-      - run: git clone --single-branch -b sched_ext-ci --depth 1 https://github.com/sched-ext/sched_ext.git linux || git clone --single-branch -b sched_ext --depth 1 https://github.com/sched-ext/sched_ext.git linux
+      # Get the latest sched-ext enabled kernel directly from the korg
+      # for-next branch
+      - run: git clone --single-branch -b for-next --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
 
       # Print the latest commit of the checked out sched-ext kernel
       - run: cd linux && git log -1 --pretty=format:"%h %ad %s" --date=short

--- a/.github/workflows/sched-ext.config
+++ b/.github/workflows/sched-ext.config
@@ -1,0 +1,34 @@
+# sched-ext mandatory options
+#
+CONFIG_BPF=y
+CONFIG_BPF_SYSCALL=y
+CONFIG_BPF_JIT=y
+CONFIG_DEBUG_INFO_BTF=y
+CONFIG_BPF_JIT_ALWAYS_ON=y
+CONFIG_BPF_JIT_DEFAULT_ON=y
+CONFIG_SCHED_CLASS_EXT=y
+
+# Enable scheduling debugging
+#
+CONFIG_SCHED_DEBUG=y
+
+# Enable extra scheduling features (for a better code coverage while testing
+# the schedulers)
+#
+CONFIG_SCHED_AUTOGROUP=y
+CONFIG_SCHED_CORE=y
+
+# Enable fully preemptible kernel for a better test coverage of the schedulers
+#
+# CONFIG_PREEMPT_NONE is not set
+# CONFIG_PREEMPT_VOLUNTARY is not set
+CONFIG_PREEMPT=y
+CONFIG_PREEMPT_COUNT=y
+CONFIG_PREEMPTION=y
+CONFIG_PREEMPT_DYNAMIC=y
+CONFIG_PREEMPT_RCU=y
+
+# Additional debugging information (useful to catch potential locking issues)
+#
+CONFIG_DEBUG_LOCKDEP=y
+CONFIG_DEBUG_ATOMIC_SLEEP=y

--- a/meson-scripts/test_sched
+++ b/meson-scripts/test_sched
@@ -15,8 +15,10 @@ GUEST_TIMEOUT=60
 # TODO:
 #   - scx_layered: temporarily excluded because it
 #     cannot run with a default configuration
+#   - scx_flatcg, scx_pair: excluded until cgroup support lands upstream
+#   - scx_mitosis: not ready yet
 #
-SCHEDULERS="scx_simple scx_central scx_flatcg scx_nest scx_pair scx_rusty scx_rustland scx_bpfland"
+SCHEDULERS="scx_simple scx_central scx_nest scx_rusty scx_rustland scx_bpfland"
 
 if [ ! -x `which vng` ]; then
     echo "vng not found, please install virtme-ng to enable testing"


### PR DESCRIPTION
Use kernel from kernel.org (for-next branch), include the .config chunk directly in the scx repository and temporarily exclude scx_flatcg and scx_pair due to the missing cgroup ABIs.