### PR TITLE
scx_lavd, scx_stats: Remove unnecessary messages

### DIFF
--- a/rust/scx_stats/src/server.rs
+++ b/rust/scx_stats/src/server.rs
@@ -223,7 +223,7 @@ where
         name: &str,
         visit: &mut impl FnMut(&ScxStatsMeta) -> Result<()>,
         nesting: &mut BTreeSet<String>,
-	visited: &mut BTreeSet<String>,
+        visited: &mut BTreeSet<String>,
     ) -> Result<()> {
         let m = match self.meta.get(name) {
             Some(v) => v,
@@ -233,9 +233,9 @@ where
         if !nesting.insert(name.into()) {
             bail!("loop in stats meta detected, {} already nested", name);
         }
-	if !visited.insert(name.into()) {
-	    return Ok(());
-	}
+        if !visited.insert(name.into()) {
+            return Ok(());
+        }
 
         visit(m)?;
 
@@ -266,13 +266,13 @@ where
         visit: &mut impl FnMut(&ScxStatsMeta) -> Result<()>,
     ) -> Result<()> {
         let mut nesting = BTreeSet::<String>::new();
-	let mut visited = BTreeSet::<String>::new();
+        let mut visited = BTreeSet::<String>::new();
         self.visit_meta_inner(from, visit, &mut nesting, &mut visited)
     }
 
     fn verify_meta(&self) -> Result<()> {
         if self.top.is_none() {
-            warn!("top-level stats metadata missing");
+            debug!("top-level stats metadata missing");
             return Ok(());
         }
 

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -684,8 +684,6 @@ fn main() -> Result<()> {
             "scx_lavd scheduler is initialized (build ID: {})",
             *build_id::SCX_FULL_VERSION
         );
-        info!(
-            "    stat: ('L'atency-critical, 'R'egular) (performance-'H'ungry, performance-'I'nsensitive) ('B'ig, li'T'tle) ('E'ligigle, 'G'reedy) ('P'reempting, 'N'ot)");
         info!("scx_lavd scheduler starts running.");
         if !sched.run()?.should_restart() {
             break;


### PR DESCRIPTION
scx_lavd unnecessarily prints out sched same field explanation and a warning message about missing "top" stats. Neither is useful. Remove both.