### PR TITLE
scx_lavd: Reset per-CPU preemption information when a CPU is released

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1747,8 +1747,12 @@ void BPF_STRUCT_OPS(lavd_update_idle, s32 cpu, bool idle)
 	 */
 	if (idle) {
 		cpuc->idle_start_clk = bpf_ktime_get_ns();
-		cpuc->lat_cri = 0;
-		cpuc->stopping_tm_est_ns = SCX_SLICE_INF;
+
+		/*
+		 * As an idle task cannot be preempted,
+		 * per-CPU preemption information should be cleared.
+		 */
+		reset_cpu_preemption_info(cpuc);
 	}
 	/*
 	 * The CPU is exiting from the idle state.

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -355,4 +355,10 @@ static bool try_yield_current_cpu(struct task_struct *p_run,
 	return ret;
 }
 
+static void reset_cpu_preemption_info(struct cpu_ctx *cpuc)
+{
+	cpuc->lat_cri = 0;
+	cpuc->stopping_tm_est_ns = SCX_SLICE_INF;
+}
+
 


### PR DESCRIPTION
When a CPU is released to serve a higher-priority scheduler class, reset per-CPU preemption information of that CPU so not choose the CPU as a victim by mistake. This solves the issue https://github.com/sched-ext/scx/issues/1039
