### PR TITLE
scx_layered: Add layer match for tgid

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -111,6 +111,7 @@ enum layer_match_kind {
 	MATCH_GROUP_ID_EQUALS,
 	MATCH_PID_EQUALS,
 	MATCH_PPID_EQUALS,
+	MATCH_TGID_EQUALS,
 
 	NR_LAYER_MATCH_KINDS,
 };
@@ -125,6 +126,7 @@ struct layer_match {
 	u32		group_id;
 	u32		pid;
 	u32		ppid;
+	u32		tgid;
 };
 
 struct layer_match_ands {

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1018,6 +1018,8 @@ static __noinline bool match_one(struct layer_match *match,
 		return p->pid == match->pid;
 	case MATCH_PPID_EQUALS:
 		return p->real_parent->pid == match->ppid;
+	case MATCH_TGID_EQUALS:
+		return p->tgid == match->tgid;
 	default:
 		scx_bpf_error("invalid match kind %d", match->kind);
 		return result;
@@ -1624,6 +1626,9 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(layered_init)
 					break;
 				case MATCH_PPID_EQUALS:
 					dbg("%s PPID %u", header, match->ppid);
+					break;
+				case MATCH_TGID_EQUALS:
+					dbg("%s TGID %u", header, match->tgid);
 					break;
 				default:
 					scx_bpf_error("%s Invalid kind", header);

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -432,6 +432,7 @@ enum LayerMatch {
     GIDEquals(u32),
     PIDEquals(u32),
     PPIDEquals(u32),
+    TGIDEquals(u32),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1438,6 +1439,10 @@ impl<'a, 'b> Scheduler<'a, 'b> {
                         LayerMatch::PPIDEquals(ppid) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_PPID_EQUALS as i32;
                             mt.ppid = *ppid;
+                        }
+                        LayerMatch::TGIDEquals(tgid) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_TGID_EQUALS as i32;
+                            mt.tgid = *tgid;
                         }
                     }
                 }


### PR DESCRIPTION
Add layer match for tgid.

Tested with a simple config:
```
[{
  "name":"tgid",
  "comment":"tgid",
  "matches":[
     [
             {"TGIDEquals":10733}
     ]
  ],
  "kind": {
    "Confined":{
      "util_range": [0.04, 0.50]
     }
  }
},{
  "name":"ppid 1",
  "comment":"ppid 1",
  "matches":[
     [{"PPIDEquals":1}]
  ],
  "kind": {
    "Confined":{
      "util_range": [0.01, 0.20]
     }
  }
},
{
  "name":"the rest",
  "comment":"the rest",
  "matches":[[]],
  "kind":{
    "Grouped": {
      "util_range": [0.05, 0.60]
    }
  }
}]
```
layer matching:
```
###### Fri, 23 Aug 2024 23:08:12 -0400 ######
tot=  17231 local=96.52 open_idle=57.98 affn_viol= 0.00 proc=20ms
busy=  4.1 util=   61.9 load=    316.8 fallback_cpu=  6
excl_coll=0 excl_preempt=0 excl_idle=0 excl_wakeup=0
  ppid 1  : util/frac=    4.1/  6.6 load/frac=      6.5:  2.1 tasks=    13
            tot=   1638 local=97.50 wake/exp/reenq= 2.50/ 0.00/ 0.00
            keep/max/busy= 0.00/ 0.00/ 0.00 kick= 0.00 yield/ign= 0.00/    0
            open_idle= 0.00 mig= 3.54 affn_viol= 0.00
            preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
            cpus=  2 [  2,  2] 00000300
  tgid    : util/frac=    2.6/  4.2 load/frac=      1.8:  0.6 tasks=     9
            tot=    551 local=80.22 wake/exp/reenq=19.78/ 0.00/ 0.00
            keep/max/busy= 0.00/ 0.00/ 0.00 kick= 0.00 yield/ign= 1.27/    0
            open_idle= 0.00 mig=22.14 affn_viol= 0.00
            preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
            cpus=  2 [  2,  2] 00000003
  the rest: util/frac=   55.2/ 89.2 load/frac=    308.5: 97.4 tasks=   134
            tot=  15042 local=97.02 wake/exp/reenq= 2.93/ 0.01/ 0.04
            keep/max/busy= 0.11/ 0.00/ 0.00 kick= 0.02 yield/ign= 0.19/    0
            open_idle=66.41 mig=53.24 affn_viol= 0.00
            preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
            cpus=  4 [  2,  4] 0000003c
^CEXIT: unregistered from user space
```