### PR TITLE
scx_lavd: Add power mode clarification to --no-prefer-turbo-core

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -101,7 +101,8 @@ struct Opts {
     #[clap(long = "prefer-little-core", action = clap::ArgAction::SetTrue)]
     prefer_little_core: bool,
 
-    /// Do not specifically prefer to schedule on turbo cores.
+    /// Do not specifically prefer to schedule on turbo cores. Normally set by the power mode, but
+    /// can be set independently if desired.
     #[clap(long = "no-prefer-turbo-core", action = clap::ArgAction::SetTrue)]
     no_prefer_turbo_core: bool,
 


### PR DESCRIPTION
`--no-prefer-turbo-core` was added after I added the clarification that scx_lavd's tunables are set by the specified power mode. Add the same clarification to it.