### PR TITLE
scx_loader: Add SwitchScheduler methods to DBUS interface

### DIFF
--- a/rust/scx_loader/README.md
+++ b/rust/scx_loader/README.md
@@ -7,6 +7,8 @@
 * **`StartScheduler` Method:**  Launches a scheduler specified by its `scx_name` (e.g., "scx_rusty") and a scheduler mode (profile) represented as an unsigned integer.
 * **`StartSchedulerWithArgs` Method:** Starts a scheduler with its `scx_name` and allows passing arbitrary CLI arguments directly to the scheduler.
 * **`StopScheduler` Method:** Terminates the currently running scheduler.
+* **`SwitchScheduler` Method:** Stops the current scheduler and starts the specified scheduler with the given mode.
+* **`SwitchSchedulerWithArgs` Method:** Stops the current scheduler and starts the specified scheduler with the provided arguments.
 * **`CurrentScheduler` Property:** Returns the `scx_name` of the active scheduler or "unknown" if none is running.
 * **`SchedulerMode` Property:** Provides information about the currently active scheduler's mode (profile).
 * **`SupportedSchedulers` Property:**  Lists the schedulers currently supported by `scx_loader`.
@@ -33,6 +35,18 @@
   ```bash
   dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.StopScheduler
   ```
+
+* **Switch Scheduler:**
+  ```bash
+  dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.SwitchScheduler string:scx_lavd uint32:2
+  ```
+  (This switches to `scx_lavd` with scheduler mode 2)
+
+* **Switch Scheduler with Arguments:**
+  ```bash
+  dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.SwitchSchedulerWithArgs string:scx_bpfland array:string:"-k","-c","0"
+  ```
+  (This switches to `scx_bpfland` with arguments `-k -c 0`)
 
 * **Get the Currently Active Scheduler:**
   ```bash

--- a/rust/scx_loader/org.scx.Loader.xml
+++ b/rust/scx_loader/org.scx.Loader.xml
@@ -6,7 +6,7 @@
       @short_description: Scheduler Loader Service
 
       The Scheduler Loader service provides an interface for managing schedulers
-      that can be used with sched-ext. It allows starting, stopping, and querying
+      that can be used with sched-ext. It allows starting, stopping, switching and querying
       the status of supported schedulers.
   -->
   <interface name="org.scx.Loader">
@@ -63,6 +63,38 @@
                     to the scheduler.
     -->
     <method name="StartSchedulerWithArgs">
+      <arg name="scx_name" type="s" direction="in"/>
+      <arg name="scx_args" type="as" direction="in"/>
+    </method>
+
+    <!--
+        SwitchScheduler:
+
+        Switches to the specified scheduler with the given mode. This method
+        will stop the currently running scheduler (if any) and then start the
+        new scheduler.
+
+        @scx_name: The name of the scheduler to switch to (e.g., "scx_rusty").
+        @sched_mode: The scheduler mode (profile) as an unsigned integer.
+                   See the SchedulerMode property for details.
+    -->
+    <method name="SwitchScheduler">
+      <arg name="scx_name" type="s" direction="in"/>
+      <arg name="sched_mode" type="u" direction="in"/>
+    </method>
+
+    <!--
+        SwitchSchedulerWithArgs:
+
+        Switches to the specified scheduler with the provided arguments. This
+        method will stop the currently running scheduler (if any) and then
+        start the new scheduler with the given arguments.
+
+        @scx_name: The name of the scheduler to switch to (e.g., "scx_bpfland").
+        @scx_args: An array of strings representing the CLI arguments to pass
+                    to the scheduler.
+    -->
+    <method name="SwitchSchedulerWithArgs">
       <arg name="scx_name" type="s" direction="in"/>
       <arg name="scx_args" type="as" direction="in"/>
     </method>


### PR DESCRIPTION
These methods allow switching between different schedulers without requiring manual stopping and starting.