### PR TITLE
meson: Add scx_lib dep to gen_bpf_o

### DIFF
--- a/meson-scripts/compile_scx_lib
+++ b/meson-scripts/compile_scx_lib
@@ -9,4 +9,4 @@ dir="$PWD/lib"
 
 libs=`find $dir -type f -name *.bpf.o | grep -v $lib.bpf.o`
 
-bpftool gen object "$output" $libs
+"$bpftool" gen object "$output" $libs

--- a/meson.build
+++ b/meson.build
@@ -270,12 +270,15 @@ bpf_includes = ['-I', join_paths(meson.current_source_dir(), 'scheds/include'),
                 '-I', join_paths(meson.current_source_dir(), 'scheds/include/bpf-compat'),
                 '-I', join_paths(meson.current_source_dir(), 'lib/include'),]
 
+lib_objs = []
+subdir('lib')
+
 #
 # Generators to build BPF skel file for C schedulers.
 #
 gen_bpf_o = generator(bpf_clang,
                       output: '@BASENAME@.o',
-                      depends: [libbpf],
+                      depends: [libbpf, scx_lib],
                       arguments: [bpf_base_cflags, '-target', 'bpf', libbpf_c_headers, bpf_includes,
                                   '-c', '@INPUT@', '-o', '@OUTPUT@'])
 
@@ -458,9 +461,6 @@ if enable_stress
       endforeach
   endif
 endif
-
-lib_objs = []
-subdir('lib')
 
 thread_dep = dependency('threads')
 


### PR DESCRIPTION
This PR introduces a dependency on scx_lib in gen_bpf_o.

Without this dependency the build fails intermittently with the
following error:

```
FAILED: scheds/c/scx_pair.p/scx_pair.bpf.skel.h scheds/c/scx_pair.p/scx_pair.bpf.subskel.h
/home/frelon/src/scx/meson-scripts/bpftool_build_skel /usr/sbin/bpftool scheds/c/scx_pair.p/scx_pair.bpf.o scheds/c/scx_pair.p/scx_pair.bpf.skel.h scheds/c/scx_pair.p/scx_pair.bpf.subskel.h /home/frelon/src/scx/build/lib/lib
libbpf: failed to get ELF header for /home/frelon/src/scx/build/lib/lib.bpf.o: invalid `Elf' handle
/home/frelon/src/scx/meson-scripts/bpftool_build_skel: line 25: 3400506 Segmentation fault      (core dumped) "$bpftool" gen object "$stem".l1o "$input" "$lib".bpf.o
```

Also updates a usage of bpftool to use the passed in path.