### PR TITLE
scx_bpfland: drop unused variable

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -328,7 +328,7 @@ impl<'a> Scheduler<'a> {
         let topo = Topology::new().unwrap();
 
         // Initialize the primary scheduling domain (based on the --primary-domain option).
-        Self::init_primary_domain(&mut skel, &topo, &opts.primary_domain)?;
+        Self::init_primary_domain(&mut skel, &opts.primary_domain)?;
 
         // Initialize L2 cache domains.
         if !opts.disable_l2 {
@@ -383,7 +383,6 @@ impl<'a> Scheduler<'a> {
 
     fn init_primary_domain(
         skel: &mut BpfSkel<'_>,
-        topo: &Topology,
         primary_domain: &Cpumask,
     ) -> Result<()> {
         info!("primary CPU domain = 0x{:x}", primary_domain);


### PR DESCRIPTION
With the global scx_utils::NR_CPU_IDS we don't need Topology anymore in init_primary_domain(), so drop the variable to fix the following build warning:

warning: unused variable: `topo`
   --> src/main.rs:385:9
    |
385 |         topo: &Topology,
    |         ^^^^ help: if this is intentional, prefix it with an underscore: `_topo`
    |
    = note: `#[warn(unused_variables)]` on by default

Fixes: 1da249f ("scx_utils::topology: Always use NR_CPU_IDS and NR_CPUS_POSSIBLE")