### PR TITLE
scx_utils: Fix UserExitInfo::new() usage.

### DIFF
--- a/rust/scx_utils/src/user_exit_info.rs
+++ b/rust/scx_utils/src/user_exit_info.rs
@@ -58,13 +58,15 @@ macro_rules! uei_read {
                 _ => std::ptr::null(),
             };
 
-            scx_utils::UserExitInfo::new(
-                &bpf_uei.kind as *const _,
-                exit_code_ptr,
-                bpf_uei.reason.as_ptr() as *const _,
-                bpf_uei.msg.as_ptr() as *const _,
-                bpf_dump,
-            )
+            unsafe {
+                scx_utils::UserExitInfo::new(
+                    &bpf_uei.kind as *const _,
+                    exit_code_ptr,
+                    bpf_uei.reason.as_ptr() as *const _,
+                    bpf_uei.msg.as_ptr() as *const _,
+                    bpf_dump,
+                )
+            }
         }
     }};
 }
@@ -134,7 +136,7 @@ impl UserExitInfo {
     /// user_exit_info, so we can't take the type directly. Instead, this
     /// method takes each member field. Use the macro uei_read!() on the C
     /// type which then calls this method with the individual fields.
-    pub fn new(
+    pub unsafe fn new(
         kind_ptr: *const i32,
         exit_code_ptr: *const i64,
         reason_ptr: *const c_char,


### PR DESCRIPTION
it is dealing with pointer with various sizes/types thus dereferencing these could be considered UB. Thus marking it as unsafe overall. reported by clippy.