### PR TITLE
scx_stats: Add support for no-value user attributes and a bunch of ot…

### DIFF
--- a/rust/scx_stats/README.md
+++ b/rust/scx_stats/README.md
@@ -64,7 +64,23 @@ defined:
 In addition, arbitrary user attributes which start with "_" can be added to
 both structs and fields. They are collected into the "user" dict of the
 containing struct or field. When the value of such user attribute is not
-specified, the string "true" is assigned by default. See the examples.
+specified, the string "true" is assigned by default. For example,
+[scripts/scxstats_to_openmetrics.py](scripts/scxstats_to_openmetrics.py)
+recognizes the following user attribute:
+
+- `_om_prefix`: The value is prefixed to the field name to form the unique
+  OpenMetrics metric name.
+
+- `_om_label`: Labels are used to distinguish different members of a dict.
+  This field attribute specifies the name of the label for a dict field.
+
+- `_om_skip`: Not all fields might make sense to translate to OpenMetrics.
+  This valueless field attribute marks the field to be skipped.
+
+[`examples/stats_defs.rs.h`](./examples/stats_defs.rs.h) shows how the above
+attributes can be used. See
+[scx_layered](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_layered/src/stats.rs)
+for practical usage.
 
 Note that scx_stats depends on [`serde`](https://crates.io/crates/serde) and
 [`serde_json`](https://crates.io/crates/serde_json) and each statistics

--- a/rust/scx_stats/examples/client.rs
+++ b/rust/scx_stats/examples/client.rs
@@ -20,7 +20,7 @@ fn main() {
     let mut client = ScxStatsClient::new().set_path(path).connect().unwrap();
 
     println!("===== Requesting \"stats_meta\":");
-    let resp = client.request::<Vec<ScxStatsMeta>>("stats_meta", vec![]);
+    let resp = client.request::<BTreeMap<String, ScxStatsMeta>>("stats_meta", vec![]);
     println!("{:#?}", &resp);
 
     println!("\n===== Requesting \"stats\" without arguments:");
@@ -33,14 +33,14 @@ fn main() {
     println!("{:#?}", &resp);
 
     println!("\n===== Requesting \"stats\" with \"target\"=\"all\":");
-    let resp = client.request::<ClusterStats>("stats", vec![("target".into(), "all".into())]);
-    println!("{:#?}", &resp);
-
-    println!("\n===== Requesting \"stats_meta\" but receiving with serde_json::Value:");
-    let resp = client.request::<serde_json::Value>("stats_meta", vec![]);
+    let resp = client.request::<ClusterStats>("stats", vec![("target".into(), "top".into())]);
     println!("{:#?}", &resp);
 
     println!("\n===== Requesting \"stats\" but receiving with serde_json::Value:");
-    let resp = client.request::<serde_json::Value>("stats", vec![("target".into(), "all".into())]);
+    let resp = client.request::<serde_json::Value>("stats", vec![("target".into(), "top".into())]);
     println!("{:#?}", &resp);
+
+    println!("\n===== Requesting \"stats_meta\" but receiving with serde_json::Value:");
+    let resp = client.request::<serde_json::Value>("stats_meta", vec![]).unwrap();
+    println!("{}", serde_json::to_string_pretty(&resp).unwrap());
 }

--- a/rust/scx_stats/examples/stats_defs.rs.h
+++ b/rust/scx_stats/examples/stats_defs.rs.h
@@ -18,7 +18,7 @@ struct ClusterStats {
     pub name: String,
     #[stat(desc = "update timestamp")]
     pub at: u64,
-    #[stat(desc = "some bitmap we want to report")]
+    #[stat(desc = "some bitmap we want to report", _om_skip)]
     pub bitmap: Vec<u32>,
     #[stat(desc = "domain statistics")]
     pub doms_dict: BTreeMap<usize, DomainStats>,

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -90,7 +90,7 @@ pub struct LayerStats {
     pub keep_fail_max_exec: f64,
     #[stat(desc = "layer: % disallowed to continue executing due to other tasks")]
     pub keep_fail_busy: f64,
-    #[stat(desc = "layer: whether is exclusive")]
+    #[stat(desc = "layer: whether is exclusive", _om_skip)]
     pub is_excl: u32,
     #[stat(desc = "layer: # times an excl task skipped a CPU as the sibling was also excl")]
     pub excl_collision: f64,
@@ -104,7 +104,7 @@ pub struct LayerStats {
     pub yield_ignore: u64,
     #[stat(desc = "layer: % migrated across CPUs")]
     pub migration: f64,
-    #[stat(desc = "layer: mask of allocated CPUs")]
+    #[stat(desc = "layer: mask of allocated CPUs", _om_skip)]
     pub cpus: Vec<u32>,
     #[stat(desc = "layer: # of CPUs assigned")]
     pub cur_nr_cpus: u32,
@@ -306,9 +306,9 @@ impl LayerStats {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(top)]
 pub struct SysStats {
-    #[stat(desc = "update interval")]
+    #[stat(desc = "update interval", _om_skip)]
     pub intv: f64,
-    #[stat(desc = "timestamp")]
+    #[stat(desc = "timestamp", _om_skip)]
     pub at: f64,
     #[stat(desc = "# sched events duringg the period")]
     pub total: u64,


### PR DESCRIPTION
…her changes

- Allow no-value user attributes which are automatically assigned "true" when specified.

- Make "top" attribute string "true" instead of bool true for consistency. Testing for existence is always enough for value-less attributes.

- Don't drop leading "_" from user attribute names when storing in dicts. Dropping makes things more confusing.

- Add "_om_skip" to scx_layered fields which don't jive well with OM. scxstats_to_openmetrics.py is updated accordignly and no longer generates warnings on those fields.

- Examples and README updated accordingly.