### PR TITLE
scx_lavd: Ensure task stealing from all compute domains

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1182,7 +1182,7 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 		/*
 		 * Traverse neighbor in the same distance in arbitrary order.
 		 */
-		for (int j = 0; j < LAVD_CPDOM_MAX_NR; j++, nuance++) {
+		for (int j = 0; j < LAVD_CPDOM_MAX_NR; j++, nuance = dsq_id + 1) {
 			if (j >= nr_nbr)
 				break;
 
@@ -1251,7 +1251,7 @@ static bool force_to_steal_task(struct cpdom_ctx *cpdomc)
 		/*
 		 * Traverse neighbor in the same distance in arbitrary order.
 		 */
-		for (int j = 0; j < LAVD_CPDOM_MAX_NR; j++, nuance++) {
+		for (int j = 0; j < LAVD_CPDOM_MAX_NR; j++, nuance = dsq_id + 1) {
 			if (j >= nr_nbr)
 				break;
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1010,6 +1010,7 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 		 * disptach the task to the idle cpu right now.
 		 */
 		direct_dispatch(p, taskc, 0);
+		scx_bpf_kick_cpu(cpu_id, SCX_KICK_IDLE);
 		return cpu_id;
 	}
 


### PR DESCRIPTION
This PR ensures task stealing from all compute domains by changing the way to iterate neighbor bits. Also, it includes a minor (latency) optimization in ops.select_cpu() path and code refactoring at ops.dispatch() for readability. 