### PR TITLE
scx_loader: Add D-Bus Introspection XML

### DIFF
--- a/rust/scx_loader/README.md
+++ b/rust/scx_loader/README.md
@@ -82,6 +82,38 @@ In case of issues with `scx_loader`, you can debug the service using the followi
      ```
    - Check the logs again for detailed debugging information.
 
+## D-Bus Introspection XML
+
+`scx_loader` provides a D-Bus Introspection XML file that describes its interface. This file can be used by language bindings and tools to interact with the service.
+
+**Using the Introspection XML:**
+
+The introspection XML can be accessed in two ways:
+
+1. **Through the D-Bus introspection interface:**
+
+   ```bash
+   dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.freedesktop.DBus.Introspectable.Introspect
+   ```
+
+   This will output the XML describing the `scx_loader` interface.
+
+2. **From the project repository:**
+
+   The XML file is also available in the provided file `org.scx.Loader.xml`.
+
+
+You can then use this XML with tools like `gdbus-codegen` or other language-specific D-Bus bindings to generate code that interacts with `scx_loader`.
+
+For example, with `gdbus-codegen`, you can generate C code for the interface:
+
+```bash
+gdbus-codegen --generate-c-code scx-loader-bindings org.scx.Loader.xml
+```
+
+This will produce header and source files that you can use to interact with `scx_loader` from your C code.
+
+
 ## Development Status
 
 `scx_loader` is under active development.  Future improvements may include:

--- a/rust/scx_loader/org.scx.Loader.xml
+++ b/rust/scx_loader/org.scx.Loader.xml
@@ -1,0 +1,78 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <!--
+      org.scx.Loader:
+      @short_description: Scheduler Loader Service
+
+      The Scheduler Loader service provides an interface for managing schedulers
+      that can be used with sched-ext. It allows starting, stopping, and querying
+      the status of supported schedulers.
+  -->
+  <interface name="org.scx.Loader">
+
+    <!--
+        CurrentScheduler:
+
+        The name of the currently running scheduler. If no scheduler is active,
+        this property will be set to "unknown".
+    -->
+    <property name="CurrentScheduler" type="s" access="read"/>
+
+    <!--
+        SchedulerMode:
+        @sched_mode: 0 = Auto, 1 = Gaming, 2 = PowerSave, 3 = LowLatency
+
+        The currently active scheduler mode.  Scheduler modes allow you to
+        apply pre-defined configurations to a scheduler that are
+        optimized for different use cases. If no scheduler is active,
+        this property will be set to 0 (Auto).
+    -->
+    <property name="SchedulerMode" type="u" access="read"/>
+
+    <!--
+        SupportedSchedulers:
+
+        A list of the schedulers currently supported by the Scheduler Loader.
+        The names of the supported schedulers will be listed as strings in
+        this array.
+    -->
+    <property name="SupportedSchedulers" type="as" access="read"/>
+
+    <!--
+        StartScheduler:
+
+        Starts the specified scheduler with the given mode.
+
+        @scx_name: The name of the scheduler to start (e.g., "scx_rusty").
+        @sched_mode: The scheduler mode (profile) as an unsigned integer.
+                   See the SchedulerMode property for details.
+    -->
+    <method name="StartScheduler">
+      <arg name="scx_name" type="s" direction="in"/>
+      <arg name="sched_mode" type="u" direction="in"/>
+    </method>
+
+    <!--
+        StartSchedulerWithArgs:
+
+        Starts the specified scheduler with the provided arguments.
+
+        @scx_name: The name of the scheduler to start (e.g., "scx_bpfland").
+        @scx_args: An array of strings representing the CLI arguments to pass
+                    to the scheduler.
+    -->
+    <method name="StartSchedulerWithArgs">
+      <arg name="scx_name" type="s" direction="in"/>
+      <arg name="scx_args" type="as" direction="in"/>
+    </method>
+
+    <!--
+        StopScheduler:
+
+        Stops the currently running scheduler.
+    -->
+    <method name="StopScheduler">
+    </method>
+  </interface>
+</node>


### PR DESCRIPTION
XML can be used for code generation like `gdbus-codegen`,`zbus-xmlgen`

refs:
- https://dbus2.github.io/zbus/client.html
- https://docs.gtk.org/gio/migrating-gdbus.html#generating-code-and-docs
- https://dbus.freedesktop.org/doc/dbus-api-design.html
- https://dbus.freedesktop.org/doc/dbus-specification.html