### PR TITLE
scheds: use llc id

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -483,7 +483,7 @@ impl<'a> Scheduler<'a> {
             for (cpu_id, cpu) in &core.cpus {
                 let cache_id = match cache_lvl {
                     2 => cpu.l2_id,
-                    3 => cpu.l3_id,
+                    3 => cpu.llc_id,
                     _ => panic!("invalid cache level {}", cache_lvl),
                 };
                 cache_id_map

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -201,7 +201,7 @@ impl<'a> Scheduler<'a> {
             for (cpu_id, cpu) in &core.cpus {
                 let cache_id = match cache_lvl {
                     2 => cpu.l2_id,
-                    3 => cpu.l3_id,
+                    3 => cpu.llc_id,
                     _ => panic!("invalid cache level {}", cache_lvl),
                 };
                 cache_id_map


### PR DESCRIPTION
Use llc_id instead of l3_id to build scheduling domain in scx_bpfland and scx_flash.