### PR TITLE
scx_lavd: improve  the autopilot mode

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -80,18 +80,17 @@ enum consts {
 	LAVD_PREEMPT_KICK_MARGIN	= (1ULL * NSEC_PER_MSEC),
 	LAVD_PREEMPT_TICK_MARGIN	= (100ULL * NSEC_PER_USEC),
 
-	LAVD_SYS_STAT_INTERVAL_NS	= (25ULL * NSEC_PER_MSEC),
+	LAVD_SYS_STAT_INTERVAL_NS	= (50ULL * NSEC_PER_MSEC),
 	LAVD_CC_PER_CORE_MAX_CTUIL	= 500, /* maximum per-core CPU utilization */
 	LAVD_CC_PER_TURBO_CORE_MAX_CTUIL = 750, /* maximum per-core CPU utilization for a turbo core */
 	LAVD_CC_NR_ACTIVE_MIN		= 1, /* num of mininum active cores */
 	LAVD_CC_NR_OVRFLW		= 1, /* num of overflow cores */
-	LAVD_CC_CPU_PIN_INTERVAL	= (3ULL * LAVD_TIME_ONE_SEC),
+	LAVD_CC_CPU_PIN_INTERVAL	= (2ULL * LAVD_TIME_ONE_SEC),
 	LAVD_CC_CPU_PIN_INTERVAL_DIV	= (LAVD_CC_CPU_PIN_INTERVAL /
 					   LAVD_SYS_STAT_INTERVAL_NS),
 
-	LAVD_AP_LOW_UTIL		= 50, /* powersave mode when cpu util <= 5% */
-	LAVD_AP_HIGH_UTIL		= 300, /* balanced mode when 5% < cpu util <= 30%,
-						  performance mode when cpu util > 30% */
+	LAVD_AP_HIGH_UTIL		= 700, /* balanced mode when 10% < cpu util <= 40%,
+						  performance mode when cpu util > 40% */
 
 	LAVD_CPDOM_MAX_NR		= 32, /* maximum number of compute domain */
 	LAVD_CPDOM_MAX_DIST		= 4,  /* maximum distance from one compute domain to another */


### PR DESCRIPTION
* dynamically decide autopilot's low watermark
    *  A single threshold for a low watermark does not work well across systems with various numbers of cores and core types. Instead of using a single low watermark value, we dynamically decide the low watermark: 1) until one little core is fully utilized or 2) until two big cores are fully utilized. This works better across systems.

* when no_freq_scaling, always set to the max freq
    * When the no_freq_scaling changes during runtime in the autopilot mode, the last target freq set would not be 1024. So the performance mode enabled by the autopilot mode would not run in the best profile. Hence, we set the target freq to 1024 always when no_freq_scaling is set.
