### PR TITLE
scx_layered: Use idle smt mask for idle selection

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -184,6 +184,7 @@ struct layer {
 	bool			preempt;
 	bool			preempt_first;
 	bool			exclusive;
+	bool			idle_smt;
 	int			growth_algo;
 
 	u64			vtime_now;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -650,7 +650,7 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 					      idle_cpumask)) >= 0)
 			goto out_put;
 	} else {
-		idle_cpumask = scx_bpf_get_idle_cpumask();
+		idle_cpumask = scx_bpf_get_idle_smtmask();
 		if (!pref_idle_cpumask || !idle_cpumask) {
 			cpu = -1;
 			goto out_put;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -650,7 +650,12 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 					      idle_cpumask)) >= 0)
 			goto out_put;
 	} else {
-		idle_cpumask = scx_bpf_get_idle_smtmask();
+		if (layer->idle_smt) {
+			idle_cpumask = scx_bpf_get_idle_smtmask();
+		} else {
+			idle_cpumask = scx_bpf_get_idle_cpumask();
+		}
+
 		if (!pref_idle_cpumask || !idle_cpumask) {
 			cpu = -1;
 			goto out_put;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -103,6 +103,7 @@ lazy_static::lazy_static! {
 			preempt: false,
 			preempt_first: false,
 			exclusive: false,
+			idle_smt: false,
                         slice_us: 20000,
                         weight: DEFAULT_LAYER_WEIGHT,
                         growth_algo: LayerGrowthAlgo::Sticky,
@@ -124,6 +125,7 @@ lazy_static::lazy_static! {
 			preempt: true,
 			preempt_first: false,
 			exclusive: true,
+			idle_smt: false,
                         slice_us: 20000,
                         weight: DEFAULT_LAYER_WEIGHT,
                         growth_algo: LayerGrowthAlgo::Sticky,
@@ -144,6 +146,7 @@ lazy_static::lazy_static! {
 			preempt: false,
 			preempt_first: false,
 			exclusive: false,
+			idle_smt: false,
                         slice_us: 20000,
                         weight: DEFAULT_LAYER_WEIGHT,
                         growth_algo: LayerGrowthAlgo::Linear,
@@ -286,6 +289,9 @@ lazy_static::lazy_static! {
 ///   starvation across layers. Weights are used in combination with
 ///   utilization to determine the infeasible adjusted weight with higher
 ///   weights having a larger adjustment in adjusted utilization.
+///
+/// - idle_smt: When selecting an idle CPU for task task migration use
+///   only idle SMT CPUs. The default is to select any idle cpu.
 ///
 /// - growth_algo: When a layer is allocated new CPUs different algorithms can
 ///   be used to determine which CPU should be allocated next. The default
@@ -509,6 +515,8 @@ enum LayerKind {
         #[serde(default)]
         weight: u32,
         #[serde(default)]
+        idle_smt: bool,
+        #[serde(default)]
         growth_algo: LayerGrowthAlgo,
         #[serde(default)]
         perf: u64,
@@ -536,6 +544,8 @@ enum LayerKind {
         #[serde(default)]
         weight: u32,
         #[serde(default)]
+        idle_smt: bool,
+        #[serde(default)]
         growth_algo: LayerGrowthAlgo,
         #[serde(default)]
         perf: u64,
@@ -559,6 +569,8 @@ enum LayerKind {
         exclusive: bool,
         #[serde(default)]
         weight: u32,
+        #[serde(default)]
+        idle_smt: bool,
         #[serde(default)]
         growth_algo: LayerGrowthAlgo,
         #[serde(default)]
@@ -1707,6 +1719,7 @@ impl<'a, 'b> Scheduler<'a, 'b> {
                     preempt,
                     preempt_first,
                     exclusive,
+                    idle_smt,
                     growth_algo,
                     nodes,
                     slice_us,
@@ -1720,6 +1733,7 @@ impl<'a, 'b> Scheduler<'a, 'b> {
                     preempt,
                     preempt_first,
                     exclusive,
+                    idle_smt,
                     growth_algo,
                     nodes,
                     slice_us,
@@ -1733,6 +1747,7 @@ impl<'a, 'b> Scheduler<'a, 'b> {
                     preempt,
                     preempt_first,
                     exclusive,
+                    idle_smt,
                     growth_algo,
                     nodes,
                     slice_us,
@@ -1755,6 +1770,7 @@ impl<'a, 'b> Scheduler<'a, 'b> {
                     layer.preempt.write(*preempt);
                     layer.preempt_first.write(*preempt_first);
                     layer.exclusive.write(*exclusive);
+                    layer.idle_smt.write(*idle_smt);
                     layer.growth_algo = growth_algo.as_bpf_enum();
                     layer.weight = if *weight <= MAX_LAYER_WEIGHT && *weight >= MIN_LAYER_WEIGHT {
                         *weight


### PR DESCRIPTION
In the non topology aware code the idle smt mask is used for finding idle cpus. Update topology aware idle selection to also use the idle smt mask. In certain benchmarks this can improve performance.

Tested on `12th Gen Intel(R) Core(TM) i3-1220P` with P/E cores and `stress-ng` configured with `BigLittle` growth algorithm on big cores.

With idle smt mask:
```
stress-ng -c 2 -t 10 -M
stress-ng: info:  [17956] setting to a 10 secs run per stressor
stress-ng: info:  [17956] dispatching hogs: 2 cpu
stress-ng: metrc: [17956] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s CPU used per       RSS Max
stress-ng: metrc: [17956]                           (secs)    (secs)    (secs)   (real time) (usr+sys time) instance (%)          (KB)
stress-ng: metrc: [17956] cpu               40708     10.00     20.00      0.00      4071.28        2035.65       100.00          7264
stress-ng: info:  [17956] skipped: 0
stress-ng: info:  [17956] passed: 2: cpu (2)
stress-ng: info:  [17956] failed: 0
stress-ng: info:  [17956] metrics untrustworthy: 0
stress-ng: info:  [17956] successful run completed in 10.00 secs
```
Idle mask:
```
stress-ng -c 2 -t 10 -M
stress-ng: info:  [18308] setting to a 10 secs run per stressor
stress-ng: info:  [18308] dispatching hogs: 2 cpu
stress-ng: metrc: [18308] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s CPU used per       RSS Max
stress-ng: metrc: [18308]                           (secs)    (secs)    (secs)   (real time) (usr+sys time) instance (%)          (KB)
stress-ng: metrc: [18308] cpu               38429     10.00     20.00      0.00      3842.14        1921.07       100.00          7360
stress-ng: info:  [18308] skipped: 0
stress-ng: info:  [18308] passed: 2: cpu (2)
stress-ng: info:  [18308] failed: 0
stress-ng: info:  [18308] metrics untrustworthy: 0
stress-ng: info:  [18308] successful run completed in 10.00 secs
```
