### PR TITLE
scx_layered: Implement empty LLC draining

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -27,6 +27,7 @@ const volatile u32 debug;
 const volatile s32 layered_tgid;
 const volatile u64 slice_ns;
 const volatile u64 max_exec_ns;
+const volatile u32 nr_cpu_ids = 1;
 const volatile u32 nr_possible_cpus = 1;
 const volatile u64 numa_cpumasks[MAX_NUMA_NODES][MAX_CPUS / 64];
 const volatile u32 llc_numa_id_map[MAX_LLCS];
@@ -240,10 +241,6 @@ static void lstat_inc(u32 id, struct layer *layer, struct cpu_ctx *cpuc)
 	lstat_add(id, layer, cpuc, 1);
 }
 
-struct lock_wrapper {
-	struct bpf_spin_lock	lock;
-};
-
 struct layer_cpumask_wrapper {
 	struct bpf_cpumask __kptr *cpumask;
 };
@@ -268,6 +265,16 @@ static struct cpumask *lookup_layer_cpumask(u32 layer_id)
 	}
 }
 
+static void layer_llc_drain_enable(struct layer *layer, u32 llc_id)
+{
+	__sync_or_and_fetch(&layer->llcs_to_drain, 1LLU << llc_id);
+}
+
+static void layer_llc_drain_disable(struct layer *layer, u32 llc_id)
+{
+	__sync_and_and_fetch(&layer->llcs_to_drain, ~(1LLU << llc_id));
+}
+
 /*
  * Returns if any cpus were added to the layer.
  */
@@ -277,7 +284,7 @@ static void refresh_cpumasks(u32 layer_id)
 	struct layer_cpumask_wrapper *cpumaskw;
 	struct layer *layer;
 	struct cpu_ctx *cpuc;
-	int cpu;
+	int cpu, llc_id;
 
 	layer = MEMBER_VPTR(layers, [layer_id]);
 	if (!layer) {
@@ -308,7 +315,6 @@ static void refresh_cpumasks(u32 layer_id)
 			if (*u8_ptr & (1 << (cpu % 8))) {
 				cpuc->layer_id = layer_id;
 				bpf_cpumask_set_cpu(cpu, layer_cpumask);
-				scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 			} else {
 				if (cpuc->layer_id == layer_id)
 					cpuc->layer_id = MAX_LAYERS;
@@ -319,9 +325,31 @@ static void refresh_cpumasks(u32 layer_id)
 		}
 	}
 
-	__sync_fetch_and_add(&layer->cpus_seq, 1);
 	bpf_rcu_read_unlock();
+
+	__sync_fetch_and_add(&layer->cpus_seq, 1);	/* MB, see below */
 	trace("LAYER[%d] now has %d cpus, seq=%llu", layer_id, layer->nr_cpus, layer->cpus_seq);
+
+	/*
+	 * layer->nr_llc_cpus[] were updated by the userspace and we've passed a
+	 * full MB in the above layer->cpus_seq update. This is interlocked with
+	 * layered_enqueue() to guarantee that a task is never left in an empty
+	 * LLC without draining enabled. Either they see 0 nr_llcs_cpus and
+	 * enable drain or we see the task it enqueued and enable drain.
+	 */
+	bpf_for(llc_id, 0, nr_llcs) {
+		if (layer->nr_llc_cpus[llc_id])
+			layer_llc_drain_disable(layer, llc_id);
+		else if (scx_bpf_dsq_nr_queued(layer_dsq_id(layer->id, llc_id)))
+			layer_llc_drain_enable(layer, llc_id);
+	}
+
+	bpf_for(cpu, 0, nr_possible_cpus) {
+		if (!(cpuc = lookup_cpu_ctx(cpu)))
+			return;
+		if (cpuc->layer_id == layer_id)
+			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+	}
 }
 
 /*
@@ -826,9 +854,26 @@ s32 BPF_STRUCT_OPS(layered_select_cpu, struct task_struct *p, s32 prev_cpu, u64 
 		taskc->dsq_id = SCX_DSQ_LOCAL;
 		scx_bpf_dispatch(p, taskc->dsq_id, layer->slice_ns, 0);
 		return cpu;
-	} else {
-		return prev_cpu;
 	}
+
+	/*
+	 * Didn't find an idle CPU. If @p gets queued on an LLC without CPUs
+	 * assigned, it will trigger LLC draining which isn't great. Find an
+	 * in-layer CPU and put it there instead.
+	 *
+	 * TODO - This should become node aware.
+	 */
+	if (taskc->all_cpus_allowed) {
+		const struct cpumask *layer_cpumask;
+
+		if (!(layer_cpumask = lookup_layer_cpumask(taskc->layer_id)))
+			return prev_cpu;
+
+		if ((cpu = bpf_cpumask_any_distribute(layer_cpumask)) < nr_cpu_ids)
+			return cpu;
+	}
+
+	return prev_cpu;
 }
 
 static __always_inline
@@ -951,6 +996,21 @@ void try_preempt(s32 task_cpu, struct task_struct *p, struct task_ctx *taskc,
 	lstat_inc(LSTAT_PREEMPT_FAIL, layer, cpuc);
 }
 
+static void layer_kick_idle_cpu(struct layer *layer)
+{
+	const struct cpumask *layer_cpumask, *idle_smtmask;;
+	s32 cpu;
+
+	if (!(layer_cpumask = lookup_layer_cpumask(layer->id)) ||
+	    !(idle_smtmask = scx_bpf_get_idle_smtmask()))
+		return;
+
+	if ((cpu = pick_idle_cpu_from(layer_cpumask, 0, idle_smtmask)) >= 0)
+		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+
+	scx_bpf_put_idle_cpumask(idle_smtmask);
+}
+
 void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 {
 	struct cpu_ctx *cpuc, *task_cpuc;
@@ -959,20 +1019,22 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 	struct layer *layer;
 	s32 task_cpu = scx_bpf_task_cpu(p);
 	u64 vtime = p->scx.dsq_vtime;
-	u32 layer_id;
+	u32 llc_id, layer_id;
 	bool try_preempt_first;
 	u64 queued_runtime;
 	u64 *lstats;
 
 	if (!(cpuc = lookup_cpu_ctx(-1)) ||
 	    !(task_cpuc = lookup_cpu_ctx(task_cpu)) ||
-	    !(taskc = lookup_task_ctx(p)) ||
-	    !(llcc = lookup_llc_ctx(task_cpuc->llc_id)))
+	    !(taskc = lookup_task_ctx(p)))
 		return;
 
+	llc_id = task_cpuc->llc_id;
 	layer_id = taskc->layer_id;
 
-	if (!(layer = lookup_layer(layer_id)))
+	if (llc_id >= MAX_LLCS ||
+	    !(llcc = lookup_llc_ctx(llc_id)) ||
+	    !(layer = lookup_layer(layer_id)))
 		return;
 
 	try_preempt_first = cpuc->try_preempt_first;
@@ -1063,24 +1125,38 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 		__sync_fetch_and_sub(&prev_llcc->queued_runtime[layer_id], taskc->runtime_avg);
 	}
 
-	taskc->qrt_llc_id = task_cpuc->llc_id;
+	taskc->qrt_llc_id = llc_id;
 	queued_runtime = __sync_fetch_and_add(&llcc->queued_runtime[layer_id],
 					      taskc->runtime_avg);
 	queued_runtime += taskc->runtime_avg;
 
 	lstats = llcc->lstats[layer_id];
 
-	// racy, don't care
+	/* racy, don't care */
 	lstats[LLC_LSTAT_LAT] =
 		((LAYER_LAT_DECAY_FACTOR - 1) * lstats[LLC_LSTAT_LAT] + queued_runtime) /
 		LAYER_LAT_DECAY_FACTOR;
 	lstats[LLC_LSTAT_CNT]++;
 
-	taskc->dsq_id = layer_dsq_id(layer_id, task_cpuc->llc_id);
+	taskc->dsq_id = layer_dsq_id(layer_id, llc_id);
 	if (layer->fifo)
 		scx_bpf_dispatch(p, taskc->dsq_id, layer->slice_ns, enq_flags);
 	else
 		scx_bpf_dispatch_vtime(p, taskc->dsq_id, layer->slice_ns, vtime, enq_flags);
+
+	/*
+	 * Interlocked with refresh_cpumasks(). scx_bpf_dispatch[_vtime]()
+	 * always goes through spin lock/unlock and has enough barriers to
+	 * guarantee that either they see the task we enqueeud or we see zero
+	 * nr_llc_cpus.
+	 *
+	 * Also interlocked with opportunistic disabling in
+	 * try_drain_layer_llcs(). See there.
+	 */
+	if (!layer->nr_llc_cpus[llc_id]) {
+		layer_llc_drain_enable(layer, llc_id);
+		layer_kick_idle_cpu(layer);
+	}
 
 preempt:
 	try_preempt(task_cpu, p, taskc, try_preempt_first, enq_flags);
@@ -1265,6 +1341,66 @@ reset:
 	return consumed;
 }
 
+static bool try_drain_layer_llcs(struct layer *layer, struct cpu_ctx *cpuc)
+{
+	u32 cnt = layer->llc_drain_cnt++;
+	u32 u;
+
+	/* alternate between prioritizing draining and owned */
+	if (cnt & 1)
+		return false;
+
+	lstat_inc(LSTAT_LLC_DRAIN_TRY, layer, cpuc);
+
+	bpf_for(u, 0, nr_llcs) {
+		u32 llc_id = (u + cnt / 2) % nr_llcs;
+		u64 dsq_id = layer_dsq_id(layer->id, llc_id);
+		u32 *vptr;
+		bool disabled = false, consumed;
+
+		if (!(layer->llcs_to_drain & (1LLU << llc_id)))
+			continue;
+
+		if ((vptr = MEMBER_VPTR(layer->nr_llc_cpus, [llc_id])) && *vptr)
+			continue;
+
+		/*
+		 * Draining is relatively expensive and we want to turn it off
+		 * as soon as possible. However, we can't turn it off after
+		 * consuming as we can race against enabling and end up turning
+		 * off draining and leave the new task in the unserviced DSQ.
+		 *
+		 * Instead, turn it off if it's likely that the DSQ is going to
+		 * be empty after consuming and re-enable afterwards if
+		 * necessary to guarantee that draining never stays disabled
+		 * with tasks in the DSQ.
+		 */
+		if (scx_bpf_dsq_nr_queued(dsq_id) <= 1) {
+			layer_llc_drain_disable(layer, llc_id);
+			disabled = true;
+		}
+
+		consumed = scx_bpf_consume(dsq_id);
+
+		/*
+		 * Interlocked with enabling in layered_enqueue(). Either we see
+		 * increased nr_queued or they see disable and re-enable. Note
+		 * that we can race against nr_llc_cpus update or other draining
+		 * CPUs and re-enable unnecessarily. Doesn't matter. Will be
+		 * re-tried on the next draining attempt.
+		 */
+		if (disabled && scx_bpf_dsq_nr_queued(dsq_id))
+			layer_llc_drain_enable(layer, llc_id);
+
+		if (consumed) {
+			lstat_inc(LSTAT_LLC_DRAIN, layer, cpuc);
+			return true;
+		}
+	}
+
+	return false;
+}
+
 static __always_inline bool try_consume_layer(u32 layer_id, struct cpu_ctx *cpuc,
 					      struct llc_ctx *llcc)
 {
@@ -1335,7 +1471,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 	struct layer *owner_layer = NULL;
 	struct cpu_ctx *cpuc, *sib_cpuc;
 	struct llc_ctx *llcc;
-	bool tried_owner = false, tried_lo_fb = false;
+	bool tried_preempting = false, tried_lo_fb = false;
 	s32 sib = sibling_cpu(cpu);
 
 	if (!(cpuc = lookup_cpu_ctx(-1)))
@@ -1434,21 +1570,32 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 		}
 	}
 
-	/* owner before preempt layers if protected or preempting */
-	if (owner_layer && (cpuc->protect_owned || owner_layer->preempt)) {
-		if (try_consume_layer(owner_layer->id, cpuc, llcc))
+	/*
+	 * Grouped/open preempt layers first if there's no owner layer or the
+	 * owner layer is not protected or preempting.
+	 */
+	if (!owner_layer || (!cpuc->protect_owned && !owner_layer->preempt)) {
+		if (try_consume_layers(cpuc->open_preempt_layer_order,
+				       nr_open_preempt_layers,
+				       cpuc->layer_id, cpuc, llcc))
 			return;
-		tried_owner = true;
+
+		tried_preempting = true;
 	}
 
-	/* grouped/open preempt layers */
-	if (try_consume_layers(cpuc->open_preempt_layer_order, nr_open_preempt_layers,
-			       cpuc->layer_id, cpuc, llcc))
-		return;
+	/* owner layer */
+	if (owner_layer) {
+		if (owner_layer->llcs_to_drain &&
+		    try_drain_layer_llcs(owner_layer, cpuc))
+			return;
+		if (try_consume_layer(owner_layer->id, cpuc, llcc))
+			return;
+	}
 
-	/* try owner if not tried yet */
-	if (owner_layer && !tried_owner &&
-	    try_consume_layer(owner_layer->id, cpuc, llcc))
+	/* try grouped/open preempting if not tried yet */
+	if (!tried_preempting &&
+	    try_consume_layers(cpuc->open_preempt_layer_order, nr_open_preempt_layers,
+			       cpuc->layer_id, cpuc, llcc))
 		return;
 
 	/* grouped/open non-preempt layers */

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -712,7 +712,7 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 		goto out_put;
 
 	/*
-	 * Try a CPU in the current LLC
+	 * Try a CPU in the previous LLC.
 	 */
 	if (nr_llcs > 1) {
 		struct llc_ctx *prev_llcc;
@@ -727,7 +727,7 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 			goto out_put;
 
 		if (!(prev_llcc = lookup_llc_ctx(prev_cpuc->llc_id)) ||
-		    prev_llcc->queued_runtime[layer_id] <= layer->xllc_mig_min_ns) {
+		    prev_llcc->queued_runtime[layer_id] < layer->xllc_mig_min_ns) {
 			lstat_inc(LSTAT_XLLC_MIGRATION_SKIP, layer, cpuc);
 			cpu = -1;
 			goto out_put;
@@ -1295,7 +1295,7 @@ static __always_inline bool try_consume_layer(u32 layer_id, struct cpu_ctx *cpuc
 			if (!(remote_llcc = lookup_llc_ctx(*llc_idp)))
 				return false;
 
-			if (remote_llcc->queued_runtime[layer_id] <= layer->xllc_mig_min_ns) {
+			if (remote_llcc->queued_runtime[layer_id] < layer->xllc_mig_min_ns) {
 				xllc_mig_skipped = true;
 				continue;
 			}

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -914,6 +914,7 @@ struct Layer {
     core_order: Vec<usize>,
 
     nr_cpus: usize,
+    nr_llc_cpus: Vec<usize>,
     cpus: Cpumask,
     allowed_cpus: Cpumask,
 }
@@ -1010,6 +1011,7 @@ impl Layer {
             core_order: core_order.clone(),
 
             nr_cpus: 0,
+            nr_llc_cpus: vec![0; topo.all_llcs.len()],
             cpus: Cpumask::new(),
             allowed_cpus,
         })
@@ -1027,6 +1029,9 @@ impl Layer {
             trace!("[{}] freeing CPUs: {}", self.name, &cpus_to_free);
             self.cpus &= &cpus_to_free.not();
             self.nr_cpus -= nr_to_free;
+            for cpu in cpus_to_free.iter() {
+                self.nr_llc_cpus[cpu_pool.topo.all_cpus[&cpu].llc_id] -= 1;
+            }
             cpu_pool.free(&cpus_to_free)?;
             nr_to_free
         } else {
@@ -1051,6 +1056,9 @@ impl Layer {
         trace!("[{}] adding CPUs: {}", &self.name, &new_cpus);
         self.cpus |= &new_cpus;
         self.nr_cpus += nr_new_cpus;
+        for cpu in new_cpus.iter() {
+            self.nr_llc_cpus[cpu_pool.topo.all_cpus[&cpu].llc_id] += 1;
+        }
         Ok(nr_new_cpus)
     }
 }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -57,6 +57,7 @@ use scx_utils::NetDev;
 use scx_utils::Topology;
 use scx_utils::UserExitInfo;
 use scx_utils::NR_CPUS_POSSIBLE;
+use scx_utils::NR_CPU_IDS;
 use stats::LayerStats;
 use stats::StatsReq;
 use stats::StatsRes;
@@ -1563,6 +1564,7 @@ impl<'a> Scheduler<'a> {
         } else {
             opts.slice_us * 1000 * 20
         };
+        skel.maps.rodata_data.nr_cpu_ids = *NR_CPU_IDS as u32;
         skel.maps.rodata_data.nr_possible_cpus = *NR_CPUS_POSSIBLE as u32;
         skel.maps.rodata_data.smt_enabled = topo.all_cpus.len() > topo.all_cores.len();
         skel.maps.rodata_data.has_little_cores = topo.has_little_cores();
@@ -1668,7 +1670,12 @@ impl<'a> Scheduler<'a> {
                 bpf_layer.cpus[cpu / 8] &= !(1 << (cpu % 8));
             }
         }
+
         bpf_layer.nr_cpus = layer.nr_cpus as u32;
+        for (llc_id, &nr_llc_cpus) in layer.nr_llc_cpus.iter().enumerate() {
+            bpf_layer.nr_llc_cpus[llc_id] = nr_llc_cpus as u32;
+        }
+
         bpf_layer.refresh_cpus = 1;
     }
 

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1660,6 +1660,7 @@ impl<'a> Scheduler<'a> {
                 bpf_layer.cpus[cpu / 8] &= !(1 << (cpu % 8));
             }
         }
+        bpf_layer.nr_cpus = layer.nr_cpus as u32;
         bpf_layer.refresh_cpus = 1;
     }
 

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -64,6 +64,8 @@ const LSTAT_XLLC_MIGRATION: usize = bpf_intf::layer_stat_id_LSTAT_XLLC_MIGRATION
 const LSTAT_XLLC_MIGRATION_SKIP: usize = bpf_intf::layer_stat_id_LSTAT_XLLC_MIGRATION_SKIP as usize;
 const LSTAT_XLAYER_WAKE: usize = bpf_intf::layer_stat_id_LSTAT_XLAYER_WAKE as usize;
 const LSTAT_XLAYER_REWAKE: usize = bpf_intf::layer_stat_id_LSTAT_XLAYER_REWAKE as usize;
+const LSTAT_LLC_DRAIN_TRY: usize = bpf_intf::layer_stat_id_LSTAT_LLC_DRAIN_TRY as usize;
+const LSTAT_LLC_DRAIN: usize = bpf_intf::layer_stat_id_LSTAT_LLC_DRAIN as usize;
 
 const LLC_LSTAT_LAT: usize = bpf_intf::llc_layer_stat_id_LLC_LSTAT_LAT as usize;
 const LLC_LSTAT_CNT: usize = bpf_intf::llc_layer_stat_id_LLC_LSTAT_CNT as usize;
@@ -79,6 +81,8 @@ fn calc_frac(a: f64, b: f64) -> f64 {
 fn fmt_pct(v: f64) -> String {
     if v >= 99.995 {
         format!("{:5.1}", v)
+    } else if v > 0.0 && v < 0.01 {
+        format!("{:5.2}", 0.01)
     } else {
         format!("{:5.2}", v)
     }
@@ -168,6 +172,10 @@ pub struct LayerStats {
     pub xlayer_wake: f64,
     #[stat(desc = "% rewakers across layers where waker has waken the task previously")]
     pub xlayer_rewake: f64,
+    #[stat(desc = "% LLC draining tried")]
+    pub llc_drain_try: f64,
+    #[stat(desc = "% LLC draining succeeded")]
+    pub llc_drain: f64,
     #[stat(desc = "mask of allocated CPUs", _om_skip)]
     pub cpus: Vec<u32>,
     #[stat(desc = "count of CPUs assigned")]
@@ -264,6 +272,8 @@ impl LayerStats {
             xlayer_rewake: lstat_pct(LSTAT_XLAYER_REWAKE),
             xllc_migration: lstat_pct(LSTAT_XLLC_MIGRATION),
             xllc_migration_skip: lstat_pct(LSTAT_XLLC_MIGRATION_SKIP),
+            llc_drain_try: lstat_pct(LSTAT_LLC_DRAIN_TRY),
+            llc_drain: lstat_pct(LSTAT_LLC_DRAIN),
             cpus: Self::bitvec_to_u32s(layer.cpus.as_raw_bitvec()),
             cur_nr_cpus: layer.cpus.weight() as u32,
             min_nr_cpus: nr_cpus_range.0 as u32,
@@ -314,15 +324,6 @@ impl LayerStats {
 
         writeln!(
             w,
-            "  {:<width$}  xlayer_wake={} xlayer_rewake={}",
-            "",
-            fmt_pct(self.xlayer_wake),
-            fmt_pct(self.xlayer_rewake),
-            width = header_width,
-        )?;
-
-        writeln!(
-            w,
             "  {:<width$}  keep/max/busy={}/{}/{} kick={} yield/ign={}/{}",
             "",
             fmt_pct(self.keep),
@@ -357,6 +358,17 @@ impl LayerStats {
             fmt_pct(self.preempt_xnuma),
             fmt_pct(self.preempt_idle),
             fmt_pct(self.preempt_fail),
+            width = header_width,
+        )?;
+
+        writeln!(
+            w,
+            "  {:<width$}  xlayer_wake/re={}/{} llc_drain/try={}/{}",
+            "",
+            fmt_pct(self.xlayer_wake),
+            fmt_pct(self.xlayer_rewake),
+            fmt_pct(self.llc_drain),
+            fmt_pct(self.llc_drain_try),
             width = header_width,
         )?;
 


### PR DESCRIPTION
A layer is served by per-LLC DSQs. Only tasks that can be serviced by all
CPUs in an LLC are put in the DSQ, so as long as a CPU is assigned to the
layer in the LLC, forward progress is guaranteed. However, if a layer-LLC
loses all its CPUs, there is no forward progress guarantee ignoring the
antistall mechanism. For a confined layer, no CPU will be visiting the empty
LLCs and even for a grouped or open layer, execution from an LLC without
CPUs assigned is lower priority than owned execution and can easily starve.
    
To resolve the problem, implement LLC draining mechanism. When layer-LLC
loses all CPUs with tasks in it, draining is turned on and other CPUs
assigned to the layer will alternate between their own execution and
draining LLCs without any CPU. The interlockings between the involved code
paths - refresh_cpumasks(), layered_enqueue() and layered_dispatch() - are
rather intricate to guarantee that no tasks end up sitting in a CPU-less
LLC. See comments for details.
