### PR TITLE
scx_layered: Reimplement layered_dispatch()

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -160,6 +160,10 @@ struct cpu_ctx {
 	u32			llc_id;
 	u32			node_id;
 	u32			perf;
+
+	u32			open_preempt_layer_order[MAX_LAYERS];
+	u32			open_layer_order[MAX_LAYERS];
+
 	struct cpu_prox_map	prox_map;
 };
 

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -48,7 +48,9 @@ enum consts {
 	LAYER_LAT_DECAY_FACTOR	= 4,
 
 	HI_FALLBACK_DSQ_BASE	= MAX_LAYERS * MAX_LLCS,
-	LO_FALLBACK_DSQ		= (MAX_LAYERS * MAX_LLCS) + MAX_LLCS + 1,
+	LO_FALLBACK_DSQ		= HI_FALLBACK_DSQ_BASE + MAX_LLCS + 1,
+
+	MAX_DSQS		= LO_FALLBACK_DSQ + 1,
 
 	/* XXX remove */
 	MAX_CGRP_PREFIXES	= 32,
@@ -161,11 +163,18 @@ struct cpu_ctx {
 	struct cpu_prox_map	prox_map;
 };
 
+struct llc_prox_map {
+	u16			llcs[MAX_LLCS];
+	u32			node_end;
+	u32			sys_end;
+};
+
 struct llc_ctx {
 	u32			id;
 	struct bpf_cpumask __kptr *cpumask;
 	u32			nr_cpus;
 	u64			lstats[MAX_LAYERS][NR_LLC_LSTATS];
+	struct llc_prox_map	prox_map;
 };
 
 struct node_ctx {


### PR DESCRIPTION
Layer and LLC orderings are now determined by userspace and BPF uses two helpers to iterate over the combinations. The overhead is lower for both topo and no-topo cases. See the reimplement commit for details.

Remaining todos:
- Layer growth doesn't always work as expected likely due to owned execution accounting and protection issue.
- scx_layered process itself should be prioritized by queueing to hi fallback.
- Implement DSQ latency based in-layer execution protection so that latency sensitive workloads can be protected from preempt workloads.
- Integrate stickiness mechanism.
- Split on node boundaries.