### PR TITLE
scx_common: Make scx_bpf_bstr_preamble declarations global

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -102,7 +102,7 @@ ___scx_bpf_bstr_format_checker(const char *fmt, ...) {}
  * refer to the initialized list of inputs to the bstr kfunc.
  */
 #define scx_bpf_bstr_preamble(fmt, args...)                                    \
-  static const char ___fmt[] = fmt;                                                  \
+  const char ___fmt[] = fmt;                                                   \
   /*                                                                           \
    * Note that __param[] must have at least one                                \
    * element to keep the verifier happy.                                       \


### PR DESCRIPTION
Make scx_bpf_bstr_preamble declarations use a non static declaration to make verification easier on older kernels.