### PR TITLE
scx_lavd: Fix typos

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -42,7 +42,7 @@ const volatile u32 	is_smt_active;
 const volatile u8	verbose;
 
 /*
- * Exit infomation
+ * Exit information
  */
 UEI_DEFINE(uei);
 

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -333,7 +333,7 @@ impl FlatTopology {
             for cpu_fid in cpu_fids.iter_mut() {
                 cpu_fid.cpu_cap = 1024 as usize;
             }
-            warn!("System does not provide proper CPU frequency infomation.");
+            warn!("System does not provide proper CPU frequency information.");
         }
 
         // Sort the cpu_fids


### PR DESCRIPTION
## Summary
Fix "infomation" to "information"