### PR TITLE
ci: bump up virtme-ng memory size from 1GB to 2GB

### DIFF
--- a/meson-scripts/test_sched
+++ b/meson-scripts/test_sched
@@ -48,7 +48,7 @@ for sched in ${!SCHEDS[@]}; do
 
     rm -f /tmp/output
     timeout --preserve-status ${GUEST_TIMEOUT} \
-        vng --force-9p -v -r ${kernel} -- \
+        vng -m 2G --force-9p -v -r ${kernel} -- \
             "timeout --foreground --preserve-status ${TEST_TIMEOUT} ${sched_path} ${args}" \
                 2> >(tee /tmp/output) </dev/null
         grep -v " Speculative Return Stack Overflow" /tmp/output | \

--- a/meson-scripts/veristat
+++ b/meson-scripts/veristat
@@ -20,7 +20,7 @@ if [ -n "${SCHED}" ]; then
   echo "Running veristat on ${BPF_PATH}"
   if [ -n "${KERNEL}" ]; then
     timeout --preserve-status ${GUEST_TIMEOUT} \
-      vng --force-9p -v --user root -r ${KERNEL} -- \
+      vng -m 2G --force-9p -v --user root -r ${KERNEL} -- \
         sudo veristat ${BPF_PATH}
     exit $?
   else
@@ -32,7 +32,7 @@ fi
 for BPF_PATH in $(find ${BUILD_DIR} -type f -name bpf.bpf.o); do
   if [ -n "${KERNEL}" ]; then
     timeout --preserve-status ${GUEST_TIMEOUT} \
-      vng --force-9p -v --user root -r ${KERNEL} -- \
+      vng -m 2G --force-9p -v --user root -r ${KERNEL} -- \
         sudo veristat ${BPF_PATH}
   else
     echo "$BPF_PATH"

--- a/meson-scripts/veristat_diff
+++ b/meson-scripts/veristat_diff
@@ -21,12 +21,12 @@ if [ -n "${SCHED}" ]; then
   echo "Running veristat on ${BPF_PATH}"
   if [ -n "${KERNEL}" ]; then
     timeout --preserve-status ${GUEST_TIMEOUT} \
-      vng --force-9p -v --rwdir "${DIFF_DIR}" --user root -r ${KERNEL} -- \
+      vng -m 2G --force-9p -v --rwdir "${DIFF_DIR}" --user root -r ${KERNEL} -- \
         veristat ${BPF_PATH} -o csv > "${DIFF_DIR}/${SCHED}_new.csv" \
 	  || echo "failed to verify ${SCHED}: ${BPF_PATH}"
     if [ -n "${DIFF_DIR}" ]; then
       timeout --preserve-status ${GUEST_TIMEOUT} \
-        vng --force-9p -v --rwdir "${DIFF_DIR}" --user root -r ${KERNEL} -- \
+        vng -m 2G --force-9p -v --rwdir "${DIFF_DIR}" --user root -r ${KERNEL} -- \
           veristat -C "${DIFF_DIR}/${SCHED}_new.csv" "${DIFF_DIR}/${SCHED}.csv" \
 	    -e file,prog,verdict,insns \
 	    || echo "failed to compare ${SCHED}: ${BPF_PATH}"
@@ -47,12 +47,12 @@ for BPF_PATH in $(find ${BUILD_DIR} -type f -name bpf.bpf.o); do
   SCHED=$(echo "${BPF_PATH}" | sed 's/.*\/rust\///g' | sed 's/\/.*//g')
   if [ -n "${KERNEL}" ]; then
     timeout --preserve-status ${GUEST_TIMEOUT} \
-      vng --force-9p -v --rwdir "${DIFF_DIR}" --user root -r ${KERNEL} -- \
+      vng -m 2G --force-9p -v --rwdir "${DIFF_DIR}" --user root -r ${KERNEL} -- \
         veristat ${BPF_PATH} -o csv > "${DIFF_DIR}/${SCHED}_new.csv" \
           || echo "failed to verify ${SCHED}: ${BPF_PATH}"
     if [ -n "${DIFF_DIR}" ]; then
       timeout --preserve-status ${GUEST_TIMEOUT} \
-        vng --force-9p -v --rwdir "${DIFF_DIR}" --user root -r ${KERNEL} -- \
+        vng -m 2G --force-9p -v --rwdir "${DIFF_DIR}" --user root -r ${KERNEL} -- \
           veristat -C "${SCHED}_new.csv" "${DIFF_DIR}/${SCHED}.csv" \
 	    -e file,prog,verdict,insns \
             || echo "failed to compare ${SCHED}: ${BPF_PATH}"


### PR DESCRIPTION
Recently, we have triggered some OOM conditions during stress tests, particularly with the user-space schedulers. To avoid this issue and prevent false positives, increase the memory size of the virtme-ng instance from the default 1GB to 2GB.