### PR TITLE
scx_layered: Migrate to metric-rs framework

### DIFF
--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -16,11 +16,13 @@ lazy_static = "1.4"
 libbpf-rs = "0.24.1"
 libc = "0.2.137"
 log = "0.4.17"
-prometheus-client = "0.19"
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.12"
+metrics = "0.23.0"
+metrics-util = "0.17.0"
+metrics-exporter-prometheus = "0.15.3"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.2" }

--- a/scheds/rust/scx_layered/src/log_recorder.rs
+++ b/scheds/rust/scx_layered/src/log_recorder.rs
@@ -1,0 +1,294 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// Copyright (c) Netflix, Inc.
+// Author: Jose Fernandez
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
+
+use bitvec::vec::BitVec;
+use log::info;
+use log::warn;
+use metrics::Counter;
+use metrics::Gauge;
+use metrics::Histogram;
+use metrics::Key;
+use metrics::KeyName;
+use metrics::Label;
+use metrics::Metadata;
+use metrics::Recorder;
+use metrics::SharedString;
+use metrics::Unit;
+use metrics_util::registry::AtomicStorage;
+use metrics_util::registry::Registry;
+
+use crate::Layer;
+use crate::LayerKind;
+use crate::LayerSpec;
+
+pub struct ArcLogRecorder(Arc<LogRecorder>);
+
+impl ArcLogRecorder {
+    pub fn new(recorder: Arc<LogRecorder>) -> Self {
+        Self(recorder)
+    }
+}
+
+impl Recorder for ArcLogRecorder {
+    fn describe_counter(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.0.describe_counter(key, unit, description);
+    }
+
+    fn describe_gauge(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.0.describe_gauge(key, unit, description);
+    }
+
+    fn describe_histogram(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.0.describe_histogram(key, unit, description);
+    }
+
+    fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter {
+        self.0.register_counter(key, metadata)
+    }
+
+    fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge {
+        self.0.register_gauge(key, metadata)
+    }
+
+    fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram {
+        self.0.register_histogram(key, metadata)
+    }
+}
+
+pub struct LogRecorder {
+    registry: Arc<Registry<Key, AtomicStorage>>,
+}
+
+impl Recorder for LogRecorder {
+    fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+
+    fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+
+    fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+
+    fn register_counter(&self, key: &Key, _: &Metadata<'_>) -> Counter {
+        self.registry
+            .get_or_create_counter(key, |c| c.clone().into())
+    }
+
+    fn register_gauge(&self, key: &Key, _: &Metadata<'_>) -> Gauge {
+        self.registry.get_or_create_gauge(key, |g| g.clone().into())
+    }
+
+    fn register_histogram(&self, key: &Key, _: &Metadata<'_>) -> Histogram {
+        self.registry
+            .get_or_create_histogram(key, |h: &Arc<metrics_util::AtomicBucket<f64>>| {
+                h.clone().into()
+            })
+    }
+}
+
+fn fmt_pct(v: f64) -> String {
+    if v >= 99.995 {
+        format!("{:5.1}", v)
+    } else {
+        format!("{:5.2}", v)
+    }
+}
+
+fn fmt_num(v: f64) -> String {
+    if v > 1_000_000.0 {
+        format!("{:5.1}m", v / 1_000_000.0)
+    } else if v > 1_000.0 {
+        format!("{:5.1}k", v / 1_000.0)
+    } else {
+        format!("{:5.0} ", v)
+    }
+}
+
+fn fmt_float(value: f64, max_decimals: usize) -> String {
+    format!("{:.1$}", value, max_decimals)
+}
+
+fn format_bitvec(bitvec: &BitVec) -> String {
+    let mut vals = Vec::<u32>::new();
+    let mut val: u32 = 0;
+    for (idx, bit) in bitvec.iter().enumerate() {
+        if idx > 0 && idx % 32 == 0 {
+            vals.push(val);
+            val = 0;
+        }
+        if *bit {
+            val |= 1 << (idx % 32);
+        }
+    }
+    vals.push(val);
+    let mut output = vals
+        .iter()
+        .fold(String::new(), |string, v| format!("{}{:08x} ", string, v));
+    output.pop();
+    output
+}
+
+impl LogRecorder {
+    pub fn new() -> Self {
+        LogRecorder {
+            registry: Arc::new(Registry::<Key, AtomicStorage>::atomic()),
+        }
+    }
+
+    pub fn report(&self, layer_specs: &Vec<LayerSpec>, layers: &Vec<Layer>) {
+        let gauge_value = |name: &str| -> f64 {
+            let key = Key::from_name(name.to_string());
+            let gauge = self.registry.get_gauge(&key);
+            match gauge {
+                Some(gauge) => f64::from_bits(gauge.load(Relaxed)),
+                None => {
+                    warn!("Metric not found: {}", key);
+                    0.0
+                }
+            }
+        };
+
+        let header_width = layer_specs
+            .iter()
+            .map(|spec| spec.name.len())
+            .max()
+            .unwrap()
+            .max(4);
+
+        info!(
+            "tot={:7} local={} open_idle={} affn_viol={} proc={:?}ms",
+            gauge_value("total"),
+            fmt_pct(gauge_value("local")),
+            fmt_pct(gauge_value("open_idle")),
+            fmt_pct(gauge_value("affn_viol")),
+            gauge_value("proc_ms"),
+        );
+
+        info!(
+            "busy={:5.1} util={:7.1} load={:9.1} fallback_cpu={:3}",
+            gauge_value("busy"),
+            gauge_value("util"),
+            gauge_value("load"),
+            gauge_value("fallback_cpu"),
+        );
+
+        info!(
+            "excl_coll={} excl_preempt={} excl_idle={} excl_wakeup={}",
+            fmt_pct(gauge_value("excl_coll")),
+            fmt_pct(gauge_value("excl_preempt")),
+            fmt_pct(gauge_value("excl_idle")),
+            fmt_pct(gauge_value("excl_wakeup")),
+        );
+
+        for (_, (spec, layer)) in layer_specs.iter().zip(layers.iter()).enumerate() {
+            let layer_gauge_value = |name: &str| -> f64 {
+                let labels = vec![Label::new("layer", spec.name.to_string())];
+                let key = Key::from_parts(name.to_string(), labels);
+                let gauge = self.registry.get_gauge(&key);
+                match gauge {
+                    Some(gauge) => f64::from_bits(gauge.load(Relaxed)),
+                    None => {
+                        warn!("Metric not found: {}", key);
+                        0.0
+                    }
+                }
+            };
+
+            info!(
+                "  {:<width$}: util/frac={:7.1}/{:5.1} load/frac={:9.1}:{:5.1} tasks={:6}",
+                spec.name,
+                layer_gauge_value("l_util"),
+                layer_gauge_value("l_util_frac"),
+                layer_gauge_value("l_load"),
+                layer_gauge_value("l_load_frac"),
+                layer_gauge_value("l_tasks"),
+                width = header_width,
+            );
+
+            info!(
+                "  {:<width$}  tot={:7} local={} wake/exp/last/reenq={}/{}/{}/{}",
+                "",
+                layer_gauge_value("l_total"),
+                fmt_pct(layer_gauge_value("l_sel_local")),
+                fmt_pct(layer_gauge_value("l_enq_wakeup")),
+                fmt_pct(layer_gauge_value("l_enq_expire")),
+                fmt_pct(layer_gauge_value("l_enq_last")),
+                fmt_pct(layer_gauge_value("l_enq_reenq")),
+                width = header_width,
+            );
+
+            info!(
+                "  {:<width$}  keep/max/busy={}/{}/{} kick={} yield/ign={}/{}",
+                "",
+                fmt_pct(layer_gauge_value("l_keep")),
+                fmt_pct(layer_gauge_value("l_keep_fail_max_exec")),
+                fmt_pct(layer_gauge_value("l_keep_fail_busy")),
+                layer_gauge_value("l_kick"),
+                layer_gauge_value("l_yield"),
+                fmt_num(layer_gauge_value("l_yield_ignore")),
+                width = header_width,
+            );
+
+            info!(
+                "  {:<width$}  open_idle={} mig={} affn_viol={}",
+                "",
+                fmt_pct(layer_gauge_value("l_open_idle")),
+                fmt_pct(layer_gauge_value("l_migration")),
+                fmt_pct(layer_gauge_value("l_affn_viol")),
+                width = header_width,
+            );
+
+            info!(
+                "  {:<width$}  preempt/first/idle/fail={}/{}/{}/{} min_exec={}/{:7.2}ms",
+                "",
+                fmt_pct(layer_gauge_value("l_preempt")),
+                fmt_pct(layer_gauge_value("l_preempt_first")),
+                fmt_pct(layer_gauge_value("l_preempt_idle")),
+                fmt_pct(layer_gauge_value("l_preempt_fail")),
+                fmt_float(layer_gauge_value("l_min_exec"), 2),
+                layer_gauge_value("l_min_exec_us") / 1000.0,
+                width = header_width,
+            );
+
+            // TODO: Include the formatted layer.cpus bitvec
+            info!(
+                "  {:<width$}  cpus={:3} [{:3},{:3}] {}",
+                "",
+                layer_gauge_value("l_cur_nr_cpus"),
+                layer_gauge_value("l_min_nr_cpus"),
+                layer_gauge_value("l_max_nr_cpus"),
+                format_bitvec(&layer.cpus),
+                width = header_width
+            );
+
+            match &layer.kind {
+                LayerKind::Confined { exclusive, .. }
+                | LayerKind::Grouped { exclusive, .. }
+                | LayerKind::Open { exclusive, .. } => {
+                    if *exclusive {
+                        info!(
+                            "  {:<width$}  excl_coll={} excl_preempt={}",
+                            "",
+                            fmt_pct(layer_gauge_value("l_excl_collision")),
+                            fmt_pct(layer_gauge_value("l_excl_preempt")),
+                            width = header_width,
+                        );
+                    } else if layer_gauge_value("l_excl_collision") != 0.0
+                        || layer_gauge_value("l_excl_preempt") != 0.0
+                    {
+                        warn!(
+                            "{}: exclusive is off but excl_coll={} excl_preempt={}",
+                            spec.name,
+                            fmt_pct(layer_gauge_value("l_excl_collision")),
+                            fmt_pct(layer_gauge_value("l_excl_preempt")),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/scheds/rust/scx_layered/src/metrics.rs
+++ b/scheds/rust/scx_layered/src/metrics.rs
@@ -1,197 +1,213 @@
-// Copyright (c) Meta Platforms, Inc. and affiliates.
+use metrics::{describe_gauge, gauge, Gauge};
 
-// This software may be used and distributed according to the terms of the
-// GNU General Public License version 2.
-use std::sync::atomic::AtomicI64;
-use std::sync::atomic::AtomicU64;
-use prometheus_client::metrics::family::Family;
-use prometheus_client::metrics::gauge::Gauge;
-use prometheus_client::registry::Registry;
+pub struct Metrics {
+    // Metrics for the entire system
+    pub total: Gauge,
+    pub local: Gauge,
+    pub open_idle: Gauge,
+    pub affn_viol: Gauge,
+    pub excl_coll: Gauge,
+    pub excl_preempt: Gauge,
+    pub excl_idle: Gauge,
+    pub excl_wakeup: Gauge,
+    pub proc_ms: Gauge,
+    pub busy: Gauge,
+    pub util: Gauge,
+    pub load: Gauge,
+    pub fallback_cpu: Gauge,
 
-#[derive(Default)]
-pub struct OpenMetricsStats {
-    pub registry: Registry,
-    pub total: Gauge<i64, AtomicI64>,
-    pub local: Gauge<f64, AtomicU64>,
-    pub open_idle: Gauge<f64, AtomicU64>,
-    pub affn_viol: Gauge<f64, AtomicU64>,
-    pub excl_idle: Gauge<f64, AtomicU64>,
-    pub excl_wakeup: Gauge<f64, AtomicU64>,
-    pub proc_ms: Gauge<i64, AtomicI64>,
-    pub busy: Gauge<f64, AtomicU64>,
-    pub util: Gauge<f64, AtomicU64>,
-    pub load: Gauge<f64, AtomicU64>,
-    pub l_util: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_util_frac: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_load: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_load_frac: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_tasks: Family<Vec<(String, String)>, Gauge<i64, AtomicI64>>,
-    pub l_total: Family<Vec<(String, String)>, Gauge<i64, AtomicI64>>,
-    pub l_sel_local: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_enq_wakeup: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_enq_expire: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_enq_last: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_enq_reenq: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_min_exec: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_min_exec_us: Family<Vec<(String, String)>, Gauge<i64, AtomicI64>>,
-    pub l_open_idle: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_preempt: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_preempt_first: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_preempt_idle: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_preempt_fail: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_affn_viol: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_keep: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_keep_fail_max_exec: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_keep_fail_busy: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_excl_collision: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_excl_preempt: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_kick: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_yield: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_yield_ignore: Family<Vec<(String, String)>, Gauge<i64, AtomicI64>>,
-    pub l_migration: Family<Vec<(String, String)>, Gauge<f64, AtomicU64>>,
-    pub l_cur_nr_cpus: Family<Vec<(String, String)>, Gauge<i64, AtomicI64>>,
-    pub l_min_nr_cpus: Family<Vec<(String, String)>, Gauge<i64, AtomicI64>>,
-    pub l_max_nr_cpus: Family<Vec<(String, String)>, Gauge<i64, AtomicI64>>,
+    // Metric names for gauges that will be created dynamically for each layer
+    pub l_util: String,
+    pub l_util_frac: String,
+    pub l_load: String,
+    pub l_load_frac: String,
+    pub l_tasks: String,
+    pub l_total: String,
+    pub l_sel_local: String,
+    pub l_enq_wakeup: String,
+    pub l_enq_expire: String,
+    pub l_enq_last: String,
+    pub l_enq_reenq: String,
+    pub l_min_exec: String,
+    pub l_min_exec_us: String,
+    pub l_open_idle: String,
+    pub l_preempt: String,
+    pub l_preempt_first: String,
+    pub l_preempt_idle: String,
+    pub l_preempt_fail: String,
+    pub l_affn_viol: String,
+    pub l_keep: String,
+    pub l_keep_fail_max_exec: String,
+    pub l_keep_fail_busy: String,
+    pub l_excl_collision: String,
+    pub l_excl_preempt: String,
+    pub l_kick: String,
+    pub l_yield: String,
+    pub l_yield_ignore: String,
+    pub l_migration: String,
+    pub l_cur_nr_cpus: String,
+    pub l_min_nr_cpus: String,
+    pub l_max_nr_cpus: String,
 }
 
-impl OpenMetricsStats {
-    pub fn new() -> OpenMetricsStats {
-        let mut metrics = OpenMetricsStats {
-            registry: <Registry>::default(),
-            ..Default::default()
-        };
-        // Helper macro to reduce on some of the boilerplate:
-        // $i: The identifier of the metric to register
-        // $help: The Help text associated with the metric
-        macro_rules! register {
-            ($i:ident, $help:expr) => {
-                metrics
-                    .registry
-                    .register(stringify!($i), $help, metrics.$i.clone())
-            };
+macro_rules! register_gauge {
+    ($gauge_name:expr, $description:expr) => {{
+        let gauge = gauge!($gauge_name);
+        describe_gauge!($gauge_name, $description);
+        gauge
+    }};
+}
+
+macro_rules! register_gauge_name {
+    ($gauge_name:expr, $description:expr) => {{
+        describe_gauge!($gauge_name, $description);
+        $gauge_name.to_string()
+    }};
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        Self {
+            total: register_gauge!("total", "Total scheduling events in the period"),
+            local: register_gauge!("local", "% that got scheduled directly into an idle CPU"),
+            open_idle: register_gauge!(
+                "open_idle",
+                "% of open layer tasks scheduled into occupied idle CPUs"
+            ),
+            affn_viol: register_gauge!(
+                "affn_viol",
+                "% which violated configured policies due to CPU affinity restrictions"
+            ),
+            excl_coll: register_gauge!(
+                "excl_coll",
+                "Number of times an exclusive task skipped a CPU as the sibling was also exclusive"
+            ),
+            excl_preempt: register_gauge!(
+                "excl_preempt",
+                "Number of times a sibling CPU was preempted for an exclusive task"
+            ),
+            excl_idle: register_gauge!(
+                "excl_idle",
+                "Number of times a CPU skipped dispatching due to sibling running an exclusive task"
+            ),
+            excl_wakeup: register_gauge!(
+                "excl_wakeup",
+                "Number of times an idle sibling CPU was woken up after an exclusive task is finished"
+            ),
+            proc_ms: register_gauge!(
+                "proc_ms",
+                "CPU time this binary has consumed during the period"
+            ),
+            busy: register_gauge!("busy", "CPU busy % (100% means all CPUs were fully occupied)"),
+            util: register_gauge!(
+                "util",
+                "CPU utilization % (100% means one CPU was fully occupied)"
+            ),
+            load: register_gauge!("load", "Sum of weight * duty_cycle for all tasks"),
+            fallback_cpu: register_gauge!(
+                "fallback_cpu",
+                "The next free or the first CPU if none is free"
+            ),
+            l_util: register_gauge_name!(
+                "l_util",
+                "CPU utilization of the layer (100% means one CPU was fully occupied)"
+            ),
+            l_util_frac: register_gauge_name!(
+                "l_util_frac",
+                "Fraction of total CPU utilization consumed by the layer"
+            ),
+            l_load: register_gauge_name!("l_load", "Sum of weight * duty_cycle for tasks in the layer"),
+            l_load_frac: register_gauge_name!(
+                "l_load_frac",
+                "Fraction of total load consumed by the layer"
+            ),
+            l_tasks: register_gauge_name!("l_tasks", "Number of tasks in the layer"),
+            l_total: register_gauge_name!("l_total", "Number of scheduling events in the layer"),
+            l_sel_local: register_gauge_name!(
+                "l_sel_local",
+                "% of scheduling events directly into an idle CPU"
+            ),
+            l_enq_wakeup: register_gauge_name!(
+                "l_enq_wakeup",
+                "% of scheduling events enqueued to layer after wakeup"
+            ),
+            l_enq_expire: register_gauge_name!(
+                "l_enq_expire",
+                "% of scheduling events enqueued to layer after slice expiration"
+            ),
+            l_enq_last: register_gauge_name!(
+                "l_enq_last",
+                "% of scheduling events enqueued as last runnable task on CPU"
+            ),
+            l_enq_reenq: register_gauge_name!(
+                "l_enq_reenq",
+                "% of scheduling events re-enqueued due to RT preemption"
+            ),
+            l_min_exec: register_gauge_name!(
+                "l_min_exec",
+                "Number of times execution duration was shorter than min_exec_us"
+            ),
+            l_min_exec_us: register_gauge_name!(
+                "l_min_exec_us",
+                "Total execution duration extended due to min_exec_us"
+            ),
+            l_open_idle: register_gauge_name!(
+                "l_open_idle",
+                "% of scheduling events into idle CPUs occupied by other layers"
+            ),
+            l_preempt: register_gauge_name!(
+                "l_preempt",
+                "% of scheduling events that preempted other tasks"
+            ),
+            l_preempt_first: register_gauge_name!(
+                "l_preempt_first",
+                "% of scheduling events that first-preempted other tasks"
+            ),
+            l_preempt_idle: register_gauge_name!(
+                "l_preempt_idle",
+                "% of scheduling events that idle-preempted other tasks"
+            ),
+            l_preempt_fail: register_gauge_name!(
+                "l_preempt_fail",
+                "% of scheduling events that attempted to preempt other tasks but failed"
+            ),
+            l_affn_viol: register_gauge_name!(
+                "l_affn_viol",
+                "% of scheduling events that violated configured policies due to CPU affinity restrictions"
+            ),
+            l_keep: register_gauge_name!(
+                "l_keep",
+                "% of scheduling events that continued executing after slice expiration"
+            ),
+            l_keep_fail_max_exec: register_gauge_name!(
+                "l_keep_fail_max_exec",
+                "% of scheduling events that weren't allowed to continue executing after slice expiration due to overrunning max_exec duration limit"
+            ),
+            l_keep_fail_busy: register_gauge_name!(
+                "l_keep_fail_busy",
+                "% of scheduling events that weren't allowed to continue executing after slice expiration to accommodate other tasks"
+            ),
+            l_excl_collision: register_gauge_name!(
+                "l_excl_collision",
+                "Number of times an exclusive task skipped a CPU as the sibling was also exclusive"
+            ),
+            l_excl_preempt: register_gauge_name!(
+                "l_excl_preempt",
+                "Number of times a sibling CPU was preempted for an exclusive task"
+            ),
+            l_kick: register_gauge_name!(
+                "l_kick",
+                "% of scheduling events that kicked a CPU from enqueue path"
+            ),
+            l_yield: register_gauge_name!("l_yield", "% of scheduling events that yielded"),
+            l_yield_ignore: register_gauge_name!("l_yield_ignore", "Number of times yield was ignored"),
+            l_migration: register_gauge_name!(
+                "l_migration",
+                "% of scheduling events that migrated across CPUs"
+            ),
+            l_cur_nr_cpus: register_gauge_name!("l_cur_nr_cpus", "Current # of CPUs assigned to the layer"),
+            l_min_nr_cpus: register_gauge_name!("l_min_nr_cpus", "Minimum # of CPUs assigned to the layer"),
+            l_max_nr_cpus: register_gauge_name!("l_max_nr_cpus", "Maximum # of CPUs assigned to the layer"),
         }
-        register!(total, "Total scheduling events in the period");
-        register!(local, "% that got scheduled directly into an idle CPU");
-        register!(
-            open_idle,
-            "% of open layer tasks scheduled into occupied idle CPUs"
-        );
-        register!(
-            affn_viol,
-            "% which violated configured policies due to CPU affinity restrictions"
-        );
-        register!(
-            excl_idle,
-            "Number of times a CPU skipped dispatching due to sibling running an exclusive task"
-        );
-        register!(
-            excl_wakeup,
-            "Number of times an idle sibling CPU was woken up after an exclusive task is finished"
-        );
-        register!(
-            proc_ms,
-            "CPU time this binary has consumed during the period"
-        );
-        register!(busy, "CPU busy % (100% means all CPUs were fully occupied)");
-        register!(
-            util,
-            "CPU utilization % (100% means one CPU was fully occupied)"
-        );
-        register!(load, "Sum of weight * duty_cycle for all tasks");
-        register!(
-            l_util,
-            "CPU utilization of the layer (100% means one CPU was fully occupied)"
-        );
-        register!(
-            l_util_frac,
-            "Fraction of total CPU utilization consumed by the layer"
-        );
-        register!(l_load, "Sum of weight * duty_cycle for tasks in the layer");
-        register!(l_load_frac, "Fraction of total load consumed by the layer");
-        register!(l_tasks, "Number of tasks in the layer");
-        register!(l_total, "Number of scheduling events in the layer");
-        register!(
-            l_sel_local,
-            "% of scheduling events directly into an idle CPU"
-        );
-        register!(
-            l_enq_wakeup,
-            "% of scheduling events enqueued to layer after wakeup"
-        );
-        register!(
-            l_enq_expire,
-            "% of scheduling events enqueued to layer after slice expiration"
-        );
-        register!(
-            l_enq_last,
-            "% of scheduling events enqueued as last runnable task on CPU"
-        );
-        register!(
-            l_enq_reenq,
-            "% of scheduling events re-enqueued due to RT preemption"
-        );
-        register!(
-            l_min_exec,
-            "Number of times execution duration was shorter than min_exec_us"
-        );
-        register!(
-            l_min_exec_us,
-            "Total execution duration extended due to min_exec_us"
-        );
-        register!(
-            l_open_idle,
-            "% of scheduling events into idle CPUs occupied by other layers"
-        );
-        register!(
-            l_preempt,
-            "% of scheduling events that preempted other tasks"
-        );
-        register!(
-            l_preempt_first,
-            "% of scheduling events that first-preempted other tasks"
-        );
-        register!(
-            l_preempt_idle,
-            "% of scheduling events that idle-preempted other tasks"
-        );
-        register!(
-            l_preempt_fail,
-            "% of scheduling events that attempted to preempt other tasks but failed"
-        );
-        register!(
-            l_affn_viol,
-            "% of scheduling events that violated configured policies due to CPU affinity restrictions"
-        );
-        register!(
-            l_keep,
-            "% of scheduling events that continued executing after slice expiration"
-        );
-        register!(
-            l_keep_fail_max_exec,
-            "% of scheduling events that weren't allowed to continue executing after slice expiration due to overrunning max_exec duration limit"
-        );
-        register!(
-            l_keep_fail_busy,
-            "% of scheduling events that weren't allowed to continue executing after slice expiration to accommodate other tasks"
-        );
-        register!(
-            l_excl_collision,
-            "Number of times an exclusive task skipped a CPU as the sibling was also exclusive"
-        );
-        register!(
-            l_excl_preempt,
-            "Number of times a sibling CPU was preempted for an exclusive task"
-        );
-        register!(
-            l_kick,
-            "% of schduling events that kicked a CPU from enqueue path"
-        );
-        register!(l_yield, "% of scheduling events that yielded");
-        register!(l_yield_ignore, "Number of times yield was ignored");
-	register!(l_migration, "% of scheduling events that migrated across CPUs");
-        register!(l_cur_nr_cpus, "Current # of CPUs assigned to the layer");
-        register!(l_min_nr_cpus, "Minimum # of CPUs assigned to the layer");
-        register!(l_max_nr_cpus, "Maximum # of CPUs assigned to the layer");
-        metrics
     }
 }


### PR DESCRIPTION
This change migrates scx_layered to the metric-rs framework. The transition is mostly seamless, with one notable exception: when the --open-metrics-format flag is enabled, Prometheus metrics will now be available at localhost:9000 instead of being printed to stdout. The flag name remains unchanged for backward compatibility but will be renamed in a future update to better reflect its new behavior.

```
17:03:24 [INFO] Enabling Prometheus endpoint: http://localhost:9000
17:03:24 [INFO] CPUs: online/possible=16/16 nr_cores=8 17:03:24 [INFO] configuring node 0, LLCs 1
17:03:24 [INFO] configuring llc 0 for node 0
17:03:24 [INFO] Layered Scheduler Attached
```

The log formatting has been preserved exactly as before. A new custom log_recorder has been added to maintain the same log format. Additionally, a new synchronous reporting approach has been implemented. The scx_utils log_recorder runs in a separate background thread, while the scx_layered log_recorder is injected into the Scheduler struct, and the `report()` function is called synchronously. This ensures that logs are flushed at the same interval as the scheduler's reporting loop and makes it easier to share the layer structs needed for some log lines.

There are no changes to the metrics themselves, but future updates will modify some of them to be counters and timers instead of gauges.

I also intend to iterate on removing boilerplate in metric capturing and log reporting. Currently, we define the metrics for capturing but don't have a way to reuse that definition when printing metrics, leading to hardcoded names. A warning has been added for attempts to access non-existent metrics to detect drift. This issue will be addressed in a future update.

[Screencast from 2024-08-08 11-02-20.webm](https://github.com/user-attachments/assets/8d7d3ced-2183-4cc0-8664-3a8d338e17e0)

