### PR TITLE
scx_layered: Reimplement CPU allocation and some other fixes

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2120,11 +2120,6 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 		return;
 
 	used = bpf_ktime_get_ns() - tctx->running_at;
-	if (used < layer->min_exec_ns) {
-		lstat_inc(LSTAT_MIN_EXEC, layer, cctx);
-		lstat_add(LSTAT_MIN_EXEC_NS, layer, cctx, layer->min_exec_ns - used);
-		used = layer->min_exec_ns;
-	}
 
 	// If the task ran on the hi fallback dsq then the cost should be
 	// charged to it.
@@ -2142,7 +2137,16 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 	cctx->prev_exclusive = cctx->current_exclusive;
 	cctx->current_exclusive = false;
 
-	/* scale the execution time by the inverse of the weight and charge */
+	/*
+	 * Apply min_exec_us, scale the execution time by the inverse of the
+	 * weight and charge.
+	 */
+	if (used < layer->min_exec_ns) {
+		lstat_inc(LSTAT_MIN_EXEC, layer, cctx);
+		lstat_add(LSTAT_MIN_EXEC_NS, layer, cctx, layer->min_exec_ns - used);
+		used = layer->min_exec_ns;
+	}
+
 	if (cctx->yielding && used < slice_ns)
 		used = slice_ns;
 	p->scx.dsq_vtime += used * 100 / p->scx.weight;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -809,15 +809,6 @@ impl Stats {
             .take(self.nr_layers)
             .map(|layer| layer.nr_tasks as usize)
             .collect();
-        let _layer_weights: Vec<usize> = skel
-            .maps
-            .bss_data
-            .layers
-            .iter()
-            .take(self.nr_layers)
-            .map(|layer| layer.weight as usize)
-            .collect();
-
         let layer_slice_us: Vec<u64> = skel
             .maps
             .bss_data
@@ -1562,7 +1553,7 @@ impl<'a> Scheduler<'a> {
             // freeing further to avoid unnecessary changes. This is solely
             // based on intution. Drop or update according to real-world
             // behavior.
-	    let nr_to_break_at = nr_to_free / 2;
+            let nr_to_break_at = nr_to_free / 2;
 
             let mut freed = false;
 
@@ -1574,9 +1565,9 @@ impl<'a> Scheduler<'a> {
                 nr_to_free -= nr_freed;
                 freed = true;
 
-		if nr_to_free <= nr_to_break_at {
-		    break;
-		}
+                if nr_to_free <= nr_to_break_at {
+                    break;
+                }
             }
 
             if freed {

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1462,6 +1462,11 @@ impl<'a> Scheduler<'a> {
         bpf_layer.refresh_cpus = 1;
     }
 
+    /// Calculate how many CPUs each layer would like to have if there were
+    /// no competition. The CPU range is determined by applying the inverse
+    /// of util_range and then capping by cpus_range. If the current
+    /// allocation is within the acceptable range, no change is made.
+    /// Returns (target, min) pair for each layer.
     fn calc_target_nr_cpus(&self) -> Vec<(usize, usize)> {
         let nr_cpus = self.cpu_pool.nr_cpus;
         let utils = &self.sched_stats.layer_utils;
@@ -1495,6 +1500,9 @@ impl<'a> Scheduler<'a> {
         targets
     }
 
+    /// Given (target, min) pair for each layer which was determined
+    /// assuming infinite number of CPUs, distribute the actual CPUs
+    /// according to their weights.
     fn weighted_target_nr_cpus(&self, targets: &Vec<(usize, usize)>) -> Vec<usize> {
         let mut nr_left = self.cpu_pool.nr_cpus;
         let weights: Vec<usize> = self

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -56,12 +56,6 @@ pub struct LayerStats {
     #[stat(desc = "sum of weight * duty_cycle for tasks")]
     pub load: f64,
     #[stat(desc = "layer load fraction adjusted for infeasible weights")]
-    pub load_frac_adj: f64,
-    #[stat(desc = "layer duty cycle adjusted for infeasible weights")]
-    pub dcycle: f64,
-    #[stat(desc = "fraction of total load")]
-    pub load_frac: f64,
-    #[stat(desc = "count of tasks")]
     pub tasks: u32,
     #[stat(desc = "count of sched events during the period")]
     pub total: u64,
@@ -177,9 +171,6 @@ impl LayerStats {
             util: stats.layer_utils[lidx] * 100.0,
             util_frac: calc_frac(stats.layer_utils[lidx], stats.total_util),
             load: normalize_load_metric(stats.layer_loads[lidx]),
-            load_frac_adj: calc_frac(stats.layer_load_sums[lidx], stats.total_load_sum),
-            dcycle: calc_frac(stats.layer_dcycle_sums[lidx], stats.total_dcycle_sum),
-            load_frac: calc_frac(stats.layer_loads[lidx], stats.total_load),
             tasks: stats.nr_layer_tasks[lidx] as u32,
             total: ltotal,
             sel_local: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_SEL_LOCAL),
@@ -221,22 +212,12 @@ impl LayerStats {
     pub fn format<W: Write>(&self, w: &mut W, name: &str, header_width: usize) -> Result<()> {
         writeln!(
             w,
-            "  {:<width$}: util/dcycle/frac={:5.1}/{:5.1}/{:7.1} tasks={:6}",
+            "  {:<width$}: util/frac={:5.1}/{:7.1} tasks={:6} load={:9.2}",
             name,
             self.util,
-            self.dcycle,
             self.util_frac,
             self.tasks,
-            width = header_width,
-        )?;
-
-        writeln!(
-            w,
-            "  {:<width$}  load/load_frac_adj/frac={:9.2}/{:2.2}/{:5.1}",
-            "",
             self.load,
-            self.load_frac_adj,
-            self.load_frac,
             width = header_width,
         )?;
 

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -166,11 +166,7 @@ impl LayerStats {
             }
         };
         let calc_frac = |a, b| {
-            if b != 0.0 {
-                a / b * 100.0
-            } else {
-                0.0
-            }
+            if b != 0.0 { a / b * 100.0 } else { 0.0 }
         };
 
         Self {


### PR DESCRIPTION
The existing load calculation was incorrect. It could enter feedback loops where a layer which is using more CPU cycles keeps getting more CPUs and vice-versa regardless of their weights. Also, as the growth and shrinking decisions are made locally in each layer, they couldn't account for global competition state which is necessary to consider for weight based distribution.

Reimplement CPU allocation so that CPUs are distributed globally and layers are converged to the target state.

While at it, make a few misc changes including printing stats in config order and correctly accounting for layer CPU time.