### PR TITLE
scx_layered: Add pid namespace layer matching

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -220,6 +220,7 @@ enum layer_match_kind {
 	MATCH_PID_EQUALS,
 	MATCH_PPID_EQUALS,
 	MATCH_TGID_EQUALS,
+	MATCH_NSPID_EQUALS,
 
 	NR_LAYER_MATCH_KINDS,
 };
@@ -235,6 +236,7 @@ struct layer_match {
 	u32		pid;
 	u32		ppid;
 	u32		tgid;
+	u64		nsid;
 };
 
 struct layer_match_ands {

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -71,6 +71,7 @@ pub enum LayerMatch {
     PIDEquals(u32),
     PPIDEquals(u32),
     TGIDEquals(u32),
+    NSPIDEquals(u64, u32),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -267,6 +267,8 @@ lazy_static! {
 ///
 /// - TGIDEquals: Matches if the task's tgid matches the value.
 ///
+/// - NSPIDEquals: Matches if the task's namespace id and pid matches the values.
+///
 /// While there are complexity limitations as the matches are performed in
 /// BPF, it is straightforward to add more types of matches.
 ///
@@ -1143,6 +1145,11 @@ impl<'a> Scheduler<'a> {
                         LayerMatch::TGIDEquals(tgid) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_TGID_EQUALS as i32;
                             mt.tgid = *tgid;
+                        }
+                        LayerMatch::NSPIDEquals(nsid, pid) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_NSPID_EQUALS as i32;
+                            mt.nsid = *nsid;
+                            mt.pid = *pid;
                         }
                     }
                 }


### PR DESCRIPTION
Tested with config:
```
...
{
  "name":"pid_ns",
  "comment":"pid_ns",
  "matches":[
     [{"NSPIDEquals":[4026531836, 132449]}]
  ],
  "kind": {
    "Confined":{
      "util_range": [0.25, 0.7],
      "growth_algo": "Random",
      "llcs": [1, 0],
      "preempt": false,
      "slice_us": 500,
      "exclusive": false
     }
  }
},
...
```
Shell:
```
$ echo $$
132449
$ readlink /proc/$$/ns/pid
pid:[4026531836]
```
layered output:
```
  pid_ns   : util/open/frac=   0.0/100.0/    0.0 tasks=     1
             tot=      0 local= 0.00 wake/exp/reenq= 0.00/ 0.00/ 0.00
             keep/max/busy= 0.00/ 0.00/ 0.00 kick= 0.00 yield/ign= 0.00/    0 
             open_idle= 0.00 mig= 0.00 xnuma_mig= 0.00 xllc_mig/skip= 0.00/ 0.00 affn_viol= 0.00
             preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00
             xlayer_wake/re= 0.00/ 0.00 llc_drain/try= 0.00/ 0.00
             slice=0.5ms min_exec= 0.00/   0.00ms
             cpus=  0 [  0,  0] 00000000 00000000 00000000
             [LLC] nr_cpus: sched% lat_ms
             [000]  0: 0.00%   0.00 |  0: 0.00%   0.00

```