### PR TITLE
scx_lavd: Switch introspection to use scx_stats

### DIFF
--- a/scheds/rust/scx_lavd/Cargo.lock
+++ b/scheds/rust/scx_lavd/Cargo.lock
@@ -994,6 +994,7 @@ dependencies = [
  "anyhow",
  "bitvec",
  "clap",
+ "crossbeam",
  "ctrlc",
  "fb_procfs",
  "hex",
@@ -1004,7 +1005,10 @@ dependencies = [
  "ordered-float 3.9.2",
  "plain",
  "rlimit",
+ "scx_stats",
+ "scx_stats_derive",
  "scx_utils",
+ "serde",
  "simplelog",
  "static_assertions",
 ]
@@ -1019,6 +1023,17 @@ dependencies = [
  "log",
  "quote",
  "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "scx_stats_derive"
+version = "1.0.3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "scx_stats",
  "serde_json",
  "syn",
 ]

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-2.0-only"
 anyhow = "1.0.65"
 bitvec = { version = "1.0", features = ["serde"] }
 clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
+crossbeam = "0.8.4"
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7"
 hex = "0.4.3"
@@ -17,7 +18,10 @@ libbpf-rs = "0.24.1"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.3" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.3" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.3" }
+serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
 static_assertions = "1.1.0"
 rlimit = "0.10.1"

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -275,7 +275,6 @@ enum {
 struct introspec {
 	volatile u64	arg;
 	volatile u32	cmd;
-	u8		requested;
 };
 
 struct msg_hdr {

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -1,0 +1,111 @@
+use anyhow::Result;
+use scx_stats_derive::Stats;
+use serde::Deserialize;
+use serde::Serialize;
+use std::io::Write;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
+pub struct TaskSample {
+    pub mseq: u64,
+    pub pid: i32,
+    pub comm: String,
+    pub stat: String,
+    pub cpu_id: u32,
+    pub victim_cpu: i32,
+    pub vdeadline_delta_ns: u64,
+    pub slice_ns: u64,
+    pub greedy_ratio: u32,
+    pub lat_cri: u32,
+    pub avg_lat_cri: u32,
+    pub static_prio: u16,
+    pub slice_boost_prio: u16,
+    pub run_freq: u64,
+    pub run_time_ns: u64,
+    pub wait_freq: u64,
+    pub wake_freq: u64,
+    pub perf_cri: u32,
+    pub avg_perf_cri: u32,
+    pub cpuperf_cur: u32,
+    pub cpu_util: u64,
+    pub nr_active: u32,
+}
+
+impl TaskSample {
+    pub fn format_header<W: Write>(w: &mut W) -> Result<()> {
+        writeln!(
+            w,
+            "| {:6} | {:7} | {:17} \
+                   | {:5} | {:4} | {:4} \
+                   | {:14} | {:8} | {:7} \
+                   | {:8} | {:7} | {:8} \
+                   | {:7} | {:9} | {:9} \
+                   | {:9} | {:9} | {:8} \
+                   | {:8} | {:8} | {:8} \
+                   | {:6} |",
+            "mseq",
+            "pid",
+            "comm",
+            "stat",
+            "cpu",
+            "vtmc",
+            "vddln_ns",
+            "slc_ns",
+            "grdy_rt",
+            "lat_cri",
+            "avg_lc",
+            "st_prio",
+            "slc_bst",
+            "run_freq",
+            "run_tm_ns",
+            "wait_freq",
+            "wake_freq",
+            "perf_cri",
+            "avg_pc",
+            "cpufreq",
+            "cpu_util",
+            "nr_act",
+        )?;
+        Ok(())
+    }
+
+    pub fn format<W: Write>(&self, w: &mut W) -> Result<()> {
+        if self.mseq % 32 == 1 {
+            Self::format_header(w)?;
+        }
+
+        writeln!(
+            w,
+            "| {:6} | {:7} | {:17} \
+               | {:5} | {:4} | {:4} \
+               | {:14} | {:8} | {:7} \
+               | {:8} | {:7} | {:8} \
+               | {:7} | {:9} | {:9} \
+               | {:9} | {:9} | {:8} \
+               | {:8} | {:8} | {:8} \
+               | {:6} |",
+            self.mseq,
+            self.pid,
+            self.comm,
+            self.stat,
+            self.cpu_id,
+            self.victim_cpu,
+            self.vdeadline_delta_ns,
+            self.slice_ns,
+            self.greedy_ratio,
+            self.lat_cri,
+            self.avg_lat_cri,
+            self.static_prio,
+            self.slice_boost_prio,
+            self.run_freq,
+            self.run_time_ns,
+            self.wait_freq,
+            self.wake_freq,
+            self.perf_cri,
+            self.avg_perf_cri,
+            self.cpuperf_cur,
+            self.cpu_util,
+            self.nr_active,
+        )?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This allows introspection to be done on-demand while the scheduler is running so that we can reduce log noise while maintaining debuggability. It should be straightforward to add other introspection criteria and different types of stats too.