### PR TITLE
fix lsp to work after multiarch support

### DIFF
--- a/scheds/include/.gitignore
+++ b/scheds/include/.gitignore
@@ -1,0 +1,1 @@
+vmlinux.h

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -9,7 +9,7 @@
 
 #ifdef LSP
 #define __bpf__
-#include "../vmlinux/vmlinux.h"
+#include "../vmlinux.h"
 #else
 #include "vmlinux.h"
 #endif

--- a/scheds/include/scx/user_exit_info.h
+++ b/scheds/include/scx/user_exit_info.h
@@ -10,6 +10,11 @@
 #ifndef __USER_EXIT_INFO_H
 #define __USER_EXIT_INFO_H
 
+#ifdef LSP
+#define __bpf__
+#include "../vmlinux.h"
+#endif
+
 enum uei_sizes {
 	UEI_REASON_LEN		= 128,
 	UEI_MSG_LEN		= 1024,
@@ -25,9 +30,7 @@ struct user_exit_info {
 
 #ifdef __bpf__
 
-#ifdef LSP
-#include "../vmlinux/vmlinux.h"
-#else
+#ifndef LSP
 #include "vmlinux.h"
 #endif
 #include <bpf/bpf_core_read.h>

--- a/scheds/include/vmlinux.h
+++ b/scheds/include/vmlinux.h
@@ -1,0 +1,1 @@
+arch/x86/vmlinux.h

--- a/scheds/rust/scx_layered/src/bpf/timer.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/timer.bpf.c
@@ -1,4 +1,13 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
+
+#ifdef LSP
+#define __bpf__
+#ifndef LSP_INC
+#include "../../../../include/scx/common.bpf.h"
+#include "timer.bpf.h"
+#endif
+#endif
+
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>

--- a/scheds/rust/scx_layered/src/bpf/timer.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/timer.bpf.h
@@ -1,6 +1,12 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
 #ifndef __LAYERED_TIMER_H
 #define __LAYERED_TIMER_H
+#ifdef LSP
+#define __bpf__
+#ifndef LSP_INC
+#include "../../../../include/scx/common.bpf.h"
+#endif
+#endif
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>


### PR DESCRIPTION
Fix lsp to work after multiarch support

I think this is a good way to enable lsp etc. to keep working with multiarch support.

If someone is working on arm and wants lsp etc. to work, they'll can overwrite the symlink to the right one for their arch (and that override is gitignored/the default is what will work best for most folks). 

![CleanShot 2024-10-24 at 10 04 29@2x](https://github.com/user-attachments/assets/6a46ea4e-0c05-4886-bed8-4e5f66838a24)
