### PR TITLE
scx_lavd: Optimize the layout of struct task_ctx

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -53,11 +53,10 @@ enum {
 	LAVD_CPDOM_MAX_NR		= 32, /* maximum number of compute domain */
 	LAVD_CPDOM_MAX_DIST		= 4,  /* maximum distance from one compute domain to another */
 
-	LAVD_STATUS_STR_LEN		= 5, /* {LR: Latency-critical, Regular}
+	LAVD_STATUS_STR_LEN		= 4, /* {LR: Latency-critical, Regular}
 						{HI: performance-Hungry, performance-Insensitive}
 						{BT: Big, liTtle}
-						{EG: Eligible, Greedy}
-						{PN: Preemption, Not} */
+						{EG: Eligible, Greedy} */
 };
 
 /*
@@ -83,8 +82,6 @@ struct sys_stat {
 	volatile u32	nr_active;	/* number of active cores */
 
 	volatile u64	nr_sched;	/* total scheduling so far */
-	volatile u64	nr_migration;	/* number of task migration */
-	volatile u64	nr_preemption;	/* number of preemption */
 	volatile u64	nr_greedy;	/* number of greedy tasks scheduled */
 	volatile u64	nr_perf_cri;	/* number of performance-critical tasks scheduled */
 	volatile u64	nr_lat_cri;	/* number of latency-critical tasks scheduled */
@@ -114,7 +111,6 @@ struct task_ctx {
 	u64	run_time_ns;		/* average runtime per schedule */
 	u64	run_freq;		/* scheduling frequency in a second */
 	u64	wait_freq;		/* waiting frequency in a second */
-
 	u64	wake_freq;		/* waking-up frequency in a second */
 	u64	svc_time;		/* total CPU time consumed for this task */
 
@@ -122,31 +118,18 @@ struct task_ctx {
 	 * Task deadline and time slice
 	 */
 	u64	vdeadline_log_clk;	/* logical clock of the deadilne */
-	u64	vdeadline_delta_ns;	/* time delta until task's virtual deadline */
-	u64	slice_ns;		/* time slice */
-	u32	greedy_ratio;		/* task's overscheduling ratio compared to its nice priority */
+	u32	*futex_uaddr;		/* futex uaddr */
 	u32	lat_cri;		/* final context-aware latency criticality */
-	u32	lat_cri_self;		/* my latency criticality */
 	u32	lat_cri_waker;		/* waker's latency criticality */
-	volatile s32 victim_cpu;
-	u16	slice_boost_prio;	/* how many times a task fully consumed the slice */
-	volatile s16 lock_boost;	/* lock boost count */
-	volatile s16 futex_boost;	/* futex boost count */
-	volatile u8 need_lock_boost;	/* need to boost lock for deadline calculation */
+	u32	perf_cri;		/* performance criticality of a task */
+	u32	slice_ns;		/* time slice */
+	s8	futex_boost;		/* futex boost count */
+	u8	is_greedy;		/* task's overscheduling ratio compared to its nice priority */
+	u8	need_lock_boost;	/* need to boost lock for deadline calculation */
 	u8	wakeup_ft;		/* regular wakeup = 1, sync wakeup = 2 */
-	volatile u32 *futex_uaddr;	/* futex uaddr */
-
-	/*
-	 * Task's performance criticality
-	 */
+	u8	slice_boost_prio;	/* how many times a task fully consumed the slice */
 	u8	on_big;			/* executable on a big core */
 	u8	on_little;		/* executable on a little core */
-	u32	perf_cri;		/* performance criticality of a task */
-
-	/*
-	 * Information for statistics collection
-	 */
-	u32	cpu_id;			/* CPU ID scheduled on */
 };
 
 /*

--- a/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
@@ -48,8 +48,7 @@ int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc, u32 cpu_id)
 	m->taskc_x.stat[1] = is_perf_cri(taskc, stat_cur) ? 'H' : 'I';
 	m->taskc_x.stat[2] = cpuc->big_core ? 'B' : 'T';
 	m->taskc_x.stat[3] = is_greedy(taskc) ? 'G' : 'E';
-	m->taskc_x.stat[4] = taskc->victim_cpu >= 0 ? 'P' : 'N';
-	m->taskc_x.stat[5] = '\0';
+	m->taskc_x.stat[4] = '\0';
 
 	memcpy(&m->taskc, taskc, sizeof(m->taskc));
 
@@ -59,9 +58,10 @@ int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc, u32 cpu_id)
 }
 
 static void proc_introspec_sched_n(struct task_struct *p,
-				   struct task_ctx *taskc, u32 cpu_id)
+				   struct task_ctx *taskc)
 {
 	u64 cur_nr, prev_nr;
+	u32 cpu_id;
 	int i;
 
 	/* do not introspect itself */
@@ -69,6 +69,7 @@ static void proc_introspec_sched_n(struct task_struct *p,
 		return;
 
 	/* introspec_arg is the number of schedules remaining */
+	cpu_id = bpf_get_smp_processor_id();
 	cur_nr = intrspc.arg;
 
 	/*
@@ -92,14 +93,11 @@ static void proc_introspec_sched_n(struct task_struct *p,
 }
 
 static void try_proc_introspec_cmd(struct task_struct *p,
-				   struct task_ctx *taskc, u32 cpu_id)
+				   struct task_ctx *taskc)
 {
-	if (LAVD_CPU_ID_HERE == cpu_id)
-		cpu_id = bpf_get_smp_processor_id();
-
 	switch(intrspc.cmd) {
 	case LAVD_CMD_SCHED_N:
-		proc_introspec_sched_n(p, taskc, cpu_id);
+		proc_introspec_sched_n(p, taskc);
 		break;
 	case LAVD_CMD_NOP:
 		/* do nothing */

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -36,8 +36,6 @@ enum consts_internal  {
 
 	LAVD_CPU_UTIL_MAX		= 1000, /* 100.0% */
 	LAVD_CPU_UTIL_MAX_FOR_CPUPERF	= 850, /* 85.0% */
-	LAVD_CPU_ID_HERE		= ((u32)-2),
-	LAVD_CPU_ID_NONE		= ((u32)-1),
 
 	LAVD_SYS_STAT_INTERVAL_NS	= (50ULL * NSEC_PER_MSEC),
 	LAVD_SYS_STAT_DECAY_TIMES	= ((2ULL * LAVD_TIME_ONE_SEC) / LAVD_SYS_STAT_INTERVAL_NS),
@@ -92,12 +90,6 @@ struct cpu_ctx {
 	volatile u64	last_kick_clk;	/* when the CPU was kicked */
 
 	/*
-	 * Information for cpu hotplug
-	 */
-	u64		online_clk;	/* when a CPU becomes online */
-	u64		offline_clk;	/* when a CPU becomes offline */
-
-	/*
 	 * Information used to keep track of latency criticality
 	 */
 	volatile u32	max_lat_cri;	/* maximum latency criticality */
@@ -145,12 +137,17 @@ struct cpu_ctx {
 	/*
 	 * Information for statistics.
 	 */
-	volatile u32	nr_migration;	/* number of migrations */
 	volatile u32	nr_preemption;	/* number of migrations */
 	volatile u32	nr_greedy;	/* number of greedy tasks scheduled */
 	volatile u32	nr_perf_cri;
 	volatile u32	nr_lat_cri;
 	volatile u32	nr_lhp;		/* number of lock holder preemption */
+
+	/*
+	 * Information for cpu hotplug
+	 */
+	u64		online_clk;	/* when a CPU becomes online */
+	u64		offline_clk;	/* when a CPU becomes offline */
 } __attribute__((aligned(CACHELINE_SIZE)));
 
 

--- a/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
@@ -53,7 +53,6 @@ static void reset_lock_futex_boost(struct task_ctx *taskc, struct cpu_ctx *cpuc)
 		cpuc->nr_lhp++;
 	}
 
-	taskc->lock_boost = 0;
 	taskc->futex_boost = 0;
 	taskc->futex_uaddr = NULL;
 	cpuc->lock_holder = false;
@@ -99,7 +98,6 @@ static void reset_lock_futex_boost(struct task_ctx *taskc, struct cpu_ctx *cpuc)
  * - int futex_lock_pi(u32 *uaddr, unsigned int flags, ktime_t *time, int trylock)
  * - int futex_unlock_pi(u32 *uaddr, unsigned int flags)
  */
-#ifdef LAVD_TRACE_FUTEX
 struct futex_vector;
 struct hrtimer_sleeper;
 
@@ -192,8 +190,6 @@ int BPF_PROG(fexit_futex_unlock_pi, u32 *uaddr, unsigned int flags, int ret)
 	}
 	return 0;
 }
-#endif /* LAVD_TRACE_FUTEX */
-
 
 /**
  * TODO: NTsync driver in recent kernel (when ntsync is fully mainlined)

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -36,8 +36,6 @@ struct sys_stat_ctx {
 	s32		avg_lat_cri;
 	u64		sum_lat_cri;
 	u32		nr_sched;
-	u32		nr_migration;
-	u32		nr_preemption;
 	u32		nr_greedy;
 	u32		nr_perf_cri;
 	u32		nr_lat_cri;
@@ -97,12 +95,6 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 
 		c->nr_lat_cri += cpuc->nr_lat_cri;
 		cpuc->nr_lat_cri = 0;
-
-		c->nr_migration += cpuc->nr_migration;
-		cpuc->nr_migration = 0;
-
-		c->nr_preemption += cpuc->nr_preemption;
-		cpuc->nr_preemption = 0;
 
 		c->nr_greedy += cpuc->nr_greedy;
 		cpuc->nr_greedy = 0;
@@ -267,8 +259,6 @@ static void update_sys_stat_next(struct sys_stat_ctx *c)
 	if (cnt++ == LAVD_SYS_STAT_DECAY_TIMES) {
 		cnt = 0;
 		stat_next->nr_sched >>= 1;
-		stat_next->nr_migration >>= 1;
-		stat_next->nr_preemption >>= 1;
 		stat_next->nr_greedy >>= 1;
 		stat_next->nr_perf_cri >>= 1;
 		stat_next->nr_lat_cri >>= 1;
@@ -283,8 +273,6 @@ static void update_sys_stat_next(struct sys_stat_ctx *c)
 	}
 
 	stat_next->nr_sched += c->nr_sched;
-	stat_next->nr_migration += c->nr_migration;
-	stat_next->nr_preemption += c->nr_preemption;
 	stat_next->nr_greedy += c->nr_greedy;
 	stat_next->nr_perf_cri += c->nr_perf_cri;
 	stat_next->nr_lat_cri += c->nr_lat_cri;

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -238,7 +238,7 @@ static bool is_perf_cri(struct task_ctx *taskc, struct sys_stat *stat_cur)
 
 static bool is_greedy(struct task_ctx *taskc)
 {
-	return taskc->greedy_ratio > 1000;
+	return taskc->is_greedy;
 }
 
 static bool is_eligible(struct task_ctx *taskc)
@@ -248,7 +248,7 @@ static bool is_eligible(struct task_ctx *taskc)
 
 static bool is_lock_holder(struct task_ctx *taskc)
 {
-	return (taskc->lock_boost > 0) || (taskc->futex_boost > 0);
+	return taskc->futex_boost > 0;
 }
 
 static bool have_scheduled(struct task_ctx *taskc)

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -627,7 +627,7 @@ impl<'a> Scheduler<'a> {
         let c_tx_cm_str: &CStr = unsafe { CStr::from_ptr(c_tx_cm) };
         let tx_comm: &str = c_tx_cm_str.to_str().unwrap();
 
-        let c_tx_st: *const c_char = (&tx.stat as *const [c_char; 6]) as *const c_char;
+        let c_tx_st: *const c_char = (&tx.stat as *const [c_char; 5]) as *const c_char;
         let c_tx_st_str: &CStr = unsafe { CStr::from_ptr(c_tx_st) };
         let tx_stat: &str = c_tx_st_str.to_str().unwrap();
 
@@ -637,10 +637,7 @@ impl<'a> Scheduler<'a> {
             comm: tx_comm.into(),
             stat: tx_stat.into(),
             cpu_id: tx.cpu_id,
-            victim_cpu: tc.victim_cpu,
-            vdeadline_delta_ns: tc.vdeadline_delta_ns,
             slice_ns: tc.slice_ns,
-            greedy_ratio: tc.greedy_ratio,
             lat_cri: tc.lat_cri,
             avg_lat_cri: tx.avg_lat_cri,
             static_prio: tx.static_prio,
@@ -712,8 +709,6 @@ impl<'a> Scheduler<'a> {
                 let nr_active = st.nr_active;
                 let nr_sched = st.nr_sched;
                 let pc_lhp = Self::get_pc(st.nr_lhp, nr_sched);
-                let pc_migration = Self::get_pc(st.nr_migration, nr_sched);
-                let pc_preemption = Self::get_pc(st.nr_preemption, nr_sched);
                 let pc_greedy = Self::get_pc(st.nr_greedy, nr_sched);
                 let pc_pc = Self::get_pc(st.nr_perf_cri, nr_sched);
                 let pc_lc = Self::get_pc(st.nr_lat_cri, nr_sched);
@@ -736,8 +731,6 @@ impl<'a> Scheduler<'a> {
                     nr_active,
                     nr_sched,
                     pc_lhp,
-                    pc_migration,
-                    pc_preemption,
                     pc_greedy,
                     pc_pc,
                     pc_lc,

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -37,12 +37,6 @@ pub struct SysStats {
     #[stat(desc = "% lock holder preemption")]
     pub pc_lhp: f64,
 
-    #[stat(desc = "% of task migration")]
-    pub pc_migration: f64,
-
-    #[stat(desc = "% of task preemption")]
-    pub pc_preemption: f64,
-
     #[stat(desc = "% of greedy tasks")]
     pub pc_greedy: f64,
 
@@ -78,15 +72,13 @@ impl SysStats {
     pub fn format_header<W: Write>(w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "\x1b[93m| {:8} | {:13} | {:9} | {:9} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:11} | {:12} | {:12} | {:12} |\x1b[0m",
+            "\x1b[93m| {:8} | {:13} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:11} | {:12} | {:12} | {:12} |\x1b[0m",
             "MSEQ",
             "SVC_TIME",
             "# Q TASK",
             "# ACT CPU",
             "# SCHED",
             "LHP%",
-            "MIGRATE%",
-            "PREEMPT%",
             "GREEDY%",
             "PERF-CR%",
             "LAT-CR%",
@@ -108,15 +100,13 @@ impl SysStats {
 
         writeln!(
             w,
-            "| {:8} | {:13} | {:9} | {:9} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:11} | {:12} | {:12} | {:12} |",
+            "| {:8} | {:13} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:11} | {:12} | {:12} | {:12} |",
             self.mseq,
             self.avg_svc_time,
             self.nr_queued_task,
             self.nr_active,
             self.nr_sched,
             GPoint(self.pc_lhp),
-            GPoint(self.pc_migration),
-            GPoint(self.pc_preemption),
             GPoint(self.pc_greedy),
             GPoint(self.pc_pc),
             GPoint(self.pc_lc),
@@ -147,14 +137,8 @@ pub struct SchedSample {
     pub stat: String,
     #[stat(desc = "CPU id where this task is scheduled on")]
     pub cpu_id: u32,
-    #[stat(desc = "Victim CPU to be preempted out (-1 = no preemption)")]
-    pub victim_cpu: i32,
-    #[stat(desc = "Assigned virtual deadline")]
-    pub vdeadline_delta_ns: u64,
     #[stat(desc = "Assigned time slice")]
-    pub slice_ns: u64,
-    #[stat(desc = "How greedy this task is in using CPU time (1000 = fair)")]
-    pub greedy_ratio: u32,
+    pub slice_ns: u32,
     #[stat(desc = "Latency criticality of this task")]
     pub lat_cri: u32,
     #[stat(desc = "Average latency criticality in a system")]
@@ -162,7 +146,7 @@ pub struct SchedSample {
     #[stat(desc = "Static priority (20 == nice 0)")]
     pub static_prio: u16,
     #[stat(desc = "Slice boost factor (number of consecutive full slice exhaustions)")]
-    pub slice_boost_prio: u16,
+    pub slice_boost_prio: u8,
     #[stat(desc = "How often this task is scheduled per second")]
     pub run_freq: u64,
     #[stat(desc = "Average runtime per schedule")]
@@ -187,23 +171,13 @@ impl SchedSample {
     pub fn format_header<W: Write>(w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "\x1b[93m| {:6} | {:7} | {:17} \
-                   | {:5} | {:4} | {:4} \
-                   | {:14} | {:8} | {:7} \
-                   | {:8} | {:7} | {:8} \
-                   | {:7} | {:9} | {:9} \
-                   | {:9} | {:9} | {:8} \
-                   | {:8} | {:8} | {:8} \
-                   | {:6} |\x1b[0m",
+            "\x1b[93m| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:7} | {:8} | {:7} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:6} |\x1b[0m",
             "MSEQ",
             "PID",
             "COMM",
             "STAT",
             "CPU",
-            "VTMC",
-            "VDDLN_NS",
             "SLC_NS",
-            "GRDY_RT",
             "LAT_CRI",
             "AVG_LC",
             "ST_PRIO",
@@ -228,23 +202,12 @@ impl SchedSample {
 
         writeln!(
             w,
-            "| {:6} | {:7} | {:17} \
-               | {:5} | {:4} | {:4} \
-               | {:14} | {:8} | {:7} \
-               | {:8} | {:7} | {:8} \
-               | {:7} | {:9} | {:9} \
-               | {:9} | {:9} | {:8} \
-               | {:8} | {:8} | {:8} \
-               | {:6} |",
-            self.mseq,
+            "| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:7} | {:8} | {:7} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:6} |", self.mseq,
             self.pid,
             self.comm,
             self.stat,
             self.cpu_id,
-            self.victim_cpu,
-            self.vdeadline_delta_ns,
             self.slice_ns,
-            self.greedy_ratio,
             self.lat_cri,
             self.avg_lat_cri,
             self.static_prio,


### PR DESCRIPTION
Reduce the size of struct task_ctx from 3 cache lines to 2 cache lines by dropping unnecessary fields and optimizing the struct layout.