### PR TITLE
remove dependency on rlimit.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,15 +1591,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
-name = "rlimit"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,7 +1646,6 @@ dependencies = [
  "ctrlc",
  "libbpf-rs",
  "log",
- "rlimit",
  "scx_stats",
  "scx_stats_derive",
  "scx_utils",
@@ -1681,7 +1671,6 @@ dependencies = [
  "log",
  "ordered-float 3.9.2",
  "plain",
- "rlimit",
  "scx_stats",
  "scx_stats_derive",
  "scx_utils",
@@ -1838,6 +1827,7 @@ dependencies = [
  "lazy_static",
  "libbpf-cargo",
  "libbpf-rs",
+ "libc",
  "log",
  "metrics",
  "metrics-util",

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -30,6 +30,7 @@ walkdir = "2.4"
 version-compare = "0.1"
 metrics = "0.23.0"
 metrics-util = "0.17.0"
+libc = "0.2.137"
 
 [build-dependencies]
 bindgen = ">=0.68, <0.70"

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -81,4 +81,5 @@ pub use log_recorder::LogRecorderBuilder;
 
 mod misc;
 pub use misc::monitor_stats;
+pub use misc::set_rlimit_infinity;
 

--- a/rust/scx_utils/src/misc.rs
+++ b/rust/scx_utils/src/misc.rs
@@ -4,6 +4,7 @@ use scx_stats::prelude::*;
 use serde::Deserialize;
 use std::thread::sleep;
 use std::time::Duration;
+use libc;
 
 pub fn monitor_stats<T>(
     stats_args: &Vec<(String, String)>,
@@ -56,4 +57,18 @@ where
     }
 
     Ok(())
+}
+
+pub fn set_rlimit_infinity(){
+    unsafe {
+        // Call setrlimit to set the locked-in-memory limit to unlimited.
+        let new_rlimit = libc::rlimit {
+            rlim_cur: libc::RLIM_INFINITY,
+            rlim_max: libc::RLIM_INFINITY,
+        };
+        let res = libc::setrlimit(libc::RLIMIT_MEMLOCK, &new_rlimit);
+        if res != 0 {
+            panic!("setrlimit failed with error code: {}", res);
+        }
+    };
 }

--- a/scheds/rust/scx_bpfland/Cargo.toml
+++ b/scheds/rust/scx_bpfland/Cargo.toml
@@ -18,7 +18,6 @@ scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version 
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.4" }
 serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
-rlimit = "0.10.1"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.4" }

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -32,8 +32,6 @@ use log::info;
 
 use log::warn;
 
-use rlimit::{getrlimit, setrlimit, Resource};
-
 use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::Skel;
 use libbpf_rs::skel::SkelBuilder;
@@ -53,6 +51,7 @@ use scx_utils::Cpumask;
 use scx_utils::Topology;
 use scx_utils::UserExitInfo;
 use scx_utils::NR_CPU_IDS;
+use scx_utils::set_rlimit_infinity;
 
 const SCHEDULER_NAME: &'static str = "scx_bpfland";
 
@@ -251,8 +250,7 @@ struct Scheduler<'a> {
 
 impl<'a> Scheduler<'a> {
     fn init(opts: &'a Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
-        let (soft_limit, _) = getrlimit(Resource::MEMLOCK).unwrap();
-        setrlimit(Resource::MEMLOCK, soft_limit, rlimit::INFINITY).unwrap();
+        set_rlimit_infinity();
 
         // Validate command line arguments.
         assert!(opts.slice_us >= opts.slice_us_min);

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -25,7 +25,6 @@ scx_utils = { path = "../../../rust/scx_utils", version = "1.0.4" }
 serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
 static_assertions = "1.1.0"
-rlimit = "0.10.1"
 plain = "0.2.3"
 gpoint = "0.2"
 

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -61,10 +61,10 @@ use scx_utils::uei_exited;
 use scx_utils::uei_report;
 use scx_utils::Topology;
 use scx_utils::UserExitInfo;
+use scx_utils::set_rlimit_infinity;
 
 use itertools::iproduct;
 use plain::Plain;
-use rlimit::{getrlimit, setrlimit, Resource};
 
 /// scx_lavd: Latency-criticality Aware Virtual Deadline (LAVD) scheduler
 ///
@@ -489,8 +489,7 @@ impl<'a> Scheduler<'a> {
     fn init(opts: &'a Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
         // Increase MEMLOCK size since the BPF scheduler might use
         // more than the current limit
-        let (soft_limit, _) = getrlimit(Resource::MEMLOCK).unwrap();
-        setrlimit(Resource::MEMLOCK, soft_limit, rlimit::INFINITY).unwrap();
+        set_rlimit_infinity();
 
         // Open the BPF prog first for verification.
         let mut skel_builder = BpfSkelBuilder::default();


### PR DESCRIPTION
The rlimit crate is the only dependency crate with a build.rs, kind of.

build.rs files complicate portability.

I say "kind of" wrt/ rlimit.rs being the only dependency crate with a build.rs because the bpf skel generation done by libbpf-rs doesn't really count because of https://facebookmicrosites.github.io/bpf/blog/2020/02/19/bpf-portability-and-co-re.html (i.e., IIUC, compiled code isn't tied to vmlinux.h version beyond "the symbols you want need to be present").

This PR removes the dependency on rlimit.rs, enabling cargo build (and the utilization of https://docs.rs/libbpf-rs/latest/libbpf_rs/#alternate-workflow downstream) to enable consumers of scx to build this crate most simply.
