### PR TITLE
scx_layered: Tweak usage decay constant

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -86,7 +86,7 @@ const NR_LLC_LSTATS: usize = bpf_intf::llc_layer_stat_id_NR_LLC_LSTATS as usize;
 const NR_LAYER_MATCH_KINDS: usize = bpf_intf::layer_match_kind_NR_LAYER_MATCH_KINDS as usize;
 
 lazy_static! {
-    static ref USAGE_DECAY: f64 = 0.5f64.powf(1.0 / USAGE_HALF_LIFE_F64);
+    static ref USAGE_DECAY: f64 = 0.2f64.powf(1.0 / USAGE_HALF_LIFE_F64);
     static ref EXAMPLE_CONFIG: LayerConfig = LayerConfig {
         specs: vec![
             LayerSpec {


### PR DESCRIPTION
Tweak the usage decay to be slightly less aggressive. This was causing layers not to grow properly. The strange thing is that on `main` it's not always reproducible, so maybe the decay is just enough to prevent layers from growing.

`main`:
<img width="1906" alt="image" src="https://github.com/user-attachments/assets/cbc7ef9e-e419-431e-b12f-7a0395ce3bb2">
`pr`:
<img width="1906" alt="image" src="https://github.com/user-attachments/assets/0692490a-bd75-4ed8-807c-d2054b596ccc">