### PR TITLE
[RFC] scx_flash: Favor prev task more in dispatch

### DIFF
--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -825,7 +825,6 @@ void BPF_STRUCT_OPS(flash_dispatch, s32 cpu, struct task_struct *prev)
 	    is_task_locked(prev)) {
 		task_unlock(prev);
 		task_refill_slice(prev);
-		return;
 	}
 
 	/*


### PR DESCRIPTION
## Summary
Originally we choose a new task to run each time we trigger "flash_dispatch", unless there's a task holding user-space lock. This leads to enormous triggers of "flash_dispatch" when we encounter heavy workloads, because each time the prev task may still be able to run, but instead we choose another task to run and let prev task wait for more.

We know shorter runtime tasks ,which are the ones we wish to prioritize, are the ones who tends to still be able to run, putting them back to origin CPU to let them finish faster and those CPU won't have to trigger "flash_dispatch" so frequently when we're dealing with heavy workloads.

## Tests
We utilize postgreSQL with pgbench to generate heavy workloads for the system and monitor the latency for queries, TPS, and number of transactions actually processed.
```
$ pgbench -h localhost -p 5432 -U postgres -c 100 -j 16 -T 120 -M prepared --protocol extended testdb
```
We compare EEVDF, scx_flash before the change and after the change.
### EEVDF
```
$ pgbench -h localhost -p 5432 -U postgres -c 100 -j 16 -T 120 -M prepared --protocol extended testdb
Password: 
pgbench (16.6 (Ubuntu 16.6-0ubuntu0.24.04.1), server 15.10 (Debian 15.10-1.pgdg120+1))
starting vacuum...end.
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 1000
query mode: extended
number of clients: 100
number of threads: 16
maximum number of tries: 1
duration: 120 s
number of transactions actually processed: 663015
number of failed transactions: 0 (0.000%)
latency average = 18.066 ms
initial connection time = 254.886 ms
tps = 5535.153684 (without initial connection time)
```

### scx_flash before change
```
$ pgbench -h localhost -p 5432 -U postgres -c 100 -j 16 -T 120 -M prepared --protocol extended testdb
Password:
pgbench (16.6 (Ubuntu 16.6-0ubuntu0.24.04.1), server 15.10 (Debian 15.10-1.pgdg120+1))
starting vacuum...end.
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 1000
query mode: extended
number of clients: 100
number of threads: 16
maximum number of tries: 1
duration: 120 s
number of transactions actually processed: 298540
number of failed transactions: 0 (0.000%)
latency average = 40.133 ms
initial connection time = 249.265 ms
tps = 2491.686311 (without initial connection time)
```

### scx_flash after change
```
$ pgbench -h localhost -p 5432 -U postgres -c 100 -j 16 -T 120 -M prepared --protocol extended testdb
Password:
pgbench (16.6 (Ubuntu 16.6-0ubuntu0.24.04.1), server 15.10 (Debian 15.10-1.pgdg120+1))
starting vacuum...end.
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 1000
query mode: extended
number of clients: 100
number of threads: 16
maximum number of tries: 1
duration: 120 s
number of transactions actually processed: 408782
number of failed transactions: 0 (0.000%)
latency average = 29.312 ms
initial connection time = 280.524 ms
tps = 3411.620821 (without initial connection time)
```

Though both perform worse than EEVDF, we can see some improvements in both number of transactions actually processed , latency average and TPS.

Btw, using bpftop to observe `flash_dispatch`, it seems that before the change, the handler's behavior tends to variate much more severse than after the change, I guess this is because before the change, CPU are too busy grabbing for new tasks from the global queue , and left tasks which is about to finish to wait unnecessary.

The tests ran on x86_64 architecture with AMD Ryzen 7 5700X3D 8-Core Processor.

*Maybe more workloads are need to be tested, please let me know I'll be happy to test them.*
