### PR TITLE
scxtop: Add additional bpf kprobes

### DIFF
--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -30,12 +30,14 @@ struct bpf_event {
 	u64		dsq_lat_us;
 	u32		dsq_nr;
 	u64		dsq_vtime;
+	u64		slice_ns;
 };
 
 struct task_ctx {
 	u64		dsq_id;
 	u64		dsq_insert_time;
 	u64		dsq_vtime;
+	u64		slice_ns;
 };
 
 #endif /* __INTF_H */

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -121,6 +121,48 @@ async fn run() -> Result<()> {
     {
         links.push(link);
     }
+    if let Ok(link) = skel
+        .progs
+        .scx_dispatch_from_dsq_set_vtime
+        .attach_kprobe(false, "scx_bpf_dispatch_from_dsq_set_vtime")
+    {
+        links.push(link);
+    }
+    if let Ok(link) = skel
+        .progs
+        .scx_dsq_move_set_vtime
+        .attach_kprobe(false, "scx_bpf_dsq_move_set_vtime")
+    {
+        links.push(link);
+    }
+    if let Ok(link) = skel
+        .progs
+        .scx_dsq_move_set_slice
+        .attach_kprobe(false, "scx_bpf_dsq_move_set_slice")
+    {
+        links.push(link);
+    }
+    if let Ok(link) = skel
+        .progs
+        .scx_dispatch_from_dsq_set_slice
+        .attach_kprobe(false, "scx_bpf_dispatch_from_dsq_set_slice")
+    {
+        links.push(link);
+    }
+    if let Ok(link) = skel
+        .progs
+        .scx_dispatch_from_dsq
+        .attach_kprobe(false, "scx_bpf_dispatch_from_dsq")
+    {
+        links.push(link);
+    }
+    if let Ok(link) = skel
+        .progs
+        .scx_dsq_move
+        .attach_kprobe(false, "scx_bpf_dsq_move")
+    {
+        links.push(link);
+    }
 
     let keymap = KeyMap::default();
     let tui = Tui::new(keymap.clone(), args.tick_rate_ms)?;


### PR DESCRIPTION
Add kprobes for handling various events so that dispatch latency and vtime tracking can be more accurate.