### PR TITLE
scxstats_to_openmetrics: fix format string

### DIFF
--- a/rust/scx_stats/scripts/scxstats_to_openmetrics.py
+++ b/rust/scx_stats/scripts/scxstats_to_openmetrics.py
@@ -22,7 +22,7 @@ def request(f, req, args={}):
     f.flush()
     resp = json.loads(f.readline())
     if resp['errno'] != 0:
-        raise Exception(f'req: {req} args: {args} failed with {resp['errno']} ({resp['args']['resp']})')
+        raise Exception(f"req: {req} args: {args} failed with {resp['errno']} ({resp['args']['resp']})")
     return resp['args']['resp']
 
 def make_om_metrics(sname, omid, field, labels, meta_db, registry):


### PR DESCRIPTION
On Python versions that perform validation of this line it fails because of a square bracket mismatch. This is due to the single quotes being parsed first. Fix by changing the outer string to double quotes.