### PR TITLE
scx_layered: Fix open layer handling

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -177,8 +177,8 @@ struct cpu_ctx {
 	u64			lo_fb_seq_at;
 	u64			lo_fb_usage_base;
 
-	u32			open_preempt_layer_order[MAX_LAYERS];
-	u32			open_layer_order[MAX_LAYERS];
+	u32			ogp_layer_order[MAX_LAYERS]; /* open/grouped preempt */
+	u32			ogn_layer_order[MAX_LAYERS]; /* open/grouped non-preempt */
 
 	struct cpu_prox_map	prox_map;
 };

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -167,6 +167,7 @@ struct cpu_ctx {
 
 	u64			hi_fb_dsq_id;
 	u64			lo_fb_dsq_id;
+	bool			in_open_layers;
 	u32			layer_id;
 	u32			task_layer_id;
 	u32			llc_id;
@@ -177,8 +178,13 @@ struct cpu_ctx {
 	u64			lo_fb_seq_at;
 	u64			lo_fb_usage_base;
 
-	u32			ogp_layer_order[MAX_LAYERS]; /* open/grouped preempt */
-	u32			ogn_layer_order[MAX_LAYERS]; /* open/grouped non-preempt */
+	u32			ogp_layer_order[MAX_LAYERS];	/* open/grouped preempt */
+	u32			ogn_layer_order[MAX_LAYERS];	/* open/grouped non-preempt */
+
+	u32			op_layer_order[MAX_LAYERS];	/* open preempt */
+	u32			on_layer_order[MAX_LAYERS];	/* open non-preempt */
+	u32			gp_layer_order[MAX_LAYERS];	/* grouped preempt */
+	u32			gn_layer_order[MAX_LAYERS];	/* grouped non-preempt */
 
 	struct cpu_prox_map	prox_map;
 };

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1621,17 +1621,31 @@ impl<'a> Scheduler<'a> {
             skel.maps.rodata_data.all_cpus[cpu / 8] |= 1 << (cpu % 8);
         }
 
-        skel.maps.rodata_data.nr_ogp_layers = layer_specs
+        skel.maps.rodata_data.nr_op_layers = layer_specs
             .iter()
             .filter(|spec| match &spec.kind {
-                LayerKind::Open { .. } | LayerKind::Grouped { .. } => spec.kind.common().preempt,
+                LayerKind::Open { .. } => spec.kind.common().preempt,
                 _ => false,
             })
             .count() as u32;
-        skel.maps.rodata_data.nr_ogn_layers = layer_specs
+        skel.maps.rodata_data.nr_on_layers = layer_specs
             .iter()
             .filter(|spec| match &spec.kind {
-                LayerKind::Open { .. } | LayerKind::Grouped { .. } => !spec.kind.common().preempt,
+                LayerKind::Open { .. } => !spec.kind.common().preempt,
+                _ => false,
+            })
+            .count() as u32;
+        skel.maps.rodata_data.nr_gp_layers = layer_specs
+            .iter()
+            .filter(|spec| match &spec.kind {
+                LayerKind::Grouped { .. } => spec.kind.common().preempt,
+                _ => false,
+            })
+            .count() as u32;
+        skel.maps.rodata_data.nr_gn_layers = layer_specs
+            .iter()
+            .filter(|spec| match &spec.kind {
+                LayerKind::Grouped { .. } => !spec.kind.common().preempt,
                 _ => false,
             })
             .count() as u32;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1357,7 +1357,7 @@ impl<'a> Scheduler<'a> {
             .context("Failed to lookup cpu_ctx")?
             .unwrap();
 
-        let open_preempt_layers: Vec<u32> = layer_specs
+        let ogp_layers: Vec<u32> = layer_specs
             .iter()
             .enumerate()
             .filter(|(_idx, spec)| match &spec.kind {
@@ -1366,7 +1366,7 @@ impl<'a> Scheduler<'a> {
             })
             .map(|(idx, _)| idx as u32)
             .collect();
-        let open_layers: Vec<u32> = layer_specs
+        let ogn_layers: Vec<u32> = layer_specs
             .iter()
             .enumerate()
             .filter(|(_idx, spec)| match &spec.kind {
@@ -1389,17 +1389,17 @@ impl<'a> Scheduler<'a> {
             cpu_ctxs[cpu].task_layer_id = MAX_LAYERS as u32;
             cpu_ctxs[cpu].is_big = is_big;
 
-            let mut p_order = open_preempt_layers.clone();
-            let mut o_order = open_layers.clone();
+            let mut ogp_order = ogp_layers.clone();
+            let mut ogn_order = ogn_layers.clone();
             fastrand::seed(cpu as u64);
-            fastrand::shuffle(&mut p_order);
-            fastrand::shuffle(&mut o_order);
+            fastrand::shuffle(&mut ogp_order);
+            fastrand::shuffle(&mut ogn_order);
 
             for i in 0..MAX_LAYERS {
-                cpu_ctxs[cpu].open_preempt_layer_order[i] =
-                    p_order.get(i).cloned().unwrap_or(MAX_LAYERS as u32);
-                cpu_ctxs[cpu].open_layer_order[i] =
-                    o_order.get(i).cloned().unwrap_or(MAX_LAYERS as u32);
+                cpu_ctxs[cpu].ogp_layer_order[i] =
+                    ogp_order.get(i).cloned().unwrap_or(MAX_LAYERS as u32);
+                cpu_ctxs[cpu].ogn_layer_order[i] =
+                    ogn_order.get(i).cloned().unwrap_or(MAX_LAYERS as u32);
             }
         }
 
@@ -1599,14 +1599,14 @@ impl<'a> Scheduler<'a> {
             skel.maps.rodata_data.all_cpus[cpu / 8] |= 1 << (cpu % 8);
         }
 
-        skel.maps.rodata_data.nr_open_preempt_layers = layer_specs
+        skel.maps.rodata_data.nr_ogp_layers = layer_specs
             .iter()
             .filter(|spec| match &spec.kind {
                 LayerKind::Open { .. } | LayerKind::Grouped { .. } => spec.kind.common().preempt,
                 _ => false,
             })
             .count() as u32;
-        skel.maps.rodata_data.nr_open_layers = layer_specs
+        skel.maps.rodata_data.nr_ogn_layers = layer_specs
             .iter()
             .filter(|spec| match &spec.kind {
                 LayerKind::Open { .. } | LayerKind::Grouped { .. } => !spec.kind.common().preempt,


### PR DESCRIPTION
Open layers get all the CPUs that aren't currently allocated to other types
of layers. If there are multiple open layers, they all share the unallocated
CPUs - ie. an otherwise unallocated CPU belongs to all open layers in the
system.
    
This wasn't handled correctly. An unallocated CPU was assigned to the first
open layer vai cpuc->layer_id and owned execution tracking and protection
only applied to the first open layer. Fix it by implementing dedicated paths
for open layers and treating all of them as the owners.
