### PR TITLE
scx_rustland_core: improve idle CPU selection API and logic

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -53,7 +53,7 @@ enum {
 	 * The task will be dispatched to the global shared DSQ and it will run
 	 * on the first CPU available.
 	 */
-	RL_CPU_ANY = 1 << 0,
+	RL_CPU_ANY = 1 << 20,
 };
 
 /*
@@ -97,7 +97,7 @@ struct queued_task_ctx {
 struct dispatched_task_ctx {
 	s32 pid;
 	s32 cpu; /* CPU where the task should be dispatched */
-	u64 flags; /* special dispatch flags */
+	u64 flags; /* task enqueue flags */
 	u64 slice_ns; /* time slice assigned to the task (0=default) */
 	u64 vtime; /* task deadline / vruntime */
 	u64 cpumask_cnt; /* cpumask generation counter */

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -453,8 +453,7 @@ impl<'a> Scheduler<'a> {
                 if cpu >= 0 {
                     dispatched_task.cpu = cpu;
                 } else {
-                    // Dispatch task on the first CPU available.
-                    dispatched_task.flags |= RL_CPU_ANY;
+                    dispatched_task.cpu = RL_CPU_ANY;
                 }
 
                 // Send task to the BPF dispatcher.


### PR DESCRIPTION
Pass enqueue flags to user-space: flags will be passed via QueuedTask.flags and can be forwarded back to BPF via DispatchedTask.flags.

These flags can be also passed to BpfScheduler.select_cpu() to apply a more refined CPU selection policy.

Moreover, avoid to prioritize the user-space scheduler too much and dispatch it only if there are no other tasks that needs to be dispatched in ops.dispatch().

This improves CPU utilization and enhances the fairness, robustness, and resilience of schedulers based on scx_rustland_core, particularly under stress test conditions.