### PR TITLE
cpumask, scx_layered: Clean up Cpumask iterator

### DIFF
--- a/scheds/rust/scx_layered/src/lib.rs
+++ b/scheds/rust/scx_layered/src/lib.rs
@@ -132,7 +132,7 @@ impl CpuPool {
         let mut cpus = cpus_to_match.clone();
         let mut cores = bitvec![0; topo.all_cores.len()];
 
-        while let Some(cpu) = cpus.as_raw_bitvec().first_one() {
+        while let Some(cpu) = cpus.iter().next() {
             let core = &topo.all_cores[&topo.all_cpus[&cpu].core_id];
 
             if core.span.and(&cpus_to_match.not()).weight() != 0 {

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1247,10 +1247,10 @@ impl<'a> Scheduler<'a> {
             core_span.clear_cpu(cpu_id).unwrap();
 
             // Convert them into arrays.
-            let mut sys_order: Vec<usize> = sys_span.into_iter().collect();
-            let mut node_order: Vec<usize> = node_span.into_iter().collect();
-            let mut llc_order: Vec<usize> = llc_span.into_iter().collect();
-            let mut core_order: Vec<usize> = core_span.into_iter().collect();
+            let mut sys_order: Vec<usize> = sys_span.iter().collect();
+            let mut node_order: Vec<usize> = node_span.iter().collect();
+            let mut llc_order: Vec<usize> = llc_span.iter().collect();
+            let mut core_order: Vec<usize> = core_span.iter().collect();
 
             // Shuffle them so that different CPUs follow different orders.
             // This isn't ideal as random shuffling won't give us complete

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1680,7 +1680,7 @@ impl<'a> Scheduler<'a> {
             let node_cpus = node.span.clone();
             for (irq, irqmask) in netdev.irqs.iter_mut() {
                 irqmask.clear_all();
-                for cpu in available_cpus.as_raw_bitvec().iter_ones() {
+                for cpu in available_cpus.iter() {
                     if !node_cpus.test_cpu(cpu) {
                         continue;
                     }
@@ -1688,7 +1688,7 @@ impl<'a> Scheduler<'a> {
                 }
                 // If no CPUs are available in the node then spread the load across the node
                 if irqmask.weight() == 0 {
-                    for cpu in node_cpus.as_raw_bitvec().iter_ones() {
+                    for cpu in node_cpus.iter() {
                         let _ = irqmask.set_cpu(cpu);
                     }
                 }

--- a/scheds/rust/scx_rusty/src/domain.rs
+++ b/scheds/rust/scx_rusty/src/domain.rs
@@ -81,7 +81,7 @@ impl DomainGroup {
 
         let mut cpu_dom_map = BTreeMap::new();
         for (id, dom) in doms.iter() {
-            for cpu in dom.mask.clone().into_iter() {
+            for cpu in dom.mask.iter() {
                 cpu_dom_map.insert(cpu, *id);
             }
         }

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -399,7 +399,7 @@ impl<'a> Scheduler<'a> {
         }
 
         for (id, dom) in domains.doms().iter() {
-            for cpu in dom.mask().into_iter() {
+            for cpu in dom.mask().iter() {
                 skel.maps.rodata_data.cpu_dom_id_map[cpu] = id
                     .clone()
                     .try_into()

--- a/scheds/rust/scx_rusty/src/tuner.rs
+++ b/scheds/rust/scx_rusty/src/tuner.rs
@@ -124,7 +124,7 @@ impl Tuner {
 
         let mut avg_util = 0.0f64;
         for (dom_id, dom) in self.dom_group.doms().iter() {
-            for cpu in dom.mask().into_iter() {
+            for cpu in dom.mask().iter() {
                 let cpu32 = cpu as u32;
                 if let (Some(curr), Some(prev)) =
                     (curr_cpu_stats.get(&cpu32), self.prev_cpu_stats.get(&cpu32))


### PR DESCRIPTION
No reason to consume the cpumask for iteration. Replace `.into_iter()` with `.iter()` and use it in layered.