### PR TITLE
scx_layered: Make stress-ng non exclusive in example

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -150,7 +150,7 @@ lazy_static::lazy_static! {
 			util_range: (0.2, 0.8),
 			preempt: true,
 			preempt_first: false,
-			exclusive: true,
+			exclusive: false,
 			idle_smt: false,
                         slice_us: 800,
                         weight: DEFAULT_LAYER_WEIGHT,


### PR DESCRIPTION
Test CI hosts are VMs currently and making stress-ng exclusive may starve the host.