### PR TITLE
scx_bpfland small fixes and improvements

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -358,7 +358,7 @@ static inline bool vtime_before(u64 a, u64 b)
 /*
  * Return task's average amount of context switches per second.
  */
-static bool task_avg_nvcsw(struct task_struct *p)
+static u64 task_avg_nvcsw(struct task_struct *p)
 {
 	struct task_ctx *tctx;
 


### PR DESCRIPTION
Small fix:
 - scx_bpfland: fix task_avg_nvcsw() return type (used in `--lowlatency` mode)

Minor improvements:
 - scx_bpfland: keep tasks running on full-idle SMT cores (from `ops.dispatch()` keep the current task running it it's the last one and if the used CPU is a full-idle SMT core)
 - scx_bpfland: always give tasks a chance to run on an idle CPU (similar logic that will be provided by the new upcoming `SCX_ENQUEUE_RQ_SELECTED` flag)