### PR TITLE
scx-scheds: set scx_bpfland as default scheduler

### DIFF
--- a/services/scx
+++ b/services/scx
@@ -1,5 +1,5 @@
 # List of scx_schedulers: scx_bpfland scx_central scx_lavd scx_layered scx_nest scx_qmap scx_rlfifo scx_rustland scx_rusty scx_simple scx_userland
-SCX_SCHEDULER=scx_rusty
+SCX_SCHEDULER=scx_bpfland
 
 # Set custom flags for each scheduler, below is an example of how to use
-#SCX_FLAGS='-u 3000 -i 0.5 -I 0.025 -l 0.5 -b -k'
+#SCX_FLAGS='-s 20000 -S 1000 -c 0 -k'


### PR DESCRIPTION
After discussion with @arighi and @htejun  we came to the conclusion that the default scheduler should be one that is actively developed. For various reasons, rusty has ceased to be actively developed, while currently the most developed scheduler that guarantees both extremely good performance seems to be bpfland. 

In addition, @arighi suggested that after enabling more PRs, it would be good to set the following flags as suggested

```
--lowlatency --primary-domain auto
```