### PR TITLE
add retries to kernel clone step

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -70,7 +70,11 @@ jobs:
         name: Clone Kernel
         # Get the latest sched-ext enabled kernel directly from the korg
         # for-next branch
-        run: git clone --single-branch -b for-next --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
+        uses: cytopia/shell-command-retry-action@v0.1.2
+        with:
+          retries: 10
+          pause: 18
+          command: git clone --single-branch -b for-next --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
 
       # guard rail because we are caching
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
add retries to kernel clone step

odds are that like, when we most care about cloning a fresh upstream (i.e. some fix was just pushed), things are going to be flakiest (i.e. no caches anywhere), so retry 10 times with ~3 minutes total between all tries when trying to clone kernel sources.

this only adds retries to the job that will block all merge queue jobs (i.e. tests) if it fails (to be polite to upstream servers etc.).

deleted caches to confirm that cloning still works here:
https://github.com/likewhatevs/scx/actions/runs/11490045108/job/31980248511