### PR TITLE
scx_lavd: propagate waker's latency criticality to its wakee

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -259,7 +259,9 @@ struct task_ctx {
 	u64	vdeadline_delta_ns;	/* time delta until task's virtual deadline */
 	u64	slice_ns;		/* time slice */
 	u32	greedy_ratio;		/* task's overscheduling ratio compared to its nice priority */
-	u32	lat_cri;		/* calculated latency criticality */
+	u32	lat_cri;		/* final context-aware latency criticality */
+	u32	lat_cri_self;		/* my latency criticality */
+	u32	lat_cri_waker;		/* waker's latency criticality */
 	volatile s32 victim_cpu;
 	u16	slice_boost_prio;	/* how many times a task fully consumed the slice */
 	u8	wakeup_ft;		/* regular wakeup = 1, sync wakeup = 2 */


### PR DESCRIPTION
If a waker is more latency critical than a wakee, inherit a waker's latency criticality for the wakee. This allows the wakee to consider the context of who wakes me up. For now, we limit such inheritance to one hop and one schedule.