### PR TITLE
ci: enable on merge_group action

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -6,7 +6,8 @@ on:
       - cron: "0 * * * *"
     push:
     pull_request:
-
+    merge_group:
+      
 jobs:
   lint:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Enabling the `caching-build` workflow on `merge_group` actions. This is required to enable merge queues which should make merging lots of PRs while getting full CI testing possible. Currently `lint` is the only required check but we will add more in future.