### PR TITLE
scx_layered: Add LLC integration test

### DIFF
--- a/scheds/rust/scx_layered/integration/layer_llc.bt
+++ b/scheds/rust/scx_layered/integration/layer_llc.bt
@@ -1,0 +1,65 @@
+#!/usr/bin/env -S bpftrace --unsafe -q
+
+/*
+ * Asserts that the `llc` layer config works properly by failing if the pid
+ * passed to the script runs on any other LLC besides LLC id 0. The layered
+ * config should restrict the pid passed to the script to run on a layer
+ * that only runs on LLC 0.
+ */
+
+BEGIN
+{
+	@bpftrace_pid = pid;
+	@sig = 0;
+
+	if ($1 == 0) {
+		// exit 137
+		@sig = 9;
+	}
+
+	// Credit to Alastair Robertson for this mapping of CPU to LLC
+	$num_cpus = *(uint32*)kaddr("__num_online_cpus");
+	$per_cpu_offsets = (uint64*)kaddr("__per_cpu_offset");
+	$cpu_to_node_map = kaddr("x86_cpu_to_node_map");
+	$ci_cpu_cacheinfo = kaddr("ci_cpu_cacheinfo");
+	$cpuid = 0;
+	while ($cpuid < $num_cpus && $cpuid < 500) {
+		$numa_id = *($cpu_to_node_map + *($per_cpu_offsets + $cpuid));
+		@cpu_to_node[$cpuid] = $numa_id;
+		$cpu_cacheinfo = (struct cpu_cacheinfo*)($ci_cpu_cacheinfo + *($per_cpu_offsets + $cpuid));
+		$l3_cacheinfo = $cpu_cacheinfo->info_list[3];
+		$l3_cacheid = $l3_cacheinfo.id;
+		@cpu_to_l3[$cpuid] = $l3_cacheid;
+		$cpuid++;
+	  }
+}
+
+profile:hz:1
+{
+	@counts[cpu] = @counts[cpu] + 1;
+	if (@counts[cpu] == 15) {
+		// exit 0
+		@sig = 15;
+	}
+}
+
+rawtracepoint:sched_switch
+{
+	$task = (struct task_struct *)arg1;
+
+	if (($task->parent->pid == $1 && @cpu_to_l3[cpu] != 0) ||
+	    ($task->real_parent->pid == $1 && @cpu_to_l3[cpu] != 0)) {
+		// exit 137
+		@sig = 9;
+	}
+}
+
+kprobe:__x64_sys_* / @bpftrace_pid == pid / {
+	if (@sig > 0) {
+		signal(@sig);
+	}
+}
+
+interval:s:1 {
+	print(("bpftrace monitoring pid", $1, "signal", @sig));
+}

--- a/scheds/rust/scx_layered/integration/layer_node.bt
+++ b/scheds/rust/scx_layered/integration/layer_node.bt
@@ -8,22 +8,22 @@
 
 BEGIN
 {
-  @bpftrace_pid = pid;
-  @sig = 0;
+	@bpftrace_pid = pid;
+	@sig = 0;
 
-  if ($1 == 0) {
-	// exit 137
-	@sig = 9;
-  }
+	if ($1 == 0) {
+		// exit 137
+		@sig = 9;
+	}
 }
 
 profile:hz:1
 {
-    @counts[cpu] = @counts[cpu] + 1;
-    if (@counts[cpu] == 15) {
-	// exit 0
-	@sig = 15;
-    }
+	@counts[cpu] = @counts[cpu] + 1;
+	if (@counts[cpu] == 15) {
+		// exit 0
+		@sig = 15;
+	}
 }
 
 rawtracepoint:sched_switch

--- a/scheds/rust/scx_layered/integration/llc.json
+++ b/scheds/rust/scx_layered/integration/llc.json
@@ -1,7 +1,7 @@
 [
   {
-    "name": "numa_0",
-    "comment": "numa0",
+    "name": "llc_0",
+    "comment": "llc0",
     "matches": [
       [
         {
@@ -20,7 +20,7 @@
           0.4,
           0.90
         ],
-        "nodes": [
+        "llcs": [
           0
         ]
       }

--- a/scheds/rust/scx_layered/integration/run_tests.sh
+++ b/scheds/rust/scx_layered/integration/run_tests.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
 layered_bin=${1:-../../../../target/release/scx_layered}
-test_scripts=( "layer_node.bt" )
+test_scripts=( "layer_node.bt" "layer_llc.bt" )
+test_configs=( "numa.json" "llc.json" )
 
-for test_script in "${test_scripts[@]}"; do
+for i in "${!test_scripts[@]}"; do
+	test_script="${test_scripts[$i]}"
+	test_config="${test_configs[$i]}"
+
 	sudo pkill -9 -f scx_layered
-	sudo "${layered_bin}" --stats 1 f:numa.json -v &
+	sudo "${layered_bin}" --stats 1 "f:${test_config}" -v &
 	layered_pid=$!
 
 	echo "layered pid ${layered_pid}"


### PR DESCRIPTION
Add an integration test for testing that the `llcs` field on the layer config works properly.


Tests pass on multi NUMA machine:
```
###### Mon, 14 Oct 2024 07:23:54 -0700 ######
tot=  45982 local=92.08 open_idle=23.55 affn_viol= 0.00 proc=6ms nodes=2
busy= 11.7 util=  930.4 load=     14.6 fallback_cpu=  4
excl_coll=0.00 excl_preempt=0.00 excl_idle=0.00 excl_wakeup=0.00
  llc_0: util/dcycle/frac/303.7/ 32.6/   32.6 load/load_frac_adj/frac=     3.05/32.64/ 20.9 tasks=    41
         tot=   5632 local=49.52 wake/exp/reenq= 0.44/50.04/ 0.00
         xlayer_wake= 0.05 xlayer_rewake= 0.00
         keep/max/busy= 1.56/ 0.04/ 0.11 kick=49.24 yield/ign= 0.00/    0 
         open_idle= 0.00 mig= 0.78 xnuma_mig= 0.00 xllc_mig= 0.00 affn_viol= 0.00
         preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms, slice=20ms
         cpus=  4 [  4,  4] 00000003 00000300 00000000
  reset: util/dcycle/frac/626.7/ 67.4/   67.4 load/load_frac_adj/frac=    11.51/67.36/ 79.1 tasks=  4140
         tot=  40350 local=98.02 wake/exp/reenq= 1.50/ 0.48/ 0.00
         xlayer_wake=28.10 xlayer_rewake= 7.08
         keep/max/busy= 0.35/ 0.01/ 0.00 kick= 0.48 yield/ign= 0.19/    0 
         open_idle=26.84 mig=21.89 xnuma_mig= 5.34 xllc_mig= 5.34 affn_viol= 0.00
         preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms, slice=20ms
         cpus= 12 [ 12, 12] 0000000c 00000cf0 0000f000
2388687
./run_tests.sh: line 7: 2451073 Killed                  sudo pkill -9 -f scx_layered
./run_tests.sh: line 7: 2388685 Killed                  sudo "${layered_bin}" --stats 1 "f:${test_config}" -v
./run_tests.sh: line 7: 2451220 Killed                  sudo pkill -9 -f stress-ng
test script layer_llc.bt passed: 0
```
Failed when `scx_layered` is killed manually:
```
###### Mon, 14 Oct 2024 07:24:57 -0700 ######
tot=  43702 local=90.08 open_idle= 4.39 affn_viol= 0.00 proc=4ms nodes=2
busy=  9.0 util=  714.3 load=      9.5 fallback_cpu=  5
excl_coll=0.00 excl_preempt=0.00 excl_idle=0.00 excl_wakeup=0.00
  llc_0: util/dcycle/frac/304.2/ 42.6/   42.6 load/load_frac_adj/frac=     3.05/42.61/ 32.2 tasks=    41
         tot=   6832 local=49.58 wake/exp/reenq= 0.34/50.03/ 0.06
         xlayer_wake= 0.00 xlayer_rewake= 0.00
         keep/max/busy= 1.30/ 0.04/ 0.04 kick=49.53 yield/ign= 0.00/    0 
         open_idle= 0.00 mig= 0.72 xnuma_mig= 0.00 xllc_mig= 0.00 affn_viol= 0.00
         preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms, slice=20ms
         cpus=  4 [  4,  4] 0000000c 00000c00 00000000
  reset: util/dcycle/frac/410.0/ 57.4/   57.4 load/load_frac_adj/frac=     6.42/57.39/ 67.8 tasks=  3269
         tot=  36870 local=97.59 wake/exp/reenq= 2.06/ 0.34/ 0.02
         xlayer_wake=37.40 xlayer_rewake= 9.38
         keep/max/busy= 0.35/ 0.01/ 0.00 kick= 0.36 yield/ign= 0.16/    0 
         open_idle= 5.21 mig=17.88 xnuma_mig= 3.36 xllc_mig= 3.36 affn_viol= 0.00
         preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00 min_exec= 0.00/   0.00ms, slice=20ms
         cpus= 14 [ 14, 14] 00000013 000013f0 0000f000
./run_tests.sh: line 7: 2516024 Killed                  sudo "${layered_bin}" --stats 1 "f:${test_config}" -v
./run_tests.sh: line 7: 2520030 Killed                  sudo "./${test_script}" "${stress_pid}"
./run_tests.sh: line 7: 2528046 Killed                  sudo pkill -9 -f stress-ng
test script layer_llc.bt failed: 137

```