### PR TITLE
scx_bpfland: minor cleanups

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -27,11 +27,6 @@ const volatile bool debug;
 #define SHARED_DSQ	1
 
 /*
- * Maximum multiplier for the dynamic task priority.
- */
-#define MAX_LATENCY_WEIGHT	1000
-
-/*
  * Default task time slice.
  */
 const volatile u64 slice_max = 20ULL * NSEC_PER_MSEC;
@@ -999,8 +994,7 @@ void BPF_STRUCT_OPS(bpfland_stopping, struct task_struct *p, bool runnable)
 	delta_t = (s64)(now - tctx->nvcsw_ts);
 	if (delta_t > NSEC_PER_SEC) {
 		u64 avg_nvcsw = tctx->nvcsw * NSEC_PER_SEC / delta_t;
-		u64 max_lat_weight = lowlatency ? MAX_LATENCY_WEIGHT :
-					MIN(nvcsw_max_thresh, MAX_LATENCY_WEIGHT);
+		u64 max_lat_weight = nvcsw_max_thresh * 100;
 
 		tctx->nvcsw = 0;
 		tctx->nvcsw_ts = now;

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -558,7 +558,6 @@ impl<'a> Scheduler<'a> {
             nr_interactive: self.skel.maps.bss_data.nr_interactive,
             nr_prio_waiting: self.skel.maps.bss_data.nr_prio_waiting,
             nr_shared_waiting: self.skel.maps.bss_data.nr_shared_waiting,
-            nvcsw_avg_thresh: self.skel.maps.bss_data.nvcsw_avg_thresh,
             nr_kthread_dispatches: self.skel.maps.bss_data.nr_kthread_dispatches,
             nr_direct_dispatches: self.skel.maps.bss_data.nr_direct_dispatches,
             nr_prio_dispatches: self.skel.maps.bss_data.nr_prio_dispatches,

--- a/scheds/rust/scx_bpfland/src/stats.rs
+++ b/scheds/rust/scx_bpfland/src/stats.rs
@@ -25,8 +25,6 @@ pub struct Metrics {
     pub nr_shared_waiting: u64,
     #[stat(desc = "Average amount of interactive tasks waiting to be dispatched")]
     pub nr_prio_waiting: u64,
-    #[stat(desc = "Average of voluntary context switches")]
-    pub nvcsw_avg_thresh: u64,
     #[stat(desc = "Number of kthread direct dispatches")]
     pub nr_kthread_dispatches: u64,
     #[stat(desc = "Number of task direct dispatches")]
@@ -41,14 +39,13 @@ impl Metrics {
     fn format<W: Write>(&self, w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "[{}] tasks -> r: {:>2}/{:<2} i: {:<2} pw: {:<4} w: {:<4} | nvcsw: {:<4} | dispatch -> k: {:<5} d: {:<5} p: {:<5} s: {:<5}",
+            "[{}] tasks -> r: {:>2}/{:<2} i: {:<2} pw: {:<4} w: {:<4} | dispatch -> k: {:<5} d: {:<5} p: {:<5} s: {:<5}",
             crate::SCHEDULER_NAME,
             self.nr_running,
             self.nr_cpus,
             self.nr_interactive,
             self.nr_prio_waiting,
             self.nr_shared_waiting,
-            self.nvcsw_avg_thresh,
             self.nr_kthread_dispatches,
             self.nr_direct_dispatches,
             self.nr_prio_dispatches,


### PR DESCRIPTION
Nothing significant, just minor cleanups / restyling and a small fix to restore the old max nvcsw limit that was incorrectly changed during the lowlatency mode refactoring.