### PR TITLE
scx_loader: fix recursion of type convertion

### DIFF
--- a/rust/scx_loader/src/config.rs
+++ b/rust/scx_loader/src/config.rs
@@ -103,7 +103,7 @@ pub fn get_scx_flags_for_mode(
     scx_sched: &SupportedSched,
     sched_mode: SchedMode,
 ) -> Vec<String> {
-    let scx_name: &str = scx_sched.into();
+    let scx_name: &str = scx_sched.clone().into();
     if let Some(sched_config) = config.scheds.get(scx_name) {
         let scx_flags = extract_scx_flags_from_config(sched_config, &sched_mode);
 

--- a/rust/scx_loader/src/lib.rs
+++ b/rust/scx_loader/src/lib.rs
@@ -44,23 +44,6 @@ pub enum SchedMode {
     Server = 4,
 }
 
-impl From<&SupportedSched> for &str {
-    fn from(scx_name: &SupportedSched) -> &'static str {
-        match scx_name {
-            SupportedSched::Bpfland => "scx_bpfland",
-            SupportedSched::Rusty => "scx_rusty",
-            SupportedSched::Lavd => "scx_lavd",
-            SupportedSched::Flash => "scx_flash",
-        }
-    }
-}
-
-impl From<SupportedSched> for &str {
-    fn from(scx_name: SupportedSched) -> &'static str {
-        scx_name.into()
-    }
-}
-
 impl FromStr for SupportedSched {
     type Err = anyhow::Error;
 
@@ -71,6 +54,24 @@ impl FromStr for SupportedSched {
             "scx_lavd" => Ok(SupportedSched::Lavd),
             "scx_flash" => Ok(SupportedSched::Flash),
             _ => Err(anyhow::anyhow!("{scx_name} is not supported")),
+        }
+    }
+}
+
+impl TryFrom<&str> for SupportedSched {
+    type Error = <SupportedSched as FromStr>::Err;
+    fn try_from(s: &str) -> Result<SupportedSched, Self::Error> {
+        <SupportedSched as FromStr>::from_str(s)
+    }
+}
+
+impl From<SupportedSched> for &str {
+    fn from(scx_name: SupportedSched) -> Self {
+        match scx_name {
+            SupportedSched::Bpfland => "scx_bpfland",
+            SupportedSched::Rusty => "scx_rusty",
+            SupportedSched::Lavd => "scx_lavd",
+            SupportedSched::Flash => "scx_flash",
         }
     }
 }

--- a/rust/scx_loader/src/main.rs
+++ b/rust/scx_loader/src/main.rs
@@ -73,7 +73,7 @@ impl ScxLoader {
     #[zbus(property)]
     async fn current_scheduler(&self) -> String {
         if let Some(current_scx) = &self.current_scx {
-            let current_scx: &str = current_scx.into();
+            let current_scx: &str = current_scx.clone().into();
             log::info!("called {current_scx:?}");
             return current_scx.to_owned();
         }
@@ -162,7 +162,7 @@ impl ScxLoader {
 
     async fn stop_scheduler(&mut self) -> zbus::fdo::Result<()> {
         if let Some(current_scx) = &self.current_scx {
-            let scx_name: &str = current_scx.into();
+            let scx_name: &str = current_scx.clone().into();
 
             log::info!("stopping {scx_name:?}..");
             let _ = self.channel.send(ScxMessage::StopSched);


### PR DESCRIPTION
Into trait was calling the Into<&SupportedSched> which was calling Into<SupportedSched> and so on.

```
    #0 0x622450e96149 in scx_loader::_$LT$impl$u20$core..convert..From$LT$scx_loader..SupportedSched$GT$$u20$for$u20$$RF$str$GT$::from::h13ba9d4271e33441 /tmp/scx/rust/scx_loader/src/lib.rs:60:9
    #1 0x622450e91af3 in _$LT$T$u20$as$u20$core..convert..Into$LT$U$GT$$GT$::into::h9481856c4f80c765 /home/vl/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:759:9
    #2 0x622450e9614a in scx_loader::_$LT$impl$u20$core..convert..From$LT$scx_loader..SupportedSched$GT$$u20$for$u20$$RF$str$GT$::from::h13ba9d4271e33441 /tmp/scx/rust/scx_loader/src/lib.rs:60:9
    #3 0x622450e91af3 in _$LT$T$u20$as$u20$core..convert..Into$LT$U$GT$$GT$::into::h9481856c4f80c765 /home/vl/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:759:9
    #4 0x622450e9614a in scx_loader::_$LT$impl$u20$core..convert..From$LT$scx_loader..SupportedSched$GT$$u20$for$u20$$RF$str$GT$::from::h13ba9d4271e33441 /tmp/scx/rust/scx_loader/src/lib.rs:60:9
    #5 0x622450e91af3 in _$LT$T$u20$as$u20$core..convert..Into$LT$U$GT$$GT$::into::h9481856c4f80c765 /home/vl/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:759:9
    #6 0x622450e9614a in scx_loader::_$LT$impl$u20$core..convert..From$LT$scx_loader..SupportedSched$GT$$u20$for$u20$$RF$str$GT$::from::h13ba9d4271e33441 /tmp/scx/rust/scx_loader/src/lib.rs:60:9
    #7 0x622450e91af3 in _$LT$T$u20$as$u20$core..convert..Into$LT$U$GT$$GT$::into::h9481856c4f80c765 /home/vl/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:759:9
    #8 0x622450e9614a in scx_loader::_$LT$impl$u20$core..convert..From$LT$scx_loader..SupportedSched$GT$$u20$for$u20$$RF$str$GT$::from::h13ba9d4271e33441 /tmp/scx/rust/scx_loader/src/lib.rs:60:9
    #9 0x622450e91af3 in _$LT$T$u20$as$u20$core..convert..Into$LT$U$GT$$GT$::into::h9481856c4f80c765 /home/vl/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:759:9
    #10 0x622450e9614a in scx_loader::_$LT$impl$u20$core..convert..From$LT$scx_loader..SupportedSched$GT$$u20$for$u20$$RF$str$GT$::from::h13ba9d4271e33441 /tmp/scx/rust/scx_loader/src/lib.rs:60:9
    #11 0x622450e91af3 in _$LT$T$u20$as$u20$core..convert..Into$LT$U$GT$$GT$::into::h9481856c4f80c765 /home/vl/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:759:9
    #12 0x622450e9614a in scx_loader::_$LT$impl$u20$core..convert..From$LT$scx_loader..SupportedSched$GT$$u20$for$u20$$RF$str$GT$::from::h13ba9d4271e33441 /tmp/scx/rust/scx_loader/src/lib.rs:60:9
    #13 0x622450e91af3 in _$LT$T$u20$as$u20$core..convert..Into$LT$U$GT$$GT$::into::h9481856c4f80c765 /home/vl/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:759:9
    #14 0x622450e9614a in scx_loader::_$LT$impl$u20$core..convert..From$LT$scx_loader..SupportedSched$GT$$u20$for$u20$$RF$str$GT$::from::h13ba9d4271e33441 /tmp/scx/rust/scx_loader/src/lib.rs:60:9
```