### PR TITLE
scx_rusty: Fix typo

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -1097,7 +1097,7 @@ void BPF_STRUCT_OPS(rusty_enqueue, struct task_struct *p, u64 enq_flags)
 	if (!(taskc = lookup_task_ctx(p)))
 		return;
 	if (!(p_cpumask = taskc->cpumask)) {
-		scx_bpf_error("NULL cpmask");
+		scx_bpf_error("NULL cpumask");
 		return;
 	}
 


### PR DESCRIPTION
## Summary
Fix "cpmask" to "cpumask"