### PR TITLE
scxtop: Fix node barchart

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -727,7 +727,7 @@ impl<'a> App<'a> {
 
     /// Generates Node bar charts.
     fn node_bars(&self, event: String) -> Vec<Bar> {
-        self.llc_data
+        self.node_data
             .iter()
             .filter(|(_node_id, node_data)| node_data.data.data.contains_key(&event.clone()))
             .map(|(node_id, node_data)| {


### PR DESCRIPTION
Fix a bug where LLC data is used in the node barchart view. 

Tested on multi NUMA machine:
<img width="1916" alt="image" src="https://github.com/user-attachments/assets/06ed3d1c-417c-4fd6-b696-834968c8ab35" />
