### PR TITLE
[rusty] Fix load stats when host is under-utilized

### DIFF
--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -83,4 +83,5 @@ pub use log_recorder::LogRecorderBuilder;
 
 mod misc;
 pub use misc::monitor_stats;
+pub use misc::normalize_load_metric;
 pub use misc::set_rlimit_infinity;

--- a/rust/scx_utils/src/misc.rs
+++ b/rust/scx_utils/src/misc.rs
@@ -90,3 +90,25 @@ pub fn read_file_usize(path: &Path) -> Result<usize> {
         }
     }
 }
+
+/* Load is reported as weight * duty cycle
+ *
+ * In the Linux kernel, EEDVF uses default weight = 1 s.t.
+ * load for a nice-0 thread runnable for time slice = 1
+ *
+ * To conform with cgroup weights convention, sched-ext uses
+ * the convention of default weight = 100 with the formula
+ * 100 * nice ^ 1.5. This means load for a nice-0 thread
+ * runnable for time slice = 100.
+ *
+ * To ensure we report load metrics consistently with the Linux
+ * kernel, we divide load by 100.0 prior to reporting metrics.
+ * This is also more intuitive for users since 1 CPU roughly
+ * means 1 unit of load.
+ *
+ * We only do this prior to reporting as its easier to work with
+ * weight as integers in BPF / userspace than floating point.
+ */
+pub fn normalize_load_metric(metric: f64) -> f64 {
+    metric / 100.0
+}

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -18,6 +18,7 @@ use log::warn;
 use scx_stats::prelude::*;
 use scx_stats_derive::stat_doc;
 use scx_stats_derive::Stats;
+use scx_utils::normalize_load_metric;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -182,7 +183,7 @@ impl LayerStats {
         Self {
             util: stats.layer_utils[lidx] * 100.0,
             util_frac: calc_frac(stats.layer_utils[lidx], stats.total_util),
-            load: stats.layer_loads[lidx],
+            load: normalize_load_metric(stats.layer_loads[lidx]),
             load_adj: calc_frac(stats.layer_load_sums[lidx], stats.total_load_sum),
             dcycle: calc_frac(stats.layer_dcycle_sums[lidx], stats.total_dcycle_sum),
             load_frac: calc_frac(stats.layer_loads[lidx], stats.total_load),
@@ -411,7 +412,7 @@ impl SysStats {
             proc_ms: stats.processing_dur.as_millis() as u64,
             busy: stats.cpu_busy * 100.0,
             util: stats.total_util * 100.0,
-            load: stats.total_load,
+            load: normalize_load_metric(stats.total_load),
             fallback_cpu: fallback_cpu as u32,
             layers: BTreeMap::new(),
         })

--- a/scheds/rust/scx_rusty/src/stats.rs
+++ b/scheds/rust/scx_rusty/src/stats.rs
@@ -12,6 +12,7 @@ use chrono::Local;
 use scx_stats::prelude::*;
 use scx_stats_derive::stat_doc;
 use scx_stats_derive::Stats;
+use scx_utils::normalize_load_metric;
 use scx_utils::Cpumask;
 use serde::Deserialize;
 use serde::Serialize;
@@ -39,6 +40,14 @@ pub struct DomainStats {
 }
 
 impl DomainStats {
+    pub fn new(load: f64, imbal: f64, delta: f64) -> Self {
+        Self {
+            load: normalize_load_metric(load),
+            imbal: normalize_load_metric(imbal),
+            delta: normalize_load_metric(delta),
+        }
+    }
+
     pub fn format<W: Write>(&self, w: &mut W, id: usize) -> Result<()> {
         writeln!(
             w,
@@ -67,6 +76,15 @@ pub struct NodeStats {
 }
 
 impl NodeStats {
+    pub fn new(load: f64, imbal: f64, delta: f64, doms: BTreeMap<usize, DomainStats>) -> Self {
+        Self {
+            load: normalize_load_metric(load),
+            imbal: normalize_load_metric(imbal),
+            delta: normalize_load_metric(delta),
+            doms,
+        }
+    }
+
     pub fn format<W: Write>(&self, w: &mut W, id: usize) -> Result<()> {
         writeln!(
             w,


### PR DESCRIPTION
This PR fixes https://github.com/sched-ext/scx/issues/609

When the machine is under-utilized when using scx_rusty (e.g. avg util < 99.9%), weights are ignored in the load balancer since all weights will be infeasible and therefore we should assume each task has equal weight. Thus, the default weight was assumed to be 1.

However, when the machine become >= 99.9% utilized, we end up using the real weights and correcting for infeasible weights. The default weight in the kernel is 100, so what ends up happening is we see load scale up by 100x which is a confusing experience for the user.

The fix is to set all weights = 100 in the load balancer if the machine is under-utilized so we don't see a major surprising jump in load metrics.

We end up using weight = 100 as opposed to 1 which might be more intuitive since scx_layered also shows with 100 multiplicative factor (e.g. 100 threads at full util = 10000 load). So I prefer being consistent between schedulers. Note scx_layered already handles this correctly by exporting raw load and load adjusted for infeasible weights in all cases.