### PR TITLE
scx_loader: Add systemd service and on-DBUS launch

### DIFF
--- a/rust/scx_loader/README.md
+++ b/rust/scx_loader/README.md
@@ -46,6 +46,42 @@
 
 **Note:** Replace the example scheduler names and arguments with the actual ones you want to use.
 
+## DBUS and Systemd Service
+
+`scx_loader` provides the `org.scx.Loader` DBUS service and is automatically started by `dbus-daemon` when an application calls into this service.  Users and administrators do not need to manually start the `scx_loader` daemon.
+
+`scx_loader` is managed by the `scx_loader.service` systemd unit. This service is distinct from the `scx.service` unit, which is used to manage schedulers directly (without DBUS).
+
+## Debugging
+
+In case of issues with `scx_loader`, you can debug the service using the following steps:
+
+1. **Check the service status:**
+   ```bash
+   systemctl status scx_loader.service
+   ```
+
+2. **View the service logs:**
+   ```bash
+   journalctl -u scx_loader.service
+   ```
+
+3. **Enable debug logging:** You can temporarily enable debug logging by modifying the systemd service file:
+
+   - Edit the service file:
+     ```bash
+     sudo systemctl edit scx_loader.service
+     ```
+   - Add the following lines under the `[Service]` section:
+     ```
+     Environment=RUST_LOG=trace
+     ```
+   - Restart the service:
+     ```bash
+     sudo systemctl restart scx_loader.service
+     ```
+   - Check the logs again for detailed debugging information.
+
 ## Development Status
 
 `scx_loader` is under active development.  Future improvements may include:

--- a/services/systemd/meson.build
+++ b/services/systemd/meson.build
@@ -4,5 +4,11 @@ systemd_system_unit_dir = systemd.get_variable(pkgconfig : 'systemdsystemunitdir
 # Install the 'scx.service' file to the systemd system unit directory
 install_data('scx.service', install_dir: systemd_system_unit_dir)
 
+# Install the 'scx_loader.service' file to the systemd system unit directory
+install_data('scx_loader.service', install_dir: systemd_system_unit_dir)
+
+# Install the 'org.scx.Loader.service' file to the dbus system services directory
+install_data('org.scx.Loader.service', install_dir: '/usr/share/dbus-1/system-services')
+
 # Install the 'scx' file to the '/etc/default' directory
 install_data('../scx', install_dir: '/etc/default')

--- a/services/systemd/org.scx.Loader.service
+++ b/services/systemd/org.scx.Loader.service
@@ -1,0 +1,5 @@
+[D-BUS Service]
+Name=org.scx.Loader
+Exec=/usr/bin/scx_loader
+User=root
+SystemdService=scx_loader.service

--- a/services/systemd/scx_loader.service
+++ b/services/systemd/scx_loader.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=DBUS on-demand loader of sched-ext schedulers
+
+[Service]
+Type=dbus
+BusName=org.scx.Loader
+ExecStart=/usr/bin/scx_loader
+KillSignal=SIGINT
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
Provide additional systemd service for `scx_loader` to be able to autostart it by DBUS, even if the service was enabled/started by user, DBUS will search by name and start it with propagation of called dbus method/property

ref: "Example 7. DBus services" https://www.freedesktop.org/software/systemd/man/256/systemd.service.html