### PR TITLE
scx_rustland: implements PartialOrd for Task.

### DIFF
--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -175,6 +175,12 @@ impl Ord for Task {
     }
 }
 
+impl PartialOrd for Task {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 // Task pool where all the tasks that needs to run are stored before dispatching (ordered by their
 // shortest deadline using a BTreeSet).
 struct TaskTree {


### PR DESCRIPTION
As there is a custom Ord implementation, PartialOrd reuses its rules to be consistent.