### PR TITLE
scx_loader: provide library crate to be used by other crates

### DIFF
--- a/rust/scx_loader/Cargo.toml
+++ b/rust/scx_loader/Cargo.toml
@@ -19,3 +19,10 @@ tokio = { version = "1.39", features = ["macros", "sync", "rt-multi-thread", "pr
 toml = "0.8.19"
 zbus = { version = "5", features = ["tokio"], default-features = false }
 zvariant = "5.1"
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "scx_loader"
+path = "src/main.rs"

--- a/rust/scx_loader/src/config.rs
+++ b/rust/scx_loader/src/config.rs
@@ -11,12 +11,12 @@ use std::path::Path;
 
 use anyhow::Result;
 use serde::Deserialize;
+use serde::Serialize;
 
-use crate::get_name_from_scx;
 use crate::SchedMode;
 use crate::SupportedSched;
 
-#[derive(Debug, PartialEq, Default, Deserialize)]
+#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
     pub default_sched: Option<SupportedSched>,
@@ -24,7 +24,7 @@ pub struct Config {
     pub scheds: HashMap<String, Sched>,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize)]
+#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct Sched {
     pub auto_mode: Option<Vec<String>>,
     pub gaming_mode: Option<Vec<String>>,
@@ -102,7 +102,8 @@ pub fn get_scx_flags_for_mode(
     scx_sched: &SupportedSched,
     sched_mode: SchedMode,
 ) -> Vec<String> {
-    if let Some(sched_config) = config.scheds.get(get_name_from_scx(scx_sched)) {
+    let scx_name: &str = scx_sched.into();
+    if let Some(sched_config) = config.scheds.get(scx_name) {
         let scx_flags = extract_scx_flags_from_config(sched_config, &sched_mode);
 
         // try to exact flags from config, otherwise fallback to hardcoded default

--- a/rust/scx_loader/src/dbus.rs
+++ b/rust/scx_loader/src/dbus.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// Copyright (c) 2024 Vladislav Nepogodin <vnepogodin@cachyos.org>
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use crate::SchedMode;
+use crate::SupportedSched;
+
+#[zbus::proxy(
+    interface = "org.scx.Loader",
+    default_service = "org.scx.Loader",
+    default_path = "/org/scx/Loader"
+)]
+pub trait LoaderClient {
+    /// Starts the specified scheduler with the given mode.
+    fn start_scheduler(&self, scx_name: SupportedSched, sched_mode: SchedMode) -> zbus::Result<()>;
+
+    /// Starts the specified scheduler with the provided arguments.
+    fn start_scheduler_with_args(
+        &self,
+        scx_name: SupportedSched,
+        scx_args: &[String],
+    ) -> zbus::Result<()>;
+
+    /// Stops the currently running scheduler.
+    fn stop_scheduler(&self) -> zbus::Result<()>;
+
+    /// Method for switching to the specified scheduler with the given mode.
+    /// This method will stop the currently running scheduler (if any) and
+    /// then start the new scheduler.
+    fn switch_scheduler(&self, scx_name: SupportedSched, sched_mode: SchedMode)
+        -> zbus::Result<()>;
+
+    /// Switches to the specified scheduler with the provided arguments. This
+    /// method will stop the currently running scheduler (if any) and then
+    /// start the new scheduler with the given arguments.
+    fn switch_scheduler_with_args(
+        &self,
+        scx_name: SupportedSched,
+        scx_args: &[String],
+    ) -> zbus::Result<()>;
+
+    /// The name of the currently running scheduler. If no scheduler is active,
+    /// this property will be set to "unknown".
+    #[zbus(property)]
+    fn current_scheduler(&self) -> zbus::Result<String>;
+
+    /// The currently active scheduler mode.  Scheduler modes allow you to
+    /// apply pre-defined configurations to a scheduler that are
+    /// optimized for different use cases. If no scheduler is active,
+    /// this property will be set to 0 (Auto).
+    #[zbus(property)]
+    fn scheduler_mode(&self) -> zbus::Result<SchedMode>;
+
+    /// A list of the schedulers currently supported by the Scheduler Loader.
+    /// The names of the supported schedulers will be listed as strings in
+    /// this array.
+    #[zbus(property)]
+    fn supported_schedulers(&self) -> zbus::Result<Vec<String>>;
+}

--- a/rust/scx_loader/src/lib.rs
+++ b/rust/scx_loader/src/lib.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// Copyright (c) 2024 Vladislav Nepogodin <vnepogodin@cachyos.org>
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+pub mod config;
+pub mod dbus;
+
+use std::str::FromStr;
+
+use serde::Deserialize;
+use serde::Serialize;
+use zvariant::OwnedValue;
+use zvariant::Type;
+use zvariant::Value;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
+#[zvariant(signature = "s")]
+#[serde(rename_all = "lowercase")]
+pub enum SupportedSched {
+    #[serde(rename = "scx_bpfland")]
+    Bpfland,
+    #[serde(rename = "scx_rusty")]
+    Rusty,
+    #[serde(rename = "scx_lavd")]
+    Lavd,
+    #[serde(rename = "scx_flash")]
+    Flash,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Type, Value, OwnedValue, PartialEq)]
+pub enum SchedMode {
+    /// Default values for the scheduler
+    Auto = 0,
+    /// Applies flags for better gaming experience
+    Gaming = 1,
+    /// Applies flags for lower power usage
+    PowerSave = 2,
+    /// Starts scheduler in low latency mode
+    LowLatency = 3,
+}
+
+impl From<&SupportedSched> for &str {
+    fn from(scx_name: &SupportedSched) -> &'static str {
+        match scx_name {
+            SupportedSched::Bpfland => "scx_bpfland",
+            SupportedSched::Rusty => "scx_rusty",
+            SupportedSched::Lavd => "scx_lavd",
+            SupportedSched::Flash => "scx_flash",
+        }
+    }
+}
+
+impl From<SupportedSched> for &str {
+    fn from(scx_name: SupportedSched) -> &'static str {
+        scx_name.into()
+    }
+}
+
+impl FromStr for SupportedSched {
+    type Err = anyhow::Error;
+
+    fn from_str(scx_name: &str) -> anyhow::Result<SupportedSched> {
+        match scx_name {
+            "scx_bpfland" => Ok(SupportedSched::Bpfland),
+            "scx_rusty" => Ok(SupportedSched::Rusty),
+            "scx_lavd" => Ok(SupportedSched::Lavd),
+            "scx_flash" => Ok(SupportedSched::Flash),
+            _ => Err(anyhow::anyhow!("{scx_name} is not supported")),
+        }
+    }
+}


### PR DESCRIPTION
provide library crate to be used by other crates, e.g CachyOS KernelManager

also provides Rust typed-interface for schedulers, with changed error for callers:
```
❯ dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.SwitchScheduler string:scx_lvd uint32:2
Error org.freedesktop.zbus.Error: unknown variant `scx_lvd`, expected one of `scx_bpfland`, `scx_rusty`, `scx_lavd`, `scx_flash`
```
instead of
```
❯ dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.SwitchScheduler string:scx_lvd uint32:2
Error org.freedesktop.DBus.Error.Failed: scx_lvd is not supported
```