### PR TITLE
lavd: make LAVD core-type (AMP) aware

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -125,6 +125,7 @@ struct sys_stat {
  */
 struct cpdom_ctx {
 	u64	id;				    /* id of this compute domain (== dsq_id) */
+	u64	alt_id;				    /* id of the closest compute domain of alternative type (== dsq id) */
 	u8	is_active;			    /* if this compute domain is active */
 	u8	nr_neighbors[LAVD_CPDOM_MAX_DIST];  /* number of neighbors per distance */
 	u64	neighbor_bits[LAVD_CPDOM_MAX_DIST]; /* bitmask of neighbor bitmask per distance */
@@ -189,6 +190,7 @@ struct cpu_ctx {
 	u16		capacity;	/* CPU capacity based on 1000 */
 	u8		big_core;	/* is it a big core? */
 	u8		cpdom_id;	/* compute domain id (== dsq_id) */
+	u8		cpdom_alt_id;	/* compute domain id of anternative type (== dsq_id) */
 	struct bpf_cpumask __kptr *tmp_a_mask;	/* temporary cpu mask */
 	struct bpf_cpumask __kptr *tmp_o_mask;	/* temporary cpu mask */
 } __attribute__((aligned(CACHELINE_SIZE)));

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -84,7 +84,7 @@ enum consts {
 	LAVD_CC_PER_CORE_MAX_CTUIL	= 500, /* maximum per-core CPU utilization */
 	LAVD_CC_NR_ACTIVE_MIN		= 1, /* num of mininum active cores */
 	LAVD_CC_NR_OVRFLW		= 1, /* num of overflow cores */
-	LAVD_CC_CPU_PIN_INTERVAL	= (100ULL * NSEC_PER_MSEC),
+	LAVD_CC_CPU_PIN_INTERVAL	= (3ULL * LAVD_TIME_ONE_SEC),
 	LAVD_CC_CPU_PIN_INTERVAL_DIV	= (LAVD_CC_CPU_PIN_INTERVAL /
 					   LAVD_SYS_STAT_INTERVAL_NS),
 

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -241,7 +241,6 @@ struct task_ctx_x {
 enum {
        LAVD_CMD_NOP		= 0x0,
        LAVD_CMD_SCHED_N		= 0x1,
-       LAVD_CMD_PID		= 0x2,
 };
 
 enum {

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -210,7 +210,7 @@ struct task_ctx {
 	u32	lat_cri;		/* calculated latency criticality */
 	volatile s32 victim_cpu;
 	u16	slice_boost_prio;	/* how many times a task fully consumed the slice */
-	u8	sync_wakeup;
+	u8	wakeup_ft;		/* regular wakeup = 1, sync wakeup = 2 */
 	/*
 	 * Task's performance criticality
 	 */

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -90,6 +90,7 @@ enum consts {
 
 	LAVD_CPDOM_MAX_NR		= 64, /* maximum number of compute domain (<= 64) */
 	LAVD_CPDOM_MAX_DIST		= 6,  /* maximum distance from one compute domain to another */
+	LAVD_CPDOM_STARV_NS		= (5ULL * NSEC_PER_MSEC),
 
 	LAVD_STATUS_STR_LEN		= 5, /* {LR: Latency-critical, Regular}
 						{HI: performance-Hungry, performance-Insensitive}
@@ -125,10 +126,12 @@ struct sys_stat {
 struct cpdom_ctx {
 	u64	id;				    /* id of this compute domain (== dsq_id) */
 	u64	alt_id;				    /* id of the closest compute domain of alternative type (== dsq id) */
+	u64	last_consume_clk;		    /* when the associated DSQ was consumed */
 	u8	is_big;				    /* is it a big core or little core? */
 	u8	is_active;			    /* if this compute domain is active */
 	u8	nr_neighbors[LAVD_CPDOM_MAX_DIST];  /* number of neighbors per distance */
 	u64	neighbor_bits[LAVD_CPDOM_MAX_DIST]; /* bitmask of neighbor bitmask per distance */
+	u64	cpumask[LAVD_CPU_ID_MAX/64];	    /* cpumasks belongs to this compute domain */
 };
 
 /*
@@ -191,6 +194,7 @@ struct cpu_ctx {
 	u8		big_core;	/* is it a big core? */
 	u8		cpdom_id;	/* compute domain id (== dsq_id) */
 	u8		cpdom_alt_id;	/* compute domain id of anternative type (== dsq_id) */
+	u8		cpdom_poll_pos;	/* index to check if a DSQ of a compute domain is starving */
 	struct bpf_cpumask __kptr *tmp_a_mask;	/* temporary cpu mask */
 	struct bpf_cpumask __kptr *tmp_o_mask;	/* temporary cpu mask */
 	struct bpf_cpumask __kptr *tmp_t_mask;	/* temporary cpu mask */

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -88,8 +88,7 @@ enum consts {
 	LAVD_CC_CPU_PIN_INTERVAL_DIV	= (LAVD_CC_CPU_PIN_INTERVAL /
 					   LAVD_SYS_STAT_INTERVAL_NS),
 
-	LAVD_CPDOM_TYPES_NR		= 2,  /* big or LITTLE */
-	LAVD_CPDOM_MAX_NR		= (64 / LAVD_CPDOM_TYPES_NR), /* maximum number of compute domain (<= 64) */
+	LAVD_CPDOM_MAX_NR		= 64, /* maximum number of compute domain (<= 64) */
 	LAVD_CPDOM_MAX_DIST		= 6,  /* maximum distance from one compute domain to another */
 
 	LAVD_STATUS_STR_LEN		= 5, /* {LR: Latency-critical, Regular}
@@ -126,6 +125,7 @@ struct sys_stat {
 struct cpdom_ctx {
 	u64	id;				    /* id of this compute domain (== dsq_id) */
 	u64	alt_id;				    /* id of the closest compute domain of alternative type (== dsq id) */
+	u8	is_big;				    /* is it a big core or little core? */
 	u8	is_active;			    /* if this compute domain is active */
 	u8	nr_neighbors[LAVD_CPDOM_MAX_DIST];  /* number of neighbors per distance */
 	u64	neighbor_bits[LAVD_CPDOM_MAX_DIST]; /* bitmask of neighbor bitmask per distance */

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -234,6 +234,8 @@ struct task_ctx {
 	/*
 	 * Task's performance criticality
 	 */
+	u8	on_big;			/* executable on a big core */
+	u8	on_little;		/* executable on a little core */
 	u32	perf_cri;		/* performance criticality of a task */
 };
 

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -193,6 +193,7 @@ struct cpu_ctx {
 	u8		cpdom_alt_id;	/* compute domain id of anternative type (== dsq_id) */
 	struct bpf_cpumask __kptr *tmp_a_mask;	/* temporary cpu mask */
 	struct bpf_cpumask __kptr *tmp_o_mask;	/* temporary cpu mask */
+	struct bpf_cpumask __kptr *tmp_t_mask;	/* temporary cpu mask */
 } __attribute__((aligned(CACHELINE_SIZE)));
 
 /*

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -63,16 +63,13 @@ enum consts {
 
 	LAVD_LC_FREQ_MAX		= 1000000,
 	LAVD_LC_RUNTIME_MAX		= LAVD_TARGETED_LATENCY_NS,
-	LAVD_LC_RUNTIME_SHIFT		= 10,
+	LAVD_LC_RUNTIME_SHIFT		= 15,
 	LAVD_LC_WAKEUP_FT		= 30,
-	LAVD_LC_STARVATION_FT		= 30,
 
 	LAVD_SLICE_BOOST_MAX_FT		= 3, /* maximum additional 3x of slice */
 	LAVD_SLICE_BOOST_MAX_STEP	= 6, /* 6 slice exhausitions in a row */
 	LAVD_NEW_PROC_PENALITY		= 5,
 	LAVD_GREEDY_RATIO_NEW		= (1000 * LAVD_NEW_PROC_PENALITY),
-
-	LAVD_ELIGIBLE_TIME_MAX		= (9999ULL * LAVD_TIME_ONE_SEC),
 
 	LAVD_CPU_UTIL_MAX		= 1000, /* 100.0% */
 	LAVD_CPU_UTIL_MAX_FOR_CPUPERF	= 850, /* 85.0% */
@@ -208,13 +205,12 @@ struct task_ctx {
 	 */
 	u64	vdeadline_log_clk;	/* logical clock of the deadilne */
 	u64	vdeadline_delta_ns;	/* time delta until task's virtual deadline */
-	u64	eligible_delta_ns;	/* time delta until task becomes eligible */
 	u64	slice_ns;		/* time slice */
 	u32	greedy_ratio;		/* task's overscheduling ratio compared to its nice priority */
 	u32	lat_cri;		/* calculated latency criticality */
 	volatile s32 victim_cpu;
 	u16	slice_boost_prio;	/* how many times a task fully consumed the slice */
-
+	u8	sync_wakeup;
 	/*
 	 * Task's performance criticality
 	 */
@@ -229,7 +225,7 @@ struct task_ctx_x {
 	u32	cpu_id;		/* where a task ran */
 	u64	cpu_util;	/* cpu utilization in [0..100] */
 	u32	avg_perf_cri;	/* average performance criticality */
-	u32	thr_lat_cri;	/* threshold for latency criticality */
+	u32	avg_lat_cri;	/* average latency criticality */
 	u32	nr_active;	/* number of active cores */
 	u32	cpuperf_cur;	/* CPU's current performance target */
 };

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -503,9 +503,6 @@ static void try_proc_introspec_cmd(struct task_struct *p,
 	case LAVD_CMD_SCHED_N:
 		proc_introspec_sched_n(p, taskc, cpu_id);
 		break;
-	case LAVD_CMD_PID:
-		proc_introspec_pid(p, taskc, cpu_id);
-		break;
 	case LAVD_CMD_NOP:
 		/* do nothing */
 		break;

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -752,9 +752,6 @@ static void clear_cpu_periodically(u32 cpu, struct bpf_cpumask *cpumask)
 	 * (LAVD_CC_CPU_PIN_INTERVAL_DIV). Hence, the bit will be
 	 * probabilistically cleared once every 100 msec (4 * 25 msec).
 	 */
-	if (!bpf_cpumask_test_cpu(cpu, cast_mask(cpumask)))
-		return;
-
 	clear = !(bpf_get_prandom_u32() % LAVD_CC_CPU_PIN_INTERVAL_DIV);
 	if (clear)
 		bpf_cpumask_clear_cpu(cpu, cpumask);

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -243,6 +243,10 @@ impl<'a> Scheduler<'a> {
         }
         debug!("{}", topo);
 
+        // Initialize compute domain contexts
+        skel.bss_mut().cpdom_ctxs[0][0].id = 0; /* TODO */
+        skel.bss_mut().cpdom_ctxs[0][0].is_active = 1; /* TODO */
+
         // Initialize skel according to @opts.
         let nr_cpus_onln = topo.nr_cpus_online() as u64;
         skel.bss_mut().nr_cpus_onln = nr_cpus_onln;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -245,14 +245,21 @@ impl<'a> Scheduler<'a> {
 
         // Initialize compute domain contexts
         // TODO: big core
-        skel.bss_mut().cpdom_ctxs[0][0].id = 0; /* TODO */
-        skel.bss_mut().cpdom_ctxs[0][0].alt_id = 1; /* TODO */
-        skel.bss_mut().cpdom_ctxs[0][0].is_active = 1; /* TODO */
+        skel.bss_mut().cpdom_ctxs[0].id = 0; /* TODO */
+        skel.bss_mut().cpdom_ctxs[0].alt_id = 1; /* TODO */
+        skel.bss_mut().cpdom_ctxs[0].is_big = 1; /* TODO */
+        skel.bss_mut().cpdom_ctxs[0].is_active = 1; /* TODO */
+        skel.bss_mut().cpdom_ctxs[0].nr_neighbors[0] = 1; /* TODO */
+        skel.bss_mut().cpdom_ctxs[0].neighbor_bits[0] = 0x1 << 1; /* TODO */
+
 
         // TODO: little core
-        skel.bss_mut().cpdom_ctxs[1][0].id = 1; /* TODO */
-        skel.bss_mut().cpdom_ctxs[1][0].alt_id = 0; /* TODO */
-        skel.bss_mut().cpdom_ctxs[1][0].is_active = 1; /* TODO */
+        skel.bss_mut().cpdom_ctxs[1].id = 1; /* TODO */
+        skel.bss_mut().cpdom_ctxs[1].alt_id = 0; /* TODO */
+        skel.bss_mut().cpdom_ctxs[1].is_big = 0; /* TODO */
+        skel.bss_mut().cpdom_ctxs[1].is_active = 1; /* TODO */
+        skel.bss_mut().cpdom_ctxs[1].nr_neighbors[0] = 1; /* TODO */
+        skel.bss_mut().cpdom_ctxs[1].neighbor_bits[0] = 0x1 << 0; /* TODO */
 
         // Initialize skel according to @opts.
         let nr_cpus_onln = topo.nr_cpus_online() as u64;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -176,23 +176,23 @@ impl FlatTopology {
 
         // Sort the cpu_fids
         if prefer_smt_core {
-            // Sort the cpu_fids  by node, llc, max_freq, core, and cpu order
+            // Sort the cpu_fids by node, llc, ^max_freq, core, and cpu order
             cpu_fids.sort_by(|a, b| {
                 a.node_id
                     .cmp(&b.node_id)
                     .then_with(|| a.llc_pos.cmp(&b.llc_pos))
-                    .then_with(|| a.max_freq.cmp(&b.max_freq))
+                    .then_with(|| b.max_freq.cmp(&a.max_freq))
                     .then_with(|| a.core_pos.cmp(&b.core_pos))
                     .then_with(|| a.cpu_pos.cmp(&b.cpu_pos))
             });
         } else {
-            // Sort the cpu_fids  by cpu, node, llc, max_freq, and core order
+            // Sort the cpu_fids by cpu, node, llc, ^max_freq, and core order
             cpu_fids.sort_by(|a, b| {
                 a.cpu_pos
                     .cmp(&b.cpu_pos)
                     .then_with(|| a.node_id.cmp(&b.node_id))
                     .then_with(|| a.llc_pos.cmp(&b.llc_pos))
-                    .then_with(|| a.max_freq.cmp(&b.max_freq))
+                    .then_with(|| b.max_freq.cmp(&a.max_freq))
                     .then_with(|| a.core_pos.cmp(&b.core_pos))
             });
         }

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -339,37 +339,37 @@ impl<'a> Scheduler<'a> {
         // Initialize CPU order topologically sorted by a cpu, node, llc, max_freq, and core order
         let topo = FlatTopology::new(opts.prefer_smt_core).expect("Failed to build host topology");
         for (pos, cpu) in topo.cpu_fids.iter().enumerate() {
-            skel.rodata_mut().cpu_order[pos] = cpu.cpu_id as u16;
-            skel.rodata_mut().__cpu_capacity_hint[cpu.cpu_id] = cpu.cpu_cap as u16;
+            skel.maps.rodata_data.cpu_order[pos] = cpu.cpu_id as u16;
+            skel.maps.rodata_data.__cpu_capacity_hint[cpu.cpu_id] = cpu.cpu_cap as u16;
         }
         debug!("{}", topo);
 
         // Initialize compute domain contexts
         for (k, v) in topo.cpdom_map.iter() {
-            skel.bss_mut().cpdom_ctxs[v.cpdom_id].id = v.cpdom_id as u64;
-            skel.bss_mut().cpdom_ctxs[v.cpdom_id].alt_id = v.cpdom_alt_id as u64;
-            skel.bss_mut().cpdom_ctxs[v.cpdom_id].is_big = k.is_big as u8;
-            skel.bss_mut().cpdom_ctxs[v.cpdom_id].is_active = 1;
+            skel.maps.bss_data.cpdom_ctxs[v.cpdom_id].id = v.cpdom_id as u64;
+            skel.maps.bss_data.cpdom_ctxs[v.cpdom_id].alt_id = v.cpdom_alt_id as u64;
+            skel.maps.bss_data.cpdom_ctxs[v.cpdom_id].is_big = k.is_big as u8;
+            skel.maps.bss_data.cpdom_ctxs[v.cpdom_id].is_active = 1;
             for cpu_id in v.cpu_ids.iter() {
                 let i = cpu_id / 64;
                 let j = cpu_id % 64;
-                skel.bss_mut().cpdom_ctxs[v.cpdom_id].cpumask[i] |= 0x01 << j;
+                skel.maps.bss_data.cpdom_ctxs[v.cpdom_id].cpumask[i] |= 0x01 << j;
             }
 
             for (k, (_d, neighbors)) in v.neighbor_map.iter().enumerate() {
-                skel.bss_mut().cpdom_ctxs[v.cpdom_id].nr_neighbors[k] = neighbors.len() as u8;
+                skel.maps.bss_data.cpdom_ctxs[v.cpdom_id].nr_neighbors[k] = neighbors.len() as u8;
                 for n in neighbors.iter() {
-                    skel.bss_mut().cpdom_ctxs[v.cpdom_id].neighbor_bits[k] = 0x1 << n;
+                    skel.maps.bss_data.cpdom_ctxs[v.cpdom_id].neighbor_bits[k] = 0x1 << n;
                 }
             }
         }
 
         // Initialize skel according to @opts.
         let nr_cpus_onln = topo.nr_cpus_online as u64;
-        skel.bss_mut().nr_cpus_onln = nr_cpus_onln;
-        skel.rodata_mut().no_core_compaction = opts.no_core_compaction;
-        skel.rodata_mut().no_freq_scaling = opts.no_freq_scaling;
-        skel.rodata_mut().verbose = opts.verbose;
+        skel.maps.bss_data.nr_cpus_onln = nr_cpus_onln;
+        skel.maps.rodata_data.no_core_compaction = opts.no_core_compaction;
+        skel.maps.rodata_data.no_freq_scaling = opts.no_freq_scaling;
+        skel.maps.rodata_data.verbose = opts.verbose;
         let intrspc = introspec::init(opts);
 
         // Attach.

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -245,14 +245,21 @@ impl<'a> Scheduler<'a> {
 
         // Initialize compute domain contexts
         // TODO: big core
+        // skel.bss_mut().cpdom_ctxs[0].id = 0; /* TODO */
+        // skel.bss_mut().cpdom_ctxs[0].alt_id = 0; /* TODO */
+        // skel.bss_mut().cpdom_ctxs[0].is_big = 1; /* TODO */
+        // skel.bss_mut().cpdom_ctxs[0].is_active = 1; /* TODO */
+        // skel.bss_mut().cpdom_ctxs[0].nr_neighbors[0] = 0; /* TODO */
+        // skel.bss_mut().cpdom_ctxs[0].neighbor_bits[0] = 0; /* TODO */
+
+        // TODO: big core
         skel.bss_mut().cpdom_ctxs[0].id = 0; /* TODO */
         skel.bss_mut().cpdom_ctxs[0].alt_id = 1; /* TODO */
         skel.bss_mut().cpdom_ctxs[0].is_big = 1; /* TODO */
         skel.bss_mut().cpdom_ctxs[0].is_active = 1; /* TODO */
         skel.bss_mut().cpdom_ctxs[0].nr_neighbors[0] = 1; /* TODO */
         skel.bss_mut().cpdom_ctxs[0].neighbor_bits[0] = 0x1 << 1; /* TODO */
-
-
+        
         // TODO: little core
         skel.bss_mut().cpdom_ctxs[1].id = 1; /* TODO */
         skel.bss_mut().cpdom_ctxs[1].alt_id = 0; /* TODO */

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -244,8 +244,15 @@ impl<'a> Scheduler<'a> {
         debug!("{}", topo);
 
         // Initialize compute domain contexts
+        // TODO: big core
         skel.bss_mut().cpdom_ctxs[0][0].id = 0; /* TODO */
+        skel.bss_mut().cpdom_ctxs[0][0].alt_id = 1; /* TODO */
         skel.bss_mut().cpdom_ctxs[0][0].is_active = 1; /* TODO */
+
+        // TODO: little core
+        skel.bss_mut().cpdom_ctxs[1][0].id = 1; /* TODO */
+        skel.bss_mut().cpdom_ctxs[1][0].alt_id = 0; /* TODO */
+        skel.bss_mut().cpdom_ctxs[1][0].is_active = 1; /* TODO */
 
         // Initialize skel according to @opts.
         let nr_cpus_onln = topo.nr_cpus_online() as u64;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -293,8 +293,8 @@ impl<'a> Scheduler<'a> {
 
         if mseq % 32 == 1 {
             info!(
-                "| {:6} | {:7} | {:17} | {:5} \
-                   | {:4} | {:4} | {:12} \
+                "| {:6} | {:7} | {:17} \
+                   | {:5} | {:4} | {:4} \
                    | {:14} | {:8} | {:7} \
                    | {:8} | {:7} | {:8} \
                    | {:7} | {:9} | {:9} \
@@ -308,11 +308,10 @@ impl<'a> Scheduler<'a> {
                 "cpu",
                 "vtmc",
                 "vddln_ns",
-                "eli_ns",
                 "slc_ns",
                 "grdy_rt",
                 "lat_cri",
-                "thr_lc",
+                "avg_lc",
                 "st_prio",
                 "slc_bst",
                 "run_freq",
@@ -336,8 +335,8 @@ impl<'a> Scheduler<'a> {
         let tx_stat: &str = c_tx_st_str.to_str().unwrap();
 
         info!(
-            "| {:6} | {:7} | {:17} | {:5} \
-               | {:4} | {:4} | {:12} \
+            "| {:6} | {:7} | {:17} \
+               | {:5} | {:4} | {:4} \
                | {:14} | {:8} | {:7} \
                | {:8} | {:7} | {:8} \
                | {:7} | {:9} | {:9} \
@@ -351,11 +350,10 @@ impl<'a> Scheduler<'a> {
             tx.cpu_id,
             tc.victim_cpu,
             tc.vdeadline_delta_ns,
-            tc.eligible_delta_ns,
             tc.slice_ns,
             tc.greedy_ratio,
             tc.lat_cri,
-            tx.thr_lat_cri,
+            tx.avg_lat_cri,
             tx.static_prio,
             tc.slice_boost_prio,
             tc.run_freq,

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -71,14 +71,6 @@ struct Opts {
     #[clap(short = 's', long, default_value = "1")]
     nr_sched_samples: u64,
 
-    /// PID to be tracked all its scheduling activities if specified
-    #[clap(short = 'p', long, default_value = "0")]
-    pid_traced: u64,
-
-    /// Exit debug dump buffer length. 0 indicates default.
-    #[clap(long, default_value = "0")]
-    exit_dump_len: u32,
-
     /// Enable verbose output including libbpf details. Specify multiple
     /// times to increase verbosity.
     #[clap(short = 'v', long, action = clap::ArgAction::Count)]
@@ -104,9 +96,6 @@ impl introspec {
         if opts.nr_sched_samples > 0 {
             intrspc.cmd = LAVD_CMD_SCHED_N;
             intrspc.arg = opts.nr_sched_samples;
-        } else if opts.pid_traced > 0 {
-            intrspc.cmd = LAVD_CMD_PID;
-            intrspc.arg = opts.pid_traced;
         } else {
             intrspc.cmd = LAVD_CMD_NOP;
         }
@@ -256,11 +245,10 @@ impl<'a> Scheduler<'a> {
 
         // Initialize skel according to @opts.
         let nr_cpus_onln = topo.nr_cpus_online() as u64;
-        skel.maps.bss_data.nr_cpus_onln = nr_cpus_onln;
-        skel.struct_ops.lavd_ops_mut().exit_dump_len = opts.exit_dump_len;
-        skel.maps.rodata_data.no_core_compaction = opts.no_core_compaction;
-        skel.maps.rodata_data.no_freq_scaling = opts.no_freq_scaling;
-        skel.maps.rodata_data.verbose = opts.verbose;
+        skel.bss_mut().nr_cpus_onln = nr_cpus_onln;
+        skel.rodata_mut().no_core_compaction = opts.no_core_compaction;
+        skel.rodata_mut().no_freq_scaling = opts.no_freq_scaling;
+        skel.rodata_mut().verbose = opts.verbose;
         let intrspc = introspec::init(opts);
 
         // Attach.


### PR DESCRIPTION
This PR makes LAVD core-type aware, supporting AMP (asymmetric multi-processor), multi-CCX, and multi-NUMA architecture. The PR consists of several parts:

- We define a "compute domain" (cpdom for short) as a collection of CPUs having the same core type (P or E) under the same LLC domain.

- The rust code builds the map of compute domain (cpdom_map) from `Topology` and decides 1) how many DSQs are necessary, 2) which CPU should use what DSQ, and 3) when the designated DSQ are empty, which DSQs are needed to be checked for task stealing.

- The BPF code -- ops.dispatch(), ops.select_cpu(), and ops.enqueue() -- pereforms based on the built cpdom_map.

- Besides the above major changes, the PR includes incremental improvement of virtual deadline calculation, tuning for core compaction, and code clean up.

The PR has been tested on three platforms: 1) SteamDeck, 2) AMD Ryzen 9 PRO 6950H, and 3) Intel i7-13700H (P/E). I have not tested multi-CCX and multi-NUMA architectures so far.

