### PR TITLE
scx_layered: Update nr_cpus when resizing layers

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1092,6 +1092,7 @@ impl Layer {
             nr_cpus,
         );
         self.cpus |= &new_cpus;
+        self.nr_cpus = self.cpus.count_ones();
         Ok(true)
     }
 
@@ -1166,6 +1167,7 @@ impl Layer {
                 trace!("{} freeing CPUs\n{}", self.name, &cpus_to_free);
                 self.cpus &= !cpus_to_free.clone();
                 cpu_pool.free(&cpus_to_free)?;
+                self.nr_cpus = self.cpus.count_ones();
                 Ok(true)
             }
             None => Ok(false),


### PR DESCRIPTION
After updating scx_layered to be topology aware the nr_cpus field on the layer was not being updated properly. Update layer growing/shrinking logic to correctly update the nr_cpus count.


### this pr
```
tot=  17690 local=82.01 open_idle=26.95 affn_viol= 0.00 proc=23ms
busy= 25.5 util= 1961.1 load=   5400.1 fallback_cpu=  2
excl_coll=0 excl_preempt=0 excl_idle=0 excl_wakeup=0
  hodgesd  : util/frac= 1918.0/ 97.8 load/frac=   4184.2: 77.5 tasks=  1344
             tot=   5268 local=46.34 wake/exp/last/reenq=18.24/ 0.82/34.21/ 0.40
             keep/max/busy=33.20/ 1.58/ 0.25 kick= 1.04 yield/ign= 0.00/    0 
             open_idle= 0.00 mig=19.72 affn_viol= 0.00
             preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
             cpus= 28 [ 26, 30] fff00000 f0000003 000003ff
  normal   : util/frac=   43.1/  2.2 load/frac=   1215.9: 22.5 tasks=  4291
             tot=  12422 local=97.13 wake/exp/last/reenq= 2.60/ 0.10/ 0.16/ 0.00
             keep/max/busy= 0.04/ 0.00/ 0.00 kick= 0.10 yield/ign= 0.12/    0 
             open_idle=38.38 mig=17.16 affn_viol= 0.00
             preempt/first/idle/fail= 0.47/ 0.00/ 1.59/ 0.53 min_exec= 0.00/   0.00ms
             cpus=  4 [  4,  8] 00000003 00000300 00000000
  random   : util/frac=    0.0/  0.0 load/frac=      0.0:  0.0 tasks=     0
             tot=      0 local= 0.00 wake/exp/last/reenq= 0.00/ 0.00/ 0.00/ 0.00
             keep/max/busy= 0.00/ 0.00/ 0.00 kick= 0.00 yield/ign= 0.00/    0 
             open_idle= 0.00 mig= 0.00 affn_viol= 0.00
             preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
             cpus=  0 [  0,  0] 00000000 00000000 00000000
             excl_coll= 0.00 excl_preempt= 0.00
  stress-ng: util/frac=    0.0/  0.0 load/frac=      0.0:  0.0 tasks=     0
             tot=      0 local= 0.00 wake/exp/last/reenq= 0.00/ 0.00/ 0.00/ 0.00
             keep/max/busy= 0.00/ 0.00/ 0.00 kick= 0.00 yield/ign= 0.00/    0 
             open_idle= 0.00 mig= 0.00 affn_viol= 0.00
             preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
             cpus=  0 [  0,  0] 00000000 00000000 00000000
```
### main
```
tot=  36600 local=85.92 open_idle=11.19 affn_viol= 0.00 proc=22ms
busy= 27.2 util= 2095.8 load=   4461.1 fallback_cpu=  2
excl_coll=0 excl_preempt=0 excl_idle=0 excl_wakeup=0
  hodgesd  : util/frac= 2033.6/ 97.0 load/frac=   2150.5: 48.2 tasks=  1013
             tot=  18652 local=76.65 wake/exp/last/reenq= 9.47/ 1.14/12.75/ 0.00
             keep/max/busy= 9.99/ 0.42/ 0.03 kick= 0.97 yield/ign= 2.67/    0 
             open_idle= 0.00 mig=10.47 affn_viol= 0.00
             preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
             cpus= 32 [  0,  0] fff00000 f000000f 00000fff
  normal   : util/frac=   62.2/  3.0 load/frac=   2310.6: 51.8 tasks=  3102
             tot=  17948 local=95.55 wake/exp/last/reenq= 2.67/ 1.10/ 0.68/ 0.00
             keep/max/busy= 0.04/ 0.00/ 0.00 kick= 1.10 yield/ign= 0.65/    0 
             open_idle=22.83 mig=17.13 affn_viol= 0.00
             preempt/first/idle/fail= 0.38/ 0.00/ 1.92/ 0.37 min_exec= 0.00/   0.00ms
             cpus=  4 [  0,  0] 00000003 00000300 00000000
  random   : util/frac=    0.0/  0.0 load/frac=      0.0:  0.0 tasks=     0
             tot=      0 local= 0.00 wake/exp/last/reenq= 0.00/ 0.00/ 0.00/ 0.00
             keep/max/busy= 0.00/ 0.00/ 0.00 kick= 0.00 yield/ign= 0.00/    0 
             open_idle= 0.00 mig= 0.00 affn_viol= 0.00
             preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
             cpus=  0 [  0,  0] 00000000 00000000 00000000
             excl_coll= 0.00 excl_preempt= 0.00
  stress-ng: util/frac=    0.0/  0.0 load/frac=      0.0:  0.0 tasks=     0
             tot=      0 local= 0.00 wake/exp/last/reenq= 0.00/ 0.00/ 0.00/ 0.00
             keep/max/busy= 0.00/ 0.00/ 0.00 kick= 0.00 yield/ign= 0.00/    0 
             open_idle= 0.00 mig= 0.00 affn_viol= 0.00
             preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
             cpus=  0 [  0,  0] 00000000 00000000 00000000

```