### PR TITLE
check if CI regression is due to missing *mutex_lock* symbols in compiled kernel

### DIFF
--- a/.github/workflows/sched-ext.config
+++ b/.github/workflows/sched-ext.config
@@ -29,6 +29,12 @@ CONFIG_PREEMPTION=y
 CONFIG_PREEMPT_DYNAMIC=y
 CONFIG_PREEMPT_RCU=y
 
+# Additional debugging information (useful to catch potential locking issues)
+#
+CONFIG_DEBUG_LOCKDEP=y
+CONFIG_DEBUG_ATOMIC_SLEEP=y
+CONFIG_PROVE_LOCKING=y
+
 # Bpftrace headers (for additional debug info)
 CONFIG_BPF=y
 CONFIG_BPF_SYSCALL=y

--- a/.github/workflows/sched-ext.config
+++ b/.github/workflows/sched-ext.config
@@ -29,12 +29,6 @@ CONFIG_PREEMPTION=y
 CONFIG_PREEMPT_DYNAMIC=y
 CONFIG_PREEMPT_RCU=y
 
-# Additional debugging information (useful to catch potential locking issues)
-#
-CONFIG_DEBUG_LOCKDEP=y
-CONFIG_DEBUG_ATOMIC_SLEEP=y
-CONFIG_PROVE_LOCKING=y
-
 # Bpftrace headers (for additional debug info)
 CONFIG_BPF=y
 CONFIG_BPF_SYSCALL=y

--- a/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
@@ -320,7 +320,7 @@ int BPF_PROG(fexit_rt_mutex_lock, struct rt_mutex *lock)
 	return 0;
 }
 
-SEC("fexit/rt_mutex_lock_interruptible_nested")
+SEC("fexit/rt_mutex_lock_interruptible")
 int BPF_PROG(fexit_rt_mutex_lock_interruptible, struct rt_mutex *lock, int ret)
 {
 	if (ret == 0) {
@@ -332,7 +332,7 @@ int BPF_PROG(fexit_rt_mutex_lock_interruptible, struct rt_mutex *lock, int ret)
 	return 0;
 }
 
-SEC("fexit/rt_mutex_lock_killable_nested")
+SEC("fexit/rt_mutex_lock_killable")
 int BPF_PROG(fexit_rt_mutex_lock_killable, struct rt_mutex *lock, int ret)
 {
 	if (ret == 0) {

--- a/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
@@ -310,7 +310,7 @@ int BPF_PROG(fexit_ww_mutex_unlock, struct ww_mutex *lock)
 #ifdef LAVD_TRACE_RT_MUTEX
 struct rt_mutex;
 
-SEC("fexit/rt_mutex_lock")
+SEC("fexit/rt_mutex_lock_nested")
 int BPF_PROG(fexit_rt_mutex_lock, struct rt_mutex *lock)
 {
 	/*
@@ -320,7 +320,7 @@ int BPF_PROG(fexit_rt_mutex_lock, struct rt_mutex *lock)
 	return 0;
 }
 
-SEC("fexit/rt_mutex_lock_interruptible")
+SEC("fexit/rt_mutex_lock_interruptible_nested")
 int BPF_PROG(fexit_rt_mutex_lock_interruptible, struct rt_mutex *lock, int ret)
 {
 	if (ret == 0) {
@@ -332,7 +332,7 @@ int BPF_PROG(fexit_rt_mutex_lock_interruptible, struct rt_mutex *lock, int ret)
 	return 0;
 }
 
-SEC("fexit/rt_mutex_lock_killable")
+SEC("fexit/rt_mutex_lock_killable_nested")
 int BPF_PROG(fexit_rt_mutex_lock_killable, struct rt_mutex *lock, int ret)
 {
 	if (ret == 0) {

--- a/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
@@ -191,7 +191,7 @@ int BPF_PROG(fexit_up, struct semaphore *sem)
  */
 #ifdef LAVD_TRACE_MUTEX
 struct mutex;
-SEC("fexit/mutex_lock")
+SEC("fexit/mutex_lock_nested")
 int BPF_PROG(fexit_mutex_lock, struct mutex *mutex)
 {
 	/*
@@ -201,7 +201,7 @@ int BPF_PROG(fexit_mutex_lock, struct mutex *mutex)
 	return 0;
 }
 
-SEC("fexit/mutex_lock_interruptible")
+SEC("fexit/mutex_lock_interruptible_nested")
 int BPF_PROG(fexit_mutex_lock_interruptible, struct mutex *mutex, int ret)
 {
 	if (ret == 0) {
@@ -213,7 +213,7 @@ int BPF_PROG(fexit_mutex_lock_interruptible, struct mutex *mutex, int ret)
 	return 0;
 }
 
-SEC("fexit/mutex_lock_killable")
+SEC("fexit/mutex_lock_killable_nested")
 int BPF_PROG(fexit_mutex_lock_killable, struct mutex *mutex, int ret)
 {
 	if (ret == 0) {


### PR DESCRIPTION
Continuation of #877 