### PR TITLE
scx_layered: Track owned/open execution times and per-LLC-layer stats

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -63,6 +63,13 @@ enum layer_kind {
 	LAYER_KIND_CONFINED,
 };
 
+enum layer_usage {
+	LAYER_USAGE_OWNED,
+	LAYER_USAGE_OPEN,
+
+	NR_LAYER_USAGES,
+};
+
 /* Statistics */
 enum global_stat_id {
 	GSTAT_EXCL_IDLE,
@@ -119,11 +126,12 @@ struct cpu_ctx {
 	bool			yielding;
 	bool			try_preempt_first;
 	bool			is_big;
-	u64			layer_usages[MAX_LAYERS];
+	u64			layer_usages[MAX_LAYERS][NR_LAYER_USAGES];
 	u64			gstats[NR_GSTATS];
 	u64			lstats[MAX_LAYERS][NR_LSTATS];
 	u64			ran_current_for;
 	u64			hi_fallback_dsq_id;
+	u32			layer_id;
 	u32			task_layer_id;
 	u32			cache_id;
 	u32			node_id;

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -133,13 +133,13 @@ struct cpu_ctx {
 	u64			hi_fallback_dsq_id;
 	u32			layer_id;
 	u32			task_layer_id;
-	u32			cache_id;
+	u32			llc_id;
 	u32			node_id;
 	u32			perf;
 	struct cpu_prox_map	prox_map;
 };
 
-struct cache_ctx {
+struct llc_ctx {
 	u32 id;
 	struct bpf_cpumask __kptr *cpumask;
 	u32 nr_cpus;
@@ -224,7 +224,7 @@ struct layer {
 
 	u64			cpus_seq;
 	u64			node_mask;
-	u64			cache_mask;
+	u64			llc_mask;
 	bool			check_no_idle;
 	u64			refresh_cpus;
 	unsigned char		cpus[MAX_CPUS_U8];

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -29,6 +29,7 @@ typedef unsigned long long u64;
 #endif
 
 enum consts {
+	CACHELINE_SIZE		= 64,
 	MAX_CPUS_SHIFT		= 9,
 	MAX_CPUS		= 1 << MAX_CPUS_SHIFT,
 	MAX_CPUS_U8		= MAX_CPUS / 8,
@@ -44,6 +45,7 @@ enum consts {
 	MIN_LAYER_WEIGHT	= 1,
 	DEFAULT_LAYER_WEIGHT	= 100,
 	USAGE_HALF_LIFE		= 100000000,	/* 100ms */
+	LAYER_LAT_DECAY_FACTOR	= 4,
 
 	HI_FALLBACK_DSQ_BASE	= MAX_LAYERS * MAX_LLCS,
 	LO_FALLBACK_DSQ		= (MAX_LAYERS * MAX_LLCS) + MAX_LLCS + 1,
@@ -108,6 +110,12 @@ enum layer_stat_id {
 	NR_LSTATS,
 };
 
+enum llc_layer_stat_id {
+	LLC_LSTAT_LAT,
+	LLC_LSTAT_CNT,
+	NR_LLC_LSTATS,
+};
+
 /* CPU proximity map from closest to farthest, starts with self */
 struct cpu_prox_map {
 	u16			cpus[MAX_CPUS];
@@ -140,18 +148,19 @@ struct cpu_ctx {
 };
 
 struct llc_ctx {
-	u32 id;
+	u32			id;
 	struct bpf_cpumask __kptr *cpumask;
-	u32 nr_cpus;
-};
+	u32			nr_cpus;
+	u64			lstats[MAX_LAYERS][NR_LLC_LSTATS];
+} __attribute__((aligned(CACHELINE_SIZE)));
 
 struct node_ctx {
-	u32 id;
+	u32			id;
 	struct bpf_cpumask __kptr *cpumask;
-	u32 nr_llcs;
-	u32 nr_cpus;
-	u64 llc_mask;
-};
+	u32			nr_llcs;
+	u32			nr_cpus;
+	u64			llc_mask;
+} __attribute__((aligned(CACHELINE_SIZE)));
 
 enum layer_match_kind {
 	MATCH_CGROUP_PREFIX,

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -152,7 +152,7 @@ struct llc_ctx {
 	struct bpf_cpumask __kptr *cpumask;
 	u32			nr_cpus;
 	u64			lstats[MAX_LAYERS][NR_LLC_LSTATS];
-} __attribute__((aligned(CACHELINE_SIZE)));
+};
 
 struct node_ctx {
 	u32			id;
@@ -160,7 +160,7 @@ struct node_ctx {
 	u32			nr_llcs;
 	u32			nr_cpus;
 	u64			llc_mask;
-} __attribute__((aligned(CACHELINE_SIZE)));
+};
 
 enum layer_match_kind {
 	MATCH_CGROUP_PREFIX,

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -85,7 +85,7 @@ static inline s32 sibling_cpu(s32 cpu)
 		return -1;
 }
 
-static struct layer *lookup_layer(u32 id)
+static __always_inline struct layer *lookup_layer(u32 id)
 {
 	if (id >= nr_layers) {
 		scx_bpf_error("invalid layer %d", id);
@@ -182,6 +182,8 @@ static struct cpu_ctx *lookup_cpu_ctx(int cpu)
 	return cpuc;
 }
 
+// XXX - Converting this to bss array triggers verifier bugs. See
+// BpfStats::read().
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__type(key, u32);
@@ -199,6 +201,8 @@ static struct node_ctx *lookup_node_ctx(u32 node)
 	return nodec;
 }
 
+// XXX - Converting this to bss array triggers verifier bugs. See
+// BpfStats::read().
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__type(key, u32);
@@ -399,6 +403,7 @@ struct task_ctx {
 	struct cached_cpus	layered_cpus_node;
 	struct bpf_cpumask __kptr *layered_node_mask;
 	bool			all_cpus_allowed;
+	bool			first_run;
 	u64			runnable_at;
 	u64			running_at;
 	u64			last_dsq;
@@ -1723,12 +1728,8 @@ static s32 create_node(u32 node_id)
 	struct cpu_ctx *cpuc;
 	s32 ret;
 
-	nodec = bpf_map_lookup_elem(&node_data, &node_id);
-	if (!nodec) {
-		/* Should never happen, it's created statically at load time. */
-		scx_bpf_error("No node%u", node_id);
+	if (!(nodec = lookup_node_ctx(node_id)))
 		return -ENOENT;
-	}
 	nodec->id = node_id;
 
 	ret = create_save_cpumask(&nodec->cpumask);
@@ -1780,11 +1781,8 @@ static s32 create_llc(u32 llc_id)
 	struct cpu_ctx *cpuc;
 	s32 ret;
 
-	llcc = bpf_map_lookup_elem(&llc_data, &llc_id);
-	if (!llcc) {
-		scx_bpf_error("No llc%u", llc_id);
+	if (!(llcc = lookup_llc_ctx(llc_id)))
 		return -ENOENT;
-	}
 	llcc->id = llc_id;
 
 	ret = create_save_cpumask(&llcc->cpumask);
@@ -1857,6 +1855,7 @@ void BPF_STRUCT_OPS(layered_runnable, struct task_struct *p, u64 enq_flags)
 		return;
 
 	taskc->runnable_at = now;
+	taskc->first_run = true;
 	maybe_refresh_layer(p, taskc);
 	adj_load(taskc->layer_id, p->scx.weight, now);
 
@@ -1872,10 +1871,30 @@ void BPF_STRUCT_OPS(layered_running, struct task_struct *p)
 	struct node_ctx *nodec;
 	struct llc_ctx *llcc;
 	s32 task_cpu = scx_bpf_task_cpu(p);
+	u32 layer_id;
 
-	if (!(cpuc = lookup_cpu_ctx(-1)) || !(taskc = lookup_task_ctx(p)) ||
-	    !(layer = lookup_layer(taskc->layer_id)))
+	if (!(cpuc = lookup_cpu_ctx(-1)) || !(llcc = lookup_llc_ctx(cpuc->llc_id)) ||
+	    !(taskc = lookup_task_ctx(p)))
 		return;
+
+	layer_id = taskc->layer_id;
+	if (!(layer = lookup_layer(layer_id)))
+		return;
+
+	if (taskc->first_run) {
+		u64 now = bpf_ktime_get_ns();
+		u64 lat = now - taskc->runnable_at;
+		u32 llc_id = cpuc->llc_id;
+		u64 *stats = llcc->lstats[layer_id];
+
+		// racy, don't care
+		stats[LLC_LSTAT_LAT] =
+			((LAYER_LAT_DECAY_FACTOR - 1) * stats[LLC_LSTAT_LAT] + lat) /
+			LAYER_LAT_DECAY_FACTOR;
+		stats[LLC_LSTAT_CNT]++;
+
+		taskc->first_run = false;
+	}
 
 	if (taskc->last_cpu >= 0 && taskc->last_cpu != task_cpu) {
 		lstat_inc(LSTAT_MIGRATION, layer, cpuc);
@@ -1884,8 +1903,6 @@ void BPF_STRUCT_OPS(layered_running, struct task_struct *p)
 		if (nodec->cpumask &&
 		    !bpf_cpumask_test_cpu(taskc->last_cpu, cast_mask(nodec->cpumask)))
 			lstat_inc(LSTAT_XNUMA_MIGRATION, layer, cpuc);
-		if (!(llcc = lookup_llc_ctx(cpuc->llc_id)))
-			return;
 		if (llcc->cpumask &&
 		    !bpf_cpumask_test_cpu(taskc->last_cpu, cast_mask(llcc->cpumask)))
 			lstat_inc(LSTAT_XLLC_MIGRATION, layer, cpuc);

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -167,19 +167,19 @@ struct {
 
 static struct cpu_ctx *lookup_cpu_ctx(int cpu)
 {
-	struct cpu_ctx *cctx;
+	struct cpu_ctx *cpuc;
 
 	if (cpu < 0)
-		cctx = bpf_map_lookup_elem(&cpu_ctxs, &zero_u32);
+		cpuc = bpf_map_lookup_elem(&cpu_ctxs, &zero_u32);
 	else
-		cctx = bpf_map_lookup_percpu_elem(&cpu_ctxs, &zero_u32, cpu);
+		cpuc = bpf_map_lookup_percpu_elem(&cpu_ctxs, &zero_u32, cpu);
 
-	if (!cctx) {
+	if (!cpuc) {
 		scx_bpf_error("no cpu_ctx for cpu %d", cpu);
 		return NULL;
 	}
 
-	return cctx;
+	return cpuc;
 }
 
 struct {
@@ -216,29 +216,29 @@ static struct llc_ctx *lookup_llc_ctx(u32 llc_id)
 	return llcc;
 }
 
-static void gstat_inc(u32 id, struct cpu_ctx *cctx)
+static void gstat_inc(u32 id, struct cpu_ctx *cpuc)
 {
 	if (id >= NR_GSTATS) {
 		scx_bpf_error("invalid global stat id %d", id);
 		return;
 	}
 
-	cctx->gstats[id]++;
+	cpuc->gstats[id]++;
 }
 
-static void lstat_add(u32 id, struct layer *layer, struct cpu_ctx *cctx, s64 delta)
+static void lstat_add(u32 id, struct layer *layer, struct cpu_ctx *cpuc, s64 delta)
 {
 	u64 *vptr;
 
-	if ((vptr = MEMBER_VPTR(*cctx, .lstats[layer->id][id])))
+	if ((vptr = MEMBER_VPTR(*cpuc, .lstats[layer->id][id])))
 		(*vptr) += delta;
 	else
 		scx_bpf_error("invalid layer or stat ids: %d, %d", id, layer->id);
 }
 
-static void lstat_inc(u32 id, struct layer *layer, struct cpu_ctx *cctx)
+static void lstat_inc(u32 id, struct layer *layer, struct cpu_ctx *cpuc)
 {
-	lstat_add(id, layer, cctx, 1);
+	lstat_add(id, layer, cpuc, 1);
 }
 
 struct lock_wrapper {
@@ -308,7 +308,7 @@ static bool refresh_cpumasks(u32 layer_id)
 	struct bpf_cpumask *layer_cpumask;
 	struct layer_cpumask_wrapper *cpumaskw;
 	struct layer *layer;
-	struct cpu_ctx *cctx;
+	struct cpu_ctx *cpuc;
 	int cpu, total = 0;
 
 	layer = MEMBER_VPTR(layers, [layer_id]);
@@ -331,7 +331,7 @@ static bool refresh_cpumasks(u32 layer_id)
 	bpf_for(cpu, 0, nr_possible_cpus) {
 		u8 *u8_ptr;
 
-		if (!(cctx = lookup_cpu_ctx(cpu))) {
+		if (!(cpuc = lookup_cpu_ctx(cpu))) {
 			bpf_rcu_read_unlock();
 			scx_bpf_error("unknown cpu");
 			return false;
@@ -339,12 +339,12 @@ static bool refresh_cpumasks(u32 layer_id)
 
 		if ((u8_ptr = MEMBER_VPTR(layers, [layer_id].cpus[cpu / 8]))) {
 			if (*u8_ptr & (1 << (cpu % 8))) {
-				cctx->layer_id = layer_id;
+				cpuc->layer_id = layer_id;
 				bpf_cpumask_set_cpu(cpu, layer_cpumask);
 				total++;
 			} else {
-				if (cctx->layer_id == layer_id)
-					cctx->layer_id = MAX_LAYERS;
+				if (cpuc->layer_id == layer_id)
+					cpuc->layer_id = MAX_LAYERS;
 				bpf_cpumask_clear_cpu(cpu, layer_cpumask);
 			}
 		} else {
@@ -418,12 +418,12 @@ static struct task_ctx *lookup_task_ctx_may_fail(struct task_struct *p)
 
 static struct task_ctx *lookup_task_ctx(struct task_struct *p)
 {
-	struct task_ctx *tctx = lookup_task_ctx_may_fail(p);
+	struct task_ctx *taskc = lookup_task_ctx_may_fail(p);
 
-	if (!tctx)
+	if (!taskc)
 		scx_bpf_error("task_ctx lookup failed");
 
-	return tctx;
+	return taskc;
 }
 
 /*
@@ -441,11 +441,11 @@ int BPF_PROG(tp_cgroup_attach_task, struct cgroup *cgrp, const char *cgrp_path,
 {
 	struct list_head *thread_head;
 	struct task_struct *next;
-	struct task_ctx *tctx;
+	struct task_ctx *taskc;
 
-	if (!(tctx = lookup_task_ctx_may_fail(leader)))
+	if (!(taskc = lookup_task_ctx_may_fail(leader)))
 		return 0;
-	tctx->refresh_layer = true;
+	taskc->refresh_layer = true;
 
 	if (!threadgroup)
 		return 0;
@@ -476,8 +476,8 @@ int BPF_PROG(tp_cgroup_attach_task, struct cgroup *cgrp, const char *cgrp_path,
 			break;
 		}
 
-		if ((tctx = lookup_task_ctx(next)))
-			tctx->refresh_layer = true;
+		if ((taskc = lookup_task_ctx(next)))
+			taskc->refresh_layer = true;
 	}
 
 	if (next)
@@ -488,10 +488,10 @@ int BPF_PROG(tp_cgroup_attach_task, struct cgroup *cgrp, const char *cgrp_path,
 SEC("tp_btf/task_rename")
 int BPF_PROG(tp_task_rename, struct task_struct *p, const char *buf)
 {
-	struct task_ctx *tctx;
+	struct task_ctx *taskc;
 
-	if ((tctx = lookup_task_ctx_may_fail(p)))
-		tctx->refresh_layer = true;
+	if ((taskc = lookup_task_ctx_may_fail(p)))
+		taskc->refresh_layer = true;
 	return 0;
 }
 
@@ -522,51 +522,51 @@ void refresh_cached_cpus(struct bpf_cpumask *mask,
 	ccpus->seq = cpus_seq;
 }
 
-static void maybe_refresh_layered_cpus(struct task_struct *p, struct task_ctx *tctx,
+static void maybe_refresh_layered_cpus(struct task_struct *p, struct task_ctx *taskc,
 				       const struct cpumask *layer_cpumask,
 				       u64 cpus_seq)
 {
-	if (should_refresh_cached_cpus(&tctx->layered_cpus, 0, cpus_seq)) {
-		refresh_cached_cpus(tctx->layered_mask, &tctx->layered_cpus, 0, cpus_seq,
+	if (should_refresh_cached_cpus(&taskc->layered_cpus, 0, cpus_seq)) {
+		refresh_cached_cpus(taskc->layered_mask, &taskc->layered_cpus, 0, cpus_seq,
 				    p->cpus_ptr, layer_cpumask);
 		trace("%s[%d] layered cpumask refreshed to seq=%llu",
-		      p->comm, p->pid, tctx->layered_cpus.seq);
+		      p->comm, p->pid, taskc->layered_cpus.seq);
 	}
 }
 
-static void maybe_refresh_layered_cpus_llc(struct task_struct *p, struct task_ctx *tctx,
+static void maybe_refresh_layered_cpus_llc(struct task_struct *p, struct task_ctx *taskc,
 					   const struct cpumask *layer_cpumask,
 					   s32 llc_id, u64 cpus_seq)
 {
-	if (should_refresh_cached_cpus(&tctx->layered_cpus_llc, llc_id, cpus_seq)) {
+	if (should_refresh_cached_cpus(&taskc->layered_cpus_llc, llc_id, cpus_seq)) {
 		struct llc_ctx *llcc;
 
 		if (!(llcc = lookup_llc_ctx(llc_id)))
 			return;
-		refresh_cached_cpus(tctx->layered_llc_mask,
-				    &tctx->layered_cpus_llc, llc_id, cpus_seq,
-				    cast_mask(tctx->layered_mask),
+		refresh_cached_cpus(taskc->layered_llc_mask,
+				    &taskc->layered_cpus_llc, llc_id, cpus_seq,
+				    cast_mask(taskc->layered_mask),
 				    cast_mask(llcc->cpumask));
 		trace("%s[%d] layered llc cpumask refreshed to llc=%d seq=%llu",
-		      p->comm, p->pid, tctx->layered_cpus_llc.id, tctx->layered_cpus_llc.seq);
+		      p->comm, p->pid, taskc->layered_cpus_llc.id, taskc->layered_cpus_llc.seq);
 	}
 }
 
-static void maybe_refresh_layered_cpus_node(struct task_struct *p, struct task_ctx *tctx,
+static void maybe_refresh_layered_cpus_node(struct task_struct *p, struct task_ctx *taskc,
 					    const struct cpumask *layer_cpumask,
 					    s32 node_id, u64 cpus_seq)
 {
-	if (should_refresh_cached_cpus(&tctx->layered_cpus_node, node_id, cpus_seq)) {
+	if (should_refresh_cached_cpus(&taskc->layered_cpus_node, node_id, cpus_seq)) {
 		struct node_ctx *nodec;
 
 		if (!(nodec = lookup_node_ctx(node_id)))
 			return;
-		refresh_cached_cpus(tctx->layered_node_mask,
-				    &tctx->layered_cpus_node, node_id, cpus_seq,
-				    cast_mask(tctx->layered_mask),
+		refresh_cached_cpus(taskc->layered_node_mask,
+				    &taskc->layered_cpus_node, node_id, cpus_seq,
+				    cast_mask(taskc->layered_mask),
 				    cast_mask(nodec->cpumask));
 		trace("%s[%d] layered node cpumask refreshed to node=%d seq=%llu",
-		      p->comm, p->pid, tctx->layered_cpus_node.id, tctx->layered_cpus_node.seq);
+		      p->comm, p->pid, taskc->layered_cpus_node.id, taskc->layered_cpus_node.seq);
 	}
 }
 
@@ -601,7 +601,7 @@ static __always_inline
 bool should_try_preempt_first(s32 cand, struct layer *layer,
 			      const struct cpumask *layered_cpumask)
 {
-	struct cpu_ctx *cand_cctx, *sib_cctx;
+	struct cpu_ctx *cand_cpuc, *sib_cpuc;
 	s32 sib;
 
 	if (!layer->preempt || !layer->preempt_first)
@@ -611,11 +611,11 @@ bool should_try_preempt_first(s32 cand, struct layer *layer,
 	    !bpf_cpumask_test_cpu(cand, layered_cpumask))
 		return false;
 
-	if (!(cand_cctx = lookup_cpu_ctx(cand)) || cand_cctx->current_preempt)
+	if (!(cand_cpuc = lookup_cpu_ctx(cand)) || cand_cpuc->current_preempt)
 		return false;
 
 	if (layer->exclusive && (sib = sibling_cpu(cand)) >= 0 &&
-	    (!(sib_cctx = lookup_cpu_ctx(sib)) || sib_cctx->current_preempt))
+	    (!(sib_cpuc = lookup_cpu_ctx(sib)) || sib_cpuc->current_preempt))
 		return false;
 
 	return true;
@@ -623,22 +623,22 @@ bool should_try_preempt_first(s32 cand, struct layer *layer,
 
 static __always_inline
 s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
-		  struct cpu_ctx *cctx, struct task_ctx *tctx, struct layer *layer,
+		  struct cpu_ctx *cpuc, struct task_ctx *taskc, struct layer *layer,
 		  bool from_selcpu)
 {
 	const struct cpumask *idle_smtmask, *layer_cpumask, *layered_cpumask, *cpumask;
-	struct cpu_ctx *prev_cctx;
+	struct cpu_ctx *prev_cpuc;
 	u64 cpus_seq;
 	s32 cpu;
 
-	if (!(layer_cpumask = lookup_layer_cpumask(tctx->layer_id)))
+	if (!(layer_cpumask = lookup_layer_cpumask(taskc->layer_id)))
 		return -1;
 
 	/* not much to do if bound to a single CPU */
 	if (p->nr_cpus_allowed == 1 && scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
 		if (layer->kind == LAYER_KIND_CONFINED &&
 		    !bpf_cpumask_test_cpu(prev_cpu, layer_cpumask))
-			lstat_inc(LSTAT_AFFN_VIOL, layer, cctx);
+			lstat_inc(LSTAT_AFFN_VIOL, layer, cpuc);
 		return prev_cpu;
 	}
 
@@ -650,11 +650,11 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 	 * @prev_cpu. The enqueue path will also retry to find an idle CPU if
 	 * the preemption attempt fails.
 	 */
-	maybe_refresh_layered_cpus(p, tctx, layer_cpumask, cpus_seq);
-	if (!(layered_cpumask = cast_mask(tctx->layered_mask)))
+	maybe_refresh_layered_cpus(p, taskc, layer_cpumask, cpus_seq);
+	if (!(layered_cpumask = cast_mask(taskc->layered_mask)))
 		return -1;
 	if (from_selcpu && should_try_preempt_first(prev_cpu, layer, layered_cpumask)) {
-		cctx->try_preempt_first = true;
+		cpuc->try_preempt_first = true;
 		return -1;
 	}
 
@@ -679,7 +679,7 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 	}
 
 	if ((nr_llcs > 1 || nr_nodes > 1) &&
-	    !(prev_cctx = lookup_cpu_ctx(prev_cpu)))
+	    !(prev_cpuc = lookup_cpu_ctx(prev_cpu)))
 		return -1;
 	if (!(idle_smtmask = scx_bpf_get_idle_smtmask()))
 		return -1;
@@ -688,9 +688,9 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 	 * Try a CPU in the current LLC
 	 */
 	if (nr_llcs > 1) {
-		maybe_refresh_layered_cpus_llc(p, tctx, layer_cpumask,
-					       prev_cctx->llc_id, cpus_seq);
-		if (!(cpumask = cast_mask(tctx->layered_llc_mask))) {
+		maybe_refresh_layered_cpus_llc(p, taskc, layer_cpumask,
+					       prev_cpuc->llc_id, cpus_seq);
+		if (!(cpumask = cast_mask(taskc->layered_llc_mask))) {
 			cpu = -1;
 			goto out_put;
 		}
@@ -711,12 +711,12 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 			cpu = -1;
 			goto out_put;
 		}
-		if (!tctx->layered_mask || !big_cpumask) {
+		if (!taskc->layered_mask || !big_cpumask) {
 			bpf_cpumask_release(tmp_cpumask);
 			cpu = -1;
 			goto out_put;
 		}
-		bpf_cpumask_and(tmp_cpumask, cast_mask(tctx->layered_mask),
+		bpf_cpumask_and(tmp_cpumask, cast_mask(taskc->layered_mask),
 				cast_mask(big_cpumask));
 		cpu = pick_idle_cpu_from(cast_mask(tmp_cpumask),
 					 prev_cpu, idle_smtmask,
@@ -730,9 +730,9 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 	 * Next try a CPU in the current node
 	 */
 	if (nr_nodes > 1) {
-		maybe_refresh_layered_cpus_node(p, tctx, layer_cpumask,
-						prev_cctx->node_id, cpus_seq);
-		if (!(cpumask = cast_mask(tctx->layered_node_mask))) {
+		maybe_refresh_layered_cpus_node(p, taskc, layer_cpumask,
+						prev_cpuc->node_id, cpus_seq);
+		if (!(cpumask = cast_mask(taskc->layered_node_mask))) {
 			cpu = -1;
 			goto out_put;
 		}
@@ -751,7 +751,7 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 	if (layer->kind != LAYER_KIND_CONFINED &&
 	    ((cpu = pick_idle_cpu_from(p->cpus_ptr, prev_cpu,
 				       idle_smtmask, layer->idle_smt)) >= 0)) {
-		lstat_inc(LSTAT_OPEN_IDLE, layer, cctx);
+		lstat_inc(LSTAT_OPEN_IDLE, layer, cpuc);
 		goto out_put;
 	}
 
@@ -767,7 +767,7 @@ out_put:
 	if (cpu >= 0) {
 		if (READ_ONCE(layer->check_no_idle))
 			WRITE_ONCE(layer->check_no_idle, false);
-	} else if (tctx->all_cpus_allowed) {
+	} else if (taskc->all_cpus_allowed) {
 		if (!READ_ONCE(layer->check_no_idle))
 			WRITE_ONCE(layer->check_no_idle, true);
 	}
@@ -778,12 +778,12 @@ out_put:
 
 s32 BPF_STRUCT_OPS(layered_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wake_flags)
 {
-	struct cpu_ctx *cctx;
-	struct task_ctx *tctx;
+	struct cpu_ctx *cpuc;
+	struct task_ctx *taskc;
 	struct layer *layer;
 	s32 cpu;
 
-	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)))
+	if (!(cpuc = lookup_cpu_ctx(-1)) || !(taskc = lookup_task_ctx(p)))
 		return prev_cpu;
 
 	/*
@@ -791,13 +791,13 @@ s32 BPF_STRUCT_OPS(layered_select_cpu, struct task_struct *p, s32 prev_cpu, u64 
 	 * As layered_select_cpu() takes place before runnable, new tasks would
 	 * still have MAX_LAYERS layer. Just return @prev_cpu.
 	 */
-	if (tctx->layer_id == MAX_LAYERS || !(layer = lookup_layer(tctx->layer_id)))
+	if (taskc->layer_id == MAX_LAYERS || !(layer = lookup_layer(taskc->layer_id)))
 		return prev_cpu;
 
-	cpu = pick_idle_cpu(p, prev_cpu, cctx, tctx, layer, true);
+	cpu = pick_idle_cpu(p, prev_cpu, cpuc, taskc, layer, true);
 
 	if (cpu >= 0) {
-		lstat_inc(LSTAT_SEL_LOCAL, layer, cctx);
+		lstat_inc(LSTAT_SEL_LOCAL, layer, cpuc);
 		u64 slice_ns = layer_slice_ns(layer);
 		scx_bpf_dispatch(p, SCX_DSQ_LOCAL, slice_ns, 0);
 		return cpu;
@@ -808,15 +808,15 @@ s32 BPF_STRUCT_OPS(layered_select_cpu, struct task_struct *p, s32 prev_cpu, u64 
 
 static __always_inline
 bool pick_idle_cpu_and_kick(struct task_struct *p, s32 task_cpu,
-			    struct cpu_ctx *cctx, struct task_ctx *tctx,
+			    struct cpu_ctx *cpuc, struct task_ctx *taskc,
 			    struct layer *layer)
 {
 	s32 cpu;
 
-	cpu = pick_idle_cpu(p, task_cpu, cctx, tctx, layer, false);
+	cpu = pick_idle_cpu(p, task_cpu, cpuc, taskc, layer, false);
 
 	if (cpu >= 0) {
-		lstat_inc(LSTAT_KICK, layer, cctx);
+		lstat_inc(LSTAT_KICK, layer, cpuc);
 		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 		return true;
 	} else {
@@ -825,23 +825,23 @@ bool pick_idle_cpu_and_kick(struct task_struct *p, s32 task_cpu,
 }
 
 static __always_inline
-bool try_preempt_cpu(s32 cand, struct task_struct *p, struct cpu_ctx *cctx,
-		     struct task_ctx *tctx, struct layer *layer,
+bool try_preempt_cpu(s32 cand, struct task_struct *p, struct cpu_ctx *cpuc,
+		     struct task_ctx *taskc, struct layer *layer,
 		     bool preempt_first)
 {
 	struct cost *costc;
-	struct cpu_ctx *cand_cctx, *sib_cctx = NULL;
+	struct cpu_ctx *cand_cpuc, *sib_cpuc = NULL;
 	s32 sib;
 
 	if (cand >= nr_possible_cpus || !bpf_cpumask_test_cpu(cand, p->cpus_ptr))
 		return false;
 
-	if (!(cand_cctx = lookup_cpu_ctx(cand)) || cand_cctx->current_preempt)
+	if (!(cand_cpuc = lookup_cpu_ctx(cand)) || cand_cpuc->current_preempt)
 		return false;
 
 	if (!(costc = lookup_cpu_cost(cand)) ||
 	    has_budget(costc, layer) == 0 ||
-	    !has_preempt_budget(costc, cand_cctx->task_layer_id, tctx->layer_id)) {
+	    !has_preempt_budget(costc, cand_cpuc->task_layer_id, taskc->layer_id)) {
 		trace("COST layer %s not enough budget to preempt", layer->name);
 		return false;
 	}
@@ -852,44 +852,44 @@ bool try_preempt_cpu(s32 cand, struct task_struct *p, struct cpu_ctx *cctx,
 	 * preempt task, we shouldn't kick it out.
 	 */
 	if (layer->exclusive && (sib = sibling_cpu(cand)) >= 0 &&
-	    (!(sib_cctx = lookup_cpu_ctx(sib)) || sib_cctx->current_preempt)) {
-		lstat_inc(LSTAT_EXCL_COLLISION, layer, cctx);
+	    (!(sib_cpuc = lookup_cpu_ctx(sib)) || sib_cpuc->current_preempt)) {
+		lstat_inc(LSTAT_EXCL_COLLISION, layer, cpuc);
 		return false;
 	}
 
 	scx_bpf_kick_cpu(cand, SCX_KICK_PREEMPT);
 
 	/*
-	 * $sib_cctx is set if @p is an exclusive task, a sibling CPU
+	 * $sib_cpuc is set if @p is an exclusive task, a sibling CPU
 	 * exists which is not running a preempt task. Let's preempt the
 	 * sibling CPU so that it can become idle. The ->maybe_idle test is
 	 * inaccurate and racy but should be good enough for best-effort
 	 * optimization.
 	 */
-	if (sib_cctx && !sib_cctx->maybe_idle) {
-		lstat_inc(LSTAT_EXCL_PREEMPT, layer, cctx);
+	if (sib_cpuc && !sib_cpuc->maybe_idle) {
+		lstat_inc(LSTAT_EXCL_PREEMPT, layer, cpuc);
 		scx_bpf_kick_cpu(sib, SCX_KICK_PREEMPT);
 	}
 
-	if (!cand_cctx->maybe_idle) {
-		lstat_inc(LSTAT_PREEMPT, layer, cctx);
+	if (!cand_cpuc->maybe_idle) {
+		lstat_inc(LSTAT_PREEMPT, layer, cpuc);
 		if (preempt_first)
-			lstat_inc(LSTAT_PREEMPT_FIRST, layer, cctx);
+			lstat_inc(LSTAT_PREEMPT_FIRST, layer, cpuc);
 	} else {
-		lstat_inc(LSTAT_PREEMPT_IDLE, layer, cctx);
+		lstat_inc(LSTAT_PREEMPT_IDLE, layer, cpuc);
 	}
 	return true;
 }
 
 static __always_inline
-void try_preempt(s32 task_cpu, struct task_struct *p, struct task_ctx *tctx,
+void try_preempt(s32 task_cpu, struct task_struct *p, struct task_ctx *taskc,
 		 bool preempt_first, u64 enq_flags)
 {
 	struct cpu_ctx *cpuc, *task_cpuc;
 	struct layer *layer;
 	s32 i;
 
-	if (!(layer = lookup_layer(tctx->layer_id)) ||
+	if (!(layer = lookup_layer(taskc->layer_id)) ||
 	    !(cpuc = lookup_cpu_ctx(-1)) ||
 	    !(task_cpuc = lookup_cpu_ctx(task_cpu)))
 		return;
@@ -899,10 +899,10 @@ void try_preempt(s32 task_cpu, struct task_struct *p, struct task_ctx *tctx,
 		 * @p prefers to preempt its previous CPU even when there are
 		 * other idle CPUs.
 		 */
-		if (try_preempt_cpu(task_cpu, p, cpuc, tctx, layer, true))
+		if (try_preempt_cpu(task_cpu, p, cpuc, taskc, layer, true))
 			return;
 		/* we skipped idle CPU picking in select_cpu. Do it here. */
-		if (pick_idle_cpu_and_kick(p, task_cpu, cpuc, tctx, layer))
+		if (pick_idle_cpu_and_kick(p, task_cpu, cpuc, taskc, layer))
 			return;
 	} else {
 		/*
@@ -911,11 +911,11 @@ void try_preempt(s32 task_cpu, struct task_struct *p, struct task_ctx *tctx,
 		 * Let's do it now.
 		 */
 		if (!(enq_flags & SCX_ENQ_WAKEUP) &&
-		    pick_idle_cpu_and_kick(p, task_cpu, cpuc, tctx, layer))
+		    pick_idle_cpu_and_kick(p, task_cpu, cpuc, taskc, layer))
 			return;
 		if (!layer->preempt)
 			return;
-		if (try_preempt_cpu(task_cpu, p, cpuc, tctx, layer, false))
+		if (try_preempt_cpu(task_cpu, p, cpuc, taskc, layer, false))
 			return;
 	}
 
@@ -925,7 +925,7 @@ void try_preempt(s32 task_cpu, struct task_struct *p, struct task_ctx *tctx,
 		if (i >= pmap->sys_end)
 			break;
 		u16 *cpu_p = MEMBER_VPTR(pmap->cpus, [i]);
-		if (cpu_p && try_preempt_cpu(*cpu_p, p, cpuc, tctx, layer, false))
+		if (cpu_p && try_preempt_cpu(*cpu_p, p, cpuc, taskc, layer, false))
 			return;
 	}
 
@@ -934,33 +934,33 @@ void try_preempt(s32 task_cpu, struct task_struct *p, struct task_ctx *tctx,
 
 void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 {
-	struct cpu_ctx *cctx, *task_cctx;
-	struct task_ctx *tctx;
+	struct cpu_ctx *cpuc, *task_cpuc;
+	struct task_ctx *taskc;
 	struct layer *layer;
 	s32 task_cpu = scx_bpf_task_cpu(p);
 	u64 vtime = p->scx.dsq_vtime;
 	bool try_preempt_first;
 
-	if (!(cctx = lookup_cpu_ctx(-1)) || !(task_cctx = lookup_cpu_ctx(task_cpu)) ||
-	    !(tctx = lookup_task_ctx(p)) || !(layer = lookup_layer(tctx->layer_id)))
+	if (!(cpuc = lookup_cpu_ctx(-1)) || !(task_cpuc = lookup_cpu_ctx(task_cpu)) ||
+	    !(taskc = lookup_task_ctx(p)) || !(layer = lookup_layer(taskc->layer_id)))
 		return;
 
-	try_preempt_first = cctx->try_preempt_first;
-	cctx->try_preempt_first = false;
+	try_preempt_first = cpuc->try_preempt_first;
+	cpuc->try_preempt_first = false;
 	u64 slice_ns = layer_slice_ns(layer);
 
-	if (cctx->yielding) {
-		lstat_inc(LSTAT_YIELD, layer, cctx);
-		cctx->yielding = false;
+	if (cpuc->yielding) {
+		lstat_inc(LSTAT_YIELD, layer, cpuc);
+		cpuc->yielding = false;
 	}
 
 	if (enq_flags & SCX_ENQ_REENQ) {
-		lstat_inc(LSTAT_ENQ_REENQ, layer, cctx);
+		lstat_inc(LSTAT_ENQ_REENQ, layer, cpuc);
 	} else {
 		if (enq_flags & SCX_ENQ_WAKEUP)
-			lstat_inc(LSTAT_ENQ_WAKEUP, layer, cctx);
+			lstat_inc(LSTAT_ENQ_WAKEUP, layer, cpuc);
 		else
-			lstat_inc(LSTAT_ENQ_EXPIRE, layer, cctx);
+			lstat_inc(LSTAT_ENQ_EXPIRE, layer, cpuc);
 	}
 
 	/*
@@ -981,12 +981,12 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 		struct cpumask *layer_cpumask;
 
 		if (layer->kind == LAYER_KIND_CONFINED &&
-		    (layer_cpumask = lookup_layer_cpumask(tctx->layer_id)) &&
+		    (layer_cpumask = lookup_layer_cpumask(taskc->layer_id)) &&
 		    !bpf_cpumask_test_cpu(task_cpu, layer_cpumask))
-			lstat_inc(LSTAT_AFFN_VIOL, layer, cctx);
+			lstat_inc(LSTAT_AFFN_VIOL, layer, cpuc);
 
-		tctx->last_dsq = task_cctx->hi_fallback_dsq_id;
-		scx_bpf_dispatch(p, tctx->last_dsq, slice_ns, enq_flags);
+		taskc->last_dsq = task_cpuc->hi_fallback_dsq_id;
+		scx_bpf_dispatch(p, taskc->last_dsq, slice_ns, enq_flags);
 		goto preempt;
 	}
 
@@ -997,8 +997,8 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 	 * confined layer may fail to be consumed for an indefinite amount of
 	 * time. Queue them to the fallback DSQ.
 	 */
-	if (layer->kind == LAYER_KIND_CONFINED && !tctx->all_cpus_allowed) {
-		lstat_inc(LSTAT_AFFN_VIOL, layer, cctx);
+	if (layer->kind == LAYER_KIND_CONFINED && !taskc->all_cpus_allowed) {
+		lstat_inc(LSTAT_AFFN_VIOL, layer, cpuc);
 		/*
 		 * We were previously dispatching to LO_FALLBACK_DSQ for any
 		 * affinitized, non-PCPU kthreads, but found that starvation
@@ -1010,44 +1010,44 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 		 * to the LLC local HI_FALLBACK_DSQ to avoid this starvation
 		 * issue.
 		 */
-		tctx->last_dsq = task_cctx->hi_fallback_dsq_id;
-		scx_bpf_dispatch(p, tctx->last_dsq, slice_ns, enq_flags);
+		taskc->last_dsq = task_cpuc->hi_fallback_dsq_id;
+		scx_bpf_dispatch(p, taskc->last_dsq, slice_ns, enq_flags);
 		goto preempt;
 	}
 
-	tctx->last_dsq = layer_dsq_id(layer->id, task_cctx->llc_id);
-	scx_bpf_dispatch_vtime(p, tctx->last_dsq, slice_ns, vtime, enq_flags);
+	taskc->last_dsq = layer_dsq_id(layer->id, task_cpuc->llc_id);
+	scx_bpf_dispatch_vtime(p, taskc->last_dsq, slice_ns, vtime, enq_flags);
 
 preempt:
-	try_preempt(task_cpu, p, tctx, try_preempt_first, enq_flags);
+	try_preempt(task_cpu, p, taskc, try_preempt_first, enq_flags);
 }
 
-static bool keep_running(struct cpu_ctx *cctx, struct task_struct *p)
+static bool keep_running(struct cpu_ctx *cpuc, struct task_struct *p)
 {
-	struct task_ctx *tctx;
+	struct task_ctx *taskc;
 	struct layer *layer;
 
-	if (cctx->yielding || !max_exec_ns)
+	if (cpuc->yielding || !max_exec_ns)
 		return false;
 
 	/* does it wanna? */
 	if (!(p->scx.flags & SCX_TASK_QUEUED))
 		goto no;
 
-	if (!(tctx = lookup_task_ctx(p)) || !(layer = lookup_layer(tctx->layer_id)))
+	if (!(taskc = lookup_task_ctx(p)) || !(layer = lookup_layer(taskc->layer_id)))
 		goto no;
 
 	u64 slice_ns = layer_slice_ns(layer);
 	/* @p has fully consumed its slice and still wants to run */
-	cctx->ran_current_for += slice_ns;
+	cpuc->ran_current_for += slice_ns;
 
 	/*
 	 * There wasn't anything in the local or global DSQ, but there may be
 	 * tasks which are affine to this CPU in some other DSQs. Let's not run
 	 * for too long.
 	 */
-	if (cctx->ran_current_for > max_exec_ns) {
-		lstat_inc(LSTAT_KEEP_FAIL_MAX_EXEC, layer, cctx);
+	if (cpuc->ran_current_for > max_exec_ns) {
+		lstat_inc(LSTAT_KEEP_FAIL_MAX_EXEC, layer, cpuc);
 		goto no;
 	}
 
@@ -1062,10 +1062,10 @@ static bool keep_running(struct cpu_ctx *cctx, struct task_struct *p)
 		 * have tasks waiting, keep running it. If there are multiple
 		 * competing preempting layers, this won't work well.
 		 */
-		u32 dsq_id = layer_dsq_id(layer->id, cctx->llc_id);
+		u32 dsq_id = layer_dsq_id(layer->id, cpuc->llc_id);
 		if (!scx_bpf_dsq_nr_queued(dsq_id)) {
 			p->scx.slice = slice_ns;
-			lstat_inc(LSTAT_KEEP, layer, cctx);
+			lstat_inc(LSTAT_KEEP, layer, cpuc);
 			return true;
 		}
 	} else {
@@ -1091,14 +1091,14 @@ static bool keep_running(struct cpu_ctx *cctx, struct task_struct *p)
 
 		if (has_idle) {
 			p->scx.slice = slice_ns;
-			lstat_inc(LSTAT_KEEP, layer, cctx);
+			lstat_inc(LSTAT_KEEP, layer, cpuc);
 			return true;
 		}
 	}
 
-	lstat_inc(LSTAT_KEEP_FAIL_BUSY, layer, cctx);
+	lstat_inc(LSTAT_KEEP_FAIL_BUSY, layer, cpuc);
 no:
-	cctx->ran_current_for = 0;
+	cpuc->ran_current_for = 0;
 	return false;
 }
 
@@ -1141,7 +1141,7 @@ int get_delay_sec(struct task_struct *p, u64 jiffies_now)
 
 /**
  * antistall_consume() - consume delayed DSQ
- * @cctx: cpu context
+ * @cpuc: cpu context
  *
  * This function consumes a delayed DSQ. This is meant to be called
  * from dispatch, before any other logic which could result in a
@@ -1153,7 +1153,7 @@ int get_delay_sec(struct task_struct *p, u64 jiffies_now)
  *
  * Return: bool indicating if a DSQ was consumed or not.
  */
-bool antistall_consume(struct cpu_ctx *cctx)
+bool antistall_consume(struct cpu_ctx *cpuc)
 {
 	u64 *antistall_dsq, jiffies_now, cur_delay;
 	bool consumed;
@@ -1162,7 +1162,7 @@ bool antistall_consume(struct cpu_ctx *cctx)
 	cur_delay = 0;
 	consumed = false;
 
-	if (!enable_antistall || !cctx)
+	if (!enable_antistall || !cpuc)
 		return false;
 
 	antistall_dsq = bpf_map_lookup_elem(&antistall_cpu_dsq, &zero_u32);
@@ -1193,7 +1193,7 @@ bool antistall_consume(struct cpu_ctx *cctx)
 
 reset:
 	trace("antistall reset DSQ[%llu] SELECTED_CPU[%llu] DELAY[%llu]",
-	      *antistall_dsq, cctx->cpu, cur_delay);
+	      *antistall_dsq, cpuc->cpu, cur_delay);
 	*antistall_dsq = SCX_DSQ_INVALID;
 	return consumed;
 }
@@ -1201,16 +1201,16 @@ reset:
 static __noinline
 void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 {
-	struct cpu_ctx *cctx, *sib_cctx;
+	struct cpu_ctx *cpuc, *sib_cpuc;
 	struct layer *layer;
 	struct cost *costc;
 	u32 u, layer_id;
 	s32 sib = sibling_cpu(cpu);
 
-	if (!(cctx = lookup_cpu_ctx(-1)) || !(costc = lookup_cpu_cost(cpu)))
+	if (!(cpuc = lookup_cpu_ctx(-1)) || !(costc = lookup_cpu_cost(cpu)))
 		return;
 
-	if (antistall_consume(cctx))
+	if (antistall_consume(cpuc))
 		return;
 
 	/*
@@ -1225,7 +1225,7 @@ void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 	 * be extending slice from ops.tick() but that's not available in older
 	 * kernels, so let's make do with this for now.
 	 */
-	if (prev && keep_running(cctx, prev))
+	if (prev && keep_running(cpuc, prev))
 		return;
 
 	/*
@@ -1233,9 +1233,9 @@ void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 	 * This test is a racy test but should be good enough for best-effort
 	 * optimization.
 	 */
-	if (sib >= 0 && (sib_cctx = lookup_cpu_ctx(sib)) &&
-	    sib_cctx->current_exclusive) {
-		gstat_inc(GSTAT_EXCL_IDLE, cctx);
+	if (sib >= 0 && (sib_cpuc = lookup_cpu_ctx(sib)) &&
+	    sib_cpuc->current_exclusive) {
+		gstat_inc(GSTAT_EXCL_IDLE, cpuc);
 		return;
 	}
 
@@ -1253,7 +1253,7 @@ void layered_dispatch_no_topo(s32 cpu, struct task_struct *prev)
 			return;
 	}
 
-	if (scx_bpf_consume(cctx->hi_fallback_dsq_id))
+	if (scx_bpf_consume(cpuc->hi_fallback_dsq_id))
 		return;
 
 	/* consume !open layers second */
@@ -1474,15 +1474,15 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 	if (disable_topology)
 		return layered_dispatch_no_topo(cpu, prev);
 
-	struct cpu_ctx *cctx, *sib_cctx;
+	struct cpu_ctx *cpuc, *sib_cpuc;
 	struct cost *costc;
 	s32 sib = sibling_cpu(cpu);
 
-	if (!(cctx = lookup_cpu_ctx(-1)) ||
+	if (!(cpuc = lookup_cpu_ctx(-1)) ||
 	    !(costc = lookup_cpu_cost(cpu)))
 		return;
 
-	if (antistall_consume(cctx))
+	if (antistall_consume(cpuc))
 		return;
 
 	/*
@@ -1497,7 +1497,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 	 * be extending slice from ops.tick() but that's not available in older
 	 * kernels, so let's make do with this for now.
 	 */
-	if (prev && keep_running(cctx, prev))
+	if (prev && keep_running(cpuc, prev))
 		return;
 
 	/*
@@ -1505,25 +1505,25 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 	 * This test is a racy test but should be good enough for best-effort
 	 * optimization.
 	 */
-	if (sib >= 0 && (sib_cctx = lookup_cpu_ctx(sib)) &&
-	    sib_cctx->current_exclusive) {
-		gstat_inc(GSTAT_EXCL_IDLE, cctx);
+	if (sib >= 0 && (sib_cpuc = lookup_cpu_ctx(sib)) &&
+	    sib_cpuc->current_exclusive) {
+		gstat_inc(GSTAT_EXCL_IDLE, cpuc);
 		return;
 	}
 
 	/* consume preempting layers first */
-	if (consume_preempting(costc, cctx->llc_id) == 0)
+	if (consume_preempting(costc, cpuc->llc_id) == 0)
 		return;
 
-	if (scx_bpf_consume(cctx->hi_fallback_dsq_id))
+	if (scx_bpf_consume(cpuc->hi_fallback_dsq_id))
 		return;
 
 	/* consume !open layers second */
-	if (consume_non_open(costc, cpu, cctx->llc_id) == 0)
+	if (consume_non_open(costc, cpu, cpuc->llc_id) == 0)
 		return;
 
 	/* consume !preempting open layers */
-	if (consume_open_no_preempt(costc, cctx->llc_id) == 0)
+	if (consume_open_no_preempt(costc, cpuc->llc_id) == 0)
 		return;
 
 	scx_bpf_consume(LO_FALLBACK_DSQ);
@@ -1644,22 +1644,22 @@ err:
 	return -EINVAL;
 }
 
-static void maybe_refresh_layer(struct task_struct *p, struct task_ctx *tctx)
+static void maybe_refresh_layer(struct task_struct *p, struct task_ctx *taskc)
 {
 	const char *cgrp_path;
 	bool matched = false;
 	u64 id;	// XXX - int makes verifier unhappy
 	pid_t pid = p->pid;
 
-	if (!tctx->refresh_layer)
+	if (!taskc->refresh_layer)
 		return;
-	tctx->refresh_layer = false;
+	taskc->refresh_layer = false;
 
 	if (!(cgrp_path = format_cgrp_path(p->cgroups->dfl_cgrp)))
 		return;
 
-	if (tctx->layer_id >= 0 && tctx->layer_id < nr_layers)
-		__sync_fetch_and_add(&layers[tctx->layer_id].nr_tasks, -1);
+	if (taskc->layer_id >= 0 && taskc->layer_id < nr_layers)
+		__sync_fetch_and_add(&layers[taskc->layer_id].nr_tasks, -1);
 
 	bpf_for(id, 0, nr_layers) {
 		if (match_layer(id, pid, cgrp_path) == 0) {
@@ -1671,10 +1671,10 @@ static void maybe_refresh_layer(struct task_struct *p, struct task_ctx *tctx)
 	if (matched) {
 		struct layer *layer = &layers[id];
 
-		tctx->layer_id = id;
-		tctx->layered_cpus.seq = layer->cpus_seq - 1;
-		tctx->layered_cpus_llc.seq = layer->cpus_seq - 1;
-		tctx->layered_cpus_node.seq = layer->cpus_seq - 1;
+		taskc->layer_id = id;
+		taskc->layered_cpus.seq = layer->cpus_seq - 1;
+		taskc->layered_cpus_llc.seq = layer->cpus_seq - 1;
+		taskc->layered_cpus_node.seq = layer->cpus_seq - 1;
 		__sync_fetch_and_add(&layer->nr_tasks, 1);
 		/*
 		 * XXX - To be correct, we'd need to calculate the vtime
@@ -1691,9 +1691,9 @@ static void maybe_refresh_layer(struct task_struct *p, struct task_ctx *tctx)
 		scx_bpf_error("[%s]%d didn't match any layer", p->comm, p->pid);
 	}
 
-	if (tctx->layer_id < nr_layers - 1)
+	if (taskc->layer_id < nr_layers - 1)
 		trace("LAYER=%d %s[%d] cgrp=\"%s\"",
-		      tctx->layer_id, p->comm, p->pid, cgrp_path);
+		      taskc->layer_id, p->comm, p->pid, cgrp_path);
 }
 
 static s32 create_save_cpumask(struct bpf_cpumask **kptr)
@@ -1720,7 +1720,7 @@ static s32 create_node(u32 node_id)
 	u32 cpu;
 	struct bpf_cpumask *cpumask;
 	struct node_ctx *nodec;
-	struct cpu_ctx *cctx;
+	struct cpu_ctx *cpuc;
 	s32 ret;
 
 	nodec = bpf_map_lookup_elem(&node_data, &node_id);
@@ -1755,13 +1755,13 @@ static s32 create_node(u32 node_id)
 
 		if (*nmask & (1LLU << (cpu % 64))) {
 			bpf_cpumask_set_cpu(cpu, cpumask);
-			if (!(cctx = lookup_cpu_ctx(cpu))) {
+			if (!(cpuc = lookup_cpu_ctx(cpu))) {
 				scx_bpf_error("cpu ctx error");
 				ret = -ENOENT;
 				break;
 			}
 
-			cctx->node_id = node_id;
+			cpuc->node_id = node_id;
 			nodec->nr_cpus++;
 			nodec->llc_mask &= (1LLU << node_id);
 		}
@@ -1777,7 +1777,7 @@ static s32 create_llc(u32 llc_id)
 	u32 cpu;
 	struct bpf_cpumask *cpumask;
 	struct llc_ctx *llcc;
-	struct cpu_ctx *cctx;
+	struct cpu_ctx *cpuc;
 	s32 ret;
 
 	llcc = bpf_map_lookup_elem(&llc_data, &llc_id);
@@ -1800,7 +1800,7 @@ static s32 create_llc(u32 llc_id)
 	}
 
 	bpf_for(cpu, 0, nr_possible_cpus) {
-		if (!(cctx = lookup_cpu_ctx(cpu))) {
+		if (!(cpuc = lookup_cpu_ctx(cpu))) {
 			bpf_rcu_read_unlock();
 			scx_bpf_error("cpu ctx error");
 			return -ENOENT;
@@ -1811,8 +1811,8 @@ static s32 create_llc(u32 llc_id)
 
 		bpf_cpumask_set_cpu(cpu, cpumask);
 		llcc->nr_cpus++;
-		cctx->llc_id = llc_id;
-		cctx->hi_fallback_dsq_id = llc_hi_fallback_dsq_id(llc_id);
+		cpuc->llc_id = llc_id;
+		cpuc->hi_fallback_dsq_id = llc_hi_fallback_dsq_id(llc_id);
 	}
 
 	dbg("CFG creating llc %d with %d cpus", llc_id, llcc->nr_cpus);
@@ -1821,136 +1821,136 @@ static s32 create_llc(u32 llc_id)
 }
 
 static __always_inline
-void on_wakeup(struct task_struct *p, struct task_ctx *tctx)
+void on_wakeup(struct task_struct *p, struct task_ctx *taskc)
 {
-	struct cpu_ctx *cctx;
+	struct cpu_ctx *cpuc;
 	struct layer *layer;
-	struct task_ctx *waker_tctx;
+	struct task_ctx *waker_taskc;
 	struct task_struct *waker;
 
-	if (!(cctx = lookup_cpu_ctx(-1)) ||
-	    !(layer = lookup_layer(tctx->layer_id)))
+	if (!(cpuc = lookup_cpu_ctx(-1)) ||
+	    !(layer = lookup_layer(taskc->layer_id)))
 		return;
 
 	if (!(waker = bpf_get_current_task_btf()) ||
-	    !(waker_tctx = lookup_task_ctx_may_fail(waker)))
+	    !(waker_taskc = lookup_task_ctx_may_fail(waker)))
 		return;
 
 	// TODO: add handling for per layer wakers
-	if (tctx->layer_id == waker_tctx->layer_id)
+	if (taskc->layer_id == waker_taskc->layer_id)
 		return;
 
-	if (tctx->last_waker == waker->pid)
-		lstat_inc(LSTAT_XLAYER_REWAKE, layer, cctx);
+	if (taskc->last_waker == waker->pid)
+		lstat_inc(LSTAT_XLAYER_REWAKE, layer, cpuc);
 
-	tctx->last_waker = waker->pid;
-	lstat_inc(LSTAT_XLAYER_WAKE, layer, cctx);
+	taskc->last_waker = waker->pid;
+	lstat_inc(LSTAT_XLAYER_WAKE, layer, cpuc);
 }
 
 
 void BPF_STRUCT_OPS(layered_runnable, struct task_struct *p, u64 enq_flags)
 {
-	struct task_ctx *tctx;
+	struct task_ctx *taskc;
 	u64 now = bpf_ktime_get_ns();
 
-	if (!(tctx = lookup_task_ctx(p)))
+	if (!(taskc = lookup_task_ctx(p)))
 		return;
 
-	tctx->runnable_at = now;
-	maybe_refresh_layer(p, tctx);
-	adj_load(tctx->layer_id, p->scx.weight, now);
+	taskc->runnable_at = now;
+	maybe_refresh_layer(p, taskc);
+	adj_load(taskc->layer_id, p->scx.weight, now);
 
 	if (enq_flags & SCX_ENQ_WAKEUP)
-		on_wakeup(p, tctx);
+		on_wakeup(p, taskc);
 }
 
 void BPF_STRUCT_OPS(layered_running, struct task_struct *p)
 {
-	struct cpu_ctx *cctx;
-	struct task_ctx *tctx;
+	struct cpu_ctx *cpuc;
+	struct task_ctx *taskc;
 	struct layer *layer;
 	struct node_ctx *nodec;
 	struct llc_ctx *llcc;
 	s32 task_cpu = scx_bpf_task_cpu(p);
 
-	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)) ||
-	    !(layer = lookup_layer(tctx->layer_id)))
+	if (!(cpuc = lookup_cpu_ctx(-1)) || !(taskc = lookup_task_ctx(p)) ||
+	    !(layer = lookup_layer(taskc->layer_id)))
 		return;
 
-	if (tctx->last_cpu >= 0 && tctx->last_cpu != task_cpu) {
-		lstat_inc(LSTAT_MIGRATION, layer, cctx);
-		if (!(nodec = lookup_node_ctx(cctx->node_id)))
+	if (taskc->last_cpu >= 0 && taskc->last_cpu != task_cpu) {
+		lstat_inc(LSTAT_MIGRATION, layer, cpuc);
+		if (!(nodec = lookup_node_ctx(cpuc->node_id)))
 			return;
 		if (nodec->cpumask &&
-		    !bpf_cpumask_test_cpu(tctx->last_cpu, cast_mask(nodec->cpumask)))
-			lstat_inc(LSTAT_XNUMA_MIGRATION, layer, cctx);
-		if (!(llcc = lookup_llc_ctx(cctx->llc_id)))
+		    !bpf_cpumask_test_cpu(taskc->last_cpu, cast_mask(nodec->cpumask)))
+			lstat_inc(LSTAT_XNUMA_MIGRATION, layer, cpuc);
+		if (!(llcc = lookup_llc_ctx(cpuc->llc_id)))
 			return;
 		if (llcc->cpumask &&
-		    !bpf_cpumask_test_cpu(tctx->last_cpu, cast_mask(llcc->cpumask)))
-			lstat_inc(LSTAT_XLLC_MIGRATION, layer, cctx);
+		    !bpf_cpumask_test_cpu(taskc->last_cpu, cast_mask(llcc->cpumask)))
+			lstat_inc(LSTAT_XLLC_MIGRATION, layer, cpuc);
 	}
-	tctx->last_cpu = task_cpu;
+	taskc->last_cpu = task_cpu;
 
 	if (vtime_before(layer->vtime_now, p->scx.dsq_vtime))
 		layer->vtime_now = p->scx.dsq_vtime;
 
-	cctx->current_preempt = layer->preempt;
-	cctx->current_exclusive = layer->exclusive;
-	tctx->running_at = bpf_ktime_get_ns();
-	cctx->task_layer_id = tctx->layer_id;
+	cpuc->current_preempt = layer->preempt;
+	cpuc->current_exclusive = layer->exclusive;
+	taskc->running_at = bpf_ktime_get_ns();
+	cpuc->task_layer_id = taskc->layer_id;
 
 	/*
 	 * If this CPU is transitioning from running an exclusive task to a
 	 * non-exclusive one, the sibling CPU has likely been idle. Wake it up.
 	 */
-	if (cctx->prev_exclusive && !cctx->current_exclusive) {
+	if (cpuc->prev_exclusive && !cpuc->current_exclusive) {
 		s32 sib = sibling_cpu(task_cpu);
-		struct cpu_ctx *sib_cctx;
+		struct cpu_ctx *sib_cpuc;
 
 		/*
 		 * %SCX_KICK_IDLE would be great here but we want to support
 		 * older kernels. Let's use racy and inaccruate custom idle flag
 		 * instead.
 		 */
-		if (sib >= 0 && (sib_cctx = lookup_cpu_ctx(sib)) &&
-		    sib_cctx->maybe_idle) {
-			gstat_inc(GSTAT_EXCL_WAKEUP, cctx);
+		if (sib >= 0 && (sib_cpuc = lookup_cpu_ctx(sib)) &&
+		    sib_cpuc->maybe_idle) {
+			gstat_inc(GSTAT_EXCL_WAKEUP, cpuc);
 			scx_bpf_kick_cpu(sib, 0);
 		}
 	}
 
-	if (layer->perf > 0 && cctx->perf != layer->perf) {
+	if (layer->perf > 0 && cpuc->perf != layer->perf) {
 		scx_bpf_cpuperf_set(task_cpu, layer->perf);
-		cctx->perf = layer->perf;
+		cpuc->perf = layer->perf;
 	}
 
-	cctx->maybe_idle = false;
+	cpuc->maybe_idle = false;
 }
 
 void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 {
-	struct cpu_ctx *cctx;
-	struct task_ctx *tctx;
+	struct cpu_ctx *cpuc;
+	struct task_ctx *taskc;
 	struct layer *layer;
 	struct cost *costc;
 	u32 budget_id;
 	s32 lid;
 	u64 used;
 
-	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)))
+	if (!(cpuc = lookup_cpu_ctx(-1)) || !(taskc = lookup_task_ctx(p)))
 		return;
 
-	lid = tctx->layer_id;
+	lid = taskc->layer_id;
 	if (!(layer = lookup_layer(lid)) || !(costc = lookup_cpu_cost(-1)))
 		return;
 
-	used = bpf_ktime_get_ns() - tctx->running_at;
+	used = bpf_ktime_get_ns() - taskc->running_at;
 
 	// If the task ran on the hi fallback dsq then the cost should be
 	// charged to it.
-	if (is_fallback_dsq(tctx->last_dsq)) {
-		budget_id = fallback_dsq_cost_id(tctx->last_dsq);
+	if (is_fallback_dsq(taskc->last_dsq)) {
+		budget_id = fallback_dsq_cost_id(taskc->last_dsq);
 	} else {
 		budget_id = layer->id;
 	}
@@ -1958,47 +1958,47 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 	u64 slice_ns = layer_slice_ns(layer);
 	record_cpu_cost(costc, budget_id, (s64)used, slice_ns);
 
-	if (cctx->layer_id == tctx->layer_id)
-		cctx->layer_usages[lid][LAYER_USAGE_OWNED] += used;
+	if (cpuc->layer_id == taskc->layer_id)
+		cpuc->layer_usages[lid][LAYER_USAGE_OWNED] += used;
 	else
-		cctx->layer_usages[lid][LAYER_USAGE_OPEN] += used;
+		cpuc->layer_usages[lid][LAYER_USAGE_OPEN] += used;
 
-	cctx->current_preempt = false;
-	cctx->prev_exclusive = cctx->current_exclusive;
-	cctx->current_exclusive = false;
+	cpuc->current_preempt = false;
+	cpuc->prev_exclusive = cpuc->current_exclusive;
+	cpuc->current_exclusive = false;
 
 	/*
 	 * Apply min_exec_us, scale the execution time by the inverse of the
 	 * weight and charge.
 	 */
 	if (used < layer->min_exec_ns) {
-		lstat_inc(LSTAT_MIN_EXEC, layer, cctx);
-		lstat_add(LSTAT_MIN_EXEC_NS, layer, cctx, layer->min_exec_ns - used);
+		lstat_inc(LSTAT_MIN_EXEC, layer, cpuc);
+		lstat_add(LSTAT_MIN_EXEC_NS, layer, cpuc, layer->min_exec_ns - used);
 		used = layer->min_exec_ns;
 	}
 
-	if (cctx->yielding && used < slice_ns)
+	if (cpuc->yielding && used < slice_ns)
 		used = slice_ns;
 	p->scx.dsq_vtime += used * 100 / p->scx.weight;
-	cctx->maybe_idle = true;
+	cpuc->maybe_idle = true;
 }
 
 void BPF_STRUCT_OPS(layered_quiescent, struct task_struct *p, u64 deq_flags)
 {
-	struct task_ctx *tctx;
+	struct task_ctx *taskc;
 
-	if ((tctx = lookup_task_ctx(p)))
-		adj_load(tctx->layer_id, -(s64)p->scx.weight, bpf_ktime_get_ns());
+	if ((taskc = lookup_task_ctx(p)))
+		adj_load(taskc->layer_id, -(s64)p->scx.weight, bpf_ktime_get_ns());
 }
 
 bool BPF_STRUCT_OPS(layered_yield, struct task_struct *from, struct task_struct *to)
 {
-	struct cpu_ctx *cctx;
-	struct task_ctx *tctx;
+	struct cpu_ctx *cpuc;
+	struct task_ctx *taskc;
 	struct layer *layer;
 
-	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(from)) ||
-	    !(layer = lookup_layer(tctx->layer_id)))
+	if (!(cpuc = lookup_cpu_ctx(-1)) || !(taskc = lookup_task_ctx(from)) ||
+	    !(layer = lookup_layer(taskc->layer_id)))
 		return false;
 
 	/*
@@ -2006,16 +2006,16 @@ bool BPF_STRUCT_OPS(layered_yield, struct task_struct *from, struct task_struct 
 	 * the task is eligible for keep_running().
 	 */
 	if (!layer->yield_step_ns) {
-		lstat_inc(LSTAT_YIELD_IGNORE, layer, cctx);
+		lstat_inc(LSTAT_YIELD_IGNORE, layer, cpuc);
 		return false;
 	}
 
 	if (from->scx.slice > layer->yield_step_ns) {
 		from->scx.slice -= layer->yield_step_ns;
-		lstat_inc(LSTAT_YIELD_IGNORE, layer, cctx);
+		lstat_inc(LSTAT_YIELD_IGNORE, layer, cpuc);
 	} else {
 		from->scx.slice = 0;
-		cctx->yielding = true;
+		cpuc->yielding = true;
 	}
 
 	return false;
@@ -2023,18 +2023,18 @@ bool BPF_STRUCT_OPS(layered_yield, struct task_struct *from, struct task_struct 
 
 void BPF_STRUCT_OPS(layered_set_weight, struct task_struct *p, u32 weight)
 {
-	struct task_ctx *tctx;
+	struct task_ctx *taskc;
 
-	if ((tctx = lookup_task_ctx(p)))
-		tctx->refresh_layer = true;
+	if ((taskc = lookup_task_ctx(p)))
+		taskc->refresh_layer = true;
 }
 
 void BPF_STRUCT_OPS(layered_set_cpumask, struct task_struct *p,
 		    const struct cpumask *cpumask)
 {
-	struct task_ctx *tctx;
+	struct task_ctx *taskc;
 
-	if (!(tctx = lookup_task_ctx(p)))
+	if (!(taskc = lookup_task_ctx(p)))
 		return;
 
 	if (!all_cpumask) {
@@ -2042,7 +2042,7 @@ void BPF_STRUCT_OPS(layered_set_cpumask, struct task_struct *p,
 		return;
 	}
 
-	tctx->all_cpus_allowed =
+	taskc->all_cpus_allowed =
 		bpf_cpumask_subset(cast_mask(all_cpumask), cpumask);
 }
 
@@ -2062,7 +2062,7 @@ static int init_cached_cpus(struct cached_cpus *ccpus)
 s32 BPF_STRUCT_OPS(layered_init_task, struct task_struct *p,
 		   struct scx_init_task_args *args)
 {
-	struct task_ctx *tctx;
+	struct task_ctx *taskc;
 	struct bpf_cpumask *cpumask;
 	s32 ret;
 
@@ -2071,59 +2071,59 @@ s32 BPF_STRUCT_OPS(layered_init_task, struct task_struct *p,
 	 * fail spuriously due to BPF recursion protection triggering
 	 * unnecessarily.
 	 */
-	tctx = bpf_task_storage_get(&task_ctxs, p, 0,
+	taskc = bpf_task_storage_get(&task_ctxs, p, 0,
 				    BPF_LOCAL_STORAGE_GET_F_CREATE);
-	if (!tctx) {
+	if (!taskc) {
 		scx_bpf_error("task_ctx allocation failure");
 		return -ENOMEM;
 	}
 
 	// Layer setup
-	ret = init_cached_cpus(&tctx->layered_cpus);
+	ret = init_cached_cpus(&taskc->layered_cpus);
 	if (ret)
 		return ret;
 	if (!(cpumask = bpf_cpumask_create()))
 		return -ENOMEM;
 
-	if ((cpumask = bpf_kptr_xchg(&tctx->layered_mask, cpumask))) {
+	if ((cpumask = bpf_kptr_xchg(&taskc->layered_mask, cpumask))) {
 		/* Should never happen as we just inserted it above. */
 		bpf_cpumask_release(cpumask);
 		return -EINVAL;
 	}
 
 	// LLC setup
-	ret = init_cached_cpus(&tctx->layered_cpus_llc);
+	ret = init_cached_cpus(&taskc->layered_cpus_llc);
 	if (ret)
 		return ret;
 
 	if (!(cpumask = bpf_cpumask_create()))
 		return -ENOMEM;
 
-	if ((cpumask = bpf_kptr_xchg(&tctx->layered_llc_mask, cpumask))) {
+	if ((cpumask = bpf_kptr_xchg(&taskc->layered_llc_mask, cpumask))) {
 		bpf_cpumask_release(cpumask);
 		return -EINVAL;
 	}
 
 	// Node setup
-	ret = init_cached_cpus(&tctx->layered_cpus_node);
+	ret = init_cached_cpus(&taskc->layered_cpus_node);
 	if (ret)
 		return ret;
 
 	if (!(cpumask = bpf_cpumask_create()))
 		return -ENOMEM;
 
-	if ((cpumask = bpf_kptr_xchg(&tctx->layered_node_mask, cpumask))) {
+	if ((cpumask = bpf_kptr_xchg(&taskc->layered_node_mask, cpumask))) {
 		bpf_cpumask_release(cpumask);
 		return -EINVAL;
 	}
 
-	tctx->pid = p->pid;
-	tctx->last_cpu = -1;
-	tctx->layer_id = MAX_LAYERS;
-	tctx->refresh_layer = true;
+	taskc->pid = p->pid;
+	taskc->last_cpu = -1;
+	taskc->layer_id = MAX_LAYERS;
+	taskc->refresh_layer = true;
 
 	if (all_cpumask)
-		tctx->all_cpus_allowed =
+		taskc->all_cpus_allowed =
 			bpf_cpumask_subset(cast_mask(all_cpumask), p->cpus_ptr);
 	else
 		scx_bpf_error("missing all_cpumask");
@@ -2141,18 +2141,18 @@ s32 BPF_STRUCT_OPS(layered_init_task, struct task_struct *p,
 void BPF_STRUCT_OPS(layered_exit_task, struct task_struct *p,
 		    struct scx_exit_task_args *args)
 {
-	struct cpu_ctx *cctx;
-	struct task_ctx *tctx;
+	struct cpu_ctx *cpuc;
+	struct task_ctx *taskc;
 
 	if (args->cancelled) {
 		return;
 	}
 
-	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)))
+	if (!(cpuc = lookup_cpu_ctx(-1)) || !(taskc = lookup_task_ctx(p)))
 		return;
 
-	if (tctx->layer_id < nr_layers)
-		__sync_fetch_and_add(&layers[tctx->layer_id].nr_tasks, -1);
+	if (taskc->layer_id < nr_layers)
+		__sync_fetch_and_add(&layers[taskc->layer_id].nr_tasks, -1);
 }
 
 static u64 dsq_first_runnable_for_ms(u64 dsq_id, u64 now)
@@ -2163,10 +2163,10 @@ static u64 dsq_first_runnable_for_ms(u64 dsq_id, u64 now)
 		return 0;
 
 	bpf_for_each(scx_dsq, p, dsq_id, 0) {
-		struct task_ctx *tctx;
+		struct task_ctx *taskc;
 
-		if ((tctx = lookup_task_ctx(p)))
-			return (now - tctx->runnable_at) / 1000000;
+		if ((taskc = lookup_task_ctx(p)))
+			return (now - taskc->runnable_at) / 1000000;
 	}
 
 	return 0;
@@ -2332,7 +2332,7 @@ static bool layered_monitor(void)
 u64 antistall_set(u64 dsq_id, u64 jiffies_now)
 {
 	struct task_struct *__p, *p = NULL;
-	struct task_ctx *tctx;
+	struct task_ctx *taskc;
 	s32 cpu;
 	u64 *antistall_dsq, *delay, cur_delay;
 	int pass;
@@ -2349,7 +2349,7 @@ u64 antistall_set(u64 dsq_id, u64 jiffies_now)
 		if (!(p = bpf_task_from_pid(__p->pid)))
 			continue;
 
-		if (!(tctx = lookup_task_ctx(p)))
+		if (!(taskc = lookup_task_ctx(p)))
 			goto unlock;
 
 		cur_delay = get_delay_sec(p, jiffies_now);
@@ -2361,7 +2361,7 @@ u64 antistall_set(u64 dsq_id, u64 jiffies_now)
 		for (pass = 0; pass < 2; ++pass) bpf_for(cpu, 0, nr_possible_cpus) {
 			const struct cpumask *cpumask;
 
-			if (!(cpumask = cast_mask(tctx->layered_mask)))
+			if (!(cpumask = cast_mask(taskc->layered_mask)))
 				goto unlock;
 
 			/* for affinity violating tasks, target all allowed CPUs */
@@ -2586,7 +2586,7 @@ static s32 init_cpu(s32 cpu, int *nr_online_cpus,
 		    struct bpf_cpumask *tmp_big_cpumask)
 {
 	const volatile u8 *u8_ptr;
-	struct cpu_ctx *cctx;
+	struct cpu_ctx *cpuc;
 	u64 *init_antistall_dsq;
 	int i;
 
@@ -2596,23 +2596,23 @@ static s32 init_cpu(s32 cpu, int *nr_online_cpus,
 		*init_antistall_dsq = SCX_DSQ_INVALID;
 	}
 
-	if (!(cctx = lookup_cpu_ctx(cpu))) {
+	if (!(cpuc = lookup_cpu_ctx(cpu))) {
 		return -ENOMEM;
 	}
-	cctx->task_layer_id = MAX_LAYERS;
+	cpuc->task_layer_id = MAX_LAYERS;
 
 	if ((u8_ptr = MEMBER_VPTR(all_cpus, [cpu / 8]))) {
 		if (*u8_ptr & (1 << (cpu % 8))) {
 			bpf_cpumask_set_cpu(cpu, cpumask);
 			(*nr_online_cpus)++;
-			if (cctx->is_big)
+			if (cpuc->is_big)
 				bpf_cpumask_set_cpu(cpu, tmp_big_cpumask);
 		}
 	} else {
 		return -EINVAL;
 	}
 
-	struct cpu_prox_map *pmap = &cctx->prox_map;
+	struct cpu_prox_map *pmap = &cpuc->prox_map;
 	dbg("CFG: CPU[%d] core/llc/node/sys=%d/%d/%d/%d",
 	    cpu, pmap->core_end, pmap->llc_end, pmap->node_end, pmap->sys_end);
 	if (pmap->sys_end > nr_possible_cpus || pmap->sys_end > MAX_CPUS) {
@@ -2636,7 +2636,7 @@ static s32 init_cpu(s32 cpu, int *nr_online_cpus,
 s32 BPF_STRUCT_OPS_SLEEPABLE(layered_init)
 {
 	struct bpf_cpumask *cpumask, *tmp_big_cpumask;
-	struct cpu_ctx *cctx;
+	struct cpu_ctx *cpuc;
 	int i, nr_online_cpus, ret;
 
 	ret = scx_bpf_create_dsq(LO_FALLBACK_DSQ, -1);

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -183,7 +183,8 @@ static struct cpu_ctx *lookup_cpu_ctx(int cpu)
 }
 
 // XXX - Converting this to bss array triggers verifier bugs. See
-// BpfStats::read().
+// BpfStats::read(). Should also be cacheline aligned which doesn't work with
+// the array map.
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__type(key, u32);
@@ -202,7 +203,8 @@ static struct node_ctx *lookup_node_ctx(u32 node)
 }
 
 // XXX - Converting this to bss array triggers verifier bugs. See
-// BpfStats::read().
+// BpfStats::read(). Should also be cacheline aligned which doesn't work with
+// the array map.
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__type(key, u32);

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -577,7 +577,7 @@ fn nodemask_from_nodes(nodes: &Vec<usize>) -> usize {
     mask
 }
 
-fn cachemask_from_llcs(llcs: &BTreeMap<usize, Arc<Llc>>) -> usize {
+fn llcmask_from_llcs(llcs: &BTreeMap<usize, Arc<Llc>>) -> usize {
     let mut mask = 0;
     for (_, cache) in llcs {
         mask |= 1 << cache.id;
@@ -1262,7 +1262,7 @@ impl<'a> Scheduler<'a> {
                     if !nodes.is_empty() && !nodes.contains(&topo_node_id) {
                         continue;
                     }
-                    layer.cache_mask |= cachemask_from_llcs(&topo_node.llcs) as u64;
+                    layer.llc_mask |= llcmask_from_llcs(&topo_node.llcs) as u64;
                 }
             }
 

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1523,7 +1523,16 @@ impl<'a> Scheduler<'a> {
                     cpus_range,
                     ..
                 } => {
-                    let util = utils[idx].iter().sum();
+                    // Guide layer sizing by utilization within each layer
+                    // to avoid oversizing grouped layers. As an empty layer
+                    // can only get CPU time through fallback or open
+                    // execution, use open cputime for empty layers.
+                    let util = if layer.nr_cpus > 0 {
+                        utils[idx][LAYER_USAGE_OWNED]
+                    } else {
+                        utils[idx][LAYER_USAGE_OPEN]
+                    };
+
                     let util = if util < 0.01 { 0.0 } else { util };
                     let low = (util / util_range.1).ceil() as usize;
                     let high = ((util / util_range.0).floor() as usize).max(low);

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1376,6 +1376,23 @@ impl<'a> Scheduler<'a> {
         } else {
             Topology::new()?
         };
+
+        /*
+         * FIXME: scx_layered incorrectly assumes that node, LLC and CPU IDs
+         * are consecutive. Verify that they are on this system and bail if
+         * not. It's lucky that core ID is not used anywhere as core IDs are
+         * not consecutive on some Ryzen CPUs.
+         */
+        if topo.nodes.keys().enumerate().any(|(i, &k)| i != k) {
+            bail!("Holes in node IDs detected: {:?}", topo.nodes.keys());
+        }
+        if topo.all_llcs.keys().enumerate().any(|(i, &k)| i != k) {
+            bail!("Holes in LLC IDs detected: {:?}", topo.all_llcs.keys());
+        }
+        if topo.all_cpus.keys().enumerate().any(|(i, &k)| i != k) {
+            bail!("Holes in CPU IDs detected: {:?}", topo.all_cpus.keys());
+        }
+
         let netdevs = if opts.netdev_irq_balance {
             warn!(
                 "Experimental netdev IRQ balancing enabled. Reset IRQ masks of network devices after use!!!"


### PR DESCRIPTION
- Track owned/open execution times per layer and base layer growth decision on owned time only.
- Track per-LLC-layer number of scheduling events and running avg of queue latencies and report them. Will be used to modulate open executions.
- Fix the problem where a zeor sized layer couldn't grow due to core quantization in CPU free/alloc paths.
- Code cleanups.
- Bail early with a clear error message if node, LLC or core IDs are not consecutive. This should be fixed in the future.