### PR TITLE
layered -- make lsp work nice on util include file

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1,6 +1,7 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
 #ifdef LSP
 #define __bpf__
+#define LSP_INC
 #include "../../../../include/scx/common.bpf.h"
 #include "../../../../include/scx/ravg_impl.bpf.h"
 #else

--- a/scheds/rust/scx_layered/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/util.bpf.c
@@ -2,8 +2,11 @@
 
 #ifdef LSP
 #define __bpf__
+#ifndef LSP_INC
 #include "../../../../include/scx/common.bpf.h"
 #include "../../../../include/scx/ravg_impl.bpf.h"
+#endif
+
 #include "intf.h"
 
 #include <stdbool.h>

--- a/scheds/rust/scx_layered/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/util.bpf.c
@@ -1,5 +1,20 @@
 /* to be included in the main bpf.c file */
 
+#ifdef LSP
+#define __bpf__
+#include "../../../../include/scx/common.bpf.h"
+#include "../../../../include/scx/ravg_impl.bpf.h"
+#include "intf.h"
+
+#include <stdbool.h>
+#include <string.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#endif
+
+
+
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(key_size, sizeof(u32));


### PR DESCRIPTION
This is what I was talking about on https://github.com/sched-ext/scx/pull/778

![WezTerm 2024-10-11 08 05 49](https://github.com/user-attachments/assets/c821cb67-6f75-410b-bdb7-4408457c6a44)

It makes it nice to edit that file, and most folks editing this file get this benefit because of https://github.com/likewhatevs/scx/blob/main/.clangd
