### PR TITLE
ci: enable verbose mode when testing schedulers

### DIFF
--- a/meson-scripts/stress_tests.ini
+++ b/meson-scripts/stress_tests.ini
@@ -1,24 +1,24 @@
 [scx_lavd]
 sched: scx_lavd
-sched_args:
+sched_args: -v
 stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
 timeout_sec: 15
 
 [scx_rusty]
 sched: scx_rusty
-sched_args:
+sched_args: -v
 stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
 timeout_sec: 15
 
 [scx_rustland]
 sched: scx_rustland
-sched_args:
+sched_args: -v
 stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
 timeout_sec: 15
 
 [scx_bpfland]
 sched: scx_bpfland
-sched_args:
+sched_args: -v
 stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
 timeout_sec: 15
 

--- a/meson-scripts/test_sched
+++ b/meson-scripts/test_sched
@@ -29,17 +29,17 @@ fi
 
 # enable running tests on individual schedulers
 if [ $# -ge 2 ] ; then
-    SCHEDS[$2]=""
+    SCHEDS[$2]="-v"
 else
-    SCHEDS["scx_simple"]=""
-    SCHEDS["scx_central"]=""
-    SCHEDS["scx_nest"]=""
-    SCHEDS["scx_flatcg"]=""
-    SCHEDS["scx_pair"]=""
-    SCHEDS["scx_rusty"]=""
-    SCHEDS["scx_rustland"]=""
-    SCHEDS["scx_bpfland"]=""
-    SCHEDS["scx_layered"]="--run-example"
+    SCHEDS["scx_simple"]="-v"
+    SCHEDS["scx_central"]="-v"
+    SCHEDS["scx_nest"]="-v"
+    SCHEDS["scx_flatcg"]="-v"
+    SCHEDS["scx_pair"]="-v"
+    SCHEDS["scx_rusty"]="-v"
+    SCHEDS["scx_rustland"]="-v"
+    SCHEDS["scx_bpfland"]="-v"
+    SCHEDS["scx_layered"]="-v --run-example"
 fi
 
 if [[ -v SCHEDS["scx_layered"] ]] ; then


### PR DESCRIPTION
Always run schedulers in verbose mode to be able to catch the details of potential BPF failures.