### PR TITLE
scx_layered: Fix verifier errors on disable antistall

### DIFF
--- a/.github/actions/install-deps-action/action.yml
+++ b/.github/actions/install-deps-action/action.yml
@@ -23,7 +23,10 @@ runs:
         linux-headers-generic linux-tools-common linux-tools-generic make \
         ninja-build pahole pkg-config python3-dev python3-pip python3-requests \
         qemu-kvm rsync stress-ng udev zstd libseccomp-dev libcap-ng-dev \
-        llvm clang python3-full curl meson bpftrace cargo rustc dwarves
+        llvm libllvm-18-ocaml-dev libllvm18 llvm-18 llvm-18-dev llvm-18-doc \
+        llvm-18-examples llvm-18-runtime clang-18 clang-tools-18 libclang-common-18-dev \
+        libclang-18-dev libclang1-18 lld-18 lldb-18 clang-format-18 python3-clang-18 \
+        python3-full curl meson bpftrace cargo rustc dwarves
       shell: bash
 
     # virtme-ng


### PR DESCRIPTION
On older 6.9 kernels the verifier complains about too many instructions in intitialize_budgets. Make this function global so that it is easier to verify.