### PR TITLE
scx_rustland_core: fix pcpu kthread stall

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland_core"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"

--- a/scheds/rust/Cargo.lock
+++ b/scheds/rust/Cargo.lock
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "scx_rustland_core"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "libbpf-rs",

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -13,11 +13,11 @@ ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "0.24.1"
 libc = "0.2.137"
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.3" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.0.0" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.0.1" }
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.3" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.0.0" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.0.1" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -20,12 +20,12 @@ serde = { version = "1.0", features = ["derive"] }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.3" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.3" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.3" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.0.0" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.0.1" }
 simplelog = "0.12"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.3" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.0.0" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.0.1" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION
Fix the `scx_rustland` stall that is triggering a bunch of failures in our CI.

This issue can be easily reproduced inside a virtme-ng instance (e.g., running our CI stress tests). With this change applied the stall doesn't seem to happen anymore.

Also bump up `scx_rustland_core` PATCH version to include this bug fix.