### PR TITLE
scx_lavd: add tunables for adjusting time slices

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -20,8 +20,8 @@ enum consts_internal  {
 	LAVD_MAX_RETRY			= 4,
 
 	LAVD_TARGETED_LATENCY_NS	= (20ULL * NSEC_PER_MSEC),
-	LAVD_SLICE_MIN_NS		= (300ULL * NSEC_PER_USEC), /* min time slice */
-	LAVD_SLICE_MAX_NS		= (3ULL * NSEC_PER_MSEC), /* max time slice */
+	LAVD_SLICE_MIN_NS_DFL		= (300ULL * NSEC_PER_USEC), /* min time slice */
+	LAVD_SLICE_MAX_NS_DFL		= (3ULL * NSEC_PER_MSEC), /* max time slice */
 
 	LAVD_LC_FREQ_MAX		= 1000000,
 	LAVD_LC_RUNTIME_MAX		= LAVD_TIME_ONE_SEC,
@@ -50,7 +50,7 @@ enum consts_internal  {
 	LAVD_AP_HIGH_UTIL		= 700, /* balanced mode when 10% < cpu util <= 40%,
 						  performance mode when cpu util > 40% */
 
-	LAVD_CPDOM_STARV_NS		= (2 * LAVD_SLICE_MAX_NS),
+	LAVD_CPDOM_STARV_NS		= (2 * LAVD_SLICE_MAX_NS_DFL),
 };
 
 const volatile u64 LAVD_TIME_INFINITY_NS;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -95,6 +95,14 @@ struct Opts {
     #[clap(long = "balanced", action = clap::ArgAction::SetTrue)]
     balanced: bool,
 
+    /// Maximum scheduling slice duration in microseconds.
+    #[clap(long = "slice-max-us", default_value = "3000")]
+    slice_max_us: u64,
+
+    /// Minimum scheduling slice duration in microseconds.
+    #[clap(long = "slice-min-us", default_value = "300")]
+    slice_min_us: u64,
+
     /// Disable core compaction and schedule tasks across all online CPUs. Core compaction attempts
     /// to keep idle CPUs idle in favor of scheduling tasks on CPUs that are already
     /// awake. See main.bpf.c for more info. Normally set by the power mode, but can be set independently if
@@ -601,6 +609,8 @@ impl<'a> Scheduler<'a> {
         };
         skel.maps.rodata_data.is_autopilot_on = opts.autopilot;
         skel.maps.rodata_data.verbose = opts.verbose;
+        skel.maps.rodata_data.slice_max_ns = opts.slice_max_us * 1000;
+        skel.maps.rodata_data.slice_min_ns = opts.slice_min_us * 1000;
     }
 
     fn get_msg_seq_id() -> u64 {


### PR DESCRIPTION
Add two command line options, --slice-max-us and --slice-min-us, to adjust task's maximum and minimum time slice values, respectively.