### PR TITLE
build: Allow to build bpftool with clang

### DIFF
--- a/meson-scripts/build_bpftool
+++ b/meson-scripts/build_bpftool
@@ -23,6 +23,13 @@ for arg in ${args[@]:(idx+1)}; do
     esac
 done
 
+extra_args=()
+# When using clang, `LLVM=1` needs to be passed as an argument. Otherwise some
+# parts of the build system will attempt to invoke GCC.
+if cc --version 2>&1 | grep clang; then
+    extra_args+="LLVM=1"
+fi
+
 cd $3
-make_out=$(env CC="$cc" CFLAGS="$cflags" "$2" -j"$4")
+make_out=$(env CC="$cc" CFLAGS="$cflags" "$2" -j"$4" $extra_args)
 exit $?


### PR DESCRIPTION
On systems which use clang, instead of GCC, as the main compiler, building any part of the Linux monorepo often requires passing `LLVM=1` in the `m̀ake` invocation. Otherwise it assumes that the system has GCC and ends up invoking `gcc` explicitly. That's the case with bpftool.

To avoid such issues, check whether the default `cc` compiler is clang and if yes, set the `LLVM` parameter accordingly.

Fixes #1143