### PR TITLE
scx_utils: remove use of deprecated bindgen API; require bindgen >=0.69

### DIFF
--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -10,9 +10,7 @@ description = "Utilities for sched_ext schedulers"
 [dependencies]
 anyhow = "1.0.65"
 bitvec = { version = "1.0", features = ["serde"] }
-# FIXME - We need to allow both 0.68 and 0.69 to accommodate fedora. See the
-# comment in BpfBuilder::bindgen_bpf_intf() for details.
-bindgen = ">=0.68, <0.70"
+bindgen = ">=0.69"
 glob = "0.3"
 hex = "0.4.3"
 lazy_static = "1.4"
@@ -34,7 +32,7 @@ libc = "0.2.137"
 
 [build-dependencies]
 anyhow = "1.0.65"
-bindgen = ">=0.68, <0.70"
+bindgen = ">=0.69"
 glob = "0.3"
 lazy_static = "1.4"
 libbpf-cargo = "0.24.1"

--- a/rust/scx_utils/src/bpf_builder.rs
+++ b/rust/scx_utils/src/bpf_builder.rs
@@ -306,13 +306,6 @@ impl BpfBuilder {
         // Tell cargo to invalidate the built crate whenever the wrapper changes
         deps.insert(input.to_string());
 
-        // FIXME - bindgen's API changed between 0.68 and 0.69 so that
-        // `bindgen::CargoCallbacks::new()` should be used instead of
-        // `bindgen::CargoCallbacks`. Unfortunately, as of Dec 2023, fedora
-        // is shipping 0.68. To accommodate fedora, allow both 0.68 and 0.69
-        // of bindgen and suppress deprecation warning. Remove the following
-        // once fedora can be updated to bindgen >= 0.69.
-        #[allow(deprecated)]
         // The bindgen::Builder is the main entry point to bindgen, and lets
         // you build up options for the resulting bindings.
         let bindings = bindgen::Builder::default()
@@ -326,7 +319,7 @@ impl BpfBuilder {
             .header(input)
             // Tell cargo to invalidate the built crate whenever any of the
             // included header files changed.
-            .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
             .generate()
             .context("Unable to generate bindings")?;
 

--- a/rust/scx_utils/src/builder.rs
+++ b/rust/scx_utils/src/builder.rs
@@ -48,18 +48,11 @@ impl Builder {
             .unwrap()
             .to_string();
 
-        // FIXME - bindgen's API changed between 0.68 and 0.69 so that
-        // `bindgen::CargoCallbacks::new()` should be used instead of
-        // `bindgen::CargoCallbacks`. Unfortunately, as of Dec 2023, fedora is
-        // shipping 0.68. To accommodate fedora, allow both 0.68 and 0.69 of
-        // bindgen and suppress deprecation warning. Remove the following once
-        // fedora can be updated to bindgen >= 0.69.
-        #[allow(deprecated)]
         let bindings = bindgen::Builder::default()
             .header(vmlinux_h)
             .allowlist_type("scx_exit_kind")
             .allowlist_type("scx_consts")
-            .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
             .generate()
             .expect("Unable to generate bindings");
 


### PR DESCRIPTION
`bindgen` version was previously fixed to `v0.68` and `v0.69` due to `v0.69` not being available on Fedora at the time.

This update removes support for `bindgen v0.68` and migrates to the new API, as Fedora now includes `v0.69`.

Closes #1001 