### PR TITLE
enable docs generation and upload

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -222,3 +222,41 @@ jobs:
       - run: cargo test --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml --no-run
       - run: vng -v --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --net user -- cargo test --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml
 
+  pages:
+    runs-on: ubuntu-22.04
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write  # To push a branch
+      pages: write  # To push to a GitHub Pages site
+      id-token: write # To update the deployment status
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/install-deps-action
+      - name: Build Book and Linux Docs
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          rustup install nightly
+          RUSTDOCFLAGS="--enable-index-page -Zunstable-options" ~/.cargo/bin/cargo +nightly doc --workspace --no-deps --bins --lib --examples --document-private-items --all-features
+          sudo apt update
+          sudo apt install build-essential graphviz sphinx-doc python3-sphinx-rtd-theme texlive-latex-recommended python3-yaml -y
+          cargo install htmlq
+          git clone --single-branch -b for-next --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
+          cd linux
+          make DOCS_THEME=sphinx_rtd_theme SPHINXDIRS=scheduler htmldocs
+          make DOCS_THEME=sphinx_rtd_theme SPHINXDIRS=bpf htmldocs
+          cd ..
+          cp -a linux/Documentation/output/scheduler target/doc/
+          cp -a linux/Documentation/output/bpf target/doc/
+          sed -i 's%<li><a href="server/index.html">server</a></li>%<li><a href="server/index.html">server</a></li><li><a href="scheduler/sched-ext.html">Kernel Sched Ext Docs</a></li><li><a href="bpf/helpers.html">Kernel Bpf Helpers Docs</a></li>%' target/doc/index.html
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'target/doc'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 libbpf/
 *.gitignore
 PKGBUILD
+target

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,2 +1,1 @@
-Cargo.lock
 target

--- a/rust/scx_rustland_core/src/alloc.rs
+++ b/rust/scx_rustland_core/src/alloc.rs
@@ -34,7 +34,7 @@ use std::num::ParseIntError;
 
 /// Buddy allocator
 ///
-/// The following code is strongly based on https://github.com/jjyr/buddy-alloc and imported
+/// The following code is strongly based on <https://github.com/jjyr/buddy-alloc> and imported
 /// directly here to make packaging easier.
 
 const OOM_MSG: &str = "requires more memory space to initialize BuddyAlloc";

--- a/rust/scx_utils/src/infeasible.rs
+++ b/rust/scx_utils/src/infeasible.rs
@@ -88,7 +88,7 @@
 //! More details on load balancing and the infeasible weights problem are
 //! provided in the following Google Drive document:
 //!
-//! https://drive.google.com/file/d/1fAoWUlmW-HTp6akuATVpMxpUpvWcGSAv
+//! <https://drive.google.com/file/d/1fAoWUlmW-HTp6akuATVpMxpUpvWcGSAv>
 //!
 //! Using the Crate
 //! ---------------
@@ -434,7 +434,7 @@ impl LoadAggregator {
         //
         // All of this is described and proven in detail in the following pdf:
         //
-        // https://drive.google.com/file/d/1fAoWUlmW-HTp6akuATVpMxpUpvWcGSAv
+        // <https://drive.google.com/file/d/1fAoWUlmW-HTp6akuATVpMxpUpvWcGSAv>
         let p = self.nr_cpus as f64;
         let mut curr_dcycle_sum = 0.0f64;
         let mut curr_load_sum = self.global_load_sum;


### PR DESCRIPTION
this pr configures documentation generation and publishing to https://sched_ext.github.io/scx once it is merged and enabled.

this would look like this page: https://likewhatevs.github.io/scx/

commits to master would trigger the generation of new docs.

the config needed to enable this beyond that in this PR is the following:
![Safari 2024-09-08 04 22 34](https://github.com/user-attachments/assets/c0d34ac8-9bb8-4a9a-99e5-1fb5df86294c)

the following page details how to have comments be such that pretty docs are rendered: https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html
