### PR TITLE
lib/sdt_alloc: rename sdt_arena_verify to avoid confusion

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -48,7 +48,7 @@ static bool sdt_verify_once;
 
 #define SDT_TASK_FN_ATTRS	inline __attribute__((unused, always_inline))
 
-__hidden void sdt_arena_verify(void)
+__hidden void sdt_subprog_init_arena(void)
 {
 	if (sdt_verify_once)
 		return;
@@ -410,7 +410,7 @@ void sdt_free_idx(struct sdt_allocator *alloc, __u64 idx)
 	int ret;
 	int i;
 
-	sdt_arena_verify();
+	sdt_subprog_init_arena();
 
 	bpf_spin_lock(&sdt_lock);
 

--- a/lib/sdt_task.bpf.c
+++ b/lib/sdt_task.bpf.c
@@ -60,7 +60,7 @@ void __arena *sdt_task_data(struct task_struct *p)
 	struct sdt_data __arena *data;
 	struct sdt_task_map_val *mval;
 
-	sdt_arena_verify();
+	sdt_subprog_init_arena();
 
 	mval = bpf_task_storage_get(&sdt_task_map, p, 0, 0);
 	if (!mval)
@@ -76,7 +76,7 @@ void sdt_task_free(struct task_struct *p)
 {
 	struct sdt_task_map_val *mval;
 
-	sdt_arena_verify();
+	sdt_subprog_init_arena();
 
 	mval = bpf_task_storage_get(&sdt_task_map, p, 0, 0);
 	if (!mval)

--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -104,7 +104,7 @@ void __arena *sdt_task_data(struct task_struct *p);
 int sdt_task_init(__u64 data_size);
 void __arena *sdt_task_alloc(struct task_struct *p);
 void sdt_task_free(struct task_struct *p);
-void sdt_arena_verify(void);
+void sdt_subprog_init_arena(void);
 
 int sdt_alloc_init(struct sdt_allocator *alloc, __u64 data_size);
 struct sdt_data __arena *sdt_alloc(struct sdt_allocator *alloc);


### PR DESCRIPTION
The sdt_arena_verify function has a misleading name, leading to the mistaken assumption it verifies arena variables. The function is in fact a workaround that ensures all subprograms explicitly access the arena map, even if they do not need to. This is because the verifier finds the arena associated with a subprogram by identifying these accesses in the bytecode, and forbids use of arena variables if it finds none.