### PR TITLE
scx_rusty: Delete unused function variable

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -220,7 +220,7 @@ static inline u32 weight_to_bucket_idx(u32 weight)
 	return weight * LB_LOAD_BUCKETS / LB_MAX_WEIGHT;
 }
 
-static void task_load_adj(struct task_struct *p, struct task_ctx *taskc,
+static void task_load_adj(struct task_ctx *taskc,
 			  u64 now, bool runnable)
 {
 	taskc->runnable = runnable;
@@ -1356,7 +1356,7 @@ void BPF_STRUCT_OPS(rusty_runnable, struct task_struct *p, u64 enq_flags)
 
 	wakee_ctx->is_kworker = p->flags & PF_WQ_WORKER;
 
-	task_load_adj(p, wakee_ctx, now, true);
+	task_load_adj(wakee_ctx, now, true);
 	dom_dcycle_adj(wakee_ctx->dom_id, wakee_ctx->weight, now, true);
 
 	if (fifo_sched)
@@ -1482,7 +1482,7 @@ void BPF_STRUCT_OPS(rusty_quiescent, struct task_struct *p, u64 deq_flags)
 	if (!(taskc = lookup_task_ctx(p)))
 		return;
 
-	task_load_adj(p, taskc, now, false);
+	task_load_adj(taskc, now, false);
 	dom_dcycle_adj(taskc->dom_id, taskc->weight, now, false);
 
 	if (fifo_sched)


### PR DESCRIPTION
## Summary
"struct task_struct *p" isn't used within the function "task_load_adj()". Delete the function parameter for cleaner code.