### PR TITLE
scx_layered: Add stats for XNUMA/XLLC migrations

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -71,6 +71,8 @@ enum layer_stat_idx {
 	LSTAT_YIELD,
 	LSTAT_YIELD_IGNORE,
 	LSTAT_MIGRATION,
+	LSTAT_XNUMA_MIGRATION,
+	LSTAT_XLLC_MIGRATION,
 	NR_LSTATS,
 };
 
@@ -86,6 +88,8 @@ struct cpu_ctx {
 	u64			lstats[MAX_LAYERS][NR_LSTATS];
 	u64			ran_current_for;
 	u32			layer_idx;
+	u32			node_idx;
+	u32			cache_idx;
 };
 
 struct cache_ctx {

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -100,6 +100,10 @@ pub struct LayerStats {
     pub yield_ignore: u64,
     #[stat(desc = "% migrated across CPUs")]
     pub migration: f64,
+    #[stat(desc = "% migrated across NUMA nodes")]
+    pub xnuma_migration: f64,
+    #[stat(desc = "% migrated across LLCs")]
+    pub xllc_migration: f64,
     #[stat(desc = "mask of allocated CPUs", _om_skip)]
     pub cpus: Vec<u32>,
     #[stat(desc = "# of CPUs assigned")]
@@ -189,6 +193,8 @@ impl LayerStats {
             yielded: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_YIELD),
             yield_ignore: lstat(bpf_intf::layer_stat_idx_LSTAT_YIELD_IGNORE) as u64,
             migration: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_MIGRATION),
+            xnuma_migration: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_XNUMA_MIGRATION),
+            xllc_migration: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_XLLC_MIGRATION),
             cpus: Self::bitvec_to_u32s(&layer.cpus),
             cur_nr_cpus: layer.cpus.count_ones() as u32,
             min_nr_cpus: nr_cpus_range.0 as u32,
@@ -236,10 +242,12 @@ impl LayerStats {
 
         writeln!(
             w,
-            "  {:<width$}  open_idle={} mig={} affn_viol={}",
+            "  {:<width$}  open_idle={} mig={} xnuma_mig={} xllc_mig={} affn_viol={}",
             "",
             fmt_pct(self.open_idle),
             fmt_pct(self.migration),
+            fmt_pct(self.xnuma_migration),
+            fmt_pct(self.xllc_migration),
             fmt_pct(self.affn_viol),
             width = header_width,
         )?;


### PR DESCRIPTION
Add stats for XNUMA/XLLC migrations. An example of the output is shown:

```
tot=  21282 local=97.47 open_idle=48.81 affn_viol= 0.00 proc=4ms
busy=  2.2 util=  166.0 load=   2039.1 fallback_cpu=  0
excl_coll=0.07 excl_preempt=0.00 excl_idle=0.05 excl_wakeup=0.04
  hodgesd  : util/frac=    5.8/  3.5 load/frac=      6.2/  0.3 tasks=   747
             tot=   4100 local=93.17 wake/exp/reenq= 6.83/ 0.00/ 0.00
             keep/max/busy= 0.02/ 0.00/ 0.00 kick= 0.00 yield/ign= 0.22/    0 
             open_idle= 0.00 mig= 7.07 xnuma_mig= 4.63 xllc_mig= 4.63 affn_viol= 0.00
             preempt/first/idle/fail= 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms
             cpus=  2 [  2,  2] 00000000 00000010 00001000
  normal   : util/frac=  160.2/ 96.5 load/frac=   2032.8/ 99.7 tasks=  4164
             tot=  17182 local=98.50 wake/exp/reenq= 1.12/ 0.38/ 0.00
             keep/max/busy= 2.27/ 0.00/ 0.00 kick= 0.38 yield/ign= 0.12/  312 
             open_idle=60.46 mig=10.01 xnuma_mig= 7.62 xllc_mig= 7.62 affn_viol= 0.00
             preempt/first/idle/fail= 0.01/ 0.00/ 0.80/ 0.32 min_exec= 0.00/   0.00ms
             cpus=  4 [  4,  4] 30000000 00000000 00000030
             excl_coll= 0.08 excl_preempt= 0.00

```
This was tested on a machine with two NUMA nodes and two LLCs so the `xnuma_mig == xllc_mig`.