### PR TITLE
scx_lavd: upgrade nix package from 0.28.0 to 0.29.0

### DIFF
--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -22,7 +22,7 @@ simplelog = "0.12"
 static_assertions = "1.1.0"
 rlimit = "0.10.1"
 plain = "0.2.3"
-nix = "0.28.0"
+nix = "0.29.0"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.2" }


### PR DESCRIPTION
For some reason, the `nix` package version 0.28.0 starts producing compilation errors.
After upgrading it to the latest version (0.29.0), everything works fine. 