### PR TITLE
scx_layered: Fix dump output format

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/cost.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/cost.bpf.c
@@ -301,8 +301,8 @@ static void initialize_budgets(u64 refresh_intvl_ns)
 		layer_weight_dur = (layer->weight * ((u64)refresh_intvl_ns * nr_possible_cpus)) /
 				    layer_weight_sum;
 		initialize_cost_layer(costc, layer_id, (s64)layer_weight_dur);
-		trace("BUDGET init global layer %d budget %lld",
-		      layer_id, costc->budget[layer_id]);
+		trace("COST GLOBAL[%d][%s] budget %lld",
+		      layer_id, layer->name, costc->budget[layer_id]);
 
 		// TODO: add L3 budgets for topology awareness
 
@@ -316,9 +316,8 @@ static void initialize_budgets(u64 refresh_intvl_ns)
 			layer_weight_dur = (layer->weight * layer_slice_ns * refresh_intvl_ns) /
 					    layer_weight_sum;
 			initialize_cost_layer(costc, layer_id, (s64)layer_weight_dur);
-			if (cpu == 0)
-				trace("BUDGET init cpu %d layer %d budget %lld",
-				      cpu, layer_id, costc->budget[layer_id]);
+			trace("COST CPU[%d][%d][%s] budget %lld",
+			      cpu, layer_id, layer->name, costc->budget[layer_id]);
 		}
 	}
 }

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2095,7 +2095,7 @@ int dump_cost(void)
 			scx_bpf_error("unabled to lookup layer %d", j);
 			continue;
 		}
-		scx_bpf_dump("GLOBAL[%d][%s] budget=%lld capacity=%lld\n",
+		scx_bpf_dump("COST GLOBAL[%d][%s] budget=%lld capacity=%lld\n",
 			     j, layer->name,
 			     costc->budget[j], costc->capacity[j]);
 	}
@@ -2107,7 +2107,7 @@ int dump_cost(void)
 				scx_bpf_error("unabled to lookup layer %d", i);
 				continue;
 			}
-			scx_bpf_dump("CPU[%d][%s][%d] budget=%lld capacity=%lld\n",
+			scx_bpf_dump("COST CPU[%d][%d][%s] budget=%lld capacity=%lld\n",
 				     i, j, layer->name,
 				     costc->budget[j], costc->capacity[j]);
 		}


### PR DESCRIPTION
Flip the order of layer id vs layer name so that the output makes sense. 

Example dump output:
```
LO_FALLBACK nr_queued=0 -0ms
COST GLOBAL[0][random] budget=22000000000 capacity=22000000000 COST GLOBAL[1][hodgesd] budget=0 capacity=0
COST GLOBAL[2][stress-ng] budget=0 capacity=0
COST GLOBAL[3][normal] budget=0 capacity=0
COST CPU[0][0][random] budget=62500000000000 capacity=62500000000000 COST CPU[0][1][random] budget=100000000000000 capacity=100000000000000 COST CPU[0][2][random] budget=124911500964411 capacity=125000000000000
```
init output:
```
x_layered-420826  [056] ....1  3433.008067: bpf_trace_printk: COST CPU[62][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008067: bpf_trace_printk: COST CPU[63][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008068: bpf_trace_printk: COST CPU[64][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008068: bpf_trace_printk: COST CPU[65][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008069: bpf_trace_printk: COST CPU[66][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008070: bpf_trace_printk: COST CPU[67][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008070: bpf_trace_printk: COST CPU[68][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008071: bpf_trace_printk: COST CPU[69][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008072: bpf_trace_printk: COST CPU[70][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008073: bpf_trace_printk: COST CPU[71][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008073: bpf_trace_printk: COST CPU[72][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008074: bpf_trace_printk: COST CPU[73][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008074: bpf_trace_printk: COST CPU[74][3][normal] budget 320000000000000
     scx_layered-420826  [056] ....1  3433.008075: bpf_trace_printk: COST CPU[75][3][normal] budget 320000000000000
```