### PR TITLE
scx_layered: Fix bug in target CPU calculation

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1752,8 +1752,8 @@ impl<'a> Scheduler<'a> {
                     }
 
                     let util = if util < 0.01 { 0.0 } else { util };
-                    let low = (util / util_range.1).ceil() as usize;
-                    let high = ((util / util_range.0).floor() as usize).max(low);
+                    let low = (util / util_range.0).ceil() as usize;
+                    let high = ((util / util_range.1).floor() as usize).max(low);
                     let target = layer.cpus.count_ones().clamp(low, high);
                     let cpus_range = cpus_range.unwrap_or((0, nr_cpus));
 


### PR DESCRIPTION
Fix a bug in target CPU calculation in utilization range use.

On `main` testing on a large machine layers don't grow properly with `cargo build --release && sudo ./target/release/scx_layered --run-example`:
<img width="1906" alt="image" src="https://github.com/user-attachments/assets/d786a0a7-0767-44ef-a93e-4d2a847af407">
```
22:25:32 [TRACE] (owned, open, util, low, high, target): [(32, 0, 32, 1, 1, 1), (128, 0, 128, 2, 6, 2), (8, 1, 8, 1, 1, 1)]
22:25:33 [TRACE] initial targets: [(1, 0), (0, 0), (2, 0), (1, 0)]
22:25:33 [TRACE] (owned, open, util, low, high, target): [(32, 0, 32, 1, 1, 1), (128, 0, 128, 2, 6, 2), (11, 2, 11, 1, 1, 1)]
22:25:33 [TRACE] initial targets: [(1, 0), (0, 0), (2, 0), (1, 0)]
22:25:33 [TRACE] (owned, open, util, low, high, target): [(36, 0, 36, 1, 1, 1), (128, 0, 128, 2, 6, 2), (10, 2, 10, 1, 1, 1)]
22:25:33 [TRACE] initial targets: [(1, 0), (0, 0), (2, 0), (1, 0)]
22:25:33 [TRACE] (owned, open, util, low, high, target): [(24, 0, 24, 1, 1, 1), (129, 0, 129, 2, 6, 2), (10, 1, 10, 1, 1, 1)]
22:25:33 [TRACE] initial targets: [(1, 0), (0, 0), (2, 0), (1, 0)]
```
vs:
<img width="1906" alt="image" src="https://github.com/user-attachments/assets/aba2f5d3-a141-4367-9d2b-7d8a560317d2">
```
22:24:24 [TRACE] initial targets: [(1, 0), (0, 0), (100, 0), (1, 0)]
22:24:24 [TRACE] (owned, open, util, low, high, target): [(22, 0, 22, 1, 1, 1), (7997, 0, 7997, 100, 399, 100), (22, 6, 22, 1, 1, 1)]
22:24:24 [TRACE] initial targets: [(1, 0), (0, 0), (100, 0), (1, 0)]
22:24:24 [TRACE] (owned, open, util, low, high, target): [(24, 0, 24, 1, 1, 1), (7996, 0, 7996, 100, 399, 100), (17, 4, 17, 1, 1, 1)]
22:24:24 [TRACE] initial targets: [(1, 0), (0, 0), (100, 0), (1, 0)]
22:24:24 [TRACE] (owned, open, util, low, high, target): [(25, 0, 25, 1, 1, 1), (7997, 0, 7997, 100, 399, 100), (13, 15, 13, 1, 1, 1)]
```
