### PR TITLE
docs: Fix link to Gentoo installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -91,7 +91,7 @@ CachyOS does provide a kernel with an unstripped vmlinux, which can be used for 
 $ sudo pacman -Sy linux-cachyos-sched-ext-debug linux-cachyos-sched-ext-debug-headers
 ```
 
-## Gentoo
+## Gentoo Linux
 Make sure you build the kernel with the right configuration, installation
 should be easy:
 ```


### PR DESCRIPTION
Currently, if you try to open the installation instructions for Gentoo from the README, it just opens the top of the INSTALL.md file, since the link is incorrect. This simple pull request fixes that.