### PR TITLE
meson: Add github action to run veristat

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,89 @@
+name: merge
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Restore veristat values
+        id: cache-veristat-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/veristat
+          key: veristat-diffs-main
+
+      # Hard turn-off interactive mode
+      - run: echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+
+      # Refresh packages list
+      - run: sudo apt update
+
+      ### DOWNLOAD AND INSTALL DEPENDENCIES ###
+
+      # Download dependencies packaged by Ubuntu
+      - run: sudo apt -y install bison busybox-static cargo cmake coreutils cpio elfutils file flex gcc gcc-multilib git iproute2 jq kbd kmod libcap-dev libelf-dev libunwind-dev libvirt-clients libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic make ninja-build pahole pkg-config python3-dev python3-pip python3-requests qemu-kvm rsync rustc stress-ng udev zstd
+
+      # clang 17
+      # Use a custom llvm.sh script which includes the -y flag for
+      # add-apt-repository. Otherwise, the CI job will hang. If and when
+      # https://github.com/opencollab/llvm-jenkins.debian.net/pull/26 is
+      # merged, we can go back to using https://apt.llvm.org/llvm.sh.
+      - run: wget https://raw.githubusercontent.com/Decave/llvm-jenkins.debian.net/fix_llvmsh/llvm.sh
+      - run: chmod +x llvm.sh
+      - run: sudo ./llvm.sh all
+      - run: sudo ln -sf /usr/bin/clang-17 /usr/bin/clang
+      - run: sudo ln -sf /usr/bin/llvm-strip-17 /usr/bin/llvm-strip
+
+      - uses: actions/checkout@v4
+
+      # meson
+      - run: pip install meson
+
+      # Install virtme-ng
+      - run: pip install virtme-ng
+
+      # Get the latest sched-ext enabled kernel directly from the korg
+      # for-next branch
+      - run: git clone --single-branch -b for-next --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
+
+      # Print the latest commit of the checked out sched-ext kernel
+      - run: cd linux && git log -1 --pretty=format:"%h %ad %s" --date=short
+
+      # Build a minimal kernel (with sched-ext enabled) using virtme-ng
+      - run: cd linux && vng -v --build --config ../.github/workflows/sched-ext.config
+
+      # Generate kernel headers
+      - run: cd linux && make headers
+
+      ### END DEPENDENCIES ###
+
+      # The actual build:
+      - run: meson setup build -Dkernel=$(pwd)/linux -Dkernel_headers=./linux/usr/include
+      - run: meson compile -C build --jobs=1
+
+      # Print CPU model before running the tests (this can be useful for
+      # debugging purposes)
+      - run: grep 'model name' /proc/cpuinfo | head -1
+
+      # Setup KVM support
+      - run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # run veristat
+      - run: meson compile -C build veristat_diff
+
+      # update veristat cache dirs
+      - run: rm -rf ~/veristat/* && cp *.csv ~/veristat/
+
+      - name: Save veristat cache
+        id: cache-veristat-save
+        uses: actions/cache/save@v4
+        with:
+          path: ~/veristat
+          key: ${{ steps.cache-primes-restore.outputs.cache-primary-key }}

--- a/.github/workflows/pr_veristat.yml
+++ b/.github/workflows/pr_veristat.yml
@@ -1,0 +1,74 @@
+name: pr-veristat
+run-name: ${{ github.actor }} PR veristat run
+jobs:
+  pr-veristat:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Restore veristat values
+        id: cache-veristat-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/veristat
+          key: veristat-diffs-main
+
+      # Hard turn-off interactive mode
+      - run: echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
+
+      # Refresh packages list
+      - run: sudo apt update
+
+      ### DOWNLOAD AND INSTALL DEPENDENCIES ###
+
+      # Download dependencies packaged by Ubuntu
+      - run: sudo apt -y install bison busybox-static cargo cmake coreutils cpio elfutils file flex gcc gcc-multilib git iproute2 jq kbd kmod libcap-dev libelf-dev libunwind-dev libvirt-clients libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic make ninja-build pahole pkg-config python3-dev python3-pip python3-requests qemu-kvm rsync rustc stress-ng udev zstd
+
+      # clang 17
+      # Use a custom llvm.sh script which includes the -y flag for
+      # add-apt-repository. Otherwise, the CI job will hang. If and when
+      # https://github.com/opencollab/llvm-jenkins.debian.net/pull/26 is
+      # merged, we can go back to using https://apt.llvm.org/llvm.sh.
+      - run: wget https://raw.githubusercontent.com/Decave/llvm-jenkins.debian.net/fix_llvmsh/llvm.sh
+      - run: chmod +x llvm.sh
+      - run: sudo ./llvm.sh all
+      - run: sudo ln -sf /usr/bin/clang-17 /usr/bin/clang
+      - run: sudo ln -sf /usr/bin/llvm-strip-17 /usr/bin/llvm-strip
+
+      - uses: actions/checkout@v4
+
+      # meson
+      - run: pip install meson
+
+      # Install virtme-ng
+      - run: pip install virtme-ng
+
+      # Get the latest sched-ext enabled kernel directly from the korg
+      # for-next branch
+      - run: git clone --single-branch -b for-next --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
+
+      # Print the latest commit of the checked out sched-ext kernel
+      - run: cd linux && git log -1 --pretty=format:"%h %ad %s" --date=short
+
+      # Build a minimal kernel (with sched-ext enabled) using virtme-ng
+      - run: cd linux && vng -v --build --config ../.github/workflows/sched-ext.config
+
+      # Generate kernel headers
+      - run: cd linux && make headers
+
+      ### END DEPENDENCIES ###
+
+      # The actual build:
+      - run: meson setup build -Dkernel=$(pwd)/linux -Dkernel_headers=./linux/usr/include -Dveristat_diff_dir=~/veristat
+      - run: meson compile -C build --jobs=1
+
+      # Print CPU model before running the tests (this can be useful for
+      # debugging purposes)
+      - run: grep 'model name' /proc/cpuinfo | head -1
+
+      # Setup KVM support
+      - run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # run veristat
+      - run: meson compile -C build veristat_diff

--- a/meson-scripts/veristat
+++ b/meson-scripts/veristat
@@ -34,9 +34,8 @@ for BPF_PATH in $(find ${BUILD_DIR} -type f -name bpf.bpf.o); do
     timeout --preserve-status ${GUEST_TIMEOUT} \
       vng --force-9p -v -r ${KERNEL} -- \
         veristat ${BPF_PATH}
-    exit $?
   else
+    echo "$BPF_PATH"
     sudo veristat ${BPF_PATH}
-    exit $?
   fi
 done

--- a/meson-scripts/veristat_diff
+++ b/meson-scripts/veristat_diff
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+GUEST_TIMEOUT=25
+BUILD_DIR=$1
+SCHED=$2
+KERNEL=$3
+DIFF_DIR=$4
+
+if [ "${KERNEL}" == "vmlinuz" ]; then
+  unset KERNEL
+fi
+
+cd $build_dir
+
+if [ -n "${KERNEL}" ] && [ ! -x `which vng` ]; then
+  echo "vng not found, please install virtme-ng to enable testing"
+  exit 1
+fi
+
+if [ -n "${SCHED}" ]; then
+  BPF_PATH=$(find ${BUILD_DIR} -type f -name bpf.bpf.o | grep ${SCHED})
+  echo "Running veristat on ${BPF_PATH}"
+  if [ -n "${KERNEL}" ]; then
+    timeout --preserve-status ${GUEST_TIMEOUT} \
+      vng --force-9p -v -r ${KERNEL} -- \
+        veristat ${BPF_PATH} -o csv > "${SCHED}.csv"
+    if [ -n "${DIFF_DIR}" ]; then
+      timeout --preserve-status ${GUEST_TIMEOUT} \
+        vng --force-9p -v -r ${KERNEL} -- \
+          veristat -C "${SCHED}.csv" "${DIFF_DIR}/${SCHED}.csv" \
+	    -e file,prog,verdict,insns
+    fi
+    exit $?
+  else
+    echo "saving veristat diff for ${SCHED}.csv"
+    sudo veristat ${BPF_PATH} -o csv > "${SCHED}.csv"
+    if [ -n "${DIFF_DIR}" ]; then
+      sudo veristat -C "${SCHED}.csv" "${DIFF_DIR}/${SCHED}.csv" \
+        -e file,prog,verdict,insns
+    fi
+    exit $?
+  fi
+fi
+
+for BPF_PATH in $(find ${BUILD_DIR} -type f -name bpf.bpf.o); do
+  SCHED=$(echo "${BPF_PATH}" | sed 's/.*\/rust\///g' | sed 's/\/.*//g')
+  if [ -n "${KERNEL}" ]; then
+    timeout --preserve-status ${GUEST_TIMEOUT} \
+      vng --force-9p -v -r ${KERNEL} -- \
+        veristat ${BPF_PATH} -o csv > "${SCHED}.csv"
+    if [ -n "${DIFF_DIR}" ]; then
+      timeout --preserve-status ${GUEST_TIMEOUT} \
+        vng --force-9p -v -r ${KERNEL} -- \
+          veristat -C "${SCHED}.csv" "${DIFF_DIR}/${SCHED}.csv" \
+	    -e file,prog,verdict,insns
+    fi
+  else
+    echo "saving veristat diff for ${SCHED}.csv"
+    sudo veristat ${BPF_PATH} -o csv > "${SCHED}.csv"
+    if [ -n "${DIFF_DIR}" ]; then
+      sudo veristat -C "${SCHED}.csv" "${DIFF_DIR}/${SCHED}.csv" \
+        -e file,prog,verdict,insns
+    fi
+  fi
+done

--- a/meson.build
+++ b/meson.build
@@ -18,10 +18,14 @@ bpf_clang = find_program(get_option('bpf_clang'))
 
 run_veristat = find_program(join_paths(meson.current_source_dir(),
                                        'meson-scripts/veristat'))
+run_veristat_diff = find_program(join_paths(meson.current_source_dir(),
+                                       'meson-scripts/veristat_diff'))
 
 enable_stress = get_option('enable_stress')
 
 veristat_scheduler = get_option('veristat_scheduler')
+
+veristat_diff_dir = get_option('veristat_diff_dir')
 
 if enable_rust
   cargo = find_program(get_option('cargo'))
@@ -330,6 +334,9 @@ run_target('test_sched', command: [test_sched, kernel])
 
 run_target('veristat', command: [run_veristat, meson.current_build_dir(),
                                  get_option('veristat_scheduler'), get_option('kernel')])
+run_target('veristat_diff', command: [run_veristat_diff, meson.current_build_dir(),
+                                 get_option('veristat_scheduler'), get_option('kernel'),
+                                 get_option('veristat_diff_dir')])
 
 if enable_rust
   subdir('rust')

--- a/meson.options
+++ b/meson.options
@@ -22,6 +22,8 @@ option('kernel', type: 'string', value: 'vmlinuz',
        description: 'kernel image used to test schedulers')
 option('veristat_scheduler', type: 'string', value: '',
        description: 'veristat scheduler to test')
+option('veristat_diff_dir', type: 'string', value: '',
+       description: 'veristat diff dir')
 option('kernel_headers', type: 'string', value: '',
        description: 'kernel headers to build the schedulers')
 option(


### PR DESCRIPTION
Add a github action to run [`veristat`](https://github.com/libbpf/veristat) during PRs and merges. This uses an [action cache](https://github.com/actions/cache) to store the veristat values when a PR is merged. An additional action is added during a PR to use the comparison mode of veristat with the diff value from the cache.