### PR TITLE
scx_layered: Implement layer config xllc_mig_min_us

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -104,6 +104,7 @@ enum layer_stat_id {
 	LSTAT_MIGRATION,
 	LSTAT_XNUMA_MIGRATION,
 	LSTAT_XLLC_MIGRATION,
+	LSTAT_XLLC_MIGRATION_SKIP,
 	LSTAT_XLAYER_WAKE,
 	LSTAT_XLAYER_REWAKE,
 	NR_LSTATS,
@@ -241,6 +242,7 @@ struct layer {
 	u64			yield_step_ns;
 	u64			slice_ns;
 	u32			weight;
+	u64			xllc_mig_min_ns;
 
 	int			kind;
 	bool			preempt;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -688,10 +688,11 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 {
 	const struct cpumask *idle_smtmask, *layer_cpumask, *layered_cpumask, *cpumask;
 	struct cpu_ctx *prev_cpuc;
+	u32 layer_id = layer->id;
 	u64 cpus_seq;
 	s32 cpu;
 
-	if (!(layer_cpumask = lookup_layer_cpumask(taskc->layer_id)))
+	if (layer_id >= MAX_LAYERS || !(layer_cpumask = lookup_layer_cpumask(layer_id)))
 		return -1;
 
 	/* not much to do if bound to a single CPU */
@@ -756,6 +757,8 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 	 * Try a CPU in the current LLC
 	 */
 	if (nr_llcs > 1) {
+		struct llc_ctx *prev_llcc;
+
 		maybe_refresh_layered_cpus_llc(p, taskc, layer_cpumask,
 					       prev_cpuc->llc_id, cpus_seq);
 		if (!(cpumask = cast_mask(taskc->layered_llc_mask))) {
@@ -764,6 +767,13 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 		}
 		if ((cpu = pick_idle_cpu_from(cpumask, prev_cpu, idle_smtmask)) >= 0)
 			goto out_put;
+
+		if (!(prev_llcc = lookup_llc_ctx(prev_cpuc->llc_id)) ||
+		    prev_llcc->queued_runtime[layer_id] <= layer->xllc_mig_min_ns) {
+			lstat_inc(LSTAT_XLLC_MIGRATION_SKIP, layer, cpuc);
+			cpu = -1;
+			goto out_put;
+		}
 	}
 
 	/*
@@ -1295,11 +1305,16 @@ reset:
 	return consumed;
 }
 
-static __always_inline
-bool try_consume_layer(u32 layer_id, struct llc_ctx *llcc)
+static __always_inline bool try_consume_layer(u32 layer_id, struct cpu_ctx *cpuc,
+					      struct llc_ctx *llcc)
 {
 	struct llc_prox_map *llc_pmap = &llcc->prox_map;
+	struct layer *layer;
+	bool xllc_mig_skipped = false;
 	u32 u;
+
+	if (!(layer = lookup_layer(layer_id)))
+		return false;
 
 	bpf_for(u, 0, llc_pmap->sys_end) {
 		u16 *llc_idp;
@@ -1309,16 +1324,31 @@ bool try_consume_layer(u32 layer_id, struct llc_ctx *llcc)
 			return false;
 		}
 
+		if (u > 0) {
+			struct llc_ctx *remote_llcc;
+
+			if (!(remote_llcc = lookup_llc_ctx(*llc_idp)))
+				return false;
+
+			if (remote_llcc->queued_runtime[layer_id] <= layer->xllc_mig_min_ns) {
+				xllc_mig_skipped = true;
+				continue;
+			}
+		}
+
 		if (scx_bpf_consume(layer_dsq_id(layer_id, *llc_idp)))
 			return true;
 	}
+
+	if (xllc_mig_skipped)
+		lstat_inc(LSTAT_XLLC_MIGRATION_SKIP, layer, cpuc);
 
 	return false;
 }
 
 static __always_inline
 bool try_consume_layers(u32 *layer_order, u32 nr, u32 exclude_layer_id,
-			struct llc_ctx *llcc)
+			struct cpu_ctx *cpuc, struct llc_ctx *llcc)
 {
 	u32 u;
 
@@ -1333,7 +1363,7 @@ bool try_consume_layers(u32 *layer_order, u32 nr, u32 exclude_layer_id,
 		if (layer_id == exclude_layer_id)
 			continue;
 
-		if (try_consume_layer(layer_id, llcc))
+		if (try_consume_layer(layer_id, cpuc, llcc))
 			return true;
 	}
 
@@ -1403,29 +1433,29 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 	 */
 	if (cpuc->cpu == fallback_cpu &&
 	    try_consume_layers(empty_layer_ids, nr_empty_layer_ids,
-			       MAX_LAYERS, llcc)) {
+			       MAX_LAYERS, cpuc, llcc)) {
 	}
 
 	/* owner before preempt layers if protected or preempting */
 	if (owner_layer && (cpuc->protect_owned || owner_layer->preempt)) {
-		if (try_consume_layer(owner_layer->id, llcc))
+		if (try_consume_layer(owner_layer->id, cpuc, llcc))
 			return;
 		tried_owner = true;
 	}
 
 	/* grouped/open preempt layers */
 	if (try_consume_layers(cpuc->open_preempt_layer_order, nr_open_preempt_layers,
-			       cpuc->layer_id, llcc))
+			       cpuc->layer_id, cpuc, llcc))
 		return;
 
 	/* try owner if not tried yet */
 	if (owner_layer && !tried_owner &&
-	    try_consume_layer(owner_layer->id, llcc))
+	    try_consume_layer(owner_layer->id, cpuc, llcc))
 		return;
 
 	/* grouped/open non-preempt layers */
 	if (try_consume_layers(cpuc->open_layer_order, nr_open_layers,
-			       cpuc->layer_id, llcc))
+			       cpuc->layer_id, cpuc, llcc))
 		return;
 
 	scx_bpf_consume(LO_FALLBACK_DSQ);

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -73,6 +73,10 @@ pub enum LayerMatch {
     TGIDEquals(u32),
 }
 
+fn xllc_mig_min_us_dfl() -> f64 {
+    crate::XLLC_MIG_MIN_US_DFL
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LayerCommon {
     #[serde(default)]
@@ -89,6 +93,8 @@ pub struct LayerCommon {
     pub exclusive: bool,
     #[serde(default)]
     pub weight: u32,
+    #[serde(default="xllc_mig_min_us_dfl")]
+    pub xllc_mig_min_us: f64,
     #[serde(default, skip_serializing)]
     pub idle_smt: Option<bool>,
     #[serde(default)]

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -93,7 +93,7 @@ pub struct LayerCommon {
     pub exclusive: bool,
     #[serde(default)]
     pub weight: u32,
-    #[serde(default="xllc_mig_min_us_dfl")]
+    #[serde(default = "xllc_mig_min_us_dfl")]
     pub xllc_mig_min_us: f64,
     #[serde(default, skip_serializing)]
     pub idle_smt: Option<bool>,

--- a/scheds/rust/scx_layered/src/lib.rs
+++ b/scheds/rust/scx_layered/src/lib.rs
@@ -26,6 +26,8 @@ use scx_utils::TopologyMap;
 
 const MAX_CPUS: usize = bpf_intf::consts_MAX_CPUS as usize;
 
+pub const XLLC_MIG_MIN_US_DFL: f64 = 100.0;
+
 lazy_static::lazy_static! {
     static ref NR_POSSIBLE_CPUS: usize = libbpf_rs::num_possible_cpus().unwrap();
 }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -108,6 +108,7 @@ lazy_static! {
                         idle_smt: None,
                         slice_us: 20000,
                         weight: DEFAULT_LAYER_WEIGHT,
+                        xllc_mig_min_us: XLLC_MIG_MIN_US_DFL,
                         growth_algo: LayerGrowthAlgo::Sticky,
                         perf: 1024,
                         nodes: vec![],
@@ -132,6 +133,7 @@ lazy_static! {
                         idle_smt: None,
                         slice_us: 20000,
                         weight: DEFAULT_LAYER_WEIGHT,
+                        xllc_mig_min_us: XLLC_MIG_MIN_US_DFL,
                         growth_algo: LayerGrowthAlgo::Sticky,
                         perf: 1024,
                         nodes: vec![],
@@ -157,6 +159,7 @@ lazy_static! {
                         idle_smt: None,
                         slice_us: 800,
                         weight: DEFAULT_LAYER_WEIGHT,
+                        xllc_mig_min_us: XLLC_MIG_MIN_US_DFL,
                         growth_algo: LayerGrowthAlgo::Topo,
                         perf: 1024,
                         nodes: vec![],
@@ -180,6 +183,7 @@ lazy_static! {
                         idle_smt: None,
                         slice_us: 20000,
                         weight: DEFAULT_LAYER_WEIGHT,
+                        xllc_mig_min_us: XLLC_MIG_MIN_US_DFL,
                         growth_algo: LayerGrowthAlgo::Linear,
                         perf: 1024,
                         nodes: vec![],
@@ -1162,6 +1166,7 @@ impl<'a> Scheduler<'a> {
                     nodes,
                     slice_us,
                     weight,
+                    xllc_mig_min_us,
                     ..
                 } = spec.kind.common();
 
@@ -1190,6 +1195,7 @@ impl<'a> Scheduler<'a> {
                 } else {
                     DEFAULT_LAYER_WEIGHT
                 };
+                layer.xllc_mig_min_ns = (xllc_mig_min_us * 1000.0) as u64;
                 layer.owned_usage_target_ppk =
                     Self::layer_owned_usage_target_ppk(spec.kind.util_range(), 0.0);
                 layer_weights.push(layer.weight.try_into().unwrap());

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -117,6 +117,8 @@ pub struct LayerStats {
     pub xnuma_migration: f64,
     #[stat(desc = "% migrated across LLCs")]
     pub xllc_migration: f64,
+    #[stat(desc = "% migration skipped across LLCs due to xllc_mig_min_us")]
+    pub xllc_migration_skip: f64,
     #[stat(desc = "% wakers across layers")]
     pub xlayer_wake: f64,
     #[stat(desc = "% rewakers across layers where waker has waken the task previously")]
@@ -226,6 +228,7 @@ impl LayerStats {
             xlayer_wake: lstat_pct(bpf_intf::layer_stat_id_LSTAT_XLAYER_WAKE),
             xlayer_rewake: lstat_pct(bpf_intf::layer_stat_id_LSTAT_XLAYER_REWAKE),
             xllc_migration: lstat_pct(bpf_intf::layer_stat_id_LSTAT_XLLC_MIGRATION),
+            xllc_migration_skip: lstat_pct(bpf_intf::layer_stat_id_LSTAT_XLLC_MIGRATION_SKIP),
             cpus: Self::bitvec_to_u32s(&layer.cpus),
             cur_nr_cpus: layer.cpus.count_ones() as u32,
             min_nr_cpus: nr_cpus_range.0 as u32,
@@ -301,12 +304,13 @@ impl LayerStats {
 
         writeln!(
             w,
-            "  {:<width$}  open_idle={} mig={} xnuma_mig={} xllc_mig={} affn_viol={}",
+            "  {:<width$}  open_idle={} mig={} xnuma_mig={} xllc_mig/skip={}/{} affn_viol={}",
             "",
             fmt_pct(self.open_idle),
             fmt_pct(self.migration),
             fmt_pct(self.xnuma_migration),
             fmt_pct(self.xllc_migration),
+            fmt_pct(self.xllc_migration_skip),
             fmt_pct(self.affn_viol),
             width = header_width,
         )?;


### PR DESCRIPTION
Now that per-DSQ queued runtimes are tracked, we can modulate cross-LLC
migrations based on them. Add a per-layer config option to skip cross-LLC
migrations if the queued runtime is below the configured value. Default to
100us which should be a safe value in most cases.