### PR TITLE
scx_layered: Fix a silly bug in `select_cpu()` and implement per-layer fifo mode

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -241,6 +241,7 @@ struct layer {
 	u64			max_exec_ns;
 	u64			yield_step_ns;
 	u64			slice_ns;
+	bool			fifo;
 	u32			weight;
 	u64			xllc_mig_min_ns;
 

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -797,7 +797,7 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 	 * If the layer is an open one, we can try the whole machine.
 	 */
 	if (layer->kind != LAYER_KIND_CONFINED &&
-	    ((cpu = pick_idle_cpu_from(p->cpus_ptr, prev_cpu, idle_smtmask) >= 0))) {
+	    (cpu = pick_idle_cpu_from(p->cpus_ptr, prev_cpu, idle_smtmask)) >= 0) {
 		lstat_inc(LSTAT_OPEN_IDLE, layer, cpuc);
 		goto out_put;
 	}

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1122,8 +1122,12 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 		LAYER_LAT_DECAY_FACTOR;
 	lstats[LLC_LSTAT_CNT]++;
 
-	scx_bpf_dispatch_vtime(p, layer_dsq_id(layer_id, task_cpuc->llc_id),
-			       slice_ns, vtime, enq_flags);
+	if (layer->fifo)
+		scx_bpf_dispatch(p, layer_dsq_id(layer_id, task_cpuc->llc_id),
+				 slice_ns, enq_flags);
+	else
+		scx_bpf_dispatch_vtime(p, layer_dsq_id(layer_id, task_cpuc->llc_id),
+				       slice_ns, vtime, enq_flags);
 
 preempt:
 	try_preempt(task_cpu, p, taskc, try_preempt_first, enq_flags);

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -86,6 +86,8 @@ pub struct LayerCommon {
     #[serde(default)]
     pub slice_us: u64,
     #[serde(default)]
+    pub fifo: bool,
+    #[serde(default)]
     pub preempt: bool,
     #[serde(default)]
     pub preempt_first: bool,

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -107,6 +107,7 @@ lazy_static! {
                         exclusive: false,
                         idle_smt: None,
                         slice_us: 20000,
+                        fifo: false,
                         weight: DEFAULT_LAYER_WEIGHT,
                         xllc_mig_min_us: XLLC_MIG_MIN_US_DFL,
                         growth_algo: LayerGrowthAlgo::Sticky,
@@ -132,6 +133,7 @@ lazy_static! {
                         exclusive: true,
                         idle_smt: None,
                         slice_us: 20000,
+                        fifo: false,
                         weight: DEFAULT_LAYER_WEIGHT,
                         xllc_mig_min_us: XLLC_MIG_MIN_US_DFL,
                         growth_algo: LayerGrowthAlgo::Sticky,
@@ -159,6 +161,7 @@ lazy_static! {
                         exclusive: false,
                         idle_smt: None,
                         slice_us: 800,
+                        fifo: false,
                         weight: DEFAULT_LAYER_WEIGHT,
                         xllc_mig_min_us: XLLC_MIG_MIN_US_DFL,
                         growth_algo: LayerGrowthAlgo::Topo,
@@ -183,6 +186,7 @@ lazy_static! {
                         exclusive: false,
                         idle_smt: None,
                         slice_us: 20000,
+                        fifo: false,
                         weight: DEFAULT_LAYER_WEIGHT,
                         xllc_mig_min_us: XLLC_MIG_MIN_US_DFL,
                         growth_algo: LayerGrowthAlgo::Linear,
@@ -1165,12 +1169,14 @@ impl<'a> Scheduler<'a> {
                     growth_algo,
                     nodes,
                     slice_us,
+                    fifo,
                     weight,
                     xllc_mig_min_us,
                     ..
                 } = spec.kind.common();
 
                 layer.slice_ns = *slice_us * 1000;
+                layer.fifo.write(*fifo);
                 layer.min_exec_ns = min_exec_us * 1000;
                 layer.yield_step_ns = if *yield_ignore > 0.999 {
                     0

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1088,11 +1088,7 @@ impl<'a> Scheduler<'a> {
         ((target * 1024.0) as u32).min(1024)
     }
 
-    fn init_layers(
-        skel: &mut OpenBpfSkel,
-        specs: &Vec<LayerSpec>,
-        topo: &Topology,
-    ) -> Result<()> {
+    fn init_layers(skel: &mut OpenBpfSkel, specs: &Vec<LayerSpec>, topo: &Topology) -> Result<()> {
         skel.maps.rodata_data.nr_layers = specs.len() as u32;
         let mut perf_set = false;
 


### PR DESCRIPTION
- Fix a silly bug critical bug in `select_cpu()`.
- Fix layer sizing when weights are not specified.
- Implement per-layer fifo mode.