### PR TITLE
scx_utils: Extend topology to support Snapdragon X Elite

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -307,6 +307,7 @@ impl FlatTopology {
     ) -> Option<(Vec<CpuFlatId>, usize)> {
         let topo = Topology::new().expect("Failed to build host topology");
         let mut cpu_fids = Vec::new();
+        debug!("{:#?}", topo);
 
         // Build a vector of cpu flat ids.
         let mut base_freq = 0;


### PR DESCRIPTION
Snapdragon X Elite processor has an unusual CPU and cache topologies. It does not have an L3 cache, and a CPU cluster with four CPUs shares the same L2 cache -- so the L2 cache is the LLC. Moreover,  CPUs in a single core span across multiple L2 domains. Lastly, the sysfs does not exports an cache id file. Specifically, it has the following topology from the scx's point of view:

```
  LLC0 - core 0 - cpu 0
       \ core 1 - cpu 1
       \ core 2 - cpu 2
       \ core 3 - cpu 3

  LLC1 - core 0 - cpu 4
       \ core 1 - cpu 5
       \ core 2 - cpu 6
       \ core 3 - cpu 7

  LLC2 - core 0 - cpu 8
       \ core 1 - cpu 9
       \ core 2 - cpu 10
       \ core 3 - cpu 11
```

To support the above architecture, changed three things:
- When there is no L3 cache, use L2 cache ID as LLC ID.
- When there is no cache id file under sysfs, assign an id based on `shared_cpu_list` of the cache.
- Allow the case that a core ID is duplicated across LLC domains.