### PR TITLE
scripts: Add ftrace perfetto helper scripts

### DIFF
--- a/scripts/ftrace_trim
+++ b/scripts/ftrace_trim
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import sys
+
+HEADER = "TASK-PID"
+BUFF_STARTED = "buffer started ###"
+
+def main():
+    nproc = int(sys.argv[2]) - 1
+
+    seen_header = False
+    proc_buffer_started = 0
+    with open(sys.argv[1]) as f:
+        for line in f:
+            l = line.replace("\n", "")
+            if HEADER in l:
+                seen_header = True
+                print(l)
+            if BUFF_STARTED in line:
+                proc_buffer_started += 1
+                continue
+            if proc_buffer_started == nproc or not seen_header:
+                print(l)
+
+
+if __name__=="__main__":
+    main()

--- a/scripts/sched_ftrace.sh
+++ b/scripts/sched_ftrace.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+duration=${1:-5}
+out=${2:-"$(pwd)/sched.ftrace"}
+cd /sys/kernel/debug/tracing
+echo 1 > tracing_on
+echo 1 > events/sched/sched_switch/enable
+timeout "${duration}" cat trace_pipe > "${out}.tmp"
+echo 0 > events/sched/sched_switch/enable
+echo 0 > tracing_on
+cd -
+./ftrace_trim "${out}.tmp" `nproc` > "${out}"
+rm "${out}.tmp"


### PR DESCRIPTION
Add a set of ftrace helper scripts for making perfetto compatible ftrace scheduler profiles. I've attached a
[perfetto profile](https://github.com/user-attachments/files/17350788/sched.CPUPROFILE) of the output (Github has dumb file name extensions, but the profile should load in perfetto). The script is a little buggy and could use some improvement, but should be a good starting point.
