### PR TITLE
scx_lavd: Optimize the use of idle CPUs

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -227,6 +227,11 @@ static bool is_migration_disabled(const struct task_struct *p)
 	return false;
 }
 
+static bool have_idle_cpus(const struct cpumask *idle_mask)
+{
+	return !bpf_cpumask_empty(idle_mask);
+}
+
 static bool is_lat_cri(struct task_ctx *taskc, struct sys_stat *stat_cur)
 {
 	return taskc->lat_cri >= stat_cur->avg_lat_cri;


### PR DESCRIPTION
This PR optimizes the use of idle CPUs in ops.select_cpu() and ops.enqueue() paths. It harvests opportunities for direct dispatch in ops.enqueue() when an ops.select_cpu() is skipped. Also, the ops.enqueue() path proactively kicks the idle CPU to reduce the latency, but it does not mark it busy since there is no guarantee that the found idle CPU schedules the task.
