### PR TITLE
scx_layered: Add override context for layer hinting

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -33,6 +33,7 @@ enum consts {
 	MAX_COMM		= 16,
 	MAX_LAYER_MATCH_ORS	= 32,
 	MAX_LAYERS		= 16,
+	MAX_LAYER_OVERRIDES	= 1024,
 	USAGE_HALF_LIFE		= 100000000,	/* 100ms */
 
 	HI_FALLBACK_DSQ		= MAX_LAYERS * MAX_DOMS,
@@ -162,4 +163,8 @@ struct layer {
 	unsigned int		perf;
 };
 
+struct user_ctx {
+	u64			task_overrides[MAX_LAYER_OVERRIDES];
+	u32			nr_overrides;
+};
 #endif /* __INTF_H */

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -34,6 +34,7 @@ enum consts {
 	MAX_LAYER_MATCH_ORS	= 32,
 	MAX_LAYERS		= 16,
 	MAX_LAYER_OVERRIDES	= 1024,
+	MAX_OVERRIDE_YIELDS	= 64,
 	USAGE_HALF_LIFE		= 100000000,	/* 100ms */
 
 	HI_FALLBACK_DSQ		= MAX_LAYERS * MAX_DOMS,
@@ -163,8 +164,12 @@ struct layer {
 	unsigned int		perf;
 };
 
-struct user_ctx {
+struct override_ctx {
+	u64			gen;
+	u64			yield_gen; // managed from BPF side
 	u64			task_overrides[MAX_LAYER_OVERRIDES];
+	u64			task_yields[MAX_OVERRIDE_YIELDS];
 	u32			nr_overrides;
+	u32			nr_yields;
 };
 #endif /* __INTF_H */

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -408,6 +408,10 @@ struct Opts {
     #[clap(short = 'e', long)]
     example: Option<String>,
 
+    /// User context bpffs mount path
+    #[clap(short = 'm', long)]
+    user_ctx_mount: Option<String>,
+
     /// Enable stats monitoring with the specified interval.
     #[clap(long)]
     stats: Option<f64>,
@@ -1616,6 +1620,11 @@ impl<'a, 'b> Scheduler<'a, 'b> {
         Self::init_nodes(&mut skel, opts, &topo);
 
         let mut skel = scx_ops_load!(skel, layered, uei)?;
+
+        if !skel.maps.user_ctxs.is_pinned() {
+            let path = opts.user_ctx_mount.clone().unwrap_or("/sys/fs/bpf/scx/user_ctxs".to_string());
+            skel.maps.user_ctxs.pin(path);
+        }
 
         let mut layers = vec![];
         for (idx, spec) in layer_specs.iter().enumerate() {


### PR DESCRIPTION
Add thread hinting to scx_layered by a user mappable map that allows for overriding layers for a pid. There's no locking or safety ☠️ yet.