### PR TITLE
scx_lavd: add missing reset_lock_futex_boost()

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -67,7 +67,6 @@ struct sys_stat {
 	volatile u64	last_update_clk;
 	volatile u64	util;		/* average of the CPU utilization */
 
-	volatile u64	load_actual;	/* average actual load of runnable tasks */
 	volatile u64	avg_svc_time;	/* average service time per task */
 	volatile u64	nr_queued_task;
 
@@ -117,7 +116,6 @@ struct task_ctx {
 	u64	wait_freq;		/* waiting frequency in a second */
 
 	u64	wake_freq;		/* waking-up frequency in a second */
-	u64	load_actual;		/* task load derived from run_time and run_freq */
 	u64	svc_time;		/* total CPU time consumed for this task */
 
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -132,9 +132,10 @@ struct task_ctx {
 	u32	lat_cri_waker;		/* waker's latency criticality */
 	volatile s32 victim_cpu;
 	u16	slice_boost_prio;	/* how many times a task fully consumed the slice */
-	u8	wakeup_ft;		/* regular wakeup = 1, sync wakeup = 2 */
 	volatile s16 lock_boost;	/* lock boost count */
 	volatile s16 futex_boost;	/* futex boost count */
+	volatile u8 need_lock_boost;	/* need to boost lock for deadline calculation */
+	u8	wakeup_ft;		/* regular wakeup = 1, sync wakeup = 2 */
 	volatile u32 *futex_uaddr;	/* futex uaddr */
 
 	/*
@@ -176,7 +177,7 @@ enum {
 };
 
 enum {
-       LAVD_MSG_TASKC		= 0x1,
+       LAVD_MSG_TASKC		= 0x1
 };
 
 struct introspec {

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -90,8 +90,6 @@ struct cpu_ctx {
 	/*
 	 * Information used to keep track of load
 	 */
-	volatile u64	load_actual;	/* actual load of runnable tasks */
-	volatile u64	load_run_time_ns; /* total runtime of runnable tasks */
 	volatile u64	tot_svc_time;	/* total service time on a CPU */
 	volatile u64	last_kick_clk;	/* when the CPU was kicked */
 

--- a/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
@@ -93,11 +93,17 @@ static void dec_futex_boost(u32 *uaddr)
 	try_dec_futex_boost(taskc, cpuc, uaddr);
 }
 
-static void reset_lock_futex_boost(struct task_ctx *taskc)
+static void reset_lock_futex_boost(struct task_ctx *taskc, struct cpu_ctx *cpuc)
 {
+	if (is_lock_holder(taskc)) {
+		taskc->need_lock_boost = true;
+		cpuc->nr_lhp++;
+	}
+
 	taskc->lock_boost = 0;
 	taskc->futex_boost = 0;
 	taskc->futex_uaddr = NULL;
+	cpuc->lock_holder = false;
 }
 
 /**

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -30,10 +30,8 @@ struct sys_stat_ctx {
 	u64		duration_total;
 	u64		idle_total;
 	u64		compute_total;
-	u64		load_actual;
 	u64		tot_svc_time;
 	u64		nr_queued_task;
-	u64		load_run_time_ns;
 	s32		max_lat_cri;
 	s32		avg_lat_cri;
 	u64		sum_lat_cri;
@@ -83,8 +81,6 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 		/*
 		 * Accumulate cpus' loads.
 		 */
-		c->load_actual += cpuc->load_actual;
-		c->load_run_time_ns += cpuc->load_run_time_ns;
 		c->tot_svc_time += cpuc->tot_svc_time;
 		cpuc->tot_svc_time = 0;
 
@@ -233,8 +229,6 @@ static void update_sys_stat_next(struct sys_stat_ctx *c)
 	struct sys_stat *stat_cur = c->stat_cur;
 	struct sys_stat *stat_next = c->stat_next;
 
-	stat_next->load_actual =
-		calc_avg(stat_cur->load_actual, c->load_actual);
 	stat_next->util =
 		calc_avg(stat_cur->util, c->new_util);
 

--- a/scripts/dsq_lat.bt
+++ b/scripts/dsq_lat.bt
@@ -51,9 +51,6 @@ rawtracepoint:sched_switch
 }
 
 interval:s:1 {
-    $scx_ops = kaddr("scx_ops");
-    $ops = (struct sched_ext_ops*)$scx_ops;
-    printf("scheduler: %s\n", $ops->name);
     print(@avg_lat);
     print(@usec_hist);
     print(@dsq_lat);


### PR DESCRIPTION
reset_lock_futex_boost() should be called every context switch of a
task. Otherwise, in the worst case, a task and that CPU could block
the preemption. To avoid such a situation, add missing
reset_lock_futex_boost() calls.