### PR TITLE
scx_layered: Put all tasks with custom affinities into the hi fallbak DSQs

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1073,8 +1073,15 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 	 * regardless of its cpumask. However, a task with custom cpumask in a
 	 * confined layer may fail to be consumed for an indefinite amount of
 	 * time. Queue them to the fallback DSQ.
+	 *
+	 * XXX - An open or grouped layer is no longer always consumed from all
+	 * CPUs as owned protection can make a CPU execute only the owning
+	 * layer. For now, throw all tasks with custom affinities to hi fallback
+	 * DSQs. Later, implement starvation prevention for lo fallback DSQs and
+	 * put them there. Also, this should become node aware so that
+	 * node-affine tasks aren't thrown into the fallback DSQs.
 	 */
-	if (layer->kind == LAYER_KIND_CONFINED && !taskc->all_cpus_allowed) {
+	if (/*layer->kind == LAYER_KIND_CONFINED && */!taskc->all_cpus_allowed) {
 		lstat_inc(LSTAT_AFFN_VIOL, layer, cpuc);
 		/*
 		 * We were previously dispatching to LO_FALLBACK_DSQ for any


### PR DESCRIPTION
It used to be that open or grouped layers are always executed from all CPUs and thus tasks with custom CPU affinities could be queued in the layer DSQs without causing stalls. However, this is no longer true as a saturated layer can close off its CPUs for open execution.

For now, work around by putting all tasks with custom affinities into hi fallback DSQs. Down the line, we should implement starvation prevention for lo fallback DSQs and put these tasks there.