### PR TITLE
add 'continue on error' to stress tests in ci jobs

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -75,6 +75,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-24.04
     needs: build-kernel
+    continue-on-error: true    
     strategy:
           matrix:
             scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]


### PR DESCRIPTION
I think I see PRs being harder to write because all parts of a CI job are cancelled when one fails.

I think I am also starting to see that we have enough largely disjoint moving pieces that there will often be one that is failing stress tests at any time.

Make CI run all stress tests always to address this.