### PR TITLE
scx_loader: tune scx_bpfland default options

### DIFF
--- a/rust/scx_loader/src/config.rs
+++ b/rust/scx_loader/src/config.rs
@@ -163,8 +163,8 @@ fn get_default_sched_for_config(scx_sched: &SupportedSched) -> Sched {
 fn get_default_scx_flags_for_mode(scx_sched: &SupportedSched, sched_mode: SchedMode) -> Vec<&str> {
     match scx_sched {
         SupportedSched::Bpfland => match sched_mode {
-            SchedMode::Gaming => vec!["-k", "-m", "performance"],
-            SchedMode::LowLatency => vec!["--lowlatency"],
+            SchedMode::Gaming => vec!["-m", "performance"],
+            SchedMode::LowLatency => vec!["-k", "-s", "5000", "-l", "5000"],
             SchedMode::PowerSave => vec!["-m", "powersave"],
             SchedMode::Auto => vec![],
         },
@@ -190,8 +190,8 @@ default_mode = "Auto"
 
 [scheds.scx_bpfland]
 auto_mode = []
-gaming_mode = ["-k", "-m", "performance"]
-lowlatency_mode = ["--lowlatency"]
+gaming_mode = ["-m", "performance"]
+lowlatency_mode = ["-k", "-s", "5000", "-l", "5000"]
 powersave_mode = ["-m", "powersave"]
 
 [scheds.scx_rusty]


### PR DESCRIPTION
With the recent rework of scx_bpfland the default options for the different profiles in scx_loader are not valid anymore.

Update them with some appropriate options.