### PR TITLE
scx_loader: Avoid race condition with start_scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,6 +2145,7 @@ dependencies = [
  "serde",
  "sysinfo",
  "tokio",
+ "tokio-util",
  "toml",
  "zbus",
  "zvariant",

--- a/rust/scx_loader/Cargo.toml
+++ b/rust/scx_loader/Cargo.toml
@@ -16,6 +16,7 @@ nix = { features = ["process", "signal"], default-features = false, version = "0
 serde = { version = "1.0", features = ["derive"] }
 sysinfo = "0.31.4"
 tokio = { version = "1.39", features = ["macros", "sync", "rt-multi-thread", "process"] }
+tokio-util = "0.7"
 toml = "0.8.19"
 zbus = { version = "5", features = ["tokio"], default-features = false }
 zvariant = "5.1"


### PR DESCRIPTION
When RunnerMessage::Switch is called frequently, start_scheduler could encounter a race condition issue, where more than one tokio async task would start the same time, messing with the child_id state.

To resolve this issue, the JoinHandle got in start_scheduler is recorded, and instead of using child_id to send SIGINT, a cancellation token from tokio-util is used, and stop_scheduler uses it to inform the async task to kill its child. And we could ensure that only one task is managing spawned scheduler process.