### PR TITLE
Etsal/bump req bpftool version

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -15,13 +15,11 @@ foreach src: libs
   objs += [bpf_o]
 endforeach
 
-if bpftool_maj < 7 or (bpftool_maj == 7 and bpftool_min >= 5)
-  scx_lib = custom_target(scx_lib_name,
-    output: scx_lib_name + '.bpf.o',
-    command: [compile_scx_lib, bpftool_exe_path, '@OUTPUT@', scx_lib_name, objs],
-    depends: objs,
+scx_lib = custom_target(scx_lib_name,
+  output: scx_lib_name + '.bpf.o',
+  command: [compile_scx_lib, bpftool_exe_path, '@OUTPUT@', scx_lib_name, objs],
+  depends: objs,
 )
-endif
 
 # Install include/lib as a lib/ subdir of our headers
 install_subdir(join_paths(meson.current_source_dir(), 'include/lib'), install_dir: 'include', install_tag: 'devel')

--- a/meson-scripts/bpftool_build_skel
+++ b/meson-scripts/bpftool_build_skel
@@ -12,21 +12,14 @@ stem="${input%.o}"
 name="${input%.bpf.o}"
 name="${name##*/}"
 
-if [ ! -z $lib ] && [ `basename $lib` == $name ];
+if [ `basename $lib` == $name ];
 then
 	"$bpftool" gen object "$stem".l1o "$input"
-	exit 0
-fi
-
-if [ ! -z $lib ];
-then
-	"$bpftool" gen object "$stem".l1o "$input" "$lib".bpf.o
 else
-	"$bpftool" gen object "$stem".l1o "$input"
+	"$bpftool" gen object "$stem".l1o "$input" "$lib".bpf.o
+	"$bpftool" gen object "$stem".l2o "$stem".l1o
+	"$bpftool" gen object "$stem".l3o "$stem".l2o
+	cmp "$stem".l2o "$stem".l3o
+	"$bpftool" gen skeleton "$stem".l3o name "$name" > "$skel"
+	"$bpftool" gen subskeleton "$stem".l3o name "$name" > "$subskel"
 fi
-
-"$bpftool" gen object "$stem".l2o "$stem".l1o
-"$bpftool" gen object "$stem".l3o "$stem".l2o
-cmp "$stem".l2o "$stem".l3o
-"$bpftool" gen skeleton "$stem".l3o name "$name" > "$skel"
-"$bpftool" gen subskeleton "$stem".l3o name "$name" > "$subskel"

--- a/meson.build
+++ b/meson.build
@@ -201,8 +201,8 @@ else
   bpftool_ver = run_command(get_bpftool_ver, bpftool_exe_path, check: true).stdout().strip()
   bpftool_maj = bpftool_ver.split('.')[0].to_int()
   bpftool_min = bpftool_ver.split('.')[1].to_int()
-  if bpftool_maj < 7 or (bpftool_maj == 7 and bpftool_min < 4)
-    error('bpftool >= 7.4 required (@0@ ver=@1@)'.format(bpftool_exe_path, bpftool_ver))
+  if bpftool_maj < 7 or (bpftool_maj == 7 and bpftool_min < 5)
+    error('bpftool >= 7.5 required (@0@ ver=@1@)'.format(bpftool_exe_path, bpftool_ver))
   endif
   # this is a noop when we're not building bpftool ourselves
   bpftool_target = custom_target('bpftool_target',

--- a/meson.build
+++ b/meson.build
@@ -192,10 +192,6 @@ if should_build_bpftool
   bpftool_commit = '183e7010387d1fc9f08051426e9a9fbd5f8d409e'
   run_command(fetch_bpftool, meson.current_build_dir(), bpftool_commit, check: true)
 
-  bpftool_ver = '7.5'
-  bpftool_maj = 7
-  bpftool_min = 4
-
   bpftool_target = custom_target('bpftool_target',
               output: '@PLAINNAME@.__PHONY__',
               input: 'meson-scripts/bpftool_dummy.c',
@@ -205,23 +201,15 @@ else
   bpftool_ver = run_command(get_bpftool_ver, bpftool_exe_path, check: true).stdout().strip()
   bpftool_maj = bpftool_ver.split('.')[0].to_int()
   bpftool_min = bpftool_ver.split('.')[1].to_int()
-
+  if bpftool_maj < 7 or (bpftool_maj == 7 and bpftool_min < 4)
+    error('bpftool >= 7.4 required (@0@ ver=@1@)'.format(bpftool_exe_path, bpftool_ver))
+  endif
   # this is a noop when we're not building bpftool ourselves
   bpftool_target = custom_target('bpftool_target',
               output: '@PLAINNAME@.__PHONY__',
               input: 'meson-scripts/bpftool_dummy.c',
               command: ['echo'],
               build_by_default: true)
-endif
-
-bpftool_no_lib = bpftool_maj < 7 or (bpftool_maj == 7 and bpftool_min < 5)
-
-if bpftool_maj < 7 or (bpftool_maj == 7 and bpftool_min < 4)
-  error('bpftool >= 7.4 required (@0@ ver=@1@)'.format(bpftool_exe_path, bpftool_ver))
-endif
-
-if bpftool_no_lib
-  message('[WARNING] bpftool >= 7.5 required for BPF libraries(@0@ ver=@1@)'.format(bpftool_exe_path, bpftool_ver))
 endif
 # end libbpf/bpftool stuff
 
@@ -286,23 +274,8 @@ lib_objs = []
 subdir('lib')
 
 #
-# Generators to build BPF skel file for C schedulers. For bpftool < 7.5 we
-# have to work around a libbpf bug that prevents linking BPF objects by not
-# compiling the library.
+# Generators to build BPF skel file for C schedulers.
 #
-
-if bpftool_no_lib
-gen_bpf_o = generator(bpf_clang,
-                      output: '@BASENAME@.o',
-                      depends: [libbpf],
-                      arguments: [bpf_base_cflags, '-target', 'bpf', libbpf_c_headers, bpf_includes,
-                                  '-c', '@INPUT@', '-o', '@OUTPUT@'])
-
-gen_bpf_skel = generator(bpftool_build_skel,
-                         output: ['@BASENAME@.skel.h','@BASENAME@.subskel.h' ],
-                         depends: [libbpf, bpftool_target],
-                         arguments: [bpftool_exe_path, '@INPUT@', '@OUTPUT0@', '@OUTPUT1@'])
-else
 gen_bpf_o = generator(bpf_clang,
                       output: '@BASENAME@.o',
                       depends: [libbpf, scx_lib],
@@ -313,7 +286,7 @@ gen_bpf_skel = generator(bpftool_build_skel,
                          output: ['@BASENAME@.skel.h','@BASENAME@.subskel.h' ],
                          depends: [libbpf, bpftool_target],
                          arguments: [bpftool_exe_path, '@INPUT@', '@OUTPUT0@', '@OUTPUT1@', scx_lib_path])
-endif
+
 
 #
 # For rust sub-projects.

--- a/scheds/c/meson.build
+++ b/scheds/c/meson.build
@@ -1,14 +1,10 @@
 c_scheds = ['scx_simple', 'scx_qmap', 'scx_central', 'scx_userland', 'scx_nest',
-            'scx_flatcg', 'scx_pair']
+            'scx_flatcg', 'scx_pair', 'scx_sdt']
 
 foreach sched: c_scheds
   thread_dep = dependency('threads')
   bpf_o = gen_bpf_o.process(sched + '.bpf.c')
-if bpftool_no_lib
-  bpf_skel = gen_bpf_skel.process(bpf_o)
-else
   bpf_skel = gen_bpf_skel.process(bpf_o, scx_lib)
-endif
   executable(sched, [bpf_skel, sched + '.c'],
              include_directories: [user_c_includes],
              dependencies: [kernel_dep, libbpf_dep, thread_dep],


### PR DESCRIPTION
As per today's discussion in today's sched_ext office hours, bump the minimum allowed version for bpftool to 7.5. Also revert our current workarounds that turn off library compilation for bpftool 7.4, which were not working properly anyway