### PR TITLE
scx: fix bug in llc mask creation

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1698,7 +1698,7 @@ static s32 create_node(u32 node_id)
 
 			cpuc->node_id = node_id;
 			nodec->nr_cpus++;
-			nodec->llc_mask &= (1LLU << node_id);
+			nodec->llc_mask |= (1LLU << node_id);
 		}
 	}
 


### PR DESCRIPTION
When creating an llc mask for a node by iterating all cpus, OR llc_mask with the new value instead of AND'ing it.
