### PR TITLE
scx_lavd: add --monitor flag and two micro-optimizations

### DIFF
--- a/scheds/rust/Cargo.lock
+++ b/scheds/rust/Cargo.lock
@@ -528,6 +528,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "gpoint"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00f1d62d57408109a871dd9e12b76645ec4284406d5ec838d277777ef1ef6c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1161,7 @@ dependencies = [
  "crossbeam",
  "ctrlc",
  "fb_procfs",
+ "gpoint",
  "hex",
  "itertools 0.13.0",
  "libbpf-rs",

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -27,6 +27,7 @@ simplelog = "0.12"
 static_assertions = "1.1.0"
 rlimit = "0.10.1"
 plain = "0.2.3"
+gpoint = "0.2"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.3" }

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -85,7 +85,7 @@ enum consts {
 	LAVD_CC_PER_TURBO_CORE_MAX_CTUIL = 750, /* maximum per-core CPU utilization for a turbo core */
 	LAVD_CC_NR_ACTIVE_MIN		= 1, /* num of mininum active cores */
 	LAVD_CC_NR_OVRFLW		= 1, /* num of overflow cores */
-	LAVD_CC_CPU_PIN_INTERVAL	= (2ULL * LAVD_TIME_ONE_SEC),
+	LAVD_CC_CPU_PIN_INTERVAL	= (1ULL * LAVD_TIME_ONE_SEC),
 	LAVD_CC_CPU_PIN_INTERVAL_DIV	= (LAVD_CC_CPU_PIN_INTERVAL /
 					   LAVD_SYS_STAT_INTERVAL_NS),
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1294,13 +1294,6 @@ static u64 calc_time_slice(struct task_struct *p, struct task_ctx *taskc,
 	}
 
 	/*
-	 * Boost time slice based on CPU's capacity to assign a longer time
-	 * slice for a more performant CPU for making each CPU's job processing
-	 * throughput similar.
-	 */
-	slice = slice * cpuc->capacity / 1024;
-
-	/*
 	 * If a task has yet to be scheduled (i.e., a freshly forked task or a
 	 * task just under sched_ext), don't give a fair amount of time slice
 	 * until knowing its properties. This helps to mitigate potential

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -197,8 +197,8 @@ char _license[] SEC("license") = "GPL";
 volatile u64		nr_cpus_onln;
 static volatile u64	nr_cpus_big;
 
-static struct sys_stat	__sys_stats[2];
-static volatile int	__sys_stat_idx;
+struct sys_stat	__sys_stats[2];
+volatile int	__sys_stat_idx;
 
 private(LAVD) struct bpf_cpumask __kptr *turbo_cpumask; /* CPU mask for turbo CPUs */
 private(LAVD) struct bpf_cpumask __kptr *big_cpumask; /* CPU mask for big CPUs */

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1626,13 +1626,14 @@ start_omask:
 	/*
 	 * If the task cannot run on either active or overflow cores,
 	 * stay on the previous core (if it is okay) or one of its taskset.
+	 * Then, put the CPU to the overflow set.
 	 */
+start_any_mask:
 	if (bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr))
 		cpu_id = prev_cpu;
-	else {
-start_any_mask:
+	else
 		cpu_id = bpf_cpumask_any_distribute(p->cpus_ptr);
-	}
+	bpf_cpumask_set_cpu(cpu_id, ovrflw);
 
 	/*
 	 * Note that we don't need to kick the picked CPU here since the

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -135,6 +135,10 @@ struct Opts {
     /// Print scheduler version and exit.
     #[clap(short = 'V', long, action = clap::ArgAction::SetTrue)]
     version: bool,
+
+    /// Show descriptions for statistics.
+    #[clap(long)]
+    help_stats: bool,
 }
 
 impl Opts {
@@ -788,6 +792,11 @@ fn main() -> Result<()> {
 
     if opts.version {
         println!("scx_lavd {}", *build_id::SCX_FULL_VERSION);
+        return Ok(());
+    }
+
+    if opts.help_stats {
+        stats::server_data(0).describe_meta(&mut std::io::stdout(), None)?;
         return Ok(());
     }
 

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -13,28 +13,51 @@ use std::thread::ThreadId;
 use std::time::Duration;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
+#[stat(top)]
 pub struct SchedSample {
+    #[stat(desc = "Sequence ID of task log")]
     pub mseq: u64,
+    #[stat(desc = "Process ID")]
     pub pid: i32,
+    #[stat(desc = "Task name")]
     pub comm: String,
+    #[stat(desc = "LR: 'L'atency-critical or 'R'egular, HI: performance-'H'ungry or performance-'I'nsensitive, BT: 'B'ig or li'T'tle, EG: 'E'ligigle or 'G'reedy, PN: 'P'reempting or 'N'ot")]
     pub stat: String,
+    #[stat(desc = "CPU id where this task is scheduled on")]
     pub cpu_id: u32,
+    #[stat(desc = "Victim CPU to be preempted out (-1 = no preemption)")]
     pub victim_cpu: i32,
+    #[stat(desc = "Assigned virtual deadline")]
     pub vdeadline_delta_ns: u64,
+    #[stat(desc = "Assigned time slice")]
     pub slice_ns: u64,
+    #[stat(desc = "How greedy this task is in using CPU time (1000 = fair)")]
     pub greedy_ratio: u32,
+    #[stat(desc = "Latency criticality of this task")]
     pub lat_cri: u32,
+    #[stat(desc = "Average latency criticality in a system")]
     pub avg_lat_cri: u32,
+    #[stat(desc = "Static priority (20 == nice 0)")]
     pub static_prio: u16,
+    #[stat(desc = "Slice boost factor (number of consecutive full slice exhaustions)")]
     pub slice_boost_prio: u16,
+    #[stat(desc = "How often this task is scheduled per second")]
     pub run_freq: u64,
+    #[stat(desc = "Average runtime per schedule")]
     pub run_time_ns: u64,
+    #[stat(desc = "How frequently this task waits for other tasks")]
     pub wait_freq: u64,
+    #[stat(desc = "How frequently this task wakes other tasks")]
     pub wake_freq: u64,
+    #[stat(desc = "Performance criticality of this task")]
     pub perf_cri: u32,
+    #[stat(desc = "Average performance criticality in a system")]
     pub avg_perf_cri: u32,
+    #[stat(desc = "Target performance level of this CPU")]
     pub cpuperf_cur: u32,
+    #[stat(desc = "CPU utilization of this particular CPU")]
     pub cpu_util: u64,
+    #[stat(desc = "Number of active CPUs when core compaction is enabled")]
     pub nr_active: u32,
 }
 
@@ -205,13 +228,6 @@ pub fn server_data(nr_cpus_onln: u64) -> StatsServerData<StatsReq, StatsRes> {
 }
 
 pub fn monitor_sched_samples(nr_samples: u64, shutdown: Arc<AtomicBool>) -> Result<()> {
-    println!("## stats");
-    println!("  LR: 'L'atency-critical or 'R'egular");
-    println!("  HI: performance-'H'ungry or performance-'I'nsensitive");
-    println!("  BT: 'B'ig or li'T'tle");
-    println!("  EG: 'E'ligigle or 'G'reedy");
-    println!("  PN: 'P'reempting or 'N'ot");
-
     scx_utils::monitor_stats::<SchedSamples>(
         &vec![
             ("target".into(), "sched_samples".into()),


### PR DESCRIPTION
This PR contains the following changes:

- Implemented --monitor and its friend options (--help-stats and --stats)
- Improve pick_idle_cpu() for pinned tasks, further preferring the previous CPU
- Drop time slice boost for big core to avoid little cores more changes to steal peformance-critical tasks