### PR TITLE
have stress tests retry 3 times

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -101,7 +101,11 @@ jobs:
       # Test schedulers
       - run: meson compile -C build test_sched
       # Stress schedulers
-      - run: meson compile -C build stress_tests
+      - uses: cytopia/shell-command-retry-action@v0.1.2
+        name: stress test
+        with:
+          retries: 3
+          command: meson compile -C build stress_tests
       - run: meson compile -C build veristat
 
   rust-test:


### PR DESCRIPTION
I saw the stress test being flaky (failing sometimes and passing others when I was touching unrelated things) the other day.

Not sure if we want to allow this to pass if it passes 1 of X times (w/ current X being 3).

Opening this PR in the event this is desirable.

Here is the relevant part of a CI job using this config:

https://github.com/likewhatevs/scx/actions/runs/10754556307/job/29825295907#step:14:1715
