### PR TITLE
scx_lavd: Drop message about unsupported multi-CXX support

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -684,10 +684,6 @@ fn main() -> Result<()> {
             *build_id::SCX_FULL_VERSION
         );
         info!(
-            "    Note that scx_lavd currently is not optimized for multi-CCX/NUMA architectures."
-        );
-        info!("    Stay tuned for future improvements!");
-        info!(
             "    stat: ('L'atency-critical, 'R'egular) (performance-'H'ungry, performance-'I'nsensitive) ('B'ig, li'T'tle) ('E'ligigle, 'G'reedy) ('P'reempting, 'N'ot)");
         info!("scx_lavd scheduler starts running.");
         if !sched.run()?.should_restart() {


### PR DESCRIPTION
LAVD got topology aware, therefore drop this message to avoid confusion at the user.