### PR TITLE
scx_rusty: Restore push domain tasks when no task found

### DIFF
--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -779,7 +779,10 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
                     .filter(|x| x.load >= OrderedFloat(to_xfer) && task_filter(x, pull_dom_id)),
             ),
         ) {
-            (None, None) => return Ok(None),
+            (None, None) => {
+                std::mem::swap(&mut push_dom.tasks, &mut SortedVec::from_unsorted(tasks));
+                return Ok(None);
+            }
             (Some(task), None) | (None, Some(task)) => (task, calc_new_imbal(*task.load)),
             (Some(task0), Some(task1)) => {
                 let (new_imbal0, new_imbal1) =

--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -759,8 +759,8 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
             .into_iter()
             .filter(|task| {
                 task.dom_mask & (1 << pull_dom_id) != 0
-                    || !(self.skip_kworkers && task.is_kworker)
-                    || !task.migrated.get()
+                    && !(self.skip_kworkers && task.is_kworker)
+                    && !task.migrated.get()
             })
             .collect();
 


### PR DESCRIPTION
## Summary
The PR includes 2 main fixes

### Restore push domain tasks
Inside the function `try_find_move_task()`, it returns directly when there's no task found to be moved. If the cause is from lack of ability to fulfilled the condition by `task_filter()`, load balancer will try to find move task again and remove `task_filter()` by setting it directly to a function returns true.

However, in the fallback case, the tasks within the domains will be empty. Swap the tasks back into domains vector before returning can solve the issue.

### Fix task filtering logic
The logic for task filtering was
```
                task.dom_mask & (1 << pull_dom_id) != 0
                    && !(self.skip_kworkers && task.is_kworker)
                    && !task.migrated.get()
```
Which might cause the tasks already be migrated to be migrate again. Causing warnings like belows
```
slice=20000us
direct_greedy_cpus=ffff
  kick_greedy_cpus=ffff
06:43:02 [WARN] Failed to update lb_data map for tptr=18446617589162519040 error=Error: File exists (os error 17)
06:43:02 [WARN] Failed to update lb_data map for tptr=18446617589162519040 error=Error: File exists (os error 17)
06:43:04 [WARN] Failed to update lb_data map for tptr=18446617589920705024 error=Error: File exists (os error 17)
06:43:04 [WARN] Failed to update lb_data map for tptr=18446617589920705024 error=Error: File exists (os error 17)
06:43:04 [WARN] Failed to update lb_data map for tptr=18446617589920705024 error=Error: File exists (os error 17)
06:43:06 [WARN] Failed to update lb_data map for tptr=18446617589082368512 error=Error: File exists (os error 17)
```
Fix the logic to exclude the task which is already migrated.

## Test
We can simply add some debug prints in the closure which was originally going to be sent into `try_find_move_task()`.
```
                    |task: &TaskInfo, pull_dom: u32| -> bool {
                        println!("Inside tasks filter");
                        (task.preferred_dom_mask & (1 << pull_dom)) > 0
                    },
```
and another one in the fallback closure
```
                if transferred.is_none() {
                    transferred = self.try_find_move_task(
                        (&mut push_dom, push_imbal),
                        (&mut pull_dom, pull_imbal),
                        |_task: &TaskInfo, _pull_dom: u32| -> bool { println!("Again in tasks filter"); true },
                        xfer,
                    )?;
                }
```
We can find that the second `task_filter()` is never going to be executed **because the tasks length is 0 in this case** ( when previos `try_find_move_task()` falls into `(None, None)` case ).
After the fix we can expect the second `task_filter()` to be executed and the debug print will show.
