### PR TITLE
ci: fix vng command to set the right amount of CPUs

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -4,7 +4,7 @@ on:
     schedule:
       - cron: "0 * * * *"
     push:
-  
+
 jobs:
   build-kernel:
     runs-on: ubuntu-22.04
@@ -17,7 +17,7 @@ jobs:
       - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
-      
+
       # use cached kernel if available, create after job if not
       - name: Cache Kernel
         id: cache-kernel
@@ -27,7 +27,7 @@ jobs:
             linux
           key: ${{ env.SCHED_EXT_KERNEL_COMMIT }}
 
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}          
+      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
         uses: ./.github/actions/install-deps-action
 
       # cache bzImage alone for rust tests (disk space limit workaround)
@@ -44,10 +44,10 @@ jobs:
         # Get the latest sched-ext enabled kernel directly from the korg
         # for-next branch
         run: git clone --single-branch -b for-next --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
-      
+
       # guard rail because we are caching
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        run: cd linux && git checkout ${{ env.SCHED_EXT_KERNEL_COMMIT }} 
+        run: cd linux && git checkout ${{ env.SCHED_EXT_KERNEL_COMMIT }}
 
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
       # Print the latest commit of the checked out sched-ext kernel
@@ -60,7 +60,7 @@ jobs:
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
       # Generate kernel headers
         run: cd linux && make headers
-      
+
   integration-test:
     runs-on: ubuntu-22.04
     needs: build-kernel
@@ -79,7 +79,7 @@ jobs:
           path: |
             linux
           key: ${{ env.SCHED_EXT_KERNEL_COMMIT }}
-  
+
       # need to re-run job when kernel head changes between build and test running.
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
         name: exit if cache stale
@@ -88,7 +88,7 @@ jobs:
       # veristat
       - run: wget https://github.com/libbpf/veristat/releases/download/v0.3.2/veristat-v0.3.2-amd64.tar.gz
       - run: tar -xvf veristat-v0.3.2-amd64.tar.gz && sudo cp veristat /usr/bin/
-      - run: sudo chmod +x /usr/bin/veristat && sudo chmod 755 /usr/bin/veristat        
+      - run: sudo chmod +x /usr/bin/veristat && sudo chmod 755 /usr/bin/veristat
 
       # The actual build:
       - run: meson setup build -Dkernel=$(pwd)/linux -Dkernel_headers=./linux/usr/include -Denable_stress=true
@@ -102,7 +102,7 @@ jobs:
       - run: meson compile -C build test_sched
       # Stress schedulers
       - run: meson compile -C build stress_tests
-      - run: meson compile -C build veristat      
+      - run: meson compile -C build veristat
 
   rust-test:
     runs-on: ubuntu-22.04
@@ -126,12 +126,12 @@ jobs:
       - if: ${{ steps.cache-bzImage.outputs.cache-hit != 'true' }}
         name: exit if cache stale
         run: exit -1
-      
+
       - uses: Swatinem/rust-cache@v2
-        with: 
+        with:
           shared-key: ${{ env.SCHED_EXT_KERNEL_COMMIT }}
           workspaces: rust
           prefix-key: "1"
       - run: cargo build  --manifest-path rust/Cargo.toml
       - run: cargo test --manifest-path rust/Cargo.toml --no-run
-      - run: vng -v -m10G -c8 --force-9p -r linux/arch/x86/boot/bzImage  --net user -- cargo test --manifest-path rust/Cargo.toml
+      - run: vng -v --memory 10G --cpu 8 --force-9p -r linux/arch/x86/boot/bzImage  --net user -- cargo test --manifest-path rust/Cargo.toml


### PR DESCRIPTION
The right options to set the amount of CPUs in vng is `-p`, not `-c`. Change the command to use the long format `--cpu` and `--memory` for better clarity.

This fixes issue #625.