### PR TITLE
layered: make disable_topology arg require equals

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -417,7 +417,7 @@ struct Opts {
     /// Disable topology awareness. When enabled, the "nodes" and "llcs" settings on
     /// a layer are ignored. Defaults to false on topologies with multiple NUMA nodes
     /// or LLCs, and true otherwise.
-    #[arg(short = 't', long, num_args = 0..=1, default_missing_value = "true")]
+    #[arg(short = 't', long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
     disable_topology: Option<bool>,
 
     /// Enable cross NUMA preemption.


### PR DESCRIPTION

The recent changes to `disable_topology` making the arg an `Option<bool>`
instead of a `bool` caused an issue with it incorrectly attaching arguments.
Make the argument `require_equals` to fix this case.

This is a behaviour change for anybody previously relying on `-t true`,
`-t false`, `--disable-topology true`, or `--disable-topology false`. The
equals syntax worked before and continues to work after, as demonstrated in the
CI.

Test plan:

Before:
```sh
$ sudo target/release/scx_layered -t f:/tmp/test.json
error: invalid value 'f:/tmp/test.json' for '--disable-topology
[<DISABLE_TOPOLOGY>]'
  [possible values: true, false]

  For more information, try '--help'.
```

After:
```sh
$ sudo target/release/scx_layered -t f:/tmp/test.json
14:44:00 [INFO] CPUs: online/possible=176/176 nr_cores=88
14:44:00 [INFO] Disabling topology awareness
...
^CEXIT: Scheduler unregistered from user space
```
