### PR TITLE
layered: track per LLC layer latency to increase stickiness

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -189,6 +189,9 @@ struct layer {
 	u64			slice_ns;
 	u32			weight;
 
+	u64			steal_minimum_abs_ns;
+	u32			steal_minimum_rel;
+
 	int			kind;
 	bool			preempt;
 	bool			preempt_first;

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -90,6 +90,10 @@ pub struct LayerCommon {
     #[serde(default)]
     pub weight: u32,
     #[serde(default)]
+    pub steal_minimum_abs_us: u64,
+    #[serde(default)]
+    pub steal_minimum_rel: u32,
+    #[serde(default)]
     pub idle_smt: bool,
     #[serde(default)]
     pub growth_algo: LayerGrowthAlgo,


### PR DESCRIPTION

This change tracks the latency of scheduling (runnable -> running) for tasks in
each layer on each LLC. It limits xLLC memory reads by maintaining a per-CPU
view of both local (per-CPU) latency and the average latency in each LLC.

Primary components:
- Track local latency for each layer using an exponential average of scheduled
  tasks.
- Decay this average with a half life of 1-second on a per-CPU basis to avoid
  making an LLC permanently fail the `should_work_steal` check.
- Collect a mean of local LLC layer latencies before each scheduling decision.
- Collect a mean of remote LLCs once every 10 milliseconds.
- Decide before each work stealing event in layered_dispatch (finding work for
  an idle CPU) whether to steal based on two new layer configuration
  parameters: steal_minimum_abs_us and steal_minimum_rel. Each represents a
  time the work-stealing CPU should be faster at scheduling that layer by than
  the stolen from CPU, in absolute microseconds ANDed with relative 1024ths.
- Minimise extra work when no layers are configured to use this feature by
  gating with a new `const volatile bool`.

There are some hardcoded constants in this change that are arbitrary, including
the weight of new values in the exponential average, the decay rate, and the
frequency of remote LLC updates. These probably need to be made variable to
extract wins on different hardware (and this hardware).

The overhead of this code when enabled is still a little high. It refreshes local
LLC latencies every dispatch which is not free, when it only needs to be done
when first checking whether to dispatch from a foreign LLC, which is hopefully
rare with `local_llc_iteration` enabled. It could also be put on a timer like
updating remote LLC latencies. These changes can be made in follow ups.

Test plan:
- TBD
