### PR TITLE
scx-scheds: Update scx_bpfland suggested flags

### DIFF
--- a/services/scx
+++ b/services/scx
@@ -2,4 +2,4 @@
 SCX_SCHEDULER=scx_bpfland
 
 # Set custom flags for each scheduler, below is an example of how to use
-#SCX_FLAGS='-s 20000 -S 1000 -c 0 -k'
+#SCX_FLAGS='-s 20000 --lowlatency --primary-domain auto'


### PR DESCRIPTION
In PR #537, it was mentioned that the suggested flags can be updated when more PRs are enabled. #536 and #540 have been enabled, so let's take advantage of the benefits that @arighi has prepared for us