### PR TITLE
layered: split out common parts of LayerKind

### DIFF
--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -41,20 +41,20 @@ impl LayerSpec {
         Ok(config.specs)
     }
 
-    pub fn nodes(&self) -> Vec<usize> {
-        match &self.kind {
-            LayerKind::Confined { nodes, .. }
-            | LayerKind::Open { nodes, .. }
-            | LayerKind::Grouped { nodes, .. } => nodes.clone(),
-        }
+    pub fn nodes(&self) -> &Vec<usize> {
+        &self.kind.common().nodes
     }
 
-    pub fn llcs(&self) -> Vec<usize> {
-        match &self.kind {
-            LayerKind::Confined { llcs, .. }
-            | LayerKind::Open { llcs, .. }
-            | LayerKind::Grouped { llcs, .. } => llcs.clone(),
-        }
+    pub fn llcs(&self) -> &Vec<usize> {
+        &self.kind.common().llcs
+    }
+
+    pub fn nodes_mut(&mut self) -> &mut Vec<usize> {
+        &mut self.kind.common_mut().nodes
+    }
+
+    pub fn llcs_mut(&mut self) -> &mut Vec<usize> {
+        &mut self.kind.common_mut().llcs
     }
 }
 
@@ -74,90 +74,54 @@ pub enum LayerMatch {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LayerCommon {
+    #[serde(default)]
+    pub min_exec_us: u64,
+    #[serde(default)]
+    pub yield_ignore: f64,
+    #[serde(default)]
+    pub slice_us: u64,
+    #[serde(default)]
+    pub preempt: bool,
+    #[serde(default)]
+    pub preempt_first: bool,
+    #[serde(default)]
+    pub exclusive: bool,
+    #[serde(default)]
+    pub weight: u32,
+    #[serde(default)]
+    pub idle_smt: bool,
+    #[serde(default)]
+    pub growth_algo: LayerGrowthAlgo,
+    #[serde(default)]
+    pub perf: u64,
+    #[serde(default)]
+    pub nodes: Vec<usize>,
+    #[serde(default)]
+    pub llcs: Vec<usize>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum LayerKind {
     Confined {
         util_range: (f64, f64),
         #[serde(default)]
         cpus_range: Option<(usize, usize)>,
-        #[serde(default)]
-        min_exec_us: u64,
-        #[serde(default)]
-        yield_ignore: f64,
-        #[serde(default)]
-        slice_us: u64,
-        #[serde(default)]
-        preempt: bool,
-        #[serde(default)]
-        preempt_first: bool,
-        #[serde(default)]
-        exclusive: bool,
-        #[serde(default)]
-        weight: u32,
-        #[serde(default)]
-        idle_smt: bool,
-        #[serde(default)]
-        growth_algo: LayerGrowthAlgo,
-        #[serde(default)]
-        perf: u64,
-        #[serde(default)]
-        nodes: Vec<usize>,
-        #[serde(default)]
-        llcs: Vec<usize>,
+
+        #[serde(flatten)]
+        common: LayerCommon,
     },
     Grouped {
         util_range: (f64, f64),
         #[serde(default)]
         cpus_range: Option<(usize, usize)>,
-        #[serde(default)]
-        min_exec_us: u64,
-        #[serde(default)]
-        yield_ignore: f64,
-        #[serde(default)]
-        slice_us: u64,
-        #[serde(default)]
-        preempt: bool,
-        #[serde(default)]
-        preempt_first: bool,
-        #[serde(default)]
-        exclusive: bool,
-        #[serde(default)]
-        weight: u32,
-        #[serde(default)]
-        idle_smt: bool,
-        #[serde(default)]
-        growth_algo: LayerGrowthAlgo,
-        #[serde(default)]
-        perf: u64,
-        #[serde(default)]
-        nodes: Vec<usize>,
-        #[serde(default)]
-        llcs: Vec<usize>,
+
+        #[serde(flatten)]
+        common: LayerCommon,
     },
     Open {
-        #[serde(default)]
-        min_exec_us: u64,
-        #[serde(default)]
-        yield_ignore: f64,
-        #[serde(default)]
-        slice_us: u64,
-        #[serde(default)]
-        preempt: bool,
-        #[serde(default)]
-        preempt_first: bool,
-        #[serde(default)]
-        exclusive: bool,
-        #[serde(default)]
-        weight: u32,
-        #[serde(default)]
-        idle_smt: bool,
-        #[serde(default)]
-        growth_algo: LayerGrowthAlgo,
-        #[serde(default)]
-        perf: u64,
-        #[serde(default)]
-        nodes: Vec<usize>,
-        #[serde(default)]
-        llcs: Vec<usize>,
+        #[serde(flatten)]
+        common: LayerCommon,
     },
 }
 
@@ -167,6 +131,22 @@ impl LayerKind {
             LayerKind::Confined { .. } => bpf_intf::layer_kind_LAYER_KIND_CONFINED as i32,
             LayerKind::Grouped { .. } => bpf_intf::layer_kind_LAYER_KIND_GROUPED as i32,
             LayerKind::Open { .. } => bpf_intf::layer_kind_LAYER_KIND_OPEN as i32,
+        }
+    }
+
+    pub fn common(&self) -> &LayerCommon {
+        match self {
+            LayerKind::Confined { common, .. }
+            | LayerKind::Grouped { common, .. }
+            | LayerKind::Open { common, .. } => common,
+        }
+    }
+
+    pub fn common_mut(&mut self) -> &mut LayerCommon {
+        match self {
+            LayerKind::Confined { common, .. }
+            | LayerKind::Grouped { common, .. }
+            | LayerKind::Open { common, .. } => common,
         }
     }
 }

--- a/scheds/rust/scx_layered/src/lib.rs
+++ b/scheds/rust/scx_layered/src/lib.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeMap;
 use anyhow::bail;
 use anyhow::Result;
 use bitvec::prelude::*;
+pub use config::LayerCommon;
 pub use config::LayerConfig;
 pub use config::LayerKind;
 pub use config::LayerMatch;

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -25,7 +25,6 @@ use serde::Serialize;
 use crate::bpf_intf;
 use crate::BpfStats;
 use crate::Layer;
-use crate::LayerKind;
 use crate::Stats;
 
 fn fmt_pct(v: f64) -> String {
@@ -174,12 +173,6 @@ impl LayerStats {
             if b != 0.0 { a / b * 100.0 } else { 0.0 }
         };
 
-        let is_excl = match &layer.kind {
-            LayerKind::Confined { exclusive, .. }
-            | LayerKind::Grouped { exclusive, .. }
-            | LayerKind::Open { exclusive, .. } => *exclusive,
-        } as u32;
-
         Self {
             util: stats.layer_utils[lidx] * 100.0,
             util_frac: calc_frac(stats.layer_utils[lidx], stats.total_util),
@@ -206,7 +199,7 @@ impl LayerStats {
             keep: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_KEEP),
             keep_fail_max_exec: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_KEEP_FAIL_MAX_EXEC),
             keep_fail_busy: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_KEEP_FAIL_BUSY),
-            is_excl,
+            is_excl: layer.kind.common().exclusive as u32,
             excl_collision: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_EXCL_COLLISION),
             excl_preempt: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_EXCL_PREEMPT),
             kick: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_KICK),


### PR DESCRIPTION

We duplicate the definition of most fields in every layer kind. This makes
reading the config harder than it needs to be, and turns every simple read of a
common field into a `match` statement that is largely redundant.

Utilise `#[serde(flatten)]` to embed a common struct into each of the LayerKind
variants. Rather than matching on the type this can be directly accessed with
`.kind.common()` and `.kind.common_mut()`. Alternatively, you can extend
existing matches to match out the common parts as demonstrated in this diff
where necessary.

There is some further code cleanup that can be done in the changed read sites,
but I wanted to make it clear that this change doesn't change behaviour, so
tried to make these changes in the least obtrusive way.

Drive-by: fix the formatting of the lazy_static section in main.rs by using
`lazy_static::lazy_static`.

Test plan:
```
# main
$ cargo build --release && target/release/scx_layered --example /tmp/test_old.json
# this change
$ cargo build --release && target/release/scx_layered --example /tmp/test_new.json
$ diff /tmp/test_{old,new}.json
# no diff
```
