### PR TITLE
scx_rustland fixes and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "scx_rustland_core"
-version = "2.1.2"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "libbpf-rs",

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland_core"
-version = "2.1.2"
+version = "2.2.2"
 edition = "2021"
 authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -82,7 +82,10 @@ pub struct QueuedTask {
     pub cpu: i32,              // CPU where the task is running
     pub flags: u64,            // task enqueue flags
     pub sum_exec_runtime: u64, // Total cpu time
+    pub nvcsw: u64,            // Total amount of voluntary context switches
     pub weight: u64,           // Task static priority
+    pub slice: u64,            // Time slice budget
+    pub vtime: u64,            // Current vruntime
     cpumask_cnt: u64,          // cpumask generation counter (private)
 }
 
@@ -107,9 +110,9 @@ impl DispatchedTask {
             pid: task.pid,
             cpu: task.cpu,
             flags: task.flags,
-            cpumask_cnt: task.cpumask_cnt,
             slice_ns: 0, // use default time slice
             vtime: 0,
+            cpumask_cnt: task.cpumask_cnt,
         }
     }
 }
@@ -144,7 +147,10 @@ impl EnqueuedMessage {
             cpu: self.inner.cpu,
             flags: self.inner.flags,
             sum_exec_runtime: self.inner.sum_exec_runtime,
+            nvcsw: self.inner.nvcsw,
             weight: self.inner.weight,
+            slice: self.inner.slice,
+            vtime: self.inner.vtime,
             cpumask_cnt: self.inner.cpumask_cnt,
         }
     }

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -83,9 +83,12 @@ struct queued_task_ctx {
 	s32 pid;
 	s32 cpu; /* CPU where the task is running */
 	u64 flags; /* task enqueue flags */
-	u64 cpumask_cnt; /* cpumask generation counter */
 	u64 sum_exec_runtime; /* Total cpu time */
+	u64 nvcsw; /* Total amount of voluntary context switches */
 	u64 weight; /* Task static priority */
+	u64 slice; /* Time slice budget */
+	u64 vtime; /* Current task's vruntime */
+	u64 cpumask_cnt; /* cpumask generation counter */
 };
 
 /*

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -13,11 +13,11 @@ ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "0.24.1"
 libc = "0.2.137"
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.5" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.1.2" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.2" }
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.5" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.1.2" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.2" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -132,11 +132,6 @@ impl<'a> Scheduler<'a> {
 
             // Dispatch the task.
             self.bpf.dispatch_task(&dispatched_task).unwrap();
-
-            // Stop dispatching if all the CPUs are busy (select_cpu() couldn't find an idle CPU).
-            if cpu < 0 {
-                break;
-            }
         }
 
         // Notify the BPF component that tasks have been dispatched.

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -20,12 +20,12 @@ serde = { version = "1.0", features = ["derive"] }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.5" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.5" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.5" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.1.2" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.2" }
 simplelog = "0.12"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.5" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.1.2" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.2" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION
Some changes to improve stability and performance of the scx_rustland_core schedulers and properly support the 6.12 kernel.

Summary of the changes:
 - scx_rustland_core now provides nvcsw, slice and dsq_vtime directly (user-space scheduler can now access this information quickly)
 - keep CPUs alive with pending tasks (this fixes issue #788)
 - restart scheduler on hotplug events (this makes scx_rustland_core schedulers more reliable)
 - scx_rustland improvements: use the new metrics provided by scx_rustland_core, apply some idle selection changes from bpfland, prioritize WAKE_SYNC tasks
 - scx_rlfifo: make it more work-conserving, so that it can be used as a better stress test for the sched_ext core

