### PR TITLE
scx_utils/scx_layered: bump to 1.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "scx_layered"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "scx_utils"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -12,12 +12,12 @@ anyhow = "1.0.65"
 plain = "0.2.3"
 libbpf-rs = "0.24.1"
 libc = "0.2.137"
-scx_utils = { path = "../scx_utils", version = "1.0.6" }
+scx_utils = { path = "../scx_utils", version = "1.0.7" }
 
 [build-dependencies]
 tar = "0.4"
 walkdir = "2.4"
-scx_utils = { path = "../scx_utils", version = "1.0.6" }
+scx_utils = { path = "../scx_utils", version = "1.0.7" }
 
 [lib]
 name = "scx_rustland_core"

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_utils"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_bpfland/Cargo.toml
+++ b/scheds/rust/scx_bpfland/Cargo.toml
@@ -15,12 +15,12 @@ libbpf-rs = "0.24.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.6" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.6" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_flash/Cargo.toml
+++ b/scheds/rust/scx_flash/Cargo.toml
@@ -15,12 +15,12 @@ libbpf-rs = "0.24.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.4" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.4" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.4" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.4" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4.17"
 ordered-float = "3.4.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.6" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.6" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
 static_assertions = "1.1.0"
@@ -29,7 +29,7 @@ plain = "0.2.3"
 gpoint = "0.2"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_layered"
-version = "1.0.6"
+version = "1.0.7"
 authors = ["Tejun Heo <htejun@meta.com>", "Meta"]
 edition = "2021"
 description = "A highly configurable multi-layer BPF / user space hybrid scheduler used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
@@ -21,13 +21,13 @@ libc = "0.2.137"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.6" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.6" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_mitosis/Cargo.toml
+++ b/scheds/rust/scx_mitosis/Cargo.toml
@@ -19,13 +19,13 @@ libbpf-rs = "0.24.1"
 libc = "0.2.137"
 log = "0.4.17"
 maplit = "1.0.2"
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -12,11 +12,11 @@ plain = "0.2.3"
 ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "0.24.1"
 libc = "0.2.137"
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.3" }
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.3" }
 
 [features]

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -19,12 +19,12 @@ ordered-float = "3.4.0"
 serde = { version = "1.0", features = ["derive"] }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.6" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.6" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.3" }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.3" }
 
 [features]

--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -19,14 +19,14 @@ log = "0.4.17"
 ordered-float = "3.4.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.6" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.6" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION

9bdccdd Merge pull request #943 from JakeHillion/pr943
b4b1879 Merge pull request #947 from sirlucjan/scx_loader_update
f2384fe scx_loader: update docs
198f079 Merge pull request #930 from hodgesds/topo-irq
41781fe scx_layered: Add netdev IRQ balancing node support
e30e5d8 scx_utils: Add netdev support
8c09ae2 Merge pull request #942 from CachyOS/feat/loader-add-flash
c258199 replace goto with unrolled loop in antistall_set
d5d4f46 scx_loader: add scx_flash as supported scheduler
489ce8a Merge pull request #939 from sched-ext/htejun/layered-updates
dbcd233 scx_layered: Work around verification failure in antistall_set() on old kernels
61f378c Merge pull request #931 from multics69/lavd-osu
88c7d47 Merge pull request #934 from sched-ext/htejun/layered-updates
aec9e86 Merge branch 'main' into htejun/layered-updates
10bf25a topology, scx_layered: Make --disable-topology handling more consistent
ff0e9c6 Merge pull request #933 from hodgesds/layered-verifier-nested
1869dd8 scx_layered: Fix verifier issues on older kernels
68e1741 scx_layered: Use cached cpu_ctx->hi_fallback_dsq_id and cpu_ctx->cached_idx
827af0b scx_layered: Fix dsq_id indexing bugs
f2c9e7f scx_layered: Don't use tctx->last_cpu when picking target llc
519a27f Merge pull request #932 from sched-ext/htejun/layered-updates
ce30010 scx_layered: Don't limit antistall execution to layered_cpumask
77eec19 Merge pull request #929 from sched-ext/htejun/layered-updates
65b49f8 Merge pull request #928 from purplewall1206/patch-1
8e6e3de Merge branch 'main' into patch-1
a7fcda8 Merge pull request #924 from sched-ext/scx-fair
5b4b6df Merge branch 'main' into scx-fair
3292be7 scx_lavd: Factor the task's runtime more aggressively in  a deadline calculation
56e0dae scx_layered: Fix linter disagreement
93a0bc9 scx_layered: Fix consume_preempting() when --local-llc-iteration
51d4945 scx_layered: Don't call scx_bpf_cpuperf_set() unnecessarily
678b101 scheds: introduce scx_flash
c7faf70 fix compile errors
75dd81e scx_layered: Improve topology aware select_cpu()
2b52d17 scx_layered: Encapsulate per-task layered cpumask caching
1293ae2 scx_layered: Stat output format update
66223bf Merge pull request #926 from JakeHillion/pr926
d35d527 layered: split out common parts of LayerKind
9016416 Merge pull request #925 from hodgesds/layered-lol
1afb7d5 scx_layered: Fix formatting
79125ef Merge pull request #919 from hodgesds/layered-dispatch-local
3a3a7d7 Merge branch 'main' into layered-dispatch-local
db46e27 Merge pull request #923 from hodgesds/layered-dsq-preempt-fix
4fc0509 scx_layered: Add flag to control llc iteration on dispatch
0096c06 scx_layered: Fix cost accounting for dsqs
72f21db Merge pull request #922 from hodgesds/layered-cost-dump-fixes
7631049 Merge pull request #921 from hodgesds/layered-formatting-fix
f7009f7 scx_layered: Fix dump format
ff15f25 scx_layered: Fix formatting
6733168 Merge pull request #918 from hodgesds/layered-slice-helper
775d09a scx_layered: Consume from local LLCs for dispatch
4fb05d9 Merge pull request #920 from hodgesds/layered-consume-fix
b2505e7 Merge branch 'main' into layered-consume-fix
1ed387d scx_layered: Fix error in dispatch consumption
cad3413 scx_layered: Add helper for layer slice duration
835f0d0 Merge pull request #890 from likewhatevs/layered-dsq-timer
89f4aa1 scx_layered: add antistall
38512bf Merge pull request #916 from sched-ext/htejun/scx_layered-verifier-workaround
bb91ad0 scx_layered: Work around older kernels choking on function calls from sleepable progs
5280206 Merge pull request #915 from LohithCV/lavd_doc_err
a2e119a scx_lavd: docs: fix typos
007fed0 Merge pull request #913 from hodgesds/layered-fallback-dump
3b47782 scx_layered: Add fallback costs to dump
73926d6 Merge pull request #912 from hodgesds/layered-mask-cleanup
5ae1b84 Merge pull request #908 from JakeHillion/pr908
ee4fd3d scx_layered: Cleanup cpumask
9a282e0 Merge pull request #911 from hodgesds/layered-idle-smt-cleanup
637fc3f scx_layered: Use layer idle_smt option
f71a9d0 Merge pull request #910 from hodgesds/layered-cost-verifier-fix
7db2ef2 scx_layered: Fix verifier issue on older kernels
ba54808 layered/topo: lift layer specific checks out of per-LLC loop
218cbea Merge pull request #907 from sched-ext/scx-loader-update-bpfland-options
191cc7f scx_loader: tune scx_bpfland default options
416de68 Merge pull request #904 from multics69/lavd-drop-padding
56357a7 Merge pull request #903 from multics69/lavd-issue-897
d7e1f69 Merge pull request #906 from hodgesds/layered-verifier-fix
3cc849f scx_layered: Fix verifier issue when tracing
d6ba3b7 Merge pull request #896 from hodgesds/layered-dsq-cost
487baa4 scx_layered: Add fallback DSQ cost accounting
debe991 Merge pull request #905 from likewhatevs/kconfig-cache-update
27a506f add CONFIG_IKCONFIG to ci Kconfig and bump cache ver
22cb9e9 scx_lavd: drop padding in cpdom_cpumask, which was a workaround
e9ba2d5 scx_lavd: update cur_logical_clk atomically
d0111b3 Merge pull request #900 from likewhatevs/enable-iconfig-proc
b962ea8 Merge pull request #894 from etsal/core_enums
5e35a12 remove stray print
7d44511 fix missing/extraneous newline
4288040 Merge branch 'main' of https://github.com/sched-ext/scx into core_enums
de5f2f9 regenerate autogen Rust file
f088540 fix linting error in autogenerated code
2f174db use the enum singleton in the userspace scheduler components
1cabed9 Autogenerate enums and BPF enum setters for Rust schedulers
d500c50 add autogenerated enum definitions for Rust schedulers
fc6ad5c add CONFIG_IKHEADERS_PROC to ci kconfig
479d515 Merge branch 'main' into core_enums
23f302c add SCX_SLICE_* macros to scx_utils and use them for the Rust schedulers
c545d23 factor enum handling into existing headers/operations
a1d0e7e autogenerate scx enum definitions
31b9fb4 set all enums in userspace before loading
ff861d3 introduce CO:RE enum readers and use them for scx_central
