### PR TITLE
scx_layered: Add big cpumask

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -368,6 +368,11 @@ impl Topology {
     pub fn nr_cpus_online(&self) -> usize {
         self.nr_cpus_online
     }
+
+    /// Returns whether the Topology has a hybrid architecture of big and little cores.
+    pub fn has_little_cores(&self) -> bool {
+        self.cores.iter().any(|c| c.core_type == CoreType::Little)
+    }
 }
 
 /// Generate a topology map from a Topology object, represented as an array of arrays.

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -95,6 +95,7 @@ struct cpu_ctx {
 	bool			maybe_idle;
 	bool			yielding;
 	bool			try_preempt_first;
+	bool			is_big;
 	u64			layer_cycles[MAX_LAYERS];
 	u64			gstats[NR_GSTATS];
 	u64			lstats[MAX_LAYERS][NR_LSTATS];
@@ -153,14 +154,14 @@ struct layer_match_ands {
 };
 
 enum layer_growth_algo {
-	STICKY,
-	LINEAR,
-	REVERSE,
-	RANDOM,
-	TOPO,
-	ROUND_ROBIN,
-	BIG_LITTLE,
-	LITTLE_BIG,
+	GROWTH_ALGO_STICKY,
+	GROWTH_ALGO_LINEAR,
+	GROWTH_ALGO_REVERSE,
+	GROWTH_ALGO_RANDOM,
+	GROWTH_ALGO_TOPO,
+	GROWTH_ALGO_ROUND_ROBIN,
+	GROWTH_ALGO_BIG_LITTLE,
+	GROWTH_ALGO_LITTLE_BIG,
 };
 
 enum dsq_iter_algo {

--- a/scheds/rust/scx_layered/src/layer_core_growth.rs
+++ b/scheds/rust/scx_layered/src/layer_core_growth.rs
@@ -39,14 +39,14 @@ pub enum LayerGrowthAlgo {
     LittleBig,
 }
 
-const GROWTH_ALGO_STICKY: i32 = bpf_intf::layer_growth_algo_STICKY as i32;
-const GROWTH_ALGO_LINEAR: i32 = bpf_intf::layer_growth_algo_LINEAR as i32;
-const GROWTH_ALGO_REVERSE: i32 = bpf_intf::layer_growth_algo_REVERSE as i32;
-const GROWTH_ALGO_RANDOM: i32 = bpf_intf::layer_growth_algo_RANDOM as i32;
-const GROWTH_ALGO_TOPO: i32 = bpf_intf::layer_growth_algo_TOPO as i32;
-const GROWTH_ALGO_ROUND_ROBIN: i32 = bpf_intf::layer_growth_algo_ROUND_ROBIN as i32;
-const GROWTH_ALGO_BIG_LITTLE: i32 = bpf_intf::layer_growth_algo_BIG_LITTLE as i32;
-const GROWTH_ALGO_LITTLE_BIG: i32 = bpf_intf::layer_growth_algo_LITTLE_BIG as i32;
+const GROWTH_ALGO_STICKY: i32 = bpf_intf::layer_growth_algo_GROWTH_ALGO_STICKY as i32;
+const GROWTH_ALGO_LINEAR: i32 = bpf_intf::layer_growth_algo_GROWTH_ALGO_LINEAR as i32;
+const GROWTH_ALGO_REVERSE: i32 = bpf_intf::layer_growth_algo_GROWTH_ALGO_REVERSE as i32;
+const GROWTH_ALGO_RANDOM: i32 = bpf_intf::layer_growth_algo_GROWTH_ALGO_RANDOM as i32;
+const GROWTH_ALGO_TOPO: i32 = bpf_intf::layer_growth_algo_GROWTH_ALGO_TOPO as i32;
+const GROWTH_ALGO_ROUND_ROBIN: i32 = bpf_intf::layer_growth_algo_GROWTH_ALGO_ROUND_ROBIN as i32;
+const GROWTH_ALGO_BIG_LITTLE: i32 = bpf_intf::layer_growth_algo_GROWTH_ALGO_BIG_LITTLE as i32;
+const GROWTH_ALGO_LITTLE_BIG: i32 = bpf_intf::layer_growth_algo_GROWTH_ALGO_LITTLE_BIG as i32;
 
 impl LayerGrowthAlgo {
     pub fn as_bpf_enum(&self) -> i32 {


### PR DESCRIPTION
Add big cpumask to scx_layered and prefer selecting big idle cores when using the `BigLittle` growth algo. Future work can be preferring selecting little idle cores for the `LittleBig` growth algo.