### PR TITLE
scx_layered: fix exit_task ctx lookup err

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1952,6 +1952,10 @@ void BPF_STRUCT_OPS(layered_exit_task, struct task_struct *p,
 	struct cpu_ctx *cctx;
 	struct task_ctx *tctx;
 
+	if(args->cancelled){
+		return;
+	}
+
 	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)))
 		return;
 


### PR DESCRIPTION
scx_layered: fix exit_task ctx lookup err

when exit_task is called with the cancelled arg, tasks have not been run on sched_ext, so task_ctx may not exist.

do not attempt hard failing lookup when this occurs, just return.