### PR TITLE
scx_layered: Add Big/Little core growth algos

### DIFF
--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -68,7 +68,7 @@ use std::ops::BitOrAssign;
 use std::ops::BitXor;
 use std::ops::BitXorAssign;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Eq, Clone, Ord, PartialEq, PartialOrd)]
 pub struct Cpumask {
     mask: BitVec<u64, Lsb0>,
 }

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -99,13 +99,13 @@ lazy_static::lazy_static! {
     pub static ref NR_CPUS_POSSIBLE: usize = libbpf_rs::num_possible_cpus().unwrap();
 }
 
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum CoreType {
     Big { turbo: bool },
     Little,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Cpu {
     id: usize,
     min_freq: usize,
@@ -163,7 +163,7 @@ impl Cpu {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Core {
     id: usize,
     pub node_id: usize,


### PR DESCRIPTION
Add layer growth algos for big/little core topologies that prefer one core type. Discussed this with @JakeHillion at LPC as another way to grow layers.