### PR TITLE
scx_layered: Fix dump_layer_cpumask()

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2475,18 +2475,12 @@ static void dump_layer_cpumask(int id)
 		return;
 
 	bpf_for(cpu, 0, scx_bpf_nr_cpu_ids()) {
-		if (!(p = MEMBER_VPTR(buf, [id++])))
+		if (!(p = MEMBER_VPTR(buf, [cpu])))
 			break;
 		if (bpf_cpumask_test_cpu(cpu, layer_cpumask))
-			*p++ = '0' + cpu % 10;
+			*p = '0' + cpu % 10;
 		else
-			*p++ = '.';
-
-		if ((cpu & 7) == 7) {
-			if (!(p = MEMBER_VPTR(buf, [id++])))
-				break;
-			*p++ = '|';
-		}
+			*p = '.';
 	}
 	buf[sizeof(buf) - 1] = '\0';
 


### PR DESCRIPTION
It was incorrectly using layer @id to index into $buf. Use a separate $idx and drop confusing noop ++'s.