### PR TITLE
scx_rusty: Support domain/core cookie policy

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/intf.h
+++ b/scheds/rust/scx_rusty/src/bpf/intf.h
@@ -100,6 +100,7 @@ struct task_ctx {
 	struct bpf_cpumask __kptr *tmp_cpumask;
 	u32 dom_id;
 	u32 weight;
+	u32 core_cookie;
 	bool runnable;
 	u64 dom_active_pids_gen;
 	u64 deadline;
@@ -135,6 +136,9 @@ struct bucket_ctx {
 
 struct dom_ctx {
 	u32 id;
+
+	u32 dom_cookie;
+
 	struct bpf_cpumask __kptr *cpumask;
 	struct bpf_cpumask __kptr *direct_greedy_cpumask;
 	struct bpf_cpumask __kptr *node_cpumask;


### PR DESCRIPTION
## Summary
Extract `core_cookie` from `task_struct` objects and take it into consideration when performing task migrations. Keep the value of cookie within a domain as equal as possible. To fit the trust model of core_sched in kernel.

The test is performed with linux kernel compilation with fio disk test in order to create severe load imbalance. After the change, the time took by kernel compilation went down from 6m29s to 6m24s , and the number of task migration within 60 secs went down from 90161 to 71570.

## Test
While running scx_rusty , open another shell and start the kernel compilation procedure.
```
$ sudo make defconfig
$ time sudo make -j $(nproc)
```
At the same time run the following fio test script
```
[global]
ioengine=libaio            # Use Linux native asynchronous I/O
direct=1                   # Use direct I/O (bypass page cache)
rw=randrw                  # Perform random read/write operations
bs=4k                      # Block size of 4 kilobytes
size=4G                    # Each job file will handle 4GB of data
numjobs=12                 # Number of jobs (simultaneous threads) to run
runtime=2400                # Run the test for 300 seconds (40 minutes)
time_based=1               # Run the test for a specified time duration
group_reporting            # Report results for the group of jobs
iodepth=64                 # Number of I/O operations to keep in flight per job

[write_test]
filename=/tmp/fio_test_file_write
rw=write                   # Sequential write operations

[read_test]
filename=/tmp/fio_test_file_read
rw=read                    # Sequential read operations
```
```
$ fio script.fio
```
The result shows that before the change , kernel compilation under scx_rusty was 6m29s.
After the change , kernel compilation went down to 6m25s.
Further, if we measure the number of task migrations within 1 mins with the following command
```
$ sudo perf stat -e sched:sched_migrate_task -a sleep 60
```
We can found that before the change, scx_rusty performed 9,0161 times of task migration, while it only needs 7,1570 time of task migration after the change.
There was almost 20000 times of task migrations which are unnecessary.

