### PR TITLE
scx: add rustfmt.toml files to avoid lookup to $HOME/.rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+# this file is here to prevent build breakages on arch
+edition = "2021"
+


### PR DESCRIPTION
I think this fixes #1065

It looks like the issue is without a rustfmt.toml in every package dir, builds in arch's build system will try to read a format config file in HOME, causing a permission denied errors. IIUC, this should avoid that.

I also added a comment to the noop rustfmt.toml files so we know why they're there in the future.