### PR TITLE
scx_layered: Add per cpu layer iterator offset

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -86,6 +86,7 @@ struct cpu_ctx {
 	u64			gstats[NR_GSTATS];
 	u64			lstats[MAX_LAYERS][NR_LSTATS];
 	u64			ran_current_for;
+	u32			layer_idx;
 };
 
 struct cache_ctx {


### PR DESCRIPTION
Add a per cpu iterator offset to round robin when iterating on layers. This is to make selection from different layers more fair so that the first layer is not always selected first.