### PR TITLE
utils: add powerpc64le to arch map

### DIFF
--- a/rust/scx_utils/src/clang_info.rs
+++ b/rust/scx_utils/src/clang_info.rs
@@ -18,6 +18,7 @@ lazy_static::lazy_static! {
     ("ppc32", "powerpc"),
     ("ppc64", "powerpc"),
     ("ppc64le", "powerpc"),
+    ("powerpc64le", "powerpc"),
     ("sparc", "sparc"),
     ("sparcv9", "sparc"),
     ("riscv32", "riscv"),


### PR DESCRIPTION
This commit fixes the following error when building for ppc64le arch:

```
[   71s]   --- stderr
[   71s]   thread 'main' panicked at rust/scx_utils/src/builder.rs:42:51:
[   71s]   called `Result::unwrap()` on an `Err` value: CPU arch powerpc64le not found in ARCH_MAP
[   71s]   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Signed-off-by: Fredrik Lönnegren <fredrik@frelon.se>
