### PR TITLE
deps: Fix compilation on older Rust toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ dependencies = [
  "serde",
  "simplelog",
  "static_assertions",
- "zbus 5.1.1",
+ "zbus",
 ]
 
 [[package]]
@@ -1808,8 +1808,8 @@ dependencies = [
  "sysinfo",
  "tokio",
  "toml",
- "zbus 4.4.0",
- "zvariant 4.2.0",
+ "zbus",
+ "zvariant",
 ]
 
 [[package]]
@@ -2866,9 +2866,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
 dependencies = [
  "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
  "async-process",
  "async-recursion",
+ "async-task",
  "async-trait",
+ "blocking",
  "enumflags2",
  "event-listener",
  "futures-core",
@@ -2887,45 +2893,9 @@ dependencies = [
  "uds_windows",
  "windows-sys 0.52.0",
  "xdg-home",
- "zbus_macros 4.4.0",
- "zbus_names 3.0.0",
- "zvariant 4.2.0",
-]
-
-[[package]]
-name = "zbus"
-version = "5.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1162094dc63b1629fcc44150bcceeaa80798cd28bcbe7fa987b65a034c258608"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-util",
- "hex",
- "nix 0.29.0",
- "ordered-stream",
- "serde",
- "serde_repr",
- "static_assertions",
- "tracing",
- "uds_windows",
- "windows-sys 0.59.0",
- "winnow",
- "xdg-home",
- "zbus_macros 5.1.1",
- "zbus_names 4.1.0",
- "zvariant 5.1.0",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
@@ -2938,22 +2908,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "zvariant_utils 2.1.0",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "5.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd2dcdce3e2727f7d74b7e33b5a89539b3cc31049562137faf7ae4eb86cd16d"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zbus_names 4.1.0",
- "zvariant 5.1.0",
- "zvariant_utils 3.0.2",
+ "zvariant_utils",
 ]
 
 [[package]]
@@ -2964,19 +2919,7 @@ checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
 dependencies = [
  "serde",
  "static_assertions",
- "zvariant 4.2.0",
-]
-
-[[package]]
-name = "zbus_names"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856b7a38811f71846fd47856ceee8bccaec8399ff53fb370247e66081ace647b"
-dependencies = [
- "serde",
- "static_assertions",
- "winnow",
- "zvariant 5.1.0",
+ "zvariant",
 ]
 
 [[package]]
@@ -3010,22 +2953,7 @@ dependencies = [
  "enumflags2",
  "serde",
  "static_assertions",
- "zvariant_derive 4.2.0",
-]
-
-[[package]]
-name = "zvariant"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1200ee6ac32f1e5a312e455a949a4794855515d34f9909f4a3e082d14e1a56f"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "static_assertions",
- "winnow",
- "zvariant_derive 5.1.0",
- "zvariant_utils 3.0.2",
+ "zvariant_derive",
 ]
 
 [[package]]
@@ -3038,20 +2966,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "zvariant_utils 2.1.0",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687e3b97fae6c9104fbbd36c73d27d149abf04fb874e2efbd84838763daa8916"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils 3.0.2",
+ "zvariant_utils",
 ]
 
 [[package]]
@@ -3063,18 +2978,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d1d011a38f12360e5fcccceeff5e2c42a8eb7f27f0dcba97a0862ede05c9c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "static_assertions",
- "syn",
- "winnow",
 ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-09-10"
-components = [ "rustfmt", "rustc-dev" ]
+channel = "1.77"
+components = ["rustfmt"]
 profile = "minimal"

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -539,12 +539,12 @@ fn create_insert_cpu(
         cpu_id,
         Arc::new(Cpu {
             id: cpu_id,
-            min_freq: min_freq,
-            max_freq: max_freq,
-            base_freq: base_freq,
-            trans_lat_ns: trans_lat_ns,
-            l2_id: l2_id,
-            l3_id: l3_id,
+            min_freq,
+            max_freq,
+            base_freq,
+            trans_lat_ns,
+            l2_id,
+            l3_id,
             core_type: core_type.clone(),
 
             core_id: *core_id,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,8 +1,5 @@
 # Get help on options with `rustfmt --help=config`
 # Please keep these in alphabetical order.
 edition = "2021"
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
 merge_derives = false
 use_field_init_shorthand = true
-version = "Two"

--- a/scheds/rust/scx_bpfland/rustfmt.toml
+++ b/scheds/rust/scx_bpfland/rustfmt.toml
@@ -1,8 +1,0 @@
-# Get help on options with `rustfmt --help=config`
-# Please keep these in alphabetical order.
-edition = "2021"
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
-merge_derives = false
-use_field_init_shorthand = true
-version = "Two"

--- a/scheds/rust/scx_flash/rustfmt.toml
+++ b/scheds/rust/scx_flash/rustfmt.toml
@@ -1,8 +1,0 @@
-# Get help on options with `rustfmt --help=config`
-# Please keep these in alphabetical order.
-edition = "2021"
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
-merge_derives = false
-use_field_init_shorthand = true
-version = "Two"

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -27,7 +27,7 @@ simplelog = "0.12"
 static_assertions = "1.1.0"
 plain = "0.2.3"
 gpoint = "0.2"
-zbus = "5"
+zbus = "4"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.7" }

--- a/scheds/rust/scx_lavd/rustfmt.toml
+++ b/scheds/rust/scx_lavd/rustfmt.toml
@@ -1,8 +1,0 @@
-# Get help on options with `rustfmt --help=config`
-# Please keep these in alphabetical order.
-edition = "2021"
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
-merge_derives = false
-use_field_init_shorthand = true
-version = "Two"

--- a/scheds/rust/scx_layered/rustfmt.toml
+++ b/scheds/rust/scx_layered/rustfmt.toml
@@ -1,8 +1,0 @@
-# Get help on options with `rustfmt --help=config`
-# Please keep these in alphabetical order.
-edition = "2021"
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
-merge_derives = false
-use_field_init_shorthand = true
-version = "Two"

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -174,7 +174,11 @@ impl LayerStats {
             }
         };
         let calc_frac = |a, b| {
-            if b != 0.0 { a / b * 100.0 } else { 0.0 }
+            if b != 0.0 {
+                a / b * 100.0
+            } else {
+                0.0
+            }
         };
 
         let util_sum = stats.layer_utils[lidx]

--- a/scheds/rust/scx_mitosis/rustfmt.toml
+++ b/scheds/rust/scx_mitosis/rustfmt.toml
@@ -1,8 +1,0 @@
-# Get help on options with `rustfmt --help=config`
-# Please keep these in alphabetical order.
-edition = "2021"
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
-merge_derives = false
-use_field_init_shorthand = true
-version = "Two"

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -527,7 +527,9 @@ impl<'a> Scheduler<'a> {
         for (cell_idx, cell) in self.cells.iter() {
             trace!(
                 "Cell {}, Load: {}, Pinned Load: {}",
-                cell_idx, cell.load, cell.pinned_load
+                cell_idx,
+                cell.load,
+                cell.pinned_load
             );
         }
         let zero = 0 as libc::__u32;

--- a/scheds/rust/scx_rlfifo/rustfmt.toml
+++ b/scheds/rust/scx_rlfifo/rustfmt.toml
@@ -1,8 +1,0 @@
-# Get help on options with `rustfmt --help=config`
-# Please keep these in alphabetical order.
-edition = "2021"
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
-merge_derives = false
-use_field_init_shorthand = true
-version = "Two"

--- a/scheds/rust/scx_rustland/rustfmt.toml
+++ b/scheds/rust/scx_rustland/rustfmt.toml
@@ -1,8 +1,0 @@
-# Get help on options with `rustfmt --help=config`
-# Please keep these in alphabetical order.
-edition = "2021"
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
-merge_derives = false
-use_field_init_shorthand = true
-version = "Two"

--- a/scheds/rust/scx_rusty/rustfmt.toml
+++ b/scheds/rust/scx_rusty/rustfmt.toml
@@ -1,8 +1,0 @@
-# Get help on options with `rustfmt --help=config`
-# Please keep these in alphabetical order.
-edition = "2021"
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
-merge_derives = false
-use_field_init_shorthand = true
-version = "Two"


### PR DESCRIPTION
This PR does the following to allow compilation with older Rust toolchain:

- Downgrade Rust version specified in `rust-toolchain.toml` to 1.77. (`sched_mitosis` requires `std::mem::offset_of`, so the Rust version cannot be further downgraded.)
- Downgrade the dependency `zbus` to v4.

@multics69 @JakeHillion 
