### PR TITLE
scx_layered: Rename load_adj statistic

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -437,13 +437,13 @@ struct Opts {
     #[clap(short = 'e', long)]
     example: Option<String>,
 
-    /// Disables preemption if the weighted load of a layer exceeds the threshold.
-    /// The default is disabled (0.0).
+    /// Disables preemption if the weighted load fraction of a layer (load_frac_adj) exceeds the
+    /// threshold. The default is disabled (0.0).
     #[clap(long, default_value = "0.0")]
     layer_preempt_weight_disable: f64,
 
-    /// Disables layer growth if the weighted load of a layer exceeds the threshold.
-    /// The default is disabled (0.0).
+    /// Disables layer growth if the weighted load fraction of a layer (load_frac_adj) exceeds the
+    /// threshold. The default is disabled (0.0).
     #[clap(long, default_value = "0.0")]
     layer_growth_weight_disable: f64,
 

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -56,8 +56,8 @@ pub struct LayerStats {
     pub util_frac: f64,
     #[stat(desc = "sum of weight * duty_cycle for tasks")]
     pub load: f64,
-    #[stat(desc = "layer load sum adjusted for infeasible weights")]
-    pub load_adj: f64,
+    #[stat(desc = "layer load fraction adjusted for infeasible weights")]
+    pub load_frac_adj: f64,
     #[stat(desc = "layer duty cycle adjusted for infeasible weights")]
     pub dcycle: f64,
     #[stat(desc = "fraction of total load")]
@@ -184,7 +184,7 @@ impl LayerStats {
             util: stats.layer_utils[lidx] * 100.0,
             util_frac: calc_frac(stats.layer_utils[lidx], stats.total_util),
             load: normalize_load_metric(stats.layer_loads[lidx]),
-            load_adj: calc_frac(stats.layer_load_sums[lidx], stats.total_load_sum),
+            load_frac_adj: calc_frac(stats.layer_load_sums[lidx], stats.total_load_sum),
             dcycle: calc_frac(stats.layer_dcycle_sums[lidx], stats.total_dcycle_sum),
             load_frac: calc_frac(stats.layer_loads[lidx], stats.total_load),
             tasks: stats.nr_layer_tasks[lidx] as u32,
@@ -228,13 +228,13 @@ impl LayerStats {
     pub fn format<W: Write>(&self, w: &mut W, name: &str, header_width: usize) -> Result<()> {
         writeln!(
             w,
-            "  {:<width$}: util/dcycle/frac/{:5.1}/{:5.1}/{:7.1} load/load_adj/frac={:9.2}/{:2.2}/{:5.1} tasks={:6}",
+            "  {:<width$}: util/dcycle/frac/{:5.1}/{:5.1}/{:7.1} load/load_frac_adj/frac={:9.2}/{:2.2}/{:5.1} tasks={:6}",
             name,
             self.util,
             self.dcycle,
             self.util_frac,
             self.load,
-            self.load_adj,
+            self.load_frac_adj,
             self.load_frac,
             self.tasks,
             width = header_width,


### PR DESCRIPTION
Rename the `load_adj` statistic to `load_frac_adj`, which is a more accurate representation of what the statistic is calculating. The statistic is a fractional representation of the load of a layer adjusted for infeasible weights.

I wasn't sure if it was worth reporting both the infeasible weighted load fraction and the weight adjusted duty cycle, but under high they are highly correlated.
```
###### Wed, 9 Oct 2024 06:23:19 -0700 ######
tot=  16064 local=26.54 open_idle= 0.00 affn_viol= 2.27 proc=6ms nodes=1
busy= 46.0 util= 8071.1 load=     99.1 fallback_cpu= 70
excl_coll=13.30 excl_preempt=6.16 excl_idle=0.27 excl_wakeup=0.00
  hodgesd  : util/dcycle/frac/ 24.5/  0.3/    0.3 load/load_frac_adj/frac=     0.03/0.04/  0.0 tasks=   207
             tot=   3805 local=65.97 wake/exp/reenq=33.69/ 0.34/ 0.00
             xlayer_wake= 1.05 xlayer_rewake= 0.42
             keep/max/busy=11.75/ 0.00/ 0.00 kick= 0.16 yield/ign= 0.21/    1 
             open_idle= 0.00 mig=28.07 xnuma_mig= 0.00 xllc_mig=22.52 affn_viol= 0.00
             preempt/first/xllc/xnuma/idle/fail= 0.24/ 0.00/ 1.13/ 0.00/14.17/38.95 min_exec= 0.00/   0.00ms, slice=0.8ms
             cpus=  2 [  2,  2] 00000001 00000000 01000000 00000000 00000000 00000000
             excl_coll=17.66 excl_preempt= 0.50
  normal   : util/dcycle/frac/ 43.6/  0.5/    0.5 load/load_frac_adj/frac=    19.11/0.07/ 19.3 tasks=  3241
             tot=  12169 local=14.41 wake/exp/reenq=85.44/ 0.15/ 0.00
             xlayer_wake= 8.49 xlayer_rewake= 1.28
             keep/max/busy=14.69/ 0.00/ 0.00 kick= 0.28 yield/ign= 0.16/  170 
             open_idle= 0.00 mig=28.21 xnuma_mig= 0.00 xllc_mig=22.65 affn_viol= 2.99
             preempt/first/xllc/xnuma/idle/fail= 1.24/ 0.42/ 1.89/ 0.00/69.59/28.96 min_exec= 0.00/   0.00ms, slice=0.8ms
             cpus=  2 [  2,  2] 00000000 00200000 00000000 00000000 00002000 00000000
             excl_coll=12.04 excl_preempt= 7.98
  random   : util/dcycle/frac/  0.0/  0.0/    0.0 load/load_frac_adj/frac=     0.00/0.00/  0.0 tasks=     0
             tot=      0 local= 0.00 wake/exp/reenq= 0.00/ 0.00/ 0.00
             xlayer_wake= 0.00 xlayer_rewake= 0.00
             keep/max/busy= 0.00/ 0.00/ 0.00 kick= 0.00 yield/ign= 0.00/    0 
             open_idle= 0.00 mig= 0.00 xnuma_mig= 0.00 xllc_mig= 0.00 affn_viol= 0.00
             preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms, slice=0.5ms
             cpus=  0 [  0,  0] 00000000 00000000 00000000 00000000 00000000 00000000
  stress-ng: util/dcycle/frac/8003.0/ 99.2/   99.2 load/load_frac_adj/frac=    80.00/99.89/ 80.7 tasks=    81
             tot=     90 local= 0.00 wake/exp/reenq= 0.00/100.0/ 0.00
             xlayer_wake= 0.00 xlayer_rewake= 0.00
             keep/max/busy=88176.7/174.4/ 0.00 kick=88.89 yield/ign= 0.00/    0 
             open_idle= 0.00 mig=76.67 xnuma_mig= 0.00 xllc_mig=13.33 affn_viol= 0.00
             preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms, slice=0.8ms
             cpus=102 [102,102] 0000fffe 001fffff fe00ffbf ff0000ff bf001fff 000000ff
```