### PR TITLE
scx_bpfland: do not allow per-CPU kthread to preempt other tasks

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -690,8 +690,7 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	 * If local_kthread is specified dispatch all kthreads directly.
 	 */
 	if (is_kthread(p) && (local_kthreads || p->nr_cpus_allowed == 1)) {
-		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL,
-				   enq_flags | SCX_ENQ_PREEMPT);
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL, enq_flags);
 		__sync_fetch_and_add(&nr_kthread_dispatches, 1);
 		return;
 	}


### PR DESCRIPTION
While prioritizing per-CPU kthreads is generally a good idea due to their critical role in the system, allowing them to preempt other tasks indiscriminately can result in significant scheduling overhead sometimes.

A notable example is starting a VM, which can be quite inefficient if we allow with per-CPU kthread preemption.

For instance, running a simple `time vng -- uname -r` produces the following results:

 - EEVDF:              1.53 seconds
 - bpfland:            3.30 seconds
 - bpfland-no-preempt: 1.32 seconds

Moreover, disabling per-CPU kthread preemption does not appear to introduce any regressions in typical latency-sensitive benchmarks.

Therefore, it makes sense to disable preemption for the per-CPU kthreads.