### PR TITLE
scx_lavd: fix CI error for missing kernel symbols

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -298,7 +298,7 @@ impl FlatTopology {
         // Build a vector of cpu flat ids.
         let mut base_freq = 0;
         let mut avg_freq = 0;
-        for (node_pos, node) in topo.nodes().iter().enumerate() {
+        for (_node_pos, node) in topo.nodes().iter().enumerate() {
             for (llc_pos, (_llc_id, llc)) in node.llcs().iter().enumerate() {
                 for (core_pos, (_core_id, core)) in llc.cores().iter().enumerate() {
                     for (cpu_pos, (cpu_id, cpu)) in core.cpus().iter().enumerate() {


### PR DESCRIPTION
Revised the lock tracking code, relying on stable symbols with various kernel configurations. There are two changes:

- Entirely drop tracing rt_mutex, which can be on and off with kconfig

- Replace mutex_lock() families to __mutex_lock(), which is stable across kernel configs. The downside of such a change is it is now possible to trace the lock fast path, so lock tracing is a bit less accurate. But let's live with it for now until a better solution is found.