### PR TITLE
scx_utils::topology: Use lazy_static instead of LazyLock

### DIFF
--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -65,8 +65,8 @@ pub use topology::Cpu;
 pub use topology::Node;
 pub use topology::Topology;
 pub use topology::TopologyMap;
-pub use topology::NR_CPU_IDS;
 pub use topology::NR_CPUS_POSSIBLE;
+pub use topology::NR_CPU_IDS;
 
 mod cpumask;
 pub use cpumask::Cpumask;


### PR DESCRIPTION
LazyLock is stable but has become so only very recently and can trigger build errors on not-too-old stable rustc's which are still in wide use. Let's use lazy_static instead for now.