### PR TITLE
scx_bpfland, scx_lavd: Improve help info a bit

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -165,8 +165,8 @@ fn parse_cpumask(cpu_str: &str) -> Result<Cpumask, anyhow::Error> {
 
 /// scx_bpfland: a vruntime-based sched_ext scheduler that prioritizes interactive workloads.
 ///
-/// This scheduler is derived from scx_rustland, but it is fully implemented in BFP with minimal
-/// user-space part written in Rust to process command line options, collect metrics and logs out
+/// This scheduler is derived from scx_rustland, but it is fully implemented in BPF. It has a minimal
+/// user-space part written in Rust to process command line options, collect metrics and log out
 /// scheduling statistics.
 ///
 /// The BPF part makes all the scheduling decisions (see src/bpf/main.bpf.c).
@@ -195,7 +195,7 @@ struct Opts {
     #[clap(short = 'l', long, allow_hyphen_values = true, default_value = "0")]
     slice_us_lag: i64,
 
-    /// Shorten interactive tasks deadline based on their average amount of voluntary context
+    /// Shorten interactive tasks' deadline based on their average amount of voluntary context
     /// switches.
     ///
     /// Enabling this option can be beneficial in soft real-time scenarios, such as audio
@@ -233,12 +233,12 @@ struct Opts {
     #[clap(long, action = clap::ArgAction::SetTrue)]
     disable_l3: bool,
 
-    /// Maximum threshold of voluntary context switch per second, used to classify interactive
+    /// Maximum threshold of voluntary context switches per second. This is used to classify interactive
     /// tasks (0 = disable interactive tasks classification).
     #[clap(short = 'c', long, default_value = "10")]
     nvcsw_max_thresh: u64,
 
-    /// Prevent the starvation making sure that at least one lower priority task is scheduled every
+    /// Prevent starvation by making sure that at least one lower priority task is scheduled every
     /// starvation_thresh_us (0 = disable starvation prevention).
     #[clap(short = 't', long, default_value = "5000")]
     starvation_thresh_us: u64,

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -56,35 +56,44 @@ static RUNNING: AtomicBool = AtomicBool::new(true);
 /// See the more detailed overview of the LAVD design at main.bpf.c.
 #[derive(Debug, Parser)]
 struct Opts {
-    /// Run in a performance mode to get maximum performance
+    /// Run in performance mode to get maximum performance.
     #[clap(long = "performance", action = clap::ArgAction::SetTrue)]
     performance: bool,
 
-    /// Run in a power-save mode to minimize power consumption
+    /// Run in powersave mode to minimize power consumption.
     #[clap(long = "powersave", action = clap::ArgAction::SetTrue)]
     powersave: bool,
 
-    /// Run in a balanced mode aiming for sweetspot between power and performance (default)
+    /// Run in balanced mode aiming for sweetspot between power and performance (default).
     #[clap(long = "balanced", action = clap::ArgAction::SetTrue)]
     balanced: bool,
 
-    /// Disable core compaction, which uses minimum CPUs for power saving, and always use all the online CPUs.
+    /// The following 4 options are set automatically by the power mode (above), but they can be
+    /// set independently if desired:
+
+    /// Disable core compaction and schedule tasks across all online CPUs. Core compaction attempts
+    /// to keep idle CPUs idle in favor of scheduling tasks on CPUs that are already
+    /// awake. See main.bpf.c for more info.
     #[clap(long = "no-core-compaction", action = clap::ArgAction::SetTrue)]
     no_core_compaction: bool,
 
-    /// Use SMT logical cores before using other physcial cores in core compaction
+    /// Schedule tasks on SMT siblings before using other physcial cores when core compaction is
+    /// enabled.
     #[clap(long = "prefer-smt-core", action = clap::ArgAction::SetTrue)]
     prefer_smt_core: bool,
 
-    /// Use little (effiency) cores before using big (performance) cores in core compaction
+    /// Schedule tasks on little (efficiency) cores before big (performance) cores when core compaction is
+    /// enabled.
     #[clap(long = "prefer-little-core", action = clap::ArgAction::SetTrue)]
     prefer_little_core: bool,
 
-    /// Disable frequency scaling by scx_lavd
+    /// Disable controlling the CPU frequency. In order to improve latency and responsiveness of
+    /// performance-critical tasks, scx_lavd increases the CPU frequency even if CPU usage is low.
+    /// See main.bpf.c for more info.
     #[clap(long = "no-freq-scaling", action = clap::ArgAction::SetTrue)]
     no_freq_scaling: bool,
 
-    /// The number of scheduling samples to be reported every second
+    /// The number of scheduling samples to be reported every second.
     /// (default: 1, 0 = disable logging)
     #[clap(short = 's', long, default_value = "1")]
     nr_sched_samples: u64,


### PR DESCRIPTION
I wanted to do some work improving the end-user documentation, as I noticed some random typos and other things that were worded a little unclearly or just not explained at all.

I made some minor grammatical changes to scx_bpfland, and I added explanations to scx_lavd that were poorly explained or missing entirely; for example, that the power mode options control the defaults for the four scheduling controls wasn't explained anywhere, and I only learned that by paging through the Rust code, or using the correct terminology "SMT sibling" rather than "logical core."

In a perfect world, the documentation for every scheduler should be formatted exactly the same, and the information useful to end users shouldn't just be embedded in the source code. While an experienced sysadmin might not mind, it is a barrier of entry for, say, a gamer who is interested in tuning scx to their needs and has installed prebuilt schedulers from their distro's repos (I think only CachyOS packages them right now, but that will likely change in the future.) This is just a small start.

I'll probably do some more work when I have the time.