### PR TITLE
scx_layered: Cleanups around topology handling

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -112,6 +112,7 @@ struct cpu_ctx {
 	u64			gstats[NR_GSTATS];
 	u64			lstats[MAX_LAYERS][NR_LSTATS];
 	u64			ran_current_for;
+	u64			hi_fallback_dsq_id;
 	u32			layer_idx;
 	u32			cache_idx;
 	u32			node_idx;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1183,9 +1183,7 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 		tctx->last_dsq = tctx->layer;
 		scx_bpf_dispatch_vtime(p, tctx->layer, slice_ns, vtime, enq_flags);
 	} else {
-		u32 llc_id = cpu_to_llc_id(tctx->last_cpu >= 0 ? tctx->last_cpu :
-					   bpf_get_smp_processor_id());
-		idx = layer_dsq_id(layer->idx, llc_id);
+		idx = layer_dsq_id(layer->idx, cpu_to_llc_id(task_cpu));
 		tctx->last_dsq = idx;
 		scx_bpf_dispatch_vtime(p, idx, slice_ns, vtime, enq_flags);
 	}
@@ -1241,9 +1239,7 @@ static bool keep_running(struct cpu_ctx *cctx, struct task_struct *p)
 				return true;
 			}
 		} else {
-			u32 dsq_id = cpu_to_llc_id(tctx->last_cpu >= 0 ?
-						   tctx->last_cpu :
-						   bpf_get_smp_processor_id());
+			u32 dsq_id = cpu_to_llc_id(bpf_get_smp_processor_id());
 			if (!scx_bpf_dsq_nr_queued(dsq_id)) {
 				p->scx.slice = slice_ns;
 				lstat_inc(LSTAT_KEEP, layer, cctx);


### PR DESCRIPTION
- Fix a couple bugs around layer -> DSQ ID mapping.
- Use fields cached in `cpu_ctx` instead of recalculating them repeatedly.
- Supply matching topology information when `--disable-topology` is specified so that it matches how the scheduler is going to behave. Reduce code branches.