### PR TITLE
Revert "fix ci errors due to __str update in kfunc signature"

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -63,11 +63,11 @@ int bpf_iter_scx_dsq_new(struct bpf_iter_scx_dsq *it, u64 dsq_id,
 struct task_struct *
 bpf_iter_scx_dsq_next(struct bpf_iter_scx_dsq *it) __ksym __weak;
 void bpf_iter_scx_dsq_destroy(struct bpf_iter_scx_dsq *it) __ksym __weak;
-void scx_bpf_exit_bstr(s64 exit_code, char *fmt__str, unsigned long long *data,
+void scx_bpf_exit_bstr(s64 exit_code, char *fmt, unsigned long long *data,
                        u32 data__sz) __ksym __weak;
-void scx_bpf_error_bstr(char *fmt__str, unsigned long long *data,
+void scx_bpf_error_bstr(char *fmt, unsigned long long *data,
                         u32 data_len) __ksym;
-void scx_bpf_dump_bstr(char *fmt__str, unsigned long long *data,
+void scx_bpf_dump_bstr(char *fmt, unsigned long long *data,
                        u32 data_len) __ksym __weak;
 u32 scx_bpf_cpuperf_cap(s32 cpu) __ksym __weak;
 u32 scx_bpf_cpuperf_cur(s32 cpu) __ksym __weak;
@@ -102,7 +102,7 @@ ___scx_bpf_bstr_format_checker(const char *fmt, ...) {}
  * refer to the initialized list of inputs to the bstr kfunc.
  */
 #define scx_bpf_bstr_preamble(fmt, args...)                                    \
-  static const char ___fmt[] = fmt;                                                  \
+  static char ___fmt[] = fmt;                                                  \
   /*                                                                           \
    * Note that __param[] must have at least one                                \
    * element to keep the verifier happy.                                       \


### PR DESCRIPTION
This reverts commit 29918c03c8293426ae4f9f5019cf8c0ef1e3e5c1.

This breaks compatibility in a way that's difficult to work around. The counterpart kernel changes have been reverted. Let's revisit this later.