### PR TITLE
vmlinux: Increase cpumask size in vmlinux.h for all arch

### DIFF
--- a/scheds/include/arch/arm/vmlinux-v6.12-rc2-g5b7c893ed5ed.h
+++ b/scheds/include/arch/arm/vmlinux-v6.12-rc2-g5b7c893ed5ed.h
@@ -2507,7 +2507,7 @@ struct sched_statistics {
 };
 
 struct cpumask {
-	unsigned long bits[1];
+	unsigned long bits[128];
 };
 
 typedef struct cpumask cpumask_t;

--- a/scheds/include/arch/arm64/vmlinux-v6.12-rc2-g5b7c893ed5ed.h
+++ b/scheds/include/arch/arm64/vmlinux-v6.12-rc2-g5b7c893ed5ed.h
@@ -221,7 +221,7 @@ struct trace_seq {
 };
 
 struct cpumask {
-	unsigned long bits[4];
+	unsigned long bits[128];
 };
 
 typedef struct cpumask cpumask_var_t[1];

--- a/scheds/include/arch/mips/vmlinux-v6.12-rc2-g5b7c893ed5ed.h
+++ b/scheds/include/arch/mips/vmlinux-v6.12-rc2-g5b7c893ed5ed.h
@@ -2435,7 +2435,7 @@ struct sched_statistics {
 };
 
 struct cpumask {
-	unsigned long bits[4];
+	unsigned long bits[128];
 };
 
 typedef struct cpumask cpumask_t;

--- a/scheds/include/arch/powerpc/vmlinux-v6.12-rc2-g5b7c893ed5ed.h
+++ b/scheds/include/arch/powerpc/vmlinux-v6.12-rc2-g5b7c893ed5ed.h
@@ -338,7 +338,7 @@ struct sched_statistics {
 };
 
 struct cpumask {
-	unsigned long bits[1];
+	unsigned long bits[128];
 };
 
 typedef struct cpumask cpumask_t;

--- a/scheds/include/arch/riscv/vmlinux-v6.12-rc2-g5b7c893ed5ed.h
+++ b/scheds/include/arch/riscv/vmlinux-v6.12-rc2-g5b7c893ed5ed.h
@@ -2062,7 +2062,7 @@ struct percpu_counter {
 };
 
 struct cpumask {
-	unsigned long bits[4];
+	unsigned long bits[128];
 };
 
 typedef struct cpumask cpumask_t;

--- a/scheds/include/arch/s390/vmlinux-v6.12-rc2-g5b7c893ed5ed.h
+++ b/scheds/include/arch/s390/vmlinux-v6.12-rc2-g5b7c893ed5ed.h
@@ -2131,7 +2131,7 @@ struct percpu_counter {
 };
 
 struct cpumask {
-	unsigned long bits[4];
+	unsigned long bits[128];
 };
 
 typedef struct cpumask cpumask_t;


### PR DESCRIPTION
The size of CPU mask (struct cpumask) is defined as too small in all architectures (e.g., unsigned long * 4) except for x86. It triggers a verifier error in lavd (e.g., arm64), so increase its size to the same as x86. The changes were tested on an arm64 platform.

This solves the following issues (on arm64).

   https://github.com/sched-ext/scx/issues/810