### PR TITLE
scx_bpfland: topology awareness

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/intf.h
+++ b/scheds/rust/scx_bpfland/src/bpf/intf.h
@@ -38,4 +38,10 @@ struct cpu_arg {
 	s32 cpu_id;
 };
 
+struct domain_arg {
+	s32 lvl_id;
+	s32 cpu_id;
+	s32 sibling_cpu_id;
+};
+
 #endif /* __INTF_H */


### PR DESCRIPTION
Introduce some concepts of topology awareness to scx_bpfland:
 - L2 / L3 cache awareness
 - cpu frequency awreness (via primary scheduling domain)

These changes enable better utilization of hybrid architectures (P-cores / E-cores) and generally improve performance by keeping tasks running on the same cores and caches, thereby enhancing the reuse of their working set.