### PR TITLE
update Tumbleweed installation notes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -180,7 +180,7 @@ $ sudo zypper refresh
 #### Installing the Kernel
 
 ```
-$ sudo zypper install --repo sched-ext --force kernel-default-base
+$ sudo zypper install --repo sched-ext --force kernel-default
 $ sudo reboot
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ are provided for select distros.
 - [Arch Linux](INSTALL.md#arch-linux)
 - [Fedora](INSTALL.md#fedora)
 - [Nix](INSTALL.md#nix)
+- [openSUSE Tumbleweed](INSTALL.md#opensuse-tumbleweed)
 
 ## Repository Structure
 


### PR DESCRIPTION
Kernel package name was change to kernel-default.

Also add link to documentation to README.md