### PR TITLE
scx_lavd: fix two potential bugs

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -2131,7 +2131,8 @@ static struct cpu_ctx *find_victim_cpu(const struct cpumask *cpumask,
 		/*
 		 * Check whether that CPU is qualified to run @p.
 		 */
-		if (cur_cpu == cpu || !can_cpu_be_kicked(now, cpuc))
+		if (cpu >= nr_cpus_onln || cur_cpu == cpu ||
+		    !can_cpu_be_kicked(now, cpuc))
 			continue;
 
 		/*

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -566,7 +566,7 @@ impl<'a> Scheduler<'a> {
                 }
                 skel.maps.bss_data.cpdom_ctxs[v.cpdom_id].nr_neighbors[k] = nr_neighbors;
                 for n in neighbors.borrow().iter() {
-                    skel.maps.bss_data.cpdom_ctxs[v.cpdom_id].neighbor_bits[k] = 0x1 << n;
+                    skel.maps.bss_data.cpdom_ctxs[v.cpdom_id].neighbor_bits[k] |= 0x1 << n;
                 }
             }
         }


### PR DESCRIPTION
This PR contains two potential bugs, one of which causes a stress test failure in CI.
- scx_lavd: do not perform the victim selection for an invalid cpu
- scx_lavd: fix incorrect neighbor_bit initialization