### PR TITLE
scx: sync default flags with CachyOS Kernel Manager

### DIFF
--- a/services/scx
+++ b/services/scx
@@ -2,4 +2,4 @@
 SCX_SCHEDULER=scx_bpfland
 
 # Set custom flags for each scheduler, below is an example of how to use
-#SCX_FLAGS='-s 20000 --lowlatency --primary-domain all'
+#SCX_FLAGS='-k -m performance'


### PR DESCRIPTION
As the option of dropping lowlatency in bpfland is being considered, and to ensure the greatest performance, it would be a good idea to use the following flags in ``/etc/default/scx``

Source: https://github.com/CachyOS/kernel-manager/commit/9b4a3fdda18911188df9a8469d561963585cde3a