### PR TITLE
scx_utils: introduce topology-aware IDs

### DIFF
--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -61,6 +61,9 @@ pub use libbpf_logger::init_libbpf_logging;
 pub mod ravg;
 
 mod topology;
+pub use topology::topology_id;
+pub use topology::topology_id_local;
+pub use topology::topology_id_node;
 pub use topology::Core;
 pub use topology::CoreType;
 pub use topology::Cpu;


### PR DESCRIPTION
On systems with multiple NUMA nodes, physical cores or caches on different nodes can share the same ID, as IDs might be reused across nodes.

To properly handle this, introduce the concept of topology IDs, that are composed of two parts:
 - lower half bits represent the local ID (e.g., core or cache ID) within a NUMA node,
 - higher half bits represent the NUMA node ID.

Moreover, provide helper functions to construct a topology ID and extract the local ID and node ID components from a given topology ID:
 - topology_id(node_id: usize, id: usize) -> usize
 - topology_id_local(topo_id: usize) -> usize
 - topology_id_node(topo_id: usize) -> usize

This should address all the issues addressed in #981 and #982.