### PR TITLE
scx_layered: Implement `allow_node_aligned` layer property

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -286,6 +286,7 @@ struct layer {
 	bool			preempt;
 	bool			preempt_first;
 	bool			exclusive;
+	bool			allow_node_aligned;
 	int			growth_algo;
 
 	u64			nr_tasks;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -894,7 +894,10 @@ s32 BPF_STRUCT_OPS(layered_select_cpu, struct task_struct *p, s32 prev_cpu, u64 
 	 * assigned, it will trigger LLC draining which isn't great. Find an
 	 * in-layer CPU and put it there instead.
 	 *
-	 * TODO - This should become node aware.
+	 * FIXME: This is most likely wrong and causing unnecessary xllc
+	 * migrations while saturated. Always returning @prev_cpu is likely a
+	 * better behavior. Ideally, this should be scoped so that it returns
+	 * the closest allowed layer CPU to @prev_cpu.
 	 */
 	if (taskc->all_cpus_allowed) {
 		const struct cpumask *layer_cpumask;

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -92,6 +92,8 @@ pub struct LayerCommon {
     #[serde(default)]
     pub exclusive: bool,
     #[serde(default)]
+    pub allow_node_aligned: bool,
+    #[serde(default)]
     pub weight: u32,
     #[serde(default)]
     pub disallow_open_after_us: Option<u64>,

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -110,6 +110,7 @@ lazy_static! {
                         preempt: false,
                         preempt_first: false,
                         exclusive: false,
+                        allow_node_aligned: false,
                         idle_smt: None,
                         slice_us: 20000,
                         fifo: false,
@@ -138,6 +139,7 @@ lazy_static! {
                         preempt: true,
                         preempt_first: false,
                         exclusive: true,
+                        allow_node_aligned: true,
                         idle_smt: None,
                         slice_us: 20000,
                         fifo: false,
@@ -168,6 +170,7 @@ lazy_static! {
                         preempt: true,
                         preempt_first: false,
                         exclusive: false,
+                        allow_node_aligned: false,
                         idle_smt: None,
                         slice_us: 800,
                         fifo: false,
@@ -195,6 +198,7 @@ lazy_static! {
                         preempt: false,
                         preempt_first: false,
                         exclusive: false,
+                        allow_node_aligned: false,
                         idle_smt: None,
                         slice_us: 20000,
                         fifo: false,
@@ -339,6 +343,11 @@ lazy_static! {
 /// - exclusive: If true, tasks in the layer will occupy the whole core. The
 ///   other logical CPUs sharing the same core will be kept idle. This isn't
 ///   a hard guarantee, so don't depend on it for security purposes.
+///
+/// - allow_node_aligned: Put node aligned tasks on layer DSQs instead of lo
+///   fallback. This is a hack to support node-affine tasks without making
+///   the whole scheduler node aware and should only be used with open
+///   layers on non-saturated machines to avoid possible stalls.
 ///
 /// - slice_us: Scheduling slice duration in microseconds.
 ///
@@ -1186,6 +1195,7 @@ impl<'a> Scheduler<'a> {
                     preempt,
                     preempt_first,
                     exclusive,
+                    allow_node_aligned,
                     growth_algo,
                     nodes,
                     slice_us,
@@ -1213,6 +1223,7 @@ impl<'a> Scheduler<'a> {
                 layer.preempt.write(*preempt);
                 layer.preempt_first.write(*preempt_first);
                 layer.exclusive.write(*exclusive);
+                layer.allow_node_aligned.write(*allow_node_aligned);
                 layer.growth_algo = growth_algo.as_bpf_enum();
                 layer.weight = *weight;
                 layer.disallow_open_after_ns = match disallow_open_after_us.unwrap() {


### PR DESCRIPTION
While cpu allocations aren't node-aware yet, an open layer can work fine with tasks with a node aligned custom cpumask as long as the machine doesn't stay fully saturated for a long time. Add allow_node_aligned layer property which puts node-aligned tassk into layer DSQs instead of the lo fallbacks.

This isn't by any chance a full-fledged NUMA support but setting `allow_node_aligned` on an open layer restores the old behavior which assumed that an open layer can almost always consume from all nodes on the system. This can still lead to stalls but can be useful in specific situations. This should be deprecated once proper numa support is implemented.