### PR TITLE
[RFC] scx_layered: Add netdev IRQ balancing

### DIFF
--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -68,7 +68,7 @@ use std::ops::BitOrAssign;
 use std::ops::BitXor;
 use std::ops::BitXorAssign;
 
-#[derive(Debug, Eq, Clone, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Eq, Clone, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Cpumask {
     mask: BitVec<u64, Lsb0>,
 }
@@ -144,6 +144,10 @@ impl Cpumask {
         Self {
             mask: BitVec::from_vec(vec),
         }
+    }
+
+    pub fn from_bitvec(bitvec: BitVec<u64, Lsb0>) -> Self {
+        Self { mask: bitvec }
     }
 
     /// Return a slice of u64's whose bits reflect the Cpumask.

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -88,5 +88,9 @@ pub use misc::monitor_stats;
 pub use misc::normalize_load_metric;
 pub use misc::set_rlimit_infinity;
 
+mod netdev;
+pub use netdev::read_netdevs;
+pub use netdev::NetDev;
+
 pub mod enums;
 pub use enums::scx_enums;

--- a/rust/scx_utils/src/netdev.rs
+++ b/rust/scx_utils/src/netdev.rs
@@ -13,13 +13,31 @@ use anyhow::Result;
 
 #[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NetDev {
-    pub iface: String,
-    pub node: usize,
+    iface: String,
+    node: usize,
     pub irqs: BTreeMap<usize, Cpumask>,
-    pub irq_hints: BTreeMap<usize, Cpumask>,
+    irq_hints: BTreeMap<usize, Cpumask>,
 }
 
 impl NetDev {
+    pub fn iface(&self) -> &str {
+        &self.iface
+    }
+
+    pub fn node(&self) -> usize {
+        self.node
+    }
+
+    pub fn irq_hints(&self) -> &BTreeMap<usize, Cpumask> {
+        &self.irq_hints
+    }
+
+    pub fn update_irq_cpumask(&mut self, irq: usize, cpumask: Cpumask) {
+        if let Some(cur_cpumask) = self.irqs.get_mut(&irq) {
+            *cur_cpumask = cpumask;
+        }
+    }
+
     pub fn apply_cpumasks(&self) -> Result<()> {
         for (irq, cpumask) in self.irqs.iter() {
             let irq_path = format!("/proc/irq/{}/smp_affinity", irq);

--- a/rust/scx_utils/src/netdev.rs
+++ b/rust/scx_utils/src/netdev.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use crate::misc::read_file_usize;
+use crate::Cpumask;
+use anyhow::Result;
+
+#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct NetDev {
+    pub iface: String,
+    pub node: usize,
+    pub irqs: BTreeMap<usize, Cpumask>,
+    pub irq_hints: BTreeMap<usize, Cpumask>,
+}
+
+impl NetDev {
+    pub fn apply_cpumasks(&self) -> Result<()> {
+        for (irq, cpumask) in self.irqs.iter() {
+            let irq_path = format!("/proc/irq/{}/smp_affinity", irq);
+            fs::write(irq_path, format!("{:#x}", cpumask))?
+        }
+        Ok(())
+    }
+}
+
+pub fn read_netdevs() -> Result<BTreeMap<String, NetDev>> {
+    let mut netdevs: BTreeMap<String, NetDev> = BTreeMap::new();
+
+    for entry in fs::read_dir("/sys/class/net")? {
+        let entry = entry?;
+        let iface = entry.file_name().to_string_lossy().into_owned();
+        let raw_path = format!("/sys/class/net/{}/device/msi_irqs", iface);
+        let msi_irqs_path = Path::new(&raw_path);
+        if !msi_irqs_path.exists() {
+            continue;
+        }
+
+        let node_path_raw = format!("/sys/class/net/{}/device/node", iface);
+        let node_path = Path::new(&node_path_raw);
+        let node = read_file_usize(node_path).unwrap_or(0);
+        let mut irqs = BTreeMap::new();
+        let mut irq_hints = BTreeMap::new();
+
+        for entry in fs::read_dir(msi_irqs_path)? {
+            let entry = entry.unwrap();
+            let irq = entry.file_name().to_string_lossy().into_owned();
+            if let Ok(irq) = irq.parse::<usize>() {
+                let affinity_raw_path = format!("/proc/irq/{}/smp_affinity", irq);
+                let smp_affinity_path = Path::new(&affinity_raw_path);
+                let smp_affinity = fs::read_to_string(smp_affinity_path)?
+                    .replace(",", "")
+                    .replace("\n", "");
+                let cpumask = Cpumask::from_str(&smp_affinity)?;
+                irqs.insert(irq, cpumask);
+
+                // affinity hints
+                let affinity_hint_raw_path = format!("/proc/irq/{}/affinity_hint", irq);
+                let affinity_hint_path = Path::new(&affinity_hint_raw_path);
+                let affinity_hint = fs::read_to_string(affinity_hint_path)?
+                    .replace(",", "")
+                    .replace("\n", "");
+                let hint_cpumask = Cpumask::from_str(&affinity_hint)?;
+                irq_hints.insert(irq, hint_cpumask);
+            }
+        }
+        netdevs.insert(
+            iface.clone(),
+            NetDev {
+                iface,
+                node,
+                irqs,
+                irq_hints,
+            },
+        );
+    }
+    Ok(netdevs)
+}

--- a/scheds/rust/scx_layered/src/lib.rs
+++ b/scheds/rust/scx_layered/src/lib.rs
@@ -222,6 +222,15 @@ impl CpuPool {
         Ok(Some(&self.core_cpus[core]))
     }
 
+    pub fn available_cpus(&self) -> BitVec<u64, Lsb0> {
+        let mut cpus = bitvec![u64, Lsb0; 0; self.nr_cpus];
+        for core in self.available_cores.iter_ones() {
+            let core_cpus = self.core_cpus[core].clone();
+            cpus |= core_cpus.as_bitslice();
+        }
+        cpus
+    }
+
     pub fn available_cpus_in_mask(&self, allowed_cpus: &BitVec) -> BitVec {
         let mut cpus = bitvec![0; self.nr_cpus];
         for core in self.available_cores.iter_ones() {

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -44,6 +44,7 @@ use scx_utils::compat;
 use scx_utils::import_enums;
 use scx_utils::init_libbpf_logging;
 use scx_utils::ravg::ravg_read;
+use scx_utils::read_netdevs;
 use scx_utils::scx_enums;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
@@ -53,6 +54,7 @@ use scx_utils::uei_report;
 use scx_utils::Cache;
 use scx_utils::CoreType;
 use scx_utils::LoadAggregator;
+use scx_utils::NetDev;
 use scx_utils::Topology;
 use scx_utils::UserExitInfo;
 use stats::LayerStats;
@@ -470,6 +472,10 @@ struct Opts {
     /// Disable antistall
     #[clap(long, default_value = "false")]
     disable_antistall: bool,
+
+    /// Enable netdev IRQ balancing
+    #[clap(long, default_value = "false")]
+    netdev_irq_balance: bool,
 
     /// Maximum task runnable_at delay (in seconds) before antistall turns on
     #[clap(long, default_value = "3")]
@@ -1215,6 +1221,7 @@ struct Scheduler<'a> {
     nr_layer_cpus_ranges: Vec<(usize, usize)>,
     processing_dur: Duration,
 
+    netdevs: BTreeMap<String, NetDev>,
     stats_server: StatsServer<StatsReq, StatsRes>,
 }
 
@@ -1403,6 +1410,11 @@ impl<'a> Scheduler<'a> {
         } else {
             Topology::new()?
         };
+        let netdevs = if opts.netdev_irq_balance {
+            read_netdevs()?
+        } else {
+            BTreeMap::new()
+        };
 
         if !disable_topology {
             if topo.nodes().len() == 1 && topo.nodes()[0].llcs().len() == 1 {
@@ -1529,6 +1541,7 @@ impl<'a> Scheduler<'a> {
             proc_reader,
             skel,
 
+            netdevs,
             stats_server,
         };
 
@@ -1546,6 +1559,26 @@ impl<'a> Scheduler<'a> {
             }
         }
         bpf_layer.refresh_cpus = 1;
+    }
+
+    fn update_netdev_cpumasks(&mut self) -> Result<()> {
+        let available_cpus = self.cpu_pool.available_cpus();
+        if available_cpus.is_empty() {
+            return Ok(());
+        }
+
+        for (iface, netdev) in self.netdevs.iter_mut() {
+            for (irq, irqmask) in netdev.irqs.iter_mut() {
+                irqmask.clear();
+                for cpu in available_cpus.iter_ones() {
+                    let _ = irqmask.set_cpu(cpu);
+                }
+                trace!("{} updating irq {} cpumask {:?}", iface, irq, irqmask);
+            }
+            netdev.apply_cpumasks()?;
+        }
+
+        Ok(())
     }
 
     fn set_bpf_layer_preemption(layer: &mut Layer, bpf_layer: &mut types::layer, preempt: bool) {
@@ -1662,6 +1695,7 @@ impl<'a> Scheduler<'a> {
             }
         }
 
+        let _ = self.update_netdev_cpumasks();
         Ok(())
     }
 


### PR DESCRIPTION
Add support for netdev IRQ balancing on available CPUs . This adds a module to the `scx_utils` crate that parses network devices and is able to update the associated IRQ affinity masks. This idea is was inspired from conversations with @danobi.

After running layered with the flag enabled IRQs from watching `/proc/interrupts` are balanced across available CPUs from the scheduler's perspective. This can be observed where the large number of interrupts were routed to single cores.
```
            CPU0       CPU1       CPU2       CPU3       CPU4       CPU5       CPU6       CPU7       CPU8       CPU9       CPU10      CPU11
 168:          0          0          0          0          0          0          0          0          0          0          1          0  PCI-MSIX-0000:56:00.0    0-edge      eth1
 171:          0          0          0      63185          0          0          0          0          0          0          0    2651043  PCI-MSIX-0000:56:00.0    1-edge      eth1-TxRx-0
 173:    3314882          0          0          0          0      90830          0          0          0          0          0          0  PCI-MSIX-0000:56:00.0    2-edge      eth1-TxRx-1
 175:          0    3670760          0          0      84690          0          0          0          0          0          0          0  PCI-MSIX-0000:56:00.0    3-edge      eth1-TxRx-2
 176:          0          0    3721104          0          0          0          0          0          0          0          0          0  PCI-MSIX-0000:56:00.0    4-edge      eth1-TxRx-3
 ```
 
 This is a very crude implementation and does not take into account hinted affinity, which can be added later.