### PR TITLE
scx_bpfland: avoid starvation of per-CPU tasks

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -668,7 +668,7 @@ s32 BPF_STRUCT_OPS(bpfland_select_cpu, struct task_struct *p,
 	s32 cpu;
 
 	cpu = pick_idle_cpu(p, prev_cpu, wake_flags, &is_idle);
-	if (is_idle) {
+	if (is_idle && !scx_bpf_dsq_nr_queued(SHARED_DSQ)) {
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, slice_max, 0);
 		__sync_fetch_and_add(&nr_direct_dispatches, 1);
 	}
@@ -745,11 +745,12 @@ static bool try_direct_dispatch(struct task_struct *p, u64 enq_flags)
 		s32 prev_cpu = scx_bpf_task_cpu(p);
 
 		/*
-		 * If the local DSQ of the assigned CPU is empty and the
+		 * If both the local and shared DSQs are empty and the
 		 * previous CPU can still be used by the task, perform the
 		 * direct dispatch.
 		 */
 		if (!scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | prev_cpu) &&
+		    !scx_bpf_dsq_nr_queued(SHARED_DSQ) &&
 		    bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr)) {
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | prev_cpu,
 					   slice_max, enq_flags);


### PR DESCRIPTION
The following scenario can lead to starvation of per-CPU tasks:
 - only task T1 and T2 are running in the system
 - T1 is allowed to run only on CPU1 (per-CPU task)
 - T2 is currently running on CPU1
 - T1 is queued to the shared DSQ, because CPU1 is busy
 - T2 keeps running on CPU1 and it's periodically re-enqueued to CPU1's local DSQ, because no other tasks are running in the system (so the local DSQ is empty)
 - T1 is sitting forever in the shared DSQ => starvation!

Example trace:
```
CPU 5   : nr_run=3 flags=0x1 cpu_rel=0 ops_qseq=8897270 pnt_seq=7289174
          curr=git[143180] class=ext_sched_class

 *R git[143180] -3ms
      scx_state/flags=3/0xd dsq_flags=0x0 ops_state/qseq=0/0
      sticky/holding_cpu=-1/-1 dsq_id=(n/a) dsq_vtime=281946533817 slice=19074269
      cpus=ff

  R kworker/5:2[139607] -5248ms
      scx_state/flags=3/0x9 dsq_flags=0x1 ops_state/qseq=0/0
      sticky/holding_cpu=-1/-1 dsq_id=0x0 dsq_vtime=282432709595 slice=20000000
      cpus=20

    kthread+0xcf/0x100
    ret_from_fork+0x31/0x50
    ret_from_fork_asm+0x1a/0x30

  R less[143181] -1ms
      scx_state/flags=3/0x9 dsq_flags=0x0 ops_state/qseq=0/0
      sticky/holding_cpu=-1/-1 dsq_id=0x8000000000000002 dsq_vtime=281946430894 slice=20000000
      cpus=ff

    __x64_sys_poll+0xd0/0x180
    do_syscall_64+0x82/0x190
    entry_SYSCALL_64_after_hwframe+0x76/0x7e
```
As we can see in the trace, kworker/5 is queued to the shared DSQ, but it's always pushed back by other tasks dispatched to the local DSQ and it never gets a chance to run.

To prevent this, ensure that the shared DSQ is empty (fully drained) before performing a direct dispatch to any local DSQ.