### PR TITLE
scripts: Refactor vtime_dist script

### DIFF
--- a/scripts/vtime_dist.bt
+++ b/scripts/vtime_dist.bt
@@ -5,26 +5,53 @@
 // GNU General Public License version 2.
 
 
-rawtracepoint:sched_wakeup,
-rawtracepoint:sched_wakeup_new,
+/*
+ * vtime_dist - Show the distribution of the change in vtime
+ *
+ * This script is used to probe scx_bpf_dispatch_vtime and prints the
+ * distribution of the difference in the vtime parameter The values are
+ * aggregated by dsq id.
+ *
+ * Processes can be filtered by passing a pid as the first parameter (0 for
+ * all pids):
+ *
+ * # filter pid 1234
+ * $ ./dsq_lat.bt 1234
+ * # all pids (default)
+ * $ ./dsq_lat.bt 0
+ *
+ * DSQs (above 0) can be filtered by passing the dsq id as the second parameter:
+ *
+ * # filter dsq 1234
+ * $ ./dsq_lat.bt 0 1234
+ */
+
+kprobe:scx_bpf_dsq_insert_vtime,
+kprobe:scx_bpf_dispatch_vtime,
 {
 	$task = (struct task_struct *)arg0;
+	$dsq = arg1;
+	$vtime = arg3;
 
 	if ($1 > 0 && $task->tgid != $1) {
 		return;
 	}
+	if ($2 > 0 && $2 != $dsq) {
+		return;
+	}
 
-	if ($task->scx.dsq->id >= 0) {
-		@dsq_vtime[$task->scx.dsq->id] = hist($task->scx.dsq_vtime);
+	if ($dsq >= 0) {
+		$prev_vtime = @dsq_vtime_now[$dsq];
+		@dsq_vtime_prev[$dsq] = $prev_vtime;
+		@dsq_vtime_now[$dsq] = $vtime;
+		@dsq_vtime_diff[$dsq] = avg($vtime - $prev_vtime);
+		@dsq_vtime[$dsq] = hist($vtime - $prev_vtime);
 	}
 }
 
 
 interval:s:1 {
-	if ($1 >0) {
-		$scx_ops = kaddr("scx_ops");
-		$ops = (struct sched_ext_ops*)$scx_ops;
-		printf("scheduler: %s\n", $ops->name);
-	}
+	print("-----------------------------------");
 	print(@dsq_vtime);
+	print(@dsq_vtime_diff);
 }


### PR DESCRIPTION
Refactor the vtime_dist script to show the distribution in the change of vtime rather than the histogram of the vtime. The histogram of the vtime is not really that useful as it should continuously be increasing. Attach to the `scx_bpf_dsq_insert_vtime` kprobe event rather than on `sched_wakeup`. Support filtering by DSQ with a script parameter and include the slice interval average and distribution to the output.

Example `scx_rusty` filtering DSQ 1:
```
$ sudo ./vtime_dist.bt 0 1
-----------------------------------
@dsq_vtime[1]: 
(..., 0)             437 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[0]                    1 |                                                    |
[1]                    0 |                                                    |
[2, 4)                 0 |                                                    |
[4, 8)                 0 |                                                    |
[8, 16)                0 |                                                    |
[16, 32)               0 |                                                    |
[32, 64)               0 |                                                    |
[64, 128)              0 |                                                    |
[128, 256)             1 |                                                    |
[256, 512)             0 |                                                    |
[512, 1K)              2 |                                                    |
[1K, 2K)               3 |                                                    |
[2K, 4K)              15 |@                                                   |
[4K, 8K)              22 |@@                                                  |
[8K, 16K)             53 |@@@@@@                                              |
[16K, 32K)            62 |@@@@@@@                                             |
[32K, 64K)            77 |@@@@@@@@@                                           |
[64K, 128K)          102 |@@@@@@@@@@@@                                        |
[128K, 256K)          66 |@@@@@@@                                             |
[256K, 512K)          35 |@@@@                                                |
[512K, 1M)            31 |@@@                                                 |
[1M, 2M)              27 |@@@                                                 |
[2M, 4M)              25 |@@                                                  |
[4M, 8M)              13 |@                                                   |
[8M, 16M)             17 |@@                                                  |
[16M, 32M)            32 |@@@                                                 |
[32M, 64M)            17 |@@                                                  |
[64M, 128M)            9 |@                                                   |
[128M, 256M)           2 |                                                    |
[256M, 512M)           1 |                                                    |
[512M, 1G)             0 |                                                    |
[1G, 2G)               0 |                                                    |
[2G, 4G)               0 |                                                    |
[4G, 8G)               1 |                                                    |

@dsq_vtime_diff[1]: 7467980

@dsq_slice_avg[1]: 20000000

@dsq_slice[1]: 
[16M, 32M)          1052 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
```
`scx_flash` (all dsqs):
```
$ sudo ./vtime_dist.bt 
-----------------------------------
@dsq_vtime[0]: 
(..., 0)              74 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[0]                    0 |                                                    |
[1]                    0 |                                                    |
[2, 4)                 0 |                                                    |
[4, 8)                 0 |                                                    |
[8, 16)                0 |                                                    |
[16, 32)               0 |                                                    |
[32, 64)               0 |                                                    |
[64, 128)              0 |                                                    |
[128, 256)             0 |                                                    |
[256, 512)             0 |                                                    |
[512, 1K)              0 |                                                    |
[1K, 2K)               0 |                                                    |
[2K, 4K)               0 |                                                    |
[4K, 8K)               0 |                                                    |
[8K, 16K)              0 |                                                    |
[16K, 32K)             0 |                                                    |
[32K, 64K)             0 |                                                    |
[64K, 128K)            0 |                                                    |
[128K, 256K)           1 |                                                    |
[256K, 512K)           1 |                                                    |
[512K, 1M)             1 |                                                    |
[1M, 2M)               7 |@@@@                                                |
[2M, 4M)              13 |@@@@@@@@@                                           |
[4M, 8M)              20 |@@@@@@@@@@@@@@                                      |
[8M, 16M)             11 |@@@@@@@                                             |
[16M, 32M)            20 |@@@@@@@@@@@@@@                                      |
[32M, 64M)            23 |@@@@@@@@@@@@@@@@                                    |
[64M, 128M)            7 |@@@@                                                |
[128M, 256M)           1 |                                                    |
[256M, 512M)          16 |@@@@@@@@@@@                                         |
[512M, 1G)            10 |@@@@@@@                                             |
[1G, 2G)              37 |@@@@@@@@@@@@@@@@@@@@@@@@@@                          |
[2G, 4G)               1 |                                                    |
[4G, 8G)               0 |                                                    |
[8G, 16G)              0 |                                                    |
[16G, 32G)             0 |                                                    |
[32G, 64G)             0 |                                                    |
[64G, 128G)            1 |                                                    |

@dsq_vtime_diff[0]: 831996573

@dsq_slice_avg[0]: 20000000

@dsq_slice[0]: 
[16M, 32M)           244 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
```