### PR TITLE
Drop journald from libalpn hooks

### DIFF
--- a/libalpm/systemd/90-scx-scheds-upgrade.hook
+++ b/libalpm/systemd/90-scx-scheds-upgrade.hook
@@ -2,7 +2,6 @@
 Type = Path
 Operation = Upgrade
 Target = etc/default/scx
-Target = etc/systemd/journald@sched-ext.conf
 Target = usr/bin/scx_*
 Target = usr/lib/systemd/system/scx.service
 


### PR DESCRIPTION
He've dropped separate journald namespace, so we don't need it in libalpm files. 