### PR TITLE
scx_lavd: Limit the slice extension of a lock holder

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -123,6 +123,7 @@ struct task_ctx {
 	s8	futex_boost;		/* futex boost count */
 	u8	is_greedy;		/* task's overscheduling ratio compared to its nice priority */
 	u8	need_lock_boost;	/* need to boost lock for deadline calculation */
+	u8	lock_holder_xted;	/* slice is already extended for a lock holder task */
 	u8	wakeup_ft;		/* regular wakeup = 1, sync wakeup = 2 */
 	u8	slice_boost_prio;	/* how many times a task fully consumed the slice */
 	u8	on_big;			/* executable on a big core */

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -156,14 +156,6 @@ static struct task_ctx *get_task_ctx(struct task_struct *p)
 	return taskc;
 }
 
-struct task_ctx *try_get_current_task_ctx(void)
-{
-	struct task_struct *p = bpf_get_current_task_btf();
-	struct task_ctx *taskc = try_get_task_ctx(p);
-
-	return taskc;
-}
-
 static struct cpu_ctx *get_cpu_ctx(void)
 {
 	const u32 idx = 0;


### PR DESCRIPTION
The scheduler extends the lock holder's time slice at ops.dispatch() to avoid preempting the lock holder, so slowing down the system-wide progress. However, this opens the possibility that the slice extension is abused by a lock holder. To mitigate the problem, check if a task's time slice is extended (lock_holder_xted) but the task is not lock holder. That means a task's time slice was extended, but it released the lock after that. In this case, give up the rest of the extended time slice of the task.