### PR TITLE
scx_rustland_core: small core design improvements

### DIFF
--- a/rust/scx_rustland_core/README.md
+++ b/rust/scx_rustland_core/README.md
@@ -54,9 +54,144 @@ scx_rustland_core = "0.1"
 
 ## Example
 
-You can find a simple example of a fully working FIFO scheduler implemented
-using the `scx_rustland_core` framework here:
-[scx_rlfifo](https://github.com/sched-ext/scx/tree/main/scheds/rust/scx_rlfifo).
+Following you can find a simple example of a fully working FIFO scheduler,
+implemented using the `scx_rustland_core` framework:
+```
+// Copyright (c) Andrea Righi <andrea.righi@linux.dev>
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+mod bpf_skel;
+pub use bpf_skel::*;
+pub mod bpf_intf;
+
+mod bpf;
+use bpf::*;
+
+use scx_utils::UserExitInfo;
+
+use libbpf_rs::OpenObject;
+
+use std::mem::MaybeUninit;
+use std::collections::VecDeque;
+
+use anyhow::Result;
+
+const SLICE_US: u64 = 5000;
+
+struct Scheduler<'a> {
+    bpf: BpfScheduler<'a>,
+    task_queue: VecDeque<QueuedTask>,
+}
+
+impl<'a> Scheduler<'a> {
+    fn init(open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
+        let bpf = BpfScheduler::init(
+            open_object,
+            0,     // exit_dump_len (buffer size of exit info, 0 = default)
+            false, // partial (false = include all tasks)
+            false, // debug (false = debug mode off)
+        )?;
+        Ok(Self { bpf, task_queue: VecDeque::new() })
+    }
+
+    fn consume_all_tasks(&mut self) {
+        // Consume all tasks that are ready to run.
+        //
+        // Each task contains the following details:
+        //
+        // pub struct QueuedTask {
+        //     pub pid: i32,              // pid that uniquely identifies a task
+        //     pub cpu: i32,              // CPU where the task is running
+        //     pub sum_exec_runtime: u64, // Total cpu time
+        //     pub weight: u64,           // Task static priority
+        // }
+        //
+        // Although the FIFO scheduler doesn't use these fields, they can provide valuable data for
+        // implementing more sophisticated scheduling policies.
+        while let Ok(Some(task)) = self.bpf.dequeue_task() {
+            self.task_queue.push_back(task);
+        }
+    }
+
+     fn dispatch_next_task(&mut self) {
+        if let Some(task) = self.task_queue.pop_front() {
+            // Create a new task to be dispatched, derived from the received enqueued task.
+            //
+            // pub struct DispatchedTask {
+            //     pub pid: i32,      // pid that uniquely identifies a task
+            //     pub cpu: i32,      // target CPU selected by the scheduler
+            //     pub flags: u64,    // special dispatch flags
+            //     pub slice_ns: u64, // time slice assigned to the task (0 = default)
+            // }
+            //
+            // The dispatched task's information are pre-populated from the QueuedTask and they can
+            // be modified before dispatching it via self.bpf.dispatch_task().
+            let mut dispatched_task = DispatchedTask::new(&task);
+
+            // Decide where the task needs to run (target CPU).
+            //
+            // A call to select_cpu() will return the most suitable idle CPU for the task,
+            // considering its previously used CPU.
+            let cpu = self.bpf.select_cpu(task.pid, task.cpu, 0);
+            if cpu >= 0 {
+                dispatched_task.cpu = cpu;
+            } else {
+                dispatched_task.flags |= RL_CPU_ANY;
+            }
+
+            // Decide for how long the task needs to run (time slice); if not specified
+            // SCX_SLICE_DFL will be used by default.
+            dispatched_task.slice_ns = SLICE_US;
+
+            // Dispatch the task on the target CPU.
+            self.bpf.dispatch_task(&dispatched_task).unwrap();
+
+            // Notify the BPF component of the number of pending tasks and immediately give a
+            // chance to run to the dispatched task.
+            self.bpf.notify_complete(self.task_queue.len() as u64);
+        }
+    }
+
+    fn dispatch_tasks(&mut self) {
+        loop {
+            // Consume all tasks before dispatching any.
+            self.consume_all_tasks();
+
+            // Dispatch one task from the queue.
+            self.dispatch_next_task();
+
+            // If no task is ready to run (or in case of error), stop dispatching tasks and notify
+            // the BPF component that all tasks have been scheduled / dispatched, with no remaining
+            // pending tasks.
+            if self.task_queue.is_empty() {
+                self.bpf.notify_complete(0);
+                break;
+            }
+        }
+    }
+
+    fn run(&mut self) -> Result<UserExitInfo> {
+        while !self.bpf.exited() {
+            self.dispatch_tasks();
+        }
+        self.bpf.shutdown_and_report()
+    }
+}
+
+fn main() -> Result<()> {
+    // Initialize and load the FIFO scheduler.
+    let mut open_object = MaybeUninit::uninit();
+    loop {
+        let mut sched = Scheduler::init(&mut open_object)?;
+        if !sched.run()?.should_restart() {
+            break;
+        }
+    }
+
+    Ok(())
+}
+```
 
 ## License
 

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -90,6 +90,7 @@ pub struct DispatchedTask {
     pub cpu: i32,      // target CPU selected by the scheduler
     pub flags: u64,    // special dispatch flags
     pub slice_ns: u64, // time slice assigned to the task (0 = default)
+    pub vtime: u64,    // task deadline / vruntime
     cpumask_cnt: u64,  // cpumask generation counter (private)
 }
 
@@ -105,6 +106,7 @@ impl DispatchedTask {
             flags: 0,
             cpumask_cnt: task.cpumask_cnt,
             slice_ns: 0, // use default time slice
+            vtime: 0,
         }
     }
 }
@@ -429,16 +431,18 @@ impl<'cb> BpfScheduler<'cb> {
             pid,
             cpu,
             flags,
-            cpumask_cnt,
             slice_ns,
+            vtime,
+            cpumask_cnt,
             ..
         } = &mut dispatched_task.as_mut();
 
         *pid = task.pid;
         *cpu = task.cpu;
         *flags = task.flags;
-        *cpumask_cnt = task.cpumask_cnt;
         *slice_ns = task.slice_ns;
+        *vtime = task.vtime;
+        *cpumask_cnt = task.cpumask_cnt;
 
         // Store the task in the user ring buffer.
         //

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -53,10 +53,6 @@ const SCHED_EXT: i32 = 7;
 #[allow(dead_code)]
 pub const RL_CPU_ANY: u64 = bpf_intf::RL_CPU_ANY as u64;
 
-// Allow to preempt the target CPU when dispatching the task.
-#[allow(dead_code)]
-pub const RL_PREEMPT_CPU: u64 = bpf_intf::RL_PREEMPT_CPU as u64;
-
 /// High-level Rust abstraction to interact with a generic sched-ext BPF component.
 ///
 /// Overview

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -54,11 +54,6 @@ enum {
 	 * on the first CPU available.
 	 */
 	RL_CPU_ANY = 1 << 0,
-
-	/*
-	 * Allow to preempt the target CPU when dispatching the task.
-	 */
-	RL_PREEMPT_CPU = 1 << 1,
 };
 
 /*

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -89,6 +89,7 @@ struct dispatched_task_ctx {
 	s32 cpu; /* CPU where the task should be dispatched */
 	u64 flags; /* special dispatch flags */
 	u64 slice_ns; /* time slice assigned to the task (0=default) */
+	u64 vtime; /* task deadline / vruntime */
 	u64 cpumask_cnt; /* cpumask generation counter */
 };
 

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -683,12 +683,7 @@ static long handle_dispatched_task(struct bpf_dynptr *dynptr, void *context)
 
 	dbg_msg("usersched: pid=%d cpu=%d cpumask_cnt=%llu slice_ns=%llu flags=%llx",
 		task->pid, task->cpu, task->cpumask_cnt, task->slice_ns, task->flags);
-	/*
-	 * Map RL_PREEMPT_CPU to SCX_ENQ_PREEMPT and allow this task to
-	 * preempt others.
-	 */
-	if (task->flags & RL_PREEMPT_CPU)
-		enq_flags = SCX_ENQ_PREEMPT;
+
 	/*
 	 * Check whether the user-space scheduler assigned a different
 	 * CPU to the task and migrate (if possible).


### PR DESCRIPTION
Small design improvements, mostly focused at enhancing `scx_rustland_core` usability.

API changes:
 - temporarily dropped `RL_PREEMPT_CPU` (preemption will be re-added later with a better design)
 - allow to specify a vtime in `DispatchedTask` (the vtime will be passed to `scx_bpf_dispatched_vtime()`)

Misc Improvements:
 - `scx_rlfifo`: refactoring to make the code more suitable to be used as a generic template
 - include the FIFO code in the `README.md` of `scx_rustland_core` (in this way the README can be used standalone as a guide on how to implement schedulers using `scx_rustland_core`)