### PR TITLE
openrc: drop separate logs

### DIFF
--- a/services/openrc/meson.build
+++ b/services/openrc/meson.build
@@ -4,9 +4,6 @@ install_data('scx.initrd', install_dir: '/etc/init.d', rename: 'scx')
 # Install the 'scx' file to the '/etc/default' directory
 install_data('../scx', install_dir: '/etc/default')
 
-# Install the 'scx.logrotate' file to /etc/logrotate.d/scx
-install_data('scx.logrotate', install_dir: '/etc/logrotate.d', rename: 'scx')
-
 # Symlinking /etc/default/scx to /etc/conf.d/scx
 install_symlink(
       'scx',

--- a/services/openrc/scx.initrd
+++ b/services/openrc/scx.initrd
@@ -10,15 +10,6 @@ command="/usr/bin/$SCX_SCHEDULER"
 command_args="$SCX_FLAGS"
 command_user="${SCX_USER:-root}:${SCX_GROUP:-root}"
 
-output_log="/var/log/${RC_SVCNAME}/${RC_SVCNAME}.log"
-error_log="$output_log"
-
-start_pre() {
-	checkpath -q -d -m 0775 -o "${command_user}" /var/cache/"${RC_SVCNAME}"
-	checkpath -q -d -m 0775 -o "${command_user}" /var/log/"${RC_SVCNAME}"
-	checkpath -q -f -m 0644 -o "${command_user}" "$output_log"
-}
-
 # stop_post() {
 # 	rm -rf /var/cache/"${RC_SVCNAME}"
 # }

--- a/services/openrc/scx.logrotate
+++ b/services/openrc/scx.logrotate
@@ -1,6 +1,0 @@
-/var/log/scx/*.log {
-    missingok
-    minsize 4M
-    notifempty
-    copytruncate
-}


### PR DESCRIPTION
Analogous to #573 - we already have scx_stats so separate log management is no longer needed. 