### PR TITLE
scx_lavd: find a victim cpu for preemption within task's compute domain

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -298,6 +298,7 @@ void bpf_cpumask_copy(struct bpf_cpumask *dst, const struct cpumask *src) __ksym
 u32 bpf_cpumask_any_distribute(const struct cpumask *cpumask) __ksym;
 u32 bpf_cpumask_any_and_distribute(const struct cpumask *src1,
 				   const struct cpumask *src2) __ksym;
+u32 bpf_cpumask_weight(const struct cpumask *cpumask) __ksym;
 
 /* rcu */
 void bpf_rcu_read_lock(void) __ksym;


### PR DESCRIPTION
Previously, we found a victim from the entire CPUs, which include remote or non-compatible CPUs. Now we limit our search for victim finding within a task's compute domain.