### PR TITLE
scx_layered: Add pid/ppid matches

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -109,6 +109,8 @@ enum layer_match_kind {
 	MATCH_NICE_EQUALS,
 	MATCH_USER_ID_EQUALS,
 	MATCH_GROUP_ID_EQUALS,
+	MATCH_PID_EQUALS,
+	MATCH_PPID_EQUALS,
 
 	NR_LAYER_MATCH_KINDS,
 };
@@ -121,6 +123,8 @@ struct layer_match {
 	int		nice;
 	u32		user_id;
 	u32		group_id;
+	u32		pid;
+	u32		ppid;
 };
 
 struct layer_match_ands {

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1014,6 +1014,10 @@ static __noinline bool match_one(struct layer_match *match,
 			result = cred->egid.val == match->group_id;
 		bpf_rcu_read_unlock();
 		return result;
+	case MATCH_PID_EQUALS:
+		return p->pid == match->pid;
+	case MATCH_PPID_EQUALS:
+		return p->real_parent->pid == match->ppid;
 	default:
 		scx_bpf_error("invalid match kind %d", match->kind);
 		return result;
@@ -1614,6 +1618,12 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(layered_init)
 					break;
 				case MATCH_GROUP_ID_EQUALS:
 					dbg("%s GROUP_ID %u", header, match->group_id);
+					break;
+				case MATCH_PID_EQUALS:
+					dbg("%s PID %u", header, match->pid);
+					break;
+				case MATCH_PPID_EQUALS:
+					dbg("%s PPID %u", header, match->ppid);
 					break;
 				default:
 					scx_bpf_error("%s Invalid kind", header);

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -195,9 +195,13 @@ lazy_static::lazy_static! {
 /// - NiceEquals: Matches if the task's nice value is exactly equal to
 ///   the pattern.
 ///
-/// - UIDEquals: Matches if the task's effective user id matches the pattern.
+/// - UIDEquals: Matches if the task's effective user id matches the value
 ///
-/// - GIDEquals: Matches if the task's effective group id matches the pattern.
+/// - GIDEquals: Matches if the task's effective group id matches the value.
+///
+/// - PIDEquals: Matches if the task's pid matches the value.
+///
+/// - PPIDEquals: Matches if the task's ppid matches the value.
 ///
 /// While there are complexity limitations as the matches are performed in
 /// BPF, it is straightforward to add more types of matches.
@@ -423,6 +427,8 @@ enum LayerMatch {
     NiceEquals(i32),
     UIDEquals(u32),
     GIDEquals(u32),
+    PIDEquals(u32),
+    PPIDEquals(u32),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1415,6 +1421,14 @@ impl<'a, 'b> Scheduler<'a, 'b> {
                         LayerMatch::GIDEquals(group_id) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_GROUP_ID_EQUALS as i32;
                             mt.group_id = *group_id;
+                        }
+                        LayerMatch::PIDEquals(pid) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_PID_EQUALS as i32;
+                            mt.pid = *pid;
+                        }
+                        LayerMatch::PPIDEquals(ppid) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_PPID_EQUALS as i32;
+                            mt.ppid = *ppid;
                         }
                     }
                 }


### PR DESCRIPTION
Add matches for pid/ppid.

tested with config:
```
[{
  "name":"pid 1",
  "comment":"pid 1",
  "matches":[
     [
	     {"PIDEquals":1}
     ]
  ],
  "kind": {
    "Confined":{
      "util_range": [0.04, 0.50]
     }
  }
},{
  "name":"ppid 1",
  "comment":"ppid 1",
  "matches":[
     [{"PPIDEquals":1}]
  ],
  "kind": {
    "Confined":{
      "util_range": [0.01, 0.20]
     }
  }
},
{
  "name":"the rest",
  "comment":"the rest",
  "matches":[[]],
  "kind":{
    "Grouped": {
      "util_range": [0.05, 0.60]
    }
  }
}]
```
`scx_layered` output:
```
tot=  54903 local=84.96 open_idle= 3.78 affn_viol= 0.00 proc=122ms
busy=  0.8 util=  131.6 load=    363.4 fallback_cpu= 12
excl_coll=0 excl_preempt=0 excl_idle=0 excl_wakeup=0
  pid 1   : util/frac=    0.1/  0.0 load/frac=      0.0:  0.0 tasks=     1
            tot=      4 local=100.0 wake/exp/last/reenq= 0.00/ 0.00/ 0.00/ 0.00
            keep/max/busy= 0.00/ 0.00/ 0.00 kick= 0.00 yield/ign= 0.00/    0 
            open_idle= 0.00 mig= 0.00 affn_viol= 0.00
            preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
            cpus=  2 [  2,  2] 00000030 00000000 00000000 00000000 00000000 00000000
  ppid 1  : util/frac=   84.6/ 64.2 load/frac=     98.9: 27.2 tasks=  2918
            tot=  44544 local=87.68 wake/exp/last/reenq= 9.80/ 0.03/ 2.46/ 0.03
            keep/max/busy= 0.08/ 0.00/ 0.00 kick= 0.03 yield/ign= 2.41/    0 
            open_idle= 0.00 mig=27.17 affn_viol= 0.00
            preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
            cpus=  8 [  8, 12] 00000ccf 00000000 00000000 00000000 00000000 00000000
  the rest: util/frac=   47.0/ 35.7 load/frac=    264.5: 72.8 tasks=  1129
            tot=  10355 local=73.25 wake/exp/last/reenq=15.48/ 3.01/ 8.23/ 0.03
            keep/max/busy= 0.23/ 0.00/ 0.00 kick= 3.03 yield/ign= 8.18/    0 
            open_idle=20.05 mig=24.16 affn_viol= 0.00
            preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
            cpus=  2 [  2,  4] 00000300 00000000 00000000 00000000 00000000 00000000
^C16:09:40 [INFO] EXIT: BPF scheduler unregistered
```