### PR TITLE
scx_layered, cpumask, topology: Cleanups

### DIFF
--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -83,10 +83,10 @@ impl Cpumask {
     }
 
     /// Build a new empty Cpumask object.
-    pub fn new() -> Result<Cpumask> {
-        Ok(Cpumask {
+    pub fn new() -> Cpumask {
+        Cpumask {
             mask: bitvec![u64, Lsb0; 0; *NR_CPU_IDS],
-        })
+        }
     }
 
     /// Build a Cpumask object from a hexadecimal string.
@@ -166,12 +166,12 @@ impl Cpumask {
     }
 
     /// Set all bits in the Cpumask to 1
-    pub fn setall(&mut self) {
+    pub fn set_all(&mut self) {
         self.mask.fill(true);
     }
 
     /// Set all bits in the Cpumask to 0
-    pub fn clear(&mut self) {
+    pub fn clear_all(&mut self) {
         self.mask.fill(false);
     }
 
@@ -304,7 +304,7 @@ impl fmt::UpperHex for Cpumask {
 
 impl BitAnd for Cpumask {
     type Output = Self;
-    fn bitand(self, rhs: Self) -> Self {
+    fn bitand(self, rhs: Cpumask) -> Self {
         self.and(&rhs)
     }
 }

--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -46,11 +46,11 @@
 //!     mask.set_cpu(0);
 //!     assert!(mask.test_cpu(0));
 //!
-//!     mask.clear();
+//!     mask.clear_all();
 //!     info!("{:#?}", mask); // 32:<00000000000000000000000000000000>
 //!     assert!(!mask.test_cpu(0));
 //!
-//!     mask.setall();
+//!     mask.set_all();
 //!     info!("{:#?}", mask); // 32:<11111111111111111111111111111111>
 //!     assert!(mask.test_cpu(0));
 //!```

--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -61,11 +61,8 @@ use anyhow::Context;
 use anyhow::Result;
 use bitvec::prelude::*;
 use std::fmt;
-use std::ops::BitAnd;
 use std::ops::BitAndAssign;
-use std::ops::BitOr;
 use std::ops::BitOrAssign;
-use std::ops::BitXor;
 use std::ops::BitXorAssign;
 
 #[derive(Debug, Eq, Clone, Hash, Ord, PartialEq, PartialOrd)]
@@ -302,41 +299,20 @@ impl fmt::UpperHex for Cpumask {
     }
 }
 
-impl BitAnd for Cpumask {
-    type Output = Self;
-    fn bitand(self, rhs: Cpumask) -> Self {
-        self.and(&rhs)
-    }
-}
-
-impl BitAndAssign for Cpumask {
-    fn bitand_assign(&mut self, rhs: Cpumask) {
+impl BitAndAssign<&Self> for Cpumask {
+    fn bitand_assign(&mut self, rhs: &Self) {
         self.mask &= &rhs.mask;
     }
 }
 
-impl BitOr for Cpumask {
-    type Output = Self;
-    fn bitor(self, rhs: Self) -> Self {
-        self.or(&rhs)
-    }
-}
-
-impl BitOrAssign for Cpumask {
-    fn bitor_assign(&mut self, rhs: Cpumask) {
+impl BitOrAssign<&Self> for Cpumask {
+    fn bitor_assign(&mut self, rhs: &Self) {
         self.mask |= &rhs.mask;
     }
 }
 
-impl BitXor for Cpumask {
-    type Output = Self;
-    fn bitxor(self, rhs: Self) -> Self {
-        self.xor(&rhs)
-    }
-}
-
-impl BitXorAssign for Cpumask {
-    fn bitxor_assign(&mut self, rhs: Cpumask) {
+impl BitXorAssign<&Self> for Cpumask {
+    fn bitxor_assign(&mut self, rhs: &Self) {
         self.mask ^= &rhs.mask;
     }
 }

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -67,7 +67,6 @@ pub use topology::Cpu;
 pub use topology::Llc;
 pub use topology::Node;
 pub use topology::Topology;
-pub use topology::TopologyMap;
 pub use topology::NR_CPUS_POSSIBLE;
 pub use topology::NR_CPU_IDS;
 

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -284,18 +284,17 @@ impl Topology {
             .any(|c| c.core_type == CoreType::Little)
     }
 
-    /// Returns a vector that maps the index of each logical core to the sibling core.
-    /// This represents the "next sibling" core within a package in systems that support SMT.
-    /// The sibling core is the other logical core that shares the physical resources
-    /// of the same physical core.
+    /// Returns a vector that maps the index of each logical CPU to the
+    /// sibling CPU. This represents the "next sibling" CPU within a package
+    /// in systems that support SMT. The sibling CPU is the other logical
+    /// CPU that shares the physical resources of the same physical core.
     ///
     /// Assuming each core holds exactly at most two cpus.
     pub fn sibling_cpus(&self) -> Vec<i32> {
         let mut sibling_cpu = vec![-1i32; *NR_CPUS_POSSIBLE];
         for core in self.all_cores.values() {
             let mut first = -1i32;
-            for (cpu_id, _) in &core.cpus {
-                let cpu = *cpu_id;
+            for (&cpu, _) in &core.cpus {
                 if first < 0 {
                     first = cpu as i32;
                 } else {

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -73,8 +73,7 @@ use crate::misc::read_file_usize;
 use crate::Cpumask;
 use anyhow::bail;
 use anyhow::Result;
-use bitvec::bitvec;
-use bitvec::vec::BitVec;
+use bitvec::prelude::*;
 use glob::glob;
 use sscanf::sscanf;
 use std::collections::BTreeMap;
@@ -358,11 +357,11 @@ impl TopologyMap {
     /// physical cores and the logical cores that run on them.
     /// The index in the vector represents the physical core, and each bit in the
     /// corresponding `BitVec` represents whether a logical core belongs to that physical core.
-    pub fn core_cpus_bitvec(&self) -> Vec<BitVec> {
-        let mut core_cpus = Vec::<BitVec>::new();
+    pub fn core_cpus_bitvec(&self) -> Vec<BitVec<u64, Lsb0>> {
+        let mut core_cpus = Vec::<BitVec<u64, Lsb0>>::new();
         for (core_id, core) in self.iter().enumerate() {
             if core_cpus.len() < core_id + 1 {
-                core_cpus.resize(core_id + 1, bitvec![0; *NR_CPUS_POSSIBLE]);
+                core_cpus.resize(core_id + 1, bitvec![u64, Lsb0; 0; *NR_CPUS_POSSIBLE]);
             }
             for cpu in core {
                 core_cpus[core_id].set(*cpu, true);

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -421,7 +421,7 @@ fn cpus_online() -> Result<Cpumask> {
     let path = "/sys/devices/system/cpu/online";
     let online = std::fs::read_to_string(&path)?;
     let online_groups: Vec<&str> = online.split(',').collect();
-    let mut mask = Cpumask::new()?;
+    let mut mask = Cpumask::new();
     for group in online_groups.iter() {
         let (min, max) = match sscanf!(group.trim(), "{usize}-{usize}") {
             Ok((x, y)) => (x, y),
@@ -529,7 +529,7 @@ fn create_insert_cpu(
     let llc = node.llcs.entry(*llc_id).or_insert(Arc::new(Llc {
         id: *llc_id,
         cores: BTreeMap::new(),
-        span: Cpumask::new()?,
+        span: Cpumask::new(),
         all_cpus: BTreeMap::new(),
 
         node_id: node.id,
@@ -559,7 +559,7 @@ fn create_insert_cpu(
     let core = llc_mut.cores.entry(*core_id).or_insert(Arc::new(Core {
         id: *core_id,
         cpus: BTreeMap::new(),
-        span: Cpumask::new()?,
+        span: Cpumask::new(),
         core_type: core_type.clone(),
 
         llc_id: *llc_id,
@@ -648,7 +648,7 @@ fn create_default_node(
     let mut node = Node {
         id: 0,
         llcs: BTreeMap::new(),
-        span: Cpumask::new()?,
+        span: Cpumask::new(),
         #[cfg(feature = "gpu-topology")]
         gpus: BTreeMap::new(),
         all_cores: BTreeMap::new(),
@@ -712,7 +712,7 @@ fn create_numa_nodes(
         let mut node = Node {
             id: node_id,
             llcs: BTreeMap::new(),
-            span: Cpumask::new()?,
+            span: Cpumask::new(),
 
             all_cores: BTreeMap::new(),
             all_cpus: BTreeMap::new(),

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -182,7 +182,6 @@ pub struct Topology {
     pub nodes: BTreeMap<usize, Node>,
     /// Cpumask all CPUs in the system.
     pub span: Cpumask,
-    pub nr_cpus_online: usize,
 
     /// Skip indices to access lower level members easily.
     pub all_llcs: BTreeMap<usize, Arc<Llc>>,
@@ -237,11 +236,9 @@ impl Topology {
             node.all_cpus = node_cpus;
         }
 
-        let nr_cpus_online = span.weight();
         Ok(Topology {
             nodes,
             span,
-            nr_cpus_online,
             all_llcs: topo_llcs,
             all_cores: topo_cores,
             all_cpus: topo_cpus,
@@ -288,15 +285,6 @@ impl Topology {
         self.all_cores
             .values()
             .any(|c| c.core_type == CoreType::Little)
-    }
-
-    /// Returns a BitVec of online CPUs.
-    pub fn cpus_bitvec(&self) -> BitVec {
-        let mut cpus = bitvec![0; *NR_CPUS_POSSIBLE];
-        for id in self.all_cpus.keys() {
-            cpus.set(*id, true);
-        }
-        cpus
     }
 
     /// Returns a vector that maps the index of each logical core to the sibling core.

--- a/scheds/rust/scx_layered/src/lib.rs
+++ b/scheds/rust/scx_layered/src/lib.rs
@@ -21,6 +21,7 @@ pub use layer_core_growth::LayerGrowthAlgo;
 use log::debug;
 use log::info;
 use scx_utils::Core;
+use scx_utils::Cpumask;
 use scx_utils::Topology;
 use scx_utils::TopologyMap;
 use scx_utils::NR_CPUS_POSSIBLE;
@@ -42,7 +43,7 @@ pub struct CpuPool {
     /// physical cores and the logical cores that run on them.
     /// The index in the vector represents the physical core, and each bit in the
     /// corresponding `BitVec` represents whether a logical core belongs to that physical core.
-    core_cpus: Vec<BitVec>,
+    core_cpus: Vec<BitVec<u64, Lsb0>>,
 
     /// A vector that maps the index of each logical core to the sibling core.
     /// This represents the "next sibling" core within a package in systems that support SMT.
@@ -52,7 +53,7 @@ pub struct CpuPool {
 
     /// A bit mask representing all available physical cores.
     /// Each bit corresponds to whether a physical core is available for task scheduling.
-    available_cores: BitVec,
+    available_cores: BitVec<u64, Lsb0>,
 
     /// The ID of the first physical core in the system.
     /// This core is often used as a default for initializing tasks.
@@ -104,7 +105,7 @@ impl CpuPool {
         let mut cpu_pool = Self {
             core_cpus,
             sibling_cpu,
-            available_cores: bitvec![1; topo.all_cores.len()],
+            available_cores: bitvec![u64, Lsb0; 1; topo.all_cores.len()],
             first_cpu,
             fallback_cpu: first_cpu,
             core_topology_to_id,
@@ -125,19 +126,19 @@ impl CpuPool {
 
     pub fn alloc_cpus<'a>(
         &'a mut self,
-        allowed_cpus: &BitVec,
+        allowed_cpus: &Cpumask,
         core_alloc_order: &[usize],
-    ) -> Option<&'a BitVec> {
-        let available_cpus = self.available_cpus_in_mask(&allowed_cpus);
+    ) -> Option<Cpumask> {
+        let available_cpus = self.available_cpus_in_mask(allowed_cpus);
         let available_cores = self.cpus_to_cores(&available_cpus).ok()?;
 
         for alloc_core in core_alloc_order {
-            match available_cores.get(*alloc_core) {
+            match available_cores.as_raw_bitvec().get(*alloc_core) {
                 Some(bit) => {
                     if *bit {
                         self.available_cores.set(*alloc_core, false);
                         self.update_fallback_cpu();
-                        return Some(&self.core_cpus[*alloc_core]);
+                        return Some(Cpumask::from_bitvec(self.core_cpus[*alloc_core].clone()));
                     }
                 }
                 None => {
@@ -148,9 +149,9 @@ impl CpuPool {
         None
     }
 
-    fn cpus_to_cores(&self, cpus_to_match: &BitVec) -> Result<BitVec> {
-        let mut cpus = cpus_to_match.clone();
-        let mut cores = bitvec![0; self.topo.all_cores.len()];
+    fn cpus_to_cores(&self, cpus_to_match: &Cpumask) -> Result<Cpumask> {
+        let mut cpus = cpus_to_match.as_raw_bitvec().clone();
+        let mut cores = bitvec![u64, Lsb0; 0; self.topo.all_cores.len()];
 
         while let Some(cpu) = cpus.first_one() {
             let core = self.topo.all_cpus[&cpu].core_id;
@@ -168,11 +169,11 @@ impl CpuPool {
             cores.set(core, true);
         }
 
-        Ok(cores)
+        Ok(Cpumask::from_bitvec(cores))
     }
 
-    pub fn free<'a>(&'a mut self, cpus_to_free: &BitVec) -> Result<()> {
-        let cores = self.cpus_to_cores(cpus_to_free)?;
+    pub fn free<'a>(&'a mut self, cpus_to_free: &Cpumask) -> Result<()> {
+        let cores = self.cpus_to_cores(cpus_to_free)?.as_raw_bitvec().clone();
         if (self.available_cores.clone() & &cores).any() {
             bail!("Some of CPUs {} are already free", cpus_to_free);
         }
@@ -183,35 +184,37 @@ impl CpuPool {
 
     pub fn next_to_free<'a>(
         &'a self,
-        cands: &BitVec,
+        cands: &Cpumask,
         core_order: impl Iterator<Item = &'a usize>,
-    ) -> Result<Option<&'a BitVec>> {
+    ) -> Result<Option<Cpumask>> {
         for pref_core in core_order {
             let core_cpus = self.core_cpus[*pref_core].clone();
-            if (core_cpus & cands.clone()).count_ones() > 0 {
-                return Ok(Some(&self.core_cpus[*pref_core]));
+            if (core_cpus & cands.as_raw_bitvec().clone()).count_ones() > 0 {
+                return Ok(Some(Cpumask::from_bitvec(
+                    self.core_cpus[*pref_core].clone(),
+                )));
             }
         }
         Ok(None)
     }
 
-    pub fn available_cpus(&self) -> BitVec<u64, Lsb0> {
+    pub fn available_cpus(&self) -> Cpumask {
         let mut cpus = bitvec![u64, Lsb0; 0; *NR_CPU_IDS];
         for core in self.available_cores.iter_ones() {
             let core_cpus = self.core_cpus[core].clone();
             cpus |= core_cpus.as_bitslice();
         }
-        cpus
+        Cpumask::from_bitvec(cpus)
     }
 
-    pub fn available_cpus_in_mask(&self, allowed_cpus: &BitVec) -> BitVec {
-        let mut cpus = bitvec![0; *NR_CPU_IDS];
+    pub fn available_cpus_in_mask(&self, allowed_cpus: &Cpumask) -> Cpumask {
+        let mut cpus = bitvec![u64, Lsb0; 0; *NR_CPU_IDS];
         for core in self.available_cores.iter_ones() {
             let mut core_cpus = self.core_cpus[core].clone();
-            core_cpus &= allowed_cpus;
+            core_cpus &= allowed_cpus.as_raw_bitvec();
             cpus |= core_cpus;
         }
-        cpus
+        Cpumask::from_bitvec(cpus)
     }
 
     fn get_core_topological_id(&self, core: &Core) -> usize {

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1955,7 +1955,7 @@ impl<'a> Scheduler<'a> {
                 }
 
                 let bpf_layer = &mut self.skel.maps.bss_data.layers[idx];
-                let available_cpus = self.cpu_pool.available_cpus_in_mask(&layer.allowed_cpus);
+                let available_cpus = self.cpu_pool.available_cpus().and(&layer.allowed_cpus);
                 let nr_available_cpus = available_cpus.weight();
 
                 // Open layers need the intersection of allowed cpus and

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1565,7 +1565,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.lo_fb_share_ppk = ((opts.lo_fb_share * 1024.0) as u32).clamp(1, 1024);
         skel.maps.rodata_data.enable_antistall = !opts.disable_antistall;
 
-        for (cpu, sib) in cpu_pool.sibling_cpu.iter().enumerate() {
+        for (cpu, sib) in topo.sibling_cpus().iter().enumerate() {
             skel.maps.rodata_data.__sibling_cpu[cpu] = *sib;
         }
         for cpu in topo.all_cpus.keys() {

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -922,7 +922,7 @@ impl Layer {
     fn new(spec: &LayerSpec, topo: &Topology, core_order: &Vec<usize>) -> Result<Self> {
         let name = &spec.name;
         let kind = spec.kind.clone();
-        let mut allowed_cpus = Cpumask::new()?;
+        let mut allowed_cpus = Cpumask::new();
         match &kind {
             LayerKind::Confined {
                 cpus_range,
@@ -935,7 +935,7 @@ impl Layer {
                     bail!("invalid cpus_range {:?}", cpus_range);
                 }
                 if nodes.len() == 0 && llcs.len() == 0 {
-                    allowed_cpus.setall();
+                    allowed_cpus.set_all();
                 } else {
                     // build up the cpus bitset
                     for (node_id, node) in &topo.nodes {
@@ -974,7 +974,7 @@ impl Layer {
                 ..
             } => {
                 if nodes.len() == 0 && llcs.len() == 0 {
-                    allowed_cpus.setall();
+                    allowed_cpus.set_all();
                 } else {
                     // build up the cpus bitset
                     for (node_id, node) in &topo.nodes {
@@ -1010,7 +1010,7 @@ impl Layer {
             core_order: core_order.clone(),
 
             nr_cpus: 0,
-            cpus: Cpumask::new()?,
+            cpus: Cpumask::new(),
             allowed_cpus,
         })
     }
@@ -1679,7 +1679,7 @@ impl<'a> Scheduler<'a> {
                 .ok_or_else(|| anyhow!("Failed to get netdev node"))?;
             let node_cpus = node.span.clone();
             for (irq, irqmask) in netdev.irqs.iter_mut() {
-                irqmask.clear();
+                irqmask.clear_all();
                 for cpu in available_cpus.as_raw_bitvec().iter_ones() {
                     if !node_cpus.test_cpu(cpu) {
                         continue;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1025,7 +1025,7 @@ impl Layer {
 
         Ok(if nr_to_free <= max_to_free {
             trace!("[{}] freeing CPUs: {}", self.name, &cpus_to_free);
-            self.cpus &= cpus_to_free.not();
+            self.cpus &= &cpus_to_free.not();
             self.nr_cpus -= nr_to_free;
             cpu_pool.free(&cpus_to_free)?;
             nr_to_free
@@ -1049,7 +1049,7 @@ impl Layer {
         let nr_new_cpus = new_cpus.weight();
 
         trace!("[{}] adding CPUs: {}", &self.name, &new_cpus);
-        self.cpus |= new_cpus;
+        self.cpus |= &new_cpus;
         self.nr_cpus += nr_new_cpus;
         Ok(nr_new_cpus)
     }

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -185,7 +185,7 @@ pub struct LayerStats {
 }
 
 impl LayerStats {
-    fn bitvec_to_u32s(bitvec: &BitVec) -> Vec<u32> {
+    fn bitvec_to_u32s(bitvec: &BitVec<u64, Lsb0>) -> Vec<u32> {
         let mut vals = Vec::<u32>::new();
         let mut val: u32 = 0;
         for (idx, bit) in bitvec.iter().enumerate() {
@@ -262,8 +262,8 @@ impl LayerStats {
             xlayer_rewake: lstat_pct(LSTAT_XLAYER_REWAKE),
             xllc_migration: lstat_pct(LSTAT_XLLC_MIGRATION),
             xllc_migration_skip: lstat_pct(LSTAT_XLLC_MIGRATION_SKIP),
-            cpus: Self::bitvec_to_u32s(&layer.cpus),
-            cur_nr_cpus: layer.cpus.count_ones() as u32,
+            cpus: Self::bitvec_to_u32s(layer.cpus.as_raw_bitvec()),
+            cur_nr_cpus: layer.cpus.weight() as u32,
             min_nr_cpus: nr_cpus_range.0 as u32,
             max_nr_cpus: nr_cpus_range.1 as u32,
             slice_us: stats.layer_slice_us[lidx],

--- a/scheds/rust/scx_rusty/src/domain.rs
+++ b/scheds/rust/scx_rusty/src/domain.rs
@@ -48,7 +48,7 @@ pub struct DomainGroup {
 
 impl DomainGroup {
     pub fn new(top: &Topology, cpumasks: &[String]) -> Result<Self> {
-        let mut span = Cpumask::new()?;
+        let mut span = Cpumask::new();
         let mut dom_numa_map = BTreeMap::new();
         // Track the domain ID separate from the LLC ID, because LLC IDs can
         // have gaps if there are offlined CPUs, and domain IDs need to be

--- a/scheds/rust/scx_rusty/src/domain.rs
+++ b/scheds/rust/scx_rusty/src/domain.rs
@@ -59,7 +59,7 @@ impl DomainGroup {
             let mut doms: BTreeMap<usize, Domain> = BTreeMap::new();
             for mask_str in cpumasks.iter() {
                 let mask = Cpumask::from_str(&mask_str)?;
-                span |= mask.clone();
+                span |= &mask;
                 doms.insert(dom_id, Domain { id: dom_id, mask });
                 dom_numa_map.insert(dom_id, 0);
                 dom_id += 1;
@@ -70,7 +70,7 @@ impl DomainGroup {
             for (node_id, node) in &top.nodes {
                 for (_, llc) in node.llcs.iter() {
                     let mask = llc.span.clone();
-                    span |= mask.clone();
+                    span |= &mask;
                     doms.insert(dom_id, Domain { id: dom_id, mask });
                     dom_numa_map.insert(dom_id, node_id.clone());
                     dom_id += 1;

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -408,7 +408,7 @@ impl<'a> Scheduler<'a> {
         }
 
         for numa in 0..domains.nr_nodes() {
-            let mut numa_mask = Cpumask::new()?;
+            let mut numa_mask = Cpumask::new();
             let node_domains = domains.numa_doms(&numa);
             for dom in node_domains.iter() {
                 let dom_mask = dom.mask();

--- a/scheds/rust/scx_rusty/src/tuner.rs
+++ b/scheds/rust/scx_rusty/src/tuner.rs
@@ -94,8 +94,8 @@ impl Tuner {
             .ok_or_else(|| anyhow!("Expected cpus_map to exist"))?;
 
         Ok(Self {
-            direct_greedy_mask: Cpumask::new()?,
-            kick_greedy_mask: Cpumask::new()?,
+            direct_greedy_mask: Cpumask::new(),
+            kick_greedy_mask: Cpumask::new(),
             fully_utilized: false,
             direct_greedy_under: direct_greedy_under / 100.0,
             kick_greedy_under: kick_greedy_under / 100.0,
@@ -138,8 +138,8 @@ impl Tuner {
         avg_util /= self.dom_group.weight() as f64;
         self.fully_utilized = avg_util >= 0.99999;
 
-        self.direct_greedy_mask.clear();
-        self.kick_greedy_mask.clear();
+        self.direct_greedy_mask.clear_all();
+        self.kick_greedy_mask.clear_all();
         for (dom_id, dom) in self.dom_group.doms().iter() {
             // Calculate the domain avg util. If there are no active CPUs,
             // it doesn't really matter. Go with 0.0 as that's less likely

--- a/scheds/rust/scx_rusty/src/tuner.rs
+++ b/scheds/rust/scx_rusty/src/tuner.rs
@@ -154,10 +154,10 @@ impl Tuner {
             let enable_kick = self.kick_greedy_under > 0.99999 || util < self.kick_greedy_under;
 
             if enable_direct {
-                self.direct_greedy_mask |= dom.mask();
+                self.direct_greedy_mask |= &dom.mask();
             }
             if enable_kick {
-                self.kick_greedy_mask |= dom.mask();
+                self.kick_greedy_mask |= &dom.mask();
             }
         }
 


### PR DESCRIPTION
Things got a bit messy over time e.g. with `TopologyMap` duplicating parts of `Topology` and `CpuPool` having a lot of `Topology` features. Let's clean them up. This shouldn't cause any behavior changes.