### PR TITLE
scx_layered: Prioritize sched userspace and fix owned execution protection

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1584,6 +1584,9 @@ impl<'a> Scheduler<'a> {
         skel.struct_ops.layered_mut().exit_dump_len = opts.exit_dump_len;
 
         skel.maps.rodata_data.debug = opts.verbose as u32;
+        // Running scx_layered inside a PID namespace would break the
+        // following.
+        skel.maps.rodata_data.layered_tgid = unsafe { libc::getpid() };
         skel.maps.rodata_data.slice_ns = opts.slice_us * 1000;
         skel.maps.rodata_data.max_exec_ns = if opts.max_exec_us > 0 {
             opts.max_exec_us * 1000

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1586,7 +1586,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.debug = opts.verbose as u32;
         // Running scx_layered inside a PID namespace would break the
         // following.
-        skel.maps.rodata_data.layered_tgid = unsafe { libc::getpid() };
+        skel.maps.rodata_data.layered_tgid = std::process::id() as i32;
         skel.maps.rodata_data.slice_ns = opts.slice_us * 1000;
         skel.maps.rodata_data.max_exec_ns = if opts.max_exec_us > 0 {
             opts.max_exec_us * 1000

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -56,10 +56,10 @@ pub struct LayerStats {
     pub index: usize,
     #[stat(desc = "Total CPU utilization (100% means one full CPU)")]
     pub util: f64,
-    #[stat(desc = "Protected CPU utilization %")]
-    pub util_protected: f64,
     #[stat(desc = "Open CPU utilization %")]
-    pub util_open: f64,
+    pub util_open_frac: f64,
+    #[stat(desc = "Protected CPU utilization %")]
+    pub util_protected_frac: f64,
     #[stat(desc = "fraction of total CPU utilization")]
     pub util_frac: f64,
     #[stat(desc = "sum of weight * duty_cycle for tasks")]
@@ -188,13 +188,13 @@ impl LayerStats {
         Self {
             index: lidx,
             util: util_sum * 100.0,
-            util_protected: if util_sum != 0.0 {
-                stats.layer_utils[lidx][LAYER_USAGE_PROTECTED] / util_sum * 100.0
+            util_open_frac: if util_sum != 0.0 {
+                stats.layer_utils[lidx][LAYER_USAGE_OPEN] / util_sum * 100.0
             } else {
                 0.0
             },
-            util_open: if util_sum != 0.0 {
-                stats.layer_utils[lidx][LAYER_USAGE_OPEN] / util_sum * 100.0
+            util_protected_frac: if util_sum != 0.0 {
+                stats.layer_utils[lidx][LAYER_USAGE_PROTECTED] / util_sum * 100.0
             } else {
                 0.0
             },
@@ -259,11 +259,11 @@ impl LayerStats {
     pub fn format<W: Write>(&self, w: &mut W, name: &str, header_width: usize) -> Result<()> {
         writeln!(
             w,
-            "  {:<width$}: util/prot/open/frac={:6.1}/{}/{}/{:7.1} tasks={:6} load={:9.2}",
+            "  {:<width$}: util/open/prot/frac={:6.1}/{}/{}/{:7.1} tasks={:6} load={:9.2}",
             name,
             self.util,
-            fmt_pct(self.util_protected),
-            fmt_pct(self.util_open),
+            fmt_pct(self.util_open_frac),
+            fmt_pct(self.util_protected_frac),
             self.util_frac,
             self.tasks,
             self.load,


### PR DESCRIPTION
- Always put scx_layered userspace in hi fallback DSQ to guarantee timely execution of scheduler userspace code. This is required as reasonable forward progress depends on userspace code running. This assumes that scx_layered is running in the root PID namespace. It might be useful to add a warning when that's not the case - e.g. look up the task from the BPF side and verify that it actually is scx_layered.
- Owned execution protection had a couple bugs which could weaken protection and prevent a layer with high util growth bound from growing. Fix them. After this change, a saturating workload can reliably grow from empty under competition from preempting layers.