### PR TITLE
scx_lavd: move time slice calculation to ops.enqueue() and ops.select_cpu() and more

### DIFF
--- a/scheds/rust/Cargo.lock
+++ b/scheds/rust/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -566,6 +566,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1074,6 +1083,7 @@ dependencies = [
  "ctrlc",
  "fb_procfs",
  "hex",
+ "itertools 0.13.0",
  "libbpf-rs",
  "libc",
  "log",

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -14,6 +14,7 @@ crossbeam = "0.8.4"
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7"
 hex = "0.4.3"
+itertools = "0.13.0"
 libbpf-rs = "0.24.1"
 libc = "0.2.137"
 log = "0.4.17"

--- a/scheds/rust/scx_lavd/README.md
+++ b/scheds/rust/scx_lavd/README.md
@@ -23,9 +23,8 @@ gaming, which requires high throughput and low tail latencies.
 
 ## Production Ready?
 
-This scheduler could be used in a production environment where the current code
-is optimized. The current code does not particularly consider multiple NUMA/CCX
-domains, so its scheduling decisions in such hardware would be suboptimal. This
-scheduler currently will mainly perform well on single CCX / single-socket
-hosts.
-
+Yes, scx_lavd should be performant across various CPU architectures, but it
+mainly targets single CCX / single-socket systems. It creates a separate
+scheduling domain per-LLC, per-core type (e.g., P or E core on Intel, big or
+LITTLE on ARM), and per-NUMA domain, so the default balanced profile should be
+performant.

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -88,8 +88,8 @@ enum consts {
 	LAVD_CC_CPU_PIN_INTERVAL_DIV	= (LAVD_CC_CPU_PIN_INTERVAL /
 					   LAVD_SYS_STAT_INTERVAL_NS),
 
-	LAVD_CPDOM_MAX_NR		= 64, /* maximum number of compute domain (<= 64) */
-	LAVD_CPDOM_MAX_DIST		= 6,  /* maximum distance from one compute domain to another */
+	LAVD_CPDOM_MAX_NR		= 32, /* maximum number of compute domain */
+	LAVD_CPDOM_MAX_DIST		= 4,  /* maximum distance from one compute domain to another */
 	LAVD_CPDOM_STARV_NS		= (5ULL * NSEC_PER_MSEC),
 
 	LAVD_STATUS_STR_LEN		= 5, /* {LR: Latency-critical, Regular}
@@ -132,7 +132,7 @@ struct cpdom_ctx {
 	u8	is_active;			    /* if this compute domain is active */
 	u8	nr_neighbors[LAVD_CPDOM_MAX_DIST];  /* number of neighbors per distance */
 	u64	neighbor_bits[LAVD_CPDOM_MAX_DIST]; /* bitmask of neighbor bitmask per distance */
-	u64	cpumask[LAVD_CPU_ID_MAX/64];	    /* cpumasks belongs to this compute domain */
+	u64	__cpumask[LAVD_CPU_ID_MAX/64];	    /* cpumasks belongs to this compute domain */
 };
 
 /*

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -133,7 +133,7 @@ struct cpdom_ctx {
 	u8	nr_neighbors[LAVD_CPDOM_MAX_DIST];  /* number of neighbors per distance */
 	u64	neighbor_bits[LAVD_CPDOM_MAX_DIST]; /* bitmask of neighbor bitmask per distance */
 	u64	__cpumask[LAVD_CPU_ID_MAX/64];	    /* cpumasks belongs to this compute domain */
-};
+} __attribute__((aligned(CACHELINE_SIZE)));
 
 /*
  * CPU context
@@ -199,6 +199,7 @@ struct cpu_ctx {
 	struct bpf_cpumask __kptr *tmp_a_mask;	/* temporary cpu mask */
 	struct bpf_cpumask __kptr *tmp_o_mask;	/* temporary cpu mask */
 	struct bpf_cpumask __kptr *tmp_t_mask;	/* temporary cpu mask */
+	struct bpf_cpumask __kptr *tmp_t2_mask;	/* temporary cpu mask */
 } __attribute__((aligned(CACHELINE_SIZE)));
 
 /*

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -108,6 +108,7 @@ struct sys_stat {
 
 	volatile u64	load_actual;	/* average actual load of runnable tasks */
 	volatile u64	avg_svc_time;	/* average service time per task */
+	volatile u64	nr_queued_task;
 
 	volatile u32	avg_lat_cri;	/* average latency criticality (LC) */
 	volatile u32	max_lat_cri;	/* maximum latency criticality (LC) */

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -362,14 +362,6 @@ static struct task_ctx *get_task_ctx(struct task_struct *p)
 	return taskc;
 }
 
-static s32 get_task_cpu_id(struct task_struct *p)
-{
-	/*
-	 * This code assumes ONFIG_THREAD_INFO_IN_TASK is on in the kernel.
-	 */
-	return READ_ONCE(p->thread_info.cpu);
-}
-
 static struct cpu_ctx *get_cpu_ctx(void)
 {
 	const u32 idx = 0;
@@ -1822,7 +1814,7 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 	 * always put the task to the global DSQ, so any idle CPU can pick it
 	 * up.
 	 */
-	cpu_id = get_task_cpu_id(p);
+	cpu_id = scx_bpf_task_cpu(p);
 	taskc = get_task_ctx(p);
 	cpuc_task = get_cpu_ctx_id(cpu_id);
 	cpuc_cur = get_cpu_ctx();

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1304,7 +1304,8 @@ static bool could_run_on_prev(struct task_struct *p, s32 prev_cpu,
 	return ret;
 }
 
-static s32 pick_idle_cpu_in(struct bpf_cpumask *cpumask)
+static __always_inline
+s32 pick_idle_cpu_in(struct bpf_cpumask *cpumask)
 {
 	s32 cpu_id;
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -229,6 +229,7 @@ static u64		cur_svc_time;
  */
 const volatile bool	no_core_compaction;
 const volatile bool	no_freq_scaling;
+const volatile u32 	is_smt_active;
 const volatile u8	verbose;
 
 UEI_DEFINE(uei);
@@ -1307,11 +1308,15 @@ static s32 pick_idle_cpu_in(struct bpf_cpumask *cpumask)
 {
 	s32 cpu_id;
 
-	/*
-	 * Pick a fully idle core within a cpumask.
-	 */
-	cpu_id = scx_bpf_pick_idle_cpu(cast_mask(cpumask), SCX_PICK_IDLE_CORE);
-	if (cpu_id < 0) {
+	if (is_smt_active) {
+		/*
+		 * Pick a fully idle core within a cpumask.
+		 */
+		cpu_id = scx_bpf_pick_idle_cpu(cast_mask(cpumask),
+					       SCX_PICK_IDLE_CORE);
+	}
+
+	if (!is_smt_active || cpu_id < 0) {
 		/*
 		 * Pick a fully idle core within a cpumask even if its
 		 * hypertwin is in use.

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1493,17 +1493,8 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 	taskc->wakeup_ft += !!(wake_flags & SCX_WAKE_SYNC);
 
 	cpu_id = pick_idle_cpu(p, taskc, prev_cpu, wake_flags, &found_idle);
-	if (found_idle) {
-		/*
-		 * Calculate the task's time slice if found an idle CPU.
-		 */
-		struct cpu_ctx *cpuc_task = get_cpu_ctx_id(cpu_id);
-		if (cpuc_task)
-			p->scx.slice = calc_time_slice(p, taskc, cpuc_task);
-		else
-			p->scx.slice = LAVD_SLICE_MIN_NS;
+	if (found_idle)
 		return cpu_id;
-	}
 
 	return (cpu_id >= 0) ? cpu_id : prev_cpu;
 }

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -2832,7 +2832,7 @@ static s32 init_per_cpu_ctx(u64 now)
 			continue;
 
 		bpf_for(i, 0, LAVD_CPU_ID_MAX/64) {
-			u64 cpumask = cpdomc->cpumask[i];
+			u64 cpumask = cpdomc->__cpumask[i];
 			bpf_for(j, 0, 64) {
 				if (cpumask & 0x1LLU << j) {
 					cpu = (i * 64) + j;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -56,6 +56,7 @@ use scx_utils::uei_report;
 use scx_utils::Topology;
 use scx_utils::UserExitInfo;
 
+use itertools::iproduct;
 use nix::sys::signal;
 use plain::Plain;
 use rlimit::{getrlimit, setrlimit, Resource};
@@ -359,21 +360,19 @@ impl FlatTopology {
         }
 
         // Build a neighbor map for each compute domain
-        for (from_k, from_v) in cpdom_map.iter() {
-            for (to_k, to_v) in cpdom_map.iter() {
-                if from_k == to_k {
-                    continue;
-                }
+        for ((from_k, from_v), (to_k, to_v)) in iproduct!(cpdom_map.iter(), cpdom_map.iter()) {
+            if from_k == to_k {
+                continue;
+            }
 
-                let d = Self::dist(from_k, to_k);
-                let mut map = from_v.neighbor_map.borrow_mut();
-                match map.get(&d) {
-                    Some(v) => {
-                        v.borrow_mut().push(to_v.cpdom_id);
-                    }
-                    None => {
-                        map.insert(d, RefCell::new(vec![to_v.cpdom_id]));
-                    }
+            let d = Self::dist(from_k, to_k);
+            let mut map = from_v.neighbor_map.borrow_mut();
+            match map.get(&d) {
+                Some(v) => {
+                    v.borrow_mut().push(to_v.cpdom_id);
+                }
+                None => {
+                    map.insert(d, RefCell::new(vec![to_v.cpdom_id]));
                 }
             }
         }


### PR DESCRIPTION
The PR contains the following changes:

- add a fast path in pick_idle_cpu() when SMT is not activated
- move time slice calculation to ops.enqueue() and ops.select_cpu()
- prefer big cores in the performance mode
- make the old BPF verifier happy
- misc. refactoring and code clean up