### PR TITLE
Set minimal meson version to silent new warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('sched_ext schedulers', 'c',
         version: '1.0.5',
         license: 'GPL-2.0',
-        meson_version : '>= 1.4.0',)
+        meson_version : '>= 1.2.0',)
 
 fs = import('fs')
 

--- a/meson.build
+++ b/meson.build
@@ -1,10 +1,7 @@
 project('sched_ext schedulers', 'c',
         version: '1.0.5',
-        license: 'GPL-2.0',)
-
-if meson.version().version_compare('<1.2')
-  error('meson >= 1.2 required')
-endif
+        license: 'GPL-2.0',
+        meson_version : '>= 1.4.0',)
 
 fs = import('fs')
 


### PR DESCRIPTION
The new version of meson displays the following warnings:

```
The Meson build system
Version: 1.6.0
Source dir: /home/lucjan/Pobrane/scx-scheds/src/scx
Build dir: /home/lucjan/Pobrane/scx-scheds/src/scx/build
Build type: native build
WARNING: Project does not target a minimum version but uses feature introduced in '1.1': meson.options file. Use meson_options.txt instead
Project name: sched_ext schedulers
Project version: 1.0.5
C compiler for the host machine: cc (gcc 14.2.1 "cc (GCC) 14.2.1 20240910")
C linker for the host machine: cc ld.bfd 2.43.0
Host machine cpu family: x86_64
Host machine cpu: x86_64
Program clang found: YES (/usr/bin/clang)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/veristat found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/veristat)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/veristat_diff found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/veristat_diff)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/run_stress_tests found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/run_stress_tests)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/get_clang_ver found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/get_clang_ver)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/get_bpftool_ver found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/get_bpftool_ver)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/bpftool_build_skel found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/bpftool_build_skel)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/get_sys_incls found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/get_sys_incls)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/test_sched found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/test_sched)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/fetch_libbpf found: YES (/bin/bash /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/fetch_libbpf)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/build_libbpf found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/build_libbpf)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/fetch_bpftool found: YES (/bin/bash /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/fetch_bpftool)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/build_bpftool found: YES (/bin/bash /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/build_bpftool)
Program jq found: YES (/usr/bin/jq)
Program make found: YES (/usr/bin/make)
Program nproc found: YES (/usr/bin/nproc)
Message: Fetching libbpf repo
Library elf found: YES
Library z found: YES
Library zstd found: YES
Message: Fetching bpftool repo
meson.build:245: WARNING: Project does not target a minimum version but uses feature introduced in '1.2.0': str.splitlines.
Message: cpu=x86_64 bpf_base_cflags=['-g', '-O2', '-Wall', '-Wno-compare-distinct-pointer-types', '-D__TARGET_ARCH_x86', '-mcpu=v3', '-mlittle-endian', '-idirafter /usr/lib/clang/18/include', '-idirafter /usr/local/include', '-idirafter /usr/include']
Program cargo found: YES (/usr/bin/cargo)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/cargo_fetch found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/cargo_fetch)
Run-time dependency threads found: YES
Dependency threads found: YES unknown (cached)
Dependency threads found: YES unknown (cached)
Dependency threads found: YES unknown (cached)
Dependency threads found: YES unknown (cached)
Dependency threads found: YES unknown (cached)
Dependency threads found: YES unknown (cached)
Found pkg-config: YES (/usr/bin/pkg-config) 2.1.1
Run-time dependency systemd found: YES 256
Dependency openrc skipped: feature openrc disabled
Run-time dependency libalpm found: YES 15.0.0
Build targets in project: 48
WARNING: Project specifies no minimum version but uses features which were added in versions:
 * 1.1: {'meson.options file'}
 * 1.2.0: {'str.splitlines'}

sched_ext schedulers 1.0.5

```

They can be removed by adding a simple modification to meson.build.

```
The Meson build system
Version: 1.6.0
Source dir: /home/lucjan/Pobrane/scx-scheds/src/scx
Build dir: /home/lucjan/Pobrane/scx-scheds/src/scx/build
Build type: native build
Project name: sched_ext schedulers
Project version: 1.0.5
C compiler for the host machine: cc (gcc 14.2.1 "cc (GCC) 14.2.1 20240910")
C linker for the host machine: cc ld.bfd 2.43.0
Host machine cpu family: x86_64
Host machine cpu: x86_64
Program clang found: YES (/usr/bin/clang)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/veristat found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/veristat)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/veristat_diff found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/veristat_diff)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/run_stress_tests found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/run_stress_tests)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/get_clang_ver found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/get_clang_ver)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/get_bpftool_ver found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/get_bpftool_ver)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/bpftool_build_skel found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/bpftool_build_skel)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/get_sys_incls found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/get_sys_incls)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/test_sched found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/test_sched)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/fetch_libbpf found: YES (/bin/bash /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/fetch_libbpf)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/build_libbpf found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/build_libbpf)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/fetch_bpftool found: YES (/bin/bash /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/fetch_bpftool)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/build_bpftool found: YES (/bin/bash /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/build_bpftool)
Program jq found: YES (/usr/bin/jq)
Program make found: YES (/usr/bin/make)
Program nproc found: YES (/usr/bin/nproc)
Message: Fetching libbpf repo
Library elf found: YES
Library z found: YES
Library zstd found: YES
Message: Fetching bpftool repo
Message: cpu=x86_64 bpf_base_cflags=['-g', '-O2', '-Wall', '-Wno-compare-distinct-pointer-types', '-D__TARGET_ARCH_x86', '-mcpu=v3', '-mlittle-endian', '-idirafter /usr/lib/clang/18/include', '-idirafter /usr/local/include', '-idirafter /usr/include']
Program cargo found: YES (/usr/bin/cargo)
Program /home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/cargo_fetch found: YES (/home/lucjan/Pobrane/scx-scheds/src/scx/meson-scripts/cargo_fetch)
Run-time dependency threads found: YES
Dependency threads found: YES unknown (cached)
Dependency threads found: YES unknown (cached)
Dependency threads found: YES unknown (cached)
Dependency threads found: YES unknown (cached)
Dependency threads found: YES unknown (cached)
Dependency threads found: YES unknown (cached)
Found pkg-config: YES (/usr/bin/pkg-config) 2.1.1
Run-time dependency systemd found: YES 256
Dependency openrc skipped: feature openrc disabled
Run-time dependency libalpm found: YES 15.0.0
Build targets in project: 48

sched_ext schedulers 1.0.5

```

Version 1.4.0 is more than half a year old, and is available in current versions of the distribution. 