### PR TITLE
scx_stats, scx_layered: Implement independent stats client sessions

### DIFF
--- a/rust/scx_stats/Cargo.toml
+++ b/rust/scx_stats/Cargo.toml
@@ -11,6 +11,7 @@ description = "Statistics transport library for sched_ext schedulers"
 
 [dependencies]
 anyhow = "1.0.65"
+crossbeam = "0.8.4"
 libc = "0.2.137"
 log = "0.4.17"
 quote = "1.0"

--- a/rust/scx_stats/README.md
+++ b/rust/scx_stats/README.md
@@ -90,7 +90,7 @@ The statistics server which serves the above structs through a UNIX domain
 socket can be launched as follows:
 
 ```rust
-    ScxStatsServer::new()
+    let _server = ScxStatsServer::new()
         .set_path(&path)
         .add_stats_meta(ClusterStats::meta())
         .add_stats_meta(DomainStats::meta())
@@ -111,9 +111,9 @@ return `serde_json::Value`. Note that `scx_stats::ToJson` automatically adds
 `.to_json()` to structs which implement both `scx_stats::Meta` and
 `serde::Serialize`.
 
-The above will launch the statistics server listening on `@path`. The client
-side is also simple. Taken from
-[`examples/client.rs`](./examples/client.rs):
+The above will launch the statistics server listening on `@path`. Note that
+the server will shutdown when `_server` variable is dropped. The client side
+is also simple. Taken from [`examples/client.rs`](./examples/client.rs):
 
 ```rust
     let mut client = ScxStatsClient::new().set_path(path).connect().unwrap();

--- a/rust/scx_stats/examples/client.rs
+++ b/rust/scx_stats/examples/client.rs
@@ -41,6 +41,8 @@ fn main() {
     println!("{:#?}", &resp);
 
     println!("\n===== Requesting \"stats_meta\" but receiving with serde_json::Value:");
-    let resp = client.request::<serde_json::Value>("stats_meta", vec![]).unwrap();
+    let resp = client
+        .request::<serde_json::Value>("stats_meta", vec![])
+        .unwrap();
     println!("{}", serde_json::to_string_pretty(&resp).unwrap());
 }

--- a/rust/scx_stats/examples/server.rs
+++ b/rust/scx_stats/examples/server.rs
@@ -1,33 +1,41 @@
-use scx_stats::{ScxStatsServer, Meta, ToJson};
+use log::{debug, warn};
+use scx_stats::{Meta, ScxStatsServer, ToJson};
 use scx_stats_derive::Stats;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::env::args;
 use std::io::Read;
+use std::thread::{current, spawn, ThreadId};
 
 // Hacky definition sharing. See stats_def.rs.h.
 include!("stats_defs.rs.h");
 
 fn main() {
+    simple_logger::SimpleLogger::new()
+        .with_level(log::LevelFilter::Info)
+        .env()
+        .init()
+        .unwrap();
+
     let stats = ClusterStats {
         name: "test cluster".into(),
         at: 12345,
-	bitmap: vec![0xdeadbeef, 0xbeefdead],
+        bitmap: vec![0xdeadbeef, 0xbeefdead],
         doms_dict: BTreeMap::from([
             (
                 0,
                 DomainStats {
                     name: "domain 0".into(),
-		    events: 1234,
-		    pressure: 1.234,
+                    events: 1234,
+                    pressure: 1.234,
                 },
             ),
             (
                 3,
                 DomainStats {
                     name: "domain 3".into(),
-		    events: 5678,
-		    pressure: 5.678,
+                    events: 5678,
+                    pressure: 5.678,
                 },
             ),
         ]),
@@ -36,13 +44,37 @@ fn main() {
     std::assert_eq!(args().len(), 2, "Usage: server UNIX_SOCKET_PATH");
     let path = args().nth(1).unwrap();
 
-    ScxStatsServer::new()
+    // If communication from the stats generating closure is not necessary,
+    // ScxStatsServer::<(), ()> can be used. This example sends thread ID
+    // and receives the formatted string just for demonstration.
+    let server = ScxStatsServer::<ThreadId, String>::new()
         .set_path(&path)
         .add_stats_meta(ClusterStats::meta())
         .add_stats_meta(DomainStats::meta())
-        .add_stats("top", Box::new(move |_| stats.to_json()))
+        .add_stats(
+            "top",
+            Box::new(move |_args, (tx, rx)| {
+                let id = current().id();
+                let res = tx.send(id);
+                debug!("Sendt {:?} {:?}", id, &res);
+                let res = rx.recv();
+                debug!("Recevied {:?}", res);
+                stats.to_json()
+            }),
+        )
         .launch()
         .unwrap();
+
+    debug!("Doing unnecessary server channel handling");
+    let (tx, rx) = server.channels();
+    spawn(move || {
+        while let Ok(id) = rx.recv() {
+            if let Err(e) = tx.send(format!("hello {:?}", &id)) {
+                warn!("Server channel errored ({:?})", &e);
+                break;
+            }
+        }
+    });
 
     println!(
         "Server listening. Run `client {:?}`.\n\

--- a/rust/scx_stats/src/lib.rs
+++ b/rust/scx_stats/src/lib.rs
@@ -8,7 +8,8 @@ pub use stats::{
 
 mod server;
 pub use server::{
-    ScxStatsErrno, ScxStatsOps, ScxStatsRequest, ScxStatsResponse, ScxStatsServer, ToJson,
+    ScxStatsErrno, ScxStatsOps, ScxStatsRequest, ScxStatsResponse, ScxStatsServer, StatsCloser,
+    StatsOpener, StatsReader, StatsReaderSend, StatsReaderSync, ToJson,
 };
 
 mod client;

--- a/rust/scx_stats/src/lib.rs
+++ b/rust/scx_stats/src/lib.rs
@@ -7,7 +7,9 @@ pub use stats::{
 };
 
 mod server;
-pub use server::{ScxStatsErrno, ScxStatsRequest, ScxStatsResponse, ScxStatsServer, ToJson};
+pub use server::{
+    ScxStatsErrno, ScxStatsOps, ScxStatsRequest, ScxStatsResponse, ScxStatsServer, ToJson,
+};
 
 mod client;
 pub use client::ScxStatsClient;

--- a/rust/scx_stats/src/server.rs
+++ b/rust/scx_stats/src/server.rs
@@ -221,9 +221,9 @@ where
         line: String,
         data: &Arc<Mutex<ScxStatsServerData<Req, Res>>>,
         ch: &ChannelPair<Req, Res>,
+        open_ops: &mut ScxStatsOpenOps<Req, Res>,
     ) -> Result<ScxStatsResponse> {
         let req: ScxStatsRequest = serde_json::from_str(&line)?;
-        let mut open_ops = ScxStatsOpenOps::new();
 
         match req.req.as_str() {
             "stats" => {
@@ -263,6 +263,7 @@ where
         exit: Arc<AtomicBool>,
     ) -> Result<()> {
         let mut stream_reader = BufReader::new(stream.try_clone()?);
+        let mut open_ops = ScxStatsOpenOps::new();
 
         loop {
             let mut line = String::new();
@@ -275,7 +276,7 @@ where
                 return Ok(());
             }
 
-            let resp = match Self::handle_request(line, &data, &inner_ch) {
+            let resp = match Self::handle_request(line, &data, &inner_ch, &mut open_ops) {
                 Ok(v) => v,
                 Err(e) => {
                     let errno = match e.downcast_ref::<ScxStatsErrno>() {

--- a/rust/scx_stats/src/server.rs
+++ b/rust/scx_stats/src/server.rs
@@ -67,8 +67,8 @@ pub trait StatsCloser<Req, Res>: FnOnce((&Sender<Req>, &Receiver<Res>)) + Send {
 impl<Req, Res, T: FnOnce((&Sender<Req>, &Receiver<Res>)) + Send> StatsCloser<Req, Res> for T {}
 
 pub struct ScxStatsOps<Req, Res> {
-    open: Box<dyn StatsOpener<Req, Res>>,
-    close: Option<Box<dyn StatsCloser<Req, Res>>>,
+    pub open: Box<dyn StatsOpener<Req, Res>>,
+    pub close: Option<Box<dyn StatsCloser<Req, Res>>>,
 }
 
 struct ScxStatsOpenOps<Req, Res> {

--- a/scheds/rust/scx_layered/Cargo.lock
+++ b/scheds/rust/scx_layered/Cargo.lock
@@ -339,10 +339,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1007,6 +1048,7 @@ name = "scx_stats"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "crossbeam",
  "libc",
  "log",
  "quote",

--- a/scheds/rust/scx_layered/Cargo.lock
+++ b/scheds/rust/scx_layered/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
  "bitvec",
  "chrono",
  "clap",
+ "crossbeam",
  "ctrlc",
  "fb_procfs",
  "lazy_static",

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.65"
 bitvec = "1.0"
 chrono = "0.4"
 clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
+crossbeam = "0.8.4"
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7"
 lazy_static = "1.4"

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -671,7 +671,8 @@ impl Stats {
 
     fn new(skel: &mut BpfSkel, proc_reader: &procfs::ProcReader) -> Result<Self> {
         let nr_layers = skel.maps.rodata_data.nr_layers as usize;
-        let bpf_stats = BpfStats::read(&read_cpu_ctxs(skel)?, nr_layers);
+        let cpu_ctxs = read_cpu_ctxs(skel)?;
+        let bpf_stats = BpfStats::read(&cpu_ctxs, nr_layers);
 
         Ok(Self {
             at: Instant::now(),
@@ -684,7 +685,7 @@ impl Stats {
 
             total_util: 0.0,
             layer_utils: vec![0.0; nr_layers],
-            prev_layer_cycles: vec![0; nr_layers],
+            prev_layer_cycles: Self::read_layer_cycles(&cpu_ctxs, nr_layers),
 
             cpu_busy: 0.0,
             prev_total_cpu: read_total_cpu(&proc_reader)?,

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -341,11 +341,7 @@ pub struct SysStats {
 }
 
 impl SysStats {
-    pub fn new(
-        stats: &Stats,
-        bstats: &BpfStats,
-        fallback_cpu: usize,
-    ) -> Result<Self> {
+    pub fn new(stats: &Stats, bstats: &BpfStats, fallback_cpu: usize) -> Result<Self> {
         let lsum = |idx| stats.bpf_stats.lstats_sums[idx as usize];
         let total = lsum(bpf_intf::layer_stat_idx_LSTAT_SEL_LOCAL)
             + lsum(bpf_intf::layer_stat_idx_LSTAT_ENQ_WAKEUP)

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -344,8 +344,7 @@ impl SysStats {
     pub fn new(
         stats: &Stats,
         bstats: &BpfStats,
-        intv: &Duration,
-        proc_dur: &Duration,
+        intv: Duration,
         fallback_cpu: usize,
     ) -> Result<Self> {
         let lsum = |idx| stats.bpf_stats.lstats_sums[idx as usize];
@@ -375,7 +374,7 @@ impl SysStats {
                 / total as f64,
             excl_wakeup: bstats.gstats[bpf_intf::global_stat_idx_GSTAT_EXCL_WAKEUP as usize] as f64
                 / total as f64,
-            proc_ms: proc_dur.as_millis() as u64,
+            proc_ms: stats.processing_dur.as_millis() as u64,
             busy: stats.cpu_busy * 100.0,
             util: stats.total_util * 100.0,
             load: stats.total_load,

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -44,7 +44,7 @@ fn fmt_num(v: u64) -> String {
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
-#[stat(_om_prefix = "l_", _om_label="layer_name")]
+#[stat(_om_prefix = "l_", _om_label = "layer_name")]
 pub struct LayerStats {
     #[stat(desc = "layer: CPU utilization (100% means one full CPU)")]
     pub util: f64,
@@ -429,16 +429,15 @@ impl SysStats {
     }
 }
 
-pub fn launch_server(sys_stats: Arc<Mutex<SysStats>>) -> Result<()> {
-    ScxStatsServer::new()
+pub fn launch_server(sys_stats: Arc<Mutex<SysStats>>) -> Result<ScxStatsServer<(), ()>> {
+    Ok(ScxStatsServer::<(), ()>::new()
         .add_stats_meta(LayerStats::meta())
         .add_stats_meta(SysStats::meta())
         .add_stats(
             "top",
-            Box::new(move |_| sys_stats.lock().unwrap().to_json()),
+            Box::new(move |_, _| sys_stats.lock().unwrap().to_json()),
         )
-        .launch()?;
-    Ok(())
+        .launch()?)
 }
 
 pub fn monitor(shutdown: Arc<AtomicBool>) -> Result<()> {


### PR DESCRIPTION
Currently, scx_layered generates stats at a fixed interval and every stats client reads out the content of the latest update. This means that a client whose poll interval is longer than the scheduler's would see sampled stats (e.g. the average and nr_cpus ranges wouldn't represent the whole period) and a client with shorter poll interval may see the same outputs repeated.

This PR implements `ScxStatsServer::add_stats_ops()` which enables the user to specify `open()` and `close()` closures. The `open()` closure creates a `read()` closure per client session which can carry mutable states. In addition, it provides multiplexed communication channels between the clients and the server user which can be useful when implementing stateful stats generation.

`scx_layered` is updated to make use of the new feature. After this PR, every client always gets accurate stats, including the time averages and period nr_layer_cpus min/max tracking, independent of each other.