### PR TITLE
scx_lavd: tuning and optimizing latency criticality calculation

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -247,7 +247,7 @@ static bool try_find_and_kick_victim_cpu(struct task_struct *p,
 	bool ret = false;
 
 	/*
-	 * Prepare a cpumak so we find a victim @p's compute domain.
+	 * Prepare a cpumak so we find a victim in @p's compute domain.
 	 */
 	cpumask = cpuc_cur->tmp_t_mask;
 	cpdomc = MEMBER_VPTR(cpdom_ctxs, [dsq_id]);


### PR DESCRIPTION
This PR includes various tuning and optimization in calculating latency criticality. 

* calculate task's latency criticality in the direct dispatch path (addressed https://github.com/sched-ext/scx/issues/856)
* move reset_lock_futex_boost() to ops.running()
* boost task's latency criticality when pinned to a single CPU