### PR TITLE
scx_layered: handle nr_to_free calculation

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1904,7 +1904,8 @@ impl<'a> Scheduler<'a> {
                 if nr_freed == 0 {
                     break;
                 }
-                nr_to_free -= nr_freed;
+
+                nr_to_free = nr_to_free.saturating_sub(nr_freed);
                 freed = true;
 
                 if nr_to_free <= nr_to_break_at {


### PR DESCRIPTION
The variable `nr_to_free` in `scx_layered/src/main.rs` is assigned an incorrect value due to a subtraction overflow, as reported in this issue #1072.

Ensure `nr_to_free` is correctly handled to prevent subtraction overflow, adding a check to set `nr_to_free` to 0 if `nr_freed` > `nr_to_free`.