### PR TITLE
scx_mitosis: Handle pinned tasks

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -24,6 +24,9 @@ enum consts {
 	MAX_CPUS_U8 = MAX_CPUS / 8,
 	MAX_CELLS = 16,
 	USAGE_HALF_LIFE = 100000000, /* 100ms */
+
+	HI_FALLBACK_DSQ = MAX_CELLS,
+	LO_FALLBACK_DSQ = MAX_CELLS + 1,
 };
 
 /* Statistics */


### PR DESCRIPTION
Pinned tasks should just be routed to a fallback DSQ. kthreads are given a higher priority than non-kthreads so use two fallback DSQs.