### PR TITLE
scx_layered: Add random layer growth algo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,6 +1689,7 @@ dependencies = [
  "clap",
  "crossbeam",
  "ctrlc",
+ "fastrand",
  "fb_procfs",
  "lazy_static",
  "libbpf-rs",

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -13,6 +13,7 @@ chrono = "0.4"
 clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
 ctrlc = { version = "3.1", features = ["termination"] }
+fastrand = "2.1.1"
 fb_procfs = "0.7"
 lazy_static = "1.4"
 libbpf-rs = "0.24.1"


### PR DESCRIPTION
Add a random layer growth algo.

output of using a config with all random growth algos:
```
12:35:34 [DEBUG] layer: random algo: Random core order: [29, 4, 23, 20, 35, 7, 22, 10, 2, 24, 39, 1, 32, 3, 16, 15, 11, 5, 14, 19, 8, 28, 25, 6, 37, 0, 13, 31, 33, 17, 38, 26, 36, 12, 34, 30, 9, 27, 18, 21]
12:35:34 [DEBUG] layer: hodgesd algo: Random core order: [13, 35, 29, 28, 0, 33, 16, 8, 3, 38, 18, 26, 14, 25, 20, 36, 9, 22, 39, 5, 23, 30, 2, 24, 1, 21, 19, 12, 4, 32, 11, 10, 27, 6, 17, 15, 31, 7, 37, 34]
12:35:34 [DEBUG] layer: stress-ng algo: Random core order: [25, 21, 34, 2, 38, 20, 10, 32, 30, 15, 3, 36, 29, 8, 9, 27, 18, 4, 5, 13, 35, 33, 7, 28, 12, 14, 6, 37, 11, 22, 31, 19, 23, 17, 24, 0, 26, 39, 16, 1]
12:35:34 [DEBUG] layer: normal algo: Random core order: [22, 3, 8, 11, 9, 13, 25, 36, 14, 12, 28, 17, 27, 37, 29, 21, 6, 15, 31, 4, 1, 34, 35, 38, 39, 26, 19, 5, 2, 0, 10, 7, 16, 18, 20, 23, 33, 24, 30, 32]
```