### PR TITLE
enable ide's etc. to work on the bpf.c files

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  Add: [-DLSP, -Wno-missing-declarations, -Wno-typedef-redefinition, -Wno-ignored-attributes, -xc]

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -27,8 +27,15 @@
  * This software may be used and distributed according to the terms of the
  * GNU General Public License version 2.
  */
+#ifdef LSP
+#define __bpf__
+#include "../../../../scheds/include/scx/common.bpf.h"
+#include "intf.h"
+#else
 #include <scx/common.bpf.h>
 #include "intf.h"
+#endif
+
 
 char _license[] SEC("license") = "GPL";
 

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -30,12 +30,11 @@
 #ifdef LSP
 #define __bpf__
 #include "../../../../scheds/include/scx/common.bpf.h"
-#include "intf.h"
 #else
 #include <scx/common.bpf.h>
-#include "intf.h"
 #endif
 
+#include "intf.h"
 
 char _license[] SEC("license") = "GPL";
 

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -7,7 +7,13 @@
 #ifndef __SCX_COMMON_BPF_H
 #define __SCX_COMMON_BPF_H
 
+#ifdef LSP
+#define __bpf__
+#include "../vmlinux/vmlinux.h"
+#else
 #include "vmlinux.h"
+#endif
+
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <asm-generic/errno.h>

--- a/scheds/include/scx/user_exit_info.h
+++ b/scheds/include/scx/user_exit_info.h
@@ -25,7 +25,11 @@ struct user_exit_info {
 
 #ifdef __bpf__
 
+#ifdef LSP
+#include "../vmlinux/vmlinux.h"
+#else
 #include "vmlinux.h"
+#endif
 #include <bpf/bpf_core_read.h>
 
 #define UEI_DEFINE(__name)							\

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -27,8 +27,6 @@ typedef unsigned long long u64;
 #include <scx/ravg.bpf.h>
 #endif
 
-#include "intf.h"
-
 enum consts {
 	MAX_CPUS_SHIFT		= 9,
 	MAX_CPUS		= 1 << MAX_CPUS_SHIFT,

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -20,7 +20,14 @@ typedef unsigned u32;
 typedef unsigned long long u64;
 #endif
 
+#ifdef LSP
+#define __bpf__
+#include "../../../../include/scx/ravg.bpf.h"
+#else
 #include <scx/ravg.bpf.h>
+#endif
+
+#include "intf.h"
 
 enum consts {
 	MAX_CPUS_SHIFT		= 9,

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1,7 +1,14 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
+#ifdef LSP
+#define __bpf__
+#include "../../../../include/scx/common.bpf.h"
+#include "../../../../include/scx/ravg_impl.bpf.h"
+#include "intf.h"
+#else
 #include <scx/common.bpf.h>
 #include <scx/ravg_impl.bpf.h>
 #include "intf.h"
+#endif
 
 #include <errno.h>
 #include <stdbool.h>

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -3,12 +3,12 @@
 #define __bpf__
 #include "../../../../include/scx/common.bpf.h"
 #include "../../../../include/scx/ravg_impl.bpf.h"
-#include "intf.h"
 #else
 #include <scx/common.bpf.h>
 #include <scx/ravg_impl.bpf.h>
-#include "intf.h"
 #endif
+
+#include "intf.h"
 
 #include <errno.h>
 #include <stdbool.h>

--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -11,7 +11,12 @@ typedef unsigned int u32;
 typedef _Bool bool;
 #endif
 
+#ifdef LSP
+#define __bpf__
+#include "../../../../include/scx/ravg.bpf.h"
+#else
 #include <scx/ravg.bpf.h>
+#endif
 
 enum consts {
 	MAX_CPUS_SHIFT = 9,

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -11,9 +11,17 @@
  * Each cell has an associated DSQ which it uses for vtime scheduling of the
  * cgroups belonging to the cell.
  */
+#ifdef LSP
+#define __bpf__ 
+#include "intf.h"
+#include "../../../../include/scx/common.bpf.h"
+#include "../../../../include/scx/ravg_impl.bpf.h"
+#else
 #include "intf.h"
 #include <scx/common.bpf.h>
 #include <scx/ravg_impl.bpf.h>
+#endif
+
 
 char _license[] SEC("license") = "GPL";
 

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -11,13 +11,14 @@
  * Each cell has an associated DSQ which it uses for vtime scheduling of the
  * cgroups belonging to the cell.
  */
+
+#include "intf.h"
+
 #ifdef LSP
 #define __bpf__ 
-#include "intf.h"
 #include "../../../../include/scx/common.bpf.h"
 #include "../../../../include/scx/ravg_impl.bpf.h"
 #else
-#include "intf.h"
 #include <scx/common.bpf.h>
 #include <scx/ravg_impl.bpf.h>
 #endif

--- a/scheds/rust/scx_rusty/src/bpf/intf.h
+++ b/scheds/rust/scx_rusty/src/bpf/intf.h
@@ -19,7 +19,12 @@ typedef unsigned int u32;
 typedef unsigned long long u64;
 #endif
 
+#ifdef LSP
+#define __bpf__
+#include "../../../../include/scx/ravg.bpf.h"
+#else
 #include <scx/ravg.bpf.h>
+#endif
 
 enum consts {
 	MAX_CPUS		= 512,

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -35,8 +35,16 @@
  * task weight, dom mask and current dom in the task_data map and executes the
  * load balance based on userspace populating the lb_data map.
  */
+
+#ifdef LSP
+#define __bpf__
+#include "../../../../include/scx/common.bpf.h"
+#include "../../../../include/scx/ravg_impl.bpf.h"
+#else
 #include <scx/common.bpf.h>
 #include <scx/ravg_impl.bpf.h>
+#endif
+
 #include "intf.h"
 
 #include <errno.h>


### PR DESCRIPTION
this makes it so that clangd and ide tools which use clangd can work on the bpf.c code.

nothing should actually be changed outside of that ide/editor environment, all the changes are ifdef'ed on LSP which is set in the added .clangd file.

![image](https://github.com/user-attachments/assets/4b71d69b-2201-4dfa-a054-516073fb10eb)
