### PR TITLE
scx_rusty: init domains when calculating averages

### DIFF
--- a/rust/scx_utils/src/infeasible.rs
+++ b/rust/scx_utils/src/infeasible.rs
@@ -311,6 +311,16 @@ impl LoadAggregator {
         }
     }
 
+    /// Init a domain and set default load values.
+    /// Does nothing if the domain already exists.
+    pub fn init_domain(&mut self, dom_id: usize) {
+        self.doms.entry(dom_id).or_insert(Domain {
+            loads: BTreeMap::new(),
+            dcycle_sum: 0.0f64,
+            load_sum: 0.0f64,
+        });
+    }
+
     /// Record an instance of some domain's load (by specifying its weight and
     /// dcycle). Returns an error if duty cycle is specified more than once
     /// for a given (Domain, weight) tuple.

--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -591,6 +591,8 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
             let dom = *dom_id;
             let dom_key = unsafe { std::mem::transmute::<u32, [u8; 4]>(dom as u32) };
 
+            aggregator.init_domain(dom);
+
             if let Some(dom_ctx_map_elem) = dom_data
                 .lookup(&dom_key, libbpf_rs::MapFlags::ANY)
                 .context("Failed to lookup dom_ctx")?


### PR DESCRIPTION
The domains are added to the aggregator when load is added (and duty_cycle is not 0.0f64).

This commit makes sure that all domains are added to the aggregator even when the calculated duty_cycle is 0.

Fixes #608 