### PR TITLE
skip skeleton creation for library

### DIFF
--- a/meson-scripts/bpftool_build_skel
+++ b/meson-scripts/bpftool_build_skel
@@ -17,9 +17,9 @@ then
 	"$bpftool" gen object "$stem".l1o "$input"
 else
 	"$bpftool" gen object "$stem".l1o "$input" "$lib".bpf.o
+	"$bpftool" gen object "$stem".l2o "$stem".l1o
+	"$bpftool" gen object "$stem".l3o "$stem".l2o
+	cmp "$stem".l2o "$stem".l3o
+	"$bpftool" gen skeleton "$stem".l3o name "$name" > "$skel"
+	"$bpftool" gen subskeleton "$stem".l3o name "$name" > "$subskel"
 fi
-"$bpftool" gen object "$stem".l2o "$stem".l1o
-"$bpftool" gen object "$stem".l3o "$stem".l2o
-cmp "$stem".l2o "$stem".l3o
-"$bpftool" gen skeleton "$stem".l3o name "$name" > "$skel"
-"$bpftool" gen subskeleton "$stem".l3o name "$name" > "$subskel"


### PR DESCRIPTION
The build system currently tries to create a skeleton file out of the library,  which fails and subsequently causes unrelated tests to fail. Change Meson to only create a skeleton out of scheduler object files.