### PR TITLE
scx_rustland_core: prevent user-space sched from starving other tasks

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -77,7 +77,7 @@ jobs:
     needs: build-kernel
     strategy:
           matrix:
-            scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
+            scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rusty ]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-deps-action
@@ -89,7 +89,7 @@ jobs:
           path: |
             /usr/lib/virtiofsd
           key: virtiofsd-binary
-      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}          
+      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
 
       # get latest head commit of sched_ext for-next
@@ -149,7 +149,7 @@ jobs:
           path: |
             /usr/lib/virtiofsd
           key: virtiofsd-binary
-      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}          
+      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
 
       # get latest head commit of sched_ext for-next
@@ -182,7 +182,7 @@ jobs:
     needs: build-kernel
     strategy:
       matrix:
-        scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
+        scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rusty ]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-deps-action
@@ -194,7 +194,7 @@ jobs:
           path: |
             /usr/lib/virtiofsd
           key: virtiofsd-binary
-      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}          
+      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
 
       # get latest head commit of sched_ext for-next

--- a/meson-scripts/stress_tests.ini
+++ b/meson-scripts/stress_tests.ini
@@ -10,12 +10,6 @@ sched_args:
 stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc`
 timeout_sec: 15
 
-[scx_rustland]
-sched: scx_rustland
-sched_args:
-stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc`
-timeout_sec: 15
-
 [scx_bpfland]
 sched: scx_bpfland
 sched_args:

--- a/meson-scripts/stress_tests.ini
+++ b/meson-scripts/stress_tests.ini
@@ -1,23 +1,23 @@
 [scx_lavd]
 sched: scx_lavd
 sched_args:
-stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
+stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc`
 timeout_sec: 15
 
 [scx_rusty]
 sched: scx_rusty
 sched_args:
-stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
+stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc`
 timeout_sec: 15
 
 [scx_rustland]
 sched: scx_rustland
 sched_args:
-stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
+stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc`
 timeout_sec: 15
 
 [scx_bpfland]
 sched: scx_bpfland
 sched_args:
-stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
+stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc`
 timeout_sec: 15


### PR DESCRIPTION
Always dispatch the user-space scheduler if there are no other tasks that needs to be dispatched in ops.dispatch().

This should prevent the recent scx_rustland CI failures with the following stress test:

   stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`