### PR TITLE
scx: enable using sccache

### DIFF
--- a/meson-scripts/build_libbpf
+++ b/meson-scripts/build_libbpf
@@ -14,6 +14,21 @@ if [ "$cc" = "ccache" ]; then
     cc="$cc ${args[idx]}"
 fi
 
+if [ "$cc" = "sccache" ]; then
+    idx=$((idx+1))
+    cc="$cc ${args[idx]}"
+fi
+
+if [ "$cc" = "ccache" ]; then
+    idx=$((idx+1))
+    cc="$cc ${args[idx]}"
+fi
+
+if [ "$cc" = "sccache" ]; then
+    idx=$((idx+1))
+    cc="$cc ${args[idx]}"
+fi
+
 declare -a cflags=()
 
 for arg in ${args[@]:(idx+1)}; do


### PR DESCRIPTION
This enables sccache to work with meson builds (it already works w/ cargo).

sccache and ccache make working on scx nicer (i.e. lsp works immediately, nice iteration time, etc.), it works so well i kinda recommend folks use it tbh.

tested a couple times w/ local meson test script:

```
❯ cat local-e2e.sh 
#!/bin/bash

set -euxo pipefail
REPOS=$HOME/repos
SCX=scx
KERNEL=sched-ext-linux
SCHED="$1"
cd $REPOS/$KERNEL
vng -v --build --pwd $REPOS/$KERNEL --config "$REPOS/$SCX/.github/workflows/sched-ext.config"
cd $REPOS/$SCX
BUILDDIR=../../../../tmp/scxbuild/
# when messing with meson
rm -rf /tmp/scxbuild
mkdir -p $BUILDDIR
meson setup -Dkernel=$REPOS/$KERNEL -Dkernel_headers=$REPOS/$KERNEL/usr/include -Denable_stress=true $BUILDDIR $REPOS/$SCX -Dbuild_outside_src=true
meson compile -C $BUILDDIR "$SCHED"
#meson compile -C $BUILDDIR "veristat_$SCHED"
meson compile -C $BUILDDIR test_sched_"$SCHED"
meson compile -C $BUILDDIR stress_tests_"$SCHED"
```
