### PR TITLE
scx_layered: remove ->open from layer struct

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -188,7 +188,6 @@ struct layer {
 	u32			weight;
 
 	int			kind;
-	bool			open;
 	bool			preempt;
 	bool			preempt_first;
 	bool			exclusive;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1356,13 +1356,6 @@ impl<'a> Scheduler<'a> {
                 }
             }
 
-            match &spec.kind {
-                LayerKind::Open { .. } | LayerKind::Grouped { .. } => {
-                    layer.open.write(true);
-                }
-                _ => {}
-            }
-
             perf_set |= layer.perf > 0;
         }
 


### PR DESCRIPTION
The ```struct layer``` that represents each ```scx_layered``` layer includes both an enum ```kind``` that represents whether the layer is open, grouped or confined, and a boolean ```open``` that represents whether the layer can expand past its current CPU mask. Whether the ```open``` variable is set depends completely on its kind, so the variable is not necessary. Remove it and update checks that use it to directly use ```kind``` instead.