### PR TITLE
scx_layered: select_cpu() fixes and updates

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -205,7 +205,8 @@ struct layer {
 	u64			cpus_seq;
 	u64			node_mask;
 	u64			cache_mask;
-	unsigned int		refresh_cpus;
+	bool			check_no_idle;
+	u64			refresh_cpus;
 	unsigned char		cpus[MAX_CPUS_U8];
 	unsigned int		nr_cpus;	// managed from BPF side
 	unsigned int		perf;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -603,7 +603,7 @@ bool should_try_preempt_first(s32 cand, struct layer *layer,
 	struct cpu_ctx *cand_cctx, *sib_cctx;
 	s32 sib;
 
-	if (!layered_cpumask || !layer->preempt || !layer->preempt_first)
+	if (!layer->preempt || !layer->preempt_first)
 		return false;
 
 	if (layer->kind == LAYER_KIND_CONFINED &&
@@ -655,15 +655,20 @@ s32 pick_idle_no_topo(struct task_struct *p, s32 prev_cpu,
 		return -1;
 	}
 
-	/*
-	 * If CPU has SMT, any wholly idle CPU is likely a better pick than
-	 * partially idle @prev_cpu.
-	 */
 	idle_smtmask = scx_bpf_get_idle_smtmask();
 	if ((cpu = pick_idle_cpu_from(layered_cpumask, prev_cpu,
-				      idle_smtmask,
-				      layer->idle_smt)) >= 0)
+				      idle_smtmask, layer->idle_smt)) >= 0)
 		goto out_put;
+
+	/*
+	 * If the layer is an open one, we can try the whole machine.
+	 */
+	if (layer->kind != LAYER_KIND_CONFINED &&
+	    ((cpu = pick_idle_cpu_from(p->cpus_ptr, prev_cpu,
+				       idle_smtmask, layer->idle_smt)) >= 0)) {
+		lstat_inc(LSTAT_OPEN_IDLE, layer, cctx);
+		goto out_put;
+	}
 
 out_put:
 	scx_bpf_put_idle_cpumask(idle_smtmask);
@@ -678,7 +683,7 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 	if (disable_topology)
 		return pick_idle_no_topo(p, prev_cpu, cctx, tctx, layer, from_selcpu);
 
-	const struct cpumask *idle_smtmask, *layer_cpumask, *cpumask;
+	const struct cpumask *idle_smtmask, *layer_cpumask, *layered_cpumask, *cpumask;
 	struct cpu_ctx *prev_cctx;
 	u64 cpus_seq;
 	s32 cpu;
@@ -703,9 +708,9 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 	 * the preemption attempt fails.
 	 */
 	maybe_refresh_layered_cpus(p, tctx, layer_cpumask, cpus_seq);
-	if (!(cpumask = cast_mask(tctx->layered_mask)))
+	if (!(layered_cpumask = cast_mask(tctx->layered_mask)))
 		return -1;
-	if (from_selcpu && should_try_preempt_first(prev_cpu, layer, cpumask)) {
+	if (from_selcpu && should_try_preempt_first(prev_cpu, layer, layered_cpumask)) {
 		cctx->try_preempt_first = true;
 		return -1;
 	}
@@ -766,12 +771,16 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 			goto out_put;
 	}
 
+	if ((cpu = pick_idle_cpu_from(layered_cpumask, prev_cpu,
+				      idle_smtmask, layer->idle_smt)) >= 0)
+		goto out_put;
+
 	/*
 	 * If the layer is an open one, we can try the whole machine.
 	 */
 	if (layer->kind != LAYER_KIND_CONFINED &&
-	    ((cpu = pick_idle_cpu_from(p->cpus_ptr, prev_cpu, idle_smtmask,
-				       layer->idle_smt)) >= 0)) {
+	    ((cpu = pick_idle_cpu_from(p->cpus_ptr, prev_cpu,
+				       idle_smtmask, layer->idle_smt)) >= 0)) {
 		lstat_inc(LSTAT_OPEN_IDLE, layer, cctx);
 		goto out_put;
 	}
@@ -1359,7 +1368,6 @@ void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 	struct cpu_ctx *cctx, *sib_cctx;
 	struct layer *layer;
 	struct cost *costc;
-	u64 dsq_id;
 	u32 idx, layer_idx;
 	s32 sib = sibling_cpu(cpu);
 
@@ -1632,7 +1640,6 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 
 	struct cpu_ctx *cctx, *sib_cctx;
 	struct cost *costc;
-	u64 dsq_id;
 	s32 sib = sibling_cpu(cpu);
 
 	if (!(cctx = lookup_cpu_ctx(-1)) ||


### PR DESCRIPTION
- Both `select_cpu[_no_topo]()` were broken. Each missing different idle CPU search steps. This is likely cause of some of the regressions seen with new versions. Fixed.
- There are no meaningful differences between `no_topo` and regular versions after dead code elimination. Drop the duplicate.
- Short-circuit `select_cpu()` when layers' CPUs are saturated. This saves ~0.6% cputime when running saturating `rd-hashd` on Ryzen 3900x.