### PR TITLE
scx_common_bpf: Append cast_mask()

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -118,14 +118,6 @@ static bool set_cpu_state(struct bpf_cpumask *cpumask, s32 cpu, bool state)
 }
 
 /*
- * Access a cpumask in read-only mode (typically to check bits).
- */
-static const struct cpumask *cast_mask(struct bpf_cpumask *mask)
-{
-	return (const struct cpumask *)mask;
-}
-
-/*
  * Allocate/re-allocate a new cpumask.
  */
 static int calloc_cpumask(struct bpf_cpumask **p_cpumask)

--- a/scheds/c/scx_nest.bpf.c
+++ b/scheds/c/scx_nest.bpf.c
@@ -152,11 +152,6 @@ static inline bool vtime_before(u64 a, u64 b)
 	return (s64)(a - b) < 0;
 }
 
-static const struct cpumask *cast_mask(struct bpf_cpumask *mask)
-{
-	return (const struct cpumask *)mask;
-}
-
 static __always_inline void
 try_make_core_reserved(s32 cpu, struct bpf_cpumask * reserved, bool promotion)
 {

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -300,6 +300,14 @@ u32 bpf_cpumask_any_and_distribute(const struct cpumask *src1,
 				   const struct cpumask *src2) __ksym;
 u32 bpf_cpumask_weight(const struct cpumask *cpumask) __ksym;
 
+/*
+ * Access a cpumask in read-only mode (typically to check bits).
+ */
+const struct cpumask *cast_mask(struct bpf_cpumask *mask)
+{
+	return (const struct cpumask *)mask;
+}
+
 /* rcu */
 void bpf_rcu_read_lock(void) __ksym;
 void bpf_rcu_read_unlock(void) __ksym;

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -289,14 +289,6 @@ static inline bool is_kthread(const struct task_struct *p)
 }
 
 /*
- * Access a cpumask in read-only mode (typically to check bits).
- */
-static const struct cpumask *cast_mask(struct bpf_cpumask *mask)
-{
-	return (const struct cpumask *)mask;
-}
-
-/*
  * Allocate/re-allocate a new cpumask.
  */
 static int calloc_cpumask(struct bpf_cpumask **p_cpumask)

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -878,11 +878,6 @@ static u64 calc_nr_active_cpus(struct sys_stat *stat_cur)
 	return nr_active;
 }
 
-static const struct cpumask *cast_mask(struct bpf_cpumask *mask)
-{
-	return (const struct cpumask *)mask;
-}
-
 static bool clear_cpu_periodically(u32 cpu, struct bpf_cpumask *cpumask)
 {
 	u32 clear;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -299,14 +299,6 @@ static struct cpumask *lookup_layer_cpumask(int idx)
 	}
 }
 
-/*
- * Access a cpumask in read-only mode (typically to check bits).
- */
-static const struct cpumask *cast_mask(struct bpf_cpumask *mask)
-{
-	return (const struct cpumask *)mask;
-}
-
 static void refresh_cpumasks(int idx)
 {
 	struct layer_cpumask_wrapper *cpumaskw;


### PR DESCRIPTION
## Summary
Remove cast_mask() function distributed throughout different schedulers and add it in common.bpf.h so every scheduler can reference it once they need to.