### PR TITLE
ci: allow parallel builds with meson

### DIFF
--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -59,7 +59,7 @@ jobs:
 
       # The actual build:
       - run: meson setup build -Dkernel=$(pwd)/linux -Dkernel_headers=./linux/usr/include -Denable_stress=true
-      - run: meson compile -C build --jobs=1
+      - run: meson compile -C build
 
       # Print CPU model before running the tests (this can be useful for
       # debugging purposes)

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -67,7 +67,7 @@ jobs:
 
       # The actual build:
       - run: meson setup build -Dkernel=$(pwd)/linux -Dkernel_headers=./linux/usr/include -Dveristat_diff_dir=$GITHUB_WORKSPACE/veristat
-      - run: meson compile -C build --jobs=1
+      - run: meson compile -C build
 
       # Print CPU model before running the tests (this can be useful for
       # debugging purposes)


### PR DESCRIPTION
Now that we have a sane build environment with meson we don't need to force sequential builds anymore (--jobs=1) and we can just run regular builds without having to worry about excessive parallelization.

See commit 43950c6 ("build: Use workspace to group rust sub-projects").