### PR TITLE
scxtop: Add CPU frequency to default sparkline view

### DIFF
--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -79,7 +79,7 @@ mod infeasible;
 pub use infeasible::LoadAggregator;
 pub use infeasible::LoadLedger;
 
-mod misc;
+pub mod misc;
 pub use misc::monitor_stats;
 pub use misc::normalize_load_metric;
 pub use misc::set_rlimit_infinity;

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -44,6 +44,7 @@ impl KeyMap {
                 state: AppState::Event,
             },
         );
+        bindings.insert(Key::Char('f'), Action::ToggleCpuFreq);
         bindings.insert(
             Key::Char('h'),
             Action::SetState {

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -32,6 +32,7 @@ pub use stats::VecStats;
 pub use theme::AppTheme;
 pub use tui::Event;
 pub use tui::Tui;
+pub use util::format_hz;
 pub use util::read_file_string;
 
 pub use plain::Plain;
@@ -121,6 +122,7 @@ pub enum Action {
         state: AppState,
     },
     NextViewState,
+    ToggleCpuFreq,
     TickRateChange {
         tick_rate_ms: u64,
     },

--- a/tools/scxtop/src/util.rs
+++ b/tools/scxtop/src/util.rs
@@ -14,3 +14,13 @@ pub fn read_file_string(path: &str) -> Result<String> {
     file.read_to_string(&mut contents)?;
     Ok(contents)
 }
+
+/// Formats a value in hz to human readable.
+pub fn format_hz(hz: u64) -> String {
+    match hz {
+        0..=999 => format!("{}Hz", hz),
+        1_000..=999_999 => format!("{:.0}MHz", hz as f64 / 1_000.0),
+        1_000_000..=999_999_999 => format!("{:.3}GHz", hz as f64 / 1_000_000.0),
+        _ => format!("{:.3}THz", hz as f64 / 1_000_000_000.0),
+    }
+}


### PR DESCRIPTION
Add CPU frequency to the sparkline default view.

sparkline:
![2025-01-10-20:59:02](https://github.com/user-attachments/assets/3c8a787d-03e2-491c-9cc4-60d7d8570a06)
barchart:
![2025-01-10-22:21:25](https://github.com/user-attachments/assets/f8d21a62-522c-4d34-816e-96e8e6818799)

Can be toggled with the `f` key.
