### PR TITLE
only compile library when using recent bpftool versions

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -15,11 +15,13 @@ foreach src: libs
   objs += [bpf_o]
 endforeach
 
-scx_lib = custom_target(scx_lib_name,
-  output: scx_lib_name + '.bpf.o',
-  command: [compile_scx_lib, bpftool_exe_path, '@OUTPUT@', scx_lib_name, objs],
-  depends: objs,
+if bpftool_maj < 7 or (bpftool_maj == 7 and bpftool_min >= 5)
+  scx_lib = custom_target(scx_lib_name,
+    output: scx_lib_name + '.bpf.o',
+    command: [compile_scx_lib, bpftool_exe_path, '@OUTPUT@', scx_lib_name, objs],
+    depends: objs,
 )
+endif
 
 # Install include/lib as a lib/ subdir of our headers
 install_subdir(join_paths(meson.current_source_dir(), 'include/scx'), install_dir: 'include', install_tag: 'devel')

--- a/meson-scripts/bpftool_build_skel
+++ b/meson-scripts/bpftool_build_skel
@@ -12,14 +12,21 @@ stem="${input%.o}"
 name="${input%.bpf.o}"
 name="${name##*/}"
 
-if [ `basename $lib` == $name ];
+if [ ! -z $lib ] && [ `basename $lib` == $name ];
 then
 	"$bpftool" gen object "$stem".l1o "$input"
-else
-	"$bpftool" gen object "$stem".l1o "$input" "$lib".bpf.o
-	"$bpftool" gen object "$stem".l2o "$stem".l1o
-	"$bpftool" gen object "$stem".l3o "$stem".l2o
-	cmp "$stem".l2o "$stem".l3o
-	"$bpftool" gen skeleton "$stem".l3o name "$name" > "$skel"
-	"$bpftool" gen subskeleton "$stem".l3o name "$name" > "$subskel"
+	exit 0
 fi
+
+if [ ! -z $lib ];
+then
+	"$bpftool" gen object "$stem".l1o "$input" "$lib".bpf.o
+else
+	"$bpftool" gen object "$stem".l1o "$input"
+fi
+
+"$bpftool" gen object "$stem".l2o "$stem".l1o
+"$bpftool" gen object "$stem".l3o "$stem".l2o
+cmp "$stem".l2o "$stem".l3o
+"$bpftool" gen skeleton "$stem".l3o name "$name" > "$skel"
+"$bpftool" gen subskeleton "$stem".l3o name "$name" > "$subskel"

--- a/meson.build
+++ b/meson.build
@@ -192,6 +192,10 @@ if should_build_bpftool
   bpftool_commit = '183e7010387d1fc9f08051426e9a9fbd5f8d409e'
   run_command(fetch_bpftool, meson.current_build_dir(), bpftool_commit, check: true)
 
+  bpftool_ver = '7.5'
+  bpftool_maj = 7
+  bpftool_min = 4
+
   bpftool_target = custom_target('bpftool_target',
               output: '@PLAINNAME@.__PHONY__',
               input: 'meson-scripts/bpftool_dummy.c',
@@ -201,15 +205,23 @@ else
   bpftool_ver = run_command(get_bpftool_ver, bpftool_exe_path, check: true).stdout().strip()
   bpftool_maj = bpftool_ver.split('.')[0].to_int()
   bpftool_min = bpftool_ver.split('.')[1].to_int()
-  if bpftool_maj < 7 or (bpftool_maj == 7 and bpftool_min < 4)
-    error('bpftool >= 7.4 required (@0@ ver=@1@)'.format(bpftool_exe_path, bpftool_ver))
-  endif
+
   # this is a noop when we're not building bpftool ourselves
   bpftool_target = custom_target('bpftool_target',
               output: '@PLAINNAME@.__PHONY__',
               input: 'meson-scripts/bpftool_dummy.c',
               command: ['echo'],
               build_by_default: true)
+endif
+
+bpftool_no_lib = bpftool_maj < 7 or (bpftool_maj == 7 and bpftool_min < 5)
+
+if bpftool_maj < 7 or (bpftool_maj == 7 and bpftool_min < 4)
+  error('bpftool >= 7.4 required (@0@ ver=@1@)'.format(bpftool_exe_path, bpftool_ver))
+endif
+
+if bpftool_no_lib
+  message('[WARNING] bpftool >= 7.5 required for BPF libraries(@0@ ver=@1@)'.format(bpftool_exe_path, bpftool_ver))
 endif
 # end libbpf/bpftool stuff
 
@@ -274,8 +286,23 @@ lib_objs = []
 subdir('lib')
 
 #
-# Generators to build BPF skel file for C schedulers.
+# Generators to build BPF skel file for C schedulers. For bpftool < 7.5 we
+# have to work around a libbpf bug that prevents linking BPF objects by not
+# compiling the library.
 #
+
+if bpftool_no_lib
+gen_bpf_o = generator(bpf_clang,
+                      output: '@BASENAME@.o',
+                      depends: [libbpf],
+                      arguments: [bpf_base_cflags, '-target', 'bpf', libbpf_c_headers, bpf_includes,
+                                  '-c', '@INPUT@', '-o', '@OUTPUT@'])
+
+gen_bpf_skel = generator(bpftool_build_skel,
+                         output: ['@BASENAME@.skel.h','@BASENAME@.subskel.h' ],
+                         depends: [libbpf, bpftool_target],
+                         arguments: [bpftool_exe_path, '@INPUT@', '@OUTPUT0@', '@OUTPUT1@'])
+else
 gen_bpf_o = generator(bpf_clang,
                       output: '@BASENAME@.o',
                       depends: [libbpf, scx_lib],
@@ -286,7 +313,7 @@ gen_bpf_skel = generator(bpftool_build_skel,
                          output: ['@BASENAME@.skel.h','@BASENAME@.subskel.h' ],
                          depends: [libbpf, bpftool_target],
                          arguments: [bpftool_exe_path, '@INPUT@', '@OUTPUT0@', '@OUTPUT1@', scx_lib_path])
-
+endif
 
 #
 # For rust sub-projects.

--- a/scheds/c/meson.build
+++ b/scheds/c/meson.build
@@ -1,10 +1,14 @@
 c_scheds = ['scx_simple', 'scx_qmap', 'scx_central', 'scx_userland', 'scx_nest',
-            'scx_flatcg', 'scx_pair', 'scx_sdt']
+            'scx_flatcg', 'scx_pair']
 
 foreach sched: c_scheds
   thread_dep = dependency('threads')
   bpf_o = gen_bpf_o.process(sched + '.bpf.c')
+if bpftool_no_lib
+  bpf_skel = gen_bpf_skel.process(bpf_o)
+else
   bpf_skel = gen_bpf_skel.process(bpf_o, scx_lib)
+endif
   executable(sched, [bpf_skel, sched + '.c'],
              include_directories: [user_c_includes],
              dependencies: [kernel_dep, libbpf_dep, thread_dep],


### PR DESCRIPTION
Some scx users have bpftool versions < 7.5.0, causing Meson system to throw errors when linking in the BPF library to schedulers. Add a workaround by only compiling the library when the bpftool is new enough.