### PR TITLE
scripts: Add slicesnoop script

### DIFF
--- a/scripts/slicesnoop.bt
+++ b/scripts/slicesnoop.bt
@@ -1,0 +1,55 @@
+#!/usr/bin/env bpftrace
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+
+/*
+ * slicesnoop - Explore the slice distribution of DSQs
+ *
+ * This script is used to explore the distrubtion of slice intervals for
+ * schedulers aggregated by DSQ id.
+ *
+ * Processes can be filtered by passing a pid as the first parameter (0 for
+ * all pids):
+ *
+ * # filter pid 1234
+ * $ ./slicesnoop.bt 1234
+ * # all pids (default)
+ * $ ./slicesnoop.bt 0
+ *
+ * DSQs (above 0) can be filtered by passing the dsq id as the second parameter:
+ *
+ * # filter dsq 1234
+ * $ ./slicesnoop.bt 0 1234
+ */
+
+kprobe:scx_bpf_dsq_insert,
+kprobe:scx_bpf_dispatch,
+kprobe:scx_bpf_dsq_insert_vtime,
+kprobe:scx_bpf_dispatch_vtime,
+{
+	$task = (struct task_struct *)arg0;
+	$dsq = arg1;
+	$slice = arg2;
+
+	if ($1 > 0 && $task->tgid != $1) {
+		return;
+	}
+	if ($2 > 0 && $2 != $dsq) {
+		return;
+	}
+
+	if ($dsq >= 0 && $slice > 0) {
+		@dsq_slice_avg[$dsq] = avg($slice);
+		@dsq_slice[$dsq] = hist($slice);
+	}
+}
+
+
+interval:s:1 {
+	print("-----------------------------------");
+	print(@dsq_slice);
+	print(@dsq_slice_avg);
+}


### PR DESCRIPTION
Add slicesnoop.bt bpftrace script that allows the introspection of slice durations aggregated by DSQs.

Example of `scx_layered` tracing the distribution of high fallback dsq (1024) slice duration:
```
$ sudo ./slicesnoop.bt 0 1024
@dsq_slice[1024]: 
[512K, 1M)           528 |@@@@@@@@@@@@@                                       |
[1M, 2M)               0 |                                                    |
[2M, 4M)               0 |                                                    |
[4M, 8M)               0 |                                                    |
[8M, 16M)              0 |                                                    |
[16M, 32M)          2051 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|

@dsq_slice_avg[1024]: 16069174
```