### PR TITLE
add CONFIG_IKCONFIG to ci Kconfig and bump cache ver

### DIFF
--- a/.github/workflows/bpf-next-test.yml
+++ b/.github/workflows/bpf-next-test.yml
@@ -33,7 +33,7 @@ jobs:
             linux/arch/x86/boot/bzImage
             linux/usr/include
             linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-bpf
+          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-bpf-1
 
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
         uses: ./.github/actions/install-deps-action
@@ -111,7 +111,7 @@ jobs:
             linux/arch/x86/boot/bzImage
             linux/usr/include
             linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-bpf
+          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-bpf-1
 
       # need to re-run job when kernel head changes between build and test running.
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -49,7 +49,7 @@ jobs:
             linux/arch/x86/boot/bzImage
             linux/usr/include
             linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-4
+          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
 
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
         uses: ./.github/actions/install-deps-action
@@ -131,7 +131,7 @@ jobs:
             linux/arch/x86/boot/bzImage
             linux/usr/include
             linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-4
+          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
 
       # need to re-run job when kernel head changes between build and test running.
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
@@ -220,7 +220,7 @@ jobs:
             linux/arch/x86/boot/bzImage
             linux/usr/include
             linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-4
+          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
 
       # need to re-run job when kernel head changes between build and test running.
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
@@ -294,7 +294,7 @@ jobs:
             linux/arch/x86/boot/bzImage
             linux/usr/include
             linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-4
+          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
 
       # need to re-run job when kernel head changes between build and test running.
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
@@ -337,7 +337,7 @@ jobs:
             linux/arch/x86/boot/bzImage
             linux/usr/include
             linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-4
+          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
 
       # need to re-run job when kernel head changes between build and test running.
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}

--- a/.github/workflows/sched-ext.config
+++ b/.github/workflows/sched-ext.config
@@ -55,3 +55,5 @@ CONFIG_DEBUG_FS=y
 # more bpftrace to make that work
 CONFIG_IKHEADERS=y
 CONFIG_IKCONFIG_PROC=y
+CONFIG_IKCONFIG=y
+


### PR DESCRIPTION
add CONFIG_IKCONFIG to ci Kconfig to enable CONFIG_IKCONFIG_PROC and bump cache ver so new kernels are build for CI with this.

