### PR TITLE
Add #stat_doc attribute macro to Stats structs

### DIFF
--- a/scheds/rust/scx_bpfland/src/stats.rs
+++ b/scheds/rust/scx_bpfland/src/stats.rs
@@ -6,10 +6,12 @@ use std::time::Duration;
 
 use anyhow::Result;
 use scx_stats::prelude::*;
+use scx_stats_derive::stat_doc;
 use scx_stats_derive::Stats;
 use serde::Deserialize;
 use serde::Serialize;
 
+#[stat_doc]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(top)]
 pub struct Metrics {

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -10,10 +10,12 @@ use anyhow::bail;
 use anyhow::Result;
 use gpoint::GPoint;
 use scx_stats::prelude::*;
+use scx_stats_derive::stat_doc;
 use scx_stats_derive::Stats;
 use serde::Deserialize;
 use serde::Serialize;
 
+#[stat_doc]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(top)]
 pub struct SysStats {
@@ -125,6 +127,7 @@ impl SysStats {
     }
 }
 
+#[stat_doc]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 pub struct SchedSample {
     #[stat(desc = "Sequence ID of this message")]

--- a/scheds/rust/scx_rustland/src/stats.rs
+++ b/scheds/rust/scx_rustland/src/stats.rs
@@ -3,10 +3,12 @@ use std::time::Duration;
 
 use anyhow::Result;
 use scx_stats::prelude::*;
+use scx_stats_derive::stat_doc;
 use scx_stats_derive::Stats;
 use serde::Deserialize;
 use serde::Serialize;
 
+#[stat_doc]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(top)]
 pub struct Metrics {

--- a/scheds/rust/scx_rusty/src/stats.rs
+++ b/scheds/rust/scx_rusty/src/stats.rs
@@ -10,6 +10,7 @@ use anyhow::Result;
 use chrono::DateTime;
 use chrono::Local;
 use scx_stats::prelude::*;
+use scx_stats_derive::stat_doc;
 use scx_stats_derive::Stats;
 use scx_utils::Cpumask;
 use serde::Deserialize;
@@ -25,6 +26,7 @@ fn signed(x: f64) -> String {
     }
 }
 
+#[stat_doc]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(_om_prefix = "d_", _om_label = "domain")]
 pub struct DomainStats {
@@ -50,6 +52,7 @@ impl DomainStats {
     }
 }
 
+#[stat_doc]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(_om_prefix = "n_", _om_label = "node")]
 pub struct NodeStats {
@@ -77,6 +80,7 @@ impl NodeStats {
     }
 }
 
+#[stat_doc]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(top)]
 pub struct ClusterStats {


### PR DESCRIPTION
`#stat_doc` extends the document from stat desc property.

Add this attribute macro to the remaining Stats structs.

This follows up #703.