### PR TITLE
scx_layered: Add additional drain to fallback DSQs

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/cost.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/cost.bpf.c
@@ -15,6 +15,7 @@ struct cost {
 	u32		idx;
 	bool		overflow;
 	bool		has_parent;
+	bool		drain_fallback;
 };
 
 
@@ -217,6 +218,7 @@ static int record_cpu_cost(struct cost *costc, u32 layer_id, s64 amount)
 	__sync_fetch_and_sub(&costc->budget[layer_id], amount);
 
 	if (costc->budget[layer_id] <= 0) {
+		costc->drain_fallback = true;
 		if (costc->has_parent) {
 			s64 budget = acquire_budget(costc, layer_id,
 						    costc->capacity[layer_id] + amount);


### PR DESCRIPTION
Fallback DSQs are not accounted with costs. If a layer is saturating the machine it is possible to not consume from the fallback DSQ and stall the task. This introduces and additional consumption from the fallback DSQ when a layer runs out of budget. In addition, tasks that use partial CPU affinities should be placed into the fallback DSQ. This change was tested with stress-ng --cacheline `nproc` for several minutes without causing stalls (which would stall on main).