### PR TITLE
migrate ci vm to 24.04

### DIFF
--- a/.github/actions/install-deps-action/action.yml
+++ b/.github/actions/install-deps-action/action.yml
@@ -16,30 +16,11 @@ runs:
     ### DOWNLOAD AND INSTALL DEPENDENCIES ###
 
     # Download dependencies packaged by Ubuntu
-    - run: sudo apt -y install bison busybox-static cargo cmake coreutils cpio elfutils file flex gcc gcc-multilib git iproute2 jq kbd kmod libcap-dev libelf-dev libunwind-dev libvirt-clients libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic make ninja-build pahole pkg-config python3-dev python3-pip python3-requests qemu-kvm rsync rustc stress-ng udev zstd libseccomp-dev libcap-ng-dev
+    - run: sudo apt -y install bison busybox-static cargo cmake coreutils cpio elfutils file flex gcc gcc-multilib git iproute2 jq kbd kmod libcap-dev libelf-dev libunwind-dev libvirt-clients libzstd-dev linux-headers-generic linux-tools-common linux-tools-generic make ninja-build pahole pkg-config python3-dev python3-pip python3-requests qemu-kvm rsync rustc stress-ng udev zstd libseccomp-dev libcap-ng-dev llvm clang python3-full pipx curl meson
       shell: bash
 
-    # clang 17
-    # Use a custom llvm.sh script which includes the -y flag for
-    # add-apt-repository. Otherwise, the CI job will hang. If and when
-    # https://github.com/opencollab/llvm-jenkins.debian.net/pull/26 is
-    # merged, we can go back to using https://apt.llvm.org/llvm.sh.
-    - run: wget https://raw.githubusercontent.com/Decave/llvm-jenkins.debian.net/fix_llvmsh/llvm.sh
-      shell: bash
-    - run: chmod +x llvm.sh
-      shell: bash
-    - run: sudo ./llvm.sh all
-      shell: bash
-    - run: sudo ln -sf /usr/bin/clang-17 /usr/bin/clang
-      shell: bash
-    - run: sudo ln -sf /usr/bin/llvm-strip-17 /usr/bin/llvm-strip
-      shell: bash
-    # meson
-    - run: pip install meson
-      shell: bash
-
-    # Install virtme-ng
-    - run: pip install virtme-ng
+    # virtme-ng
+    - run: pip3 install virtme-ng --break-system-packages
       shell: bash
 
     # Setup KVM support

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-kernel:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       # redundancy to exit fast
       - run: echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
@@ -73,7 +73,7 @@ jobs:
         run: cd linux && make headers
 
   integration-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-kernel
     strategy:
           matrix:
@@ -133,7 +133,7 @@ jobs:
       - run: meson compile -C build veristat_${{ matrix.scheduler }}
 
   rust-test-core:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-kernel
     strategy:
       matrix:
@@ -178,7 +178,7 @@ jobs:
       - run: vng -v --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --net user -- cargo test --manifest-path rust/${{ matrix.component }}/Cargo.toml
 
   rust-test-schedulers:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build-kernel
     strategy:
       matrix:
@@ -223,7 +223,7 @@ jobs:
       - run: vng -v --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --net user -- cargo test --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml
 
   pages:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: write  # To push a branch
@@ -236,8 +236,9 @@ jobs:
       - uses: ./.github/actions/install-deps-action
       - name: Build Book and Linux Docs
         run: |
-          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          curl https://sh.rustup.rs -sSf | RUSTUP_INIT_SKIP_PATH_CHECK=yes sh -s -- -y
           rustup install nightly
+          export PATH="~/.cargo/bin:$PATH"
           RUSTDOCFLAGS="--enable-index-page -Zunstable-options" ~/.cargo/bin/cargo +nightly doc --workspace --no-deps --bins --lib --examples --document-private-items --all-features
           sudo apt update
           sudo apt install build-essential graphviz sphinx-doc python3-sphinx-rtd-theme texlive-latex-recommended python3-yaml -y


### PR DESCRIPTION
migrate ci vm to ubuntu 24.04

things checked:
* ci works with all caches deleted: https://github.com/likewhatevs/scx/actions/runs/10788376061
* ci works with caches present: https://github.com/likewhatevs/scx/actions/runs/10788172911 
* generated documentation still works: https://likewhatevs.github.io/scx/

Closes: #639