### PR TITLE
scx_rustland refactoring

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "scx_rustland_core"
 version = "1.0.1"
 edition = "2021"
-authors = ["Andrea Righi <andrea.righi@canonical.com>"]
+authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"
 repository = "https://github.com/sched-ext/scx"
 description = "Framework to implement sched_ext schedulers running in user space"

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -57,9 +57,6 @@ pub const RL_PREEMPT_CPU: u64 = bpf_intf::RL_PREEMPT_CPU as u64;
 /// objects) and dispatch tasks (in the form of DispatchedTask objects), using respectively the
 /// methods dequeue_task() and dispatch_task().
 ///
-/// The CPU ownership map can be accessed using the method get_cpu_pid(), this also allows to keep
-/// track of the idle and busy CPUs, with the corresponding PIDs associated to them.
-///
 /// BPF counters and statistics can be accessed using the methods nr_*_mut(), in particular
 /// nr_queued_mut() and nr_scheduled_mut() can be updated to notify the BPF component if the
 /// user-space scheduler has some pending work to do or not.
@@ -382,14 +379,6 @@ impl<'cb> BpfScheduler<'cb> {
         };
 
         unsafe { pthread_setschedparam(pthread_self(), SCHED_EXT, &param as *const sched_param) }
-    }
-
-    // Get the pid running on a certain CPU, if no tasks are running return 0.
-    #[allow(dead_code)]
-    pub fn get_cpu_pid(&self, cpu: i32) -> u32 {
-        let cpu_map_ptr = self.skel.bss().cpu_map.as_ptr();
-
-        unsafe { *cpu_map_ptr.offset(cpu as isize) }
     }
 
     // Receive a task to be scheduled from the BPF dispatcher.

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -302,6 +302,12 @@ impl<'cb> BpfScheduler<'cb> {
         }
     }
 
+    // Counter of the online CPUs.
+    #[allow(dead_code)]
+    pub fn nr_online_cpus_mut(&mut self) -> &mut u64 {
+        &mut self.skel.bss_mut().nr_online_cpus
+    }
+
     // Counter of currently running tasks.
     #[allow(dead_code)]
     pub fn nr_running_mut(&mut self) -> &mut u64 {

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Andrea Righi <andrea.righi@canonical.com>
+// Copyright (c) Andrea Righi <andrea.righi@linux.dev>
 
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -65,7 +65,6 @@ struct queued_task_ctx {
 	s32 cpu; /* CPU where the task is running (-1 = exiting) */
 	u64 cpumask_cnt; /* cpumask generation counter */
 	u64 sum_exec_runtime; /* Total cpu time */
-	u64 nvcsw; /* Voluntary context switches */
 	u64 weight; /* Task static priority */
 };
 

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -1,4 +1,4 @@
-/* Copyright (c) Andrea Righi <andrea.righi@canonical.com> */
+/* Copyright (c) Andrea Righi <andrea.righi@linux.dev> */
 /*
  * scx_rustland_core: BPF backend for schedulers running in user-space.
  *

--- a/rust/scx_rustland_core/src/alloc.rs
+++ b/rust/scx_rustland_core/src/alloc.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Andrea Righi <andrea.righi@canonical.com>
+// Copyright (c) Andrea Righi <andrea.righi@linux.dev>
 
 // Buddy allocator code imported from https://github.com/jjyr/buddy-alloc
 // and distributed under the terms of the MIT license.

--- a/rust/scx_rustland_core/src/rustland_builder.rs
+++ b/rust/scx_rustland_core/src/rustland_builder.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Andrea Righi <andrea.righi@canonical.com>
+// Copyright (c) Andrea Righi <andrea.righi@linux.dev>
 
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scx_rlfifo"
 version = "1.0.1"
-authors = ["Andrea Righi <andrea.righi@canonical.com>", "Canonical"]
+authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 edition = "2021"
 description = "A simple FIFO scheduler in Rust that runs in user-space"
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -9,7 +9,6 @@ pub mod bpf_intf;
 mod bpf;
 use bpf::*;
 
-use scx_utils::Topology;
 use scx_utils::UserExitInfo;
 
 use std::sync::atomic::AtomicBool;

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -27,6 +27,7 @@ impl<'a> Scheduler<'a> {
     fn init() -> Result<Self> {
         let bpf = BpfScheduler::init(
             0,                        // exit_dump_len (buffer size of exit info)
+            false,                    // partial (include all tasks if false)
             5000,                     // slice_ns (default task time slice)
             true,                     // full_user (schedule all tasks in user-space)
             false,                    // low_power (low power mode)

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -30,7 +30,6 @@ impl<'a> Scheduler<'a> {
         let bpf = BpfScheduler::init(
             5000,                     // slice_ns (default task time slice)
             topo.nr_cpu_ids() as i32, // nr_cpus (max CPUs available in the system)
-            false,                    // partial (include all tasks if disabled)
             0,                        // exit_dump_len (buffer size of exit info)
             true,                     // full_user (schedule all tasks in user-space)
             false,                    // low_power (low power mode)

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Andrea Righi <andrea.righi@canonical.com>
+// Copyright (c) Andrea Righi <andrea.righi@linux.dev>
 
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -26,14 +26,12 @@ struct Scheduler<'a> {
 
 impl<'a> Scheduler<'a> {
     fn init() -> Result<Self> {
-        let topo = Topology::new().expect("Failed to build host topology");
         let bpf = BpfScheduler::init(
-            5000,                     // slice_ns (default task time slice)
-            topo.nr_cpu_ids() as i32, // nr_cpus (max CPUs available in the system)
             0,                        // exit_dump_len (buffer size of exit info)
+            5000,                     // slice_ns (default task time slice)
             true,                     // full_user (schedule all tasks in user-space)
             false,                    // low_power (low power mode)
-            false,                    // fifo_sched (enable BPF FIFO scheduling)
+            false,                    // verbose (verbose output)
             false,                    // debug (debug mode)
         )?;
         Ok(Self { bpf })

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scx_rustland"
 version = "1.0.1"
-authors = ["Andrea Righi <andrea.righi@canonical.com>", "Canonical"]
+authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 edition = "2021"
 description = "A BPF component (dispatcher) that implements the low level sched-ext functionalities and a user-space counterpart (scheduler), written in Rust, that implements the actual scheduling policy. This is used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Andrea Righi <andrea.righi@canonical.com>
+// Copyright (c) Andrea Righi <andrea.righi@linux.dev>
 
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -582,9 +582,10 @@ impl<'a> Scheduler<'a> {
 
     // Print internal scheduler statistics (fetched from the BPF part).
     fn print_stats(&mut self) {
-        // Show minimum vruntime (this should be constantly incrementing).
+        // Show online CPUs, minimum vruntime and time slice.
         info!(
-            "min_vruntime={} slice={}us",
+            "cpus={} min_vruntime={} slice={}us",
+            *self.bpf.nr_online_cpus_mut(),
             self.min_vruntime,
             self.slice_ns / NSEC_PER_USEC,
         );

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -101,6 +101,11 @@ struct Opts {
     #[clap(short = 'l', long, action = clap::ArgAction::SetTrue)]
     low_power: bool,
 
+    /// If specified, only tasks which have their scheduling policy set to SCHED_EXT using
+    /// sched_setscheduler(2) are switched. Otherwise, all tasks are switched.
+    #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
+    partial: bool,
+
     /// Exit debug dump buffer length. 0 indicates default.
     #[clap(long, default_value = "0")]
     exit_dump_len: u32,
@@ -278,6 +283,7 @@ impl<'a> Scheduler<'a> {
         // Low-level BPF connector.
         let bpf = BpfScheduler::init(
             opts.exit_dump_len,
+            opts.partial,
             opts.slice_us,
             opts.full_user,
             opts.low_power,


### PR DESCRIPTION
First set of changes to re-align `scx_rustland` with the recent changes done in `scx_bpfland`, mostly re-using the same idle selection logic and the CPU hotplugging support.

The other major change involves removing the interactive task classification from the BPF component (in `scx_rustland_core`) and re-implementing it fully in user space in `scx_rustland`. This allows to eliminate the overhead of sending the `nvcsw` counter for each task to the user-space part, so all the potential schedulers based on `scx_rustland_core` that don't require this logic can benefit from this.

These changes are potentially introducing performance regressions in `scx_rustland`, but they can be fixed/improved later, these changes are also in preparation to define a better and more generic user-space API, so at the moment `scx_rustland` will prioritize the design of the user-space framework more than the performance (for performance we have `scx_bpfland`).

Last minor change: updated my copyright info in `scx_rustland_core`, `scx_rustland` and `scx_rlfifo`, dropping my old email that doesn't work anymore.