### PR TITLE
scx_layered: Make vtime_now per-LLC

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -172,6 +172,7 @@ struct llc_ctx {
 	u32			id;
 	struct bpf_cpumask __kptr *cpumask;
 	u32			nr_cpus;
+	u64			vtime_now[MAX_LAYERS];
 	u64			queued_runtime[MAX_LAYERS];
 	u64			lstats[MAX_LAYERS][NR_LLC_LSTATS];
 	struct llc_prox_map	prox_map;
@@ -248,7 +249,6 @@ struct layer {
 	int			growth_algo;
 
 	u32			owned_usage_target_ppk;
-	u64			vtime_now;
 	u64			nr_tasks;
 
 	u64			cpus_seq;


### PR DESCRIPTION
On multi-LLC machines, a layer uses one DSQ per LLC; however, the DSQs all
share one per-layer vtime_now. Cacheline contention aside, this makes
vtime_now progression erratic as a single DSQ executing can easily progress
the per-layer vtime_now past the heads of other DSQs which in turn can
collapse vtime based ordering in other DSQs.
    
Make vtime_now per DSQ and translate between vtimelines when a tasks jumps
between LLCs. In rd-hashd CPU saturation scenario on ryzen 3900x, this
reduces the gap from EEVDF from >10% to ~5%.
