### PR TITLE
readme: specify cargo install --locked be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ built and installed without cloning this repository as long as the necessary
 toolchains are available. Simply run:
 
 ```
-$ cargo install scx_rusty
+$ cargo install --locked scx_rusty
 ```
 
 and `scx_rusty` will be built and installed as `~/.cargo/bin/scx_rusty`.


### PR DESCRIPTION
specify cargo install --locked be used to prevent segfaults.

best I can tell, this has something to do with libbpf 1.5.0 being pulled in when cargo install without `--locked` is used (or when Cargo.lock is removed).

cargo tree does not show 1.5.0 as a dependency when libbpf-sys is set to =1.4.6 everywhere in this repo, but the packages downloaded includes libbpf-sys 1.5.0, so for now maybe lets just update the readme so folks don't get segfaults when running cargo install.