### PR TITLE
ci: enable SCHED_MC in the virtme-ng kernel config

### DIFF
--- a/.github/workflows/sched-ext.config
+++ b/.github/workflows/sched-ext.config
@@ -17,6 +17,7 @@ CONFIG_SCHED_DEBUG=y
 #
 CONFIG_SCHED_AUTOGROUP=y
 CONFIG_SCHED_CORE=y
+CONFIG_SCHED_MC=y
 
 # Enable fully preemptible kernel for a better test coverage of the schedulers
 #


### PR DESCRIPTION
Enabling SCHED_MC in the kernel used for testing allows us to potentially run more complext tests, simulating different CPU topologies and have access to such topology data through the in-kernel scheduler's information.

This can be useful as we add more topology awareness logic to the sched_ext core (e.g., in the built-in idle CPU selection policy).

Therefore add this option to the default .config (and also fix a missing newline at the end of the file).