### PR TITLE
scx_rustland_core: proactively wake up CPUs when selected by user space

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -730,6 +730,15 @@ int rs_select_cpu(struct task_cpu_arg *input)
 
 	bpf_task_release(p);
 
+	/*
+	 * Wake-up the CPU if idle. Use SCX_KICK_IDLE to prevent unecessary
+	 * rescheduling events in case the CPU is already awake (since we don't
+	 * know exactly what the user-space scheduler is doing we can't
+	 * implicitly assume that the target CPU is idle here).
+	 */
+	if (cpu >= 0)
+		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+
 	return cpu;
 }
 


### PR DESCRIPTION
Automatically wake up an idle CPU when the user-space scheduler selects it via BpfScheduler->select_cpu().

This helps to speed up the enqueue->user-space->dispatch pipeline, particuarly after the pick_next_task() rework in kernel 6.12 and later.

This seems to address issue #788.