### PR TITLE
scx_rusty: fix single dom short-circuit

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -477,9 +477,6 @@ static u32 cpu_to_dom_id(s32 cpu)
 {
 	const volatile u32 *dom_idp;
 
-	if (nr_doms <= 1)
-		return 0;
-
 	dom_idp = MEMBER_VPTR(cpu_dom_id_map, [cpu]);
 	if (!dom_idp)
 		return MAX_DOMS;


### PR DESCRIPTION
Remove a short-circuit in cpu_to_dom_id that will return domain id 0 for any input.

This fixes a crash of scx_rusty when running with a single domain and any CPU is offline.

Fixes #723 