### PR TITLE
scx_layered: Refactor layer growth order

### DIFF
--- a/scheds/rust/scx_layered/src/layer_core_growth.rs
+++ b/scheds/rust/scx_layered/src/layer_core_growth.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use clap::Parser;
@@ -69,7 +70,23 @@ impl LayerGrowthAlgo {
         }
     }
 
-    pub fn layer_core_order(
+    pub fn layer_core_orders(
+        cpu_pool: &CpuPool,
+        layer_specs: &[LayerSpec],
+        topo: &Topology,
+    ) -> BTreeMap<usize, Vec<usize>> {
+        let mut core_orders = BTreeMap::new();
+
+        for (idx, spec) in layer_specs.iter().enumerate() {
+            let layer_growth_algo = spec.kind.common().growth_algo.clone();
+            let core_order = layer_growth_algo.layer_core_order(cpu_pool, spec, idx, topo);
+            core_orders.insert(idx, core_order);
+        }
+
+        core_orders
+    }
+
+    fn layer_core_order(
         &self,
         cpu_pool: &CpuPool,
         spec: &LayerSpec,


### PR DESCRIPTION
Refactor layer growth order to be more sticky to cores by using the core growth order to shrink layers. Move layer core growth order creation to a separate helper that has context on all layers. This will be used in the future for more topology aware core growth.

Layers have a tendency to "walk" across cores when growing/shrinking which can lead to suboptimal layouts over time. Consider the following simple configuration for a machine with Big/Little cores:
```
[
  {
    "name": "powersave",
    "comment": "powersave",
    "matches": [[]],
    "kind": {
      "Confined": {
        "util_range": [
          0.4,
          0.8
        ],
        "slice_us": 800,
        "preempt": false,
        "growth_algo": "LittleBig",
        "idle_smt": true,
        "perf": 256,
        "preempt_first": false,
        "exclusive": false
      }
    }
  }
]
```
When load is placed on the layer the growth should happen towards the lower cores on the system:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/16e6152a-37a0-493c-ad66-e94debb5b10a">
After load is removed off the system the layer should compact towards it's preferred set of cores:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/65d01d1d-de37-4892-82d1-bcd5ca0a5ee8">

In contrast, on `main` after several iterations load ends up on Big cores:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/63b0e415-56e2-41f0-b22f-e531a6186641">

When layers shrink they do not consider the core growth order and end up compacting the `LittleBig` layer completely onto Big cores:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/0f166441-8c29-4a43-ad4a-3ce253e82aba">

