### PR TITLE
scripts: Add dsq latency script

### DIFF
--- a/scripts/dsq_lat.bt
+++ b/scripts/dsq_lat.bt
@@ -1,0 +1,60 @@
+#!/usr/bin/env bpftrace
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+#include <linux/sched.h>
+#include <linux/sched/ext.h>
+
+rawtracepoint:sched_wakeup,
+rawtracepoint:sched_wakeup_new,
+{
+	$task = (struct task_struct *)arg0;
+
+	if ($1 > 0 && $task->tgid != $1) {
+		return;
+	}
+
+	@qtime[$task->pid] = nsecs;
+	if ($task->scx.dsq->id >= 0) {
+		@dsq_time[$task->scx.dsq->id] = nsecs;
+	}
+}
+
+rawtracepoint:sched_switch
+{
+	$prev = (struct task_struct *)arg1;
+	$next = (struct task_struct *)arg2;
+	$prev_state = arg3;
+
+	if ($1 > 0 && $next->tgid != $1) {
+		return;
+	}
+
+	if ($prev_state == TASK_RUNNING) {
+		@qtime[$prev->pid] = nsecs;
+	}
+
+	$nsec = @qtime[$next->pid];
+	if ($nsec) {
+		$usec = (nsecs - $nsec) / 1000;
+		@usec_total_stats = stats($usec);
+		@usec_hist = hist($usec);
+		@tasks[$next->comm, $next->pid] = stats($usec);
+		@avg_lat = avg($usec);
+		if ($prev->scx.dsq->id >= 0) {
+			@dsq_lat[$prev->scx.dsq->id] = avg($usec);
+		}
+	}
+	delete(@qtime[$next->pid]);
+}
+
+interval:s:1 {
+    $scx_ops = kaddr("scx_ops");
+    $ops = (struct sched_ext_ops*)$scx_ops;
+    printf("scheduler: %s\n", $ops->name);
+    print(@avg_lat);
+    print(@usec_hist);
+    print(@dsq_lat);
+}


### PR DESCRIPTION
This change adds a bpftrace script to monitor runq latency as well as dsq latency.
```
scheduler: layered
@avg_lat: 396

@usec_hist: 
[0]                16807 |@@@@@@@@                                            |
[1]                69339 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                   |
[2, 4)            106525 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[4, 8)             82849 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@            |
[8, 16)            76488 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@               |
[16, 32)           63287 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                      |
[32, 64)           49775 |@@@@@@@@@@@@@@@@@@@@@@@@                            |
[64, 128)          14701 |@@@@@@@                                             |
[128, 256)          2163 |@                                                   |
[256, 512)           968 |                                                    |
[512, 1K)            827 |                                                    |
[1K, 2K)             786 |                                                    |
[2K, 4K)             812 |                                                    |
[4K, 8K)            1044 |                                                    |
[8K, 16K)           1198 |                                                    |
[16K, 32K)          1037 |                                                    |
[32K, 64K)           717 |                                                    |
[64K, 128K)          565 |                                                    |
[128K, 256K)         257 |                                                    |
[256K, 512K)          20 |                                                    |

@dsq_avg_lat[0]: 396
@dsq_avg_lat[7]: 1651
@dsq_avg_lat[6]: 1925
@dsq_avg_lat[3]: 3557
```


<img width="1910" alt="image" src="https://github.com/user-attachments/assets/5fa30507-4074-4d4f-bb79-f52294a06136">
