### PR TITLE
scx_rustland_core: user-space framework refactoring

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -182,7 +182,6 @@ impl<'cb> BpfScheduler<'cb> {
         exit_dump_len: u32,
         partial: bool,
         slice_us: u64,
-        low_power: bool,
         verbose: bool,
         debug: bool,
     ) -> Result<Self> {
@@ -241,7 +240,6 @@ impl<'cb> BpfScheduler<'cb> {
 
         skel.maps.bss_data.usersched_pid = std::process::id();
         skel.maps.rodata_data.slice_ns = slice_us * 1000;
-        skel.maps.rodata_data.low_power = low_power;
         skel.maps.rodata_data.debug = debug;
 
         // Attach BPF scheduler.

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -181,12 +181,11 @@ impl<'cb> BpfScheduler<'cb> {
         open_object: &'cb mut MaybeUninit<OpenObject>,
         exit_dump_len: u32,
         partial: bool,
-        verbose: bool,
         debug: bool,
     ) -> Result<Self> {
         // Open the BPF prog first for verification.
         let mut skel_builder = BpfSkelBuilder::default();
-        skel_builder.obj_builder.debug(verbose);
+        skel_builder.obj_builder.debug(debug);
         let mut skel = scx_ops_open!(skel_builder, open_object, rustland)?;
 
         // Lock all the memory to prevent page faults that could trigger potential deadlocks during

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -77,7 +77,7 @@ pub const RL_PREEMPT_CPU: u64 = bpf_intf::RL_PREEMPT_CPU as u64;
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone)]
 pub struct QueuedTask {
     pub pid: i32,              // pid that uniquely identifies a task
-    pub cpu: i32,              // CPU where the task is running (-1 = exiting)
+    pub cpu: i32,              // CPU where the task is running
     pub sum_exec_runtime: u64, // Total cpu time
     pub weight: u64,           // Task static priority
     cpumask_cnt: u64,          // cpumask generation counter (private)
@@ -397,8 +397,6 @@ impl<'cb> BpfScheduler<'cb> {
     }
 
     // Receive a task to be scheduled from the BPF dispatcher.
-    //
-    // NOTE: if task.cpu is negative the task is exiting and it does not require to be scheduled.
     pub fn dequeue_task(&mut self) -> Result<Option<QueuedTask>, i32> {
         match self.queued.consume_raw() {
             0 => Ok(None),

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -9,21 +9,21 @@ use crate::bpf_intf;
 use crate::bpf_intf::*;
 use crate::bpf_skel::*;
 
-use std::fs::File;
-use std::io::Read;
 use std::ffi::c_int;
 use std::ffi::c_ulong;
+use std::fs::File;
+use std::io::Read;
 
 use anyhow::Context;
 use anyhow::Result;
 
 use plain::Plain;
 
-use libbpf_rs::OpenObject;
-use libbpf_rs::ProgramInput;
 use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::Skel;
 use libbpf_rs::skel::SkelBuilder;
+use libbpf_rs::OpenObject;
+use libbpf_rs::ProgramInput;
 
 use libc::{pthread_self, pthread_setschedparam, sched_param};
 
@@ -86,11 +86,11 @@ pub struct QueuedTask {
 // Task queued for dispatching to the BPF component (see bpf_intf::dispatched_task_ctx).
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone)]
 pub struct DispatchedTask {
-    pub pid: i32,         // pid that uniquely identifies a task
-    pub cpu: i32,         // target CPU selected by the scheduler
-    pub flags: u64,       // special dispatch flags
-    pub slice_ns: u64,    // time slice assigned to the task (0 = default)
-    cpumask_cnt: u64,     // cpumask generation counter (private)
+    pub pid: i32,      // pid that uniquely identifies a task
+    pub cpu: i32,      // target CPU selected by the scheduler
+    pub flags: u64,    // special dispatch flags
+    pub slice_ns: u64, // time slice assigned to the task (0 = default)
+    cpumask_cnt: u64,  // cpumask generation counter (private)
 }
 
 impl DispatchedTask {
@@ -181,7 +181,6 @@ impl<'cb> BpfScheduler<'cb> {
         open_object: &'cb mut MaybeUninit<OpenObject>,
         exit_dump_len: u32,
         partial: bool,
-        slice_us: u64,
         verbose: bool,
         debug: bool,
     ) -> Result<Self> {
@@ -239,7 +238,6 @@ impl<'cb> BpfScheduler<'cb> {
         skel.struct_ops.rustland_mut().exit_dump_len = exit_dump_len;
 
         skel.maps.bss_data.usersched_pid = std::process::id();
-        skel.maps.rodata_data.slice_ns = slice_us * 1000;
         skel.maps.rodata_data.debug = debug;
 
         // Attach BPF scheduler.

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -18,13 +18,19 @@
 #define __kptr
 #endif
 
-#ifndef __KERNEL__
+#ifndef __VMLINUX_H__
 typedef unsigned char u8;
+typedef unsigned short u16;
 typedef unsigned int u32;
-typedef int s32;
-typedef unsigned long long u64;
-typedef long long s64;
-#endif
+typedef unsigned long u64;
+
+typedef signed char s8;
+typedef signed short s16;
+typedef signed int s32;
+typedef signed long s64;
+
+typedef int pid_t;
+#endif /* __VMLINUX_H__ */
 
 /* Check a condition at build time */
 #define BUILD_BUG_ON(expr) \
@@ -56,6 +62,15 @@ enum {
 };
 
 /*
+ * Specify a target CPU for a specific PID.
+ */
+struct task_cpu_arg {
+	pid_t pid;
+	s32 cpu;
+	u64 flags;
+};
+
+/*
  * Task sent to the user-space scheduler by the BPF dispatcher.
  *
  * All attributes are collected from the kernel by the the BPF component.
@@ -78,8 +93,8 @@ struct dispatched_task_ctx {
 	s32 pid;
 	s32 cpu; /* CPU where the task should be dispatched */
 	u64 flags; /* special dispatch flags */
-	u64 cpumask_cnt; /* cpumask generation counter */
 	u64 slice_ns; /* time slice assigned to the task (0=default) */
+	u64 cpumask_cnt; /* cpumask generation counter */
 };
 
 #endif /* __INTF_H */

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -77,7 +77,7 @@ struct task_cpu_arg {
  */
 struct queued_task_ctx {
 	s32 pid;
-	s32 cpu; /* CPU where the task is running (-1 = exiting) */
+	s32 cpu; /* CPU where the task is running */
 	u64 cpumask_cnt; /* cpumask generation counter */
 	u64 sum_exec_runtime; /* Total cpu time */
 	u64 weight; /* Task static priority */

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -87,19 +87,6 @@ const volatile bool debug;
 		bpf_printk(_fmt, ##__VA_ARGS__);			\
 } while(0)
 
- /*
-  * Enable/disable low-power mode.
-  *
-  * When low-power mode is enabled, the scheduler behaves in a more non-work
-  * conserving way: the CPUs operate at reduced capacity, which slows down
-  * CPU-bound tasks, enhancing the prioritization of interactive workloads.
-  *
-  * In summary, enabling low-power mode will limit the performance of
-  * CPU-intensive tasks, reducing power consumption, while maintaining
-  * effective prioritization of interactive tasks.
-  */
-const volatile bool low_power;
-
 /*
  * CPUs in the system have SMT is enabled.
  */
@@ -880,8 +867,7 @@ void BPF_STRUCT_OPS(rustland_update_idle, s32 cpu, bool idle)
 		 * Wake up the idle CPU and trigger a resched, so that it can
 		 * immediately accept dispatched tasks.
 		 */
-		if (!low_power || !nr_running)
-			scx_bpf_kick_cpu(cpu, 0);
+		scx_bpf_kick_cpu(cpu, 0);
 	}
 }
 

--- a/scheds/rust/scx_rlfifo/Cargo.lock
+++ b/scheds/rust/scx_rlfifo/Cargo.lock
@@ -295,10 +295,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -893,6 +934,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "scx_stats"
+version = "1.0.3"
+dependencies = [
+ "anyhow",
+ "crossbeam",
+ "libc",
+ "log",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "scx_utils"
 version = "1.0.3"
 dependencies = [
@@ -909,6 +964,8 @@ dependencies = [
  "metrics-util",
  "paste",
  "regex",
+ "scx_stats",
+ "serde",
  "sscanf",
  "tar",
  "vergen",

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -32,11 +32,11 @@ impl<'a> Scheduler<'a> {
     fn init(open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
         let bpf = BpfScheduler::init(
             open_object,
-            0,                        // exit_dump_len (buffer size of exit info)
-            false,                    // partial (include all tasks if false)
-            SLICE_US,                 // default time slice (in us)
-            false,                    // verbose (verbose output)
-            false,                    // debug (debug mode)
+            0,        // exit_dump_len (buffer size of exit info)
+            false,    // partial (include all tasks if false)
+            SLICE_US, // default time slice (in us)
+            false,    // verbose (verbose output)
+            false,    // debug (debug mode)
         )?;
         Ok(Self { bpf })
     }

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -34,7 +34,6 @@ impl<'a> Scheduler<'a> {
             open_object,
             0,        // exit_dump_len (buffer size of exit info)
             false,    // partial (include all tasks if false)
-            SLICE_US, // default time slice (in us)
             false,    // verbose (verbose output)
             false,    // debug (debug mode)
         )?;
@@ -93,7 +92,8 @@ impl<'a> Scheduler<'a> {
                         dispatched_task.flags |= RL_CPU_ANY;
                     }
 
-                    // Decide for how long the task needs to run (time slice).
+                    // Decide for how long the task needs to run (time slice); if not specified
+                    // SCX_SLICE_DFL will be used by default.
                     dispatched_task.slice_ns = SLICE_US;
 
                     // Dispatch the task on the target CPU.
@@ -111,6 +111,7 @@ impl<'a> Scheduler<'a> {
     }
 
     fn print_stats(&mut self) {
+        // Internal scx_rustland_core statistics.
         let nr_user_dispatches = *self.bpf.nr_user_dispatches_mut();
         let nr_kernel_dispatches = *self.bpf.nr_kernel_dispatches_mut();
         let nr_cancel_dispatches = *self.bpf.nr_cancel_dispatches_mut();

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -69,7 +69,7 @@ impl<'a> Scheduler<'a> {
                 }
                 Ok(None) => {
                     // Notify the BPF component that all tasks have been scheduled and dispatched.
-                    self.bpf.update_tasks(Some(0), Some(0));
+                    self.bpf.notify_complete(0);
                     break;
                 }
                 Err(_) => {

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -52,19 +52,15 @@ impl<'a> Scheduler<'a> {
             // Get queued taks and dispatch them in order (FIFO).
             match self.bpf.dequeue_task() {
                 Ok(Some(task)) => {
-                    // task.cpu < 0 is used to to notify an exiting task, in this
-                    // case we can simply ignore the task.
-                    if task.cpu >= 0 {
-                        let mut dispatched_task = DispatchedTask::new(&task);
+                    let mut dispatched_task = DispatchedTask::new(&task);
 
-                        // Allow to dispatch on the first CPU available.
-                        dispatched_task.flags |= RL_CPU_ANY;
+                    // Allow to dispatch on the first CPU available.
+                    dispatched_task.flags |= RL_CPU_ANY;
 
-                        let _ = self.bpf.dispatch_task(&dispatched_task);
+                    let _ = self.bpf.dispatch_task(&dispatched_task);
 
-                        // Give the task a chance to run and prevent overflowing the dispatch queue.
-                        std::thread::yield_now();
-                    }
+                    // Give the task a chance to run and prevent overflowing the dispatch queue.
+                    std::thread::yield_now();
                 }
                 Ok(None) => {
                     // Notify the BPF component that all tasks have been scheduled and dispatched.

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -33,7 +33,6 @@ impl<'a> Scheduler<'a> {
             0,                        // exit_dump_len (buffer size of exit info)
             false,                    // partial (include all tasks if false)
             5000,                     // slice_ns (default task time slice)
-            true,                     // full_user (schedule all tasks in user-space)
             false,                    // low_power (low power mode)
             false,                    // verbose (verbose output)
             false,                    // debug (debug mode)
@@ -59,7 +58,7 @@ impl<'a> Scheduler<'a> {
                         let mut dispatched_task = DispatchedTask::new(&task);
 
                         // Allow to dispatch on the first CPU available.
-                        dispatched_task.set_flag(RL_CPU_ANY);
+                        dispatched_task.flags |= RL_CPU_ANY;
 
                         let _ = self.bpf.dispatch_task(&dispatched_task);
 

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -32,19 +32,11 @@ impl<'a> Scheduler<'a> {
     fn init(open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
         let bpf = BpfScheduler::init(
             open_object,
-            0,        // exit_dump_len (buffer size of exit info)
-            false,    // partial (include all tasks if false)
-            false,    // verbose (verbose output)
-            false,    // debug (debug mode)
+            0,        // exit_dump_len (buffer size of exit info, 0 = default)
+            false,    // partial (false = include all tasks)
+            false,    // debug (false = debug mode off)
         )?;
         Ok(Self { bpf })
-    }
-
-    fn now() -> u64 {
-        SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
     }
 
     fn dispatch_tasks(&mut self) {
@@ -128,6 +120,13 @@ impl<'a> Scheduler<'a> {
             nr_failed_dispatches,
             nr_sched_congested,
         );
+    }
+
+    fn now() -> u64 {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
     }
 
     fn run(&mut self, shutdown: Arc<AtomicBool>) -> Result<UserExitInfo> {

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -22,6 +22,8 @@ use std::time::SystemTime;
 
 use anyhow::Result;
 
+const SLICE_US: u64 = 5000;
+
 struct Scheduler<'a> {
     bpf: BpfScheduler<'a>,
 }
@@ -32,7 +34,7 @@ impl<'a> Scheduler<'a> {
             open_object,
             0,                        // exit_dump_len (buffer size of exit info)
             false,                    // partial (include all tasks if false)
-            5000,                     // slice_ns (default task time slice)
+            SLICE_US,                 // default time slice (in us)
             false,                    // verbose (verbose output)
             false,                    // debug (debug mode)
         )?;
@@ -48,37 +50,64 @@ impl<'a> Scheduler<'a> {
 
     fn dispatch_tasks(&mut self) {
         loop {
-            // Get queued taks and dispatch them in order (FIFO).
+            // Consume a taks that wants to run.
             match self.bpf.dequeue_task() {
+                // Consume a task that is ready to run.
+                //
+                // The task contains the following details:
+                //
+                // pub struct QueuedTask {
+                //     pub pid: i32,              // pid that uniquely identifies a task
+                //     pub cpu: i32,              // CPU where the task is running
+                //     pub sum_exec_runtime: u64, // Total cpu time
+                //     pub weight: u64,           // Task static priority
+                // }
+                //
+                // Although the FIFO scheduler doesn't use these fields, they can provide
+                // valuable data for implementing more sophisticated scheduling policies.
                 Ok(Some(task)) => {
+                    // Create a new task to be dispatched, derived from the received enqueued task.
+                    //
+                    // pub struct DispatchedTask {
+                    //     pub pid: i32,      // pid that uniquely identifies a task
+                    //     pub cpu: i32,      // target CPU selected by the scheduler
+                    //     pub flags: u64,    // special dispatch flags
+                    //     pub slice_ns: u64, // time slice assigned to the task (0 = default)
+                    // }
+                    //
+                    // The dispatched task's information are pre-populated from the QueuedTask and
+                    // they can be modified before dispatching it via self.bpf.dispatch_task().
                     let mut dispatched_task = DispatchedTask::new(&task);
 
-                    // Try to pick an idle CPU for the task.
-                    let cpu = self.bpf.select_cpu(dispatched_task.pid, dispatched_task.cpu, 0);
+                    // Decide where the task needs to run (target CPU).
+                    //
+                    // A call to select_cpu() will return the most suitable idle CPU for the task,
+                    // considering its previously used CPU.
+                    let cpu = self.bpf.select_cpu(task.pid, task.cpu, 0);
                     if cpu >= 0 {
+                        // Assign the selected CPU to the task to be dispatched.
                         dispatched_task.cpu = cpu;
                     } else {
-                        // Dispatch task on the first CPU available.
+                        // No idle CPU found: dspatch task on the first CPU available via the flag
+                        // RL_CPU_ANY.
                         dispatched_task.flags |= RL_CPU_ANY;
                     }
 
-                    let _ = self.bpf.dispatch_task(&dispatched_task);
+                    // Decide for how long the task needs to run (time slice).
+                    dispatched_task.slice_ns = SLICE_US;
 
-                    // Give the task a chance to run and prevent overflowing the dispatch queue.
-                    std::thread::yield_now();
+                    // Dispatch the task on the target CPU.
+                    self.bpf.dispatch_task(&dispatched_task).unwrap();
                 }
-                Ok(None) => {
-                    // Notify the BPF component that all tasks have been scheduled and dispatched.
+                Ok(None) | Err(_) => {
+                    // If no task is ready to run (or in case of error), stop dispatching tasks and
+                    // notify the BPF component that all tasks have been scheduled / dispatched,
+                    // with no remaining pending tasks.
                     self.bpf.notify_complete(0);
-                    break;
-                }
-                Err(_) => {
                     break;
                 }
             }
         }
-        // All queued tasks have been dipatched, yield to reduce scheduler's CPU consumption.
-        std::thread::yield_now();
     }
 
     fn print_stats(&mut self) {

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -33,7 +33,6 @@ impl<'a> Scheduler<'a> {
             0,                        // exit_dump_len (buffer size of exit info)
             false,                    // partial (include all tasks if false)
             5000,                     // slice_ns (default task time slice)
-            false,                    // low_power (low power mode)
             false,                    // verbose (verbose output)
             false,                    // debug (debug mode)
         )?;

--- a/scheds/rust/scx_rustland/Cargo.lock
+++ b/scheds/rust/scx_rustland/Cargo.lock
@@ -304,10 +304,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -969,6 +1010,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "scx_stats"
+version = "1.0.3"
+dependencies = [
+ "anyhow",
+ "crossbeam",
+ "libc",
+ "log",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "scx_utils"
 version = "1.0.3"
 dependencies = [
@@ -985,6 +1040,8 @@ dependencies = [
  "metrics-util",
  "paste",
  "regex",
+ "scx_stats",
+ "serde",
  "sscanf",
  "tar",
  "vergen",

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -265,7 +265,6 @@ impl<'a> Scheduler<'a> {
             open_object,
             opts.exit_dump_len,
             opts.partial,
-            opts.slice_us,
             opts.verbose,
             opts.debug,
         )?;

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -541,7 +541,6 @@ impl<'a> Scheduler<'a> {
     fn sync_interactive_tasks(&mut self, stats: &[TaskStat]) {
         self.interactive_pids.clear();
 
-        info!("{:<8} {:>10} {} <-- interactive tasks", "[pid]", "[nvcsw]", "[comm]");
         for i in 0..stats.len() {
             let stat = &stats[i];
 
@@ -551,13 +550,7 @@ impl<'a> Scheduler<'a> {
                 break;
             }
             self.interactive_pids.push(stat.pid);
-            info!(
-                "{:<8} {:>10} {}",
-                stat.pid, stat.nvcsw, stat.comm
-            );
         }
-
-        log::logger().flush();
     }
 
     fn update_interactive_stats(&mut self) -> std::io::Result<Vec<TaskStat>> {

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -92,14 +92,10 @@ struct Opts {
     #[clap(long, default_value = "0")]
     exit_dump_len: u32,
 
-    /// Enable verbose output, including libbpf details.
+    /// Enable verbose output, including libbpf details. Moreover, BPF scheduling events will be
+    /// reported in debugfs (e.g., /sys/kernel/debug/tracing/trace_pipe).
     #[clap(short = 'v', long, action = clap::ArgAction::SetTrue)]
     verbose: bool,
-
-    /// If specified, all the BPF scheduling events will be reported in
-    /// debugfs (e.g., /sys/kernel/debug/tracing/trace_pipe).
-    #[clap(short = 'd', long, action = clap::ArgAction::SetTrue)]
-    debug: bool,
 
     /// Print scheduler version and exit.
     #[clap(short = 'V', long, action = clap::ArgAction::SetTrue)]
@@ -266,7 +262,6 @@ impl<'a> Scheduler<'a> {
             opts.exit_dump_len,
             opts.partial,
             opts.verbose,
-            opts.debug,
         )?;
         info!("{} scheduler attached", SCHEDULER_NAME);
 

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -83,14 +83,6 @@ struct Opts {
     #[clap(short = 'S', long, default_value = "500")]
     slice_us_min: u64,
 
-    /// When low-power mode is enabled, the scheduler behaves in a more non-work conserving way:
-    /// the CPUs operate at reduced capacity, which slows down CPU-bound tasks, enhancing the
-    /// prioritization of interactive workloads.  In summary, enabling low-power mode will limit
-    /// the performance of CPU-intensive tasks, reducing power consumption, while maintaining
-    /// effective prioritization of interactive tasks.
-    #[clap(short = 'l', long, action = clap::ArgAction::SetTrue)]
-    low_power: bool,
-
     /// If specified, only tasks which have their scheduling policy set to SCHED_EXT using
     /// sched_setscheduler(2) are switched. Otherwise, all tasks are switched.
     #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
@@ -275,7 +267,6 @@ impl<'a> Scheduler<'a> {
             opts.exit_dump_len,
             opts.partial,
             opts.slice_us,
-            opts.low_power,
             opts.verbose,
             opts.debug,
         )?;

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -352,13 +352,6 @@ impl<'a> Scheduler<'a> {
         loop {
             match self.bpf.dequeue_task() {
                 Ok(Some(task)) => {
-                    // Check for exiting tasks (cpu < 0) and remove their corresponding entries in
-                    // the task map (if present).
-                    if task.cpu < 0 {
-                        self.task_map.tasks.remove(&task.pid);
-                        continue;
-                    }
-
                     // Update task information and determine vruntime.
                     let vruntime = self.update_enqueued(&task);
                     let timestamp = Self::now();


### PR DESCRIPTION
Second round of big refactoring in `scx_rustland_core`.

This set of changes is aimed to redesign the user-space framework in a better way, giving more importance to the design of the framework itself rather than the schedulers' performance (however, in case of scx_rustland it also seems to improve performance from the previous version).

Summary of the changes:
 - Idle CPU selection can be done fully in user-space (the user-space scheduler can pick an idle CPU via `self.bpf.select_cpu(pid, prev_cpu, flags)` mimicking the BPF's `select_cpu()` interface)
 - All tasks are always sent to user-space, there's no BPF shortcut anymore (surprisingly this doesn't seem to introduce any noticeable latency)
 - Dropped some ugly APIs (notifying exiting tasks, low_power, full_user): low_power will be re-introduced in the future with better topology awareness capabilities

NOTE: with these changes some options in `scx_rustland` are not supported anymore, so this may break some workflows, but, considering that most of the rustland users are now using `scx_bpfland` for better performance, this shouldn't be a problem.

Edit:
 - hide global slice_us (sine we have a per-task method to set the time slice, the global value is redundant)
  - merge verbose and debug options
  - hide shutdown boilerplate in BpfScheduler
  - update README.md