### PR TITLE
scx_layered: lighten/reduce nested loops in layered dispatch

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1240,22 +1240,23 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 		bool open = MEMBER_VPTR(layers, [layer_idx].open);
 		u32 layer_cpus = *MEMBER_VPTR(layers[layer_idx], .nr_cpus);
 		struct cpumask *layer_cpumask;
-    bool have_layer_cpumask = layer_cpumask = lookup_layer_cpumask(idx);
+	    bool have_layer_cpumask = layer_cpumask = lookup_layer_cpumask(idx);
 		bool cpumask_test = false;
-    if (have_layer_cpumask) 
-      cpumask_test = bpf_cpumask_test_cpu(cpu, layer_cpumask);
-    bool layer_matches = (have_layer_cpumask && (cpumask_test ||
-						(cpu <= nr_possible_cpus && cpu == fallback_cpu &&
-						layer_cpus == 0))); 
+		if (have_layer_cpumask)
+			cpumask_test = bpf_cpumask_test_cpu(cpu, layer_cpumask);
+	    bool layer_matches = (have_layer_cpumask && 
+							 (cpumask_test ||
+							 (cpu <= nr_possible_cpus && 
+							  cpu == fallback_cpu &&
+							  layer_cpus == 0))); 
 		
 		if (disable_topology) {
-
 			/* consume preempting layers first */
 			if (preempt && scx_bpf_consume(idx))
 				return;
 
 			/* make sure hi fallback dsq is empty */
-      dsq_id = cpu_hi_fallback_dsq_id(cpu);
+		    dsq_id = cpu_hi_fallback_dsq_id(cpu);
 			if (scx_bpf_consume(dsq_id))
 				return;
 
@@ -1279,26 +1280,26 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 			u64 non_preempting_open_dsq;
 
 			bpf_for(llc_id, 0, nr_llcs) {
-
-        dsq_id = layer_dsq_id(layer_idx, llc_id);
-	  		/* consume preempting layers first, with no delay */
+				dsq_id = layer_dsq_id(layer_idx, llc_id);
+				/* consume preempting layers first, with no delay */
 				if (preempt && scx_bpf_consume(dsq_id))
 					return;
-        dsq_id = llc_hi_fallback_dsq_id(llc_id);
+				dsq_id = llc_hi_fallback_dsq_id(llc_id);
 				/* make sure hi fallback dsq is empty, with no delay  */
 				if (scx_bpf_consume(dsq_id))
 					return;
 
 				/* consume matching layers */
 				if (layer_matches && !matching_dsq){ 
-            matching_dsq = dsq_id;
-            break;
+					matching_dsq = dsq_id;
+					break;
 				}
 				/* consume !preempting open layers */			
-				if ((!preempt && open) && !non_preempting_open_dsq
-            && matching_dsq)
-					non_preempting_open_dsq = dsq_id;
+				if ((!preempt && open) && !non_preempting_open_dsq 
+					&& matching_dsq)
+						non_preempting_open_dsq = dsq_id;
 			}
+
 			/* preserve priority order of dsq execution */
 			if(!matching_dsq) {
 				if (scx_bpf_consume(matching_dsq))
@@ -1308,9 +1309,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 				if (scx_bpf_consume(non_preempting_open_dsq))
 					return;
 			}
-
 		}
-
 	}
 	/* consume lo fallback dsq */
 	scx_bpf_consume(LO_FALLBACK_DSQ);

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1240,15 +1240,15 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 		bool open = MEMBER_VPTR(layers, [layer_idx].open);
 		u32 layer_cpus = *MEMBER_VPTR(layers[layer_idx], .nr_cpus);
 		struct cpumask *layer_cpumask;
-	    bool have_layer_cpumask = layer_cpumask = lookup_layer_cpumask(idx);
+		bool have_layer_cpumask = layer_cpumask = lookup_layer_cpumask(idx);
 		bool cpumask_test = false;
 		if (have_layer_cpumask)
 			cpumask_test = bpf_cpumask_test_cpu(cpu, layer_cpumask);
 	    bool layer_matches = (have_layer_cpumask && 
-							 (cpumask_test ||
-							 (cpu <= nr_possible_cpus && 
-							  cpu == fallback_cpu &&
-							  layer_cpus == 0))); 
+							(cpumask_test ||
+							(cpu <= nr_possible_cpus && 
+							cpu == fallback_cpu &&
+							layer_cpus == 0))); 
 		
 		if (disable_topology) {
 			/* consume preempting layers first */

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1234,82 +1234,85 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 	// round robin order.
 	cpu_ctx_layer_idx_inc(cctx);
 
-	/* consume preempting layers first */
 	bpf_for(idx, 0, nr_layers) {
+		layer_idx = iter_layer_dsq_ctx(idx, cctx->layer_idx);
+		bool preempt = MEMBER_VPTR(layers, [layer_idx].preempt);
+		bool open = MEMBER_VPTR(layers, [layer_idx].open);
+		u32 layer_cpus = *MEMBER_VPTR(layers[layer_idx], .nr_cpus);
+		struct cpumask *layer_cpumask;
+    bool have_layer_cpumask = layer_cpumask = lookup_layer_cpumask(idx);
+		bool cpumask_test = false;
+    if (have_layer_cpumask) 
+      cpumask_test = bpf_cpumask_test_cpu(cpu, layer_cpumask);
+    bool layer_matches = (have_layer_cpumask && (cpumask_test ||
+						(cpu <= nr_possible_cpus && cpu == fallback_cpu &&
+						layer_cpus == 0))); 
+		
 		if (disable_topology) {
-			if (MEMBER_VPTR(layers, [idx].preempt) && scx_bpf_consume(idx))
+
+			/* consume preempting layers first */
+			if (preempt && scx_bpf_consume(idx))
 				return;
-		} else {
-			layer_idx = iter_layer_dsq_ctx(idx, cctx->layer_idx);
-			bpf_for(llc_id, 0, nr_llcs) {
-				dsq_id = layer_dsq_id(layer_idx, llc_id);
-				if (MEMBER_VPTR(layers, [layer_idx].preempt) &&
-				    scx_bpf_consume(dsq_id))
-					return;
-			}
-		}
-	}
 
-	dsq_id = cpu_hi_fallback_dsq_id(cpu);
-	if (scx_bpf_consume(dsq_id))
-		return;
-
-	/* consume !open layers second */
-	bpf_for(idx, 0, nr_layers) {
-		if (disable_topology) {
-			layer_idx = idx;
-			struct layer *layer = &layers[idx];
-			struct cpumask *layer_cpumask;
+			/* make sure hi fallback dsq is empty */
+      dsq_id = cpu_hi_fallback_dsq_id(cpu);
+			if (scx_bpf_consume(dsq_id))
+				return;
 
 			/* consume matching layers */
-			if (!(layer_cpumask = lookup_layer_cpumask(idx)))
-				return;
-
-			if (bpf_cpumask_test_cpu(cpu, layer_cpumask) ||
-			    (cpu == fallback_cpu && layer->nr_cpus == 0)) {
-				if (scx_bpf_consume(idx))
-					return;
-			}
-		} else {
-			layer_idx = iter_layer_dsq_ctx(idx, cctx->layer_idx);
-			bpf_for(llc_id, 0, nr_llcs) {
-				struct layer *layer = &layers[layer_idx];
-				struct cpumask *layer_cpumask;
-				dsq_id = layer_dsq_id(layer_idx, llc_id);
-
-				/* consume matching layers */
-				if (!(layer_cpumask = lookup_layer_cpumask(layer_idx)))
-					return;
-
-				if (bpf_cpumask_test_cpu(cpu, layer_cpumask) ||
-				    (cpu <= nr_possible_cpus && cpu == fallback_cpu &&
-				     MEMBER_VPTR(layer, ->nr_cpus) == 0)) {
-					if (scx_bpf_consume(dsq_id))
+			if (have_layer_cpumask)
+			{
+				if (cpumask_test ||
+					(cpu == fallback_cpu && layer_cpus == 0)) {
+					if (scx_bpf_consume(idx))
 						return;
 				}
 			}
-		}
-	}
 
-	/* consume !preempting open layers */
-	bpf_for(idx, 0, nr_layers) {
-		if (disable_topology) {
+			/* consume !preempting open layers */			
 			if (!layers[idx].preempt && layers[idx].open &&
 			    scx_bpf_consume(idx))
 				return;
-		} else {
-			layer_idx = iter_layer_dsq_ctx(idx, cctx->layer_idx);
-			bpf_for(llc_id, 0, nr_llcs) {
-				dsq_id = layer_dsq_id(layer_idx, llc_id);
 
-				if (!MEMBER_VPTR(layers, [layer_idx].preempt) &&
-				    MEMBER_VPTR(layers, [layer_idx].open) &&
-				    scx_bpf_consume(dsq_id))
+		} else {
+			u64 matching_dsq;
+			u64 non_preempting_open_dsq;
+
+			bpf_for(llc_id, 0, nr_llcs) {
+
+        dsq_id = layer_dsq_id(layer_idx, llc_id);
+	  		/* consume preempting layers first, with no delay */
+				if (preempt && scx_bpf_consume(dsq_id))
+					return;
+        dsq_id = llc_hi_fallback_dsq_id(llc_id);
+				/* make sure hi fallback dsq is empty, with no delay  */
+				if (scx_bpf_consume(dsq_id))
+					return;
+
+				/* consume matching layers */
+				if (layer_matches && !matching_dsq){ 
+            matching_dsq = dsq_id;
+            break;
+				}
+				/* consume !preempting open layers */			
+				if ((!preempt && open) && !non_preempting_open_dsq
+            && matching_dsq)
+					non_preempting_open_dsq = dsq_id;
+			}
+			/* preserve priority order of dsq execution */
+			if(!matching_dsq) {
+				if (scx_bpf_consume(matching_dsq))
 					return;
 			}
-		}
-	}
+			if(!non_preempting_open_dsq) {
+				if (scx_bpf_consume(non_preempting_open_dsq))
+					return;
+			}
 
+		}
+
+	}
+	/* consume lo fallback dsq */
 	scx_bpf_consume(LO_FALLBACK_DSQ);
 }
 

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1244,7 +1244,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 		bool cpumask_test = false;
 		if (have_layer_cpumask)
 			cpumask_test = bpf_cpumask_test_cpu(cpu, layer_cpumask);
-	    bool layer_matches = (have_layer_cpumask && 
+		bool layer_matches = (have_layer_cpumask && 
 							(cpumask_test ||
 							(cpu <= nr_possible_cpus && 
 							cpu == fallback_cpu &&


### PR DESCRIPTION
I *think* (like, *maybe* think) this improves the responsiveness of layered by fixing some off-by-1 error.

Interesting thing about the results below:
18.72/15.60=1.2 (main fork user sec / branch fork user sec)
146579/131561=1.114152370 (main bogo ops / branch bogo ops)
9/7.66 = 1.17493473  (main cpu used % per instance / branch cpu used % per instance)

I think that, in combination with the rest of the results, is saying:
This change reduces the absolute number of instructions executed for this test, but it decreases how long it takes (in terms of time) for those instructions to be executed and how much CPU% those insns cost.

```
main

STRESS OUTPUT
stress-ng: info:  [295] setting to a 14 secs run per stressor
stress-ng: info:  [295] dispatching hogs: 32 cpu, 32 fork
stress-ng: info:  [295] note: /proc/sys/kernel/sched_autogroup_enabled is 1 and this can impact scheduling throughput for processes not attached to a tty. Setting this to 0 may improve performance metrics
stress-ng: metrc: [295] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s CPU used per       RSS Max
stress-ng: metrc: [295]                           (secs)    (secs)    (secs)   (real time) (usr+sys time) instance (%)          (KB)
stress-ng: metrc: [295] cpu              632537     14.00    279.98      0.62     45175.58        2254.20        62.63          6400
stress-ng: metrc: [295] fork             146579     14.00     18.72     21.60     10469.61        3635.57         9.00          2628
stress-ng: info:  [295] skipped: 0
stress-ng: info:  [295] passed: 63: cpu (31) fork (32)
stress-ng: info:  [295] failed: 0
stress-ng: info:  [295] metrics untrustworthy: 0
stress-ng: info:  [295] successful run completed in 14.02 secs
STRESS OUTPUT DONE
[   26.559795] ACPI: PM: Preparing to enter system sleep state S5
[   26.559945] kvm: exiting hardware virtualization
[   26.560172] reboot: Power down
[ble: elapsed 59.949s (CPU 554.7%)] ./local-e2e.sh scx_layered


branch

STRESS OUTPUT
stress-ng: info:  [296] setting to a 14 secs run per stressor
stress-ng: info:  [296] dispatching hogs: 32 cpu, 32 fork
stress-ng: info:  [296] note: /proc/sys/kernel/sched_autogroup_enabled is 1 and this can impact scheduling throughput for processes not attached to a tty. Setting this to 0 may improve performance metrics
stress-ng: metrc: [296] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s CPU used per       RSS Max
stress-ng: metrc: [296]                           (secs)    (secs)    (secs)   (real time) (usr+sys time) instance (%)          (KB)
stress-ng: metrc: [296] cpu              633144     14.00    279.68      0.96     45220.31        2256.05        62.64          6396
stress-ng: metrc: [296] fork             131561     14.00     15.60     18.72      9397.07        3833.80         7.66          2812
stress-ng: info:  [296] skipped: 0
stress-ng: info:  [296] passed: 63: cpu (31) fork (32)
stress-ng: info:  [296] failed: 0
stress-ng: info:  [296] metrics untrustworthy: 0
stress-ng: info:  [296] successful run completed in 14.02 secs
STRESS OUTPUT DONE
[   26.590950] ACPI: PM: Preparing to enter system sleep state S5
[   26.591101] kvm: exiting hardware virtualization
[   26.591221] reboot: Power down
[ble: elapsed 62.462s (CPU 528.8%)] ./local-e2e.sh scx_layered
```