### PR TITLE
scx_layered: Add layer growth algo to layer bpf config

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -144,6 +144,16 @@ struct layer_match_ands {
 	int			nr_match_ands;
 };
 
+enum layer_growth_algo {
+    STICKY,
+    LINEAR,
+    RANDOM,
+    TOPO,
+    ROUND_ROBIN,
+    BIG_LITTLE,
+    LITTLE_BIG,
+};
+
 struct layer {
 	struct layer_match_ands	matches[MAX_LAYER_MATCH_ORS];
 	unsigned int		nr_match_ors;
@@ -156,6 +166,7 @@ struct layer {
 	bool			preempt;
 	bool			preempt_first;
 	bool			exclusive;
+	int			growth_algo;
 
 	u64			vtime_now;
 	u64			nr_tasks;


### PR DESCRIPTION
Add an enum for the layer growth algo to the bpf layer config. This will be useful for implementing topology aware layer growth algorithms. When selecting an idle CPU the current logic tries to keep tasks local to LLC/NUMA node. However, for certain growth algorithms (ex: RoundRobin) this is suboptimal. Adding the layer growth algorithm will allow for different paths for CPU selection in the idle/preemption paths.