### PR TITLE
override rust version used for document generation

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -364,7 +364,8 @@ jobs:
       - uses: ./.github/actions/install-deps-action
       - name: Build Book and Linux Docs
         run: |
-          RUSTDOCFLAGS="--enable-index-page -Zunstable-options" ~/.cargo/bin/cargo doc --workspace --no-deps --bins --lib --examples --document-private-items
+          cd / && rustup component add rustfmt && cd $OLDPWD
+          RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --workspace --no-deps --bins --lib --examples --document-private-items
           sudo apt install build-essential graphviz sphinx-doc python3-sphinx-rtd-theme texlive-latex-recommended python3-yaml -y
           cargo install htmlq
           git clone --single-branch -b for-next --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux


### PR DESCRIPTION
fix ci document generation job (i broke it when setting rust version to stable).

works here: https://github.com/likewhatevs/scx/actions/runs/12149452075/job/33880144230