### PR TITLE
scx_layered: Add matcher for when tgid is or is not equal to pid

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -243,6 +243,7 @@ enum layer_match_kind {
 	MATCH_SCXCMD_JOIN,
 
 	NR_LAYER_MATCH_KINDS,
+	MATCH_PID_TGID_EQUALS,
 };
 
 struct layer_match {
@@ -257,6 +258,7 @@ struct layer_match {
 	u32		ppid;
 	u32		tgid;
 	u64		nsid;
+	u32		pid_tgid_eq;
 };
 
 struct layer_match_ands {

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -241,9 +241,9 @@ enum layer_match_kind {
 	MATCH_NSPID_EQUALS,
 	MATCH_NS_EQUALS,
 	MATCH_SCXCMD_JOIN,
+	MATCH_IS_GROUP_LEADER,
 
 	NR_LAYER_MATCH_KINDS,
-	MATCH_IS_GROUP_LEADER,
 };
 
 struct layer_match {
@@ -258,7 +258,7 @@ struct layer_match {
 	u32		ppid;
 	u32		tgid;
 	u64		nsid;
-	bool	is_group_leader;
+	bool		is_group_leader;
 };
 
 struct layer_match_ands {

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -243,7 +243,7 @@ enum layer_match_kind {
 	MATCH_SCXCMD_JOIN,
 
 	NR_LAYER_MATCH_KINDS,
-	MATCH_PID_TGID_EQUALS,
+	MATCH_IS_GROUP_LEADER,
 };
 
 struct layer_match {
@@ -258,7 +258,7 @@ struct layer_match {
 	u32		ppid;
 	u32		tgid;
 	u64		nsid;
-	u32		pid_tgid_eq;
+	bool	is_group_leader;
 };
 
 struct layer_match_ands {

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1838,10 +1838,10 @@ static __noinline bool match_one(struct layer_match *match,
 		return match_prefix(match->comm_prefix, taskc->join_layer,
 			SCXCMD_COMLEN);
 	}
-	case MATCH_PID_TGID_EQUALS: {
+	case MATCH_IS_GROUP_LEADER: {
 		// There is nuance to this around exec(2)s and group leader swaps.
 		// See https://github.com/sched-ext/scx/issues/610 for more details.
-		return p->tgid == p->pid && match->pid_tgid_eq;
+		return p->tgid == p->pid && match->is_group_leader;
 	}
 	default:
 		scx_bpf_error("invalid match kind %d", match->kind);
@@ -2865,8 +2865,8 @@ static s32 init_layer(int layer_id)
 			case MATCH_NS_EQUALS:
 				dbg("%s NSID %lld", header, match->nsid);
 				break;
-			case MATCH_PID_TGID_EQUALS:
-				dbg("%s PID %d", header, match->pid_tgid_eq);
+			case MATCH_IS_GROUP_LEADER:
+				dbg("%s PID %d", header, match->is_group_leader);
 				break;
 			default:
 				scx_bpf_error("%s Invalid kind", header);

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1838,6 +1838,11 @@ static __noinline bool match_one(struct layer_match *match,
 		return match_prefix(match->comm_prefix, taskc->join_layer,
 			SCXCMD_COMLEN);
 	}
+	case MATCH_PID_TGID_EQUALS: {
+		// There is nuance to this around exec(2)s and group leader swaps.
+		// See https://github.com/sched-ext/scx/issues/610 for more details.
+		return p->tgid == p->pid && match->pid_tgid_eq;
+	}
 	default:
 		scx_bpf_error("invalid match kind %d", match->kind);
 		return result;
@@ -2859,6 +2864,9 @@ static s32 init_layer(int layer_id)
 				break;
 			case MATCH_NS_EQUALS:
 				dbg("%s NSID %lld", header, match->nsid);
+				break;
+			case MATCH_PID_TGID_EQUALS:
+				dbg("%s PID %d", header, match->pid_tgid_eq);
 				break;
 			default:
 				scx_bpf_error("%s Invalid kind", header);

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -74,7 +74,7 @@ pub enum LayerMatch {
     NSPIDEquals(u64, u32),
     NSEquals(u32),
     CmdJoin(String),
-    TgidPidEq(u32),
+    IsGroupLeader(bool),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -74,6 +74,7 @@ pub enum LayerMatch {
     NSPIDEquals(u64, u32),
     NSEquals(u32),
     CmdJoin(String),
+    TgidPidEq(u32),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -288,6 +288,10 @@ lazy_static! {
 ///
 /// - NSEquals: Matches if the task's namespace id matches the values.
 ///
+/// - IsGroupLeader: Bool. When true, matches if the task is group leader
+///   (i.e. PID == TGID), aka the thread from which other threads are made.
+///   When false, matches if the task is *not* the group leader (i.e. the rest).
+///
 /// While there are complexity limitations as the matches are performed in
 /// BPF, it is straightforward to add more types of matches.
 ///
@@ -1183,9 +1187,9 @@ impl<'a> Scheduler<'a> {
                             mt.kind = bpf_intf::consts_SCXCMD_OP_JOIN as i32;
                             copy_into_cstr(&mut mt.comm_prefix, joincmd);
                         }
-                        LayerMatch::TgidPidEq(polarity) => {
-                            mt.kind = bpf_intf::layer_match_kind_MATCH_PID_TGID_EQUALS as i32;
-                            mt.pid_tgid_eq = *polarity;
+                        LayerMatch::IsGroupLeader(polarity) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_IS_GROUP_LEADER as i32;
+                            mt.is_group_leader.write(*polarity);
                         }
                     }
                 }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1183,6 +1183,10 @@ impl<'a> Scheduler<'a> {
                             mt.kind = bpf_intf::consts_SCXCMD_OP_JOIN as i32;
                             copy_into_cstr(&mut mt.comm_prefix, joincmd);
                         }
+                        LayerMatch::TgidPidEq(polarity) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_PID_TGID_EQUALS as i32;
+                            mt.pid_tgid_eq = *polarity;
+                        }
                     }
                 }
                 layer.matches[or_i].nr_match_ands = or.len() as i32;


### PR DESCRIPTION
Add a matcher, `TgidPidEq`, which accepts a c boolean (i.e. 0 is false, non-zero is true), for when TGID is (or is not) equal to PID.

The intent is to be able to use this matcher to express either of the following:
* "Scope matched tasks to those where PID is TGID"
* "Scope matched tasks to those where PID is NOT TGID"

in combination with other matchers (i.e. `CommPrefix`).

Need to write a cfg to test this still.