### PR TITLE
scx_layered: Fix error in dispatch consumption

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/cost.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/cost.bpf.c
@@ -280,7 +280,7 @@ int record_cpu_cost(struct cost *costc, u32 budget_id, s64 amount)
 /*
  * Returns the slice_ns of a layer if there is appropriate budget.
  */
-int has_budget(struct cost *costc, struct layer *layer)
+__weak int has_budget(struct cost *costc, struct layer *layer)
 {
 	if (!layer || !costc) {
 		scx_bpf_error("can't happen");

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1392,7 +1392,7 @@ __weak int consume_non_open(struct cost *costc, s32 cpu, u32 my_llc_id)
 
 		struct cpumask *layer_cpumask;
 		if (!(layer_cpumask = lookup_layer_cpumask(layer_idx)))
-			return 0;
+			return -ENOENT;
 		if (!bpf_cpumask_test_cpu(cpu, layer_cpumask) &&
 		    (cpu > nr_possible_cpus || cpu != fallback_cpu || layer->nr_cpus != 0))
 			continue;


### PR DESCRIPTION
Fix bug is consume_non_open where it improperly returns 0 when the DSQ is not consumed due to the layer mask not being found.