### PR TITLE
scx_layered: Fix stats formatting

### DIFF
--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -386,7 +386,7 @@ impl SysStats {
 
         writeln!(
             w,
-            "excl_coll={} excl_preempt={} excl_idle={} excl_wakeup={}",
+            "excl_coll={:.2} excl_preempt={:.2} excl_idle={:.2} excl_wakeup={:.2}",
             self.excl_collision, self.excl_preempt, self.excl_idle, self.excl_wakeup
         )?;
 


### PR DESCRIPTION
Fix formatting precision of stats to have lower precision for readability. The existing formatting is hard to read:

tot=   1538 local=31.27 open_idle= 2.73 affn_viol=23.80 proc=4ms
busy=  1.1 util=   16.6 load=     32.7 fallback_cpu=  6
excl_coll=0.06501950585175553 excl_preempt=0.26007802340702213 excl_idle=0.16384915474642392 excl_wakeup=0.25097529258777634

With this fix stats are far more readable formatting:

tot=    441 local=33.56 open_idle= 0.00 affn_viol=20.63 proc=3ms
busy=  0.4 util=    6.3 load=     33.6 fallback_cpu=  6
excl_coll=0.454 excl_preempt=0.000 excl_idle=0.132 excl_wakeup=0.200