### PR TITLE
scx_layered: Add layer name to bpf

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -37,6 +37,7 @@ enum consts {
 	MAX_LLCS		= 64,
 	MAX_COMM		= 16,
 	MAX_LAYER_MATCH_ORS	= 32,
+	MAX_LAYER_NAME		= 64,
 	MAX_LAYERS		= 16,
 	MAX_LAYER_WEIGHT	= 10000,
 	MIN_LAYER_WEIGHT	= 1,
@@ -207,6 +208,7 @@ struct layer {
 	unsigned char		cpus[MAX_CPUS_U8];
 	unsigned int		nr_cpus;	// managed from BPF side
 	unsigned int		perf;
+	char			name[MAX_LAYER_NAME];
 };
 
 #endif /* __INTF_H */

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -70,6 +70,7 @@ const USAGE_HALF_LIFE_F64: f64 = USAGE_HALF_LIFE as f64 / 1_000_000_000.0;
 const NR_GSTATS: usize = bpf_intf::global_stat_idx_NR_GSTATS as usize;
 const NR_LSTATS: usize = bpf_intf::layer_stat_idx_NR_LSTATS as usize;
 const NR_LAYER_MATCH_KINDS: usize = bpf_intf::layer_match_kind_NR_LAYER_MATCH_KINDS as usize;
+const MAX_LAYER_NAME: usize = bpf_intf::consts_MAX_LAYER_NAME as usize;
 
 #[rustfmt::skip]
 lazy_static::lazy_static! {
@@ -1330,6 +1331,9 @@ impl<'a> Scheduler<'a> {
                     } else {
                         (layer.slice_ns as f64 * (1.0 - *yield_ignore)) as u64
                     };
+                    let mut layer_name: String = spec.name.clone();
+                    layer_name.truncate(MAX_LAYER_NAME);
+                    copy_into_cstr(&mut layer.name, layer_name.as_str());
                     layer.preempt.write(*preempt);
                     layer.preempt_first.write(*preempt_first);
                     layer.exclusive.write(*exclusive);


### PR DESCRIPTION
Add the layer name to the bpf representation of a layer. When printing debug output print the layer name as well as the layer index.

Example output from trace:
```
  [061] ....1 5946587.990977: bpf_trace_printk: CFG: Dumping configuration, nr_online_cpus=80 smt_enabled=1 little_cores=0
           <...>-995151  [061] ....1 5946587.990979: bpf_trace_printk: CFG LAYER[0][hodgesd] min_exec_ns=0 open=1 preempt=0 exclusive=0
           <...>-995151  [061] ....1 5946587.990980: bpf_trace_printk: CFG   OR[00]
           <...>-995151  [061] ....1 5946587.990981: bpf_trace_printk: CFG     AND[00]: USER_ID 224791
           <...>-995151  [061] ....1 5946587.990983: bpf_trace_printk: CFG LAYER[1][stress-ng] min_exec_ns=0 open=1 preempt=0 exclusive=0
           <...>-995151  [061] ....1 5946587.990983: bpf_trace_printk: CFG   OR[00]
           <...>-995151  [061] ....1 5946587.990985: bpf_trace_printk: CFG     AND[00]: COMM_PREFIX "stress-ng"
           <...>-995151  [061] ....1 5946587.990985: bpf_trace_printk: CFG   OR[01]
           <...>-995151  [061] ....1 5946587.990986: bpf_trace_printk: CFG     AND[00]: PCOMM_PREFIX "stress-ng"
           <...>-995151  [061] ....1 5946587.990987: bpf_trace_printk: CFG LAYER[2][normal] min_exec_ns=0 open=1 preempt=0 exclusive=0
           <...>-995151  [061] ....1 5946587.990988: bpf_trace_printk: CFG   OR[00]
           <...>-995151  [061] ....1 5946587.990988: bpf_trace_printk: CFG     DEFAULT
           <...>-995151  [061] ....1 5946587.990990: bpf_trace_printk: CFG creating dsq 0 for layer 0 hodgesd on node 0 in llc 0
           <...>-995151  [061] ....1 5946587.990992: bpf_trace_printk: CFG creating dsq 1 for layer 0 hodgesd on node 0 in llc 1
           <...>-995151  [061] ....1 5946587.990993: bpf_trace_printk: CFG creating dsq 2 for layer 1 stress-ng on node 1 in llc 0
           <...>-995151  [061] ....1 5946587.990995: bpf_trace_printk: CFG creating dsq 3 for layer 1 stress-ng on node 1 in llc 1
           <...>-995151  [061] ....1 5946587.990996: bpf_trace_printk: CFG creating dsq 4 for layer 2 normal on node 0 in llc 0
           <...>-995151  [061] ....1 5946587.990998: bpf_trace_printk: CFG creating dsq 5 for layer 2 normal on node 0 in llc 1
```