### PR TITLE
scx_lavd: set correct size for cpu_ctx_stor

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -276,7 +276,7 @@ struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__type(key, u32);
 	__type(value, struct cpu_ctx);
-	__uint(max_entries, LAVD_CPU_ID_MAX);
+	__uint(max_entries, 1);
 } cpu_ctx_stor SEC(".maps");
 
 /*


### PR DESCRIPTION
The max_entries parameter in BPF_MAP_TYPE_PERCPU_ARRAY defines the number of values per CPU and for cpu_ctx_stor we only need one item: the CPU context.

Set max_entries to 1 to avoid allocating unnecessary memory and slightly reduce the memory footprint.