### PR TITLE
scx_layered: Add decayed vtime for starvation prevention

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -181,6 +181,7 @@ struct layer {
 	int			growth_algo;
 
 	u64			vtime_now;
+	u64			vtime_decay;
 	u64			nr_tasks;
 
 	u64			load;


### PR DESCRIPTION
Add a decayed vtime that is used to calculate a weighted decayed vtime based on layer weights. The weighted decayed vtime is then used to determine if a layer is being starved. When a layer is determined to be started it will prioritized for DSQ consumption. Thanks to @JakeHillion for helping with the implementation.

Tested with/without topology awareness by running `nproc * 2` of `stress-ng` for 35 seconds with no scheduler ejections. On the `main` branch the scheduler will eject if running `stress-ng -c $(nproc)`.
```
$ sudo stress-ng -c $(($(nproc) * 2)) -t 35
stress-ng: info:  [1165012] setting to a 35 secs run per stressor
stress-ng: info:  [1165012] dispatching hogs: 160 cpu
stress-ng: info:  [1165012] skipped: 0
stress-ng: info:  [1165012] passed: 160: cpu (160)
stress-ng: info:  [1165012] failed: 0
stress-ng: info:  [1165012] metrics untrustworthy: 0
stress-ng: info:  [1165012] successful run completed in 35.09 secs
$ stress-ng -c $(($(nproc) * 2)) -t 35
stress-ng: info:  [1052981] setting to a 35 secs run per stressor
stress-ng: info:  [1052981] dispatching hogs: 160 cpu
stress-ng: info:  [1052981] skipped: 0
stress-ng: info:  [1052981] passed: 160: cpu (160)
stress-ng: info:  [1052981] failed: 0
stress-ng: info:  [1052981] metrics untrustworthy: 0
stress-ng: info:  [1052981] successful run completed in 35.27 secs
$ sudo stress-ng -c $(($(nproc) * 2)) -t 35
stress-ng: info:  [1061554] setting to a 35 secs run per stressor
stress-ng: info:  [1061554] dispatching hogs: 160 cpu
stress-ng: info:  [1061554] skipped: 0
stress-ng: info:  [1061554] passed: 160: cpu (160)
stress-ng: info:  [1061554] failed: 0
stress-ng: info:  [1061554] metrics untrustworthy: 0
stress-ng: info:  [1061554] successful run completed in 37.44 secs
```

Performance numbers:
`main`:
```
$ sudo stress-ng -c 10 -t 20 -M
stress-ng: info:  [1244923] setting to a 20 secs run per stressor
stress-ng: info:  [1244923] dispatching hogs: 10 cpu
stress-ng: metrc: [1244923] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s CPU used per       RSS Max
stress-ng: metrc: [1244923]                           (secs)    (secs)    (secs)   (real time) (usr+sys time) instance (%)          (KB)
stress-ng: metrc: [1244923] cpu              259307     20.00    199.49      0.04     12963.66        1299.58        99.75          5120
stress-ng: info:  [1244923] skipped: 0
stress-ng: info:  [1244923] passed: 10: cpu (10)
stress-ng: info:  [1244923] failed: 0
stress-ng: info:  [1244923] metrics untrustworthy: 0
stress-ng: info:  [1244923] successful run completed in 20.01 secs
```
branch:
```
$ sudo stress-ng -c 10 -t 20 -M
stress-ng: info:  [1251999] setting to a 20 secs run per stressor
stress-ng: info:  [1251999] dispatching hogs: 10 cpu
stress-ng: metrc: [1251999] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s CPU used per       RSS Max
stress-ng: metrc: [1251999]                           (secs)    (secs)    (secs)   (real time) (usr+sys time) instance (%)          (KB)
stress-ng: metrc: [1251999] cpu              256058     20.00    199.37      0.05     12801.52        1283.99        99.70          5120
stress-ng: info:  [1251999] skipped: 0
stress-ng: info:  [1251999] passed: 10: cpu (10)
stress-ng: info:  [1251999] failed: 0
stress-ng: info:  [1251999] metrics untrustworthy: 0
stress-ng: info:  [1251999] successful run completed in 20.01 secs
```
The variance of a run is a few hundred ops/sec so there is little/no noticeable performance impact.