### PR TITLE
scx: Add scx_bpf_dump_header helper

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -23,6 +23,9 @@
 #define PF_KTHREAD 0x00200000   /* I am a kernel thread */
 #define PF_EXITING 0x00000004
 #define CLOCK_MONOTONIC 1
+extern int LINUX_KERNEL_VERSION __kconfig;
+extern const char CONFIG_CC_VERSION_TEXT[64] __kconfig __weak;
+extern const char CONFIG_LOCALVERSION[64] __kconfig __weak;
 
 /*
  * Earlier versions of clang/pahole lost upper 32bits in 64bit enums which can
@@ -148,6 +151,20 @@ ___scx_bpf_bstr_format_checker(const char *fmt, ...) {}
     scx_bpf_bstr_preamble(fmt, args)                                           \
         scx_bpf_dump_bstr(___fmt, ___param, sizeof(___param));                 \
     ___scx_bpf_bstr_format_checker(fmt, ##args);                               \
+  })
+
+/*
+ * scx_bpf_dump_header() is a wrapper around scx_bpf_dump that adds a header
+ * of system information for debugging.
+ */
+#define scx_bpf_dump_header()							\
+  ({										\
+    scx_bpf_dump("kernel: %d.%d.%d %s\ncc: %s\n",				\
+		 LINUX_KERNEL_VERSION >> 16,					\
+		 LINUX_KERNEL_VERSION >> 8 & 0xFF,				\
+		 LINUX_KERNEL_VERSION & 0xFF,					\
+		 CONFIG_LOCALVERSION,						\
+		 CONFIG_CC_VERSION_TEXT);					\
   })
 
 #define BPF_STRUCT_OPS(name, args...)                                          \

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2198,6 +2198,8 @@ void BPF_STRUCT_OPS(layered_dump, struct scx_dump_ctx *dctx)
 	int i, j, id;
 	struct layer *layer;
 
+	scx_bpf_dump_header();
+
 	bpf_for(i, 0, nr_layers) {
 		layer = lookup_layer(i);
 		if (!layer) {


### PR DESCRIPTION
Add scx_bpf_dump_header helper to dump common system information which can be used during scheduler dumping to provide a standard set of debugging information. This implements #1009.

Tested with patch:
```
diff --git a/scheds/rust/scx_layered/src/bpf/main.bpf.c b/scheds/rust/scx_layered/src/bpf/main.bpf.c
index c8c1dad..04e6a36 100644
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -993,20 +993,21 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
        struct cpu_ctx *cpuc, *task_cpuc;
        struct task_ctx *taskc;
        struct llc_ctx *llcc;
        struct layer *layer;
        s32 task_cpu = scx_bpf_task_cpu(p);
        u64 vtime = p->scx.dsq_vtime;
        u32 layer_id;
        bool try_preempt_first;
        u64 queued_runtime;
        u64 *lstats;
+       scx_bpf_error("oh no!");
 
        if (!(cpuc = lookup_cpu_ctx(-1)) ||
            !(task_cpuc = lookup_cpu_ctx(task_cpu)) ||
            !(taskc = lookup_task_ctx(p)) ||
            !(llcc = lookup_llc_ctx(task_cpuc->llc_id)))
                return;
 
        layer_id = taskc->layer_id;
 
        if (!(layer = lookup_layer(layer_id)))
  ```
  dump output:
  ```

DEBUG DUMP
================================================================================

swapper/23[0] triggered exit kind 1025:
  scx_bpf_error (oh no!)

Backtrace:
  scx_bpf_error_bstr+0x77/0x80
  bpf_prog_ca8ba986c9b72323_layered_enqueue+0x59/0x1a0f

kernel: 6.9.5 
cc: clang version 15.0.7 (Red Hat 15.0.7-2.el9)
LAYER[0][random]DSQ[0] nr_cpus=0 nr_queued=0 -0ms cpus=
LAYER[0][random]DSQ[1] nr_cpus=0 nr_queued=0 -0ms cpus=
01234567|89012345|67890123|45678901|23456789|01234567|89012345|67890123|45678901|23456789|
LAYER[1][hodgesd]DSQ[2] nr_cpus=0 nr_queued=0 -0ms cpus=

```
It would be real nice to get the clang version of the bpf compiler as well, but I'm not sure how to get that. If this change makes sense I'll update all the schedulers to add the header.