### PR TITLE
scx_bpfland: cpu frequency and energy awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,3 +410,4 @@ sched_ext in various ways. Followings are some examples:
 - [Changwoo's blog: sched_ext: a BPF-extensible scheduler class (Part 1) (December, 2023)](https://blogs.igalia.com/changwoo/sched-ext-a-bpf-extensible-scheduler-class-part-1/)
 - [arighi's blog: Getting started with sched-ext development (April, 2024)](https://arighi.blogspot.com/2024/04/getting-started-with-sched-ext.html)
 - [Changwoo's blog: sched_ext: scheduler architecture and interfaces (Part 2) (June, 2024)](https://blogs.igalia.com/changwoo/sched-ext-scheduler-architecture-and-interfaces-part-2/)
+- [arighi's YT channel: scx_bpfland Linux scheduler demo: topology awareness (August, 2024)](https://youtu.be/R-FEZOveG-I)

--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -168,6 +168,16 @@ impl Cpumask {
         self.mask.count_ones()
     }
 
+    /// Return true if the Cpumask has no bit set, false otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.mask.count_ones() == 0
+    }
+
+    /// Return true if the Cpumask has all bits set, false otherwise.
+    pub fn is_full(&self) -> bool {
+        self.mask.count_ones() == *NR_CPU_IDS
+    }
+
     /// The total size of the cpumask.
     pub fn len(&self) -> usize {
         *NR_CPU_IDS

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -1250,12 +1250,20 @@ int enable_primary_cpu(struct cpu_arg *input)
 	if (err)
 		return err;
 	/*
-	 * Enable the target CPU in the primary scheduling domain.
+	 * Enable the target CPU in the primary scheduling domain. If the
+	 * target CPU is a negative value, clear the whole mask (this can be
+	 * used to reset the primary domain).
 	 */
 	bpf_rcu_read_lock();
 	mask = primary_cpumask;
-	if (mask)
-		bpf_cpumask_set_cpu(input->cpu_id, mask);
+	if (mask) {
+		s32 cpu = input->cpu_id;
+
+		if (cpu < 0)
+			bpf_cpumask_clear(mask);
+		else
+			bpf_cpumask_set_cpu(cpu, mask);
+	}
 	bpf_rcu_read_unlock();
 
 	return err;

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -51,15 +51,24 @@ use scx_utils::NR_CPU_IDS;
 
 const SCHEDULER_NAME: &'static str = "scx_bpfland";
 
-fn get_primary_cpus(powersave: bool) -> std::io::Result<Vec<usize>> {
+#[derive(PartialEq)]
+enum Powermode {
+    Powersave,
+    Performance,
+    Turbo,
+}
+
+fn get_primary_cpus(mode: Powermode) -> std::io::Result<Vec<usize>> {
     let topo = Topology::new().unwrap();
 
     // Iterate over each CPU directory and collect CPU ID and its base operational frequency to
     // distinguish between fast and slow cores.
     let mut cpu_freqs = Vec::new();
+    let mut max_cpu_freqs = Vec::new();
     for core in topo.cores().into_iter() {
         for (cpu_id, cpu) in core.cpus() {
             cpu_freqs.push((*cpu_id, cpu.base_freq()));
+            max_cpu_freqs.push((*cpu_id, cpu.max_freq()));
         }
     }
     if cpu_freqs.is_empty() {
@@ -69,26 +78,35 @@ fn get_primary_cpus(powersave: bool) -> std::io::Result<Vec<usize>> {
     // Find the smallest maximum frequency.
     let min_freq = cpu_freqs.iter().map(|&(_, freq)| freq).min().unwrap();
 
+    // Find the highest maximum frequency.
+    let max_freq = max_cpu_freqs.iter().map(|&(_, freq)| freq).max().unwrap();
+
     // Check if all CPUs have the smallest frequency.
     let all_have_min_freq = cpu_freqs.iter().all(|&(_, freq)| freq == min_freq);
 
-    let selected_cpu_ids: Vec<usize> = if all_have_min_freq {
-        // If all CPUs have the smallest frequency, return all CPU IDs.
-        cpu_freqs.into_iter().map(|(cpu_id, _)| cpu_id).collect()
-    } else if powersave {
-        // If powersave is true, return the CPUs with the smallest frequency.
+    let selected_cpu_ids: Vec<usize> = if mode == Powermode::Turbo {
+        // Turbo: return the CPUs with the highest max frequency.
+        max_cpu_freqs
+            .into_iter()
+            .filter(|&(_, freq)| freq == max_freq)
+            .map(|(cpu_id, _)| cpu_id)
+            .collect()
+    } else if all_have_min_freq || mode == Powermode::Powersave {
+        // Powersave: return the CPUs with the smallest base frequency.
         cpu_freqs
             .into_iter()
             .filter(|&(_, freq)| freq == min_freq)
             .map(|(cpu_id, _)| cpu_id)
             .collect()
-    } else {
-        // If powersave is false, return the CPUs with the highest frequency.
+    } else if mode == Powermode::Performance {
+        // Performance: return the CPUs with a base frequency greater than the minimum.
         cpu_freqs
             .into_iter()
-            .filter(|&(_, freq)| freq != min_freq)
+            .filter(|&(_, freq)| freq > min_freq)
             .map(|(cpu_id, _)| cpu_id)
             .collect()
+    } else {
+        Vec::new()
     };
 
     Ok(selected_cpu_ids)
@@ -126,11 +144,11 @@ fn cpus_to_cpumask(cpus: &Vec<usize>) -> String {
 fn parse_cpumask(cpu_str: &str) -> Result<Cpumask, anyhow::Error> {
     match cpu_str {
         "powersave" => {
-            let cpus = get_primary_cpus(true).unwrap();
+            let cpus = get_primary_cpus(Powermode::Powersave).unwrap();
             Cpumask::from_str(&cpus_to_cpumask(&cpus))
         }
         "performance" => {
-            let cpus = get_primary_cpus(false).unwrap();
+            let cpus = get_primary_cpus(Powermode::Performance).unwrap();
             Cpumask::from_str(&cpus_to_cpumask(&cpus))
         }
         "auto" => {
@@ -345,6 +363,9 @@ impl<'a> Scheduler<'a> {
 
         // Initialize the primary scheduling domain (based on the --primary-domain option).
         let energy_profile = Self::read_energy_profile();
+        if let Err(err) = Self::init_turbo_domain(&mut skel, &opts.primary_domain, &energy_profile) {
+            warn!("failed to initialize turbo domain: error {}", err);
+        }
         if let Err(err) = Self::init_energy_domain(&mut skel, &opts.primary_domain, &energy_profile) {
             warn!("failed to initialize primary domain: error {}", err);
         }
@@ -401,28 +422,6 @@ impl<'a> Scheduler<'a> {
         Ok(())
     }
 
-    fn init_primary_domain(
-        skel: &mut BpfSkel<'_>,
-        primary_domain: &Cpumask,
-    ) -> Result<()> {
-        info!("primary CPU domain = 0x{:x}", primary_domain);
-
-        // Clear the primary domain by passing a negative CPU id.
-        if let Err(err) = Self::enable_primary_cpu(skel, -1) {
-            warn!("failed to reset primary domain: error {}", err);
-        }
-        // Update primary scheduling domain.
-        for cpu in 0..*NR_CPU_IDS {
-            if primary_domain.test_cpu(cpu) {
-                if let Err(err) = Self::enable_primary_cpu(skel, cpu as i32) {
-                    warn!("failed to add CPU {} to primary domain: error {}", cpu, err);
-                }
-            }
-        }
-
-        Ok(())
-    }
-
     fn read_energy_profile() -> String {
         let res = File::open("/sys/devices/system/cpu/cpufreq/policy0/energy_performance_preference")
             .and_then(|mut file| {
@@ -434,11 +433,32 @@ impl<'a> Scheduler<'a> {
         res.unwrap_or_else(|_| "none".to_string())
     }
 
-    fn init_energy_domain(skel: &mut BpfSkel<'_>, primary_domain: &Cpumask, energy_profile: &String) -> Result<()> {
+    fn enable_turbo_cpu(skel: &mut BpfSkel<'_>, cpu: i32) -> Result<(), u32> {
+        let prog = &mut skel.progs.enable_turbo_cpu;
+        let mut args = cpu_arg {
+            cpu_id: cpu as c_int,
+        };
+        let input = ProgramInput {
+            context_in: Some(unsafe {
+                std::slice::from_raw_parts_mut(
+                    &mut args as *mut _ as *mut u8,
+                    std::mem::size_of_val(&args),
+                )
+            }),
+            ..Default::default()
+        };
+        let out = prog.test_run(input).unwrap();
+        if out.return_value != 0 {
+            return Err(out.return_value);
+        }
+
+        Ok(())
+    }
+
+    fn init_turbo_domain(skel: &mut BpfSkel<'_>, primary_domain: &Cpumask, energy_profile: &String) -> Result<()> {
         let domain = if primary_domain.is_empty() {
             let cpus = match energy_profile.as_str() {
-                "power" => get_primary_cpus(true).unwrap_or(Vec::new()),
-                "performance" => get_primary_cpus(false).unwrap_or(Vec::new()),
+                "balance_power" => get_primary_cpus(Powermode::Turbo).unwrap_or(Vec::new()),
                 &_ => Vec::new(),
             };
             if cpus.is_empty() {
@@ -451,17 +471,71 @@ impl<'a> Scheduler<'a> {
         } else {
             primary_domain.clone()
         };
-        Self::init_primary_domain(skel, &domain)?;
+
+        info!("Turbo CPU domain = 0x{:x}", domain);
+
+        // Clear the turbo domain by passing a negative CPU id.
+        if let Err(err) = Self::enable_turbo_cpu(skel, -1) {
+            warn!("failed to reset primary domain: error {}", err);
+        }
+        for cpu in 0..*NR_CPU_IDS {
+            if domain.test_cpu(cpu) {
+                if let Err(err) = Self::enable_turbo_cpu(skel, cpu as i32) {
+                    warn!("failed to add CPU {} to turbo domain: error {}", cpu, err);
+                }
+            }
+        }
 
         Ok(())
     }
 
-    fn refresh_energy_domain(&mut self) {
+    fn init_energy_domain(skel: &mut BpfSkel<'_>, primary_domain: &Cpumask, energy_profile: &String) -> Result<()> {
+        let domain = if primary_domain.is_empty() {
+            let cpus = match energy_profile.as_str() {
+                "power" => get_primary_cpus(Powermode::Powersave).unwrap_or(Vec::new()),
+                "balance_power" => get_primary_cpus(Powermode::Performance).unwrap_or(Vec::new()),
+                "balance_performance" => get_primary_cpus(Powermode::Performance).unwrap_or(Vec::new()),
+                "performance" => get_primary_cpus(Powermode::Performance).unwrap_or(Vec::new()),
+                &_ => Vec::new(),
+            };
+            if cpus.is_empty() {
+                let mut cpumask = Cpumask::new()?;
+                cpumask.setall();
+                cpumask
+            } else {
+                Cpumask::from_str(&cpus_to_cpumask(&cpus))?
+            }
+        } else {
+            primary_domain.clone()
+        };
+
+        info!("primary CPU domain = 0x{:x}", domain);
+
+        // Clear the primary domain by passing a negative CPU id.
+        if let Err(err) = Self::enable_primary_cpu(skel, -1) {
+            warn!("failed to reset primary domain: error {}", err);
+        }
+        // Update primary scheduling domain.
+        for cpu in 0..*NR_CPU_IDS {
+            if domain.test_cpu(cpu) {
+                if let Err(err) = Self::enable_primary_cpu(skel, cpu as i32) {
+                    warn!("failed to add CPU {} to primary domain: error {}", cpu, err);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn refresh_sched_domain(&mut self) {
         if self.opts.primary_domain.is_empty() {
             let energy_profile = Self::read_energy_profile();
             if energy_profile != self.energy_profile {
                 self.energy_profile = energy_profile.clone();
 
+                if let Err(err) = Self::init_turbo_domain(&mut self.skel, &self.opts.primary_domain, &energy_profile) {
+                    warn!("failed to refresh turbo domain: error {}", err);
+                }
                 if let Err(err) = Self::init_energy_domain(&mut self.skel, &self.opts.primary_domain, &energy_profile) {
                     warn!("failed to refresh primary domain: error {}", err);
                 }
@@ -634,7 +708,7 @@ impl<'a> Scheduler<'a> {
     fn run(&mut self, shutdown: Arc<AtomicBool>) -> Result<UserExitInfo> {
         while !shutdown.load(Ordering::Relaxed) && !self.exited() {
             self.refresh_cache_domains();
-            self.refresh_energy_domain();
+            self.refresh_sched_domain();
             self.update_stats();
             std::thread::sleep(Duration::from_millis(1000));
         }


### PR DESCRIPTION
A set of changes to make bpfland aware of the different CPU frequencies in the system (including P-cores, E-cores, Turbo Boost), as well as the energy profiles, and to adjust the primary scheduling domain based on this information.

The benefits of this change are explained in this video demo:
https://youtu.be/R-FEZOveG-I