### PR TITLE
scx_layered: Fix verifier issue when tracing

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/cost.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/cost.bpf.c
@@ -398,7 +398,7 @@ static void initialize_budgets(u64 refresh_intvl_ns)
 			layer_weight_dur = (HI_FALLBACK_DSQ_WEIGHT * slice_ns * refresh_intvl_ns) /
 					    layer_weight_sum;
 			initialize_budget(costc, budget_id, (s64)layer_weight_dur);
-			if (cpu == 0 && llc_id == 0)
+			if (cpu == 0 && llc_id == 0 && budget_id < MAX_GLOBAL_BUDGETS)
 				trace("COST CPU DSQ[%d][%d] budget %lld",
 				      cpu, budget_id, costc->budget[budget_id]);
 		}


### PR DESCRIPTION
```
$ cargo build --release && sudo ./target/release/scx_layered  --run-example -vvv
14:44:59 [DEBUG] layer: batch algo: Sticky core order: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39]
14:44:59 [DEBUG] layer: immediate algo: Sticky core order: [36, 37, 38, 39, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35]
14:44:59 [DEBUG] layer: stress-ng algo: Topo core order: [33, 5, 36, 14, 31, 18, 24, 12, 35, 9, 39, 16, 30, 2, 32, 8, 38, 13, 22, 15, 23, 6, 25, 11, 27, 10, 28, 17, 20, 3, 37, 7, 26, 4, 21, 1, 34, 19, 29, 0]
14:44:59 [DEBUG] layer: normal algo: Linear core order: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39]
14:44:59 [INFO] Layered Scheduler Attached. Run `scx_layered --monitor` for metrics.
14:44:59 [TRACE] layer-batch adding 2 CPUs to 0 CPUs
14:44:59 [TRACE] batch grew, adjusted=1
14:44:59 [TRACE] layer-batch adding 2 CPUs to 2 CPUs
14:44:59 [TRACE] batch grew, adjusted=2
14:44:59 [TRACE] layer-batch adding 2 CPUs to 4 CPUs
14:44:59 [TRACE] batch grew, adjusted=3
14:44:59 [TRACE] batch done resizing, adjusted=3
14:44:59 [TRACE] layer-normal adding 2 CPUs to 0 CPUs
14:44:59 [TRACE] normal grew, adjusted=1
14:44:59 [TRACE] normal done resizing, adjusted=1
14:44:59 [TRACE] layer-batch adding 2 CPUs to 6 CPUs
14:44:59 [TRACE] batch grew, adjusted=1
14:44:59 [TRACE] batch done resizing, adjusted=1
14:44:59 [TRACE] layer-normal adding 2 CPUs to 2 CPUs
14:44:59 [TRACE] normal grew, adjusted=1
14:44:59 [TRACE] normal done resizing, adjusted=1
^CEXIT: Scheduler unregistered from user space
14:45:00 [DEBUG] listener exiting
14:45:00 [DEBUG] proxy: add_res disconnected, terminating
```