### PR TITLE
meson: Install rust projects in tools dir

### DIFF
--- a/meson-scripts/install_rust_user_scheds
+++ b/meson-scripts/install_rust_user_scheds
@@ -54,3 +54,22 @@ for manifest in "$MESON_SOURCE_ROOT"/rust/*/Cargo.toml; do
 
     install -D "${bins[0]}" "${DESTDIR}/${MESON_INSTALL_PREFIX}/bin/${name}"
 done
+
+for manifest in "$MESON_SOURCE_ROOT"/tools/*/Cargo.toml; do
+    source_dir="${manifest%/Cargo.toml}"
+    target_dir="${MESON_BUILD_ROOT}"
+    name="${source_dir##*/}"
+
+    bins=($(ls -t "${target_dir}/"*"/${name}"))
+    if [ ${#bins[@]} -lt 1 ]; then
+        echo "Cannot find a binary for $name under $target_dir" 1>&2
+        exit 1
+    fi
+
+    # XXX - Can we detect the current buildtype and install the correct one?
+    if [ ${#bins[@]} -gt 1 ]; then
+        echo "Found multiple binaries for $name under $target_dir, installing the latest which may not be what you want" 1>&2
+    fi
+
+    install -D "${bins[0]}" "${DESTDIR}/${MESON_INSTALL_PREFIX}/bin/${name}"
+done


### PR DESCRIPTION
Update meson-scripts/install_rust_user_scheds to also install
rust projects found in the tools/ directory.

This will install scxtop when running 'meson install'.

Fixes #1182 