### PR TITLE
scx_layered: Add topology aware core growth selection

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -166,6 +166,8 @@ impl Cpu {
 #[derive(Debug, Clone)]
 pub struct Core {
     id: usize,
+    pub node_id: usize,
+    pub llc_id: usize,
     cpus: BTreeMap<usize, Cpu>,
     span: Cpumask,
     pub core_type: CoreType,
@@ -525,6 +527,8 @@ fn create_insert_cpu(
 
     let core = cache.cores.entry(core_id).or_insert(Core {
         id: core_id,
+        llc_id: llc_id,
+        node_id: node.id,
         cpus: BTreeMap::new(),
         span: Cpumask::new()?,
         core_type: core_type.clone(),

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -268,6 +268,11 @@ lazy_static::lazy_static! {
 ///
 /// - slice_us: Scheduling slice duration in microseconds.
 ///
+/// - growth_algo: When a layer is allocated new CPUs different algorithms can
+///   be used to determine which CPU should be allocated next. The default
+///   algorithm is a "sticky" algorithm that attempts to spread layers evenly
+///   across cores.
+///
 /// - perf: CPU performance target. 0 means no configuration. A value
 ///   between 1 and 1024 indicates the performance level CPUs running tasks
 ///   in this layer are configured to using scx_bpf_cpuperf_set().
@@ -450,9 +455,18 @@ enum LayerMatch {
 #[derive(Clone, Debug, Parser, Serialize, Deserialize)]
 #[clap(rename_all = "snake_case")]
 enum LayerGrowthAlgo {
+    /// Sticky attempts to place layers evenly spaced across cores.
     Sticky,
+    /// Linear starts with the lowest number CPU and grows towards the total
+    /// number of CPUs.
     Linear,
+    /// Random core selection order.
     Random,
+    /// Topo uses the order of the nodes/llcs in the layer config to determine
+    /// the order of CPUs to select when growing a layer. It starts from the
+    /// llcs configuration and then the NUMA configuration for any CPUs not
+    /// specified.
+    Topo,
 }
 
 impl Default for LayerGrowthAlgo {
@@ -558,6 +572,20 @@ impl LayerSpec {
             serde_json::from_str(input)?
         };
         Ok(config.specs)
+    }
+    fn nodes(&self) -> Vec<usize> {
+        match &self.kind {
+            LayerKind::Confined { nodes, .. }
+            | LayerKind::Open { nodes, .. }
+            | LayerKind::Grouped { nodes, .. } => nodes.clone(),
+        }
+    }
+    fn llcs(&self) -> Vec<usize> {
+        match &self.kind {
+            LayerKind::Confined { llcs, .. }
+            | LayerKind::Open { llcs, .. }
+            | LayerKind::Grouped { llcs, .. } => llcs.clone(),
+        }
     }
 }
 
@@ -1140,6 +1168,50 @@ fn layer_core_order(
             linear();
             fastrand::seed(layer_idx.try_into().unwrap());
             fastrand::shuffle(&mut core_order);
+        LayerGrowthAlgo::Topo => {
+            let spec_nodes = spec.nodes();
+            let spec_llcs = spec.llcs();
+            let topo_nodes = topo.nodes();
+
+            if spec_nodes.len() + spec_llcs.len() == 0 {
+                // XXX: fallback to something more sane (round robin when it exists)
+                linear();
+            } else {
+                let mut offset;
+                for spec_llc in &spec_llcs {
+                    offset = 0;
+                    for topo_node in topo_nodes {
+                        for topo_llc in topo_node.llcs().values() {
+                            if *spec_llc != topo_llc.id() {
+                                continue;
+                            }
+                            for (id, _core) in topo_llc.cores().keys().enumerate() {
+                                let core_id = id + offset;
+                                if !core_order.contains(&core_id) {
+                                    core_order.push(core_id);
+                                }
+                            }
+                        }
+                        offset += topo_node.cores().len();
+                    }
+                }
+                for spec_node in &spec_nodes {
+                    offset = 0;
+                    for topo_node in topo_nodes {
+                        if *spec_node != topo_node.id() {
+                            offset += topo_node.cores().len();
+                            continue;
+                        }
+                        for (id, _core) in topo_node.cores().keys().enumerate() {
+                            let core_id = id + offset;
+                            if !core_order.contains(&core_id) {
+                                core_order.push(core_id);
+                            }
+                        }
+                        offset += topo_node.cores().len();
+                    }
+                }
+            }
         }
     }
     core_order


### PR DESCRIPTION
Add topology aware core growth selection, which uses the order of the `llcs`/`nodes` layer config to determine which cores should be selected first when growing a layer.

`scx_layered` output:
```
15:57:39 [DEBUG] layer: random algo: Sticky core order: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39]
15:57:39 [DEBUG] layer: hodgesd algo: Topo core order: [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
15:57:39 [DEBUG] layer: stress-ng algo: Topo core order: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39]
15:57:39 [DEBUG] layer: normal algo: Topo core order: [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
```
config:
```
[{
  "name":"random",
  "comment":"random user",
  "matches":[
     [{"UIDEquals":1234}]
  ],
  "kind": {
    "Confined":{
      "nodes":[1],
      "util_range": [0.05, 0.7],
      "grow_algo": "Topo",
      "llcs": [1, 0],
      "preempt": false,
      "slice_us": 5000,
      "exclusive": true
     }
  }
},
{
  "name":"hodgesd",
  "comment":"hodgesd user",
  "matches":[
     [{"UIDEquals":224791}]
  ],
  "kind": {
    "Confined":{
      "nodes":[1,0],
      "slice_us": 1500,
      "util_range": [0.05, 0.3],
      "growth_algo": "Topo",
      "exclusive": false
     }
  }
},{
  "name":"stress-ng",
  "comment":"stress-ng slice",
  "matches":[
     [
	     {"CommPrefix":"stress-ng"}
     ],[
	     {"PcommPrefix":"stress-ng"}
     ]],
  "kind": {
    "Confined":{
      "util_range": [0.01, 0.90],
      "slice_us": 25500,
      "growth_algo": "Topo",
      "preempt": true,
      "preempt_first": true,
      "nodes":[0, 1],
      "exclusive": true
     }
  }
},
{
  "name":"normal",
  "comment":"the rest",
  "matches":[[]],
  "kind":{
    "Grouped": {
      "util_range": [0.05, 0.7],
      "preempt": true,
      "slice_us": 1000,
      "growth_algo": "Topo",
      "exclusive": true,
      "llcs":[1, 0]
    }
  }
}]
```
node configuration:
```
$ lscpu | grep -i numa
NUMA node(s):                         2
NUMA node0 CPU(s):                    0-19,40-59
NUMA node1 CPU(s):                    20-39,60-79
```