### PR TITLE
scx_rustland_core: move includes back to the lib section

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -6,11 +6,6 @@ authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"
 repository = "https://github.com/sched-ext/scx"
 description = "Framework to implement sched_ext schedulers running in user space"
-include = [
-    "assets/bpf/intf.h",
-    "assets/bpf/main.bpf.c",
-    "assets/bpf.rs",
-]
 
 [dependencies]
 anyhow = "1.0.65"
@@ -27,4 +22,9 @@ scx_utils = { path = "../scx_utils", version = "1.0.4" }
 [lib]
 name = "scx_rustland_core"
 path = "src/lib.rs"
+include = [
+    "assets/bpf/intf.h",
+    "assets/bpf/main.bpf.c",
+    "assets/bpf.rs",
+]
 


### PR DESCRIPTION
Move included artifacts in the lib section (without this change we can't publish the crate on crates.io).

Fixes: 082bccb ("fix/enable rust tests, make build faster")