### PR TITLE
scx_layered: Fix core selection

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1069,39 +1069,22 @@ impl Layer {
             }
         }
 
-        let mut nodes = topo.nodes().iter().collect::<Vec<_>>().clone();
-        let num_nodes = nodes.len();
         let is_left = idx % 2 == 0;
         let rot_by = |idx, len| -> usize { if idx <= len { idx } else { idx % len } };
-        if is_left {
-            nodes.rotate_left(rot_by(idx, num_nodes));
-        } else {
-            nodes.rotate_right(rot_by(idx, num_nodes));
-        }
 
         let mut core_order = vec![];
-        for node in nodes.iter() {
-            let mut llcs = node.llcs().clone().into_values().collect::<Vec<_>>().clone();
-            let num_llcs = llcs.len();
-            if is_left {
-                llcs.rotate_left(rot_by(idx, num_llcs));
-            } else {
-                llcs.rotate_right(rot_by(idx, num_llcs));
-            }
+        for i in 0..topo.cores().len() {
+            core_order.push(i);
+        }
 
-            for llc in llcs.iter() {
-                let mut llc_cores = llc.cores().clone().into_values().collect::<Vec<_>>().clone();
-                let num_cores = llc_cores.len();
-
+        for node in topo.nodes().iter() {
+            for (_, llc) in node.llcs() {
+                let llc_cores = llc.cores().len();
+                let rot = rot_by(llc_cores + (idx << 1), llc_cores);
                 if is_left {
-                    llc_cores.rotate_left(rot_by(idx, num_cores));
+                    core_order.rotate_left(rot);
                 } else {
-                    llc_cores.rotate_right(rot_by(idx, num_cores));
-                }
-
-
-                for llc_core in llc_cores.iter() {
-                    core_order.push(llc_core.id());
+                    core_order.rotate_right(rot);
                 }
             }
         }


### PR DESCRIPTION
Fix a bug introduced in #510 where it assumed core ids are incremental. This refactors the core ordering for layers to be far more simple and provide some space for layer core isolation in low utilization.


Tested by adding some logs on the core selection values:
```
$ sudo ./bin_local/bin/scx_layered --monitor 5 f:user.json -vvv 2>&1 | grep xxx
02:25:45 [TRACE] xxx layer random cores 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 
02:25:45 [TRACE] xxx layer hodgesd cores 36, 37, 38, 39, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 
02:25:45 [TRACE] xxx layer stress-ng cores 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 0, 1, 2, 3, 4, 5, 6, 7, 
02:25:45 [TRACE] xxx layer normal cores 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 
```
Using the following config:
```
[{
  "name":"random",
  "comment":"random user",
  "matches":[
     [{"UIDEquals":1234}]
  ],
  "kind": {
    "Confined":{
      "nodes":[1],
      "util_range": [0.05, 0.7],
      "preempt": false,
      "exclusive": true
     }
  }
},
{
  "name":"hodgesd",
  "comment":"hodgesd user",
  "matches":[
     [{"UIDEquals":224791}]
  ],
  "kind": {
    "Confined":{
      "nodes":[1],
      "util_range": [0.05, 0.3],
      "exclusive": false
     }
  }
},{
  "name":"stress-ng",
  "comment":"stress-ng slice",
  "matches":[
     [
             {"CommPrefix":"stress-ng"}
     ],[
             {"PcommPrefix":"stress-ng"}
     ]],
  "kind": {
    "Confined":{
      "util_range": [0.05, 0.70],
      "nodes":[1],
      "exclusive": false
     }
  }
},
{
  "name":"normal",
  "comment":"the rest",
  "matches":[[]],
  "kind":{
    "Grouped": {
      "util_range": [0.05, 0.7],
      "preempt": true,
      "exclusive": true,
      "nodes":[0]
    }
  }
}]
```
`stress-ng` run as user:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/c757c90f-6d5d-4046-a517-4bf93b7bd950">
`stress-ng` run as root:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0a91ddb5-7713-4b0a-bedd-30e7bbfa4798">