### PR TITLE
scx_utils: emit compilation warning when compiling multiple *.bpf.c files

### DIFF
--- a/rust/scx_utils/src/bpf_builder.rs
+++ b/rust/scx_utils/src/bpf_builder.rs
@@ -343,13 +343,17 @@ impl BpfBuilder {
         for filename in self.sources.iter() {
             let obj = self.out_dir.join(name.replace(".bpf.c", ".bpf.o"));
 
-            SkeletonBuilder::new()
+            let output = SkeletonBuilder::new()
                 .debug(true)
                 .source(filename)
                 .obj(&obj)
                 .clang(&self.clang.clang)
                 .clang_args(&self.cflags)
                 .build()?;
+
+            for line in String::from_utf8_lossy(output.stderr()).lines() {
+                println!("cargo:warning={}", line);
+            }
 
             linker.add_file(&obj)?;
         }


### PR DESCRIPTION
Commit a4739e9 introduces code in ```scx_utils``` to capture and emit Clang warnings when compiling the BPF schedulers.  Schedulers like ```scx_layered``` use a separate code path in ```scx_utils``` in which we still do not emit Clang warnings. Reuse the code from a4739e9 in those code paths to emit warnings for schedulers that use multiple compilation units.