### PR TITLE
scx_bpfland: server workload improvements

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -787,7 +787,7 @@ static void kick_task_cpu(struct task_struct *p)
 
 	cpu = pick_idle_cpu(p, cpu, 0, &is_idle);
 	if (is_idle)
-		scx_bpf_kick_cpu(cpu, 0);
+		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 }
 
 /*

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -286,7 +286,7 @@ static u64 task_weight(const struct task_struct *p, const struct task_ctx *tctx)
 	 * Scale the static task weight by the average amount of voluntary
 	 * context switches to determine the dynamic weight.
 	 */
-	u64 prio = p->scx.weight * CLAMP(tctx->avg_nvcsw, 1, nvcsw_max_thresh);
+	u64 prio = p->scx.weight * CLAMP(tctx->avg_nvcsw, 1, nvcsw_max_thresh ? : 1);
 
 	return CLAMP(prio, 1, MAX_TASK_WEIGHT);
 }


### PR DESCRIPTION
A set of improvements for scx_bpfland to enhance performance in server-oriented workloads.

When interactive task classification is disabled (`-c 0`), scx_bpfland can be suitable for more server-oriented scenarios, such as build servers. It can also serve as a "server profile" scheduler when used with tools like `cachyos-kernel-manager` in CachyOS.

With these changes and this "server profile" enabled, I'm able to speed up parallel kernel builds by ~2-3% (that seems to be consistent both AMD and Intel systems).