### PR TITLE
meson: Add veristat script

### DIFF
--- a/meson-scripts/veristat
+++ b/meson-scripts/veristat
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+GUEST_TIMEOUT=25
+BUILD_DIR=$1
+SCHED=$2
+KERNEL=$3
+
+if [ "${KERNEL}" == "vmlinuz" ]; then
+  unset KERNEL
+fi
+
+cd $build_dir
+
+if [ -n "${KERNEL}" ] && [ ! -x `which vng` ]; then
+  echo "vng not found, please install virtme-ng to enable testing"
+  exit 1
+fi
+
+if [ -n "${SCHED}" ]; then
+  BPF_PATH=$(find ${BUILD_DIR} -type f -name bpf.bpf.o | grep ${SCHED})
+  echo "Running veristat on ${BPF_PATH}"
+  if [ -n "${KERNEL}" ]; then
+    timeout --preserve-status ${GUEST_TIMEOUT} \
+      vng --force-9p -v -r ${KERNEL} -- \
+        veristat ${BPF_PATH}
+    exit $?
+  else
+    sudo veristat ${BPF_PATH}
+    exit $?
+  fi
+fi
+
+for BPF_PATH in $(find ${BUILD_DIR} -type f -name bpf.bpf.o); do
+  if [ -n "${KERNEL}" ]; then
+    timeout --preserve-status ${GUEST_TIMEOUT} \
+      vng --force-9p -v -r ${KERNEL} -- \
+        veristat ${BPF_PATH}
+    exit $?
+  else
+    sudo veristat ${BPF_PATH}
+    exit $?
+  fi
+done

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,12 @@ serialize = get_option('serialize')
 
 bpf_clang = find_program(get_option('bpf_clang'))
 
+run_veristat = find_program(join_paths(meson.current_source_dir(),
+                                       'meson-scripts/veristat'))
+
 enable_stress = get_option('enable_stress')
+
+veristat_scheduler = get_option('veristat_scheduler')
 
 if enable_rust
   cargo = find_program(get_option('cargo'))
@@ -322,6 +327,9 @@ if get_option('kernel') != ''
 endif
 
 run_target('test_sched', command: [test_sched, kernel])
+
+run_target('veristat', command: [run_veristat, meson.current_build_dir(),
+                                 get_option('veristat_scheduler'), get_option('kernel')])
 
 if enable_rust
   subdir('rust')

--- a/meson.options
+++ b/meson.options
@@ -20,6 +20,8 @@ option('enable_stress', type: 'boolean', value: 'true',
        description: 'Enable stress tests')
 option('kernel', type: 'string', value: 'vmlinuz',
        description: 'kernel image used to test schedulers')
+option('veristat_scheduler', type: 'string', value: '',
+       description: 'veristat scheduler to test')
 option('kernel_headers', type: 'string', value: '',
        description: 'kernel headers to build the schedulers')
 option(


### PR DESCRIPTION
Add a meson script to run veristat. This can later be used to generate reports for BPF program complexity at PR time.


### local example:
```
$ meson setup build -Dscheduler=scx_lavd --reconfigure
$ meson compile -C build veristat 
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /usr/bin/ninja -C /home/hodgesd/scx/build veristat
ninja: Entering directory `/home/hodgesd/scx/build'
[0/1] Running external command veristat (wrapped by meson to set env)
Running veristat on /home/hodgesd/scx/build/scheds/rust/scx_lavd/debug/build/scx_lavd-75563794c6a33502/out/bpf.bpf.o
Processing 'bpf.bpf.o'...
File       Program           Verdict  Duration (us)  Insns  States  Peak states
---------  ----------------  -------  -------------  -----  ------  -----------
bpf.bpf.o  lavd_cpu_offline  success           6666  12566     458          301
bpf.bpf.o  lavd_cpu_online   success           7040  12566     458          301
bpf.bpf.o  lavd_dispatch     success           2349    153      15           15
bpf.bpf.o  lavd_enable       success             46     33       2            2
bpf.bpf.o  lavd_enqueue      success           5614   4499     325          190
bpf.bpf.o  lavd_exit         success             39     25       2            2
bpf.bpf.o  lavd_init         success           6273   8215     375          328
bpf.bpf.o  lavd_init_task    success             57     92       4            4
bpf.bpf.o  lavd_quiescent    success             87     80       6            6
bpf.bpf.o  lavd_runnable     success           6819    112       8            8
bpf.bpf.o  lavd_running      success            721   1416      80           80
bpf.bpf.o  lavd_select_cpu   success           5784    171      17           17
bpf.bpf.o  lavd_stopping     success            137    166      14           14
bpf.bpf.o  lavd_tick         success            272    198      18           18
bpf.bpf.o  lavd_update_idle  success             61     49       3            3
---------  ----------------  -------  -------------  -----  ------  -----------
Done. Processed 1 files, 0 programs. Skipped 15 files, 0 programs.
```
### VNG example:
```
$ git clone --single-branch -b for-next --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
$ cd linux && vng -v --build --config ../.github/workflows/sched-ext.config
$ make headers && cd ..
$ meson setup build -Dkernel=$(pwd)/linux -Dkernel_headers=./linux/usr/include -Dscheduler=scx_lavd
...
sched_ext schedulers 1.0.2

  User defined options
    kernel        : /home/hodgesd/scx/linux
    kernel_headers: ./linux/usr/include
    scheduler     : scx_lavd

$ meson compile -C build 
$ meson compile -C build veristat  
[    4.605192] virtme-init: waiting for udev to settle
[    4.800171] virtme-init: udev is done
[    4.963616] virtme-init: Setting hostname to virtme-ng...
[    5.018210] ip (556) used greatest stack depth: 12392 bytes left
[    5.156856] virtme-init: starting script
Processing 'bpf.bpf.o'...
File       Program           Verdict  Duration (us)  Insns  States  Peak states
---------  ----------------  -------  -------------  -----  ------  -----------
bpf.bpf.o  lavd_cpu_offline  success           8113  12566     458          299
bpf.bpf.o  lavd_cpu_online   success           8340  12566     458          299
bpf.bpf.o  lavd_dispatch     success           2143    153      15           15
bpf.bpf.o  lavd_enable       success             38     33       2            2
bpf.bpf.o  lavd_enqueue      success           4643   4499     325          190
bpf.bpf.o  lavd_exit         success             31     25       2            2
bpf.bpf.o  lavd_init         success           5466   8215     375          328
bpf.bpf.o  lavd_init_task    success             53     92       4            4
bpf.bpf.o  lavd_quiescent    success             67     80       6            6
bpf.bpf.o  lavd_runnable     success           5728    112       8            8
bpf.bpf.o  lavd_running      success            920   1416      80           80
bpf.bpf.o  lavd_select_cpu   success           4924    171      17           17
bpf.bpf.o  lavd_stopping     success            126    166      14           14
bpf.bpf.o  lavd_tick         success            312    198      18           18
bpf.bpf.o  lavd_update_idle  success             50     49       3            3
---------  ----------------  -------  -------------  -----  ------  -----------
Done. Processed 1 files, 0 programs. Skipped 15 files, 0 programs.
[    6.320858] virtme-init: script returned {0}
Powering off.
[    6.388654] ACPI: PM: Preparing to enter system sleep state S5
[    6.389718] kvm: exiting hardware virtualization
[    6.390623] reboot: Power down
```
Ideally, when #462  is implemented then the diff version of `veristat` can run against `main` to get a report of any BPF program performance changes.