### PR TITLE
scx_stats: Shorten exported names and add prelude module

### DIFF
--- a/rust/scx_stats/examples/client.rs
+++ b/rust/scx_stats/examples/client.rs
@@ -1,4 +1,4 @@
-use scx_stats::{ScxStatsClient, ScxStatsMeta};
+use scx_stats::prelude::*;
 use scx_stats_derive::Stats;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -17,10 +17,10 @@ fn main() {
     std::assert_eq!(args().len(), 2, "Usage: client UNIX_SOCKET_PATH");
     let path = args().nth(1).unwrap();
 
-    let mut client = ScxStatsClient::new().set_path(path).connect().unwrap();
+    let mut client = StatsClient::new().set_path(path).connect().unwrap();
 
     println!("===== Requesting \"stats_meta\":");
-    let resp = client.request::<BTreeMap<String, ScxStatsMeta>>("stats_meta", vec![]);
+    let resp = client.request::<BTreeMap<String, StatsMeta>>("stats_meta", vec![]);
     println!("{:#?}", &resp);
 
     println!("\n===== Requesting \"stats\" without arguments:");

--- a/rust/scx_stats/examples/server.rs
+++ b/rust/scx_stats/examples/server.rs
@@ -1,5 +1,5 @@
 use log::{debug, info, warn};
-use scx_stats::{Meta, ScxStatsServer, ScxStatsServerData, ToJson};
+use scx_stats::prelude::*;
 use scx_stats_derive::Stats;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -45,9 +45,9 @@ fn main() {
     let path = args().nth(1).unwrap();
 
     // If communication from the stats generating closure is not necessary,
-    // ScxStatsServer::<(), ()> can be used. This example sends thread ID
-    // and receives the formatted string just for demonstration.
-    let sdata = ScxStatsServerData::<ThreadId, String>::new()
+    // StatsServer::<(), ()> can be used. This example sends thread ID and
+    // receives the formatted string just for demonstration.
+    let sdata = StatsServerData::<ThreadId, String>::new()
         .add_meta(ClusterStats::meta())
         .add_meta(DomainStats::meta())
         .add_stats(
@@ -65,7 +65,7 @@ fn main() {
     info!("stats_meta:");
     sdata.describe_meta(&mut std::io::stderr(), None).unwrap();
 
-    let server = ScxStatsServer::<ThreadId, String>::new(sdata)
+    let server = StatsServer::<ThreadId, String>::new(sdata)
         .set_path(&path)
         .launch()
         .unwrap();

--- a/rust/scx_stats/src/lib.rs
+++ b/rust/scx_stats/src/lib.rs
@@ -2,16 +2,19 @@ pub use serde_json;
 
 mod stats;
 pub use stats::{
-    Meta, ScxStatsAttr, ScxStatsData, ScxStatsField, ScxStatsFieldAttrs, ScxStatsKind,
-    ScxStatsMeta, ScxStatsMetaAux, ScxStatsStructAttrs,
+    Meta, StatsAttr, StatsData, StatsField, StatsFieldAttrs, StatsKind, StatsMeta, StatsMetaAux,
+    StatsStructAttrs,
 };
 
 mod server;
 pub use server::{
-    ScxStatsErrno, ScxStatsOps, ScxStatsRequest, ScxStatsResponse, ScxStatsServer,
-    ScxStatsServerData, StatsCloser, StatsOpener, StatsReader, StatsReaderSend, StatsReaderSync,
-    ToJson,
+    StatsCloser, StatsErrno, StatsOpener, StatsOps, StatsReader, StatsReaderSend, StatsReaderSync,
+    StatsRequest, StatsResponse, StatsServer, StatsServerData, ToJson,
 };
 
 mod client;
-pub use client::ScxStatsClient;
+pub use client::StatsClient;
+
+pub mod prelude {
+    pub use crate::*;
+}

--- a/rust/scx_utils/src/misc.rs
+++ b/rust/scx_utils/src/misc.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use log::info;
-use scx_stats::ScxStatsClient;
+use scx_stats::prelude::*;
 use serde::Deserialize;
 use std::thread::sleep;
 use std::time::Duration;
@@ -16,7 +16,7 @@ where
 {
     let mut retry_cnt: u32 = 0;
     while !should_exit() {
-        let mut client = match ScxStatsClient::new().connect() {
+        let mut client = match StatsClient::new().connect() {
             Ok(v) => v,
             Err(e) => match e.downcast_ref::<std::io::Error>() {
                 Some(ioe) if ioe.kind() == std::io::ErrorKind::ConnectionRefused => {

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -46,7 +46,7 @@ use libbpf_rs::OpenObject;
 use log::debug;
 use log::info;
 use log::warn;
-use scx_stats::ScxStatsServer;
+use scx_stats::prelude::*;
 use scx_utils::build_id;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
@@ -406,7 +406,7 @@ struct Scheduler<'a> {
     intrspc: introspec,
     intrspc_rx: Receiver<SchedSample>,
     sampler_tid: Option<ThreadId>,
-    stats_server: ScxStatsServer<StatsReq, StatsRes>,
+    stats_server: StatsServer<StatsReq, StatsRes>,
 }
 
 impl<'a> Scheduler<'a> {
@@ -432,7 +432,7 @@ impl<'a> Scheduler<'a> {
         // Attach.
         let mut skel = scx_ops_load!(skel, lavd_ops, uei)?;
         let struct_ops = Some(scx_ops_attach!(skel, lavd_ops)?);
-        let stats_server = ScxStatsServer::new(stats::server_data(nr_cpus_onln)).launch()?;
+        let stats_server = StatsServer::new(stats::server_data(nr_cpus_onln)).launch()?;
 
         // Build a ring buffer for instrumentation
         let (intrspc_tx, intrspc_rx) = channel::bounded(65536);

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -1,11 +1,6 @@
 use anyhow::bail;
 use anyhow::Result;
-use scx_stats::Meta;
-use scx_stats::ScxStatsOps;
-use scx_stats::ScxStatsServerData;
-use scx_stats::StatsOpener;
-use scx_stats::StatsReader;
-use scx_stats::ToJson;
+use scx_stats::prelude::*;
 use scx_stats_derive::Stats;
 use serde::Deserialize;
 use serde::Serialize;
@@ -170,7 +165,7 @@ pub enum StatsRes {
     SchedSamples(SchedSamples),
 }
 
-pub fn server_data(nr_cpus_onln: u64) -> ScxStatsServerData<StatsReq, StatsRes> {
+pub fn server_data(nr_cpus_onln: u64) -> StatsServerData<StatsReq, StatsRes> {
     let samples_open: Box<dyn StatsOpener<StatsReq, StatsRes>> =
         Box::new(move |(req_ch, res_ch)| {
             let tid = std::thread::current().id();
@@ -196,11 +191,11 @@ pub fn server_data(nr_cpus_onln: u64) -> ScxStatsServerData<StatsReq, StatsRes> 
             Ok(read)
         });
 
-    ScxStatsServerData::new()
+    StatsServerData::new()
         .add_meta(SchedSample::meta())
         .add_ops(
             "sched_samples",
-            ScxStatsOps {
+            StatsOps {
                 open: samples_open,
                 close: None,
             },

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -43,7 +43,7 @@ use log::debug;
 use log::info;
 use log::trace;
 use log::warn;
-use scx_stats::ScxStatsServer;
+use scx_stats::prelude::*;
 use scx_utils::compat;
 use scx_utils::init_libbpf_logging;
 use scx_utils::ravg::ravg_read;
@@ -1384,7 +1384,7 @@ struct Scheduler<'a, 'b> {
     nr_layer_cpus_ranges: Vec<(usize, usize)>,
     processing_dur: Duration,
 
-    stats_server: ScxStatsServer<StatsReq, StatsRes>,
+    stats_server: StatsServer<StatsReq, StatsRes>,
 }
 
 impl<'a, 'b> Scheduler<'a, 'b> {
@@ -1620,7 +1620,7 @@ impl<'a, 'b> Scheduler<'a, 'b> {
 
         // Attach.
         let struct_ops = scx_ops_attach!(skel, layered)?;
-        let stats_server = ScxStatsServer::new(stats::server_data()).launch()?;
+        let stats_server = StatsServer::new(stats::server_data()).launch()?;
 
         let sched = Self {
             struct_ops: Some(struct_ops),
@@ -1938,8 +1938,8 @@ fn main() -> Result<()> {
     let opts = Opts::parse();
 
     if opts.help_stats {
-	stats::server_data().describe_meta(&mut std::io::stdout(), None)?;
-	return Ok(());
+        stats::server_data().describe_meta(&mut std::io::stdout(), None)?;
+        return Ok(());
     }
 
     let llv = match opts.verbose {

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -8,13 +8,7 @@ use bitvec::prelude::*;
 use chrono::DateTime;
 use chrono::Local;
 use log::warn;
-use scx_stats::Meta;
-use scx_stats::ScxStatsOps;
-use scx_stats::ScxStatsServerData;
-use scx_stats::StatsCloser;
-use scx_stats::StatsOpener;
-use scx_stats::StatsReader;
-use scx_stats::ToJson;
+use scx_stats::prelude::*;
 use scx_stats_derive::Stats;
 use serde::Deserialize;
 use serde::Serialize;
@@ -432,7 +426,7 @@ pub enum StatsRes {
     Bye,
 }
 
-pub fn server_data() -> ScxStatsServerData<StatsReq, StatsRes> {
+pub fn server_data() -> StatsServerData<StatsReq, StatsRes> {
     let open: Box<dyn StatsOpener<StatsReq, StatsRes>> = Box::new(move |(req_ch, res_ch)| {
         let tid = current().id();
         req_ch.send(StatsReq::Hello(tid))?;
@@ -463,12 +457,12 @@ pub fn server_data() -> ScxStatsServerData<StatsReq, StatsRes> {
         }
     });
 
-    ScxStatsServerData::new()
+    StatsServerData::new()
         .add_meta(LayerStats::meta())
         .add_meta(SysStats::meta())
         .add_ops(
             "top",
-            ScxStatsOps {
+            StatsOps {
                 open,
                 close: Some(close),
             },

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -45,7 +45,7 @@ use libbpf_rs::skel::SkelBuilder;
 use libbpf_rs::MapCore as _;
 use libbpf_rs::OpenObject;
 use log::info;
-use scx_stats::ScxStatsServer;
+use scx_stats::prelude::*;
 use scx_utils::build_id;
 use scx_utils::compat;
 use scx_utils::init_libbpf_logging;
@@ -348,7 +348,7 @@ struct Scheduler<'a> {
     nr_lb_data_errors: u64,
 
     tuner: Tuner,
-    stats_server: ScxStatsServer<StatsCtx, (StatsCtx, ClusterStats)>,
+    stats_server: StatsServer<StatsCtx, (StatsCtx, ClusterStats)>,
 }
 
 impl<'a> Scheduler<'a> {
@@ -446,7 +446,7 @@ impl<'a> Scheduler<'a> {
         // Attach.
         let mut skel = scx_ops_load!(skel, rusty, uei)?;
         let struct_ops = Some(scx_ops_attach!(skel, rusty)?);
-        let stats_server = ScxStatsServer::new(stats::server_data()).launch()?;
+        let stats_server = StatsServer::new(stats::server_data()).launch()?;
 
         info!("Rusty scheduler started! Run `scx_rusty --monitor` for metrics.");
 
@@ -629,8 +629,8 @@ fn main() -> Result<()> {
     }
 
     if opts.help_stats {
-	stats::server_data().describe_meta(&mut std::io::stdout(), None)?;
-	return Ok(());
+        stats::server_data().describe_meta(&mut std::io::stdout(), None)?;
+        return Ok(());
     }
 
     let llv = match opts.verbose {

--- a/scheds/rust/scx_rusty/src/stats.rs
+++ b/scheds/rust/scx_rusty/src/stats.rs
@@ -2,12 +2,7 @@ use crate::StatsCtx;
 use anyhow::Result;
 use chrono::DateTime;
 use chrono::Local;
-use scx_stats::Meta;
-use scx_stats::ScxStatsOps;
-use scx_stats::ScxStatsServerData;
-use scx_stats::StatsOpener;
-use scx_stats::StatsReader;
-use scx_stats::ToJson;
+use scx_stats::prelude::*;
 use scx_stats_derive::Stats;
 use scx_utils::Cpumask;
 use serde::Deserialize;
@@ -215,7 +210,7 @@ impl ClusterStats {
     }
 }
 
-pub fn server_data() -> ScxStatsServerData<StatsCtx, (StatsCtx, ClusterStats)> {
+pub fn server_data() -> StatsServerData<StatsCtx, (StatsCtx, ClusterStats)> {
     let open: Box<dyn StatsOpener<StatsCtx, (StatsCtx, ClusterStats)>> =
         Box::new(move |(req_ch, res_ch)| {
             // Send one bogus request on open to establish prev_sc.
@@ -234,11 +229,11 @@ pub fn server_data() -> ScxStatsServerData<StatsCtx, (StatsCtx, ClusterStats)> {
             Ok(read)
         });
 
-    ScxStatsServerData::new()
+    StatsServerData::new()
         .add_meta(DomainStats::meta())
         .add_meta(NodeStats::meta())
         .add_meta(ClusterStats::meta())
-        .add_ops("top", ScxStatsOps { open, close: None })
+        .add_ops("top", StatsOps { open, close: None })
 }
 
 pub fn monitor(intv: Duration, shutdown: Arc<AtomicBool>) -> Result<()> {


### PR DESCRIPTION
Let's make it a bit easier to use:

- Shorten exported names by changing the prefix from ScxStats to Stats. This should be distinctive enough and more inline with how most libraries name their exports.

- Importing the right set of traits can be tricky. Introduce prelude module so that importing is a bit less painful.