### PR TITLE
scx_stats: Make StatsServerData::describe_meta() output more readable

### DIFF
--- a/rust/scx_stats/src/server.rs
+++ b/rust/scx_stats/src/server.rs
@@ -294,7 +294,7 @@ where
         self.visit_meta(from, &mut |m| {
             nwidth = nwidth.max(m.name.len());
             (fwidth, dwidth) = m.fields.iter().fold((fwidth, dwidth), |acc, (n, f)| {
-                (acc.0.max(n.len()), acc.1.max(f.data.to_string().len()))
+                (acc.0.max(n.len()), acc.1.max(f.data.to_string().len() + 2))
             });
             Ok(())
         })?;
@@ -317,12 +317,12 @@ where
                     w,
                     "  {:fw$} {:dw$}",
                     fname,
-                    f.data.to_string(),
+                    format!("({})", f.data.to_string()),
                     fw = fwidth,
                     dw = dwidth
                 )?;
                 if let Some(desc) = &f.attrs.desc {
-                    write!(w, " {}", desc)?;
+                    write!(w, " : {}", desc)?;
                 }
                 writeln!(w, "")?;
             }


### PR DESCRIPTION
Add deliminators to make the output easier on the eyes.

Before:
```
$ scx_bpfland --help-stats
[Metrics]                                                                                                  
  nr_cpus              u64 Number of online CPUs                                                         
  nr_direct_dispatches u64 Number of task direct dispatches                      
  nr_interactive       u64 Number of running interactive tasks       
  nr_prio_dispatches   u64 Number of interactive task dispatches                                         
  nr_running           u64 Number of running tasks                                                       
  nr_shared_dispatches u64 Number of regular task dispatches                                             
  nr_waiting           u64 Average amount of tasks waiting to be dispatched   
  nvcsw_avg_thresh     u64 Average of voluntary context switches   
```

After:
```
$ scx_bpfland --help-stats
[Metrics]
  nr_cpus              (u64) : Number of online CPUs
  nr_direct_dispatches (u64) : Number of task direct dispatches
  nr_interactive       (u64) : Number of running interactive tasks
  nr_prio_dispatches   (u64) : Number of interactive task dispatches
  nr_running           (u64) : Number of running tasks
  nr_shared_dispatches (u64) : Number of regular task dispatches
  nr_waiting           (u64) : Average amount of tasks waiting to be dispatched
  nvcsw_avg_thresh     (u64) : Average of voluntary context switches
```