### PR TITLE
scx_utils: Display the tag value for nested counters in log_recorder

### DIFF
--- a/rust/scx_utils/src/log_recorder.rs
+++ b/rust/scx_utils/src/log_recorder.rs
@@ -172,7 +172,7 @@ pub trait MetricFormatter {
             Some(percentage) => {
                 // Assuming only one label for now
                 let name = match key.labels().next() {
-                    Some(label) => label.key(),
+                    Some(label) => label.value(),
                     None => "Unknown",
                 };
 


### PR DESCRIPTION
The log_recorder was incorrectly displaying the tag name instead of the value for nested counters.

After the fix:
```
21:19:35 [INFO] Counters:
21:19:35 [INFO]   dispatched_tasks_total: 2672 [890.5/s]
21:19:35 [INFO]     prev_idle: 1814 (67.9%) [604.6/s]
21:19:35 [INFO]     wsync_prev_idle: 676 (25.3%) [225.3/s]
21:19:35 [INFO]     direct_dispatch: 97 (3.6%) [32.3/s]
21:19:35 [INFO]     dsq: 78 (2.9%) [26.0/s]
21:19:35 [INFO]     wsync: 7 (0.3%) [2.3/s]
21:19:35 [INFO]     pinned: 0 (0.0%) [0.0/s]
21:19:35 [INFO]     greedy_idle: 0 (0.0%) [0.0/s]
21:19:35 [INFO]     greedy_xnuma: 0 (0.0%) [0.0/s]
21:19:35 [INFO]     direct_greedy: 0 (0.0%) [0.0/s]
21:19:35 [INFO]     direct_greedy_far: 0 (0.0%) [0.0/s]
21:19:35 [INFO]     greedy_local: 0 (0.0%) [0.0/s]
21:19:35 [INFO]   dl_clamped_total: 40 [13.3/s]
21:19:35 [INFO]   dl_preset_total: 38 [12.7/s]
21:19:35 [INFO]   kick_greedy_total: 0 [0.0/s]
21:19:35 [INFO]   lb_data_errors_total: 0 [0.0/s]
21:19:35 [INFO]   load_balance_total: 0 [0.0/s]
21:19:35 [INFO]   repatriate_total: 0 [0.0/s]
21:19:35 [INFO]   task_errors_total: 0 [0.0/s]
```