### PR TITLE
lavd_lavd: initial support for AMP (asynmmetric multi-processor) architecture

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -67,8 +67,8 @@ enum consts {
 	LAVD_LC_RUNTIME_SHIFT		= 10,
 	LAVD_LC_STARVATION_FT		= 1024,
 
-	LAVD_SLICE_BOOST_MAX_FT		= 2, /* maximum additional 2x of slice */
-	LAVD_SLICE_BOOST_MAX_STEP	= 8, /* 8 slice exhausitions in a row */
+	LAVD_SLICE_BOOST_MAX_FT		= 3, /* maximum additional 2x of slice */
+	LAVD_SLICE_BOOST_MAX_STEP	= 6, /* 8 slice exhausitions in a row */
 	LAVD_GREEDY_RATIO_NEW		= 2000,
 
 	LAVD_ELIGIBLE_TIME_MAX		= (1ULL * LAVD_TIME_ONE_SEC),
@@ -171,6 +171,7 @@ struct cpu_ctx {
 	 * Fields for core compaction
 	 *
 	 */
+	u16		capacity;	/* CPU capacity based on 1000 */
 	struct bpf_cpumask __kptr *tmp_a_mask;	/* temporary cpu mask */
 	struct bpf_cpumask __kptr *tmp_o_mask;	/* temporary cpu mask */
 } __attribute__((aligned(CACHELINE_SIZE)));

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -70,11 +70,8 @@ enum consts {
 	LAVD_SLICE_BOOST_MAX_FT		= 2, /* maximum additional 2x of slice */
 	LAVD_SLICE_BOOST_MAX_STEP	= 8, /* 8 slice exhausitions in a row */
 	LAVD_GREEDY_RATIO_NEW		= 2000,
-	LAVD_GREEDY_RATIO_MAX		= USHRT_MAX,
 
-	LAVD_ELIGIBLE_TIME_LAT_FT	= 16,
 	LAVD_ELIGIBLE_TIME_MAX		= (1ULL * LAVD_TIME_ONE_SEC),
-	LAVD_REFILL_NR			= 2,
 
 	LAVD_CPU_UTIL_MAX		= 1000, /* 100.0% */
 	LAVD_CPU_UTIL_MAX_FOR_CPUPERF	= 850, /* 85.0% */
@@ -86,14 +83,14 @@ enum consts {
 	LAVD_PREEMPT_TICK_MARGIN	= (1ULL * NSEC_PER_USEC),
 
 	LAVD_SYS_STAT_INTERVAL_NS	= (25ULL * NSEC_PER_MSEC),
-	LAVD_TC_PER_CORE_MAX_CTUIL	= 500, /* maximum per-core CPU utilization */
-	LAVD_TC_NR_ACTIVE_MIN		= 1, /* num of mininum active cores */
-	LAVD_TC_NR_OVRFLW		= 1, /* num of overflow cores */
-	LAVD_TC_CPU_PIN_INTERVAL	= (100ULL * NSEC_PER_MSEC),
-	LAVD_TC_CPU_PIN_INTERVAL_DIV	= (LAVD_TC_CPU_PIN_INTERVAL /
+	LAVD_CC_PER_CORE_MAX_CTUIL	= 500, /* maximum per-core CPU utilization */
+	LAVD_CC_NR_ACTIVE_MIN		= 1, /* num of mininum active cores */
+	LAVD_CC_NR_OVRFLW		= 1, /* num of overflow cores */
+	LAVD_CC_CPU_PIN_INTERVAL	= (100ULL * NSEC_PER_MSEC),
+	LAVD_CC_CPU_PIN_INTERVAL_DIV	= (LAVD_CC_CPU_PIN_INTERVAL /
 					   LAVD_SYS_STAT_INTERVAL_NS),
 
-	LAVD_ELIGIBLE_DSQ		= 0, /* a global DSQ for eligible tasks */
+	LAVD_GLOBAL_DSQ			= 0, /* a global DSQ for eligible tasks */
 };
 
 /*

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -2220,8 +2220,10 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 	 * urgently increases according to task's target but it decreases
 	 * gradually according to EWMA of past performance targets.
 	 */
-	calc_cpuperf_target(stat_cur, taskc, cpuc);
-	try_increase_cpuperf_target(cpuc);
+	if (!no_freq_scaling) {
+		calc_cpuperf_target(stat_cur, taskc, cpuc);
+		try_increase_cpuperf_target(cpuc);
+	}
 
 	/*
 	 * Update running task's information for preemption


### PR DESCRIPTION
This is the initial support for AMP architecture, such as Intel Alder Lake (P/E). Initially, we tackle the problem from the core compaction point of view.

- Now, the core compaction is AMP-aware, so the more performant core will be chosen first.
- The time slice calculation is also AMP-aware, so the time slice on a CPU will be proportional to the CPU's capacity. Since a task on a more performant core will have a longer slice, but a task on a less performant core will get a shorter slice. This way, the performant core is more likely to be clock-boosted, and a task on a less performant core will have a higher chance of being scheduled on the more performant core.
- Besides these two, there are some clean-ups and tuning related to the core compaction feature.

With these changes, the kernel compilation time (with default options) is reduced from 7:35 to 6:28 with "make -j3" on a 14-core (20-cpu) Raptor Lake processor.