### PR TITLE
scx_lavd: introduce "autopilot" mode and misc. optimization & bug fix

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -89,6 +89,10 @@ enum consts {
 	LAVD_CC_CPU_PIN_INTERVAL_DIV	= (LAVD_CC_CPU_PIN_INTERVAL /
 					   LAVD_SYS_STAT_INTERVAL_NS),
 
+	LAVD_AP_LOW_UTIL		= 50, /* powersave mode when cpu util <= 5% */
+	LAVD_AP_HIGH_UTIL		= 300, /* balanced mode when 5% < cpu util <= 30%,
+						  performance mode when cpu util > 30% */
+
 	LAVD_CPDOM_MAX_NR		= 32, /* maximum number of compute domain */
 	LAVD_CPDOM_MAX_DIST		= 4,  /* maximum distance from one compute domain to another */
 	LAVD_CPDOM_STARV_NS		= (5ULL * NSEC_PER_MSEC),
@@ -299,6 +303,8 @@ enum {
 	LAVD_PM_PERFORMANCE	= 0,
 	LAVD_PM_BALANCED	= 1,
 	LAVD_PM_POWERSAVE	= 2,
+
+	LAVD_PM_MAX		= 3
 };
 
 struct power_arg {

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -72,6 +72,11 @@ use rlimit::{getrlimit, setrlimit, Resource};
 /// See the more detailed overview of the LAVD design at main.bpf.c.
 #[derive(Debug, Parser)]
 struct Opts {
+    /// Automatically decide the scheduler's power mode based on system load.
+    /// This is a recommended mode if you don't understand the following options:
+    #[clap(long = "autopilot", action = clap::ArgAction::SetTrue)]
+    autopilot: bool,
+
     /// Automatically decide the scheduler's power mode based on the system's energy profile.
     #[clap(long = "autopower", action = clap::ArgAction::SetTrue)]
     autopower: bool,
@@ -551,6 +556,7 @@ impl<'a> Scheduler<'a> {
             Ok(ret) => (ret == 1) as u32,
             Err(_)  => 0,
         };
+        skel.maps.rodata_data.is_autopilot_on = opts.autopilot;
         skel.maps.rodata_data.verbose = opts.verbose;
     }
 

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -692,32 +692,43 @@ impl<'a> Scheduler<'a> {
         res.unwrap_or_else(|_| "none".to_string())
     }
 
-    fn update_power_profile(&mut self) -> bool {
+    fn update_power_profile(&mut self, prev_profile: String) -> (bool, String) {
         const LAVD_PM_PERFORMANCE: s32 = 0;
         const LAVD_PM_BALANCED: s32 = 1;
         const LAVD_PM_POWERSAVE: s32 = 2;
 
         let profile = Self::read_energy_profile();
-        if profile == "performance" {
-            let _ = self.set_power_profile(LAVD_PM_PERFORMANCE);
-        } else if profile == "balance_performance" {
-            let _ = self.set_power_profile(LAVD_PM_BALANCED);
-        } else if profile == "power" {
-            let _ = self.set_power_profile(LAVD_PM_POWERSAVE);
-        } else {
-            return false;
+        if profile == prev_profile {
+            // If the profile is the same, skip updaring the profile for BPF.
+            return (true, profile);
         }
 
-        true
+        if profile == "performance" {
+            let _ = self.set_power_profile(LAVD_PM_PERFORMANCE);
+            info!("Set the scheduler's power profile to performance mode.");
+        } else if profile == "balance_performance" {
+            let _ = self.set_power_profile(LAVD_PM_BALANCED);
+            info!("Set the scheduler's power profile to balanced mode.");
+        } else if profile == "power" {
+            let _ = self.set_power_profile(LAVD_PM_POWERSAVE);
+            info!("Set the scheduler's power profile to power-save mode.");
+        } else {
+            // We don't know how to handle an unknown energy profile,
+            // so we just give up updating the profile from now on.
+            return (false, profile);
+        }
+
+        (true, profile)
     }
 
     fn run(&mut self, auto: bool, shutdown: Arc<AtomicBool>) -> Result<UserExitInfo> {
         let (res_ch, req_ch) = self.stats_server.channels();
         let mut auto = auto;
+        let mut profile = "unknown".to_string();
 
         while !shutdown.load(Ordering::Relaxed) && !self.exited() {
             if auto {
-                auto = self.update_power_profile();
+                (auto, profile) = self.update_power_profile(profile);
             }
 
             match req_ch.recv_timeout(Duration::from_secs(1)) {


### PR DESCRIPTION
The PR contains the following changes:

- Introduce "autopilot" mode, which dynamically switch the scheduler's power mode between powrsave, balanced, and performance according to system-wide CPU utilization. Under low load (<5%), the scheduler runs  with powersave mode. Under moderate load (5% < x < 30%), it runs with balanced mode. Under high load (>30%), it runs with performance mode.
- Rename the "--auto" option to "--autopower" to avoid the confusion with the "autopilot" mode.
- Print the power mode change in the autopower mode
- Add a fastpath in ops.select_cpu() for a sharply pinned task
- Improve the accuracy of cpu utilization calculation