### PR TITLE
lib/sdt_alloc: fix LLVM19 compilation error

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -488,7 +488,8 @@ __hidden
 struct sdt_data __arena *sdt_alloc(struct sdt_allocator *alloc)
 {
 	struct sdt_alloc_stack __arena *stack = prealloc_stack;
-	struct sdt_data __arena *data = NULL, __arena *val;
+	struct sdt_data __arena *data = NULL;
+	struct sdt_data __arena *val;
 	sdt_desc_t *desc;
 	struct sdt_chunk __arena *chunk;
 	__u64 idx, pos;

--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -106,7 +106,7 @@ void sdt_task_free(struct task_struct *p);
 void sdt_arena_verify(void);
 
 int sdt_alloc_init(struct sdt_allocator *alloc, __u64 data_size);
-struct sdt_data __arena __arena *sdt_alloc(struct sdt_allocator *alloc);
+struct sdt_data __arena *sdt_alloc(struct sdt_allocator *alloc);
 void sdt_free_idx(struct sdt_allocator *alloc, __u64 idx);
 
 #endif /* __BPF__ */


### PR DESCRIPTION
Fix a compilation error on Clang 19 caused by defining multiple arena pointers in a single comma separated statement. Also fix a duplicate use of ```__arena``` that causes LLVM to emit a warning.