### PR TITLE
Fix build on non-x86 architectures

### DIFF
--- a/meson-scripts/get_sys_incls
+++ b/meson-scripts/get_sys_incls
@@ -18,4 +18,4 @@ clang="$1"
 
 "$clang" -dM -E - < /dev/null \
     | grep '__riscv_xlen ' \
-    | awk '{printf("-D__riscv_xlen=%d -D__BITS_PER_LONG=%d", $$3, $$3)}'
+    | awk '{printf("-D__riscv_xlen=%d -D__BITS_PER_LONG=%d", $3, $3)}'

--- a/rust/scx_utils/src/bpf_builder.rs
+++ b/rust/scx_utils/src/bpf_builder.rs
@@ -227,12 +227,12 @@ impl BpfBuilder {
             _ => vec![],
         });
 
-        cflags.push(format!("-I{}", &bpf_h));
         cflags.push(format!(
             "-I{}/arch/{}",
             &bpf_h,
             &clang.kernel_target().unwrap()
         ));
+        cflags.push(format!("-I{}", &bpf_h));
         cflags.push(format!("-I{}/bpf-compat", &bpf_h));
 
         cflags.append(&mut match env::var("BPF_EXTRA_CFLAGS_POST_INCL") {


### PR DESCRIPTION
- Use single dollar sign instead of double since it is already single-quoted, so no need to escape.
- ~~Remove vmlinux.h in scheds/include that points to x86's. It overrides the vmlinux.h include in arch/*.~~
- Reorder include arguments so that scheds/include/vmlinux.h does not override arch/*/vmlinux.h.

Tested and built successfully on real RISC-V hardware after applying the patch.