### PR TITLE
scx_utils::cpumask,topology: Misc updates

### DIFF
--- a/rust/scx_utils/build.rs
+++ b/rust/scx_utils/build.rs
@@ -9,7 +9,8 @@ include!("src/builder.rs");
 fn main() {
     Builder::new().build();
     EmitBuilder::builder()
-        .all_git()
+        .git_sha(true)
+        .git_dirty(true)
         .cargo_target_triple()
         .emit()
         .unwrap();

--- a/rust/scx_utils/src/bpf_builder.rs
+++ b/rust/scx_utils/src/bpf_builder.rs
@@ -337,11 +337,10 @@ impl BpfBuilder {
         };
 
         // Assemble cflags.
-        let mut cflags: Vec<String> =
-            ["-g", "-O2", "-Wall", "-Wno-compare-distinct-pointer-types"]
-                .into_iter()
-                .map(|x| x.into())
-                .collect();
+        let mut cflags: Vec<String> = ["-g", "-O2", "-Wall", "-Wno-compare-distinct-pointer-types"]
+            .into_iter()
+            .map(|x| x.into())
+            .collect();
         cflags.push(format!("-D__TARGET_ARCH_{}", &kernel_target));
         cflags.push("-mcpu=v3".into());
         cflags.push(format!("-m{}-endian", endian));
@@ -487,14 +486,13 @@ impl BpfBuilder {
         // Tell cargo to invalidate the built crate whenever the wrapper changes
         deps.insert(input.to_string());
 
-	// FIXME - bindgen's API changed between 0.68 and 0.69 so that
-	// `bindgen::CargoCallbacks::new()` should be used instead of
-	// `bindgen::CargoCallbacks`. Unfortunately, as of Dec 2023, fedora
-	// is shipping 0.68. To accommodate fedora, allow both 0.68 and 0.69
-	// of bindgen and suppress deprecation warning. Remove the following
-	// once fedora can be updated to bindgen >= 0.69.
-	#[allow(deprecated)]
-
+        // FIXME - bindgen's API changed between 0.68 and 0.69 so that
+        // `bindgen::CargoCallbacks::new()` should be used instead of
+        // `bindgen::CargoCallbacks`. Unfortunately, as of Dec 2023, fedora
+        // is shipping 0.68. To accommodate fedora, allow both 0.68 and 0.69
+        // of bindgen and suppress deprecation warning. Remove the following
+        // once fedora can be updated to bindgen >= 0.69.
+        #[allow(deprecated)]
         // The bindgen::Builder is the main entry point to bindgen, and lets
         // you build up options for the resulting bindings.
         let bindings = bindgen::Builder::default()

--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -119,10 +119,7 @@ impl Cpumask {
             }
         }
 
-        Ok(Self {
-            mask,
-            nr_cpus,
-        })
+        Ok(Self { mask, nr_cpus })
     }
 
     /// Return a slice of u64's whose bits reflect the Cpumask.
@@ -170,12 +167,8 @@ impl Cpumask {
     /// exceeds the number of possible CPUs on the host, false is returned.
     pub fn test_cpu(&self, cpu: usize) -> bool {
         match self.mask.get(cpu) {
-            Some(bit) => {
-                *bit
-            }
-            None => {
-                false
-            }
+            Some(bit) => *bit,
+            None => false,
         }
     }
 
@@ -331,7 +324,10 @@ impl IntoIterator for Cpumask {
     type IntoIter = CpumaskIntoIterator;
 
     fn into_iter(self) -> CpumaskIntoIterator {
-        CpumaskIntoIterator { mask: self, index: 0 }
+        CpumaskIntoIterator {
+            mask: self,
+            index: 0,
+        }
     }
 }
 

--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -195,19 +195,6 @@ impl Cpumask {
     }
 }
 
-impl fmt::Display for Cpumask {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let slice = self.as_raw_slice();
-        let mut remaining_width = *NR_CPU_IDS + 2;
-        write!(f, "{:#0width$b}", slice[0], width = remaining_width.min(66))?;
-        for submask in &slice[1..] {
-            remaining_width -= 64;
-            write!(f, "{:0width$b}", submask, width = remaining_width.min(64))?;
-        }
-        Ok(())
-    }
-}
-
 impl Cpumask {
     fn fmt_with(&self, f: &mut fmt::Formatter<'_>, case: char) -> fmt::Result {
         let mut masks: Vec<u32> = self
@@ -240,6 +227,12 @@ impl Cpumask {
             }
         }
         Ok(())
+    }
+}
+
+impl fmt::Display for Cpumask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_with(f, 'x')
     }
 }
 

--- a/rust/scx_utils/src/infeasible.rs
+++ b/rust/scx_utils/src/infeasible.rs
@@ -287,7 +287,7 @@ impl LoadAggregator {
         if !self.dcycle_only && approx_ge(self.max_weight as f64, self.infeasible_threshold()) {
             self.adjust_infeas_weights();
         }
-        
+
         let mut dom_load_sums = Vec::new();
         let mut dom_dcycle_sums = Vec::new();
 
@@ -310,10 +310,14 @@ impl LoadAggregator {
     /// for a given (Domain, weight) tuple.
     pub fn record_dom_load(&mut self, dom_id: usize, weight: usize, dcycle: f64) -> Result<()> {
         if weight < MIN_WEIGHT {
-            bail!("weight {} is less than minimum weight {}", weight, MIN_WEIGHT);
+            bail!(
+                "weight {} is less than minimum weight {}",
+                weight,
+                MIN_WEIGHT
+            );
         }
 
-        let domain = self.doms.entry(dom_id).or_insert(Domain{
+        let domain = self.doms.entry(dom_id).or_insert(Domain {
             loads: BTreeMap::new(),
             dcycle_sum: 0.0f64,
             load_sum: 0.0f64,

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -30,8 +30,8 @@
 //! Utility modules which can be useful for userspace component of sched_ext
 //! schedulers.
 
-pub use paste::paste;
 pub use log::warn;
+pub use paste::paste;
 
 mod bindings;
 
@@ -42,12 +42,12 @@ mod builder;
 pub use builder::Builder;
 
 mod user_exit_info;
-pub use user_exit_info::ScxExitKind;
 pub use user_exit_info::ScxConsts;
-pub use user_exit_info::SCX_ECODE_RSN_HOTPLUG;
-pub use user_exit_info::SCX_ECODE_ACT_RESTART;
+pub use user_exit_info::ScxExitKind;
 pub use user_exit_info::UeiDumpPtr;
 pub use user_exit_info::UserExitInfo;
+pub use user_exit_info::SCX_ECODE_ACT_RESTART;
+pub use user_exit_info::SCX_ECODE_RSN_HOTPLUG;
 pub use user_exit_info::UEI_DUMP_PTR_MUTEX;
 
 pub mod build_id;

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -65,6 +65,8 @@ pub use topology::Cpu;
 pub use topology::Node;
 pub use topology::Topology;
 pub use topology::TopologyMap;
+pub use topology::NR_CPU_IDS;
+pub use topology::NR_CPUS_POSSIBLE;
 
 mod cpumask;
 pub use cpumask::Cpumask;

--- a/rust/scx_utils/src/libbpf_logger.rs
+++ b/rust/scx_utils/src/libbpf_logger.rs
@@ -3,7 +3,7 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
-use libbpf_rs::{PrintLevel, set_print};
+use libbpf_rs::{set_print, PrintLevel};
 
 fn print_to_log(level: PrintLevel, msg: String) {
     match level {
@@ -13,8 +13,6 @@ fn print_to_log(level: PrintLevel, msg: String) {
     }
 }
 
-pub fn init_libbpf_logging(
-    level: Option<PrintLevel>,
-) {
+pub fn init_libbpf_logging(level: Option<PrintLevel>) {
     set_print(Some((level.unwrap_or(PrintLevel::Debug), print_to_log)));
 }

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -263,7 +263,15 @@ impl Topology {
 
         let nr_cpus_possible = libbpf_rs::num_possible_cpus().unwrap();
         let nr_cpus_online = span.weight();
-        Ok(Topology { nodes, cores, cpus, span, nr_cpus_possible, nr_cpus_online, nr_cpu_ids, })
+        Ok(Topology {
+            nodes,
+            cores,
+            cpus,
+            span,
+            nr_cpus_possible,
+            nr_cpus_online,
+            nr_cpu_ids,
+        })
     }
 
     /// Get a slice of the NUMA nodes on the host.
@@ -348,7 +356,7 @@ impl TopologyMap {
             map.push(cpu_ids);
         }
 
-        Ok(TopologyMap { map, })
+        Ok(TopologyMap { map })
     }
 
     pub fn iter(&self) -> Iter<Vec<usize>> {
@@ -384,12 +392,10 @@ fn cpus_online() -> Result<Cpumask> {
     for group in online_groups.iter() {
         let (min, max) = match sscanf!(group.trim(), "{usize}-{usize}") {
             Ok((x, y)) => (x, y),
-            Err(_) => {
-                match sscanf!(group.trim(), "{usize}") {
-                    Ok(x) => (x, x),
-                    Err(_) => {
-                        bail!("Failed to parse online cpus {}", group.trim());
-                    }
+            Err(_) => match sscanf!(group.trim(), "{usize}") {
+                Ok(x) => (x, x),
+                Err(_) => {
+                    bail!("Failed to parse online cpus {}", group.trim());
                 }
             },
         };
@@ -436,13 +442,13 @@ fn create_insert_cpu(cpu_id: usize, node: &mut Node, online_mask: &Cpumask) -> R
     let max_freq = read_file_usize(&freq_path.join("scaling_max_freq")).unwrap_or(0);
     let trans_lat_ns = read_file_usize(&freq_path.join("cpuinfo_transition_latency")).unwrap_or(0);
 
-    let cache = node.llcs.entry(llc_id).or_insert(Cache{
+    let cache = node.llcs.entry(llc_id).or_insert(Cache {
         id: llc_id,
         cores: BTreeMap::new(),
         span: Cpumask::new()?,
     });
 
-    let core = cache.cores.entry(core_id).or_insert(Core{
+    let core = cache.cores.entry(core_id).or_insert(Core {
         id: core_id,
         cpus: BTreeMap::new(),
         span: Cpumask::new()?,

--- a/scheds/rust/scx_rusty/Cargo.lock
+++ b/scheds/rust/scx_rusty/Cargo.lock
@@ -215,9 +215,9 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "camino"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3054fea8a20d8ff3968d5b22cc27501d2b08dc4decdb31b184323f00c5ef23bb"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68064e60dbf1f17005c2fde4d07c16d8baa506fd7ffed8ccab702d93617975c7"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
  "jobserver",
  "libc",
@@ -588,9 +588,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.156"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"
@@ -1353,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+checksum = "04182dffc9091a404e0fc069ea5cd60e5b866c3adf881eff99a32d048242dffa"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -1643,9 +1643,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1765,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1895,9 +1895,9 @@ checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
 name = "untrusted"

--- a/scheds/rust/scx_rusty/src/domain.rs
+++ b/scheds/rust/scx_rusty/src/domain.rs
@@ -3,7 +3,6 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -49,7 +48,7 @@ pub struct DomainGroup {
 }
 
 impl DomainGroup {
-    pub fn new(top: Arc<Topology>, cpumasks: &[String]) -> Result<Self> {
+    pub fn new(top: &Topology, cpumasks: &[String]) -> Result<Self> {
         let mut span = Cpumask::new()?;
         let mut dom_numa_map = BTreeMap::new();
         // Track the domain ID separate from the LLC ID, because LLC IDs can

--- a/scheds/rust/scx_rusty/src/domain.rs
+++ b/scheds/rust/scx_rusty/src/domain.rs
@@ -62,7 +62,7 @@ impl DomainGroup {
             for mask_str in cpumasks.iter() {
                 let mask = Cpumask::from_str(&mask_str)?;
                 span |= mask.clone();
-                doms.insert(dom_id, Domain { id: dom_id, mask, });
+                doms.insert(dom_id, Domain { id: dom_id, mask });
                 dom_numa_map.insert(dom_id, 0);
                 dom_id += 1;
             }
@@ -73,7 +73,7 @@ impl DomainGroup {
                 for (_, llc) in node.llcs().iter() {
                     let mask = llc.span().clone();
                     span |= mask.clone();
-                    doms.insert(dom_id, Domain { id: dom_id, mask, });
+                    doms.insert(dom_id, Domain { id: dom_id, mask });
                     dom_numa_map.insert(dom_id, node_id.clone());
                     dom_id += 1;
                 }
@@ -88,7 +88,13 @@ impl DomainGroup {
             }
         }
 
-        Ok(Self { doms, cpu_dom_map, dom_numa_map, num_numa_nodes, span })
+        Ok(Self {
+            doms,
+            cpu_dom_map,
+            dom_numa_map,
+            num_numa_nodes,
+            span,
+        })
     }
 
     pub fn numa_doms(&self, numa_id: &usize) -> Vec<Domain> {

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -207,6 +207,10 @@ struct Opts {
     #[clap(short = 'v', long, action = clap::ArgAction::Count)]
     verbose: u8,
 
+    /// Print version and exit.
+    #[clap(long)]
+    version: bool,
+
     /// Enable the Prometheus endpoint for metrics on port 9000.
     #[clap(long, action = clap::ArgAction::SetTrue)]
     enable_prometheus: bool,
@@ -657,6 +661,11 @@ impl<'a> Drop for Scheduler<'a> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if opts.version {
+        println!("scx_rusty: {}", *build_id::SCX_FULL_VERSION);
+        return Ok(());
+    }
 
     let llv = match opts.verbose {
         0 => simplelog::LevelFilter::Info,


### PR DESCRIPTION
- Formatting.
- Use nr_cpu_ids where necessary.
- Always use lazy constants `NR_CPU_IDS` and `NR_CPUS_POSSIBLE` 
- Make cpumask default to printing in hex.