### PR TITLE
get_clang_ver: Fix regex for LLVM RC Versions

### DIFF
--- a/meson-scripts/get_clang_ver
+++ b/meson-scripts/get_clang_ver
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-"$1" --version | sed -nr 's/^.*clang version ([\.0-9]*)(git)?(\+.*)?( .*)?$/\1/p'
+"$1" --version | sed -nr 's/^.*clang version ([\.0-9]*)(git)?(-rc.*)?(\+.*)?( .*)?$/\1/p'


### PR DESCRIPTION
Currently, when using a llvm rc version, the get_clang_ver output is empty, there fore we get following:
```
meson.build:64:2: ERROR: Problem encountered: Unable to find clang version
```

Fix this issue, with adding the "rc" to the regex.
Tested with LLVM 18.1.8 and 19.1.0-rc3