### PR TITLE
scx_layered: Change default DSQ iter algo

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -36,7 +36,7 @@ const volatile bool xnuma_preemption = false;
 const volatile s32 __sibling_cpu[MAX_CPUS];
 const volatile unsigned char all_cpus[MAX_CPUS_U8];
 const volatile u32 layer_iteration_order[MAX_LAYERS];
-const volatile u32 dsq_iter_algo = DSQ_ITER_ROUND_ROBIN;
+const volatile u32 dsq_iter_algo = DSQ_ITER_LINEAR;
 
 private(all_cpumask) struct bpf_cpumask __kptr *all_cpumask;
 private(big_cpumask) struct bpf_cpumask __kptr *big_cpumask;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -516,7 +516,7 @@ impl DsqIterAlgo {
 
 impl Default for DsqIterAlgo {
     fn default() -> Self {
-        DsqIterAlgo::RoundRobin
+        DsqIterAlgo::Linear
     }
 }
 


### PR DESCRIPTION
Change the default DSQ iter algo from round robin to linear in to be consistent. ***NOTE***, the actual default value is already [`linear`](https://github.com/sched-ext/scx/blob/main/scheds/rust/scx_layered/src/main.rs#L453).