### PR TITLE
meson: do not link BPF library into C schedulers by default

### DIFF
--- a/meson-scripts/bpftool_build_skel
+++ b/meson-scripts/bpftool_build_skel
@@ -6,20 +6,14 @@ bpftool="$1"
 input="$2"
 skel="$3"
 subskel="$4"
-lib="$5"
 
 stem="${input%.o}"
 name="${input%.bpf.o}"
 name="${name##*/}"
 
-if [ `basename $lib` == $name ];
-then
-	"$bpftool" gen object "$stem".l1o "$input"
-else
-	"$bpftool" gen object "$stem".l1o "$input" "$lib".bpf.o
-	"$bpftool" gen object "$stem".l2o "$stem".l1o
-	"$bpftool" gen object "$stem".l3o "$stem".l2o
-	cmp "$stem".l2o "$stem".l3o
-	"$bpftool" gen skeleton "$stem".l3o name "$name" > "$skel"
-	"$bpftool" gen subskeleton "$stem".l3o name "$name" > "$subskel"
-fi
+"$bpftool" gen object "$stem".l1o "$input"
+"$bpftool" gen object "$stem".l2o "$stem".l1o
+"$bpftool" gen object "$stem".l3o "$stem".l2o
+cmp "$stem".l2o "$stem".l3o
+"$bpftool" gen skeleton "$stem".l3o name "$name" > "$skel"
+"$bpftool" gen subskeleton "$stem".l3o name "$name" > "$subskel"

--- a/meson-scripts/bpftool_build_skel_lib
+++ b/meson-scripts/bpftool_build_skel_lib
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+bpftool="$1"
+input="$2"
+skel="$3"
+subskel="$4"
+lib="$5"
+
+stem="${input%.o}"
+name="${input%.bpf.o}"
+name="${name##*/}"
+
+if [ -z "$lib" ] || [ `basename $lib` == $name ];
+then
+	"$bpftool" gen object "$stem".l1o "$input"
+else
+	"$bpftool" gen object "$stem".l1o "$input" "$lib".bpf.o
+	"$bpftool" gen object "$stem".l2o "$stem".l1o
+	"$bpftool" gen object "$stem".l3o "$stem".l2o
+	cmp "$stem".l2o "$stem".l3o
+	"$bpftool" gen skeleton "$stem".l3o name "$name" > "$skel"
+	"$bpftool" gen subskeleton "$stem".l3o name "$name" > "$subskel"
+fi

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,8 @@ get_bpftool_ver = find_program(join_paths(meson.current_source_dir(),
                                           'meson-scripts/get_bpftool_ver'))
 bpftool_build_skel = find_program(join_paths(meson.current_source_dir(),
                                              'meson-scripts/bpftool_build_skel'))
+bpftool_build_skel_lib = find_program(join_paths(meson.current_source_dir(),
+                                             'meson-scripts/bpftool_build_skel_lib'))
 get_sys_incls = find_program(join_paths(meson.current_source_dir(),
                                         'meson-scripts/get_sys_incls'))
 test_sched  = find_program(join_paths(meson.current_source_dir(),
@@ -284,9 +286,13 @@ gen_bpf_o = generator(bpf_clang,
 
 gen_bpf_skel = generator(bpftool_build_skel,
                          output: ['@BASENAME@.skel.h','@BASENAME@.subskel.h' ],
+                         depends: [libbpf, bpftool_target],
+                         arguments: [bpftool_exe_path, '@INPUT@', '@OUTPUT0@', '@OUTPUT1@'])
+
+gen_bpf_skel_lib = generator(bpftool_build_skel_lib,
+                         output: ['@BASENAME@.skel.h','@BASENAME@.subskel.h' ],
                          depends: [libbpf, bpftool_target, scx_lib],
                          arguments: [bpftool_exe_path, '@INPUT@', '@OUTPUT0@', '@OUTPUT1@', scx_lib_path])
-
 
 #
 # For rust sub-projects.

--- a/meson.build
+++ b/meson.build
@@ -278,13 +278,13 @@ subdir('lib')
 #
 gen_bpf_o = generator(bpf_clang,
                       output: '@BASENAME@.o',
-                      depends: [libbpf, scx_lib],
+                      depends: [libbpf],
                       arguments: [bpf_base_cflags, '-target', 'bpf', libbpf_c_headers, bpf_includes,
                                   '-c', '@INPUT@', '-o', '@OUTPUT@'])
 
 gen_bpf_skel = generator(bpftool_build_skel,
                          output: ['@BASENAME@.skel.h','@BASENAME@.subskel.h' ],
-                         depends: [libbpf, bpftool_target],
+                         depends: [libbpf, bpftool_target, scx_lib],
                          arguments: [bpftool_exe_path, '@INPUT@', '@OUTPUT0@', '@OUTPUT1@', scx_lib_path])
 
 

--- a/scheds/c/meson.build
+++ b/scheds/c/meson.build
@@ -4,7 +4,7 @@ c_scheds = ['scx_simple', 'scx_qmap', 'scx_central', 'scx_userland', 'scx_nest',
 foreach sched: c_scheds
   thread_dep = dependency('threads')
   bpf_o = gen_bpf_o.process(sched + '.bpf.c')
-  bpf_skel = gen_bpf_skel.process(bpf_o, scx_lib)
+  bpf_skel = gen_bpf_skel.process(bpf_o)
   executable(sched, [bpf_skel, sched + '.c'],
              include_directories: [user_c_includes],
              dependencies: [kernel_dep, libbpf_dep, thread_dep],

--- a/scheds/c/meson.build
+++ b/scheds/c/meson.build
@@ -1,10 +1,22 @@
 c_scheds = ['scx_simple', 'scx_qmap', 'scx_central', 'scx_userland', 'scx_nest',
-            'scx_flatcg', 'scx_pair', 'scx_sdt']
+            'scx_flatcg', 'scx_pair']
+
+c_scheds_lib = ['scx_sdt']
+
+thread_dep = dependency('threads')
 
 foreach sched: c_scheds
-  thread_dep = dependency('threads')
   bpf_o = gen_bpf_o.process(sched + '.bpf.c')
   bpf_skel = gen_bpf_skel.process(bpf_o)
+  executable(sched, [bpf_skel, sched + '.c'],
+             include_directories: [user_c_includes],
+             dependencies: [kernel_dep, libbpf_dep, thread_dep],
+             install: true)
+endforeach
+
+foreach sched: c_scheds_lib
+  bpf_o = gen_bpf_o.process(sched + '.bpf.c')
+  bpf_skel = gen_bpf_skel_lib.process(bpf_o)
   executable(sched, [bpf_skel, sched + '.c'],
              include_directories: [user_c_includes],
              dependencies: [kernel_dep, libbpf_dep, thread_dep],


### PR DESCRIPTION
Meson currently defaults to building and linking the BPF library into all existing C schedulers, but that has caused build errors even for schedulers that do not use it (most recently scx_vder). Split the existing Meson build path in two, depending on whether the library should be linked into the scheduler. 

This change does not affect Rust schedulers.