### PR TITLE
scx_layered: Make verification easier on older kernels

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/util.bpf.c
@@ -99,6 +99,7 @@ bool __noinline match_prefix(const char *prefix, const char *str, u32 max_len)
 	}
 
 	bpf_for(c, 0, max_len) {
+		c &= 0xfff;
 		if (c > len) {
 			scx_bpf_error("invalid length");
 			return false; /* appease the verifier */


### PR DESCRIPTION
Refactor some BPF code to make verification easier on older kernels. This is to make it easier to maintain backports.