### PR TITLE
scx_stats, scx_rusty, scx_layered: Implement `--help-stats`

### DIFF
--- a/rust/scx_stats/examples/server.rs
+++ b/rust/scx_stats/examples/server.rs
@@ -49,8 +49,8 @@ fn main() {
     // and receives the formatted string just for demonstration.
     let server = ScxStatsServer::<ThreadId, String>::new()
         .set_path(&path)
-        .add_stats_meta(ClusterStats::meta())
-        .add_stats_meta(DomainStats::meta())
+        .add_meta(ClusterStats::meta())
+        .add_meta(DomainStats::meta())
         .add_stats(
             "top",
             Box::new(move |_args, (tx, rx)| {

--- a/rust/scx_stats/examples/server.rs
+++ b/rust/scx_stats/examples/server.rs
@@ -1,4 +1,4 @@
-use log::{debug, warn};
+use log::{debug, info, warn};
 use scx_stats::{Meta, ScxStatsServer, ToJson};
 use scx_stats_derive::Stats;
 use serde::{Deserialize, Serialize};
@@ -65,6 +65,9 @@ fn main() {
         .launch()
         .unwrap();
 
+    info!("stats_meta:");
+    server.describe_meta(&mut std::io::stderr(), None).unwrap();
+
     debug!("Doing unnecessary server channel handling");
     let (tx, rx) = server.channels();
     spawn(move || {
@@ -76,12 +79,9 @@ fn main() {
         }
     });
 
-    println!(
-        "Server listening. Run `client {:?}`.\n\
-         Use `socat - UNIX-CONNECT:{:?}` for raw connection.\n\
-         Press any key to exit.",
-        &path, &path,
-    );
+    info!("Server listening. Run `client {:?}`.", &path);
+    info!("Use `socat - UNIX-CONNECT:{:?}` for raw connection.", &path);
+    info!("Press any key to exit.");
 
     let mut buf: [u8; 1] = [0];
     let _ = std::io::stdin().read(&mut buf);

--- a/rust/scx_stats/src/lib.rs
+++ b/rust/scx_stats/src/lib.rs
@@ -8,8 +8,9 @@ pub use stats::{
 
 mod server;
 pub use server::{
-    ScxStatsErrno, ScxStatsOps, ScxStatsRequest, ScxStatsResponse, ScxStatsServer, StatsCloser,
-    StatsOpener, StatsReader, StatsReaderSend, StatsReaderSync, ToJson,
+    ScxStatsErrno, ScxStatsOps, ScxStatsRequest, ScxStatsResponse, ScxStatsServer,
+    ScxStatsServerData, StatsCloser, StatsOpener, StatsReader, StatsReaderSend, StatsReaderSync,
+    ToJson,
 };
 
 mod client;

--- a/rust/scx_stats/src/server.rs
+++ b/rust/scx_stats/src/server.rs
@@ -294,7 +294,13 @@ where
             Ok(())
         })?;
 
+        let mut first = true;
         self.visit_meta(from, &mut |m| {
+            if !first {
+                writeln!(w, "")?;
+            }
+            first = false;
+
             write!(w, "[{:nw$}]", m.name, nw = nwidth)?;
             if let Some(desc) = &m.attrs.desc {
                 write!(w, " {}", desc)?;

--- a/rust/scx_stats/src/stats.rs
+++ b/rust/scx_stats/src/stats.rs
@@ -53,6 +53,18 @@ impl ScxStatsKind {
     }
 }
 
+impl std::fmt::Display for ScxStatsKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::I64 => write!(f, "i64"),
+            Self::U64 => write!(f, "u64"),
+            Self::Float => write!(f, "float"),
+            Self::String => write!(f, "string"),
+            Self::Struct(name) => write!(f, "{}", name),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ScxStatsData {
     #[serde(rename = "datum")]
@@ -169,6 +181,16 @@ impl ScxStatsData {
             }
         }
         Ok(Self::Datum(kind))
+    }
+}
+
+impl std::fmt::Display for ScxStatsData {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Datum(kind) => write!(f, "{}", kind),
+            Self::Array(kind) => write!(f, "[{}]", kind),
+            Self::Dict { key, datum } => write!(f, "{{{}:{}}}", key, datum),
+        }
     }
 }
 

--- a/scheds/rust/scx_bpfland/Cargo.lock
+++ b/scheds/rust/scx_bpfland/Cargo.lock
@@ -400,10 +400,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1386,6 +1427,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "scx_stats"
+version = "1.0.3"
+dependencies = [
+ "anyhow",
+ "crossbeam",
+ "libc",
+ "log",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "scx_utils"
 version = "1.0.3"
 dependencies = [
@@ -1402,6 +1457,8 @@ dependencies = [
  "metrics-util",
  "paste",
  "regex",
+ "scx_stats",
+ "serde",
  "sscanf",
  "tar",
  "vergen",

--- a/scheds/rust/scx_lavd/Cargo.lock
+++ b/scheds/rust/scx_lavd/Cargo.lock
@@ -304,10 +304,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -969,6 +1010,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "scx_stats"
+version = "1.0.3"
+dependencies = [
+ "anyhow",
+ "crossbeam",
+ "libc",
+ "log",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "scx_utils"
 version = "1.0.3"
 dependencies = [
@@ -985,6 +1040,8 @@ dependencies = [
  "metrics-util",
  "paste",
  "regex",
+ "scx_stats",
+ "serde",
  "sscanf",
  "tar",
  "vergen",

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -416,6 +416,10 @@ struct Opts {
     #[clap(long)]
     run_example: bool,
 
+    /// Show descriptions for statistics.
+    #[clap(long)]
+    help_stats: bool,
+
     /// Layer specification. See --help.
     specs: Vec<String>,
 }
@@ -1927,6 +1931,11 @@ fn verify_layer_specs(specs: &[LayerSpec]) -> Result<()> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if opts.help_stats {
+	stats::server_data().describe_meta(&mut std::io::stdout(), None)?;
+	return Ok(());
+    }
 
     let llv = match opts.verbose {
         0 => simplelog::LevelFilter::Info,

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1611,7 +1611,7 @@ impl<'a, 'b> Scheduler<'a, 'b> {
 
         // Attach.
         let struct_ops = scx_ops_attach!(skel, layered)?;
-        let stats_server = stats::launch_server()?;
+        let stats_server = ScxStatsServer::new(stats::server_data()).launch()?;
 
         let sched = Self {
             struct_ops: Some(struct_ops),

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -464,9 +464,9 @@ pub fn launch_server() -> Result<ScxStatsServer<StatsReq, StatsRes>> {
     });
 
     Ok(ScxStatsServer::new()
-        .add_stats_meta(LayerStats::meta())
-        .add_stats_meta(SysStats::meta())
-        .add_stats_ops(
+        .add_meta(LayerStats::meta())
+        .add_meta(SysStats::meta())
+        .add_ops(
             "top",
             ScxStatsOps {
                 open,
@@ -477,7 +477,7 @@ pub fn launch_server() -> Result<ScxStatsServer<StatsReq, StatsRes>> {
 }
 
 pub fn monitor(intv: Duration, shutdown: Arc<AtomicBool>) -> Result<()> {
-    scx_utils::monitor_stats::<SysStats>(
+     scx_utils::monitor_stats::<SysStats>(
         &vec![],
         intv,
         || shutdown.load(Ordering::Relaxed),

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -10,7 +10,7 @@ use chrono::Local;
 use log::warn;
 use scx_stats::Meta;
 use scx_stats::ScxStatsOps;
-use scx_stats::ScxStatsServer;
+use scx_stats::ScxStatsServerData;
 use scx_stats::StatsCloser;
 use scx_stats::StatsOpener;
 use scx_stats::StatsReader;
@@ -432,7 +432,7 @@ pub enum StatsRes {
     Bye,
 }
 
-pub fn launch_server() -> Result<ScxStatsServer<StatsReq, StatsRes>> {
+pub fn server_data() -> ScxStatsServerData<StatsReq, StatsRes> {
     let open: Box<dyn StatsOpener<StatsReq, StatsRes>> = Box::new(move |(req_ch, res_ch)| {
         let tid = current().id();
         req_ch.send(StatsReq::Hello(tid))?;
@@ -463,7 +463,7 @@ pub fn launch_server() -> Result<ScxStatsServer<StatsReq, StatsRes>> {
         }
     });
 
-    Ok(ScxStatsServer::new()
+    ScxStatsServerData::new()
         .add_meta(LayerStats::meta())
         .add_meta(SysStats::meta())
         .add_ops(
@@ -473,11 +473,10 @@ pub fn launch_server() -> Result<ScxStatsServer<StatsReq, StatsRes>> {
                 close: Some(close),
             },
         )
-        .launch()?)
 }
 
 pub fn monitor(intv: Duration, shutdown: Arc<AtomicBool>) -> Result<()> {
-     scx_utils::monitor_stats::<SysStats>(
+    scx_utils::monitor_stats::<SysStats>(
         &vec![],
         intv,
         || shutdown.load(Ordering::Relaxed),

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -50,69 +50,69 @@ fn fmt_num(v: u64) -> String {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(_om_prefix = "l_", _om_label = "layer_name")]
 pub struct LayerStats {
-    #[stat(desc = "layer: CPU utilization (100% means one full CPU)")]
+    #[stat(desc = "CPU utilization (100% means one full CPU)")]
     pub util: f64,
-    #[stat(desc = "layer: fraction of total CPU utilization")]
+    #[stat(desc = "fraction of total CPU utilization")]
     pub util_frac: f64,
-    #[stat(desc = "layer: sum of weight * duty_cycle for tasks")]
+    #[stat(desc = "sum of weight * duty_cycle for tasks")]
     pub load: f64,
-    #[stat(desc = "layer: fraction of total load")]
+    #[stat(desc = "fraction of total load")]
     pub load_frac: f64,
-    #[stat(desc = "layer: # tasks")]
+    #[stat(desc = "# tasks")]
     pub tasks: u32,
-    #[stat(desc = "layer: # sched events duringg the period")]
+    #[stat(desc = "# sched events duringg the period")]
     pub total: u64,
-    #[stat(desc = "layer: % dispatched into idle CPU")]
+    #[stat(desc = "% dispatched into idle CPU")]
     pub sel_local: f64,
-    #[stat(desc = "layer: % enqueued after wakeup")]
+    #[stat(desc = "% enqueued after wakeup")]
     pub enq_wakeup: f64,
-    #[stat(desc = "layer: % enqueued after slice expiration")]
+    #[stat(desc = "% enqueued after slice expiration")]
     pub enq_expire: f64,
-    #[stat(desc = "layer: % re-enqueued due to RT preemption")]
+    #[stat(desc = "% re-enqueued due to RT preemption")]
     pub enq_reenq: f64,
-    #[stat(desc = "layer: # times exec duration < min_exec_us")]
+    #[stat(desc = "# times exec duration < min_exec_us")]
     pub min_exec: f64,
-    #[stat(desc = "layer: total exec durations extended due to min_exec_us")]
+    #[stat(desc = "total exec durations extended due to min_exec_us")]
     pub min_exec_us: u64,
-    #[stat(desc = "layer: % dispatche into idle CPUs occupied by other layers")]
+    #[stat(desc = "% dispatche into idle CPUs occupied by other layers")]
     pub open_idle: f64,
-    #[stat(desc = "layer: % preempted other tasks")]
+    #[stat(desc = "% preempted other tasks")]
     pub preempt: f64,
-    #[stat(desc = "layer: % first-preempted other tasks")]
+    #[stat(desc = "% first-preempted other tasks")]
     pub preempt_first: f64,
-    #[stat(desc = "layer: % idle-preempted other tasks")]
+    #[stat(desc = "% idle-preempted other tasks")]
     pub preempt_idle: f64,
-    #[stat(desc = "layer: % attempted to preempt other tasks but failed")]
+    #[stat(desc = "% attempted to preempt other tasks but failed")]
     pub preempt_fail: f64,
-    #[stat(desc = "layer: % violated config due to CPU affinity")]
+    #[stat(desc = "% violated config due to CPU affinity")]
     pub affn_viol: f64,
-    #[stat(desc = "layer: % continued executing after slice expiration")]
+    #[stat(desc = "% continued executing after slice expiration")]
     pub keep: f64,
-    #[stat(desc = "layer: % disallowed to continue executing due to max_exec")]
+    #[stat(desc = "% disallowed to continue executing due to max_exec")]
     pub keep_fail_max_exec: f64,
-    #[stat(desc = "layer: % disallowed to continue executing due to other tasks")]
+    #[stat(desc = "% disallowed to continue executing due to other tasks")]
     pub keep_fail_busy: f64,
-    #[stat(desc = "layer: whether is exclusive", _om_skip)]
+    #[stat(desc = "whether is exclusive", _om_skip)]
     pub is_excl: u32,
-    #[stat(desc = "layer: # times an excl task skipped a CPU as the sibling was also excl")]
+    #[stat(desc = "# times an excl task skipped a CPU as the sibling was also excl")]
     pub excl_collision: f64,
-    #[stat(desc = "layer: % a sibling CPU was preempted for an exclusive task")]
+    #[stat(desc = "% a sibling CPU was preempted for an exclusive task")]
     pub excl_preempt: f64,
-    #[stat(desc = "layer: % kicked a CPU from enqueue path")]
+    #[stat(desc = "% kicked a CPU from enqueue path")]
     pub kick: f64,
-    #[stat(desc = "layer: % yielded")]
+    #[stat(desc = "% yielded")]
     pub yielded: f64,
-    #[stat(desc = "layer: # times yield was ignored")]
+    #[stat(desc = "# times yield was ignored")]
     pub yield_ignore: u64,
-    #[stat(desc = "layer: % migrated across CPUs")]
+    #[stat(desc = "% migrated across CPUs")]
     pub migration: f64,
-    #[stat(desc = "layer: mask of allocated CPUs", _om_skip)]
+    #[stat(desc = "mask of allocated CPUs", _om_skip)]
     pub cpus: Vec<u32>,
-    #[stat(desc = "layer: # of CPUs assigned")]
+    #[stat(desc = "# of CPUs assigned")]
     pub cur_nr_cpus: u32,
-    #[stat(desc = "layer: minimum # of CPUs assigned")]
+    #[stat(desc = "minimum # of CPUs assigned")]
     pub min_nr_cpus: u32,
-    #[stat(desc = "layer: maximum # of CPUs assigned")]
+    #[stat(desc = "maximum # of CPUs assigned")]
     pub max_nr_cpus: u32,
 }
 

--- a/scheds/rust/scx_rlfifo/Cargo.lock
+++ b/scheds/rust/scx_rlfifo/Cargo.lock
@@ -295,10 +295,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -893,6 +934,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "scx_stats"
+version = "1.0.3"
+dependencies = [
+ "anyhow",
+ "crossbeam",
+ "libc",
+ "log",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "scx_utils"
 version = "1.0.3"
 dependencies = [
@@ -909,6 +964,8 @@ dependencies = [
  "metrics-util",
  "paste",
  "regex",
+ "scx_stats",
+ "serde",
  "sscanf",
  "tar",
  "vergen",

--- a/scheds/rust/scx_rustland/Cargo.lock
+++ b/scheds/rust/scx_rustland/Cargo.lock
@@ -304,10 +304,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -969,6 +1010,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "scx_stats"
+version = "1.0.3"
+dependencies = [
+ "anyhow",
+ "crossbeam",
+ "libc",
+ "log",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "scx_utils"
 version = "1.0.3"
 dependencies = [
@@ -985,6 +1040,8 @@ dependencies = [
  "metrics-util",
  "paste",
  "regex",
+ "scx_stats",
+ "serde",
  "sscanf",
  "tar",
  "vergen",

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -220,6 +220,10 @@ struct Opts {
     /// Print version and exit.
     #[clap(long)]
     version: bool,
+
+    /// Show descriptions for statistics.
+    #[clap(long)]
+    help_stats: bool,
 }
 
 fn read_cpu_busy_and_total(reader: &procfs::ProcReader) -> Result<(u64, u64)> {
@@ -623,6 +627,11 @@ fn main() -> Result<()> {
     if opts.version {
         println!("scx_rusty: {}", *build_id::SCX_FULL_VERSION);
         return Ok(());
+    }
+
+    if opts.help_stats {
+	stats::server_data().describe_meta(&mut std::io::stdout(), None)?;
+	return Ok(());
     }
 
     let llv = match opts.verbose {

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -443,7 +443,7 @@ impl<'a> Scheduler<'a> {
         // Attach.
         let mut skel = scx_ops_load!(skel, rusty, uei)?;
         let struct_ops = Some(scx_ops_attach!(skel, rusty)?);
-        let stats_server = stats::launch_server()?;
+        let stats_server = ScxStatsServer::new(stats::server_data()).launch()?;
 
         info!("Rusty scheduler started! Run `scx_rusty --monitor` for metrics.");
 

--- a/scheds/rust/scx_rusty/src/stats.rs
+++ b/scheds/rust/scx_rusty/src/stats.rs
@@ -235,10 +235,10 @@ pub fn launch_server() -> Result<ScxStatsServer<StatsCtx, (StatsCtx, ClusterStat
         });
 
     Ok(ScxStatsServer::new()
-        .add_stats_meta(DomainStats::meta())
-        .add_stats_meta(NodeStats::meta())
-        .add_stats_meta(ClusterStats::meta())
-        .add_stats_ops("top", ScxStatsOps { open, close: None })
+        .add_meta(DomainStats::meta())
+        .add_meta(NodeStats::meta())
+        .add_meta(ClusterStats::meta())
+        .add_ops("top", ScxStatsOps { open, close: None })
         .launch()?)
 }
 

--- a/scheds/rust/scx_rusty/src/stats.rs
+++ b/scheds/rust/scx_rusty/src/stats.rs
@@ -4,7 +4,7 @@ use chrono::DateTime;
 use chrono::Local;
 use scx_stats::Meta;
 use scx_stats::ScxStatsOps;
-use scx_stats::ScxStatsServer;
+use scx_stats::ScxStatsServerData;
 use scx_stats::StatsOpener;
 use scx_stats::StatsReader;
 use scx_stats::ToJson;
@@ -215,7 +215,7 @@ impl ClusterStats {
     }
 }
 
-pub fn launch_server() -> Result<ScxStatsServer<StatsCtx, (StatsCtx, ClusterStats)>> {
+pub fn server_data() -> ScxStatsServerData<StatsCtx, (StatsCtx, ClusterStats)> {
     let open: Box<dyn StatsOpener<StatsCtx, (StatsCtx, ClusterStats)>> =
         Box::new(move |(req_ch, res_ch)| {
             // Send one bogus request on open to establish prev_sc.
@@ -234,12 +234,11 @@ pub fn launch_server() -> Result<ScxStatsServer<StatsCtx, (StatsCtx, ClusterStat
             Ok(read)
         });
 
-    Ok(ScxStatsServer::new()
+    ScxStatsServerData::new()
         .add_meta(DomainStats::meta())
         .add_meta(NodeStats::meta())
         .add_meta(ClusterStats::meta())
         .add_ops("top", ScxStatsOps { open, close: None })
-        .launch()?)
 }
 
 pub fn monitor(intv: Duration, shutdown: Arc<AtomicBool>) -> Result<()> {


### PR DESCRIPTION
Teach scx_stats to generate summary of stats metadata and use that to implement `--help-stats` for scx_rusty and scx_layered. The output looks like the following:
```
$ scheds/rust/scx_layered/target/debug/scx_layered --help-stats
[SysStats  ]
  affn_viol          float               % violated config due to CPU affinity
  at                 float               timestamp
  busy               float               CPU busy % (100% means all CPU)
  excl_collision     float               # times an excl task skipped a CPU as the sibling was also excl
  excl_idle          float               # times a CPU skipped dispatching due to an excl task on the sibling
  excl_preempt       float               # times a sibling CPU was preempted for an excl task
  excl_wakeup        float               # times an idle sibling CPU was woken up after an excl task is finished
  fallback_cpu       u64                 fallback CPU
  layers             {string:LayerStats} per-layer statistics
  load               float               sum of weight * duty_cycle for all tasks
  local              float               % dispatched directly into an idle CPU
  open_idle          float               % open layer tasks scheduled into allocated but idle CPUs
  proc_ms            u64                 CPU time this binary consumed during the period
  total              u64                 # sched events duringg the period
  util               float               CPU util % (100% means one CPU)

[LayerStats]
  affn_viol          float               % violated config due to CPU affinity
  cpus               [u64]               mask of allocated CPUs
  cur_nr_cpus        u64                 # of CPUs assigned
  enq_expire         float               % enqueued after slice expiration
  enq_reenq          float               % re-enqueued due to RT preemption
  enq_wakeup         float               % enqueued after wakeup
  excl_collision     float               # times an excl task skipped a CPU as the sibling was also excl
  excl_preempt       float               % a sibling CPU was preempted for an exclusive task
  is_excl            u64                 whether is exclusive
  keep               float               % continued executing after slice expiration
  keep_fail_busy     float               % disallowed to continue executing due to other tasks
  keep_fail_max_exec float               % disallowed to continue executing due to max_exec
  kick               float               % kicked a CPU from enqueue path
  load               float               sum of weight * duty_cycle for tasks
  load_frac          float               fraction of total load
  max_nr_cpus        u64                 maximum # of CPUs assigned
  migration          float               % migrated across CPUs
  min_exec           float               # times exec duration < min_exec_us
  min_exec_us        u64                 total exec durations extended due to min_exec_us
  min_nr_cpus        u64                 minimum # of CPUs assigned
  open_idle          float               % dispatche into idle CPUs occupied by other layers
  preempt            float               % preempted other tasks
  preempt_fail       float               % attempted to preempt other tasks but failed
  preempt_first      float               % first-preempted other tasks
  preempt_idle       float               % idle-preempted other tasks
  sel_local          float               % dispatched into idle CPU
  tasks              u64                 # tasks
  total              u64                 # sched events duringg the period
  util               float               CPU utilization (100% means one full CPU)
  util_frac          float               fraction of total CPU utilization
  yield_ignore       u64                 # times yield was ignored
  yielded            float               % yielded
```

```
$ scheds/rust/scx_rusty/target/debug/scx_rusty --help-stats
[ClusterStats]
  at_us              u64               timestamp
  cpu_busy           float             CPU busy % (100% means all CPU)
  direct             float             % directly dispatched to CPU (--kthreads-local or local domain)
  direct_greedy_cpus [u64]            
  dl_clamp           float             % accumulated vtime budget clamped
  dl_preset          float             % accumulated vtime budget used as-is
  dsq_dispatch       float             % scheduled from local domain
  greedy             float             % directly dispatched to CPU (foreign domain, local node)
  greedy_far         float             % directly dispatched to CPU (foreign node)
  greedy_idle        float             % directly dispatched to idle previous CPU in a different domain
  greedy_local       float             % scheduled from foreign domain
  greedy_xnuma       float             % scheduled from foreign node
  kick_greedy        float             % foreign domain CPU kicked on enqueue
  kick_greedy_cpus   [u64]            
  lb_at_us           u64               timestamp of the last load balancing
  lb_data_err        u64               # of BPF lb data get errros
  load               float             sum of weight * duty_cycle for all tasks
  nodes              {u64:NodeStats}   per-node statistics
  nr_migrations      u64               # of migrations from load balancing
  pinned             float             % directly dispatched to CPU due to restricted to one CPU
  prev_idle          float             % directly dispatched to idle previous CPU
  repatriate         float             % repatriated to local domain on enqueue
  slice_us           u64               scheduling slice in usecs
  sync_prev_idle     float             % WAKE_SYNC directly dispatched to idle previous CPU
  task_get_err       u64               # of BPF task get errors
  time_used          float             time spent running scheduler userspace
  total              u64               # sched events duringg the period
  wake_sync          float             % WAKE_SYNC directly dispatched to waker CPU

[NodeStats   ]
  delta              float             load migrated for load balancing
  doms               {u64:DomainStats} per-domain statistics
  imbal              float             load imbalance from average
  load               float             sum of weight * duty_cycle for all tasks

[DomainStats ]
  delta              float             load migrated for load balancing
  imbal              float             load imbalance from average
  load               float             sum of weight * duty_cycle for all tasks
```