### PR TITLE
scx_utils: Add cores helper to node topology

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -265,6 +265,17 @@ impl Node {
         cpus
     }
 
+    /// Get the map of all Cores for this NUMA node.
+    pub fn cores(&self) -> BTreeMap<usize, Core> {
+        let mut cores = BTreeMap::new();
+        for (_, llc) in &self.llcs {
+            for (core_id, core) in llc.cores() {
+                cores.insert(*core_id, core.clone());
+            }
+        }
+        cores
+    }
+
     // Get the map of all GPUs for this NUMA node.
     pub fn gpus(&self) -> &BTreeMap<GpuIndex, Gpu> {
         &self.gpus


### PR DESCRIPTION
Add a helper for getting the cores per node.