### PR TITLE
scx_layered: Add DSQ context

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -42,6 +42,7 @@ enum consts {
 	MIN_LAYER_WEIGHT	= 1,
 	DEFAULT_LAYER_WEIGHT	= 100,
 	USAGE_HALF_LIFE		= 100000000,	/* 100ms */
+	USAGE_HALF_LIFE_SEC	= USAGE_HALF_LIFE * 10,	/* 1s */
 
 	HI_FALLBACK_DSQ_BASE	= MAX_LAYERS * MAX_LLCS,
 	LO_FALLBACK_DSQ		= (MAX_LAYERS * MAX_LLCS) + MAX_LLCS + 1,
@@ -103,6 +104,12 @@ struct cpu_ctx {
 	u32			layer_idx;
 	u32			cache_idx;
 	u32			node_idx;
+};
+
+struct dsq_ctx {
+	u64 vtime_now;
+	u64 usage_avg;
+	struct ravg_data vtime_rd;
 };
 
 struct cache_ctx {


### PR DESCRIPTION
Add context for DSQs for tracking vtime and avg vtime.

some output from `trace`:
```
          <idle>-0       [000] d.h.1 4698978.290296: bpf_trace_printk: DSQ[0] usage_avg: 0 vtime_now; 12142054 ravg: 64313
          <idle>-0       [000] d.h.1 4698978.290297: bpf_trace_printk: DSQ[1] usage_avg: 0 vtime_now; 0 ravg: 0
          <idle>-0       [000] d.h.1 4698978.290298: bpf_trace_printk: DSQ[2] usage_avg: 1411949 vtime_now; 8950678140 ravg: 3462294305
          <idle>-0       [000] d.h.1 4698978.290299: bpf_trace_printk: DSQ[3] usage_avg: 0 vtime_now; 23401062580 ravg: 15538729024
          <idle>-0       [000] d.h.1 4698978.290300: bpf_trace_printk: DSQ[4] usage_avg: 0 vtime_now; 0 ravg: 0
          <idle>-0       [000] d.h.1 4698978.290300: bpf_trace_printk: DSQ[5] usage_avg: 0 vtime_now; 0 ravg: 0
          <idle>-0       [000] d.h.1 4698978.290301: bpf_trace_printk: DSQ[6] usage_avg: 0 vtime_now; 9345761902 ravg: 2277506371
          <idle>-0       [000] d.h.1 4698978.290302: bpf_trace_printk: DSQ[7] usage_avg: 0 vtime_now; 9345730072 ravg: 2179806149
          <idle>-0       [000] d.h.1 4698978.290303: bpf_trace_printk: DSQ[1024] usage_avg: 896 vtime_now; 899095518 ravg: 171967308
          <idle>-0       [000] d.h.1 4698978.290304: bpf_trace_printk: DSQ[1025] usage_avg: 0 vtime_now; 747609880 ravg: 83412288
          <idle>-0       [000] d.h.1 4698978.291296: bpf_trace_printk: DSQ[0] usage_avg: 0 vtime_now; 12142054 ravg: 64313
          <idle>-0       [000] d.h.1 4698978.291297: bpf_trace_printk: DSQ[1] usage_avg: 0 vtime_now; 0 ravg: 0
          <idle>-0       [000] d.h.1 4698978.291298: bpf_trace_printk: DSQ[2] usage_avg: 1235451 vtime_now; 8950678140 ravg: 3462294305
          <idle>-0       [000] d.h.1 4698978.291299: bpf_trace_printk: DSQ[3] usage_avg: 0 vtime_now; 23401062580 ravg: 15538729024
          <idle>-0       [000] d.h.1 4698978.291300: bpf_trace_printk: DSQ[4] usage_avg: 0 vtime_now; 0 ravg: 0
          <idle>-0       [000] d.h.1 4698978.291301: bpf_trace_printk: DSQ[5] usage_avg: 0 vtime_now; 0 ravg: 0
          <idle>-0       [000] d.h.1 4698978.291302: bpf_trace_printk: DSQ[6] usage_avg: 0 vtime_now; 9345761902 ravg: 2277506371
          <idle>-0       [000] d.h.1 4698978.291303: bpf_trace_printk: DSQ[7] usage_avg: 0 vtime_now; 9345730072 ravg: 2179806149
          <idle>-0       [000] d.h.1 4698978.291304: bpf_trace_printk: DSQ[1024] usage_avg: 784 vtime_now; 899095518 ravg: 171967308
          <idle>-0       [000] d.h.1 4698978.291305: bpf_trace_printk: DSQ[1025] usage_avg: 0 vtime_now; 747609880 ravg: 83412288
```