### PR TITLE
scx_bpfland: properly classify Intel Turbo Boost CPUs

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -82,6 +82,7 @@ pub struct Cpu {
     id: usize,
     min_freq: usize,
     max_freq: usize,
+    base_freq: usize,
     trans_lat_ns: usize,
     l2_id: usize,
     l3_id: usize,
@@ -102,6 +103,14 @@ impl Cpu {
     /// Get the maximum scaling frequency of this CPU
     pub fn max_freq(&self) -> usize {
         self.max_freq
+    }
+
+    /// Get the base operational frequency of this CPU
+    ///
+    /// This is only available on Intel Turbo Boost CPUs, if not available this will simply return
+    /// maximum frequency.
+    pub fn base_freq(&self) -> usize {
+        self.base_freq
     }
 
     /// Get the transition latency of the CPU in nanoseconds
@@ -434,6 +443,7 @@ fn create_insert_cpu(cpu_id: usize, node: &mut Node, online_mask: &Cpumask) -> R
     let freq_path = cpu_path.join("cpufreq");
     let min_freq = read_file_usize(&freq_path.join("scaling_min_freq")).unwrap_or(0);
     let max_freq = read_file_usize(&freq_path.join("scaling_max_freq")).unwrap_or(0);
+    let base_freq = read_file_usize(&freq_path.join("base_frequency")).unwrap_or(max_freq);
     let trans_lat_ns = read_file_usize(&freq_path.join("cpuinfo_transition_latency")).unwrap_or(0);
 
     let cache = node.llcs.entry(llc_id).or_insert(Cache{
@@ -454,6 +464,7 @@ fn create_insert_cpu(cpu_id: usize, node: &mut Node, online_mask: &Cpumask) -> R
             id: cpu_id,
             min_freq: min_freq,
             max_freq: max_freq,
+            base_freq: base_freq,
             trans_lat_ns: trans_lat_ns,
             l2_id: l2_id,
             l3_id: l3_id,

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -53,11 +53,12 @@ const SCHEDULER_NAME: &'static str = "scx_bpfland";
 fn get_primary_cpus(powersave: bool) -> std::io::Result<Vec<usize>> {
     let topo = Topology::new().unwrap();
 
-    // Iterate over each CPU directory and collect CPU ID and its max frequency.
+    // Iterate over each CPU directory and collect CPU ID and its base operational frequency to
+    // distinguish between fast and slow cores.
     let mut cpu_freqs = Vec::new();
     for core in topo.cores().into_iter() {
         for (cpu_id, cpu) in core.cpus() {
-            cpu_freqs.push((*cpu_id, cpu.max_freq()));
+            cpu_freqs.push((*cpu_id, cpu.base_freq()));
         }
     }
     if cpu_freqs.is_empty() {


### PR DESCRIPTION
With Intel Turbo Boost enabled, some CPUs might show a higher maximum frequency than others, even if they are not actually faster cores.

Instead of relying on the maximum frequency to classify fast and slow cores, use the base frequency, that ensures a more accurate distinction between Intel Turbo Boost CPUs and genuinely faster CPUs.

With this change, bpfland can correctly use all CPUs as the primary scheduling domain in non-hybrid architectures when using `--primary-domain performance`, instead of only selecting the subset of turbo boost-ed CPUs.