### PR TITLE
scx_layered: Fix cost accounting for fallback dsqs

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/cost.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/cost.bpf.h
@@ -15,8 +15,8 @@
 
 enum cost_consts {
 	COST_GLOBAL_KEY		= 0,
-	HI_FALLBACK_DSQ_WEIGHT	= 50,
-	LO_FALLBACK_DSQ_WEIGHT	= 10,
+	HI_FALLBACK_DSQ_WEIGHT	= 95,
+	LO_FALLBACK_DSQ_WEIGHT	= 85,
 
 	/*
 	 * Max global budgets map fallback DSQs (per LLC) as well as layers.


### PR DESCRIPTION
Fix cost accounting for fallback DSQs on refresh that DSQ budgets get refilled appropriately. Previously there were no budgets for fallback DSQs so they couldn't be used for any sort of cost/weight calculation. Add helper functions for converting to and from a DSQ id to a LLC budget id. 

During preemption a layer should check if it is attempting to preempt from a layer that has more budget and only preempt if the preempting layer has more budget. This greatly reduces the potential for stalls when a machine is close to saturation.