### PR TITLE
scx_lavd: fix div by zero error in some installations

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -175,8 +175,16 @@ impl FlatTopology {
         }
 
         // Initialize cpu capacity
-        for cpu_fid in cpu_fids.iter_mut() {
-            cpu_fid.cpu_cap = ((cpu_fid.max_freq * 1024) / base_freq) as usize;
+        if base_freq > 0 {
+            for cpu_fid in cpu_fids.iter_mut() {
+                cpu_fid.cpu_cap = ((cpu_fid.max_freq * 1024) / base_freq) as usize;
+            }
+        } else {
+            // Unfortunately, the frequency information in sysfs seems not always correct in some
+            // distributions.
+            for cpu_fid in cpu_fids.iter_mut() {
+                cpu_fid.cpu_cap = 1024 as usize;
+            }
         }
 
         // Sort the cpu_fids

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -28,6 +28,7 @@ use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::Skel;
 use libbpf_rs::skel::SkelBuilder;
 use log::debug;
+use log::warn;
 use log::info;
 use scx_utils::build_id;
 use scx_utils::scx_ops_attach;
@@ -185,6 +186,7 @@ impl FlatTopology {
             for cpu_fid in cpu_fids.iter_mut() {
                 cpu_fid.cpu_cap = 1024 as usize;
             }
+            warn!("System does not provide proper CPU frequency infomation.");
         }
 
         // Sort the cpu_fids


### PR DESCRIPTION
The max frequency information from topology (from sysfs) seems not always true. In some installations, it returns zero for all CPUs. In this case, let's just consider all CPUs have the same capacity (1024), hoping the kernel can give more preceise information.