### PR TITLE
scripts: Add bpftrace script to trace CPU frequency

### DIFF
--- a/scripts/freq_trace.bt
+++ b/scripts/freq_trace.bt
@@ -1,0 +1,18 @@
+#!/usr/bin/env bpftrace
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+rawtracepoint:cpu_frequency
+{
+	$freq = arg0;
+	$cpu = arg1;
+
+	@freq_hist = lhist($freq, 0, 6000000, 50000);
+	@avg_freq[$cpu] = avg($freq);
+}
+
+interval:s:1 {
+    print(@avg_freq);
+    print(@freq_hist);
+}


### PR DESCRIPTION
Add a bpftrace script for tracing frequency changes.

example output:
```
@avg_freq[154]: 1100000
@avg_freq[164]: 1100000
@avg_freq[115]: 1100000
@avg_freq[169]: 1100000
@avg_freq[9]: 1104761
@avg_freq[82]: 1110000
@avg_freq[37]: 1112500
@avg_freq[174]: 1125000

@freq_hist: 
[1000000, 1050000)     448 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ |
[1050000, 1100000)       0 |                                                    |
[1100000, 1150000)      35 |@@@@                                                |
[1150000, 1200000)       0 |                                                    |
[1200000, 1250000)     451 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
```