### PR TITLE
scx_layered: Cleanup dump format

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1801,6 +1801,7 @@ void BPF_STRUCT_OPS(layered_dump, struct scx_dump_ctx *dctx)
 				scx_bpf_dump("LAYER[%d]DSQ[%d] nr_cpus=%u nr_queued=%d -%llums cpus=",
 					     i, idx, layers[i].nr_cpus, scx_bpf_dsq_nr_queued(idx),
 					     dsq_first_runnable_for_ms(idx, now));
+				scx_bpf_dump("\n");
 			}
 		}
 		dump_layer_cpumask(i);


### PR DESCRIPTION
Trying to track down some stall issues and the output format when using topology awareness is messy. Add in some line breaks per layer DSQ.

new output:
```
swapper/7[0] triggered exit kind 1026:
  runnable task stall (watchdog failed to check in for 30.001s)

Backtrace:
  scx_tick+0x69/0x70
  scheduler_tick+0xf4/0x2a0
  update_process_times+0x89/0xa0
  tick_nohz_handler+0xc0/0x100
  __hrtimer_run_queues+0xea/0x250
  hrtimer_interrupt+0xf0/0x390
  __sysvec_apic_timer_interrupt+0x47/0x110
  sysvec_apic_timer_interrupt+0x68/0x80
  asm_sysvec_apic_timer_interrupt+0x16/0x20
  cpuidle_enter_state+0x119/0x240
  cpuidle_enter+0x28/0x40
  do_idle+0x160/0x1f0
  cpu_startup_entry+0x26/0x30
  start_secondary+0x7e/0x80
  common_startup_64+0x13e/0x140

LAYER[0]DSQ[1] nr_cpus=0 nr_queued=0 -0ms cpus=
01234567|89012345|67890123|45678901|23456789|01234567|89012345|67890123|45678901|23456789|

LAYER[2]DSQ[4] nr_cpus=20 nr_queued=0 -0ms cpus=
LAYER[2]DSQ[5] nr_cpus=20 nr_queued=41 -1ms cpus=


HI_FALLBACK[1024] nr_queued=0 -0ms
HI_FALLBACK[1025] nr_queued=0 -0ms
LO_FALLBACK nr_queued=0 -0ms
```