### PR TITLE
dev_guide: document cargo fmt

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -30,6 +30,15 @@ load between scheduling domains becomes a difficult problem. sched_ext has a
 common crate for calculating weights between scheduling domains. See the
 `infeasible` crate in `rust/scx_utils/src` for the implementation.
 
+## Rust
+We use `cargo fmt` to ensure consistency in our Rust code. This runs on PRs in
+the CI and will fail with a patch if your code doesn't match. We currently need
+a nightly version of Rust to format so have pinned this for consistency. To run
+locally (with rustup) run:
+
+    $ rustup install nightly-2024-09-10
+    $ cargo +nightly-2024-09-10 fmt
+
 ## Useful Tools
 ### perf
 


### PR DESCRIPTION
Added documentation of how to match the CI in formatting. It involves two steps: mutating your rustup toolchains to have the right nightly version, and running the formatting. Because of this I've avoided making it a script as I don't want to mess with anyone's local state, but this does mean we'll have to keep it in sync with the CI (CI is always the source of truth here).