### PR TITLE
scx_bpfland: prevent reading energy profile if not available

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -507,7 +507,7 @@ impl<'a> Scheduler<'a> {
     }
 
     fn refresh_sched_domain(&mut self) {
-        if self.opts.primary_domain.is_empty() {
+        if self.opts.primary_domain.is_empty() && self.energy_profile != "none" {
             let energy_profile = Self::read_energy_profile();
             if energy_profile != self.energy_profile {
                 self.energy_profile = energy_profile.clone();


### PR DESCRIPTION
Avoid to periodically read the current performance profile from /sys/devices/system/cpu/cpufreq/policy0/energy_performance_preference if it's not available (i.e., with older CPUs or kernels without cpufreq).

This fixes issue #560.