### PR TITLE
scx_rusty: Remove skip_while in find_first_candidate

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -1507,7 +1507,6 @@ static u32 task_pick_domain(struct task_ctx *taskc, struct task_struct *p,
 {
 	s32 cpu = bpf_get_smp_processor_id();
 	u32 first_dom = NO_DOM_FOUND, dom, preferred_dom = NO_DOM_FOUND;
-	int has_preferred_dom;
 
 	if (cpu < 0 || cpu >= MAX_CPUS)
 		return NO_DOM_FOUND;


### PR DESCRIPTION
## Summary
Followed [commit 1c3b563](https://github.com/sched-ext/scx/commit/1c3b563cafd760cddef7d96689e10c94f5171f70), move the checking of task.migrated.get() into the vector filter. In this way, we can remove the skip_while() call in find_first_candidate().