### PR TITLE
scx_bpfland: do not rely on scx_utils::autopower

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -34,7 +34,6 @@ use libbpf_rs::ProgramInput;
 use log::info;
 use log::warn;
 use scx_stats::prelude::*;
-use scx_utils::autopower::fetch_power_profile;
 use scx_utils::build_id;
 use scx_utils::import_enums;
 use scx_utils::scx_enums;
@@ -154,8 +153,7 @@ struct Opts {
     /// tasks may overflow to other available CPUs.
     ///
     /// Special values:
-    ///  - "auto" = automatically detect the CPUs based on the active power profile;
-    ///     require power-profiles-daemon being running.
+    ///  - "auto" = automatically detect the CPUs based on the current energy profile
     ///  - "performance" = automatically detect and prioritize the fastest CPUs
     ///  - "powersave" = automatically detect and prioritize the slowest CPUs
     ///  - "all" = all CPUs assigned to the primary domain
@@ -216,7 +214,7 @@ struct Scheduler<'a> {
     skel: BpfSkel<'a>,
     struct_ops: Option<libbpf_rs::Link>,
     opts: &'a Opts,
-    power_profile: String,
+    energy_profile: String,
     stats_server: StatsServer<(), Metrics>,
     user_restart: bool,
 }
@@ -263,12 +261,13 @@ impl<'a> Scheduler<'a> {
         let topo = Topology::new().unwrap();
 
         // Initialize the primary scheduling domain and the preferred domain.
-        let power_profile = fetch_power_profile();
-        if let Err(err) = Self::init_energy_domain(&mut skel, &opts.primary_domain, &power_profile)
+        let energy_profile = Self::read_energy_profile();
+        if let Err(err) = Self::init_energy_domain(&mut skel, &opts.primary_domain, &energy_profile)
         {
             warn!("failed to initialize primary domain: error {}", err);
         }
-        if let Err(err) = Self::init_cpufreq_perf(&mut skel, &opts.primary_domain, &power_profile) {
+        if let Err(err) = Self::init_cpufreq_perf(&mut skel, &opts.primary_domain, &energy_profile)
+        {
             warn!(
                 "failed to initialize cpufreq performance level: error {}",
                 err
@@ -292,7 +291,7 @@ impl<'a> Scheduler<'a> {
             skel,
             struct_ops,
             opts,
-            power_profile,
+            energy_profile,
             stats_server,
             user_restart: false,
         })
@@ -320,6 +319,30 @@ impl<'a> Scheduler<'a> {
         Ok(())
     }
 
+    fn read_energy_profile() -> String {
+        let energy_pref_path =
+            "/sys/devices/system/cpu/cpufreq/policy0/energy_performance_preference";
+        let scaling_governor_path = "/sys/devices/system/cpu/cpufreq/policy0/scaling_governor";
+
+        let res = File::open(energy_pref_path)
+            .and_then(|mut file| {
+                let mut contents = String::new();
+                file.read_to_string(&mut contents)?;
+                Ok(contents.trim().to_string())
+            })
+            .or_else(|_| {
+                File::open(scaling_governor_path)
+                    .and_then(|mut file| {
+                        let mut contents = String::new();
+                        file.read_to_string(&mut contents)?;
+                        Ok(contents.trim().to_string())
+                    })
+                    .or_else(|_| Ok("none".to_string()))
+            });
+
+        res.unwrap_or_else(|_: String| "none".to_string())
+    }
+
     fn epp_to_cpumask(profile: Powermode) -> Result<Cpumask> {
         let mut cpus = get_primary_cpus(profile).unwrap_or(Vec::new());
         if cpus.is_empty() {
@@ -331,14 +354,18 @@ impl<'a> Scheduler<'a> {
     fn init_energy_domain(
         skel: &mut BpfSkel<'_>,
         primary_domain: &String,
-        power_profile: &String,
+        energy_profile: &String,
     ) -> Result<()> {
         let domain = match primary_domain.as_str() {
             "powersave" => Self::epp_to_cpumask(Powermode::Powersave)?,
             "performance" => Self::epp_to_cpumask(Powermode::Performance)?,
-            "auto" => match power_profile.as_str() {
-                "power-saver" => Self::epp_to_cpumask(Powermode::Powersave)?,
-                "performance" | "balanced" => Self::epp_to_cpumask(Powermode::Performance)?,
+            "auto" => match energy_profile.as_str() {
+                "power" | "balance_power" | "powersave" => {
+                    Self::epp_to_cpumask(Powermode::Powersave)?
+                }
+                "balance_performance" | "performance" => {
+                    Self::epp_to_cpumask(Powermode::Performance)?
+                }
                 &_ => Self::epp_to_cpumask(Powermode::Any)?,
             },
             "all" => Self::epp_to_cpumask(Powermode::Any)?,
@@ -367,12 +394,12 @@ impl<'a> Scheduler<'a> {
     fn init_cpufreq_perf(
         skel: &mut BpfSkel<'_>,
         primary_domain: &String,
-        power_profile: &String,
+        energy_profile: &String,
     ) -> Result<()> {
         let perf_lvl: i64 = match primary_domain.as_str() {
-            "auto" => match power_profile.as_str() {
+            "auto" => match energy_profile.as_str() {
                 "performance" => 1024,
-                "power-saver" => 0,
+                "power" | "powersave" => 0,
                 &_ => -1,
             },
             "performance" => 1024,
@@ -394,10 +421,10 @@ impl<'a> Scheduler<'a> {
     }
 
     fn refresh_sched_domain(&mut self) -> bool {
-        if self.power_profile != "none" {
-            let power_profile = fetch_power_profile();
-            if power_profile != self.power_profile {
-                self.power_profile = power_profile.clone();
+        if self.energy_profile != "none" {
+            let energy_profile = Self::read_energy_profile();
+            if energy_profile != self.energy_profile {
+                self.energy_profile = energy_profile.clone();
 
                 if self.opts.primary_domain == "auto" {
                     return true;
@@ -405,7 +432,7 @@ impl<'a> Scheduler<'a> {
                 if let Err(err) = Self::init_cpufreq_perf(
                     &mut self.skel,
                     &self.opts.primary_domain,
-                    &power_profile,
+                    &energy_profile,
                 ) {
                     warn!("failed to refresh cpufreq performance level: error {}", err);
                 }


### PR DESCRIPTION
Relying on scx_utils::autopower reuires power-profiles-daemon running, this has introduced a regression in certain systems that don't have this service available.

Restore the old behavior for now, we will fix scx_utils::autopower later.

Fixes: 939d4f5 ("scx_utils: move autopower into scx_utils")