### PR TITLE
scx_bpfland: Remove the usage of cast_mask in bpfland_enqueue

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -847,7 +847,7 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	 * task, wake them up to see whether they'd be able to steal the just
 	 * queued task.
 	 */
-	cpu = scx_bpf_pick_idle_cpu(cast_mask(p->cpus_ptr), 0);
+	cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
 	if (cpu >= 0)
 		scx_bpf_kick_cpu(cpu, 0);
 }


### PR DESCRIPTION
## Summary
The usage of `cast_mask()` within `bpfland_enqueue` aims to cast the type of "p->cpus_ptr" from "struct bpf_cpumask *" to "const struct cpumask *". However, the type of "p->cpus_ptr" is already "const cpumask_t *" aka "const struct cpumask *", so no conversion is needed.

Moreover, passing a value of type "struct cpumask *" into "struct bpf_cpumask *" leads to compiling error.