### PR TITLE
scx_rusty: Cleanup naming

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_rusty/src/bpf/lb_domain.h
@@ -76,7 +76,7 @@ void lb_domain_free(dom_ptr domc)
 }
 
 static __always_inline
-struct lb_domain *lb_domain_val(u32 dom_id)
+struct lb_domain *lb_domain_get(u32 dom_id)
 {
 	return bpf_map_lookup_elem(&lb_domain_map, &dom_id);
 }
@@ -85,7 +85,7 @@ static dom_ptr try_lookup_dom_ctx_arena(u32 dom_id)
 {
 	struct lb_domain *lb_domain;
 
-	lb_domain = lb_domain_val(dom_id);
+	lb_domain = lb_domain_get(dom_id);
 	if (!lb_domain)
 		return NULL;
 
@@ -118,7 +118,7 @@ static struct bpf_spin_lock *lookup_dom_vtime_lock(dom_ptr domc)
 {
 	struct lb_domain *lb_domain;
 
-	lb_domain = lb_domain_val(domc->id);
+	lb_domain = lb_domain_get(domc->id);
 	if (!lb_domain) {
 		scx_bpf_error("Failed to lookup dom map value");
 		return NULL;

--- a/scheds/rust/scx_rusty/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_rusty/src/bpf/lb_domain.h
@@ -19,76 +19,76 @@ struct {
 	__type(value, struct lb_domain);
 	__uint(max_entries, MAX_DOMS);
 	__uint(map_flags, 0);
-} sdt_dom_map SEC(".maps");
+} lb_domain_map SEC(".maps");
 
-struct sdt_allocator sdt_dom_allocator;
+struct sdt_allocator lb_domain_allocator;
 
 __hidden __noinline
-int sdt_dom_init(void)
+int lb_domain_init(void)
 {
-	return sdt_alloc_init(&sdt_dom_allocator, sizeof(struct dom_ctx));
+	return sdt_alloc_init(&lb_domain_allocator, sizeof(struct dom_ctx));
 }
 
 __hidden __noinline
-dom_ptr sdt_dom_alloc(u32 dom_id)
+dom_ptr lb_domain_alloc(u32 dom_id)
 {
 	struct sdt_data __arena *data = NULL;
-	struct lb_domain mval;
+	struct lb_domain lb_domain;
 	dom_ptr domc;
 	int ret;
 
-	data = sdt_alloc(&sdt_dom_allocator);
+	data = sdt_alloc(&lb_domain_allocator);
 	cast_kern(data);
 
-	mval.tid = data->tid;
-	mval.domc = (dom_ptr)data->payload;
+	lb_domain.tid = data->tid;
+	lb_domain.domc = (dom_ptr)data->payload;
 
-	ret = bpf_map_update_elem(&sdt_dom_map, &dom_id, &mval,
+	ret = bpf_map_update_elem(&lb_domain_map, &dom_id, &lb_domain,
 				    BPF_EXIST);
 	if (ret) {
-		sdt_free_idx(&sdt_dom_allocator, data->tid.idx);
+		sdt_free_idx(&lb_domain_allocator, data->tid.idx);
 		return NULL;
 	}
 
-	domc = mval.domc;
+	domc = lb_domain.domc;
 	cast_kern(domc);
 
 	return domc;
 }
 
 __hidden
-void sdt_dom_free(dom_ptr domc)
+void lb_domain_free(dom_ptr domc)
 {
-	struct lb_domain *mval;
+	struct lb_domain *lb_domain;
 	u32 key = domc->id;
 
 	sdt_subprog_init_arena();
 
-	mval = bpf_map_lookup_elem(&sdt_dom_map, &key);
-	if (!mval)
+	lb_domain = bpf_map_lookup_elem(&lb_domain_map, &key);
+	if (!lb_domain)
 		return;
 
-	sdt_free_idx(&sdt_dom_allocator, mval->tid.idx);
-	mval->domc = NULL;
+	sdt_free_idx(&lb_domain_allocator, lb_domain->tid.idx);
+	lb_domain->domc = NULL;
 
-	bpf_map_delete_elem(&sdt_dom_map, &key);
+	bpf_map_delete_elem(&lb_domain_map, &key);
 }
 
 static __always_inline
-struct lb_domain *sdt_dom_val(u32 dom_id)
+struct lb_domain *lb_domain_val(u32 dom_id)
 {
-	return bpf_map_lookup_elem(&sdt_dom_map, &dom_id);
+	return bpf_map_lookup_elem(&lb_domain_map, &dom_id);
 }
 
 static dom_ptr try_lookup_dom_ctx_arena(u32 dom_id)
 {
-	struct lb_domain *mval;
+	struct lb_domain *lb_domain;
 
-	mval = sdt_dom_val(dom_id);
-	if (!mval)
+	lb_domain = lb_domain_val(dom_id);
+	if (!lb_domain)
 		return NULL;
 
-	return mval->domc;
+	return lb_domain->domc;
 }
 
 static dom_ptr try_lookup_dom_ctx(u32 dom_id)
@@ -115,13 +115,13 @@ static dom_ptr lookup_dom_ctx(u32 dom_id)
 
 static struct bpf_spin_lock *lookup_dom_vtime_lock(dom_ptr domc)
 {
-	struct lb_domain *mval;
+	struct lb_domain *lb_domain;
 
-	mval = sdt_dom_val(domc->id);
-	if (!mval) {
+	lb_domain = lb_domain_val(domc->id);
+	if (!lb_domain) {
 		scx_bpf_error("Failed to lookup dom map value");
 		return NULL;
 	}
 
-	return &mval->vtime_lock;
+	return &lb_domain->vtime_lock;
 }

--- a/scheds/rust/scx_rusty/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_rusty/src/bpf/lb_domain.h
@@ -21,6 +21,7 @@ struct {
 	__uint(map_flags, 0);
 } lb_domain_map SEC(".maps");
 
+volatile dom_ptr dom_ctxs[MAX_DOMS];
 struct sdt_allocator lb_domain_allocator;
 
 __hidden __noinline

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -76,7 +76,6 @@ const volatile u32 dom_numa_id_map[MAX_DOMS];
 const volatile u64 dom_cpumasks[MAX_DOMS][MAX_CPUS / 64];
 const volatile u64 numa_cpumasks[MAX_NUMA_NODES][MAX_CPUS / 64];
 const volatile u32 load_half_life = 1000000000	/* 1s */;
-volatile dom_ptr doms[MAX_DOMS];
 
 const volatile bool kthreads_local;
 const volatile bool fifo_sched = false;
@@ -1784,8 +1783,8 @@ static s32 create_dom(u32 dom_id)
 	if (!domc)
 		return -ENOMEM;
 
-	doms[dom_id] = domc;
-	cast_user(doms[dom_id]);
+	dom_ctxs[dom_id] = domc;
+	cast_user(dom_ctxs[dom_id]);
 
 	lb_domain = lb_domain_val(dom_id);
 	if (!lb_domain) {

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -195,17 +195,6 @@ struct {
 	__uint(map_flags, 0);
 } node_data SEC(".maps");
 
-/*
- * Domain context
- */
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__type(key, u32);
-	__type(value, struct dom_ctx);
-	__uint(max_entries, MAX_DOMS);
-	__uint(map_flags, 0);
-} dom_data SEC(".maps");
-
 struct lock_wrapper {
 	struct bpf_spin_lock lock;
 };

--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -627,7 +627,7 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
         // Read active_tasks and update read_idx and gen.
         const MAX_TPTRS: u64 = bpf_intf::consts_MAX_DOM_ACTIVE_TPTRS as u64;
         let dom_ctx =
-            unsafe { &mut *(self.skel.maps.bss_data.doms[dom.id] as *mut bpf_intf::dom_ctx) };
+            unsafe { &mut *(self.skel.maps.bss_data.dom_ctxs[dom.id] as *mut bpf_intf::dom_ctx) };
         let active_tasks = &mut dom_ctx.active_tasks;
 
         let (mut ridx, widx) = (active_tasks.read_idx, active_tasks.write_idx);

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -459,7 +459,7 @@ impl<'a> Scheduler<'a> {
 
             let mut ctx = dom.ctx.lock().unwrap();
 
-            *ctx = Some(skel.maps.bss_data.doms[id] as *mut bpf_intf::dom_ctx);
+            *ctx = Some(skel.maps.bss_data.dom_ctxs[id] as *mut bpf_intf::dom_ctx);
         }
 
         info!("Rusty scheduler started! Run `scx_rusty --monitor` for metrics.");


### PR DESCRIPTION
Rename functions, variables, and data structures relevant to domains to have consistent and more descriptive naming.