### PR TITLE
Enable Link-Time Optimization (LTO) for the Rust part

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ members = ["rust/scx_stats",
            "scheds/rust/scx_layered",
            "scheds/rust/scx_mitosis"]
 resolver = "2"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Related to https://github.com/sched-ext/scx/issues/1010 but doesn't completely resolve it