### PR TITLE
scx_rustland_core: update documentation about the new API

### DIFF
--- a/rust/scx_rustland_core/README.md
+++ b/rust/scx_rustland_core/README.md
@@ -105,6 +105,9 @@ impl<'a> Scheduler<'a> {
         //     pub cpu: i32,              // CPU where the task is running
         //     pub sum_exec_runtime: u64, // Total cpu time
         //     pub weight: u64,           // Task static priority
+        //     pub nvcsw: u64,            // Total amount of voluntary context switches
+        //     pub slice: u64,            // Remaining time slice budget
+        //     pub vtime: u64,            // Current task vruntime / deadline (set by the scheduler)
         // }
         //
         // Although the FIFO scheduler doesn't use these fields, they can provide valuable data for

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -47,6 +47,9 @@
 //!     pub flags: u64,            // task's enqueue flags
 //!     pub sum_exec_runtime: u64, // Total cpu time in nanoseconds
 //!     pub weight: u64,           // Task priority in the range [1..10000] (default is 100)
+//!     pub nvcsw: u64,            // Total amount of voluntary context switches
+//!     pub slice: u64,            // Remaining time slice budget
+//!     pub vtime: u64,            // Current task vruntime / deadline (set by the scheduler)
 //! }
 //!
 //! Each task dispatched using dispatch_task() contains the following:


### PR DESCRIPTION
Update the documentation adding the new task statistics provided by scx_rustland_core.

Fixes: be681c7 ("scx_rustland_core: pass nvcsw, slice and dsq_vtime to user-space")