### PR TITLE
scheds: Use crate version for --version

### DIFF
--- a/rust/scx_utils/src/build_id.rs
+++ b/rust/scx_utils/src/build_id.rs
@@ -29,7 +29,7 @@ lazy_static::lazy_static! {
     };
 }
 
-fn full_version(semver: &str) -> String {
+pub fn full_version(semver: &str) -> String {
     let mut ver = semver.to_string();
     if GIT_VERSION.len() > 0 {
         write!(ver, "-{}", &*GIT_VERSION).unwrap();

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -233,7 +233,7 @@ impl<'a> Scheduler<'a> {
         info!(
             "{} {} {}",
             SCHEDULER_NAME,
-            *build_id::SCX_FULL_VERSION,
+            build_id::full_version(env!("CARGO_PKG_VERSION")),
             if smt_enabled { "SMT on" } else { "SMT off" }
         );
 
@@ -578,7 +578,11 @@ fn main() -> Result<()> {
     let opts = Opts::parse();
 
     if opts.version {
-        println!("{} {}", SCHEDULER_NAME, *build_id::SCX_FULL_VERSION);
+        println!(
+            "{} {}",
+            SCHEDULER_NAME,
+            build_id::full_version(env!("CARGO_PKG_VERSION"))
+        );
         return Ok(());
     }
 

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -132,7 +132,7 @@ impl<'a> Scheduler<'a> {
         info!(
             "{} {} {}",
             SCHEDULER_NAME,
-            *build_id::SCX_FULL_VERSION,
+            build_id::full_version(env!("CARGO_PKG_VERSION")),
             if smt_enabled { "SMT on" } else { "SMT off" }
         );
 
@@ -290,7 +290,11 @@ fn main() -> Result<()> {
     let opts = Opts::parse();
 
     if opts.version {
-        println!("{} {}", SCHEDULER_NAME, *build_id::SCX_FULL_VERSION);
+        println!(
+            "{} {}",
+            SCHEDULER_NAME,
+            build_id::full_version(env!("CARGO_PKG_VERSION"))
+        );
         return Ok(());
     }
 

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -888,7 +888,10 @@ fn main() -> Result<()> {
     let mut opts = Opts::parse();
 
     if opts.version {
-        println!("scx_lavd {}", *build_id::SCX_FULL_VERSION);
+        println!(
+            "scx_lavd {}",
+            build_id::full_version(env!("CARGO_PKG_VERSION"))
+        );
         return Ok(());
     }
 
@@ -940,7 +943,7 @@ fn main() -> Result<()> {
         let mut sched = Scheduler::init(&opts, &mut open_object)?;
         info!(
             "scx_lavd scheduler is initialized (build ID: {})",
-            *build_id::SCX_FULL_VERSION
+            build_id::full_version(env!("CARGO_PKG_VERSION"))
         );
         info!("scx_lavd scheduler starts running.");
         if !sched.run(&opts, shutdown.clone())?.should_restart() {

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -361,7 +361,7 @@ impl<'a> Scheduler<'a> {
         init_libbpf_logging(None);
         info!(
             "Running scx_rusty (build ID: {})",
-            *build_id::SCX_FULL_VERSION
+            build_id::full_version(env!("CARGO_PKG_VERSION"))
         );
         let mut skel = scx_ops_open!(skel_builder, open_object, rusty).unwrap();
 
@@ -628,7 +628,10 @@ fn main() -> Result<()> {
     let opts = Opts::parse();
 
     if opts.version {
-        println!("scx_rusty: {}", *build_id::SCX_FULL_VERSION);
+        println!(
+            "scx_rusty: {}",
+            build_id::full_version(env!("CARGO_PKG_VERSION"))
+        );
         return Ok(());
     }
 


### PR DESCRIPTION
For bpfland, flash, lavd and rusty this changes the --version to report
the version in the Cargo.toml for each scheduler, instead of the version
of scx_utils.

Fixes #1168 

Signed-off-by: Fredrik Lönnegren <fredrik@frelon.se>
