### PR TITLE
scx_bpfland: improvements

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -535,7 +535,6 @@ impl<'a> Scheduler<'a> {
         Metrics {
             nr_running: self.skel.maps.bss_data.nr_running,
             nr_cpus: self.skel.maps.bss_data.nr_online_cpus,
-            nr_interactive: self.skel.maps.bss_data.nr_interactive,
             nr_kthread_dispatches: self.skel.maps.bss_data.nr_kthread_dispatches,
             nr_direct_dispatches: self.skel.maps.bss_data.nr_direct_dispatches,
             nr_shared_dispatches: self.skel.maps.bss_data.nr_shared_dispatches,

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -397,7 +397,7 @@ impl<'a> Scheduler<'a> {
     ) -> Result<()> {
         let perf_lvl: i64 = match primary_domain.as_str() {
             "auto" => match energy_profile.as_str() {
-                "performance" => 1024,
+                "performance" | "balance_performance" => 1024,
                 "power" | "powersave" => 0,
                 &_ => -1,
             },

--- a/scheds/rust/scx_bpfland/src/stats.rs
+++ b/scheds/rust/scx_bpfland/src/stats.rs
@@ -19,8 +19,6 @@ pub struct Metrics {
     pub nr_running: u64,
     #[stat(desc = "Number of online CPUs")]
     pub nr_cpus: u64,
-    #[stat(desc = "Number of running interactive tasks")]
-    pub nr_interactive: u64,
     #[stat(desc = "Number of kthread direct dispatches")]
     pub nr_kthread_dispatches: u64,
     #[stat(desc = "Number of task direct dispatches")]
@@ -33,11 +31,10 @@ impl Metrics {
     fn format<W: Write>(&self, w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "[{}] tasks -> r: {:>2}/{:<2} i: {:<2} | dispatch -> k: {:<5} d: {:<5} s: {:<5}",
+            "[{}] tasks -> r: {:>2}/{:<2} | dispatch -> k: {:<5} d: {:<5} s: {:<5}",
             crate::SCHEDULER_NAME,
             self.nr_running,
             self.nr_cpus,
-            self.nr_interactive,
             self.nr_kthread_dispatches,
             self.nr_direct_dispatches,
             self.nr_shared_dispatches


### PR DESCRIPTION
A set of changes to improve bpfland performance and stability:
 - use a new virtual deadline algorithm (`deadline = vruntime + exec_vruntime`)
 - get rid of the interactive task classification logic via nvcsw
 - allow tasks to overflow from the primary domain more aggressively (fixes #1145)
 - add a new `--cpufreq` option to enable frequency scaling (otherwise cpu frequency will be only adjusted when running in powersave mode)
 - add a new `--local-pcpu` option to prioritize per-cpu tasks
 - allow to prioritize all kthreads using `--local-kthreads`