### PR TITLE
scx_rusty: Fix verifier errors on older kernels

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -598,7 +598,7 @@ const int sched_prio_to_weight[DL_MAX_LAT_PRIO + 1] = {
  /*  15 */        36,        29,        23,        18,        15,
 };
 
-static u64 sched_prio_to_latency_weight(u64 prio)
+static __noinline u64 sched_prio_to_latency_weight(u64 prio)
 {
 	if (prio >= DL_MAX_LAT_PRIO) {
 		scx_bpf_error("Invalid prio index");


### PR DESCRIPTION
Tested on 6.12-rc6 as well with various versions of clang 18.X