### PR TITLE
scx_flash: Explicitly return in "fexit_vfs_fsync_range"

### DIFF
--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -265,6 +265,7 @@ int BPF_PROG(fexit_vfs_fsync_range, struct file *file, u64 start, u64 end, int d
 	tctx = try_lookup_task_ctx(p);
 	if (tctx)
 		tctx->avg_nvcsw = 0;
+	return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
To elimate warning `src/bpf/main.bpf.c:268:2: error: non-void function '____fexit_vfs_fsync_range' should return a value [-Wreturn-type]` during compilation, explicitly return 0 within `fexit_vfs_fsync_range()`.
