### PR TITLE
Replace PID with Task Pointer in Rusty

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/intf.h
+++ b/scheds/rust/scx_rusty/src/bpf/intf.h
@@ -63,7 +63,7 @@ enum consts {
 	 * this isn't a practical problem as the LB rounds are best-effort
 	 * anyway and will be retried until loads are balanced.
 	 */
-	MAX_DOM_ACTIVE_PIDS	= 1024,
+	MAX_DOM_ACTIVE_TPTRS	= 1024,
 };
 
 /* Statistics */
@@ -106,7 +106,7 @@ struct task_ctx {
 	u32 dom_id;
 	u32 weight;
 	bool runnable;
-	u64 dom_active_pids_gen;
+	u64 dom_active_tptrs_gen;
 	u64 deadline;
 
 	u64 sum_runtime;


### PR DESCRIPTION
~I wasnt't able to reopen https://github.com/sched-ext/scx/pull/672 because I force pushed (just learned about that limit).~

~This is a continuation of that PR.~

~I closed that PR and opened https://github.com/sched-ext/scx/pull/710 because, while the first PR's approach passed stress tests and seemed to work, it kind of didn't make sense that I could deref the casted pointer to task_struct.~

~I updated that initial PR to explicltly deref that casted pointer to confirm this works/the verifier allows it and it seems to work so, this works?~

see latest comment

