### PR TITLE
version-tool: Suppress spurious dependency version mismatch warning

### DIFF
--- a/version-tool.py
+++ b/version-tool.py
@@ -50,7 +50,7 @@ def do_meson_ver(new_ver):
     with open(path, 'w') as f:
         f.writelines(lines)
 
-    return new_ver
+    return ver
 
 def get_rust_paths():
     result = subprocess.run(['git', 'ls-files'], stdout=subprocess.PIPE)
@@ -108,7 +108,7 @@ def do_rust_ver(path, new_ver):
     with open(path, 'w') as f:
         f.writelines(lines)
 
-    return new_ver
+    return ver
 
 def do_rust_deps(path, deps, new_deps):
     with open(path, 'r') as f:


### PR DESCRIPTION
When updating in-tree crate versions, do_rust_ver() was returning the new version string which is then put into rust_deps triggering version mismatch warning in do_rust_deps().

There's no reason for do_meson_ver() and do_rust_ver() to return the new version. Always return the old version.