### PR TITLE
scx_lavd: Optimize performance criticality calculation

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -41,6 +41,16 @@ volatile u64		performance_mode_ns;
 volatile u64		balanced_mode_ns;
 volatile u64		powersave_mode_ns;
 
+static bool is_perf_cri(struct task_ctx *taskc, struct sys_stat *stat_cur)
+{
+	if (!have_little_core)
+		return true;
+
+	if (READ_ONCE(taskc->on_big) && READ_ONCE(taskc->on_little))
+		return taskc->perf_cri >= stat_cur->thr_perf_cri;
+	return READ_ONCE(taskc->on_big);
+}
+
 static u64 calc_nr_active_cpus(struct sys_stat *stat_cur)
 {
 	u64 nr_active;

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -229,13 +229,6 @@ static bool is_lat_cri(struct task_ctx *taskc, struct sys_stat *stat_cur)
 	return taskc->lat_cri >= stat_cur->avg_lat_cri;
 }
 
-static bool is_perf_cri(struct task_ctx *taskc, struct sys_stat *stat_cur)
-{
-	if (READ_ONCE(taskc->on_big) && READ_ONCE(taskc->on_little))
-		return taskc->perf_cri >= stat_cur->thr_perf_cri;
-	return READ_ONCE(taskc->on_big);
-}
-
 static bool is_greedy(struct task_ctx *taskc)
 {
 	return taskc->is_greedy;


### PR DESCRIPTION
Move the performance criticality calculation to the ops.enqueue() path, where the performance criticality information is used. Also, skip the calculation if the processor architecture is not hybrid (i.e., no little core).