### PR TITLE
scx_layered: More cleanups and an antistall fix

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/cost.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/cost.bpf.c
@@ -345,7 +345,7 @@ __weak int has_budget(struct cost *costc, struct layer *layer)
 		return 0;
 	}
 
-	u32 layer_id = layer->idx;
+	u32 layer_id = layer->id;
 	if (layer_id > nr_layers) {
 		scx_bpf_error("invalid layer %d", layer_id);
 		return 0;

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -64,13 +64,13 @@ enum layer_kind {
 };
 
 /* Statistics */
-enum global_stat_idx {
+enum global_stat_id {
 	GSTAT_EXCL_IDLE,
 	GSTAT_EXCL_WAKEUP,
 	NR_GSTATS,
 };
 
-enum layer_stat_idx {
+enum layer_stat_id {
 	LSTAT_SEL_LOCAL,
 	LSTAT_ENQ_WAKEUP,
 	LSTAT_ENQ_EXPIRE,
@@ -123,9 +123,9 @@ struct cpu_ctx {
 	u64			lstats[MAX_LAYERS][NR_LSTATS];
 	u64			ran_current_for;
 	u64			hi_fallback_dsq_id;
-	u32			layer_idx;
-	u32			cache_idx;
-	u32			node_idx;
+	u32			task_layer_id;
+	u32			cache_id;
+	u32			node_id;
 	u32			perf;
 	struct cpu_prox_map	prox_map;
 };
@@ -193,7 +193,7 @@ enum layer_growth_algo {
 struct layer {
 	struct layer_match_ands	matches[MAX_LAYER_MATCH_ORS];
 	unsigned int		nr_match_ors;
-	unsigned int		idx;
+	unsigned int		id;
 	u64			min_exec_ns;
 	u64			max_exec_ns;
 	u64			yield_step_ns;

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -111,6 +111,7 @@ struct cpu_prox_map {
 };
 
 struct cpu_ctx {
+	s32			cpu;
 	bool			current_preempt;
 	bool			current_exclusive;
 	bool			prev_exclusive;

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -118,7 +118,7 @@ struct cpu_ctx {
 	bool			yielding;
 	bool			try_preempt_first;
 	bool			is_big;
-	u64			layer_cycles[MAX_LAYERS];
+	u64			layer_usages[MAX_LAYERS];
 	u64			gstats[NR_GSTATS];
 	u64			lstats[MAX_LAYERS][NR_LSTATS];
 	u64			ran_current_for;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1959,7 +1959,7 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 	u64 slice_ns = layer_slice_ns(layer);
 	record_cpu_cost(costc, budget_id, (s64)used, slice_ns);
 
-	cctx->layer_cycles[lidx] += used;
+	cctx->layer_usages[lidx] += used;
 	cctx->current_preempt = false;
 	cctx->prev_exclusive = cctx->current_exclusive;
 	cctx->current_exclusive = false;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2670,20 +2670,14 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(layered_init)
 			bpf_cpumask_release(cpumask);
 
 		// create the dsqs for the layer
-		if (disable_topology) {
-			ret = scx_bpf_create_dsq(i, -1);
+		bpf_for(j, 0, nr_llcs) {
+			int node_id = llc_node_id(i);
+			dbg("CFG creating dsq %llu for layer %d %s on node %d in llc %d",
+			    llc_dsq_id, i, layer->name, node_id, j);
+			ret = scx_bpf_create_dsq(llc_dsq_id, node_id);
 			if (ret < 0)
 				return ret;
-		} else {
-			bpf_for(j, 0, nr_llcs) {
-				int node_id = llc_node_id(i);
-				dbg("CFG creating dsq %llu for layer %d %s on node %d in llc %d",
-				    llc_dsq_id, i, layer->name, node_id, j);
-				ret = scx_bpf_create_dsq(llc_dsq_id, node_id);
-				if (ret < 0)
-					return ret;
-				llc_dsq_id++;
-			}
+			llc_dsq_id++;
 		}
 	}
 	initialize_budgets(15LLU * NSEC_PER_SEC);

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -699,6 +699,7 @@ fn initialize_cpu_ctxs(skel: &BpfSkel, topo: &Topology) -> Result<()> {
 
         let topo_cpu = topo.all_cpus.get(&cpu).unwrap();
         let is_big = topo_cpu.core_type == CoreType::Big { turbo: true };
+        cpu_ctxs[cpu].cpu = cpu as i32;
         cpu_ctxs[cpu].is_big = is_big;
     }
 

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -781,7 +781,7 @@ struct Stats {
 
     total_util: f64, // Running AVG of sum of layer_utils
     layer_utils: Vec<f64>,
-    prev_layer_cycles: Vec<u64>,
+    prev_layer_usages: Vec<u64>,
 
     cpu_busy: f64, // Read from /proc, maybe higher than total_util
     prev_total_cpu: procfs::CpuStat,
@@ -820,16 +820,16 @@ impl Stats {
         (layer_loads.iter().sum(), layer_loads)
     }
 
-    fn read_layer_cycles(cpu_ctxs: &[bpf_intf::cpu_ctx], nr_layers: usize) -> Vec<u64> {
-        let mut layer_cycles = vec![0u64; nr_layers];
+    fn read_layer_usages(cpu_ctxs: &[bpf_intf::cpu_ctx], nr_layers: usize) -> Vec<u64> {
+        let mut layer_usages = vec![0u64; nr_layers];
 
         for cpu in 0..*NR_CPUS_POSSIBLE {
             for layer in 0..nr_layers {
-                layer_cycles[layer] += cpu_ctxs[cpu].layer_cycles[layer];
+                layer_usages[layer] += cpu_ctxs[cpu].layer_usages[layer];
             }
         }
 
-        layer_cycles
+        layer_usages
     }
 
     fn new(skel: &mut BpfSkel, proc_reader: &procfs::ProcReader) -> Result<Self> {
@@ -850,7 +850,7 @@ impl Stats {
 
             total_util: 0.0,
             layer_utils: vec![0.0; nr_layers],
-            prev_layer_cycles: Self::read_layer_cycles(&cpu_ctxs, nr_layers),
+            prev_layer_usages: Self::read_layer_usages(&cpu_ctxs, nr_layers),
 
             cpu_busy: 0.0,
             prev_total_cpu: read_total_cpu(&proc_reader)?,
@@ -894,10 +894,10 @@ impl Stats {
 
         let (total_load, layer_loads) = Self::read_layer_loads(skel, self.nr_layers);
 
-        let cur_layer_cycles = Self::read_layer_cycles(&cpu_ctxs, self.nr_layers);
-        let cur_layer_utils: Vec<f64> = cur_layer_cycles
+        let cur_layer_usages = Self::read_layer_usages(&cpu_ctxs, self.nr_layers);
+        let cur_layer_utils: Vec<f64> = cur_layer_usages
             .iter()
-            .zip(self.prev_layer_cycles.iter())
+            .zip(self.prev_layer_usages.iter())
             .map(|(cur, prev)| (cur - prev) as f64 / 1_000_000_000.0 / elapsed)
             .collect();
         let layer_utils: Vec<f64> = cur_layer_utils
@@ -931,7 +931,7 @@ impl Stats {
 
             total_util: layer_utils.iter().sum(),
             layer_utils: layer_utils.try_into().unwrap(),
-            prev_layer_cycles: cur_layer_cycles,
+            prev_layer_usages: cur_layer_usages,
 
             cpu_busy,
             prev_total_cpu: cur_total_cpu,

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -73,8 +73,8 @@ const MAX_LAYER_MATCH_ORS: usize = bpf_intf::consts_MAX_LAYER_MATCH_ORS as usize
 const MAX_LAYERS: usize = bpf_intf::consts_MAX_LAYERS as usize;
 const USAGE_HALF_LIFE: u32 = bpf_intf::consts_USAGE_HALF_LIFE;
 const USAGE_HALF_LIFE_F64: f64 = USAGE_HALF_LIFE as f64 / 1_000_000_000.0;
-const NR_GSTATS: usize = bpf_intf::global_stat_idx_NR_GSTATS as usize;
-const NR_LSTATS: usize = bpf_intf::layer_stat_idx_NR_LSTATS as usize;
+const NR_GSTATS: usize = bpf_intf::global_stat_id_NR_GSTATS as usize;
+const NR_LSTATS: usize = bpf_intf::layer_stat_id_NR_LSTATS as usize;
 const NR_LAYER_MATCH_KINDS: usize = bpf_intf::layer_match_kind_NR_LAYER_MATCH_KINDS as usize;
 const MAX_LAYER_NAME: usize = bpf_intf::consts_MAX_LAYER_NAME as usize;
 

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -154,10 +154,10 @@ impl LayerStats {
         nr_cpus_range: (usize, usize),
     ) -> Self {
         let lstat = |sidx| bstats.lstats[lidx][sidx as usize];
-        let ltotal = lstat(bpf_intf::layer_stat_idx_LSTAT_SEL_LOCAL)
-            + lstat(bpf_intf::layer_stat_idx_LSTAT_ENQ_WAKEUP)
-            + lstat(bpf_intf::layer_stat_idx_LSTAT_ENQ_EXPIRE)
-            + lstat(bpf_intf::layer_stat_idx_LSTAT_ENQ_REENQ);
+        let ltotal = lstat(bpf_intf::layer_stat_id_LSTAT_SEL_LOCAL)
+            + lstat(bpf_intf::layer_stat_id_LSTAT_ENQ_WAKEUP)
+            + lstat(bpf_intf::layer_stat_id_LSTAT_ENQ_EXPIRE)
+            + lstat(bpf_intf::layer_stat_id_LSTAT_ENQ_REENQ);
         let lstat_pct = |sidx| {
             if ltotal != 0 {
                 lstat(sidx) as f64 / ltotal as f64 * 100.0
@@ -176,34 +176,34 @@ impl LayerStats {
             load: normalize_load_metric(stats.layer_loads[lidx]),
             tasks: stats.nr_layer_tasks[lidx] as u32,
             total: ltotal,
-            sel_local: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_SEL_LOCAL),
-            enq_wakeup: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_ENQ_WAKEUP),
-            enq_expire: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_ENQ_EXPIRE),
-            enq_reenq: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_ENQ_REENQ),
-            min_exec: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_MIN_EXEC),
-            min_exec_us: (lstat(bpf_intf::layer_stat_idx_LSTAT_MIN_EXEC_NS) / 1000) as u64,
-            open_idle: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_OPEN_IDLE),
-            preempt: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_PREEMPT),
-            preempt_xllc: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_PREEMPT_XLLC),
-            preempt_xnuma: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_PREEMPT_XNUMA),
-            preempt_first: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_PREEMPT_FIRST),
-            preempt_idle: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_PREEMPT_IDLE),
-            preempt_fail: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_PREEMPT_FAIL),
-            affn_viol: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_AFFN_VIOL),
-            keep: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_KEEP),
-            keep_fail_max_exec: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_KEEP_FAIL_MAX_EXEC),
-            keep_fail_busy: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_KEEP_FAIL_BUSY),
+            sel_local: lstat_pct(bpf_intf::layer_stat_id_LSTAT_SEL_LOCAL),
+            enq_wakeup: lstat_pct(bpf_intf::layer_stat_id_LSTAT_ENQ_WAKEUP),
+            enq_expire: lstat_pct(bpf_intf::layer_stat_id_LSTAT_ENQ_EXPIRE),
+            enq_reenq: lstat_pct(bpf_intf::layer_stat_id_LSTAT_ENQ_REENQ),
+            min_exec: lstat_pct(bpf_intf::layer_stat_id_LSTAT_MIN_EXEC),
+            min_exec_us: (lstat(bpf_intf::layer_stat_id_LSTAT_MIN_EXEC_NS) / 1000) as u64,
+            open_idle: lstat_pct(bpf_intf::layer_stat_id_LSTAT_OPEN_IDLE),
+            preempt: lstat_pct(bpf_intf::layer_stat_id_LSTAT_PREEMPT),
+            preempt_xllc: lstat_pct(bpf_intf::layer_stat_id_LSTAT_PREEMPT_XLLC),
+            preempt_xnuma: lstat_pct(bpf_intf::layer_stat_id_LSTAT_PREEMPT_XNUMA),
+            preempt_first: lstat_pct(bpf_intf::layer_stat_id_LSTAT_PREEMPT_FIRST),
+            preempt_idle: lstat_pct(bpf_intf::layer_stat_id_LSTAT_PREEMPT_IDLE),
+            preempt_fail: lstat_pct(bpf_intf::layer_stat_id_LSTAT_PREEMPT_FAIL),
+            affn_viol: lstat_pct(bpf_intf::layer_stat_id_LSTAT_AFFN_VIOL),
+            keep: lstat_pct(bpf_intf::layer_stat_id_LSTAT_KEEP),
+            keep_fail_max_exec: lstat_pct(bpf_intf::layer_stat_id_LSTAT_KEEP_FAIL_MAX_EXEC),
+            keep_fail_busy: lstat_pct(bpf_intf::layer_stat_id_LSTAT_KEEP_FAIL_BUSY),
             is_excl: layer.kind.common().exclusive as u32,
-            excl_collision: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_EXCL_COLLISION),
-            excl_preempt: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_EXCL_PREEMPT),
-            kick: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_KICK),
-            yielded: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_YIELD),
-            yield_ignore: lstat(bpf_intf::layer_stat_idx_LSTAT_YIELD_IGNORE) as u64,
-            migration: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_MIGRATION),
-            xnuma_migration: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_XNUMA_MIGRATION),
-            xlayer_wake: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_XLAYER_WAKE),
-            xlayer_rewake: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_XLAYER_REWAKE),
-            xllc_migration: lstat_pct(bpf_intf::layer_stat_idx_LSTAT_XLLC_MIGRATION),
+            excl_collision: lstat_pct(bpf_intf::layer_stat_id_LSTAT_EXCL_COLLISION),
+            excl_preempt: lstat_pct(bpf_intf::layer_stat_id_LSTAT_EXCL_PREEMPT),
+            kick: lstat_pct(bpf_intf::layer_stat_id_LSTAT_KICK),
+            yielded: lstat_pct(bpf_intf::layer_stat_id_LSTAT_YIELD),
+            yield_ignore: lstat(bpf_intf::layer_stat_id_LSTAT_YIELD_IGNORE) as u64,
+            migration: lstat_pct(bpf_intf::layer_stat_id_LSTAT_MIGRATION),
+            xnuma_migration: lstat_pct(bpf_intf::layer_stat_id_LSTAT_XNUMA_MIGRATION),
+            xlayer_wake: lstat_pct(bpf_intf::layer_stat_id_LSTAT_XLAYER_WAKE),
+            xlayer_rewake: lstat_pct(bpf_intf::layer_stat_id_LSTAT_XLAYER_REWAKE),
+            xllc_migration: lstat_pct(bpf_intf::layer_stat_id_LSTAT_XLLC_MIGRATION),
             cpus: Self::bitvec_to_u32s(&layer.cpus),
             cur_nr_cpus: layer.cpus.count_ones() as u32,
             min_nr_cpus: nr_cpus_range.0 as u32,
@@ -375,10 +375,10 @@ pub struct SysStats {
 impl SysStats {
     pub fn new(stats: &Stats, bstats: &BpfStats, fallback_cpu: usize) -> Result<Self> {
         let lsum = |idx| stats.bpf_stats.lstats_sums[idx as usize];
-        let total = lsum(bpf_intf::layer_stat_idx_LSTAT_SEL_LOCAL)
-            + lsum(bpf_intf::layer_stat_idx_LSTAT_ENQ_WAKEUP)
-            + lsum(bpf_intf::layer_stat_idx_LSTAT_ENQ_EXPIRE)
-            + lsum(bpf_intf::layer_stat_idx_LSTAT_ENQ_REENQ);
+        let total = lsum(bpf_intf::layer_stat_id_LSTAT_SEL_LOCAL)
+            + lsum(bpf_intf::layer_stat_id_LSTAT_ENQ_WAKEUP)
+            + lsum(bpf_intf::layer_stat_id_LSTAT_ENQ_EXPIRE)
+            + lsum(bpf_intf::layer_stat_id_LSTAT_ENQ_REENQ);
         let lsum_pct = |idx| {
             if total != 0 {
                 lsum(idx) as f64 / total as f64 * 100.0
@@ -391,14 +391,14 @@ impl SysStats {
             at: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs_f64(),
             nr_nodes: stats.nr_nodes,
             total,
-            local: lsum_pct(bpf_intf::layer_stat_idx_LSTAT_SEL_LOCAL),
-            open_idle: lsum_pct(bpf_intf::layer_stat_idx_LSTAT_OPEN_IDLE),
-            affn_viol: lsum_pct(bpf_intf::layer_stat_idx_LSTAT_AFFN_VIOL),
-            excl_collision: lsum_pct(bpf_intf::layer_stat_idx_LSTAT_EXCL_COLLISION),
-            excl_preempt: lsum_pct(bpf_intf::layer_stat_idx_LSTAT_EXCL_PREEMPT),
-            excl_idle: bstats.gstats[bpf_intf::global_stat_idx_GSTAT_EXCL_IDLE as usize] as f64
+            local: lsum_pct(bpf_intf::layer_stat_id_LSTAT_SEL_LOCAL),
+            open_idle: lsum_pct(bpf_intf::layer_stat_id_LSTAT_OPEN_IDLE),
+            affn_viol: lsum_pct(bpf_intf::layer_stat_id_LSTAT_AFFN_VIOL),
+            excl_collision: lsum_pct(bpf_intf::layer_stat_id_LSTAT_EXCL_COLLISION),
+            excl_preempt: lsum_pct(bpf_intf::layer_stat_id_LSTAT_EXCL_PREEMPT),
+            excl_idle: bstats.gstats[bpf_intf::global_stat_id_GSTAT_EXCL_IDLE as usize] as f64
                 / total as f64,
-            excl_wakeup: bstats.gstats[bpf_intf::global_stat_idx_GSTAT_EXCL_WAKEUP as usize] as f64
+            excl_wakeup: bstats.gstats[bpf_intf::global_stat_id_GSTAT_EXCL_WAKEUP as usize] as f64
                 / total as f64,
             proc_ms: stats.processing_dur.as_millis() as u64,
             busy: stats.cpu_busy * 100.0,


### PR DESCRIPTION
- Remove `disable_toplogy` special case from DSQ init path.
- Rename `cpu_ctx->layer_cycles` to `cpu_ctx->layer_usages`.
- Rename `idx` to `id` and other name related cleanups.
- `layer_id` type and uninit state cleanups.
- Fix `antistall_consume()` skipping incorrectly.