### PR TITLE
scx_layered: fix stalls on ci

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1335,7 +1335,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 			}
 
 
-		  dsq_id = cpu_hi_fallback_dsq_id(cpu);
+			dsq_id = cpu_hi_fallback_dsq_id(cpu);
 			if (scx_bpf_consume(dsq_id))
 				return;
 


### PR DESCRIPTION
This fixes stalls on CI.

It makes checks around dispatch be more explicit (by initializing them to -1).

It also checks `cpu_hi_fallback_dsq_id` before checking for matching and open layers.

It also restores some up cleaned-up logic around preemption that that err, prevents stalls.

I tested it without each of these changes so these are the minimum to fix things.