### PR TITLE
scx_layered: add timer antistall

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -187,6 +187,7 @@ jobs:
           matrix:
             scheduler: [ scx_layered ]
             topo: ['--disable-topology=false', '--disable-topology=true']
+            antistall: ['', '--disable-antistall']
           fail-fast: false
     steps:
       # prevent cache permission errors
@@ -228,7 +229,7 @@ jobs:
         run: exit -1
 
       # The actual build:
-      - run: meson setup build -Dkernel=../linux/arch/x86/boot/bzImage -Dkernel_headers=../linux -Denable_stress=true -Dvng_rw_mount=true -Dextra_sched_args=" ${{ matrix.topo }}"
+      - run: meson setup build -Dkernel=../linux/arch/x86/boot/bzImage -Dkernel_headers=../linux -Denable_stress=true -Dvng_rw_mount=true -Dextra_sched_args=" ${{ matrix.topo }} ${{ matrix.antistall }}"
       - run: meson compile -C build ${{ matrix.scheduler }}
 
       # Print CPU model before running the tests (this can be useful for
@@ -255,7 +256,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.scheduler }}_${{ matrix.topo }}_${{ matrix.test_name }}_logs_${{ github.run_id }}_${{ github.run_attempt }}
+          name: ${{ matrix.scheduler }}_${{ matrix.topo }}_${{ matrix.test_name }}_logs_${{ github.run_id }}_${{ github.run_attempt }}_${{ matrix.antistall }}
           path: ./log_save/*.ci.log
           # it's all txt files w/ 90 day retention, lets be nice.
           compression-level: 9

--- a/scheds/rust/scx_layered/src/bpf/timer.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/timer.bpf.h
@@ -25,6 +25,7 @@ struct layered_timer {
 
 enum layer_timer_callbacks {
 	LAYERED_MONITOR,
+	ANTISTALL_TIMER,
 	NOOP_TIMER,
 	MAX_TIMERS,
 };

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -458,6 +458,14 @@ struct Opts {
     #[clap(long)]
     run_example: bool,
 
+    /// Disable antistall
+    #[clap(long, default_value = "false")]
+    disable_antistall: bool,
+
+    /// Maximum task runnable_at delay (in seconds) before antistall turns on
+    #[clap(long, default_value = "3")]
+    antistall_sec: u64,
+
     /// Show descriptions for statistics.
     #[clap(long)]
     help_stats: bool,
@@ -1486,8 +1494,12 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.has_little_cores = topo.has_little_cores();
         skel.maps.rodata_data.disable_topology = disable_topology;
         skel.maps.rodata_data.xnuma_preemption = opts.xnuma_preemption;
+        skel.maps.rodata_data.antistall_sec = opts.antistall_sec;
         if opts.monitor_disable {
             skel.maps.rodata_data.monitor_disable = opts.monitor_disable;
+        }
+        if opts.disable_antistall {
+            skel.maps.rodata_data.enable_antistall = !opts.disable_antistall;
         }
         for (cpu, sib) in cpu_pool.sibling_cpu.iter().enumerate() {
             skel.maps.rodata_data.__sibling_cpu[cpu] = *sib;


### PR DESCRIPTION
This PR adds a timer to layered that will, once per second, replace dispatch logic with logic to check all DSQs for tasks which have not been ran within the past 5 seconds.

When this check finds such a task, dispatch consumes that DSQ.

This is continued for all runs of dispatch until there are no such tasks.

This makes `stress-ng -c 80 -M --affinity 80 -t 60` (which reproduces stalls on my machine on main) not reproduce stalls.

![Screenshot_20241104_133231](https://github.com/user-attachments/assets/9281f677-d75d-47c3-9435-76cd4b12622c)

The configs used were:
```
❯ cat repos/layered-config.json 
[
{
  "name":"patso",
  "comment":"patso user",
  "matches":[
     [{"UIDEquals":1000}]
  ],
  "kind": {
    "Open":{
      "slice_us": 1000,
      "preempt": false,
      "preempt_first": false,
      "exclusive": false,
      "weight": 100
     }
  }
},{
  "name":"stress-ng",
  "comment":"stress-ng slice",
  "matches":[
     [
	    {"CommPrefix":"stress-ng"}
     ],[
	    {"PcommPrefix":"stress-ng"}
     ]],
  "kind": {
    "Open":{
      "slice_us": 1000,
      "preempt": false,
      "preempt_first": false,
      "exclusive": false,
      "weight": 100
     }
  }
},
{
  "name":"normal",
  "comment":"the rest",
  "matches":[[]],
  "kind":{
    "Open": {
      "slice_us": 1000,
      "preempt": false,
      "preempt_first": false,
      "exclusive": false,
      "weight": 200
    }
  }
}]

❯ cat repos/new-layered-config.json 
[
  {
    "name": "random",
    "comment": "random threads",
    "matches": [
      [
        {
          "CommPrefix": "dontmatter"
        }
      ],
      [
        {
          "CommPrefix": "DONTMATTER"
        }
      ]
    ],
    "kind": {
      "Open": {
        "min_exec_us": 0,
        "slice_us": 1000,
        "preempt": false,
        "exclusive": false,
        "growth_algo": "Random",
        "weight": 200
      }
    }
},
  {
    "name": "all",
    "comment": "all threads",
    "matches": [
      []
    ],
    "kind": {
      "Open": {
        "min_exec_us": 50,
        "slice_us": 1000,
        "preempt": false,
        "exclusive": false,
        "growth_algo": "Random",
        "weight": 100
      }
    }
  }
]

```

Note -- this does not fix this issue when run-example config is used with that stress test. I *think* weights working properly with fallbacks solves that though (and that is another thing WIP), because I think the issue with that is that it effectively dumps all load into a single layer (i.e. I think this could fix it if timer frequency was higher, but also like, that effectively caps the ability to prioritize so weights are probably better for preventing stalls in the "bad config" case).
```
DEBUG DUMP
================================================================================

stress-ng-cpu[191725] triggered exit kind 1026:
  runnable task stall (watchdog failed to check in for 30.004s)

Backtrace:
  scx_tick+0x81/0x90
  sched_tick+0xdf/0x2d0
  update_process_times+0x96/0xb0
  tick_nohz_handler+0x8b/0x130
  __hrtimer_run_queues+0x11b/0x280
  hrtimer_interrupt+0xfa/0x230
  __sysvec_apic_timer_interrupt+0x4f/0x110
  sysvec_apic_timer_interrupt+0x38/0x90
  asm_sysvec_apic_timer_interrupt+0x1a/0x20

LAYER[0][batch] nr_cpus=2 nr_queued=26 -22963ms cpus=01......|........|........|........|
LAYER[1][immediate] nr_cpus=1 nr_queued=0 -0ms cpus=
LAYER[2][stress-ng] nr_cpus=27 nr_queued=0 -0ms cpus=
LAYER[3][normal] nr_cpus=2 nr_queued=101 -24731ms cpus=
HI_FALLBACK[1024] nr_queued=30 -21313ms
LO_FALLBACK nr_queued=0 -0ms
COST GLOBAL[0][batch] budget=8000000000 capacity=8000000000
COST GLOBAL[1][immediate] budget=0 capacity=0
COST GLOBAL[2][stress-ng] budget=0 capacity=0
COST GLOBAL[3][normal] budget=0 capacity=0
COST CPU[0][0][batch] budget=4999998739034397 capacity=5000000000000000
COST CPU[0][1][batch] budget=5000000000000000 capacity=5000000000000000
COST CPU[0][2][batch] budget=199972794717495 capacity=200000000000000
COST CPU[0][3][batch] budget=4999999494460853 capacity=5000000000000000
COST CPU[1][0][immediate] budget=4999998739034397 capacity=5000000000000000
COST CPU[1][1][immediate] budget=5000000000000000 capacity=5000000000000000
COST CPU[1][2][immediate] budget=199972794717495 capacity=200000000000000
COST CPU[1][3][immediate] budget=4999999494460853 capacity=5000000000000000
COST CPU[2][0][stress-ng] budget=4999998739034397 capacity=5000000000000000
COST CPU[2][1][stress-ng] budget=5000000000000000 capacity=5000000000000000
COST CPU[2][2][stress-ng] budget=199972794717495 capacity=200000000000000
COST CPU[2][3][stress-ng] budget=4999999494460853 capacity=5000000000000000
COST CPU[3][0][normal] budget=4999998739034397 capacity=5000000000000000
COST CPU[3][1][normal] budget=5000000000000000 capacity=5000000000000000
COST CPU[3][2][normal] budget=199972794717495 capacity=200000000000000
COST CPU[3][3][normal] budget=4999999494460853 capacity=5000000000000000
```