### PR TITLE
scx_layered: Add per layer time slices to stats

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -781,6 +781,8 @@ struct Stats {
 
     processing_dur: Duration,
     prev_processing_dur: Duration,
+
+    layer_slice_us: Vec<u64>,
 }
 
 impl Stats {
@@ -846,6 +848,8 @@ impl Stats {
 
             processing_dur: Default::default(),
             prev_processing_dur: Default::default(),
+
+            layer_slice_us: vec![0; nr_layers],
         })
     }
 
@@ -866,6 +870,15 @@ impl Stats {
             .iter()
             .take(self.nr_layers)
             .map(|layer| layer.nr_tasks as usize)
+            .collect();
+
+        let layer_slice_us: Vec<u64> = skel
+            .maps
+            .bss_data
+            .layers
+            .iter()
+            .take(self.nr_layers)
+            .map(|layer| layer.slice_ns / 1000 as u64)
             .collect();
 
         let (total_load, layer_loads) = Self::read_layer_loads(skel, self.nr_layers);
@@ -916,6 +929,8 @@ impl Stats {
 
             processing_dur,
             prev_processing_dur: cur_processing_dur,
+
+            layer_slice_us,
         };
         Ok(())
     }

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -125,6 +125,8 @@ pub struct LayerStats {
     pub min_nr_cpus: u32,
     #[stat(desc = "maximum # of CPUs assigned")]
     pub max_nr_cpus: u32,
+    #[stat(desc = "slice duration config")]
+    pub slice_us: u64,
 }
 
 impl LayerStats {
@@ -212,6 +214,7 @@ impl LayerStats {
             cur_nr_cpus: layer.cpus.count_ones() as u32,
             min_nr_cpus: nr_cpus_range.0 as u32,
             max_nr_cpus: nr_cpus_range.1 as u32,
+            slice_us: stats.layer_slice_us[lidx],
         }
     }
 
@@ -276,7 +279,7 @@ impl LayerStats {
 
         writeln!(
             w,
-            "  {:<width$}  preempt/first/xllc/xnuma/idle/fail={}/{}/{}/{}/{}/{} min_exec={}/{:7.2}ms",
+            "  {:<width$}  preempt/first/xllc/xnuma/idle/fail={}/{}/{}/{}/{}/{} min_exec={}/{:7.2}ms, slice={}ms",
             "",
             fmt_pct(self.preempt),
             fmt_pct(self.preempt_first),
@@ -286,6 +289,7 @@ impl LayerStats {
             fmt_pct(self.preempt_fail),
             fmt_pct(self.min_exec),
             self.min_exec_us as f64 / 1000.0,
+            self.slice_us as f64 / 1000.0,
             width = header_width,
         )?;
 


### PR DESCRIPTION
Basically addressing issue #720, described from @hodgesds:

> In `scx_layered` the time slice can be [configured per layer](https://github.com/sched ext/scx/blob/main/scheds/rust/scx_layered/src/main.rs#L493). This should be added to the [`LayerStats`](https://github.com/sched-ext/scx/blob/main/scheds/rust/scx_layered/src/stats.rs#L51) for each layer. During stats [refresh](https://github.com/sched-ext/scx/blob/main/scheds/rust/scx_layered/src/main.rs#L852) read the time slice duration (from the bpf skel) to the layer and add it to the stats. Finally, update the [format](https://github.com/sched-ext/scx/blob/main/scheds/rust/scx_layered/src/stats.rs#L218) method for `LayerStats` to print the per layer time slices.