### PR TITLE
scx_layered: Fix dump format

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2286,12 +2286,12 @@ int dump_cost(void)
 
 	// Per CPU costs
 	bpf_for(i, 0, nr_possible_cpus) {
-		if (!(costc = lookup_cpu_cost(j))) {
+		if (!(costc = lookup_cpu_cost(i))) {
 			scx_bpf_error("unabled to lookup layer %d", i);
 			continue;
 		}
 		bpf_for(j, 0, nr_layers) {
-			layer = lookup_layer(i);
+			layer = lookup_layer(j);
 			if (!layer) {
 				scx_bpf_error("unabled to lookup layer %d", i);
 				continue;


### PR DESCRIPTION
Fix a small bug where incorrect per CPU costs were being dumped. The output format should now appropriately match the per-CPU costs. The following dump shows the correct format:

    HI_FALLBACK[1024] nr_queued=46 -25755ms
    HI_FALLBACK[1025] nr_queued=43 -25947ms
    LO_FALLBACK nr_queued=0 -0ms
    COST GLOBAL[0][random] budget=16791955959896739
    capacity=16791955959896739
    COST GLOBAL[1][hodgesd] budget=16791955959896739
    capacity=16791955959896739
    COST GLOBAL[2][stress-ng] budget=43243243243243243
    capacity=43243243243243243
    COST GLOBAL[3][normal] budget=33583911919793478
    capacity=33583911919793478
    COST FALLBACK[1024][0] budget=16791955959896739
    capacity=16791955959896739
    COST FALLBACK[1025][1] budget=16791955959896739
    capacity=16791955959896739
    COST CPU[0][0][random] budget=5405405405405405 capacity=5405405405405405
    COST CPU[0][1][hodgesd] budget=2702702694605435
    capacity=2702702702702702
    COST CPU[0][2][stress-ng] budget=540514231324919
    capacity=540540540540540
    COST CPU[0][3][normal] budget=5405405342325615 capacity=5405405405405405
    COST CPU[0]FALLBACK[0][1024] budget=0 capacity=5405405405405405
    COST CPU[0]FALLBACK[1][1025] budget=1 capacity=2702702694605435
    COST CPU[1][0][random] budget=5405405405405405 capacity=5405405405405405
    COST CPU[1][1][hodgesd] budget=2702702675501951
    capacity=2702702702702702
    COST CPU[1][2][stress-ng] budget=540514250569731
    capacity=540540540540540