### PR TITLE
scx_layered: Refactor dsq_lat script

### DIFF
--- a/scripts/dsq_lat.bt
+++ b/scripts/dsq_lat.bt
@@ -4,21 +4,42 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
-#include <linux/sched.h>
-#include <linux/sched/ext.h>
+/*
+ * dsq_lat.bt - Observe DSQ latencies
+ *
+ * Prints an average and histogram of DSQ latencies by timestamping from when a
+ * task is enqueued to a DSQ to when a task is running.
+ *
+ * PIDs can be filtered by passing a parameter to dsq_lat.bt (0 for all pids):
+ *
+ * # filter PID 1234
+ * $ ./dsq_lat.bt 1234
+ *
+ * DSQs can be filtered by passing a second parameter:
+ *
+ * # filter DSQ 789
+ * $ ./dsq_lat.bt 0 789
+ *
+ */
 
-rawtracepoint:sched_wakeup,
-rawtracepoint:sched_wakeup_new,
+kprobe:scx_bpf_dsq_insert,
+kprobe:scx_bpf_dispatch,
+kprobe:scx_bpf_dsq_insert_vtime,
+kprobe:scx_bpf_dispatch_vtime,
 {
 	$task = (struct task_struct *)arg0;
+	$dsq = arg1;
 
 	if ($1 > 0 && $task->tgid != $1) {
 		return;
 	}
+	if ($2 > 0 && $2 != $dsq) {
+		return;
+	}
 
-	@qtime[$task->pid] = nsecs;
-	if ($task->scx.dsq->id >= 0) {
-		@dsq_time[$task->scx.dsq->id] = nsecs;
+	if ($dsq >= 0) {
+		@qtime[$task->pid] = nsecs;
+		@task_dsq[$task->pid] = $dsq;
 	}
 }
 
@@ -32,26 +53,28 @@ rawtracepoint:sched_switch
 		return;
 	}
 
-	if ($prev_state == TASK_RUNNING) {
-		@qtime[$prev->pid] = nsecs;
+	$start = @qtime[$next->pid];
+	$dsq = @task_dsq[$next->pid];
+	if ($2 > 0 && $2 != $dsq) {
+		delete(@qtime[$next->pid]);
+		delete(@task_dsq[$next->pid]);
+		return;
 	}
 
-	$nsec = @qtime[$next->pid];
-	if ($nsec) {
-		$usec = (nsecs - $nsec) / 1000;
-		@usec_total_stats = stats($usec);
-		@usec_hist = hist($usec);
-		@tasks[$next->comm, $next->pid] = stats($usec);
-		@avg_lat = avg($usec);
-		if ($prev->scx.dsq->id >= 0) {
-			@dsq_lat[$prev->scx.dsq->id] = avg($usec);
-		}
+	if ($start && $dsq > 0 && $dsq < 2<<16) {
+		$dur = nsecs - $start;
+		$usec = $dur / 1000;
+		@lat_avg_usec[$dsq] = avg($usec);
+		@dsq_hist_usec[$dsq] = hist($usec);
+		@dsq_lat_avg_usec[$dsq] = avg($usec);
 	}
 	delete(@qtime[$next->pid]);
+	delete(@task_dsq[$next->pid]);
 }
 
 interval:s:1 {
-    print(@avg_lat);
-    print(@usec_hist);
-    print(@dsq_lat);
+	print("------------------------------");
+	print(@lat_avg_usec);
+	print(@dsq_hist_usec);
+	print(@dsq_lat_avg_usec);
 }


### PR DESCRIPTION
Refactor the dsq_lat.bt script to be more precise with accounting for DSQ latencies by timestamping when a task is put onto a DSQ. Track the DSQ that the task was dispatched onto in a separate BPF map. Add support for filtering by DSQ.

Example with `scx_layered`:
```
@dsq_hist_usec[4]: 
[4, 8)               195 |                                                    |
[8, 16)            10438 |@@@@@                                               |
[16, 32)            7056 |@@@                                                 |
[32, 64)            3010 |@                                                   |
[64, 128)            699 |                                                    |
[128, 256)           381 |                                                    |
[256, 512)           153 |                                                    |
[512, 1K)          98524 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[1K, 2K)            2002 |@                                                   |
[2K, 4K)              46 |                                                    |

@dsq_hist_usec[5]: 
[4, 8)               111 |                                                    |
[8, 16)             9211 |@@@@                                                |
[16, 32)           13030 |@@@@@@@                                             |
[32, 64)            7571 |@@@@                                                |
[64, 128)           1162 |                                                    |
[128, 256)           567 |                                                    |
[256, 512)           286 |                                                    |
[512, 1K)          96681 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[1K, 2K)            2064 |@                                                   |
[2K, 4K)              15 |                                                    |

@dsq_hist_usec[6]: 
[1]                   69 |                                                    |
[2, 4)              2241 |@@@@                                                |
[4, 8)             10292 |@@@@@@@@@@@@@@@@@@@@                                |
[8, 16)            26206 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[16, 32)           19143 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@               |
[32, 64)           16863 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                   |
[64, 128)          15885 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                     |
[128, 256)         16185 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                    |
[256, 512)         18688 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@               |
[512, 1K)          20684 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@           |
[1K, 2K)            4282 |@@@@@@@@                                            |
[2K, 4K)            1163 |@@                                                  |
[4K, 8K)             368 |                                                    |
[8K, 16K)            117 |                                                    |

@dsq_lat_avg_usec[6]: 272
@dsq_lat_avg_usec[1]: 715
@dsq_lat_avg_usec[5]: 768
@dsq_lat_avg_usec[7]: 826
@dsq_lat_avg_usec[4]: 835
@dsq_lat_avg_usec[1024]: 21111
@dsq_lat_avg_usec[1025]: 73858

```