### PR TITLE
scx_lavd: fix a performance regression bug (`perf bench -f simple sched messaging`)

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -29,6 +29,7 @@ enum consts_internal  {
 	LAVD_LC_RUNTIME_MAX		= LAVD_TIME_ONE_SEC,
 	LAVD_LC_WEIGHT_BOOST		= 128, /* 2^7 */
 	LAVD_LC_GREEDY_PENALTY		= 20,  /* 20% */
+	LAVD_LC_FREQ_OVER_RUNTIME	= 100,  /* 100x */
 
 	LAVD_SLICE_BOOST_MAX_FT		= 3, /* maximum additional 3x of slice */
 	LAVD_SLICE_BOOST_MAX_STEP	= 6, /* 6 slice exhausitions in a row */

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -259,7 +259,7 @@ static u64 calc_runtime_factor(u64 runtime, u64 weight_ft)
 static u64 calc_freq_factor(u64 freq, u64 weight_ft)
 {
 	u64 ft = sigmoid_u64(freq, LAVD_LC_FREQ_MAX);
-	return (ft * weight_ft) + 1;
+	return (ft * weight_ft * LAVD_LC_FREQ_OVER_RUNTIME) + 1;
 }
 
 static u64 calc_weight_factor(struct task_struct *p, struct task_ctx *taskc,
@@ -367,7 +367,7 @@ static void calc_virtual_deadline_delta(struct task_struct *p,
 	greedy_ratio = calc_greedy_ratio(taskc);
 	greedy_ft = calc_greedy_factor(greedy_ratio);
 
-	deadline = (taskc->run_time_ns / lat_cri) * greedy_ft;
+	deadline = (LAVD_SLICE_MAX_NS / lat_cri) * greedy_ft;
 	taskc->vdeadline_delta_ns = deadline;
 }
 


### PR DESCRIPTION
Two changes are incorporated to fix the performance regression in `perf bench -f simple sched messaging`.

- Avoid self-IPI at preemption: sending a self-IPI can trigger immediate preemption but it imposes prohibitive overhead in some workloads. So let's go back to the old way, resetting task's time slice to zero.
- 
- Deprioritize a long runtime by prioritizing frequencies further: directly using runtime gives too much penalty so penalize the long runtime task indirectly by prioritizing frequencies.