### PR TITLE
scx_bpfland: prevent per-CPU DSQ stall with per-CPU kthreads

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -146,12 +146,11 @@ struct Opts {
     #[clap(short = 'L', long, action = clap::ArgAction::SetTrue)]
     lowlatency: bool,
 
-    /// Enable per-CPU kthreads prioritization.
+    /// Enable kthreads prioritization.
     ///
-    /// Enabling this can enhance the performance of interrupt-driven workloads (e.g., networking
-    /// throughput) over regular system/user workloads. However, it may also introduce
-    /// interactivity issues or unfairness under heavy interrupt-driven loads, such as high RX
-    /// network traffic.
+    /// Enabling this can improve system performance, but it may also introduce interactivity
+    /// issues or unfairness in scenarios with high kthread activity, such as heavy I/O or network
+    /// traffic.
     #[clap(short = 'k', long, action = clap::ArgAction::SetTrue)]
     local_kthreads: bool,
 
@@ -587,6 +586,7 @@ impl<'a> Scheduler<'a> {
             nr_interactive: self.skel.maps.bss_data.nr_interactive,
             nr_waiting: self.skel.maps.bss_data.nr_waiting,
             nvcsw_avg_thresh: self.skel.maps.bss_data.nvcsw_avg_thresh,
+            nr_kthread_dispatches: self.skel.maps.bss_data.nr_kthread_dispatches,
             nr_direct_dispatches: self.skel.maps.bss_data.nr_direct_dispatches,
             nr_prio_dispatches: self.skel.maps.bss_data.nr_prio_dispatches,
             nr_shared_dispatches: self.skel.maps.bss_data.nr_shared_dispatches,

--- a/scheds/rust/scx_bpfland/src/stats.rs
+++ b/scheds/rust/scx_bpfland/src/stats.rs
@@ -25,6 +25,8 @@ pub struct Metrics {
     pub nr_waiting: u64,
     #[stat(desc = "Average of voluntary context switches")]
     pub nvcsw_avg_thresh: u64,
+    #[stat(desc = "Number of kthread direct dispatches")]
+    pub nr_kthread_dispatches: u64,
     #[stat(desc = "Number of task direct dispatches")]
     pub nr_direct_dispatches: u64,
     #[stat(desc = "Number of interactive task dispatches")]
@@ -37,13 +39,14 @@ impl Metrics {
     fn format<W: Write>(&self, w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "[{}] tasks -> run: {:>2}/{:<2} int: {:<2} wait: {:<4} | nvcsw: {:<4} | dispatch -> dir: {:<5} prio: {:<5} shr: {:<5}",
+            "[{}] tasks -> run: {:>2}/{:<2} int: {:<2} wait: {:<4} | nvcsw: {:<4} | dispatch -> kth: {:<5} dir: {:<5} pri: {:<5} shr: {:<5}",
             crate::SCHEDULER_NAME,
             self.nr_running,
             self.nr_cpus,
             self.nr_interactive,
             self.nr_waiting,
             self.nvcsw_avg_thresh,
+            self.nr_kthread_dispatches,
             self.nr_direct_dispatches,
             self.nr_prio_dispatches,
             self.nr_shared_dispatches
@@ -53,6 +56,7 @@ impl Metrics {
 
     fn delta(&self, rhs: &Self) -> Self {
         Self {
+            nr_kthread_dispatches: self.nr_kthread_dispatches - rhs.nr_kthread_dispatches,
             nr_direct_dispatches: self.nr_direct_dispatches - rhs.nr_direct_dispatches,
             nr_prio_dispatches: self.nr_prio_dispatches - rhs.nr_prio_dispatches,
             nr_shared_dispatches: self.nr_shared_dispatches - rhs.nr_shared_dispatches,


### PR DESCRIPTION
Since per-CPU kthreads may show an inconsistent prev_cpu and/or cpumask, dispatch them directly to local DSQ and allow to preempt the current running task.

This allows to prevent per-CPU kthread stalls and it also helps to prioritize them, as are usually important for system performance and responsiveness.

Moreover, change the behavior of --local-kthreads to prioritize all kthreads when this option is used.

This addresses issue #728.

NOTE: ideally we may want to fix this in the kernel by making sure to always expose a consistent prev_cpu and cpumask also for kthreads, but at the moment this change allows to prevent some annoying stalls and performance-wise it doesn't seem to introduce any regression. In fact, the usual gaming/fps benchmarks show even a slight improvement in responsiveness with this change applied.