### PR TITLE
scx_lavd: more accurately determine the performance criticality threshold

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -120,6 +120,9 @@ struct sys_stat {
 	volatile u32	max_lat_cri;	/* maximum latency criticality (LC) */
 	volatile u32	thr_lat_cri;	/* latency criticality threshold for kicking */
 
+	volatile u32	min_perf_cri;	/* minimum performance criticality */
+	volatile u32	avg_perf_cri;	/* average performance criticality */
+	volatile u32	max_perf_cri;	/* maximum performance criticality */
 	volatile u32	thr_perf_cri;	/* performance criticality threshold */
 
 	volatile u32	nr_violation;	/* number of utilization violation */
@@ -187,6 +190,8 @@ struct cpu_ctx {
 	 * Information used to keep track of performance criticality
 	 */
 	volatile u64	sum_perf_cri;	/* sum of performance criticality */
+	volatile u64	min_perf_cri;	/* mininum performance criticality */
+	volatile u64	max_perf_cri;	/* maximum performance criticality */
 
 	/*
 	 * Information of a current running task for preemption

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -120,7 +120,7 @@ struct sys_stat {
 	volatile u32	max_lat_cri;	/* maximum latency criticality (LC) */
 	volatile u32	thr_lat_cri;	/* latency criticality threshold for kicking */
 
-	volatile u32	avg_perf_cri;	/* average performance criticality */
+	volatile u32	thr_perf_cri;	/* performance criticality threshold */
 
 	volatile u32	nr_violation;	/* number of utilization violation */
 	volatile u32	nr_active;	/* number of active cores */
@@ -289,7 +289,7 @@ struct task_ctx_x {
 	u16	static_prio;	/* nice priority */
 	u32	cpu_id;		/* where a task ran */
 	u64	cpu_util;	/* cpu utilization in [0..100] */
-	u32	avg_perf_cri;	/* average performance criticality */
+	u32	thr_perf_cri;	/* performance criticality threshold */
 	u32	avg_lat_cri;	/* average latency criticality */
 	u32	nr_active;	/* number of active cores */
 	u32	cpuperf_cur;	/* CPU's current performance target */

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -637,7 +637,7 @@ impl<'a> Scheduler<'a> {
             wait_freq: tc.wait_freq,
             wake_freq: tc.wake_freq,
             perf_cri: tc.perf_cri,
-            avg_perf_cri: tx.avg_perf_cri,
+            thr_perf_cri: tx.thr_perf_cri,
             cpuperf_cur: tx.cpuperf_cur,
             cpu_util: tx.cpu_util,
             nr_active: tx.nr_active,

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -165,8 +165,8 @@ pub struct SchedSample {
     pub wake_freq: u64,
     #[stat(desc = "Performance criticality of this task")]
     pub perf_cri: u32,
-    #[stat(desc = "Average performance criticality in a system")]
-    pub avg_perf_cri: u32,
+    #[stat(desc = "Performance criticality threshold")]
+    pub thr_perf_cri: u32,
     #[stat(desc = "Target performance level of this CPU")]
     pub cpuperf_cur: u32,
     #[stat(desc = "CPU utilization of this particular CPU")]
@@ -205,7 +205,7 @@ impl SchedSample {
             "WAIT_FREQ",
             "WAKE_FREQ",
             "PERF_CRI",
-            "AVG_PC",
+            "THR_PC",
             "CPUFREQ",
             "CPU_UTIL",
             "NR_ACT",
@@ -246,7 +246,7 @@ impl SchedSample {
             self.wait_freq,
             self.wake_freq,
             self.perf_cri,
-            self.avg_perf_cri,
+            self.thr_perf_cri,
             self.cpuperf_cur,
             self.cpu_util,
             self.nr_active,


### PR DESCRIPTION
We used the average performance criticality of tasks as a threshold to
determine the proper core type (big or little). However, if the big
core's compute capacity is not half of the total compute capacity, such
an average-based determination becomes suboptimal. If fewer tasks are
classified as performance-critical tasks and requested to run on big
cores, the big cores would be wasted by stealing arbitrary
non-performance-critical tasks. That could result in performance
instability.

Hence, determine the threshold more accurately by considering (active)
big cores' compute capacity and the (approximated) distribution of
performance criticality of tasks.