### PR TITLE
scx_rustland_core: bump up major version to 2.0.0

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland_core"
-version = "1.0.3"
+version = "2.0.0"
 edition = "2021"
 authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"

--- a/scheds/rust/Cargo.lock
+++ b/scheds/rust/Cargo.lock
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "scx_rustland_core"
-version = "1.0.3"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "libbpf-rs",

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -13,11 +13,11 @@ ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "0.24.1"
 libc = "0.2.137"
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.3" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "1.0.3" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.0.0" }
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.3" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "1.0.3" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.0.0" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -20,12 +20,12 @@ serde = { version = "1.0", features = ["derive"] }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.3" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.3" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.3" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "1.0.3" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.0.0" }
 simplelog = "0.12"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.3" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "1.0.3" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.0.0" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION
The scx_rustland_core API has been redesigned recently, breaking the compatibility with the past.

Considering that Rust crates should update their major version when the previous API becomes incompatible [1], bump up the version to 2.0.0.

[1] https://semver.org/