### PR TITLE
scheds: Sync scx schedulers with the kernel changes: time_helpers and scx_bpf_now()

### DIFF
--- a/scheds/c/scx_central.bpf.c
+++ b/scheds/c/scx_central.bpf.c
@@ -87,11 +87,6 @@ struct {
 	__type(value, struct central_timer);
 } central_timer SEC(".maps");
 
-static bool vtime_before(u64 a, u64 b)
-{
-	return (s64)(a - b) < 0;
-}
-
 s32 BPF_STRUCT_OPS(central_select_cpu, struct task_struct *p,
 		   s32 prev_cpu, u64 wake_flags)
 {
@@ -245,7 +240,7 @@ void BPF_STRUCT_OPS(central_running, struct task_struct *p)
 	s32 cpu = scx_bpf_task_cpu(p);
 	u64 *started_at = ARRAY_ELEM_PTR(cpu_started_at, cpu, nr_cpu_ids);
 	if (started_at)
-		*started_at = bpf_ktime_get_ns() ?: 1;	/* 0 indicates idle */
+		*started_at = scx_bpf_now() ?: 1;	/* 0 indicates idle */
 }
 
 void BPF_STRUCT_OPS(central_stopping, struct task_struct *p, bool runnable)
@@ -258,7 +253,7 @@ void BPF_STRUCT_OPS(central_stopping, struct task_struct *p, bool runnable)
 
 static int central_timerfn(void *map, int *key, struct bpf_timer *timer)
 {
-	u64 now = bpf_ktime_get_ns();
+	u64 now = scx_bpf_now();
 	u64 nr_to_kick = nr_queued;
 	s32 i, curr_cpu;
 
@@ -279,7 +274,7 @@ static int central_timerfn(void *map, int *key, struct bpf_timer *timer)
 		/* kick iff the current one exhausted its slice */
 		started_at = ARRAY_ELEM_PTR(cpu_started_at, cpu, nr_cpu_ids);
 		if (started_at && *started_at &&
-		    vtime_before(now, *started_at + slice_ns))
+		    time_before(now, *started_at + slice_ns))
 			continue;
 
 		/* and there's something pending */

--- a/scheds/c/scx_flatcg.bpf.c
+++ b/scheds/c/scx_flatcg.bpf.c
@@ -137,11 +137,6 @@ static u64 div_round_up(u64 dividend, u64 divisor)
 	return (dividend + divisor - 1) / divisor;
 }
 
-static bool vtime_before(u64 a, u64 b)
-{
-	return (s64)(a - b) < 0;
-}
-
 static bool cgv_node_less(struct bpf_rb_node *a, const struct bpf_rb_node *b)
 {
 	struct cgv_node *cgc_a, *cgc_b;
@@ -271,7 +266,7 @@ static void cgrp_cap_budget(struct cgv_node *cgv_node, struct fcg_cgrp_ctx *cgc)
 	 */
 	max_budget = (cgrp_slice_ns * nr_cpus * cgc->hweight) /
 		(2 * FCG_HWEIGHT_ONE);
-	if (vtime_before(cvtime, cvtime_now - max_budget))
+	if (time_before(cvtime, cvtime_now - max_budget))
 		cvtime = cvtime_now - max_budget;
 
 	cgv_node->cvtime = cvtime;
@@ -401,7 +396,7 @@ void BPF_STRUCT_OPS(fcg_enqueue, struct task_struct *p, u64 enq_flags)
 		 * Limit the amount of budget that an idling task can accumulate
 		 * to one slice.
 		 */
-		if (vtime_before(tvtime, cgc->tvtime_now - SCX_SLICE_DFL))
+		if (time_before(tvtime, cgc->tvtime_now - SCX_SLICE_DFL))
 			tvtime = cgc->tvtime_now - SCX_SLICE_DFL;
 
 		scx_bpf_dsq_insert_vtime(p, cgrp->kn->id, SCX_SLICE_DFL,
@@ -535,7 +530,7 @@ void BPF_STRUCT_OPS(fcg_running, struct task_struct *p)
 		 * from multiple CPUs and thus racy. Any error should be
 		 * contained and temporary. Let's just live with it.
 		 */
-		if (vtime_before(cgc->tvtime_now, p->scx.dsq_vtime))
+		if (time_before(cgc->tvtime_now, p->scx.dsq_vtime))
 			cgc->tvtime_now = p->scx.dsq_vtime;
 	}
 	bpf_cgroup_release(cgrp);
@@ -645,7 +640,7 @@ static bool try_pick_next_cgroup(u64 *cgidp)
 	cgv_node = container_of(rb_node, struct cgv_node, rb_node);
 	cgid = cgv_node->cgid;
 
-	if (vtime_before(cvtime_now, cgv_node->cvtime))
+	if (time_before(cvtime_now, cgv_node->cvtime))
 		cvtime_now = cgv_node->cvtime;
 
 	/*
@@ -734,7 +729,7 @@ void BPF_STRUCT_OPS(fcg_dispatch, s32 cpu, struct task_struct *prev)
 	struct fcg_cpu_ctx *cpuc;
 	struct fcg_cgrp_ctx *cgc;
 	struct cgroup *cgrp;
-	u64 now = bpf_ktime_get_ns();
+	u64 now = scx_bpf_now();
 	bool picked_next = false;
 
 	cpuc = find_cpu_ctx();
@@ -744,7 +739,7 @@ void BPF_STRUCT_OPS(fcg_dispatch, s32 cpu, struct task_struct *prev)
 	if (!cpuc->cur_cgid)
 		goto pick_next_cgroup;
 
-	if (vtime_before(now, cpuc->cur_at + cgrp_slice_ns)) {
+	if (time_before(now, cpuc->cur_at + cgrp_slice_ns)) {
 		if (scx_bpf_dsq_move_to_local(cpuc->cur_cgid)) {
 			stat_inc(FCG_STAT_CNS_KEEP);
 			return;
@@ -920,14 +915,14 @@ void BPF_STRUCT_OPS(fcg_cgroup_move, struct task_struct *p,
 		    struct cgroup *from, struct cgroup *to)
 {
 	struct fcg_cgrp_ctx *from_cgc, *to_cgc;
-	s64 vtime_delta;
+	s64 delta;
 
 	/* find_cgrp_ctx() triggers scx_ops_error() on lookup failures */
 	if (!(from_cgc = find_cgrp_ctx(from)) || !(to_cgc = find_cgrp_ctx(to)))
 		return;
 
-	vtime_delta = p->scx.dsq_vtime - from_cgc->tvtime_now;
-	p->scx.dsq_vtime = to_cgc->tvtime_now + vtime_delta;
+	delta = time_delta(p->scx.dsq_vtime, from_cgc->tvtime_now);
+	p->scx.dsq_vtime = to_cgc->tvtime_now + delta;
 }
 
 s32 BPF_STRUCT_OPS_SLEEPABLE(fcg_init)

--- a/scheds/c/scx_pair.bpf.c
+++ b/scheds/c/scx_pair.bpf.c
@@ -239,11 +239,6 @@ u64 nr_cgrp_next, nr_cgrp_coll, nr_cgrp_empty;
 
 UEI_DEFINE(uei);
 
-static bool time_before(u64 a, u64 b)
-{
-	return (s64)(a - b) < 0;
-}
-
 void BPF_STRUCT_OPS(pair_enqueue, struct task_struct *p, u64 enq_flags)
 {
 	struct cgroup *cgrp;

--- a/scheds/c/scx_pair.bpf.c
+++ b/scheds/c/scx_pair.bpf.c
@@ -313,7 +313,7 @@ static int try_dispatch(s32 cpu)
 	struct pair_ctx *pairc;
 	struct bpf_map *cgq_map;
 	struct task_struct *p;
-	u64 now = bpf_ktime_get_ns();
+	u64 now = scx_bpf_now();
 	bool kick_pair = false;
 	bool expired, pair_preempted;
 	u32 *vptr, in_pair_mask;

--- a/scheds/c/scx_simple.bpf.c
+++ b/scheds/c/scx_simple.bpf.c
@@ -52,11 +52,6 @@ static void stat_inc(u32 idx)
 		(*cnt_p)++;
 }
 
-static inline bool vtime_before(u64 a, u64 b)
-{
-	return (s64)(a - b) < 0;
-}
-
 s32 BPF_STRUCT_OPS(simple_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wake_flags)
 {
 	bool is_idle = false;
@@ -84,7 +79,7 @@ void BPF_STRUCT_OPS(simple_enqueue, struct task_struct *p, u64 enq_flags)
 		 * Limit the amount of budget that an idling task can accumulate
 		 * to one slice.
 		 */
-		if (vtime_before(vtime, vtime_now - SCX_SLICE_DFL))
+		if (time_before(vtime, vtime_now - SCX_SLICE_DFL))
 			vtime = vtime_now - SCX_SLICE_DFL;
 
 		scx_bpf_dsq_insert_vtime(p, SHARED_DSQ, SCX_SLICE_DFL, vtime,
@@ -108,7 +103,7 @@ void BPF_STRUCT_OPS(simple_running, struct task_struct *p)
 	 * thus racy. Any error should be contained and temporary. Let's just
 	 * live with it.
 	 */
-	if (vtime_before(vtime_now, p->scx.dsq_vtime))
+	if (time_before(vtime_now, p->scx.dsq_vtime))
 		vtime_now = p->scx.dsq_vtime;
 }
 

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -415,6 +415,99 @@ static __always_inline const struct cpumask *cast_mask(struct bpf_cpumask *mask)
 void bpf_rcu_read_lock(void) __ksym;
 void bpf_rcu_read_unlock(void) __ksym;
 
+/*
+ * Time helpers, most of which are from jiffies.h.
+ */
+
+/**
+ * time_delta - Calculate the delta between new and old time stamp
+ * @after: first comparable as u64
+ * @before: second comparable as u64
+ *
+ * Return: the time difference, which is >= 0
+ */
+static inline s64 time_delta(u64 after, u64 before)
+{
+	return (s64)(after - before) > 0 ? : 0;
+}
+
+/**
+ * time_after - returns true if the time a is after time b.
+ * @a: first comparable as u64
+ * @b: second comparable as u64
+ *
+ * Do this with "<0" and ">=0" to only test the sign of the result. A
+ * good compiler would generate better code (and a really good compiler
+ * wouldn't care). Gcc is currently neither.
+ *
+ * Return: %true is time a is after time b, otherwise %false.
+ */
+static inline bool time_after(u64 a, u64 b)
+{
+	 return (s64)(b - a) < 0;
+}
+
+/**
+ * time_before - returns true if the time a is before time b.
+ * @a: first comparable as u64
+ * @b: second comparable as u64
+ *
+ * Return: %true is time a is before time b, otherwise %false.
+ */
+static inline bool time_before(u64 a, u64 b)
+{
+	return time_after(b, a);
+}
+
+/**
+ * time_after_eq - returns true if the time a is after or the same as time b.
+ * @a: first comparable as u64
+ * @b: second comparable as u64
+ *
+ * Return: %true is time a is after or the same as time b, otherwise %false.
+ */
+static inline bool time_after_eq(u64 a, u64 b)
+{
+	 return (s64)(a - b) >= 0;
+}
+
+/**
+ * time_before_eq - returns true if the time a is before or the same as time b.
+ * @a: first comparable as u64
+ * @b: second comparable as u64
+ *
+ * Return: %true is time a is before or the same as time b, otherwise %false.
+ */
+static inline bool time_before_eq(u64 a, u64 b)
+{
+	return time_after_eq(b, a);
+}
+
+/**
+ * time_in_range - Calculate whether a is in the range of [b, c].
+ * @a: time to test
+ * @b: beginning of the range
+ * @c: end of the range
+ *
+ * Return: %true is time a is in the range [b, c], otherwise %false.
+ */
+static inline bool time_in_range(u64 a, u64 b, u64 c)
+{
+	return time_after_eq(a, b) && time_before_eq(a, c);
+}
+
+/**
+ * time_in_range_open - Calculate whether a is in the range of [b, c).
+ * @a: time to test
+ * @b: beginning of the range
+ * @c: end of the range
+ *
+ * Return: %true is time a is in the range [b, c), otherwise %false.
+ */
+static inline bool time_in_range_open(u64 a, u64 b, u64 c)
+{
+	return time_after_eq(a, b) && time_before(a, c);
+}
 
 /*
  * Other helpers

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -83,6 +83,7 @@ bool scx_bpf_task_running(const struct task_struct *p) __ksym;
 s32 scx_bpf_task_cpu(const struct task_struct *p) __ksym;
 struct rq *scx_bpf_cpu_rq(s32 cpu) __ksym;
 struct cgroup *scx_bpf_task_cgroup(struct task_struct *p) __ksym __weak;
+u64 scx_bpf_now(void) __ksym __weak;
 
 /*
  * Use the following as @it__iter when calling scx_bpf_dsq_move[_vtime]() from

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -83,6 +83,11 @@ bool scx_bpf_task_running(const struct task_struct *p) __ksym;
 s32 scx_bpf_task_cpu(const struct task_struct *p) __ksym;
 struct rq *scx_bpf_cpu_rq(s32 cpu) __ksym;
 struct cgroup *scx_bpf_task_cgroup(struct task_struct *p) __ksym __weak;
+
+/*
+ * Return a monotonically non-decreasing time in nanoseconds,
+ * use bpf_ktime_get_ns() if you have high-precision timing requirements
+ */
 u64 scx_bpf_now(void) __ksym __weak;
 
 /*

--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -125,6 +125,11 @@ bool scx_bpf_dispatch_vtime_from_dsq___compat(struct bpf_iter_scx_dsq *it__iter,
 	false;									\
 })
 
+#define scx_bpf_now()								\
+	(bpf_ksym_exists(scx_bpf_now) ?						\
+	 scx_bpf_now() :							\
+	 bpf_ktime_get_ns())
+
 /*
  * Define sched_ext_ops. This may be expanded to define multiple variants for
  * backward compatibility. See compat.h::SCX_OPS_LOAD/ATTACH().

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -189,17 +189,6 @@ struct task_ctx *try_lookup_task_ctx(const struct task_struct *p)
 }
 
 /*
- * Compare two vruntime values, returns true if the first value is less than
- * the second one.
- *
- * Copied from scx_simple.
- */
-static inline bool vtime_before(u64 a, u64 b)
-{
-	return (s64)(a - b) < 0;
-}
-
-/*
  * Return true if the target task @p is a kernel thread.
  */
 static inline bool is_kthread(const struct task_struct *p)
@@ -321,7 +310,7 @@ static u64 task_deadline(struct task_struct *p, struct task_ctx *tctx)
 	/*
 	 * Limit the vruntime to to avoid excessively penalizing tasks.
 	 */
-	if (vtime_before(p->scx.dsq_vtime, min_vruntime))
+	if (time_before(p->scx.dsq_vtime, min_vruntime))
 		p->scx.dsq_vtime = min_vruntime;
 
 	return p->scx.dsq_vtime + scale_inverse_fair(p, tctx, tctx->sum_runtime);
@@ -922,7 +911,7 @@ void BPF_STRUCT_OPS(bpfland_running, struct task_struct *p)
 	/*
 	 * Update global vruntime.
 	 */
-	if (vtime_before(vtime_now, p->scx.dsq_vtime))
+	if (time_before(vtime_now, p->scx.dsq_vtime))
 		vtime_now = p->scx.dsq_vtime;
 }
 

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -830,7 +830,7 @@ void BPF_STRUCT_OPS(bpfland_dispatch, s32 cpu, struct task_struct *prev)
  */
 static void update_cpuperf_target(struct task_struct *p, struct task_ctx *tctx)
 {
-	u64 now = bpf_ktime_get_ns();
+	u64 now = scx_bpf_now();
 	s32 cpu = scx_bpf_task_cpu(p);
 	u64 perf_lvl, delta_runtime, delta_t;
 	struct cpu_ctx *cctx;
@@ -882,7 +882,7 @@ static void update_cpuperf_target(struct task_struct *p, struct task_ctx *tctx)
 	 */
 	scx_bpf_cpuperf_set(cpu, perf_lvl);
 
-	cctx->last_running = bpf_ktime_get_ns();
+	cctx->last_running = scx_bpf_now();
 	cctx->prev_runtime = cctx->tot_runtime;
 }
 
@@ -895,7 +895,7 @@ void BPF_STRUCT_OPS(bpfland_running, struct task_struct *p)
 	tctx = try_lookup_task_ctx(p);
 	if (!tctx)
 		return;
-	tctx->last_run_at = bpf_ktime_get_ns();
+	tctx->last_run_at = scx_bpf_now();
 
 	/*
 	 * Adjust target CPU frequency before the task starts to run.
@@ -921,7 +921,7 @@ void BPF_STRUCT_OPS(bpfland_running, struct task_struct *p)
  */
 void BPF_STRUCT_OPS(bpfland_stopping, struct task_struct *p, bool runnable)
 {
-	u64 now = bpf_ktime_get_ns(), slice;
+	u64 now = scx_bpf_now(), slice;
 	s32 cpu = scx_bpf_task_cpu(p);
 	s64 delta_t;
 	struct cpu_ctx *cctx;
@@ -1043,7 +1043,7 @@ void BPF_STRUCT_OPS(bpfland_set_cpumask, struct task_struct *p,
 
 void BPF_STRUCT_OPS(bpfland_enable, struct task_struct *p)
 {
-	u64 now = bpf_ktime_get_ns();
+	u64 now = scx_bpf_now();
 	struct task_ctx *tctx;
 
 	/* Initialize task's vruntime */

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -872,7 +872,7 @@ void BPF_STRUCT_OPS(flash_running, struct task_struct *p)
 	tctx = try_lookup_task_ctx(p);
 	if (!tctx)
 		return;
-	tctx->last_run_at = bpf_ktime_get_ns();
+	tctx->last_run_at = scx_bpf_now();
 
 	/*
 	 * Update global vruntime.
@@ -883,7 +883,7 @@ void BPF_STRUCT_OPS(flash_running, struct task_struct *p)
 
 void BPF_STRUCT_OPS(flash_stopping, struct task_struct *p, bool runnable)
 {
-	u64 now = bpf_ktime_get_ns(), slice;
+	u64 now = scx_bpf_now(), slice;
 	s64 delta_t;
 	struct task_ctx *tctx;
 
@@ -967,7 +967,7 @@ void BPF_STRUCT_OPS(flash_set_cpumask, struct task_struct *p,
 
 void BPF_STRUCT_OPS(flash_enable, struct task_struct *p)
 {
-	u64 now = bpf_ktime_get_ns();
+	u64 now = scx_bpf_now();
 	struct task_ctx *tctx;
 
 	p->scx.dsq_vtime = vtime_now;

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -318,17 +318,6 @@ static u64 calc_avg_clamp(u64 old_val, u64 new_val, u64 low, u64 high)
 }
 
 /*
- * Compare two vruntime values, returns true if the first value is less than
- * the second one.
- *
- * Copied from scx_simple.
- */
-static inline bool vtime_before(u64 a, u64 b)
-{
-	return (s64)(a - b) < 0;
-}
-
-/*
  * Return true if the target task @p is a kernel thread, false instead.
  */
 static inline bool is_kthread(const struct task_struct *p)
@@ -490,7 +479,7 @@ static u64 task_vtime(struct task_struct *p, struct task_ctx *tctx)
 	/*
 	 * Limit the vruntime to to avoid excessively penalizing tasks.
 	 */
-	if (vtime_before(p->scx.dsq_vtime, min_vruntime)) {
+	if (time_before(p->scx.dsq_vtime, min_vruntime)) {
 		p->scx.dsq_vtime = min_vruntime;
 		tctx->deadline = p->scx.dsq_vtime + task_deadline(p, tctx);
 	}
@@ -888,7 +877,7 @@ void BPF_STRUCT_OPS(flash_running, struct task_struct *p)
 	/*
 	 * Update global vruntime.
 	 */
-	if (vtime_before(vtime_now, p->scx.dsq_vtime))
+	if (time_before(vtime_now, p->scx.dsq_vtime))
 		vtime_now = p->scx.dsq_vtime;
 }
 

--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -196,7 +196,7 @@ unlock_out:
 
 static void update_power_mode_time(void)
 {
-	u64 now = bpf_ktime_get_ns();
+	u64 now = scx_bpf_now();
 	u64 delta;
 
 	if (last_power_mode_clk == 0)

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -59,7 +59,7 @@ static void init_sys_stat_ctx(struct sys_stat_ctx *c)
 	c->stat_cur = get_sys_stat_cur();
 	c->stat_next = get_sys_stat_next();
 	c->min_perf_cri = 1000;
-	c->now = bpf_ktime_get_ns();
+	c->now = scx_bpf_now();
 	c->duration = c->now - c->stat_cur->last_update_clk;
 	c->stat_next->last_update_clk = c->now;
 }

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1589,7 +1589,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 	 * after the DSQ had tasks queued for longer than lo_fb_wait_ns.
 	 */
 	if (scx_bpf_dsq_nr_queued(cpuc->lo_fb_dsq_id)) {
-		u64 now = bpf_ktime_get_ns();
+		u64 now = scx_bpf_now();
 		u64 dur, usage;
 
 		/*
@@ -2059,7 +2059,7 @@ void on_wakeup(struct task_struct *p, struct task_ctx *taskc)
 void BPF_STRUCT_OPS(layered_runnable, struct task_struct *p, u64 enq_flags)
 {
 	struct task_ctx *taskc;
-	u64 now = bpf_ktime_get_ns();
+	u64 now = scx_bpf_now();
 
 	if (!(taskc = lookup_task_ctx(p)))
 		return;
@@ -2079,7 +2079,7 @@ void BPF_STRUCT_OPS(layered_running, struct task_struct *p)
 	struct node_ctx *nodec;
 	struct llc_ctx *llcc;
 	s32 task_cpu = scx_bpf_task_cpu(p);
-	u64 now = bpf_ktime_get_ns();
+	u64 now = scx_bpf_now();
 	u32 layer_id;
 
 	if (!(cpuc = lookup_cpu_ctx(-1)) || !(llcc = lookup_llc_ctx(cpuc->llc_id)) ||
@@ -2157,7 +2157,7 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 	struct cpu_ctx *cpuc;
 	struct task_ctx *taskc;
 	struct layer *task_layer;
-	u64 now = bpf_ktime_get_ns();
+	u64 now = scx_bpf_now();
 	u64 usage_since_idle;
 	s32 task_lid;
 	u64 used;
@@ -2495,7 +2495,7 @@ static void dump_layer_cpumask(int id)
 
 void BPF_STRUCT_OPS(layered_dump, struct scx_dump_ctx *dctx)
 {
-	u64 now = bpf_ktime_get_ns();
+	u64 now = scx_bpf_now();
 	u64 dsq_id;
 	int i, j;
 	struct layer *layer;

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -758,11 +758,6 @@ static __always_inline bool pick_idle_cpu_and_kick(struct task_struct *p,
 	}
 }
 
-static inline bool vtime_before(u64 a, u64 b)
-{
-	return (s64)(a - b) < 0;
-}
-
 void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 {
 	struct cpu_ctx *cctx;
@@ -791,7 +786,7 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 	 * Limit the amount of budget that an idling task can accumulate
 	 * to one slice.
 	 */
-	if (vtime_before(vtime, cell->vtime_now - slice_ns))
+	if (time_before(vtime, cell->vtime_now - slice_ns))
 		vtime = cell->vtime_now - slice_ns;
 
 	if (p->flags & PF_KTHREAD && p->nr_cpus_allowed == 1) {
@@ -880,7 +875,7 @@ void BPF_STRUCT_OPS(mitosis_running, struct task_struct *p)
 	if (!(tctx = lookup_task_ctx(p)) || !(cell = lookup_cell(tctx->cell)))
 		return;
 
-	if (vtime_before(cell->vtime_now, p->scx.dsq_vtime))
+	if (time_before(cell->vtime_now, p->scx.dsq_vtime))
 		cell->vtime_now = p->scx.dsq_vtime;
 
 	tctx->started_running_at = bpf_ktime_get_ns();

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -848,7 +848,7 @@ static inline void runnable(struct task_struct *p, struct task_ctx *tctx,
 		tctx->cell = cgc->cell;
 	}
 
-	adj_load(p, tctx, cgrp, p->scx.weight, bpf_ktime_get_ns());
+	adj_load(p, tctx, cgrp, p->scx.weight, scx_bpf_now());
 }
 
 void BPF_STRUCT_OPS(mitosis_runnable, struct task_struct *p, u64 enq_flags)
@@ -878,7 +878,7 @@ void BPF_STRUCT_OPS(mitosis_running, struct task_struct *p)
 	if (time_before(cell->vtime_now, p->scx.dsq_vtime))
 		cell->vtime_now = p->scx.dsq_vtime;
 
-	tctx->started_running_at = bpf_ktime_get_ns();
+	tctx->started_running_at = scx_bpf_now();
 }
 
 void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
@@ -896,7 +896,7 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 	if (!(cell = lookup_cell(cidx)))
 		return;
 
-	used = bpf_ktime_get_ns() - tctx->started_running_at;
+	used = scx_bpf_now() - tctx->started_running_at;
 	/* scale the execution time by the inverse of the weight and charge */
 	p->scx.dsq_vtime += used * 100 / p->scx.weight;
 
@@ -916,7 +916,7 @@ static inline void quiescent(struct task_struct *p, struct cgroup *cgrp)
 	if (!(tctx = lookup_task_ctx(p)))
 		return;
 
-	adj_load(p, tctx, cgrp, -(s64)p->scx.weight, bpf_ktime_get_ns());
+	adj_load(p, tctx, cgrp, -(s64)p->scx.weight, scx_bpf_now());
 }
 
 void BPF_STRUCT_OPS(mitosis_quiescent, struct task_struct *p, u64 deq_flags)

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -377,11 +377,6 @@ static struct lock_wrapper *lookup_dom_vtime_lock(u32 dom_id)
 	return lockw;
 }
 
-static inline bool vtime_before(u64 a, u64 b)
-{
-	return (s64)(a - b) < 0;
-}
-
 static u64 scale_up_fair(u64 value, u64 weight)
 {
 	return value * weight / 100;
@@ -839,7 +834,7 @@ static void clamp_task_vtime(struct task_struct *p, struct task_ctx *taskc, u64 
 	 * and then coming back and having essentially full use of the CPU for
 	 * an entire day until it's caught up to the other tasks' vtimes.
 	 */
-	if (vtime_before(p->scx.dsq_vtime, min_vruntime)) {
+	if (time_before(p->scx.dsq_vtime, min_vruntime)) {
 		p->scx.dsq_vtime = min_vruntime;
 		taskc->deadline = p->scx.dsq_vtime + task_compute_dl(p, taskc, enq_flags);
 		stat_add(RUSTY_STAT_DL_CLAMP, 1);
@@ -1486,7 +1481,7 @@ static void running_update_vtime(struct task_struct *p,
 		return;
 
 	bpf_spin_lock(&lockw->lock);
-	if (vtime_before(dom_min_vruntime(domc), p->scx.dsq_vtime))
+	if (time_before(dom_min_vruntime(domc), p->scx.dsq_vtime))
 		WRITE_ONCE(domc->min_vruntime, p->scx.dsq_vtime);
 	bpf_spin_unlock(&lockw->lock);
 }

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -884,7 +884,7 @@ static bool task_set_domain(struct task_struct *p __arg_trusted,
 	 * here and @p might not be able to run in @dom_id anymore. Verify.
 	 */
 	if (bpf_cpumask_intersects(cast_mask(d_cpumask), p->cpus_ptr)) {
-		u64 now = bpf_ktime_get_ns();
+		u64 now = scx_bpf_now();
 
 		if (!init_dsq_vtime)
 			dom_xfer_task(p, new_dom_id, now);
@@ -1445,7 +1445,7 @@ static u64 update_freq(u64 freq, u64 interval)
 
 void BPF_STRUCT_OPS(rusty_runnable, struct task_struct *p, u64 enq_flags)
 {
-	u64 now = bpf_ktime_get_ns(), interval;
+	u64 now = scx_bpf_now(), interval;
 	struct task_struct *waker;
 	struct task_ctx *wakee_ctx, *waker_ctx;
 
@@ -1535,7 +1535,7 @@ void BPF_STRUCT_OPS(rusty_running, struct task_struct *p)
 		return;
 
 	running_update_vtime(p, taskc, domc);
-	taskc->last_run_at = bpf_ktime_get_ns();
+	taskc->last_run_at = scx_bpf_now();
 }
 
 static void stopping_update_vtime(struct task_struct *p,
@@ -1548,7 +1548,7 @@ static void stopping_update_vtime(struct task_struct *p,
 	if (!lockw)
 		return;
 
-	now = bpf_ktime_get_ns();
+	now = scx_bpf_now();
 	delta = now - taskc->last_run_at;
 
 	taskc->sum_runtime += delta;
@@ -1577,7 +1577,7 @@ void BPF_STRUCT_OPS(rusty_stopping, struct task_struct *p, bool runnable)
 
 void BPF_STRUCT_OPS(rusty_quiescent, struct task_struct *p, u64 deq_flags)
 {
-	u64 now = bpf_ktime_get_ns(), interval;
+	u64 now = scx_bpf_now(), interval;
 	struct task_ctx *taskc;
 	struct dom_ctx *domc;
 
@@ -1681,7 +1681,7 @@ void BPF_STRUCT_OPS(rusty_set_cpumask, struct task_struct *p,
 s32 BPF_STRUCT_OPS_SLEEPABLE(rusty_init_task, struct task_struct *p,
 		   struct scx_init_task_args *args)
 {
-	u64 now = bpf_ktime_get_ns();
+	u64 now = scx_bpf_now();
 	struct task_struct *p_map;
 	struct bpfmask_wrapper wrapper;
 	struct bpfmask_wrapper *mask_map_value;


### PR DESCRIPTION
As the kernel patch for scx_bpf_now() and time helpers are merged (https://lore.kernel.org/lkml/20250109131456.7055-1-changwoo@igalia.com/), sync up the relevant headers and scx schedulers to use time helpers. 