### PR TITLE
[layered] Implement reverse weight DSQ algorithm

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -142,9 +142,13 @@ static __noinline u32 iter_layer_dsq_ctx(int idx, u32 layer_idx)
 		return ret;
 	}
 	case DSQ_ITER_REVERSE_WEIGHT: {
-		// TODO: Correctly implement this algo, see:
-		// https://github.com/sched-ext/scx/issues/738
-		return dsq_iter_weight_ctx(idx);
+		u32 ret;
+		ret = dsq_iter_weight_ctx(nr_layers - 1 - idx);
+		if (ret >= nr_layers) {
+			scx_bpf_error("can't happen");
+			return ret;
+		}
+		return ret;
 	}
 	default:
 		scx_bpf_error("unknown dsq iter algo");


### PR DESCRIPTION
This PR addresses https://github.com/sched-ext/scx/issues/738 by implementing a reverse weight iteration algorithm in scx-layered. This means we iterate through DSQs from layers with the highest weight to lowest weight. The goal is to avoid stalls that happen from lower weighted layers consuming all available resources. Although the opposite problem could happen here, so this is just a temporary algorithm until we have more robust load balancing across layers.