### PR TITLE
scx_stats, scx_layered: Add `om_prefix` attribute and fix s/stat/stats/ stragglers

### DIFF
--- a/rust/scx_stats/README.md
+++ b/rust/scx_stats/README.md
@@ -46,7 +46,7 @@ struct ClusterStats {
     pub at: u64,
     #[stat(desc = "some bitmap we want to report")]
     pub bitmap: Vec<u32>,
-    #[stat(desc = "domain statistics")]
+    #[stat(desc = "domain statistics", om_prefix="d_")]
     pub doms_dict: BTreeMap<usize, DomainStats>,
 }
 ```

--- a/rust/scx_stats/README.md
+++ b/rust/scx_stats/README.md
@@ -116,8 +116,8 @@ When implementing a generic client which does not have access to the
 statistics struct definitions, the metadata can come handy:
 
 ```rust
-    println!("\n===== Requesting \"stat_meta\" but receiving with serde_json::Value:");
-    let resp = client.request::<serde_json::Value>("stat_meta", vec![]);
+    println!("\n===== Requesting \"stats_meta\" but receiving with serde_json::Value:");
+    let resp = client.request::<serde_json::Value>("stats_meta", vec![]);
     println!("{:#?}", &resp);
 ```
 
@@ -196,8 +196,8 @@ Press any key to exit.
 ```
 $ RUST_LOG=trace cargo run --example client -- ~/tmp/socket
 ...
-===== Requesting "stat" but receiving with serde_json::Value:
-2024-08-15T22:13:23.769Z TRACE [scx_stats::client] Sending: {"req":"stat","args":{"target":"all"}}
+===== Requesting "stats" but receiving with serde_json::Value:
+2024-08-15T22:13:23.769Z TRACE [scx_stats::client] Sending: {"req":"stats","args":{"target":"all"}}
 2024-08-15T22:13:23.769Z TRACE [scx_stats::client] Received: {"errno":0,"args":{"resp":{"at":12345,"bitmap":[3735928559,3203391149],"doms_dict":{"0":{"events":1234,"name":"domain 0","pressure":1.234},"3":{"events":5678,"name":"domain 3","pressure":5.678}},"name":"test cluster"}}}
 Ok(
     Object {

--- a/rust/scx_stats/examples/client.rs
+++ b/rust/scx_stats/examples/client.rs
@@ -24,7 +24,7 @@ struct ClusterStats {
     pub at: u64,
     #[stat(desc = "some bitmap we want to report")]
     pub bitmap: Vec<u32>,
-    #[stat(desc = "domain statistics")]
+    #[stat(desc = "domain statistics", om_prefix="d_")]
     pub doms_dict: BTreeMap<usize, DomainStats>,
 }
 

--- a/rust/scx_stats/examples/client.rs
+++ b/rust/scx_stats/examples/client.rs
@@ -24,7 +24,7 @@ struct ClusterStats {
     pub at: u64,
     #[stat(desc = "some bitmap we want to report")]
     pub bitmap: Vec<u32>,
-    #[stat(desc = "domain statistics", om_prefix="d_")]
+    #[stat(desc = "domain statistics", om_prefix = "d_")]
     pub doms_dict: BTreeMap<usize, DomainStats>,
 }
 
@@ -40,28 +40,28 @@ fn main() {
 
     let mut client = ScxStatsClient::new().set_path(path).connect().unwrap();
 
-    println!("===== Requesting \"stat_meta\":");
-    let resp = client.request::<Vec<ScxStatsMeta>>("stat_meta", vec![]);
+    println!("===== Requesting \"stats_meta\":");
+    let resp = client.request::<Vec<ScxStatsMeta>>("stats_meta", vec![]);
     println!("{:#?}", &resp);
 
-    println!("\n===== Requesting \"stat\" without arguments:");
-    let resp = client.request::<ClusterStats>("stat", vec![]);
+    println!("\n===== Requesting \"stats\" without arguments:");
+    let resp = client.request::<ClusterStats>("stats", vec![]);
     println!("{:#?}", &resp);
 
-    println!("\n===== Requesting \"stat\" with \"target\"=\"non-existent\":");
+    println!("\n===== Requesting \"stats\" with \"target\"=\"non-existent\":");
     let resp =
-        client.request::<ClusterStats>("stat", vec![("target".into(), "non-existent".into())]);
+        client.request::<ClusterStats>("stats", vec![("target".into(), "non-existent".into())]);
     println!("{:#?}", &resp);
 
-    println!("\n===== Requesting \"stat\" with \"target\"=\"all\":");
-    let resp = client.request::<ClusterStats>("stat", vec![("target".into(), "all".into())]);
+    println!("\n===== Requesting \"stats\" with \"target\"=\"all\":");
+    let resp = client.request::<ClusterStats>("stats", vec![("target".into(), "all".into())]);
     println!("{:#?}", &resp);
 
-    println!("\n===== Requesting \"stat_meta\" but receiving with serde_json::Value:");
-    let resp = client.request::<serde_json::Value>("stat_meta", vec![]);
+    println!("\n===== Requesting \"stats_meta\" but receiving with serde_json::Value:");
+    let resp = client.request::<serde_json::Value>("stats_meta", vec![]);
     println!("{:#?}", &resp);
 
-    println!("\n===== Requesting \"stat\" but receiving with serde_json::Value:");
-    let resp = client.request::<serde_json::Value>("stat", vec![("target".into(), "all".into())]);
+    println!("\n===== Requesting \"stats\" but receiving with serde_json::Value:");
+    let resp = client.request::<serde_json::Value>("stats", vec![("target".into(), "all".into())]);
     println!("{:#?}", &resp);
 }

--- a/rust/scx_stats/examples/client.rs
+++ b/rust/scx_stats/examples/client.rs
@@ -17,7 +17,7 @@ struct DomainStats {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Stats)]
-#[stat(desc = "cluster statistics")]
+#[stat(desc = "cluster statistics", all)]
 struct ClusterStats {
     pub name: String,
     #[stat(desc = "update timestamp")]

--- a/rust/scx_stats/examples/client.rs
+++ b/rust/scx_stats/examples/client.rs
@@ -7,7 +7,7 @@ use std::env::args;
 // DomainStat and ClusterStat definitions must match the ones in server.rs.
 //
 #[derive(Clone, Debug, Serialize, Deserialize, Stats)]
-#[stat(desc = "domain statistics")]
+#[stat(desc = "domain statistics", field_prefix="d_")]
 struct DomainStats {
     pub name: String,
     #[stat(desc = "an event counter")]
@@ -24,7 +24,7 @@ struct ClusterStats {
     pub at: u64,
     #[stat(desc = "some bitmap we want to report")]
     pub bitmap: Vec<u32>,
-    #[stat(desc = "domain statistics", om_prefix = "d_")]
+    #[stat(desc = "domain statistics")]
     pub doms_dict: BTreeMap<usize, DomainStats>,
 }
 

--- a/rust/scx_stats/examples/server.rs
+++ b/rust/scx_stats/examples/server.rs
@@ -18,7 +18,7 @@ struct DomainStats {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Stats)]
-#[stat(desc = "cluster statistics")]
+#[stat(desc = "cluster statistics", all)]
 struct ClusterStats {
     pub name: String,
     #[stat(desc = "update timestamp")]

--- a/rust/scx_stats/examples/server.rs
+++ b/rust/scx_stats/examples/server.rs
@@ -8,7 +8,7 @@ use std::io::Read;
 // DomainStat and ClusterStat definitions must match the ones in client.rs.
 //
 #[derive(Clone, Debug, Serialize, Deserialize, Stats)]
-#[stat(desc = "domain statistics")]
+#[stat(desc = "domain statistics", field_prefix="d_")]
 struct DomainStats {
     pub name: String,
     #[stat(desc = "an event counter")]
@@ -25,7 +25,7 @@ struct ClusterStats {
     pub at: u64,
     #[stat(desc = "some bitmap we want to report")]
     pub bitmap: Vec<u32>,
-    #[stat(desc = "domain statistics", om_prefix="d_")]
+    #[stat(desc = "domain statistics")]
     pub doms_dict: BTreeMap<usize, DomainStats>,
 }
 

--- a/rust/scx_stats/examples/server.rs
+++ b/rust/scx_stats/examples/server.rs
@@ -25,7 +25,7 @@ struct ClusterStats {
     pub at: u64,
     #[stat(desc = "some bitmap we want to report")]
     pub bitmap: Vec<u32>,
-    #[stat(desc = "domain statistics")]
+    #[stat(desc = "domain statistics", om_prefix="d_")]
     pub doms_dict: BTreeMap<usize, DomainStats>,
 }
 

--- a/rust/scx_stats/src/client.rs
+++ b/rust/scx_stats/src/client.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 pub struct ScxStatsClient {
     base_path: PathBuf,
     sched_path: PathBuf,
-    stat_path: PathBuf,
+    stats_path: PathBuf,
     path: Option<PathBuf>,
 
     stream: Option<UnixStream>,
@@ -21,7 +21,7 @@ impl ScxStatsClient {
         Self {
             base_path: PathBuf::from("/var/run/scx"),
             sched_path: PathBuf::from("root"),
-            stat_path: PathBuf::from("stat"),
+            stats_path: PathBuf::from("stats"),
             path: None,
 
             stream: None,
@@ -39,8 +39,8 @@ impl ScxStatsClient {
         self
     }
 
-    pub fn set_stat_path<P: AsRef<Path>>(mut self, path: P) -> Self {
-        self.stat_path = PathBuf::from(path.as_ref());
+    pub fn set_stats_path<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.stats_path = PathBuf::from(path.as_ref());
         self
     }
 
@@ -51,7 +51,7 @@ impl ScxStatsClient {
 
     pub fn connect(mut self) -> Result<Self> {
         if self.path.is_none() {
-            self.path = Some(self.base_path.join(&self.sched_path).join(&self.stat_path));
+            self.path = Some(self.base_path.join(&self.sched_path).join(&self.stats_path));
         }
         let path = &self.path.as_ref().unwrap();
 

--- a/rust/scx_stats/src/lib.rs
+++ b/rust/scx_stats/src/lib.rs
@@ -2,8 +2,8 @@ pub use serde_json;
 
 mod stats;
 pub use stats::{
-    Meta, ScxStatsAttr, ScxStatsAttrs, ScxStatsData, ScxStatsField, ScxStatsKind, ScxStatsMeta,
-    ScxStatsMetaAux,
+    Meta, ScxStatsAttr, ScxStatsData, ScxStatsField, ScxStatsFieldAttrs, ScxStatsKind,
+    ScxStatsMeta, ScxStatsMetaAux, ScxStatsStructAttrs,
 };
 
 mod server;

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -45,79 +45,71 @@ fn fmt_num(v: u64) -> String {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 pub struct LayerStats {
-    #[stat(desc = "CPU utilization of the layer (100% means one CPU was fully occupied)")]
+    #[stat(desc = "layer: CPU utilization (100% means one full CPU)")]
     pub util: f64,
-    #[stat(desc = "Fraction of total CPU utilization consumed by the layer")]
+    #[stat(desc = "layer: fraction of total CPU utilization")]
     pub util_frac: f64,
-    #[stat(desc = "Sum of weight * duty_cycle for tasks in the layer")]
+    #[stat(desc = "layer: sum of weight * duty_cycle for tasks")]
     pub load: f64,
-    #[stat(desc = "Fraction of total load consumed by the layer")]
+    #[stat(desc = "layer: fraction of total load")]
     pub load_frac: f64,
-    #[stat(desc = "Number of tasks in the layer")]
+    #[stat(desc = "layer: # tasks")]
     pub tasks: u32,
-    #[stat(desc = "Number of scheduling events in the layer")]
+    #[stat(desc = "layer: # sched events duringg the period")]
     pub total: u64,
-    #[stat(desc = "% of scheduling events directly into an idle CPU")]
+    #[stat(desc = "layer: % dispatched into idle CPU")]
     pub sel_local: f64,
-    #[stat(desc = "% of scheduling events enqueued to layer after wakeup")]
+    #[stat(desc = "layer: % enqueued after wakeup")]
     pub enq_wakeup: f64,
-    #[stat(desc = "% of scheduling events enqueued to layer after slice expiration")]
+    #[stat(desc = "layer: % enqueued after slice expiration")]
     pub enq_expire: f64,
-    #[stat(desc = "% of scheduling events enqueued as last runnable task on CPU")]
+    #[stat(desc = "layer: % enqueued as last runnable task on CPU")]
     pub enq_last: f64,
-    #[stat(desc = "% of scheduling events re-enqueued due to RT preemption")]
+    #[stat(desc = "layer: % re-enqueued due to RT preemption")]
     pub enq_reenq: f64,
-    #[stat(desc = "Number of times execution duration was shorter than min_exec_us")]
+    #[stat(desc = "layer: # times exec duration < min_exec_us")]
     pub min_exec: f64,
-    #[stat(desc = "Total execution duration extended due to min_exec_us")]
+    #[stat(desc = "layer: total exec durations extended due to min_exec_us")]
     pub min_exec_us: u64,
-    #[stat(desc = "% of scheduling events into idle CPUs occupied by other layers")]
+    #[stat(desc = "layer: % dispatche into idle CPUs occupied by other layers")]
     pub open_idle: f64,
-    #[stat(desc = "% of scheduling events that preempted other tasks")]
+    #[stat(desc = "layer: % preempted other tasks")]
     pub preempt: f64,
-    #[stat(desc = "% of scheduling events that first-preempted other tasks")]
+    #[stat(desc = "layer: % first-preempted other tasks")]
     pub preempt_first: f64,
-    #[stat(desc = "% of scheduling events that idle-preempted other tasks")]
+    #[stat(desc = "layer: % idle-preempted other tasks")]
     pub preempt_idle: f64,
-    #[stat(desc = "% of scheduling events that attempted to preempt other tasks but failed")]
+    #[stat(desc = "layer: % attempted to preempt other tasks but failed")]
     pub preempt_fail: f64,
-    #[stat(
-        desc = "% of scheduling events that violated configured policies due to CPU affinity restrictions"
-    )]
+    #[stat(desc = "layer: % violated config due to CPU affinity")]
     pub affn_viol: f64,
-    #[stat(desc = "% of scheduling events that continued executing after slice expiration")]
+    #[stat(desc = "layer: % continued executing after slice expiration")]
     pub keep: f64,
-    #[stat(
-        desc = "% of scheduling events that weren't allowed to continue executing after slice expiration due to overrunning max_exec duration limit"
-    )]
+    #[stat(desc = "layer: % disallowed to continue executing due to max_exec")]
     pub keep_fail_max_exec: f64,
-    #[stat(
-        desc = "% of scheduling events that weren't allowed to continue executing after slice expiration to accommodate other tasks"
-    )]
+    #[stat(desc = "layer: % disallowed to continue executing due to other tasks")]
     pub keep_fail_busy: f64,
-    #[stat(desc = "Whether layer is exclusive")]
+    #[stat(desc = "layer: whether is exclusive")]
     pub is_excl: u32,
-    #[stat(
-        desc = "Number of times an exclusive task skipped a CPU as the sibling was also exclusive"
-    )]
+    #[stat(desc = "layer: # times an excl task skipped a CPU as the sibling was also excl")]
     pub excl_collision: f64,
-    #[stat(desc = "Number of times a sibling CPU was preempted for an exclusive task")]
+    #[stat(desc = "layer: % a sibling CPU was preempted for an exclusive task")]
     pub excl_preempt: f64,
-    #[stat(desc = "% of schduling events that kicked a CPU from enqueue path")]
+    #[stat(desc = "layer: % kicked a CPU from enqueue path")]
     pub kick: f64,
-    #[stat(desc = "% of scheduling events that yielded")]
+    #[stat(desc = "layer: % yielded")]
     pub yielded: f64,
-    #[stat(desc = "Number of times yield was ignored")]
+    #[stat(desc = "layer: # times yield was ignored")]
     pub yield_ignore: u64,
-    #[stat(desc = "% of scheduling events that migrated across CPUs")]
+    #[stat(desc = "layer: % migrated across CPUs")]
     pub migration: f64,
-    #[stat(desc = "Mask of allocated CPUs")]
+    #[stat(desc = "layer: mask of allocated CPUs")]
     pub cpus: Vec<u32>,
-    #[stat(desc = "Current # of CPUs assigned to the layer")]
+    #[stat(desc = "layer: # of CPUs assigned")]
     pub cur_nr_cpus: u32,
-    #[stat(desc = "Minimum # of CPUs assigned to the layer")]
+    #[stat(desc = "layer: minimum # of CPUs assigned")]
     pub min_nr_cpus: u32,
-    #[stat(desc = "Maximum # of CPUs assigned to the layer")]
+    #[stat(desc = "layer: maximum # of CPUs assigned")]
     pub max_nr_cpus: u32,
 }
 
@@ -312,43 +304,37 @@ impl LayerStats {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 pub struct SysStats {
-    #[stat(desc = "Update interval")]
+    #[stat(desc = "update interval")]
     pub intv: f64,
-    #[stat(desc = "Timestamp")]
+    #[stat(desc = "timestamp")]
     pub at: f64,
-    #[stat(desc = "Total scheduling events in the period")]
+    #[stat(desc = "# sched events duringg the period")]
     pub total: u64,
-    #[stat(desc = "% that got scheduled directly into an idle CPU")]
+    #[stat(desc = "% dispatched directly into an idle CPU")]
     pub local: f64,
-    #[stat(desc = "% of open layer tasks scheduled into occupied idle CPUs")]
+    #[stat(desc = "% open layer tasks scheduled into allocated but idle CPUs")]
     pub open_idle: f64,
-    #[stat(desc = "% which violated configured policies due to CPU affinity restrictions")]
+    #[stat(desc = "% violated config due to CPU affinity")]
     pub affn_viol: f64,
-    #[stat(
-        desc = "Number of times an exclusive task skipped a CPU as the sibling was also exclusive"
-    )]
+    #[stat(desc = "# times an excl task skipped a CPU as the sibling was also excl")]
     pub excl_collision: f64,
-    #[stat(desc = "Number of times a sibling CPU was preempted for an exclusive task")]
+    #[stat(desc = "# times a sibling CPU was preempted for an excl task")]
     pub excl_preempt: f64,
-    #[stat(
-        desc = "Number of times a CPU skipped dispatching due to sibling running an exclusive task"
-    )]
+    #[stat(desc = "# times a CPU skipped dispatching due to an excl task on the sibling")]
     pub excl_idle: f64,
-    #[stat(
-        desc = "Number of times an idle sibling CPU was woken up after an exclusive task is finished"
-    )]
+    #[stat(desc = "# times an idle sibling CPU was woken up after an excl task is finished")]
     pub excl_wakeup: f64,
-    #[stat(desc = "CPU time this binary has consumed during the period")]
+    #[stat(desc = "CPU time this binary consumed during the period")]
     pub proc_ms: u64,
-    #[stat(desc = "CPU busy % (100% means all CPUs were fully occupied)")]
+    #[stat(desc = "CPU busy % (100% means all CPU)")]
     pub busy: f64,
-    #[stat(desc = "CPU utilization % (100% means one CPU was fully occupied)")]
+    #[stat(desc = "CPU util % (100% means one CPU)")]
     pub util: f64,
-    #[stat(desc = "Sum of weight * duty_cycle for all tasks")]
+    #[stat(desc = "sum of weight * duty_cycle for all tasks")]
     pub load: f64,
-    #[stat(desc = "Fallback CPU")]
+    #[stat(desc = "fallback CPU")]
     pub fallback_cpu: u32,
-    #[stat(desc = "Per-layer statistics")]
+    #[stat(desc = "per-layer statistics")]
     pub layers: BTreeMap<String, LayerStats>,
 }
 

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -303,6 +303,7 @@ impl LayerStats {
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
+#[stat(all)]
 pub struct SysStats {
     #[stat(desc = "update interval")]
     pub intv: f64,

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -334,7 +334,7 @@ pub struct SysStats {
     pub load: f64,
     #[stat(desc = "fallback CPU")]
     pub fallback_cpu: u32,
-    #[stat(desc = "per-layer statistics")]
+    #[stat(desc = "per-layer statistics", om_prefix = "l_")]
     pub layers: BTreeMap<String, LayerStats>,
 }
 

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -444,7 +444,7 @@ pub fn monitor(shutdown: Arc<AtomicBool>) -> Result<()> {
     let mut last_at = 0.0;
 
     while !shutdown.load(Ordering::Relaxed) {
-        let sst = client.request::<SysStats>("stat", vec![])?;
+        let sst = client.request::<SysStats>("stats", vec![])?;
         if sst.at != last_at {
             let dt = DateTime::<Local>::from(UNIX_EPOCH + Duration::from_secs_f64(sst.at));
             println!("###### {} ######", dt.to_rfc2822());


### PR DESCRIPTION
- Multiple attributes in a single stat block fixed.
- `om_prefix` added and will be used by openmetrics bridge tool.
- s/stat/stats stragglers renamed.