### PR TITLE
meson.build: enable LTO and -O3 for C schedulers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,11 @@
 project('sched_ext schedulers', 'c',
         version: '1.0.8',
         license: 'GPL-2.0',
-        meson_version : '>= 1.2.0',)
+        meson_version : '>= 1.2.0',
+        default_options : [
+          'optimization=3',
+          'b_lto=true',
+        ])
 
 fs = import('fs')
 
@@ -247,7 +251,7 @@ if cpu not in arch_dict
 endif
 
 sys_incls = run_command(get_sys_incls, bpf_clang, check: true).stdout().splitlines()
-bpf_base_cflags = ['-g', '-O2', '-Wall', '-Wno-compare-distinct-pointer-types',
+bpf_base_cflags = ['-g', '-O3', '-Wall', '-Wno-compare-distinct-pointer-types',
                    '-D__TARGET_ARCH_' + arch_dict[cpu], '-mcpu=v3',
                    '-m@0@-endian'.format(host_machine.endian())] + sys_incls
 


### PR DESCRIPTION
Follow-up of https://github.com/sched-ext/scx/pull/1011.

We can also set `b_lto_mode` to `thin`. Clang is especially good with thin-lto I hear. (https://mesonbuild.com/Builtin-options.html#base-options)

CC https://github.com/sched-ext/scx/issues/1010
CC @ptr1337 @htejun