### PR TITLE
scx_lavd: Optimize the cpuc_ctx layout for cache friendliness

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -82,14 +82,11 @@ struct sys_stat {
 	volatile u32	nr_active;	/* number of active cores */
 
 	volatile u64	nr_sched;	/* total scheduling so far */
-	volatile u64	nr_greedy;	/* number of greedy tasks scheduled */
 	volatile u64	nr_perf_cri;	/* number of performance-critical tasks scheduled */
 	volatile u64	nr_lat_cri;	/* number of latency-critical tasks scheduled */
 	volatile u64	nr_big;		/* scheduled on big core */
 	volatile u64	nr_pc_on_big;	/* performance-critical tasks scheduled on big core */
 	volatile u64	nr_lc_on_big;	/* latency-critical tasks scheduled on big core */
-
-	volatile u64	nr_lhp;		/* number of lock holder preemption */
 };
 
 /*

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -100,8 +100,8 @@ struct cpu_ctx {
 	 * Information used to keep track of performance criticality
 	 */
 	volatile u64	sum_perf_cri;	/* sum of performance criticality */
-	volatile u64	min_perf_cri;	/* mininum performance criticality */
-	volatile u64	max_perf_cri;	/* maximum performance criticality */
+	volatile u32	min_perf_cri;	/* mininum performance criticality */
+	volatile u32	max_perf_cri;	/* maximum performance criticality */
 
 	/*
 	 * Information of a current running task for preemption
@@ -109,8 +109,7 @@ struct cpu_ctx {
 	volatile u64	stopping_tm_est_ns; /* estimated stopping time */
 	volatile u16	lat_cri;	/* latency criticality */
 	volatile u8	is_online;	/* is this CPU online? */
-	volatile bool	lock_holder;	/* is a lock holder running */
-	s32		cpu_id;		/* cpu id */
+	volatile u8	lock_holder;	/* is a lock holder running */
 
 	/*
 	 * Information for CPU frequency scaling
@@ -123,16 +122,13 @@ struct cpu_ctx {
 	 * Fields for core compaction
 	 *
 	 */
+	u16		cpu_id;		/* cpu id */
 	u16		capacity;	/* CPU capacity based on 1000 */
 	u8		big_core;	/* is it a big core? */
 	u8		turbo_core;	/* is it a turbo core? */
 	u8		cpdom_id;	/* compute domain id (== dsq_id) */
 	u8		cpdom_alt_id;	/* compute domain id of anternative type (== dsq_id) */
 	u8		cpdom_poll_pos;	/* index to check if a DSQ of a compute domain is starving */
-	struct bpf_cpumask __kptr *tmp_a_mask;	/* temporary cpu mask */
-	struct bpf_cpumask __kptr *tmp_o_mask;	/* temporary cpu mask */
-	struct bpf_cpumask __kptr *tmp_t_mask;	/* temporary cpu mask */
-	struct bpf_cpumask __kptr *tmp_t2_mask;	/* temporary cpu mask */
 
 	/*
 	 * Information for statistics.
@@ -145,6 +141,14 @@ struct cpu_ctx {
 	 */
 	u64		online_clk;	/* when a CPU becomes online */
 	u64		offline_clk;	/* when a CPU becomes offline */
+
+	/*
+	 * Temporary cpu masks
+	 */
+	struct bpf_cpumask __kptr *tmp_a_mask;
+	struct bpf_cpumask __kptr *tmp_o_mask;
+	struct bpf_cpumask __kptr *tmp_t_mask;
+	struct bpf_cpumask __kptr *tmp_t2_mask;
 } __attribute__((aligned(CACHELINE_SIZE)));
 
 

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -137,11 +137,8 @@ struct cpu_ctx {
 	/*
 	 * Information for statistics.
 	 */
-	volatile u32	nr_preemption;	/* number of migrations */
-	volatile u32	nr_greedy;	/* number of greedy tasks scheduled */
 	volatile u32	nr_perf_cri;
 	volatile u32	nr_lat_cri;
-	volatile u32	nr_lhp;		/* number of lock holder preemption */
 
 	/*
 	 * Information for cpu hotplug

--- a/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
@@ -48,10 +48,8 @@ static void dec_futex_boost(u32 *uaddr)
 
 static void reset_lock_futex_boost(struct task_ctx *taskc, struct cpu_ctx *cpuc)
 {
-	if (is_lock_holder(taskc)) {
+	if (is_lock_holder(taskc))
 		taskc->need_lock_boost = true;
-		cpuc->nr_lhp++;
-	}
 
 	taskc->futex_boost = 0;
 	taskc->futex_uaddr = NULL;

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -549,6 +549,18 @@ static void update_stat_for_running(struct task_struct *p,
 	}
 
 	/*
+	 * Update task state when starts running.
+	 */
+	taskc->wakeup_ft = 0;
+	taskc->last_running_clk = now;
+
+	/*
+	 * Reset task's lock and futex boost count
+	 * for a lock holder to be boosted only once.
+	 */
+	reset_lock_futex_boost(taskc, cpuc);
+
+	/*
 	 * Update per-CPU latency criticality information
 	 * for every-scheduled tasks.
 	 */
@@ -570,24 +582,6 @@ static void update_stat_for_running(struct task_struct *p,
 	}
 
 	/*
-	 * Reset task's lock and futex boost count
-	 * for a lock holder to be boosted only once.
-	 */
-	reset_lock_futex_boost(taskc, cpuc);
-
-	/*
-	 * It is clear there is no need to consider the suspended duration
-	 * while running a task, so reset the suspended duration to zero.
-	 */
-	reset_suspended_duration(cpuc);
-
-	/*
-	 * Update task state when starts running.
-	 */
-	taskc->wakeup_ft = 0;
-	taskc->last_running_clk = now;
-
-	/*
 	 * Update statistics information.
 	 */
 	if (is_lat_cri(taskc, stat_cur))
@@ -595,6 +589,12 @@ static void update_stat_for_running(struct task_struct *p,
 
 	if (is_perf_cri(taskc, stat_cur))
 		cpuc->nr_perf_cri++;
+
+	/*
+	 * It is clear there is no need to consider the suspended duration
+	 * while running a task, so reset the suspended duration to zero.
+	 */
+	reset_suspended_duration(cpuc);
 }
 
 static void update_stat_for_stopping(struct task_struct *p,

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -389,7 +389,7 @@ static u64 calc_virtual_deadline_delta(struct task_struct *p,
 					struct task_ctx *taskc,
 					u64 enq_flags)
 {
-	u64 deadline, lat_cri, adj_runtime;
+	u64 deadline, adj_runtime;
 	u32 greedy_ratio, greedy_ft;
 
 	/*
@@ -595,9 +595,6 @@ static void update_stat_for_running(struct task_struct *p,
 
 	if (is_perf_cri(taskc, stat_cur))
 		cpuc->nr_perf_cri++;
-
-	if (is_greedy(taskc))
-		cpuc->nr_greedy++;
 }
 
 static void update_stat_for_stopping(struct task_struct *p,

--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -41,6 +41,16 @@ volatile u64		performance_mode_ns;
 volatile u64		balanced_mode_ns;
 volatile u64		powersave_mode_ns;
 
+static bool is_perf_cri(struct task_ctx *taskc, struct sys_stat *stat_cur)
+{
+	if (!have_little_core)
+		return true;
+
+	if (READ_ONCE(taskc->on_big) && READ_ONCE(taskc->on_little))
+		return taskc->perf_cri >= stat_cur->thr_perf_cri;
+	return READ_ONCE(taskc->on_big);
+}
+
 static u64 calc_nr_active_cpus(struct sys_stat *stat_cur)
 {
 	u64 nr_active;

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -296,7 +296,6 @@ static bool try_yield_current_cpu(struct task_struct *p_run,
 	struct task_struct *p_wait;
 	struct task_ctx *taskc_wait;
 	struct preemption_info prm_run, prm_wait;
-	s32 cpu_id = scx_bpf_task_cpu(p_run), wait_vtm_cpu_id;
 	bool ret = false;
 
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -36,13 +36,11 @@ struct sys_stat_ctx {
 	s32		avg_lat_cri;
 	u64		sum_lat_cri;
 	u32		nr_sched;
-	u32		nr_greedy;
 	u32		nr_perf_cri;
 	u32		nr_lat_cri;
 	u32		nr_big;
 	u32		nr_pc_on_big;
 	u32		nr_lc_on_big;
-	u64		nr_lhp;
 	u64		min_perf_cri;
 	u64		avg_perf_cri;
 	u64		max_perf_cri;
@@ -95,12 +93,6 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 
 		c->nr_lat_cri += cpuc->nr_lat_cri;
 		cpuc->nr_lat_cri = 0;
-
-		c->nr_greedy += cpuc->nr_greedy;
-		cpuc->nr_greedy = 0;
-
-		c->nr_lhp += cpuc->nr_lhp;
-		cpuc->nr_lhp = 0;
 
 		/*
 		 * Accumulate task's latency criticlity information.
@@ -266,13 +258,11 @@ static void update_sys_stat_next(struct sys_stat_ctx *c)
 	if (cnt++ == LAVD_SYS_STAT_DECAY_TIMES) {
 		cnt = 0;
 		stat_next->nr_sched >>= 1;
-		stat_next->nr_greedy >>= 1;
 		stat_next->nr_perf_cri >>= 1;
 		stat_next->nr_lat_cri >>= 1;
 		stat_next->nr_big >>= 1;
 		stat_next->nr_pc_on_big >>= 1;
 		stat_next->nr_lc_on_big >>= 1;
-		stat_next->nr_lhp >>= 1;
 
 		__sync_fetch_and_sub(&performance_mode_ns, performance_mode_ns/2);
 		__sync_fetch_and_sub(&balanced_mode_ns, balanced_mode_ns/2);
@@ -280,13 +270,11 @@ static void update_sys_stat_next(struct sys_stat_ctx *c)
 	}
 
 	stat_next->nr_sched += c->nr_sched;
-	stat_next->nr_greedy += c->nr_greedy;
 	stat_next->nr_perf_cri += c->nr_perf_cri;
 	stat_next->nr_lat_cri += c->nr_lat_cri;
 	stat_next->nr_big += c->nr_big;
 	stat_next->nr_pc_on_big += c->nr_pc_on_big;
 	stat_next->nr_lc_on_big += c->nr_lc_on_big;
-	stat_next->nr_lhp += c->nr_lhp;
 
 	update_power_mode_time();
 }

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -229,13 +229,6 @@ static bool is_lat_cri(struct task_ctx *taskc, struct sys_stat *stat_cur)
 	return taskc->lat_cri >= stat_cur->avg_lat_cri;
 }
 
-static bool is_perf_cri(struct task_ctx *taskc, struct sys_stat *stat_cur)
-{
-	if (READ_ONCE(taskc->on_big) && READ_ONCE(taskc->on_little))
-		return taskc->perf_cri >= stat_cur->thr_perf_cri;
-	return READ_ONCE(taskc->on_big);
-}
-
 static bool is_greedy(struct task_ctx *taskc)
 {
 	return taskc->is_greedy;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -704,12 +704,9 @@ impl<'a> Scheduler<'a> {
                 let st = bss_data.__sys_stats[0];
 
                 let mseq = self.mseq_id;
-                let avg_svc_time = st.avg_svc_time;
                 let nr_queued_task = st.nr_queued_task;
                 let nr_active = st.nr_active;
                 let nr_sched = st.nr_sched;
-                let pc_lhp = Self::get_pc(st.nr_lhp, nr_sched);
-                let pc_greedy = Self::get_pc(st.nr_greedy, nr_sched);
                 let pc_pc = Self::get_pc(st.nr_perf_cri, nr_sched);
                 let pc_lc = Self::get_pc(st.nr_lat_cri, nr_sched);
                 let nr_big = st.nr_big;
@@ -726,12 +723,9 @@ impl<'a> Scheduler<'a> {
 
                 StatsRes::SysStats(SysStats {
                     mseq,
-                    avg_svc_time,
                     nr_queued_task,
                     nr_active,
                     nr_sched,
-                    pc_lhp,
-                    pc_greedy,
                     pc_pc,
                     pc_lc,
                     pc_big,

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -22,9 +22,6 @@ pub struct SysStats {
     #[stat(desc = "Sequence ID of this message")]
     pub mseq: u64,
 
-    #[stat(desc = "Average runtime per schedule")]
-    pub avg_svc_time: u64,
-
     #[stat(desc = "Number of runnable tasks in runqueues")]
     pub nr_queued_task: u64,
 
@@ -33,12 +30,6 @@ pub struct SysStats {
 
     #[stat(desc = "Number of context switches")]
     pub nr_sched: u64,
-
-    #[stat(desc = "% lock holder preemption")]
-    pub pc_lhp: f64,
-
-    #[stat(desc = "% of greedy tasks")]
-    pub pc_greedy: f64,
 
     #[stat(desc = "% of performance-critical tasks")]
     pub pc_pc: f64,
@@ -72,14 +63,11 @@ impl SysStats {
     pub fn format_header<W: Write>(w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "\x1b[93m| {:8} | {:13} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:11} | {:12} | {:12} | {:12} |\x1b[0m",
+            "\x1b[93m| {:8} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:11} | {:12} | {:12} | {:12} |\x1b[0m",
             "MSEQ",
-            "SVC_TIME",
             "# Q TASK",
             "# ACT CPU",
             "# SCHED",
-            "LHP%",
-            "GREEDY%",
             "PERF-CR%",
             "LAT-CR%",
             "BIG%",
@@ -100,14 +88,11 @@ impl SysStats {
 
         writeln!(
             w,
-            "| {:8} | {:13} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:11} | {:12} | {:12} | {:12} |",
+            "| {:8} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:11} | {:12} | {:12} | {:12} |",
             self.mseq,
-            self.avg_svc_time,
             self.nr_queued_task,
             self.nr_active,
             self.nr_sched,
-            GPoint(self.pc_lhp),
-            GPoint(self.pc_greedy),
             GPoint(self.pc_pc),
             GPoint(self.pc_lc),
             GPoint(self.pc_big),


### PR DESCRIPTION
Squeeze the size of cpuc_ctx by reducing some member sizes and reorganizing the structure layout to improve cache locality. Also,  drop less useful stat fields to optimize cache locality.

