### PR TITLE
scx_lib: use the proper bpftool

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -9,7 +9,7 @@ foreach src: libs
             input: src + '.bpf.c',
             command: [bpf_clang, bpf_base_cflags, '-target', 'bpf', libbpf_c_headers, bpf_includes,
                         '-c', '@INPUT@', '-o', '@OUTPUT@'],
-            depends: [libbpf]
+            depends: [libbpf, bpftool_target]
             )
 
   objs += [bpf_o]

--- a/meson-scripts/compile_scx_lib
+++ b/meson-scripts/compile_scx_lib
@@ -9,4 +9,4 @@ dir="$PWD/lib"
 
 libs=`find $dir -type f -name *.bpf.o | grep -v $lib.bpf.o`
 
-"$bpftool" gen object "$output" $libs
+${bpftool} gen object "$output" $libs


### PR DESCRIPTION
Make sure to use the right bpftool when building scx_lib, instead of always relying on the system's bpftool.

Fixes: 3d72a8e ("add library infrastructure and turn allocator into a library")