### PR TITLE
layered: bpf: add layer kind to layer

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -50,6 +50,12 @@ enum consts {
 	MAX_CGRP_PREFIXES = 32
 };
 
+enum layer_kind {
+	LAYER_KIND_OPEN,
+	LAYER_KIND_GROUPED,
+	LAYER_KIND_CONFINED,
+};
+
 /* Statistics */
 enum global_stat_idx {
 	GSTAT_EXCL_IDLE,
@@ -174,6 +180,8 @@ struct layer {
 	u64			yield_step_ns;
 	u64			slice_ns;
 	u32			weight;
+
+	int			kind;
 	bool			open;
 	bool			preempt;
 	bool			preempt_first;

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::bpf_intf;
 use crate::LayerGrowthAlgo;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -158,4 +159,14 @@ pub enum LayerKind {
         #[serde(default)]
         llcs: Vec<usize>,
     },
+}
+
+impl LayerKind {
+    pub fn as_bpf_enum(&self) -> i32 {
+        match self {
+            LayerKind::Confined { .. } => bpf_intf::layer_kind_LAYER_KIND_CONFINED as i32,
+            LayerKind::Grouped { .. } => bpf_intf::layer_kind_LAYER_KIND_GROUPED as i32,
+            LayerKind::Open { .. } => bpf_intf::layer_kind_LAYER_KIND_OPEN as i32,
+        }
+    }
 }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1268,6 +1268,7 @@ impl<'a> Scheduler<'a> {
             }
 
             layer.nr_match_ors = spec.matches.len() as u32;
+            layer.kind = spec.kind.as_bpf_enum();
 
             match &spec.kind {
                 LayerKind::Confined {


### PR DESCRIPTION

Currently we have an approximation of LayerKind in the BPF code with `open` on
the layer, but it is difficult/impossible to tell the difference between an
Open and a Grouped layer. Add a `kind` field to the BPF `layer` and plumb
through an enum from the Rust side.
