### PR TITLE
scx_rusty: Fix logical error when filtering tasks

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -288,8 +288,6 @@ static inline bool vtime_before(u64 a, u64 b)
  */
 static inline u64 task_vtime(struct task_struct *p)
 {
-	u64 vtime = p->scx.dsq_vtime;
-
 	/*
 	 * Limit the vruntime to (vtime_now - slice_ns_lag) to avoid
 	 * excessively penalizing tasks.

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1687,13 +1687,6 @@ static bool try_yield_current_cpu(struct task_struct *p_run,
 	return ret;
 }
 
-static bool is_lat_cri_task(struct task_ctx *taskc)
-{
-	struct sys_stat *stat_cur = get_sys_stat_cur();
-
-	return taskc->lat_cri > stat_cur->thr_lat_cri;
-}
-
 static void put_global_rq(struct task_struct *p, struct task_ctx *taskc,
 			  struct cpu_ctx *cpuc, u64 enq_flags)
 {

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -9,8 +9,6 @@ pub mod bpf_intf;
 mod bpf;
 use bpf::*;
 
-use scx_utils::Topology;
-use scx_utils::TopologyMap;
 use scx_utils::UserExitInfo;
 
 use std::thread;
@@ -25,7 +23,6 @@ use std::time::SystemTime;
 
 use std::fs::File;
 use std::io::{self, Read};
-use std::path::Path;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -264,7 +261,6 @@ impl TaskTree {
 // Main scheduler object
 struct Scheduler<'a> {
     bpf: BpfScheduler<'a>, // BPF connector
-    topo_map: TopologyMap, // Host topology
     task_pool: TaskTree,   // tasks ordered by vruntime
     task_map: TaskInfoMap, // map pids to the corresponding task information
     proc_stats: HashMap<i32, u64>, // Task statistics from procfs
@@ -280,9 +276,6 @@ impl<'a> Scheduler<'a> {
         opts: &Opts,
         open_object: &'a mut MaybeUninit<OpenObject>,
     ) -> Result<Self> {
-        // Initialize core mapping topology.
-        let topo = Topology::new().expect("Failed to build host topology");
-        let topo_map = TopologyMap::new(&topo).expect("Failed to generate topology map");
 
         // Low-level BPF connector.
         let bpf = BpfScheduler::init(
@@ -300,7 +293,6 @@ impl<'a> Scheduler<'a> {
         // Return scheduler object.
         Ok(Self {
             bpf,
-            topo_map,
             task_pool: TaskTree::new(),
             task_map: TaskInfoMap::new(),
             proc_stats: HashMap::new(),


### PR DESCRIPTION
## Summary
The logic of tasks filtering were moved from `find_first_candidate()` into a vector filter operation in commit 1c3b563. However, it was forgotten to transfer the logic with "NOT" since now `.filter()` will populate the tasks we want, rather than `.skip_while()` which was throwing unwanted tasks out.

That's why the logic here should be reverse so we won't take kworker or migrated tasks into considerations.