### PR TITLE
bpf_builder: emit warnings from clang

### DIFF
--- a/rust/scx_utils/src/bpf_builder.rs
+++ b/rust/scx_utils/src/bpf_builder.rs
@@ -380,12 +380,16 @@ impl BpfBuilder {
         let obj = self.out_dir.join(format!("{}.bpf.o", name));
         let skel_path = self.out_dir.join(format!("{}_skel.rs", name));
 
-        SkeletonBuilder::new()
+        let output = SkeletonBuilder::new()
             .source(input)
             .obj(&obj)
             .clang(&self.clang.clang)
             .clang_args(&self.cflags)
             .build_and_generate(&skel_path)?;
+
+        for line in String::from_utf8_lossy(output.stderr()).lines() {
+            println!("cargo:warning={}", line);
+        }
 
         let c_path = PathBuf::from(input);
         let dir = c_path


### PR DESCRIPTION

Use the new feature in libbpf-cargo to emit warnings from clang when building.
There are a fair amount of warnings but I won't fix them here.

Closes #895

Test plan:
- `cargo build --release` - warnings look good!
- CI
