### PR TITLE
scx_layered: Deprecate idle_smt layer config

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -245,7 +245,6 @@ struct layer {
 	bool			preempt;
 	bool			preempt_first;
 	bool			exclusive;
-	bool			idle_smt;
 	int			growth_algo;
 
 	u32			owned_usage_target_ppk;

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -89,8 +89,8 @@ pub struct LayerCommon {
     pub exclusive: bool,
     #[serde(default)]
     pub weight: u32,
-    #[serde(default)]
-    pub idle_smt: bool,
+    #[serde(default, skip_serializing)]
+    pub idle_smt: Option<bool>,
     #[serde(default)]
     pub growth_algo: LayerGrowthAlgo,
     #[serde(default)]


### PR DESCRIPTION
24fba4ab8de9 ("scx_layered: Add idle smt layer configuration") added the idle_smt layer config but

- It flipped the default from preferring idle cores to not having preference.

- Misdocumented what it meant. It doesn't only pick idle cores. It tries to pick an idle core first and if that fails pick any idle CPU.

A follow-up commit 637fc3f6e136 ("scx_layered: Use layer idle_smt option") made it more confusing. If idle_smt is set, the idle core prioritizing logic is disabled.

The first commit disables idle core prioritization by overriding idle_smtmask to be idle_cpumask if idle_smt is *clear* and the second commit disables the same by disabling the code path when the flag is *set*. ie. Both options did exactly the same thing.

Recently, 75dd81e3e657 ("scx_layered: Improve topology aware select_cpu()") restored the function of the flag by dropping the cpumask override. However, this made the actual behavior the opposite of the documented one by leaving only the behavior of the second commit which implemented the reverse behavior.

This flag is hopeless. History aside, the name itself is too confusing. idle_smt - is it saying that the flag is going to prefer idle smt *thread* or idle smt *core*? While the name is transferred from idle_cpumask/smtmask, there, the meaning of the former is clear which also makes it difficult to confuse what the latter means.

Preferring idle cores was one of the drivers of performance gain identified during earlier ads experiments. Let's just drop the flag to restore the previous behavior and retry if necessary.