### PR TITLE
scx_rustland_core: prevent CI failures

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -518,7 +518,7 @@ impl<'cb> BpfScheduler<'cb> {
             LIBBPF_STOP => {
                 // A valid task is received, convert data to a proper task struct.
                 let task = unsafe { EnqueuedMessage::from_bytes(&BUF.0).to_queued_task() };
-                self.skel.maps.bss_data.nr_queued -= 1;
+                self.skel.maps.bss_data.nr_queued.saturating_sub(1);
 
                 Ok(Some(task))
             }

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -850,13 +850,12 @@ void BPF_STRUCT_OPS(rustland_enqueue, struct task_struct *p, u64 enq_flags)
 		return;
 
 	/*
-	 * Always dispatch per-CPU kthreads directly on their target CPU.
+	 * Always dispatch all kthreads directly on their target CPU.
 	 *
-	 * This allows to prioritize critical kernel threads that may
-	 * potentially stall the entire system if they are blocked for too long
-	 * (i.e., ksoftirqd/N, rcuop/N, etc.).
+	 * This allows to prevent critical kernel threads from being stuck in
+	 * user-space causing system hangs.
 	 */
-	if (is_kthread(p) && p->nr_cpus_allowed == 1) {
+	if (is_kthread(p)) {
 		s32 cpu = scx_bpf_task_cpu(p);
 
 		scx_bpf_dispatch_vtime(p, cpu_to_dsq(cpu),


### PR DESCRIPTION
A couple of changes that should finally prevent all the CI failures.

With this applied, the schedulers based on scx_rustland_core will always dispatch kthreads directly from the BPF component. This should be a safer option for now, allowing to prevent potential stalls also under heavy stress test conditions.

In the future, we will provide a better API to enforce stricter selection criteria for tasks permitted to bypass user-space scheduling.