### PR TITLE
scx_lvad: Fix warning about unhandled Result in write!().

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -132,7 +132,7 @@ struct FlatTopology {
 impl fmt::Display for FlatTopology {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for cpu_fid in self.cpu_fids.iter() {
-            write!(f, "\n{:?}", cpu_fid);
+            write!(f, "\n{:?}", cpu_fid).expect("Failed to write");
         }
         Ok(())
     }


### PR DESCRIPTION
This trivial change fixes a compiler warning about an unhandled Result type that is returned by the write!() macro.