### PR TITLE
enable bpftrace when using stress tests

### DIFF
--- a/meson-scripts/run_stress_tests
+++ b/meson-scripts/run_stress_tests
@@ -48,6 +48,8 @@ def run_stress_test(
     timeout_sec = int(config.get("timeout_sec"))
     if vng_path:
         vm_input = f"{stress_cmd} & timeout --foreground --preserve-status {timeout_sec} {sched_cmd}"
+        if bpftrace_scripts := config.get('bpftrace_scripts'):
+            vm_input = f"\"{build_dir}/bpftrace_stress_wrapper.sh\" '{stress_cmd}' '{sched_cmd}' '{timeout_sec}' '{bpftrace_scripts}'"
         cmd = [vng_path, "--user", "root", "-v", "--", vm_input]
         err = sys.stderr if output == "-" else open(output, "w")
         out = sys.stdout if output == "-" else err

--- a/meson-scripts/stress_tests.ini
+++ b/meson-scripts/stress_tests.ini
@@ -21,3 +21,10 @@ sched: scx_bpfland
 sched_args:
 stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
 timeout_sec: 15
+
+[scx_layered]
+sched: scx_layered
+sched_args: --run-example --stats 1
+stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
+timeout_sec: 15
+bpftrace_scripts: dsq_lat.bt,process_runqlat.bt

--- a/meson-scripts/stress_tests.ini
+++ b/meson-scripts/stress_tests.ini
@@ -24,7 +24,7 @@ timeout_sec: 15
 
 [scx_layered]
 sched: scx_layered
-sched_args: --run-example --stats 1
+sched_args: --run-example
 stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
 timeout_sec: 15
 bpftrace_scripts: dsq_lat.bt,process_runqlat.bt

--- a/meson.build
+++ b/meson.build
@@ -383,11 +383,34 @@ run_target('veristat_diff', command: [run_veristat_diff, meson.current_build_dir
                                  get_option('veristat_diff_dir')])
 
 if enable_stress
+  # not sure there's a better way
+  # only different...
+  copys = [
+    custom_target('copy stress wrapper',
+      input : 'scripts/bpftrace_stress_wrapper.sh',
+      output :  'bpftrace_stress_wrapper.sh',
+      command : ['cp', '-a', '@INPUT@', '@OUTPUT@'],
+      install : false,
+      build_by_default : true),
+     custom_target('copy dsq_lat',
+      input : 'scripts/dsq_lat.bt',
+      output :  'dsq_lat.bt',
+      command : ['cp', '-a', '@INPUT@', '@OUTPUT@'],
+      install : false,
+      build_by_default : true),
+      custom_target('copy runq_lat',
+        input : 'scripts/process_runqlat.bt',
+        output :  'process_runqlat.bt',
+        command : ['cp', '-a', '@INPUT@', '@OUTPUT@'],
+        install : false,
+        build_by_default : true)
+    ]
+
   run_target('stress_tests', command: [run_stress_tests, '-k', kernel, '-b',
-                                       meson.current_build_dir()])
+                                       meson.current_build_dir()], depends: [copys])
   foreach s : rust_scheds
     run_target('stress_tests_'+s, command: [run_stress_tests, '-k', kernel, '-b',
-                                            meson.current_build_dir(), '--sched', s])
+                                            meson.current_build_dir(), '--sched', s], depends: [copys])
   endforeach
 endif
 

--- a/scripts/bpftrace_stress_wrapper.sh
+++ b/scripts/bpftrace_stress_wrapper.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+STRESS_CMD="$1"
+SCHED_CMD="$2"
+TIMEOUT_SEC="$3"
+BPFTRACE_SCRIPTS="$4"
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+for a in $(echo "$BPFTRACE_SCRIPTS" | tr ',' ' '); do
+  bpftrace "$SCRIPT_DIR/$a" > "$(basename a).txt" 2>&1 &
+done
+
+$STRESS_CMD > stress_cmd.txt 2>&1 &
+
+STRESS_PID=$!
+
+timeout --foreground --preserve-status $TIMEOUT_SEC $SCHED_CMD > sched_output.txt 2>&1 &
+
+STATUS_PID=$!
+
+tail --pid=$STATUS_PID -f sched_output.txt
+
+for a in $(echo "$BPFTRACE_SCRIPTS" | tr ',' ' '); do
+  echo "$a OUTPUT"
+  cat "$(basename a).txt"
+  echo "$a OUTPUT DONE"
+done
+
+echo "STRESS OUTPUT"
+cat stress_cmd.txt
+echo "STRESS OUTPUT DONE"
+
+# if anything isn't right, exit non 0 so we know.
+wait $STRESS_PID
+wait $STATUS_PID


### PR DESCRIPTION
update meson/stress test runner to enable running bpftrace scripts while running stress tests.

this might blow up CI logs a bit but like, it will blow them up with debug info.

I think later I'll see if I can get vng to mount rw such that individual log files can be saved as CI run artifacts.