### PR TITLE
scx/common.bpf.h: Compatible kfunc string arguments

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -102,7 +102,7 @@ ___scx_bpf_bstr_format_checker(const char *fmt, ...) {}
  * refer to the initialized list of inputs to the bstr kfunc.
  */
 #define scx_bpf_bstr_preamble(fmt, args...)                                    \
-  static const char ___fmt[] = fmt;                                                  \
+  static typeof(fmt) ___fmt = fmt;                                             \
   /*                                                                           \
    * Note that __param[] must have at least one                                \
    * element to keep the verifier happy.                                       \


### PR DESCRIPTION
Kernel commit 3e99aee7ce48 ("sched-ext: Use correct annotation for strings in kfuncs") introduced proper annotations for kfunc string arguments, that are now properly considered as const strings.

Commit 29918c0 ("fix ci errors due to __str update in kfunc signature") applied the same change to common.bpf.h, but this broke the compatibility with old kernels that don't have the annotation change.

Support both formats by relying on the compiler to determine the type of the format string.

Fixes: 29918c0 ("fix ci errors due to __str update in kfunc signature")