### PR TITLE
enable build and test outside src dir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,8 @@ veristat_scheduler = get_option('veristat_scheduler')
 
 veristat_diff_dir = get_option('veristat_diff_dir')
 
+build_outside_src = get_option('build_outside_src')
+
 if enable_stress
   run_stress_tests = find_program(join_paths(meson.current_source_dir(),
                                       'meson-scripts/run_stress_tests'))
@@ -121,7 +123,11 @@ if should_build_libbpf
 
   foreach path : libbpf_header_paths
     libbpf_h += ['@0@'.format(libbpf_path) + path]
-    libbpf_local_h += ['.@0@/libbpf'.format(local_build_path) +  path]
+    if not build_outside_src
+      libbpf_local_h += ['.@0@/libbpf'.format(local_build_path) +  path]
+    else
+      libbpf_local_h += ['@0@/libbpf'.format(local_build_path) +  path]
+    endif
   endforeach
 
   message('Fetching libbpf repo')

--- a/meson.options
+++ b/meson.options
@@ -42,3 +42,9 @@ option(
   value: 'auto',
   description: 'install pacman hooks'
 )
+option(
+  'build_outside_src',
+  type: 'boolean',
+  value: false,
+  description: 'enable build cmds to work outside of src dir',
+)


### PR DESCRIPTION
enable build and test outside src dir

add a option `build_outside_src`, defaulted
to false, to undo a tweak to enable meson to work
well with builds within src dir.

this makes some tools work better + enables
moving builds etc. to /tmp (faster for iteration if ramdisk)

this enables scripts like the following, which make iteration time nice and fast:
```
#!/bin/bash

set -euxo pipefail
REPOS=/home/patso/repos
SCX=scx
KERNEL=sched-ext-linux
SCHED="$1"
cd $REPOS/$KERNEL
vng -v --build --pwd $REPOS/$KERNEL --config "$REPOS/$SCX/.github/workflows/sched-ext.config"
cd $REPOS/$SCX
BUILDDIR=../../../../tmp/scxbuild/
# when messing with meson
# rm -rf /tmp/scxbuild
mkdir -p $BUILDDIR
meson setup -Dkernel=$REPOS/$KERNEL -Dkernel_headers=$REPOS/$KERNEL/usr/include -Denable_stress=true -Dbpftool=/usr/bin/bpftool $BUILDDIR $REPOS/$SCX -Dbuild_outside_src=true
meson compile -C $BUILDDIR "$SCHED"
meson compile -C $BUILDDIR test_sched_"$SCHED"
meson compile -C $BUILDDIR stress_tests_"$SCHED"
```

`./local-e2e.sh scx_layered`
...
```
15:48:49 [INFO] CPUs: online/possible=32/32 nr_cores=32
15:48:49 [WARN] libbpf: map 'layered': BPF skeleton version is old, skipping map auto-attachment...

[    0.630701] sched_ext: BPF scheduler "layered" enabled
15:48:49 [INFO] Layered Scheduler Attached. Run `scx_layered --monitor` for metrics.
[   30.575919] sched_ext: BPF scheduler "layered" disabled (unregistered from user space)
EXIT: unregistered from user space
[   30.730614] ACPI: PM: Preparing to enter system sleep state S5
[   30.730731] kvm: exiting hardware virtualization
[   30.730835] reboot: Power down
OK: scx_layered
+ meson compile -C ../../../../tmp/scxbuild/ stress_tests_scx_layered
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /usr/bin/ninja -C /tmp/scxbuild stress_tests_scx_layered
ninja: Entering directory `/tmp/scxbuild'
[0/1] Running external command stress_tests_scx_layered (wrapped by meson to set env)

gentoo in scx on  enable-build-outside-src [$] is 📦 v1.0.4 via 🐍 v3.12.6 via 🦀 v1.80.1 took 32s 
```

ci checks the case when default, so if that passes (err, passes as it usually does), this did nothing other than enable that/is good to go.