### PR TITLE
scx_layered: point costc to global struct when initializing budgets

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/cost.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/cost.bpf.c
@@ -286,13 +286,13 @@ static void initialize_budgets(u64 refresh_intvl_ns)
 		layer_weight_sum += layer->weight;
 	}
 
-	costc = initialize_cost(global, global, false, false, false);
-	if (!costc) {
-		scx_bpf_error("failed to initialize global budget");
-		return;
-	}
-
 	bpf_for(layer_id, 0, nr_layers) {
+		costc = initialize_cost(global, global, false, false, false);
+		if (!costc) {
+			scx_bpf_error("failed to initialize global budget");
+			return;
+		}
+
 		layer = &layers[layer_id];
 		if (!layer) {
 			scx_bpf_error("failed to lookup layer %d", layer_id);


### PR DESCRIPTION
During ```initialize_budgets()``` the ```costc``` pointer is used to initialize the global and local cost structs with the layer weights. However, the code only initializes the global cost struct for the first loop, after which the ```costc``` pointer points to a local cost struct instead. Initialize ```costc``` on every loop to point to the global cost struct and initialize all of its weights.