### PR TITLE
verifier workarounds

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2541,7 +2541,7 @@ u64 antistall_set(u64 dsq_id, u64 jiffies_now)
 look_for_cpu:
 		bpf_for(cpu, 0, nr_possible_cpus) {
 			const struct cpumask *cpumask;
-			
+
 			if (!(cpumask = cast_mask(tctx->layered_mask)))
 				goto unlock;
 

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2549,9 +2549,9 @@ look_for_cpu:
 			if (bpf_cpumask_empty(cpumask) && tctx->task_cpumask)
 				cpumask = cast_mask(tctx->task_cpumask);
 
-			if (cpumask && !bpf_cpumask_test_cpu(cpu, cpumask)) {
+			if (cpumask && !bpf_cpumask_test_cpu(cpu, cpumask))
 				continue;
-			}
+			
 
 			antistall_dsq = bpf_map_lookup_percpu_elem(&antistall_cpu_dsq, &zero, cpu);
 			delay = bpf_map_lookup_percpu_elem(&antistall_cpu_max_delay, &zero, cpu);


### PR DESCRIPTION
make scx code work on older kernel code in the for-next branch of the sched_ext kernel tree.