### PR TITLE
scx_layered: Make layered work in pid namespaces

### DIFF
--- a/scheds/include/scx/namespace.bpf.h
+++ b/scheds/include/scx/namespace.bpf.h
@@ -5,11 +5,16 @@
 #ifndef __SCHED_EXT_NAMESPACE_BPF_H
 #define __SCHED_EXT_NAMESPACE_BPF_H
 
+#ifdef LSP
+#define __bpf__
+#include "../vmlinux.h"
+#else
 #include "vmlinux.h"
+#endif
 
-struct pid_namespace* get_task_pid_ns(const struct task_struct* task);
+struct pid_namespace* get_task_pid_ns(const struct task_struct* task, enum pid_type);
 struct pid* get_task_pid_ptr(const struct task_struct* task, enum pid_type type);
-pid_t get_task_ns_pid(const struct task_struct* task, enum pid_type type);
+pid_t get_task_ns_pid(const struct task_struct* task);
 
 pid_t get_pid_nr_ns(struct pid* pid, struct pid_namespace* ns);
 pid_t get_ns_pid(void);


### PR DESCRIPTION
Add an additional helper function to translate the scx_layered userspace tgid when running in a pid namespace.


Tested by running layered in a separate pid namespace:
```
$ cargo build --release && sudo unshare --mount-proc --fork -p ./target/release/scx_layered --run-example --stats 1 -vvv
```
Output from trace:
```
$ sudo bpftool prog trace | grep tgid
           <...>-242372  [061] ....1 3574039.989305: bpf_trace_printk: CFG layered running with tgid: 242372
$ pidof scx_layered
242372
```