### PR TITLE
scx_bpfland: adjust task time slice as a function of waiting tasks

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -94,8 +94,7 @@ static u64 starvation_prio_ts;
 /*
  * Scheduling statistics.
  */
-volatile u64 nr_direct_dispatches, nr_kthread_dispatches,
-		nr_shared_dispatches, nr_prio_dispatches;
+volatile u64 nr_direct_dispatches, nr_shared_dispatches, nr_prio_dispatches;
 
 /*
  * Amount of currently running tasks.
@@ -549,7 +548,7 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	if (local_kthreads && is_kthread(p) && p->nr_cpus_allowed == 1) {
 		s32 cpu = scx_bpf_task_cpu(p);
 		if (!dispatch_direct_cpu(p, cpu, enq_flags)) {
-			__sync_fetch_and_add(&nr_kthread_dispatches, 1);
+			__sync_fetch_and_add(&nr_direct_dispatches, 1);
 			return;
 		}
 	}

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -100,7 +100,7 @@ volatile u64 nr_direct_dispatches, nr_kthread_dispatches,
 /*
  * Amount of currently running tasks.
  */
-volatile u64 nr_running, nr_interactive, nr_online_cpus;
+volatile u64 nr_running, nr_waiting, nr_interactive, nr_online_cpus;
 
 /*
  * Exit information.
@@ -316,9 +316,6 @@ static u64 nr_tasks_waiting(void)
  */
 static inline u64 task_slice(struct task_struct *p)
 {
-	static u64 nr_waiting;
-	u64 scaling;
-
 	/*
 	 * Refresh the amount of waiting tasks to get a more accurate scaling
 	 * factor for the time slice.

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -113,7 +113,6 @@ struct Metrics {
     nr_interactive: Gauge,
     nr_waiting: Gauge,
     nvcsw_avg_thresh: Gauge,
-    nr_kthread_dispatches: Gauge,
     nr_direct_dispatches: Gauge,
     nr_prio_dispatches: Gauge,
     nr_shared_dispatches: Gauge,
@@ -133,9 +132,6 @@ impl Metrics {
             ),
             nvcsw_avg_thresh: gauge!(
                 "nvcsw_avg_thresh", "info" => "Average of voluntary context switches"
-            ),
-            nr_kthread_dispatches: gauge!(
-                "nr_kthread_dispatches", "info" => "Number of kthread direct dispatches"
             ),
             nr_direct_dispatches: gauge!(
                 "nr_direct_dispatches", "info" => "Number of task direct dispatches"
@@ -228,7 +224,6 @@ impl<'a> Scheduler<'a> {
         let nr_interactive = self.skel.bss().nr_interactive;
         let nr_waiting = self.skel.bss().nr_waiting;
         let nvcsw_avg_thresh = self.skel.bss().nvcsw_avg_thresh;
-        let nr_kthread_dispatches = self.skel.bss().nr_kthread_dispatches;
         let nr_direct_dispatches = self.skel.bss().nr_direct_dispatches;
         let nr_prio_dispatches = self.skel.bss().nr_prio_dispatches;
         let nr_shared_dispatches = self.skel.bss().nr_shared_dispatches;
@@ -246,9 +241,6 @@ impl<'a> Scheduler<'a> {
         self.metrics
             .nvcsw_avg_thresh.set(nvcsw_avg_thresh as f64);
         self.metrics
-            .nr_kthread_dispatches
-            .set(nr_kthread_dispatches as f64);
-        self.metrics
             .nr_direct_dispatches
             .set(nr_direct_dispatches as f64);
         self.metrics
@@ -259,13 +251,12 @@ impl<'a> Scheduler<'a> {
             .set(nr_shared_dispatches as f64);
 
         // Log scheduling statistics.
-        info!("running: {:>4}/{:<4} interactive: {:<4} wait: {:<4} | nvcsw: {:<4} | kthread: {:<6} | direct: {:<6} | prio: {:<6} | shared: {:<6}",
+        info!("running: {:>4}/{:<4} interactive: {:<4} wait: {:<4} | nvcsw: {:<4} | direct: {:<6} prio: {:<6} shared: {:<6}",
             nr_running,
             nr_cpus,
             nr_interactive,
             nr_waiting,
             nvcsw_avg_thresh,
-            nr_kthread_dispatches,
             nr_direct_dispatches,
             nr_prio_dispatches,
             nr_shared_dispatches);


### PR DESCRIPTION
Scale the variable task time slice inversely proportional to the amount of tasks waiting on the shared and priority DSQs:
- if the system is not fully saturated tasks will be directly dispatched to the available CPUs and they can use the max time slice;
- as soon as the system becomes over-commissioned tasks will be queued either to the priority DSQ (interactive) or the shared DSQ (regular) and the time slice will be adjusted inversely proportional to the total amount of waiting tasks (evaluated a simple moving average).

This change has been tested with positive result by the CachyOS community running micro-benchmarks as well as practical user workloads (gaming with background activity, testing system responsiveness, audio, etc.).

Moreover, the metrics reported by the scheduler have been adjusted as following:
 - add average amount of waiting tasks
 - add periodic samples of the task's time slice
 - drop kthread dispatches (and merge this with direct dispatches - when enabled)