### PR TITLE
scx_lavd: prioritize the turbo boost-able cores

### DIFF
--- a/scheds/rust/Cargo.lock
+++ b/scheds/rust/Cargo.lock
@@ -1087,7 +1087,6 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "log",
- "nix 0.29.0",
  "ordered-float 3.9.2",
  "plain",
  "rlimit",

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -27,7 +27,6 @@ simplelog = "0.12"
 static_assertions = "1.1.0"
 rlimit = "0.10.1"
 plain = "0.2.3"
-nix = { version = "0.29.0", features = ["signal"] }
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.3" }

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -82,6 +82,7 @@ enum consts {
 
 	LAVD_SYS_STAT_INTERVAL_NS	= (25ULL * NSEC_PER_MSEC),
 	LAVD_CC_PER_CORE_MAX_CTUIL	= 500, /* maximum per-core CPU utilization */
+	LAVD_CC_PER_TURBO_CORE_MAX_CTUIL = 750, /* maximum per-core CPU utilization for a turbo core */
 	LAVD_CC_NR_ACTIVE_MIN		= 1, /* num of mininum active cores */
 	LAVD_CC_NR_OVRFLW		= 1, /* num of overflow cores */
 	LAVD_CC_CPU_PIN_INTERVAL	= (3ULL * LAVD_TIME_ONE_SEC),
@@ -193,6 +194,7 @@ struct cpu_ctx {
 	 */
 	u16		capacity;	/* CPU capacity based on 1000 */
 	u8		big_core;	/* is it a big core? */
+	u8		turbo_core;	/* is it a turbo core? */
 	u8		cpdom_id;	/* compute domain id (== dsq_id) */
 	u8		cpdom_alt_id;	/* compute domain id of anternative type (== dsq_id) */
 	u8		cpdom_poll_pos;	/* index to check if a DSQ of a compute domain is starving */

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -117,6 +117,10 @@ struct Opts {
     /// times to increase verbosity.
     #[clap(short = 'v', long, action = clap::ArgAction::Count)]
     verbose: u8,
+
+    /// Print scheduler version and exit.
+    #[clap(short = 'V', long, action = clap::ArgAction::SetTrue)]
+    version: bool,
 }
 
 impl Opts {
@@ -691,6 +695,11 @@ fn init_signal_handlers() {
 fn main() -> Result<()> {
     let mut opts = Opts::parse();
     opts.proc().unwrap();
+
+    if opts.version {
+        println!("scx_lavd {}", *build_id::SCX_FULL_VERSION);
+        return Ok(());
+    }
 
     init_log(&opts);
     init_signal_handlers();

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -101,6 +101,10 @@ struct Opts {
     #[clap(long = "prefer-little-core", action = clap::ArgAction::SetTrue)]
     prefer_little_core: bool,
 
+    /// Do not specifically prefer to schedule on turbo cores.
+    #[clap(long = "no-prefer-turbo-core", action = clap::ArgAction::SetTrue)]
+    no_prefer_turbo_core: bool,
+
     /// Disable controlling the CPU frequency. In order to improve latency and responsiveness of
     /// performance-critical tasks, scx_lavd increases the CPU frequency even if CPU usage is low.
     /// See main.bpf.c for more info. Normally set by the power mode, but can be set independently
@@ -129,18 +133,21 @@ impl Opts {
             self.no_core_compaction = true;
             self.prefer_smt_core = false;
             self.prefer_little_core = false;
+            self.no_prefer_turbo_core = false;
             self.no_freq_scaling = true;
         }
         if self.powersave {
             self.no_core_compaction = false;
             self.prefer_smt_core = true;
             self.prefer_little_core = true;
+            self.no_prefer_turbo_core = true;
             self.no_freq_scaling = false;
         }
         if self.balanced {
             self.no_core_compaction = false;
             self.prefer_smt_core = false;
             self.prefer_little_core = false;
+            self.no_prefer_turbo_core = false;
             self.no_freq_scaling = false;
         }
 
@@ -516,6 +523,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.bss_data.nr_cpus_onln = nr_cpus_onln;
         skel.maps.rodata_data.no_core_compaction = opts.no_core_compaction;
         skel.maps.rodata_data.no_freq_scaling = opts.no_freq_scaling;
+        skel.maps.rodata_data.no_prefer_turbo_core = opts.no_prefer_turbo_core;
         skel.maps.rodata_data.is_smt_active = match FlatTopology::is_smt_active() {
             Ok(ret) => (ret == 1) as u32,
             Err(_)  => 0,


### PR DESCRIPTION
This PR contains three commits:

- Prioritize the turbo boostable cores in `performance` and `balanced` profiles by default. When seeking an idle CPU at ops.select_cpu(), the turbo bootable cores are chosen before checking the other active cores. To manually control the behavior, `--no-prefer-turbo-core` option is added.

- Replace nix signal handler to ctrlc

- Add `--version` option