### PR TITLE
ci: enable lockdep in the virtme-ng kernel config

### DIFF
--- a/.github/workflows/sched-ext.config
+++ b/.github/workflows/sched-ext.config
@@ -33,6 +33,7 @@ CONFIG_PREEMPT_RCU=y
 #
 CONFIG_DEBUG_LOCKDEP=y
 CONFIG_DEBUG_ATOMIC_SLEEP=y
+CONFIG_PROVE_LOCKING=y
 
 # Bpftrace headers (for additional debug info)
 CONFIG_BPF=y


### PR DESCRIPTION
Set CONFIG_PROVE_LOCKING=y in the defalut virtme-ng config, to enable lockdep and additional lock debugging features, which can help catch lock-related kernel issues in advance.