### PR TITLE
scx_layered: setup matrix job to run key paths of layered through verifier/stress

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -164,7 +164,7 @@ jobs:
         if: always()
       - run: mkdir -p ./log_save/
         if: always()
-      # no symlink following here (to avoid cycles)
+      # no symlink following here (to avoid cycle`s)
       - run: sudo find '/home/runner/' -iname '*.ci.log' -exec mv {} ./log_save/ \;
         if: always()
       - name: upload debug logs, bpftrace, veristat, dmesg, etc.
@@ -172,6 +172,87 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.scheduler }}_logs_${{ github.run_id }}_${{ github.run_attempt }}
+          path: ./log_save/*.ci.log
+          # it's all txt files w/ 90 day retention, lets be nice.
+          compression-level: 9
+
+  layered-matrix:
+    runs-on: ubuntu-24.04
+    needs: build-kernel
+    strategy:
+          matrix:
+            scheduler: [ scx_layered ]
+            topo: ['', '-t']
+            dsq_iter_algo: [linear, round_robin, weight]
+          fail-fast: false
+    steps:
+      # prevent cache permission errors
+      - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar      
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.scheduler }}
+          prefix-key: "4"
+      - uses: ./.github/actions/install-deps-action
+      # cache virtiofsd (goes away w/ 24.04)
+      - name: Cache virtiofsd
+        id: cache-virtiofsd
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/lib/virtiofsd
+          key: virtiofsd-binary
+      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}          
+        run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
+
+      # get latest head commit of sched_ext for-next
+      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
+
+      # use cached kernel if available, create after job if not
+      - name: Cache Kernel
+        id: cache-kernel
+        uses: actions/cache@v4
+        with:
+          path: |
+            linux/arch/x86/boot/bzImage
+            linux/usr/include
+            linux/**/*.h
+          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-4
+
+      # need to re-run job when kernel head changes between build and test running.
+      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
+        name: exit if cache stale
+        run: exit -1
+
+      # The actual build:
+      - run: meson setup build -Dkernel=../linux/arch/x86/boot/bzImage -Dkernel_headers=../linux -Denable_stress=true -Dvng_rw_mount=true -Dextra_sched_args=" ${{ matrix.topo }} --dsq-iter-algo ${{ matrix.dsq_iter_algo }}"
+      - run: meson compile -C build ${{ matrix.scheduler }}
+
+      # Print CPU model before running the tests (this can be useful for
+      # debugging purposes)
+      - run: grep 'model name' /proc/cpuinfo | head -1
+
+      # Stress schedulers
+      - uses: cytopia/shell-command-retry-action@v0.1.2
+        name: stress test ${{ matrix.topo }} ${{ matrix.dsq_iter_algo }}
+        if: always()
+        with:
+          retries: 3
+          command: meson compile -C build stress_tests_${{ matrix.scheduler }}
+      - run: meson compile -C build veristat_${{ matrix.scheduler }}
+        if: always()
+      - run: sudo cat /var/log/dmesg > host-dmesg.ci.log
+        if: always()
+      - run: mkdir -p ./log_save/
+        if: always()
+        # no symlink following here (to avoid cycle`s)
+      - run: sudo find '/home/runner/' -iname '*.ci.log' -exec mv {} ./log_save/ \;
+        if: always()
+      - name: upload debug logs, bpftrace, dmesg, etc.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.scheduler }}_${{ matrix.topo }}_${{ matrix.dsq_iter_algo }}_${{ matrix.test_name }}_logs_${{ github.run_id }}_${{ github.run_attempt }}
           path: ./log_save/*.ci.log
           # it's all txt files w/ 90 day retention, lets be nice.
           compression-level: 9

--- a/meson-scripts/run_stress_tests
+++ b/meson-scripts/run_stress_tests
@@ -42,11 +42,14 @@ def run_stress_test(
     verbose: bool,
     rw: bool,
     headers: str,
+    extra_scheduler_args: str,
 ) -> int:
     scheduler_args = config.get('scheduler_args')
     stress_cmd = config.get('stress_cmd')
     s_path = sched_path(build_dir, config.get('sched'))
     sched_cmd = s_path + " " + config.get('sched_args')
+    if extra_scheduler_args:
+        sched_cmd = sched_cmd + " " + extra_scheduler_args
     timeout_sec = int(config.get("timeout_sec"))
     if vng_path:
         cmd = [vng_path, "-m", "10G", "--cpus", "10", "--user", "root", "-v", "-r", kernel]
@@ -101,7 +104,8 @@ def stress_tests(args: Namespace) -> None:
             args.kernel,
             args.verbose,
             args.rw,
-            args.headers
+            args.headers,
+            args.extra_scheduler_args,
         )
     for test_name, ret in return_codes.items():
         if ret not in (143, 0):
@@ -136,6 +140,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         '--headers', default='', help='Kernel Headers Path'
+    )
+    parser.add_argument(
+        '--extra-scheduler-args', default='', help='a quoted string of extra scheduler args'
     )
 
     args = parser.parse_args()

--- a/meson.build
+++ b/meson.build
@@ -415,15 +415,35 @@ if enable_stress
 
   if get_option('vng_rw_mount') == true
       foreach s : rust_scheds
-        run_target('stress_tests_'+s, command: [run_stress_tests, '-k', kernel, '-b',
-                                                meson.current_build_dir(), '--sched', s,
-                                                '--rw', 'true', '--headers', get_option('kernel_headers')],
+      if get_option('kernel_headers') == ''
+        run_target('stress_tests_'+s, command: [run_stress_tests, '-k', kernel,
+                                                '-b', meson.current_build_dir(), '--sched', s,
+                                                '--rw', 'true',
+                                                '--extra-scheduler-args', get_option('extra_sched_args')],
                                                 depends: [copys])
+      else
+        run_target('stress_tests_'+s, command: [run_stress_tests, '-k', kernel,
+                                                '-b', meson.current_build_dir(), '--sched', s,
+                                                '--rw', 'true', 
+                                                '--headers', get_option('kernel_headers'),
+                                                '--extra-scheduler-args', get_option('extra_sched_args')],
+                                                depends: [copys])
+      endif
       endforeach
   else
       foreach s : rust_scheds
-        run_target('stress_tests_'+s, command: [run_stress_tests, '-k', kernel, '-b',
-                                                meson.current_build_dir(), '--sched', s], depends: [copys])
+        if get_option('kernel_headers') == ''
+          run_target('stress_tests_'+s, command: [run_stress_tests, '-k', kernel, 
+                                              '-b', meson.current_build_dir(), '--sched', s,
+                                              '--extra-scheduler-args', get_option('extra_sched_args')],
+                                              depends: [copys])
+        else
+          run_target('stress_tests_'+s, command: [run_stress_tests, '-k', kernel, 
+                                              '-b', meson.current_build_dir(), '--sched', s,
+                                              '--headers', get_option('kernel_headers'),
+                                              '--extra-scheduler-args', get_option('extra_sched_args')],
+                                              depends: [copys])
+        endif
       endforeach
   endif
 endif

--- a/meson.options
+++ b/meson.options
@@ -54,3 +54,9 @@ option(
   value: false,
   description: 'make vng builds mount rw (for log upload)',
 )
+option(
+  'extra_sched_args',
+  type: 'string',
+  value: '',
+  description: 'extra sched args for stress tests',
+)


### PR DESCRIPTION
scx_layered: setup matrix job to run key paths of layered through verifier/stress

this will increase delays wrt/ ci jobs (i.e. they'll still be fast, but they're probably going to be throttled a bit).

that being said, it these cover the fixes in #768, so idk lets do it?

also updates local stress runs a bit (fixes an issue w/ header pass option and enables arg passthrough).

seems to work fine + is better than what we have now wrt/ keeping main not broken.

![image](https://github.com/user-attachments/assets/e922c64a-9aca-40d4-b2cf-abf4240c5b73)

![image](https://github.com/user-attachments/assets/29d0be36-dcb8-4670-9720-d3aacadadf27)
