### PR TITLE
scx_layered: Fix declarations in timer

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2072,7 +2072,7 @@ static bool layered_monitor(void)
 }
 
 
-static __always_inline bool run_timer_cb(int key)
+static bool run_timer_cb(int key)
 {
 	switch (key) {
 	case LAYERED_MONITOR:
@@ -2085,8 +2085,8 @@ static __always_inline bool run_timer_cb(int key)
 }
 
 struct layered_timer layered_timers[MAX_TIMERS] = {
-	{15 * NSEC_PER_SEC, CLOCK_BOOTTIME, 0},
-	{0, CLOCK_BOOTTIME, 0},
+	{15LLU * NSEC_PER_SEC, CLOCK_BOOTTIME, 0},
+	{0LLU, CLOCK_BOOTTIME, 0},
 };
 
 // TODO: separate this out to a separate compilation unit

--- a/scheds/rust/scx_layered/src/bpf/timer.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/timer.bpf.c
@@ -2,6 +2,7 @@
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
+#include "timer.bpf.h"
 
 
 struct timer_wrapper {

--- a/scheds/rust/scx_layered/src/bpf/timer.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/timer.bpf.h
@@ -12,7 +12,7 @@ enum timer_consts {
 
 struct layered_timer {
 	// if set to 0 the timer will only be scheduled once
-	int interval_ns;
+	u64 interval_ns;
 	u64 init_flags;
 	u64 start_flags;
 };
@@ -22,4 +22,9 @@ enum layer_timer_callbacks {
 	NOOP_TIMER,
 	MAX_TIMERS,
 };
+
+static bool run_timer_cb(int key);
+
+extern struct layered_timer layered_timers[MAX_TIMERS];
+
 #endif /* __LAYERED_TIMER_H */


### PR DESCRIPTION
Add a forward declaration to be more kind to tools and fix int->u64 casting.