### PR TITLE
scx_layered: fix ci

### DIFF
--- a/meson-scripts/run_stress_tests
+++ b/meson-scripts/run_stress_tests
@@ -49,7 +49,7 @@ def run_stress_test(
     sched_cmd = s_path + " " + config.get('sched_args')
     timeout_sec = int(config.get("timeout_sec"))
     if vng_path:
-        cmd = [vng_path, "--user", "root", "-v", "-r", kernel]
+        cmd = [vng_path, "-m", "10G", "--cpus", "10", "--user", "root", "-v", "-r", kernel]
         if config.get("qemu_opts"):
             cmd += ['--qemu-opts']
             cmd += [f"'{config.get("qemu_opts")}'"]

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1255,84 +1255,82 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 	if (!disable_topology && dsq_iter_algo == DSQ_ITER_ROUND_ROBIN)
 		cpu_ctx_layer_idx_inc(cctx);
 
+	/* consume preempting layers first */
 	bpf_for(idx, 0, nr_layers) {
-		layer_idx = iter_layer_dsq_ctx(idx, cctx->layer_idx);
-		bool preempt = MEMBER_VPTR(layers, [layer_idx].preempt);
-		bool open = MEMBER_VPTR(layers, [layer_idx].open);
-		u32 layer_cpus = *MEMBER_VPTR(layers[layer_idx], .nr_cpus);
-		struct cpumask *layer_cpumask;
-		bool have_layer_cpumask = layer_cpumask = lookup_layer_cpumask(idx);
-		bool cpumask_test = false;
-		if (have_layer_cpumask)
-			cpumask_test = bpf_cpumask_test_cpu(cpu, layer_cpumask);
-		bool layer_matches = (have_layer_cpumask && 
-							(cpumask_test ||
-							(cpu <= nr_possible_cpus && 
-							cpu == fallback_cpu &&
-							layer_cpus == 0))); 
-		
 		if (disable_topology) {
-			/* consume preempting layers first */
-			if (preempt && scx_bpf_consume(idx))
+			if (MEMBER_VPTR(layers, [idx].preempt) && scx_bpf_consume(idx))
 				return;
-
-			/* make sure hi fallback dsq is empty */
-		    dsq_id = cpu_hi_fallback_dsq_id(cpu);
-			if (scx_bpf_consume(dsq_id))
-				return;
-
-			/* consume matching layers */
-			if (have_layer_cpumask)
-			{
-				if (cpumask_test ||
-					(cpu == fallback_cpu && layer_cpus == 0)) {
-					if (scx_bpf_consume(idx))
-						return;
-				}
-			}
-
-			/* consume !preempting open layers */			
-			if (!layers[idx].preempt && layers[idx].open &&
-			    scx_bpf_consume(idx))
-				return;
-
 		} else {
-			u64 matching_dsq = -1;
-			u64 non_preempting_open_dsq;
-
+			layer_idx = iter_layer_dsq_ctx(idx, cctx->layer_idx);
 			bpf_for(llc_id, 0, nr_llcs) {
 				dsq_id = layer_dsq_id(layer_idx, llc_id);
-				/* consume preempting layers first, with no delay */
-				if (preempt && scx_bpf_consume(dsq_id))
-					return;
-				dsq_id = llc_hi_fallback_dsq_id(llc_id);
-				/* make sure hi fallback dsq is empty, with no delay  */
-				if (scx_bpf_consume(dsq_id))
-					return;
-
-				/* consume matching layers */
-				if (layer_matches && matching_dsq == -1) {
-					matching_dsq = dsq_id;
-					break;
-				}
-				/* consume !preempting open layers */			
-				if ((!preempt && open) && !non_preempting_open_dsq 
-					&& matching_dsq)
-						non_preempting_open_dsq = dsq_id;
-			}
-
-			/* preserve priority order of dsq execution */
-			if (matching_dsq != -1) {
-				if (scx_bpf_consume(matching_dsq))
-					return;
-			}
-			if(!non_preempting_open_dsq) {
-				if (scx_bpf_consume(non_preempting_open_dsq))
+				if (MEMBER_VPTR(layers, [layer_idx].preempt) &&
+				    scx_bpf_consume(dsq_id))
 					return;
 			}
 		}
 	}
-	/* consume lo fallback dsq */
+
+	dsq_id = cpu_hi_fallback_dsq_id(cpu);
+	if (scx_bpf_consume(dsq_id))
+		return;
+
+	/* consume !open layers second */
+	bpf_for(idx, 0, nr_layers) {
+		if (disable_topology) {
+			layer_idx = idx;
+			struct layer *layer = &layers[idx];
+			struct cpumask *layer_cpumask;
+
+			/* consume matching layers */
+			if (!(layer_cpumask = lookup_layer_cpumask(idx)))
+				return;
+
+			if (bpf_cpumask_test_cpu(cpu, layer_cpumask) ||
+			    (cpu == fallback_cpu && layer->nr_cpus == 0)) {
+				if (scx_bpf_consume(idx))
+					return;
+			}
+		} else {
+			layer_idx = iter_layer_dsq_ctx(idx, cctx->layer_idx);
+			bpf_for(llc_id, 0, nr_llcs) {
+				struct layer *layer = &layers[layer_idx];
+				struct cpumask *layer_cpumask;
+				dsq_id = layer_dsq_id(layer_idx, llc_id);
+
+				/* consume matching layers */
+				if (!(layer_cpumask = lookup_layer_cpumask(layer_idx)))
+					return;
+
+				if (bpf_cpumask_test_cpu(cpu, layer_cpumask) ||
+				    (cpu <= nr_possible_cpus && cpu == fallback_cpu &&
+				     MEMBER_VPTR(layer, ->nr_cpus) == 0)) {
+					if (scx_bpf_consume(dsq_id))
+						return;
+				}
+			}
+		}
+	}
+
+	/* consume !preempting open layers */
+	bpf_for(idx, 0, nr_layers) {
+		if (disable_topology) {
+			if (!layers[idx].preempt && layers[idx].open &&
+			    scx_bpf_consume(idx))
+				return;
+		} else {
+			layer_idx = iter_layer_dsq_ctx(idx, cctx->layer_idx);
+			bpf_for(llc_id, 0, nr_llcs) {
+				dsq_id = layer_dsq_id(layer_idx, llc_id);
+
+				if (!MEMBER_VPTR(layers, [layer_idx].preempt) &&
+				    MEMBER_VPTR(layers, [layer_idx].open) &&
+				    scx_bpf_consume(dsq_id))
+					return;
+			}
+		}
+	}
+
 	scx_bpf_consume(LO_FALLBACK_DSQ);
 }
 


### PR DESCRIPTION
this PR fixes CI.

the old stress test config wasn't testing much (it was testing something, but what, idk).

the new config tests things well.

the shortest path to fixing CI is reverting the loop reorganizing I merged this morning *and* setting vng configuration to the same settings used for `test_sched` (w/o this, w/ the new config, stress OOMs on high core machines).