### PR TITLE
Install: Rework Arch Linux section

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,44 +58,9 @@ $ meson install -C build
 
 ## Arch Linux
 
-Import the gpg key. This can be skipped if the signature checking is disabled.
-
 ```
-$ sudo pacman-key --recv-keys F3B607488DB35A47 --keyserver keyserver.ubuntu.com
-$ sudo pacman-key --lsign-key F3B607488DB35A47
+sudo pacman -S scx-scheds
 ```
-
-If you haven't imported the GPG key, append the following line.
-
-```
-SigLevel = Never
-```
-
-#### Adding the Repository
-
-Install packages with a list of mirrors and GPG keys
-
-```
-$ sudo pacman -U 'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-keyring-20240331-1-any.pkg.tar.zst' 'https://mirror.cachyos.org/repo/x86_64/cachyos/cachyos-mirrorlist-18-1-any.pkg.tar.zst'
-```
-
-Add the following custom repository section to `/etc/pacman.conf`.
-
-```
-# cachyos repos
-[cachyos]
-Include = /etc/pacman.d/cachyos-mirrorlist
-```
-
-#### Installing the Kernel and Schedulers
-
-```
-$ sudo pacman -Sy cachyos/linux-sched-ext cachyos/linux-sched-ext-headers cachyos/scx-scheds
-```
-
-:warning: The kernel installs as `/boot/vmlinuz-linux-sched-ext` along with
-the matching initramfs. Update the bootloader configuration to add the boot
-entry for the new kernel.
 
 #### Setting Up Dev Environment
 
@@ -103,14 +68,6 @@ In addition to the packages from the previous step, install the following.
 
 ```
 $ sudo pacman -Sy meson cargo bpf pahole
-```
-
-#### Using Debug Kernel
-
-CachyOS does provide a kernel with an unstripped vmlinux, which can be used for debugging.
-
-```
-$ sudo pacman -Sy linux-cachyos-sched-ext-debug linux-cachyos-sched-ext-debug-headers
 ```
 
 ## Gentoo Linux
@@ -229,4 +186,3 @@ $ sudo scx_rusty
 #### Setting up Dev Environment
 
 No additional steps needed here other than what is mentioned in the main README.md.
-


### PR DESCRIPTION
scx-scheds and the 6.12 Kernel is now available in the official archlinux repository.
Therefore remove the instructions via the cachyos repository.

The only outstanding thing, is to get a proper unstripped vmlinux, which is used to debug sched-ext.
There is some ongoing [work](https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/merge_requests/3) to get this into the official archlinux repository.