### PR TITLE
scx_layered: fix stalls w/ affinitized threads

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1061,7 +1061,7 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 		vtime = layer->vtime_now - layer_slice_ns;
 
 	if (!tctx->all_cpus_allowed){
-		scx_bpf_dispatch(p, idx, slice_ns, enq_flags);
+		scx_bpf_dispatch(p, SCX_DSQ_GLOBAL, slice_ns, enq_flags);
 		goto preempt;
 	}
 	/*

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -46,8 +46,6 @@ struct layer layers[MAX_LAYERS];
 u32 fallback_cpu;
 static u32 preempt_cursor;
 
-static volatile uint32_t dsq_timer_check_flag = 0;
-
 #define dbg(fmt, args...)	do { if (debug) bpf_printk(fmt, ##args); } while (0)
 #define trace(fmt, args...)	do { if (debug > 1) bpf_printk(fmt, ##args); } while (0)
 
@@ -1218,77 +1216,14 @@ static __noinline
 void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 {
 	struct cpu_ctx *cctx, *sib_cctx;
-	struct task_struct *p;
-	struct task_ctx *tctx;
 	struct layer *layer;
 	struct cost *cost;
-	u64 dsq_id, now;
+	u64 dsq_id;
 	u32 idx, layer_idx;
 	s32 sib = sibling_cpu(cpu);
 
 	if (!(cctx = lookup_cpu_ctx(-1)) || !(cost = lookup_cpu_cost(cpu)))
 		return;
-
-	if(dsq_timer_check_flag){
-		bpf_for(idx, 0, nr_layers) {
-			layer_idx = idx;
-
-			// check non-fallback dsqs.
-			bpf_for_each(scx_dsq, p, layer_idx, 0) {
-				now = bpf_ktime_get_ns();
-
-				if ((tctx = lookup_task_ctx(p))) {
-					if(tctx->runnable_at) {
-						if(now - tctx->runnable_at > NSEC_PER_MSEC * 5) {
-							if(scx_bpf_consume(dsq_id))
-								return;
-						} else {
-							// if the first entry in a dsq is ok, the dsq is ok.
-							break;
-						}
-					}
-				}
-			}
-		}
-
-		// check fallback dsqs
-		dsq_id = cpu_hi_fallback_dsq_id(cpu);
-		bpf_for_each(scx_dsq, p, dsq_id, 0) {
-			now = bpf_ktime_get_ns();
-
-			if ((tctx = lookup_task_ctx(p))) {
-				if(tctx->runnable_at) {
-					if(now - tctx->runnable_at > NSEC_PER_MSEC * 5) {
-						if(scx_bpf_consume(dsq_id))
-							return;
-					} else {
-						// if the first entry in a dsq is ok, the dsq is ok.
-						break;
-					}
-				}
-			}
-		}
-
-		bpf_for_each(scx_dsq, p, LO_FALLBACK_DSQ, 0) {
-			now = bpf_ktime_get_ns();
-
-			if ((tctx = lookup_task_ctx(p))) {
-				if(tctx->runnable_at) {
-					if(now - tctx->runnable_at > NSEC_PER_MSEC * 5) {
-						if(scx_bpf_consume(LO_FALLBACK_DSQ))
-								return;
-					} else {
-						// if the first entry in a dsq is ok, the dsq is ok.
-						break;
-					}
-				}
-			}
-		}
-
-		// all dsqs are ok, clear check flag.
-		__sync_fetch_and_and(&dsq_timer_check_flag, 0);
-		return;
-	}
 
 	/*
 	 * if @prev was on SCX and is still runnable, we are here because @prev
@@ -2164,24 +2099,12 @@ static bool layered_monitor(void)
 	return true;
 }
 
-static bool hack_dsq_check_flag_reset(void){
-	if(dsq_timer_check_flag) {
-		// flag was not cleared, ignore this tick.
-		return true;
-	} else {
-		// flag was cleared, reset it.
-		__sync_fetch_and_or(&dsq_timer_check_flag, 1);
-	}
-	return true;
-}
 
 static bool run_timer_cb(int key)
 {
 	switch (key) {
 	case LAYERED_MONITOR:
 		return layered_monitor();
-	case HACK_DSQ_CHECK:
-		return hack_dsq_check_flag_reset();
 	case NOOP_TIMER:
 	case MAX_TIMERS:
 	default:
@@ -2192,7 +2115,6 @@ static bool run_timer_cb(int key)
 struct layered_timer layered_timers[MAX_TIMERS] = {
 	{15LLU * NSEC_PER_SEC, CLOCK_BOOTTIME, 0},
 	{0LLU, CLOCK_BOOTTIME, 0},
-	{5LLU * NSEC_PER_SEC, CLOCK_BOOTTIME, 0},
 };
 
 // TODO: separate this out to a separate compilation unit

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1107,7 +1107,7 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 		 * issue.
 		 */
 		idx = cpu_hi_fallback_dsq_id(task_cpu);
-		scx_bpf_dispatch(p, LO_FALLBACK_DSQ, slice_ns, enq_flags);
+		scx_bpf_dispatch(p, idx, slice_ns, enq_flags);
 		goto preempt;
 	}
 
@@ -1244,7 +1244,7 @@ void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 								return;
 						} else {
 							// if the first entry in a dsq is ok, the dsq is ok.
-							// break;
+							break;
 						}
 					}
 				}
@@ -1263,7 +1263,7 @@ void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 							return;
 					} else {
 						// if the first entry in a dsq is ok, the dsq is ok.
-						// break;
+						break;
 					}
 				}
 			}
@@ -1279,7 +1279,7 @@ void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 								return;
 					} else {
 						// if the first entry in a dsq is ok, the dsq is ok.
-						// break;
+						break;
 					}
 				}
 			}

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2188,7 +2188,7 @@ static bool run_timer_cb(int key)
 struct layered_timer layered_timers[MAX_TIMERS] = {
 	{15LLU * NSEC_PER_SEC, CLOCK_BOOTTIME, 0},
 	{0LLU, CLOCK_BOOTTIME, 0},
-	{15LLU * NSEC_PER_SEC, CLOCK_BOOTTIME, 0},
+	{5LLU * NSEC_PER_SEC, CLOCK_BOOTTIME, 0},
 };
 
 // TODO: separate this out to a separate compilation unit

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1061,7 +1061,7 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 		vtime = layer->vtime_now - layer_slice_ns;
 
 	if (!tctx->all_cpus_allowed){
-		scx_bpf_dispatch(p, SCX_DSQ_GLOBAL, slice_ns, enq_flags);
+		scx_bpf_dispatch(p, SCX_DSQ_LOCAL, slice_ns, enq_flags);
 		goto preempt;
 	}
 	/*

--- a/scheds/rust/scx_layered/src/bpf/timer.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/timer.bpf.h
@@ -26,7 +26,6 @@ struct layered_timer {
 enum layer_timer_callbacks {
 	LAYERED_MONITOR,
 	NOOP_TIMER,
-	HACK_DSQ_CHECK,
 	MAX_TIMERS,
 };
 

--- a/scheds/rust/scx_layered/src/bpf/timer.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/timer.bpf.h
@@ -26,6 +26,7 @@ struct layered_timer {
 enum layer_timer_callbacks {
 	LAYERED_MONITOR,
 	NOOP_TIMER,
+	HACK_DSQ_CHECK,
 	MAX_TIMERS,
 };
 


### PR DESCRIPTION
latest commit is the one that ran for 5 mins w/ `stress-ng -c 128 -M --affinity 128` and no stall

![Alacritty 2024-10-31 10 06 51](https://github.com/user-attachments/assets/b85a1ffe-e174-45df-a55c-dee24d8d9a69)

don't understand it yet but think there's something to this commit (because 5 minutes and no stall, commit before it stalled).