### PR TITLE
layered: update for old verifier compatibility

### DIFF
--- a/.github/actions/install-deps-action/action.yml
+++ b/.github/actions/install-deps-action/action.yml
@@ -15,6 +15,13 @@ runs:
 
     ### DOWNLOAD AND INSTALL DEPENDENCIES ###
 
+    # Get some packages from nixpkgs for newer revisions
+    - uses: DeterminateSystems/nix-installer-action@main
+    - run: |
+        nix registry add nixpkgs github:NixOS/nixpkgs/8edf06bea5bcbee082df1b7369ff973b91618b8d
+        echo "BPF_CLANG=$(nix build --print-out-paths --no-link nixpkgs#clang)/bin/clang" >> $GITHUB_ENV
+      shell: bash
+
     # Download dependencies packaged by Ubuntu
     - run: |
         sudo apt install -f -y bison busybox-static cmake coreutils \

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -144,7 +144,7 @@ jobs:
       - run: sudo chmod +x /usr/bin/veristat && sudo chmod 755 /usr/bin/veristat
 
       # The actual build:
-      - run: meson setup build -Dkernel=../linux/arch/x86/boot/bzImage -Dkernel_headers=../linux -Denable_stress=true -Dvng_rw_mount=true
+      - run: meson setup build -Dkernel=../linux/arch/x86/boot/bzImage -Dkernel_headers=../linux -Denable_stress=true -Dvng_rw_mount=true -Dbpf_clang="$BPF_CLANG"
       - run: meson compile -C build ${{ matrix.scheduler }}
 
       # Print CPU model before running the tests (this can be useful for


### PR DESCRIPTION

Update layered to increase kernel backwards compatibility.

Change the check in `calc_preferred_cost` to `>MAX_LLCS` rather than `>nr_llcs`.
Both are constant at verification time but the old verifiers are happier with
the macro constant. Note that neither of these should be necessary because of
the inlined `rotate_layer_id` ending with a mod.

Add a `MEMBER_VPTR` to finish making this happy.

Make `initialize_budgets` weak. This prevents it being inlined and makes it
verify as a global function. It's only called from init so this is fine, and
it makes reading verifier errors significantly simpler than when this very
large function gets inlined.

Test plan:
- Tested on a 6.4.3 verifier kernel and a 6.9 verifier kernel. CI will test on
  6.12+.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/sched-ext/scx/pull/951).
* __->__ #951
* #988