### PR TITLE
scx_layered: Add per layer timeslice

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -141,6 +141,7 @@ struct layer {
 	u64			min_exec_ns;
 	u64			max_exec_ns;
 	u64			yield_step_ns;
+	u64			slice_ns;
 	bool			open;
 	bool			preempt;
 	bool			preempt_first;


### PR DESCRIPTION
Allow setting a different timeslice per layer.

tested by adding some debug logs:
```
diff --git a/scheds/rust/scx_layered/src/bpf/main.bpf.c b/scheds/rust/scx_layered/src/bpf/main.bpf.c
index 14e6fc9..ebf3362 100644
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1230,20 +1230,21 @@ void BPF_STRUCT_OPS(layered_running, struct task_struct *p)
        if (tctx->last_cpu >= 0 && tctx->last_cpu != task_cpu)
                lstat_inc(LSTAT_MIGRATION, layer, cctx);
        tctx->last_cpu = task_cpu;
 
        if (vtime_before(layer->vtime_now, p->scx.dsq_vtime))
                layer->vtime_now = p->scx.dsq_vtime;
 
        cctx->current_preempt = layer->preempt;
        cctx->current_exclusive = layer->exclusive;
        tctx->running_at = bpf_ktime_get_ns();
+       dbg("CFG: layer: %d slice: %llu", layer->idx, layer->slice_ns);
 
        /*
         * If this CPU is transitioning from running an exclusive task to a
         * non-exclusive one, the sibling CPU has likely been idle. Wake it up.
         */
        if (cctx->prev_exclusive && !cctx->current_exclusive) {
                s32 sib = sibling_cpu(task_cpu);
                struct cpu_ctx *sib_cctx;
 
                /*
```
output:
```
   stress-ng-cpu-3306897 [023] dN..1 434025.244529: bpf_trace_printk: CFG: layer: 2 slice: 4000000
   stress-ng-cpu-3306898 [045] dN..1 434025.244529: bpf_trace_printk: CFG: layer: 2 slice: 4000000
   stress-ng-cpu-3306903 [074] dN..1 434025.244529: bpf_trace_printk: CFG: layer: 2 slice: 4000000
   grep-3306226 [051] dN..1 434025.244529: bpf_trace_printk: CFG: layer: 1 slice: 1500000

```