### PR TITLE
scx_lavd: Correct the type of taskc within lavd_dispatch()

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1233,8 +1233,9 @@ void BPF_STRUCT_OPS(lavd_dispatch, s32 cpu, struct task_struct *prev)
 {
 	u64 now = bpf_ktime_get_ns();
 	struct cpu_ctx *cpuc;
+	struct task_ctx *taskc;
 	struct bpf_cpumask *active, *ovrflw;
-	struct task_struct *p, *taskc;
+	struct task_struct *p;
 	u64 dsq_id = 0;
 	bool try_consume = false;
 


### PR DESCRIPTION
## Summary
The type of `taskc` within `lavd_dispatch()` was `struct task_struct *`, while it should be `struct task_ctx *`.