### PR TITLE
scx_layered: Refactor cost naming

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -778,7 +778,7 @@ bool try_preempt_cpu(s32 cand, struct task_struct *p, struct cpu_ctx *cctx,
 		     struct task_ctx *tctx, struct layer *layer,
 		     bool preempt_first)
 {
-	struct cost *cost;
+	struct cost *costc;
 	struct cpu_ctx *cand_cctx, *sib_cctx = NULL;
 	s32 sib;
 
@@ -788,7 +788,7 @@ bool try_preempt_cpu(s32 cand, struct task_struct *p, struct cpu_ctx *cctx,
 	if (!(cand_cctx = lookup_cpu_ctx(cand)) || cand_cctx->current_preempt)
 		return false;
 
-	if (!(cost = lookup_cpu_cost(cand)) || has_budget(cost, layer) == 0)
+	if (!(costc = lookup_cpu_cost(cand)) || has_budget(costc, layer) == 0)
 		return false;
 
 	/*
@@ -1213,12 +1213,12 @@ void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 {
 	struct cpu_ctx *cctx, *sib_cctx;
 	struct layer *layer;
-	struct cost *cost;
+	struct cost *costc;
 	u64 dsq_id;
 	u32 idx, layer_idx;
 	s32 sib = sibling_cpu(cpu);
 
-	if (!(cctx = lookup_cpu_ctx(-1)) || !(cost = lookup_cpu_cost(cpu)))
+	if (!(cctx = lookup_cpu_ctx(-1)) || !(costc = lookup_cpu_cost(cpu)))
 		return;
 
 	/*
@@ -1249,13 +1249,13 @@ void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 
 	/* consume preempting layers first */
 	bpf_for(idx, 0, nr_layers) {
-		layer_idx = rotate_layer_id(cost->pref_layer, idx);
+		layer_idx = rotate_layer_id(costc->pref_layer, idx);
 		if (layer_idx >= nr_layers) {
 			scx_bpf_error("can't happen");
 			return;
 		}
 		layer = MEMBER_VPTR(layers, [layer_idx]);
-		if (has_budget(cost, layer) == 0)
+		if (has_budget(costc, layer) == 0)
 			continue;
 		if (layer->preempt && scx_bpf_consume(layer_idx))
 			return;
@@ -1267,13 +1267,13 @@ void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 
 	/* consume !open layers second */
 	bpf_for(idx, 0, nr_layers) {
-		layer_idx = rotate_layer_id(cost->pref_layer, idx);
+		layer_idx = rotate_layer_id(costc->pref_layer, idx);
 		if (layer_idx >= nr_layers) {
 			scx_bpf_error("can't happen");
 			return;
 		}
 		layer = MEMBER_VPTR(layers, [layer_idx]);
-		if (has_budget(cost, layer) == 0)
+		if (has_budget(costc, layer) == 0)
 			continue;
 		struct cpumask *layer_cpumask;
 
@@ -1290,13 +1290,13 @@ void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 
 	/* consume !preempting open layers */
 	bpf_for(idx, 0, nr_layers) {
-		layer_idx = rotate_layer_id(cost->pref_layer, idx);
+		layer_idx = rotate_layer_id(costc->pref_layer, idx);
 		if (layer_idx >= nr_layers) {
 			scx_bpf_error("can't happen");
 			return;
 		}
 		layer = MEMBER_VPTR(layers, [layer_idx]);
-		if (has_budget(cost, layer) == 0)
+		if (has_budget(costc, layer) == 0)
 			continue;
 		if (!layer->preempt && layers->open &&
 		    scx_bpf_consume(layer_idx))
@@ -1877,7 +1877,7 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 	struct cpu_ctx *cctx;
 	struct task_ctx *tctx;
 	struct layer *layer;
-	struct cost *cost;
+	struct cost *costc;
 	s32 lidx;
 	u64 used;
 
@@ -1885,7 +1885,7 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 		return;
 
 	lidx = tctx->layer;
-	if (!(layer = lookup_layer(lidx)) || !(cost = lookup_cpu_cost(-1)))
+	if (!(layer = lookup_layer(lidx)) || !(costc = lookup_cpu_cost(-1)))
 		return;
 
 	used = bpf_ktime_get_ns() - tctx->running_at;
@@ -1895,7 +1895,7 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 		used = layer->min_exec_ns;
 	}
 
-	record_cpu_cost(cost, layer->idx, (s64)used);
+	record_cpu_cost(costc, layer->idx, (s64)used);
 	cctx->layer_cycles[lidx] += used;
 	cctx->current_preempt = false;
 	cctx->prev_exclusive = cctx->current_exclusive;


### PR DESCRIPTION
Refactor cost struct usage so that it always is used as `costc` for clarity.