### PR TITLE
meson: Install scx header files

### DIFF
--- a/scheds/meson.build
+++ b/scheds/meson.build
@@ -8,4 +8,6 @@ bpf_includes = ['-I', join_paths(meson.current_source_dir(), 'include'),
 # passed in as executable::include_directories.
 user_c_includes = include_directories('include')
 
+install_subdir(join_paths(meson.current_source_dir(), 'include/scx'), install_dir: 'include', install_tag: 'devel')
+
 subdir('c')


### PR DESCRIPTION
Install scx headers to /usr/include/scx for easier packaging.

Signed-off-by: Fredrik Lönnegren <fredrik@frelon.se>
