### PR TITLE
scx_layered: Add stress-ng example layer

### DIFF
--- a/meson-scripts/stress_tests.ini
+++ b/meson-scripts/stress_tests.ini
@@ -24,7 +24,7 @@ timeout_sec: 15
 
 [scx_layered]
 sched: scx_layered
-sched_args: --run-example
+sched_args: --run-example -v
 stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
 timeout_sec: 15
 bpftrace_scripts: dsq_lat.bt,process_runqlat.bt

--- a/meson-scripts/test_sched
+++ b/meson-scripts/test_sched
@@ -43,7 +43,7 @@ else
 fi
 
 if [[ -v SCHEDS["scx_layered"] ]] ; then
-    SCHEDS["scx_layered"]="--run-example"
+    SCHEDS["scx_layered"]="--run-example -v"
 fi
 
 printf "testing scheds:\n"

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -135,6 +135,32 @@ lazy_static::lazy_static! {
                     },
 		},
 		LayerSpec {
+                    name: "stress-ng".into(),
+                    comment: Some("stress-ng test layer".into()),
+                    matches: vec![vec![
+			LayerMatch::CommPrefix("stress-ng".into()),
+                    ],
+                    vec![
+			LayerMatch::PcommPrefix("stress-ng".into()),
+                    ]],
+                    kind: LayerKind::Confined {
+			cpus_range: None,
+			min_exec_us: 800,
+			yield_ignore: 0.0,
+			util_range: (0.2, 0.8),
+			preempt: true,
+			preempt_first: false,
+			exclusive: true,
+			idle_smt: false,
+                        slice_us: 800,
+                        weight: DEFAULT_LAYER_WEIGHT,
+                        growth_algo: LayerGrowthAlgo::Topo,
+			perf: 1024,
+			nodes: vec![],
+			llcs: vec![],
+                    },
+		},
+		LayerSpec {
                     name: "normal".into(),
                     comment: Some("the rest".into()),
                     matches: vec![vec![]],


### PR DESCRIPTION
Add a stress-ng example layer, which will be used for CI testing with stress-ng.