### PR TITLE
scx_layered: Add topology integration test

### DIFF
--- a/scheds/rust/scx_layered/integration/layer_node.bt
+++ b/scheds/rust/scx_layered/integration/layer_node.bt
@@ -1,0 +1,48 @@
+#!/usr/bin/env -S bpftrace --unsafe -q
+
+/*
+ * Asserts that the `node` layer config works properly by failing if the pid
+ * passed to the script runs on NUMA node 1. The layered config should restrict
+ * the pid passed to the script to run on a layer that only runs on NUMA node 0.
+ */
+
+BEGIN
+{
+  @bpftrace_pid = pid;
+  @sig = 0;
+
+  if ($1 == 0) {
+	// exit 137
+	@sig = 9;
+  }
+}
+
+profile:hz:1
+{
+    @counts[cpu] = @counts[cpu] + 1;
+    if (@counts[cpu] == 15) {
+	// exit 0
+	@sig = 15;
+    }
+}
+
+rawtracepoint:sched_switch
+{
+	$task = (struct task_struct *)arg1;
+
+	if (($task->parent->pid == $1 && numaid == 1) ||
+	    ($task->real_parent->pid == $1 && numaid == 1)) {
+		// exit 137
+		@sig = 9;
+	}
+}
+
+kprobe:__x64_sys_* / @bpftrace_pid == pid / {
+	if (@sig > 0) {
+		signal(@sig);
+	}
+}
+
+interval:s:1 {
+	print(("bpftrace monitoring pid", $1, "signal", @sig));
+}

--- a/scheds/rust/scx_layered/integration/numa.json
+++ b/scheds/rust/scx_layered/integration/numa.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name": "numa_0",
+    "comment": "numa0",
+    "matches": [
+      [
+        {
+          "CommPrefix": "stress-ng"
+        }
+      ],
+      [
+        {
+          "PcommPrefix": "stress-ng"
+        }
+      ]
+    ],
+    "kind": {
+      "Confined": {
+        "util_range": [
+          0.4,
+          0.90
+        ],
+	"growth_algo": "Linear",
+        "nodes": [
+          0
+        ]
+      }
+    }
+  },
+  {
+    "name": "reset",
+    "comment": "the rest",
+    "matches":[[]],
+    "kind": {
+      "Grouped": {
+        "util_range": [
+          0.05,
+          0.60
+        ]
+      }
+    }
+  }
+]

--- a/scheds/rust/scx_layered/integration/numa_tests.sh
+++ b/scheds/rust/scx_layered/integration/numa_tests.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+layered_bin=${1:-../../../../target/release/scx_layered}
+test_scripts=( "layer_node.bt" )
+
+for test_script in "${test_scripts[@]}"; do
+	sudo pkill -9 -f scx_layered
+	sudo "${layered_bin}" --stats 1 f:numa.json -v &
+	layered_pid=$!
+
+	echo "layered pid ${layered_pid}"
+	sleep 2
+
+	stress-ng -c 2 -f 1 -t 30 &
+	stress_pid=$!
+
+	echo "stress-ng pid ${stress_pid}"
+	sleep 1
+
+	sudo "./${test_script}" "${stress_pid}"
+	test_exit=$?
+
+	pidof scx_layered && sudo pkill -9 -f scx_layered
+	# always cleanup stress-ng
+	sudo pkill -9 -f stress-ng
+
+	if [ $test_exit -ne 0 ]; then
+		echo "test script ${test_script} failed: ${test_exit}"
+		exit $test_exit;
+	fi
+	echo "test script ${test_script} passed: ${test_exit}"
+done


### PR DESCRIPTION
Add a bpftrace script that does a topology aware test. The test script runs a bpftrace script that asserts that `stress-ng` processes are scheduled on NUMA node 0 only. This is a first attempt so it won't be added to meson or CI, mostly just for local testing.

output when successful:
```
###### Sun, 13 Oct 2024 20:20:14 -0700 ######
tot=  50848 local=91.46 open_idle= 2.02 affn_viol= 0.00 proc=4ms nodes=2
busy= 10.9 util=  849.4 load=     15.1 fallback_cpu=  8
excl_coll=0.00 excl_preempt=0.00 excl_idle=0.00 excl_wakeup=0.00
  numa_0: util/dcycle/frac/302.0/ 35.6/   35.6 load/load_frac_adj/frac=     3.06/35.55/ 20.2 tasks=   162
          tot=   6757 local=49.47 wake/exp/reenq= 0.49/50.04/ 0.00
          xlayer_wake= 0.00 xlayer_rewake= 0.00
          keep/max/busy= 1.30/ 0.04/ 0.06 kick=49.25 yield/ign= 0.00/    0 
          open_idle= 0.00 mig= 0.77 xnuma_mig= 0.00 xllc_mig= 0.00 affn_viol= 0.00
          preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms, slice=20ms
          cpus=  4 [  4,  4] 0000000a 00000a00 00000000
  reset : util/dcycle/frac/547.4/ 64.4/   64.4 load/load_frac_adj/frac=    12.06/64.45/ 79.8 tasks=  4757
          tot=  44091 local=97.89 wake/exp/reenq= 1.95/ 0.16/ 0.00
          xlayer_wake=30.89 xlayer_rewake= 7.73
          keep/max/busy= 0.33/ 0.01/ 0.00 kick= 0.16 yield/ign= 0.22/    0 
          open_idle= 2.32 mig=16.00 xnuma_mig= 3.36 xllc_mig= 3.36 affn_viol= 0.00
          preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms, slice=20ms
          cpus= 20 [ 20, 20] 000000f5 0000f5f0 0000f000
666992
./numa_tests.sh: line 7: 728092 Killed                  sudo pkill -9 -f scx_layered
./numa_tests.sh: line 7: 666985 Killed                  sudo "${layered_bin}" --stats 1 f:numa.json -v
./numa_tests.sh: line 7: 728230 Killed                  sudo pkill -9 -f stress-ng
test script layer_node.bt passed 0
```
output when manually killing `scx_layered`:
```
###### Sun, 13 Oct 2024 20:20:53 -0700 ######
tot=  53535 local=86.44 open_idle=24.64 affn_viol= 0.00 proc=5ms nodes=2
busy= 11.1 util=  871.7 load=     16.0 fallback_cpu=  4
excl_coll=0.00 excl_preempt=0.00 excl_idle=0.00 excl_wakeup=0.00
  numa_0: util/dcycle/frac/293.2/ 33.7/   33.6 load/load_frac_adj/frac=     3.05/33.65/ 19.0 tasks=    96
          tot=   7870 local=30.15 wake/exp/reenq=19.80/50.00/ 0.05
          xlayer_wake= 0.00 xlayer_rewake= 0.00
          keep/max/busy= 0.55/ 0.00/ 0.51 kick=30.15 yield/ign= 0.03/    0 
          open_idle= 0.00 mig= 1.00 xnuma_mig= 0.04 xllc_mig= 0.04 affn_viol= 0.00
          preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms, slice=20ms
          cpus=  4 [  0,  4] 0000000c 00000c00 00000000
  reset : util/dcycle/frac/578.6/ 66.3/   66.4 load/load_frac_adj/frac=    12.97/66.35/ 81.0 tasks=  3146
          tot=  45665 local=96.14 wake/exp/reenq= 3.56/ 0.29/ 0.01
          xlayer_wake=34.91 xlayer_rewake= 8.68
          keep/max/busy= 0.41/ 0.02/ 0.00 kick= 0.30 yield/ign= 0.13/    0 
          open_idle=28.88 mig=24.73 xnuma_mig= 4.25 xllc_mig= 4.25 affn_viol= 0.00
          preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms, slice=20ms
          cpus= 12 [ 12, 12] 00000003 000003f0 0000f000
./layer_node.bt:33:26-28: WARNING: comparison of integers of different signs: 'int32' and 'unsigned int64' can lead to undefined behavior
    if (($task->parent->pid == $1 && numaid == 1) ||
                            ~~
./layer_node.bt:34:31-33: WARNING: comparison of integers of different signs: 'int32' and 'unsigned int64' can lead to undefined behavior
        ($task->real_parent->pid == $1 && numaid == 1)) {
                                 ~~
./numa_tests.sh: line 7: 735036 Killed                  sudo "${layered_bin}" --stats 1 f:numa.json -v
./numa_tests.sh: line 7: 739154 Killed                  sudo "./${test_script}" "${stress_pid}"
./numa_tests.sh: line 7: 742937 Killed                  sudo pkill -9 -f stress-ng
test script layer_node.bt failed: 137
```