### PR TITLE
scx_utils: Fix build args

### DIFF
--- a/rust/scx_utils/src/bpf_builder.rs
+++ b/rust/scx_utils/src/bpf_builder.rs
@@ -338,7 +338,7 @@ impl BpfBuilder {
 
         // Assemble cflags.
         let mut cflags: Vec<String> =
-            ["-g", "-O2", "-Wall", "-Wno-compare-distinct-pointer-types'"]
+            ["-g", "-O2", "-Wall", "-Wno-compare-distinct-pointer-types"]
                 .into_iter()
                 .map(|x| x.into())
                 .collect();


### PR DESCRIPTION
Fix args to bpf_builder, existing warnings display for "-Wno-compare-distinct-pointer-types'".

Example warning from failed build (for separate reason):
```
~/scx/scheds/rust/scx_layered (layered-glob)]$ cargo build 
   Compiling scx_layered v1.0.1 (/home/hodgesd/scx/scheds/rust/scx_layered)
error: failed to run custom build command for `scx_layered v1.0.1 (/home/hodgesd/scx/scheds/rust/scx_layered)`

Caused by:
  process didn't exit successfully: `/home/hodgesd/scx/scheds/rust/scx_layered/target/debug/build/scx_layered-a0d2b0a273b2f960/build-script-build` (exit status: 101)
  --- stdout
  scx_utils:clang=("clang", "18.1.8", "x86_64") ["-g", "-O2", "-Wall", "-Wno-compare-distinct-pointer-types'", "-D__TARGET_ARCH_x86", "-mcpu=v3", "-mlittle-endian", "-idirafter", "/home/hodgesd/devtools/llvm/20240802/lib/clang/18/include", "-idirafter", "/usr/local/include", "-idirafter", "/usr/include", "-I/home/hodgesd/scx/scheds/rust/scx_layered/target/debug/build/scx_layered-abb23c1f20b3cc64/out/scx_utils-bpf_h", "-I/home/hodgesd/scx/scheds/rust/scx_layered/target/debug/build/scx_layered-abb23c1f20b3cc64/out/scx_utils-bpf_h/vmlinux", "-I/home/hodgesd/scx/scheds/rust/scx_layered/target/debug/build/scx_layered-abb23c1f20b3cc64/out/scx_utils-bpf_h/bpf-compat"]
  cargo:rerun-if-env-changed=TARGET
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS

  --- stderr
  warning: unknown warning option '-Wno-compare-distinct-pointer-types''; did you mean '-Wno-compare-distinct-pointer-types'? [-Wunknown-warning-option]
  warning: unknown warning option '-Wno-compare-distinct-pointer-types''; did you mean '-Wno-compare-distinct-pointer-types'? [-Wunknown-warning-option]
  ```