### PR TITLE
lint: enable cargo fmt

### DIFF
--- a/.github/workflows/build-scheds.yml
+++ b/.github/workflows/build-scheds.yml
@@ -2,6 +2,21 @@ name: build-scheds
 run-name: ${{ github.actor }} PR run
 on: [pull_request]
 jobs:
+  lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install deps
+        run: |
+          curl https://sh.rustup.rs -sSf | RUSTUP_INIT_SKIP_PATH_CHECK=yes sh -s -- -y
+          rustup install nightly-2024-09-10
+          export PATH="~/.cargo/bin:$PATH"
+
+      - uses: actions/checkout@v4
+
+      # Lint code
+      - run: cargo +nightly-2024-09-10 fmt
+      - run: git diff --exit-code
+
   build-schedulers:
     runs-on: ubuntu-22.04
     steps:

--- a/rust/scx_loader/src/main.rs
+++ b/rust/scx_loader/src/main.rs
@@ -180,8 +180,7 @@ async fn worker_loop(mut receiver: UnboundedReceiver<ScxMessage>) -> Result<()> 
     // setup channel for scheduler runner
     let (runner_tx, runner_rx) = tokio::sync::mpsc::channel::<RunnerMessage>(1);
 
-    let run_sched_future =
-        tokio::spawn(async move { handle_child_process(runner_rx).await });
+    let run_sched_future = tokio::spawn(async move { handle_child_process(runner_rx).await });
 
     // prepare future for tokio
     tokio::pin!(run_sched_future);

--- a/rust/scx_rustland_core/src/alloc.rs
+++ b/rust/scx_rustland_core/src/alloc.rs
@@ -26,11 +26,11 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
-use std::sync::Mutex;
 use std::alloc::{GlobalAlloc, Layout};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::num::ParseIntError;
+use std::sync::Mutex;
 
 /// Buddy allocator
 ///

--- a/rust/scx_rustland_core/src/rustland_builder.rs
+++ b/rust/scx_rustland_core/src/rustland_builder.rs
@@ -31,7 +31,10 @@ impl RustLandBuilder {
     pub fn build(&mut self) -> Result<()> {
         // Embed the BPF source files.
         let intf = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/bpf/intf.h"));
-        let skel = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/bpf/main.bpf.c"));
+        let skel = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/assets/bpf/main.bpf.c"
+        ));
         let bpf = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/bpf.rs"));
 
         // Generate BPF backend code (C).

--- a/rust/scx_utils/src/bpf_builder.rs
+++ b/rust/scx_utils/src/bpf_builder.rs
@@ -590,11 +590,9 @@ mod tests {
 
         println!("vmlinux.h: ver={:?} sha1={:?}", &ver, &sha1,);
 
-        assert!(
-            regex::Regex::new(r"^([1-9][0-9]*\.[1-9][0-9][a-z0-9-]*)$")
-                .unwrap()
-                .is_match(&ver)
-        );
+        assert!(regex::Regex::new(r"^([1-9][0-9]*\.[1-9][0-9][a-z0-9-]*)$")
+            .unwrap()
+            .is_match(&ver));
         assert!(regex::Regex::new(r"^[0-9a-z]{12}$")
             .unwrap()
             .is_match(&sha1));

--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -95,12 +95,12 @@ impl Cpumask {
             "none" => {
                 let mask = bitvec![u64, Lsb0; 0; *NR_CPU_IDS];
                 return Ok(Self { mask });
-            },
+            }
             "all" => {
                 let mask = bitvec![u64, Lsb0; 1; *NR_CPU_IDS];
                 return Ok(Self { mask });
-            },
-            _ => {},
+            }
+            _ => {}
         }
         let hex_str = {
             let mut tmp_str = cpumask

--- a/rust/scx_utils/src/infeasible.rs
+++ b/rust/scx_utils/src/infeasible.rs
@@ -112,7 +112,7 @@
 //!```rust
 //!     use scx_utils::LoadAggregator;
 //!     use log::info;
-//! 
+//!
 //!     let mut aggregator = LoadAggregator::new(32, false);
 //!     // Create a LoadAggregator object, specifying the number of CPUs on the
 //!     // system, and whether it should only aggregate duty cycle.

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -82,4 +82,3 @@ pub use log_recorder::LogRecorderBuilder;
 mod misc;
 pub use misc::monitor_stats;
 pub use misc::set_rlimit_infinity;
-

--- a/rust/scx_utils/src/misc.rs
+++ b/rust/scx_utils/src/misc.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
+use libc;
 use log::info;
 use scx_stats::prelude::*;
 use serde::Deserialize;
 use std::thread::sleep;
 use std::time::Duration;
-use libc;
 
 pub fn monitor_stats<T>(
     stats_args: &Vec<(String, String)>,
@@ -59,7 +59,7 @@ where
     Ok(())
 }
 
-pub fn set_rlimit_infinity(){
+pub fn set_rlimit_infinity() {
     unsafe {
         // Call setrlimit to set the locked-in-memory limit to unlimited.
         let new_rlimit = libc::rlimit {

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -610,7 +610,9 @@ fn create_gpus() -> BTreeMap<usize, Vec<Gpu>> {
                 let Ok(nvidia_gpu) = nvml.device_by_index(i) else {
                     continue;
                 };
-                let graphics_boost_clock = nvidia_gpu.max_customer_boost_clock(Clock::Graphics).unwrap_or(0);
+                let graphics_boost_clock = nvidia_gpu
+                    .max_customer_boost_clock(Clock::Graphics)
+                    .unwrap_or(0);
                 let sm_boost_clock = nvidia_gpu.max_customer_boost_clock(Clock::SM).unwrap_or(0);
                 let Ok(memory_info) = nvidia_gpu.memory_info() else {
                     continue;
@@ -629,8 +631,8 @@ fn create_gpus() -> BTreeMap<usize, Vec<Gpu>> {
                 let numa_path = format!("/sys/bus/pci/devices/{}/numa_node", fixed_bus_id);
                 let numa_node = read_file_usize(&Path::new(&numa_path)).unwrap_or(0);
 
-                let gpu = Gpu{
-                    index: GpuIndex::Nvidia{nvml_id: index},
+                let gpu = Gpu {
+                    index: GpuIndex::Nvidia { nvml_id: index },
                     node_id: numa_node as usize,
                     max_graphics_clock: graphics_boost_clock as usize,
                     max_sm_clock: sm_boost_clock as usize,
@@ -661,7 +663,7 @@ fn create_default_node(online_mask: &Cpumask) -> Result<Vec<Node>> {
                 node_gpus.insert(gpu.index, gpu.clone());
             }
         }
-        _ => {},
+        _ => {}
     };
 
     let mut node = Node {
@@ -708,7 +710,7 @@ fn create_numa_nodes(online_mask: &Cpumask) -> Result<Vec<Node>> {
                     node_gpus.insert(gpu.index, gpu.clone());
                 }
             }
-            _ => {},
+            _ => {}
         };
 
         let mut node = Node {

--- a/scheds/rust/scx_bpfland/src/stats.rs
+++ b/scheds/rust/scx_bpfland/src/stats.rs
@@ -1,13 +1,14 @@
-use anyhow::Result;
-use scx_stats::prelude::*;
-use scx_stats_derive::Stats;
-use serde::Deserialize;
-use serde::Serialize;
 use std::io::Write;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
+
+use anyhow::Result;
+use scx_stats::prelude::*;
+use scx_stats_derive::Stats;
+use serde::Deserialize;
+use serde::Serialize;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(top)]

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -6,10 +6,6 @@ mod bpf_skel;
 mod stats;
 pub use bpf_skel::*;
 pub mod bpf_intf;
-use stats::LayerStats;
-use stats::StatsReq;
-use stats::StatsRes;
-use stats::SysStats;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
@@ -57,6 +53,10 @@ use scx_utils::Topology;
 use scx_utils::UserExitInfo;
 use serde::Deserialize;
 use serde::Serialize;
+use stats::LayerStats;
+use stats::StatsReq;
+use stats::StatsRes;
+use stats::SysStats;
 
 const RAVG_FRAC_BITS: u32 = bpf_intf::ravg_consts_RAVG_FRAC_BITS;
 const MAX_CPUS: usize = bpf_intf::consts_MAX_CPUS as usize;
@@ -455,7 +455,9 @@ enum LayerGrowthAlgo {
 }
 
 impl Default for LayerGrowthAlgo {
-    fn default() -> Self { LayerGrowthAlgo::Sticky }
+    fn default() -> Self {
+        LayerGrowthAlgo::Sticky
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1093,8 +1095,8 @@ fn layer_core_order(
     spec: &LayerSpec,
     growth_algo: LayerGrowthAlgo,
     layer_idx: usize,
-    topo: &Topology
-    ) -> Vec<usize> {
+    topo: &Topology,
+) -> Vec<usize> {
     let mut core_order = vec![];
     match growth_algo {
         LayerGrowthAlgo::Sticky => {
@@ -1144,12 +1146,7 @@ struct Layer {
 }
 
 impl Layer {
-    fn new(
-        spec: &LayerSpec,
-        idx: usize,
-        cpu_pool: &CpuPool,
-        topo: &Topology,
-    ) -> Result<Self> {
+    fn new(spec: &LayerSpec, idx: usize, cpu_pool: &CpuPool, topo: &Topology) -> Result<Self> {
         let name = &spec.name;
         let kind = spec.kind.clone();
         let mut cpus = bitvec![0; cpu_pool.nr_cpus];
@@ -1276,8 +1273,7 @@ impl Layer {
         {
             trace!(
                 "layer-{} needs more CPUs (util={:.3}) but is over the load fraction",
-                &self.name,
-                layer_util
+                &self.name, layer_util
             );
             return Ok(false);
         }
@@ -1665,12 +1661,7 @@ impl<'a, 'b> Scheduler<'a, 'b> {
 
         let mut layers = vec![];
         for (idx, spec) in layer_specs.iter().enumerate() {
-            layers.push(Layer::new(
-                &spec,
-                idx,
-                &cpu_pool,
-                &topo,
-            )?);
+            layers.push(Layer::new(&spec, idx, &cpu_pool, &topo)?);
         }
 
         // Other stuff.

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -1,17 +1,3 @@
-use crate::bpf_intf;
-use crate::BpfStats;
-use crate::Layer;
-use crate::LayerKind;
-use crate::Stats;
-use anyhow::{bail, Result};
-use bitvec::prelude::*;
-use chrono::DateTime;
-use chrono::Local;
-use log::warn;
-use scx_stats::prelude::*;
-use scx_stats_derive::Stats;
-use serde::Deserialize;
-use serde::Serialize;
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::sync::atomic::AtomicBool;
@@ -22,6 +8,23 @@ use std::thread::ThreadId;
 use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
+
+use anyhow::bail;
+use anyhow::Result;
+use bitvec::prelude::*;
+use chrono::DateTime;
+use chrono::Local;
+use log::warn;
+use scx_stats::prelude::*;
+use scx_stats_derive::Stats;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::bpf_intf;
+use crate::BpfStats;
+use crate::Layer;
+use crate::LayerKind;
+use crate::Stats;
 
 fn fmt_pct(v: f64) -> String {
     if v >= 99.995 {
@@ -147,11 +150,7 @@ impl LayerStats {
             }
         };
         let calc_frac = |a, b| {
-            if b != 0.0 {
-                a / b * 100.0
-            } else {
-                0.0
-            }
+            if b != 0.0 { a / b * 100.0 } else { 0.0 }
         };
 
         let is_excl = match &layer.kind {

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -66,17 +66,15 @@ mod bpf_skel;
 pub use bpf_skel::*;
 pub mod bpf_intf;
 
+#[rustfmt::skip]
 mod bpf;
-use bpf::*;
-
-use scx_utils::UserExitInfo;
-
-use libbpf_rs::OpenObject;
-
 use std::mem::MaybeUninit;
 use std::time::SystemTime;
 
 use anyhow::Result;
+use bpf::*;
+use libbpf_rs::OpenObject;
+use scx_utils::UserExitInfo;
 
 // Maximum time slice (in nanoseconds) that a task can use before it is re-enqueued.
 const SLICE_NS: u64 = 5_000_000;

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -6,29 +6,28 @@ mod bpf_skel;
 pub use bpf_skel::*;
 pub mod bpf_intf;
 
+#[rustfmt::skip]
 mod bpf;
 use bpf::*;
 
 mod stats;
-use scx_stats::prelude::*;
-use stats::Metrics;
-
-use scx_utils::UserExitInfo;
-
 use std::collections::BTreeSet;
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
+use std::io::{self};
 use std::mem::MaybeUninit;
 use std::time::Duration;
 use std::time::SystemTime;
-
-use std::fs::File;
-use std::io::{self, Read};
 
 use anyhow::Result;
 use clap::Parser;
 use libbpf_rs::OpenObject;
 use log::info;
 use log::warn;
+use scx_stats::prelude::*;
+use scx_utils::UserExitInfo;
+use stats::Metrics;
 
 const SCHEDULER_NAME: &'static str = "RustLand";
 

--- a/scheds/rust/scx_rustland/src/stats.rs
+++ b/scheds/rust/scx_rustland/src/stats.rs
@@ -1,10 +1,11 @@
+use std::io::Write;
+use std::time::Duration;
+
 use anyhow::Result;
 use scx_stats::prelude::*;
 use scx_stats_derive::Stats;
 use serde::Deserialize;
 use serde::Serialize;
-use std::io::Write;
-use std::time::Duration;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(top)]

--- a/scheds/rust/scx_rusty/src/domain.rs
+++ b/scheds/rust/scx_rusty/src/domain.rs
@@ -5,7 +5,6 @@
 use std::collections::BTreeMap;
 
 use anyhow::Result;
-
 use scx_utils::Cpumask;
 use scx_utils::Topology;
 

--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -131,14 +131,9 @@
 //! - We're not accounting for cgroups when performing load balancing.
 
 use core::cmp::Ordering;
-
-use crate::bpf_intf;
-use crate::bpf_skel::*;
-use crate::stats::DomainStats;
-use crate::stats::NodeStats;
-use crate::DomainGroup;
-
 use std::cell::Cell;
+use std::collections::BTreeMap;
+use std::collections::VecDeque;
 use std::fmt;
 use std::sync::Arc;
 
@@ -153,8 +148,12 @@ use scx_utils::ravg::ravg_read;
 use scx_utils::LoadAggregator;
 use scx_utils::LoadLedger;
 use sorted_vec::SortedVec;
-use std::collections::BTreeMap;
-use std::collections::VecDeque;
+
+use crate::bpf_intf;
+use crate::bpf_skel::*;
+use crate::stats::DomainStats;
+use crate::stats::NodeStats;
+use crate::DomainGroup;
 
 const RAVG_FRAC_BITS: u32 = bpf_intf::ravg_consts_RAVG_FRAC_BITS;
 

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -16,9 +16,6 @@ pub mod load_balance;
 use load_balance::LoadBalancer;
 
 mod stats;
-use stats::ClusterStats;
-use stats::NodeStats;
-
 use std::collections::BTreeMap;
 use std::mem::MaybeUninit;
 use std::sync::atomic::AtomicBool;
@@ -28,6 +25,9 @@ use std::time::Duration;
 use std::time::Instant;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
+
+use stats::ClusterStats;
+use stats::NodeStats;
 
 #[macro_use]
 extern crate static_assertions;

--- a/scheds/rust/scx_rusty/src/stats.rs
+++ b/scheds/rust/scx_rusty/src/stats.rs
@@ -1,4 +1,11 @@
-use crate::StatsCtx;
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::UNIX_EPOCH;
+
 use anyhow::Result;
 use chrono::DateTime;
 use chrono::Local;
@@ -7,13 +14,8 @@ use scx_stats_derive::Stats;
 use scx_utils::Cpumask;
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::BTreeMap;
-use std::io::Write;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-use std::time::Duration;
-use std::time::UNIX_EPOCH;
+
+use crate::StatsCtx;
 
 fn signed(x: f64) -> String {
     if x >= 0.0f64 {

--- a/scheds/rust/scx_rusty/src/tuner.rs
+++ b/scheds/rust/scx_rusty/src/tuner.rs
@@ -5,16 +5,15 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use crate::sub_or_zero;
-use crate::BpfSkel;
-use crate::DomainGroup;
-
 use ::fb_procfs as procfs;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Result;
-
 use scx_utils::Cpumask;
+
+use crate::sub_or_zero;
+use crate::BpfSkel;
+use crate::DomainGroup;
 
 fn calc_util(curr: &procfs::CpuStat, prev: &procfs::CpuStat) -> Result<f64> {
     match (curr, prev) {


### PR DESCRIPTION
Use `cargo fmt` with a specific nightly branch in the CI to enforce formatting. Globally format these files while the diff is still small so we can stay on top of it.

Test plan:
- CI check passes.