### PR TITLE
scx_layered: Fix verifier issue on older kernels

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/cost.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/cost.bpf.c
@@ -122,7 +122,8 @@ static struct cost *initialize_cost(u32 cost_idx, u32 parent_idx,
 /*
  * Initializes a budget.
  */
-static void initialize_budget(struct cost *costc, u32 budget_id, s64 capacity)
+static __noinline void initialize_budget(struct cost *costc, u32 budget_id,
+					 s64 capacity)
 {
 	if (budget_id >= MAX_GLOBAL_BUDGETS) {
 		scx_bpf_error("invalid budget id %d", budget_id);


### PR DESCRIPTION
On some older kernels layered fails to validate. Prevent certain helpers from being inlined to pass the verifier.