### PR TITLE
lib: remove header install step now that headers are in scheds/include

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -20,6 +20,3 @@ scx_lib = custom_target(scx_lib_name,
   command: [compile_scx_lib, bpftool_exe_path, '@OUTPUT@', scx_lib_name, objs],
   depends: objs,
 )
-
-# Install include/lib as a lib/ subdir of our headers
-install_subdir(join_paths(meson.current_source_dir(), 'include/lib'), install_dir: 'include', install_tag: 'devel')


### PR DESCRIPTION
The library headers got moved to scheds/include a while ago, so they get installed along with them. Remove the now unnecessary header install command from lib/.