### PR TITLE
scx_layered: Add user and group layers

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -107,6 +107,8 @@ enum layer_match_kind {
 	MATCH_NICE_ABOVE,
 	MATCH_NICE_BELOW,
 	MATCH_NICE_EQUALS,
+	MATCH_USER_ID_EQUALS,
+	MATCH_GROUP_ID_EQUALS,
 
 	NR_LAYER_MATCH_KINDS,
 };
@@ -117,6 +119,8 @@ struct layer_match {
 	char		comm_prefix[MAX_COMM];
 	char		pcomm_prefix[MAX_COMM];
 	int		nice;
+	u32		user_id;
+	u32		group_id;
 };
 
 struct layer_match_ands {

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -125,6 +125,10 @@ lazy_static::lazy_static! {
 /// - NiceEquals: Matches if the task's nice value is exactly equal to
 ///   the pattern.
 ///
+/// - UserId: Matches if the task's effective user id matches the pattern.
+///
+/// - GroupId: Matches if the task's effective group id matches the pattern.
+///
 /// While there are complexity limitations as the matches are performed in
 /// BPF, it is straightforward to add more types of matches.
 ///
@@ -340,6 +344,8 @@ enum LayerMatch {
     NiceAbove(i32),
     NiceBelow(i32),
     NiceEquals(i32),
+    UserId(u32),
+    GroupId(u32),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1288,6 +1294,14 @@ impl<'a, 'b> Scheduler<'a, 'b> {
                         LayerMatch::NiceEquals(nice) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_NICE_EQUALS as i32;
                             mt.nice = *nice;
+                        }
+                        LayerMatch::UserId(user_id) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_USER_ID_EQUALS as i32;
+                            mt.user_id = *user_id;
+                        }
+                        LayerMatch::GroupId(group_id) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_GROUP_ID_EQUALS as i32;
+                            mt.group_id = *group_id;
                         }
                     }
                 }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -125,9 +125,9 @@ lazy_static::lazy_static! {
 /// - NiceEquals: Matches if the task's nice value is exactly equal to
 ///   the pattern.
 ///
-/// - UserId: Matches if the task's effective user id matches the pattern.
+/// - UIDEquals: Matches if the task's effective user id matches the pattern.
 ///
-/// - GroupId: Matches if the task's effective group id matches the pattern.
+/// - GIDEquals: Matches if the task's effective group id matches the pattern.
 ///
 /// While there are complexity limitations as the matches are performed in
 /// BPF, it is straightforward to add more types of matches.
@@ -344,8 +344,8 @@ enum LayerMatch {
     NiceAbove(i32),
     NiceBelow(i32),
     NiceEquals(i32),
-    UserId(u32),
-    GroupId(u32),
+    UIDEquals(u32),
+    GIDEquals(u32),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1295,11 +1295,11 @@ impl<'a, 'b> Scheduler<'a, 'b> {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_NICE_EQUALS as i32;
                             mt.nice = *nice;
                         }
-                        LayerMatch::UserId(user_id) => {
+                        LayerMatch::UIDEquals(user_id) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_USER_ID_EQUALS as i32;
                             mt.user_id = *user_id;
                         }
-                        LayerMatch::GroupId(group_id) => {
+                        LayerMatch::GIDEquals(group_id) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_GROUP_ID_EQUALS as i32;
                             mt.group_id = *group_id;
                         }


### PR DESCRIPTION
Add a layer match based on either the effective user id or the effective group id. This allows for creating layers for individual users or groups.


Test:
```
$ id
uid=224791(hodgesd) gid=100(users) groups=100(users)
```
config:
```
$ cat user.json 
[{
  "name":"hodgesd",
  "comment":"hodgesd user",
  "matches":[
     [{"UIDEquals":224791}]
  ],
  "kind": {
    "Open":{
      "min_exec_us":0,
      "preempt": true,
      "exclusive": true
     }
  }
},
{
  "name":"normal",
  "comment":"the rest",
  "matches":[[]],
  "kind":{
    "Open": {
      "min_exec_us":0,
      "preempt":false,
      "exclusive":false
    }
  }
}]
```
`scx_layered` has layers for my user:
```
18:56:35 [INFO] excl_coll= 0.00 excl_preempt= 0.00 excl_idle= 0.00 excl_wakeup= 0.02
18:56:35 [INFO]   hodgesd: util/frac=    9.8/  5.5 load/frac=      9.6:  3.2 tasks=   355
18:56:35 [INFO]            tot=    621 local=94.85 wake/exp/last/reenq= 3.70/ 0.48/ 0.97/ 0.00
18:56:35 [INFO]            keep/max/busy= 0.97/ 0.00/ 0.00 kick= 0.48 yield/ign= 0.00/    0 
18:56:35 [INFO]            open_idle= 0.00 mig=17.23 affn_viol= 0.00
18:56:35 [INFO]            preempt/first/idle/fail= 0.16/ 0.00/ 3.54/ 0.00 min_exec= 0.00/   0.00ms
18:56:35 [INFO]            cpus=  0 [  0,  0] 00000000 00000000 00000000
18:56:35 [INFO]            excl_coll= 0.00 excl_preempt= 0.00
18:56:35 [INFO]   normal : util/frac=  167.2/ 94.5 load/frac=    288.6: 96.8 tasks=  3203
18:56:35 [INFO]            tot=  26836 local=95.83 wake/exp/last/reenq= 1.79/ 0.56/ 1.82/ 0.01
18:56:35 [INFO]            keep/max/busy= 0.28/ 0.00/ 0.00 kick= 0.57 yield/ign= 1.56/    0 
18:56:35 [INFO]            open_idle= 0.00 mig= 6.58 affn_viol= 0.00
18:56:35 [INFO]            preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
18:56:35 [INFO]            cpus=  0 [  0,  0] 00000000 00000000 00000000
```
