### PR TITLE
scx_layered: initial attempt at adding gpu layer match filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,6 +2124,8 @@ dependencies = [
  "libbpf-rs 0.25.0-beta.1",
  "libc",
  "log",
+ "nvml-wrapper",
+ "once_cell",
  "scx_stats",
  "scx_stats_derive",
  "scx_utils",

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -25,6 +25,8 @@ scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.12"
+nvml-wrapper = "0.10.0"
+once_cell = "1.20.2"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -64,6 +64,7 @@ enum consts {
 
 	SCXCMD_PREFIX		= 0x5C10,
 	SCXCMD_COMLEN		= 13,
+	MAX_GPU_PIDS 		= 100000,
 };
 
 static inline void ___consts_sanity_check___(void) {
@@ -242,6 +243,8 @@ enum layer_match_kind {
 	MATCH_NS_EQUALS,
 	MATCH_SCXCMD_JOIN,
 	MATCH_IS_GROUP_LEADER,
+	MATCH_USING_GPU,
+	MATCH_USED_GPU,
 
 	NR_LAYER_MATCH_KINDS,
 };
@@ -259,6 +262,8 @@ struct layer_match {
 	u32		tgid;
 	u64		nsid;
 	bool		is_group_leader;
+	bool	using_gpu;
+	bool	used_gpu;
 };
 
 struct layer_match_ands {

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -182,7 +182,7 @@ struct {
 	__type(key, u32);
 	__type(value, u32);
 	__uint(max_entries, MAX_GPU_PIDS);
-	__uint(map_flags, 0);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } all_gpu_pid SEC(".maps");
 
 
@@ -192,7 +192,7 @@ struct {
 	__type(key, u32);
 	__type(value, u32);
 	__uint(max_entries, MAX_GPU_PIDS);
-	__uint(map_flags, 0);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } cur_gpu_pid SEC(".maps");
 
 // XXX - Converting this to bss array triggers verifier bugs. See

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -54,6 +54,7 @@ const volatile u32 lo_fb_share_ppk = 128;	/* !0 for veristat */
 
 /* Flag to enable or disable antistall feature */
 const volatile bool enable_antistall = true;
+const volatile bool enable_gpu_support = false;
 /* Delay permitted, in seconds, before antistall activates */
 const volatile u64 antistall_sec = 3;
 const u32 zero_u32 = 0;
@@ -173,6 +174,26 @@ static bool cpuc_in_layer(struct cpu_ctx *cpuc, struct layer *layer)
 	else
 		return cpuc->layer_id == layer->id;
 }
+
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	// u32 comes from nvml
+	__type(key, u32);
+	__type(value, u32);
+	__uint(max_entries, MAX_GPU_PIDS);
+	__uint(map_flags, 0);
+} all_gpu_pid SEC(".maps");
+
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	// u32 comes from nvml
+	__type(key, u32);
+	__type(value, u32);
+	__uint(max_entries, MAX_GPU_PIDS);
+	__uint(map_flags, 0);
+} cur_gpu_pid SEC(".maps");
 
 // XXX - Converting this to bss array triggers verifier bugs. See
 // BpfStats::read(). Should also be cacheline aligned which doesn't work with
@@ -1841,6 +1862,39 @@ static __noinline bool match_one(struct layer_match *match,
 		// See https://github.com/sched-ext/scx/issues/610 for more details.
 		return (p->tgid == p->pid) == match->is_group_leader;
 	}
+	case MATCH_USING_GPU: {
+			u32 pid;
+			u32 gpu_pid;
+			bool pid_present = false;
+
+			if (!enable_gpu_support)
+				return match->used_gpu;
+
+			pid = p->pid;
+			gpu_pid = bpf_map_lookup_elem(&cur_gpu_pid, &pid) == 0;
+
+			if (gpu_pid)
+				pid_present = true;
+
+			return pid_present == match->used_gpu;
+	}
+	case MATCH_USED_GPU: {
+			u32 pid;
+			u32 gpu_pid;
+			bool pid_present = false;
+
+			if (!enable_gpu_support)
+				return match->used_gpu;
+
+			pid = p->pid;
+			gpu_pid = bpf_map_lookup_elem(&all_gpu_pid, &pid) == 0;
+
+			if (gpu_pid)
+				pid_present = true;
+
+			return pid_present == match->used_gpu;
+	}
+
 	default:
 		scx_bpf_error("invalid match kind %d", match->kind);
 		return result;
@@ -2868,6 +2922,12 @@ static s32 init_layer(int layer_id)
 				break;
 			case MATCH_IS_GROUP_LEADER:
 				dbg("%s PID %d", header, match->is_group_leader);
+				break;
+			case MATCH_USING_GPU:
+				dbg("%s PID %d", header, match->using_gpu);
+				break;
+			case MATCH_USED_GPU:
+				dbg("%s PID %d", header, match->used_gpu);
 				break;
 			default:
 				scx_bpf_error("%s Invalid kind", header);

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -75,6 +75,8 @@ pub enum LayerMatch {
     NSEquals(u32),
     CmdJoin(String),
     IsGroupLeader(bool),
+    IsUsingGpu(bool),
+    IsOrHasUsedGpu(bool),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -75,8 +75,8 @@ pub enum LayerMatch {
     NSEquals(u32),
     CmdJoin(String),
     IsGroupLeader(bool),
-    IsUsingGpu(bool),
-    IsOrHasUsedGpu(bool),
+    UsingGpu(bool),
+    UsedGpu(bool),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -7,6 +7,7 @@ mod stats;
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::ffi::CString;
 use std::fs;
 use std::io::Write;
@@ -32,12 +33,14 @@ use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::Skel;
 use libbpf_rs::skel::SkelBuilder;
 use libbpf_rs::MapCore as _;
+use libbpf_rs::MapHandle;
 use libbpf_rs::OpenObject;
 use libbpf_rs::ProgramInput;
 use log::debug;
 use log::info;
 use log::trace;
 use log::warn;
+use nvml_wrapper::Nvml;
 use scx_layered::*;
 use scx_stats::prelude::*;
 use scx_utils::compat;
@@ -217,6 +220,8 @@ lazy_static! {
     };
 }
 
+static NVML_CELL: once_cell::sync::OnceCell<Nvml> = once_cell::sync::OnceCell::new();
+
 /// scx_layered: A highly configurable multi-layer sched_ext scheduler
 ///
 /// scx_layered allows classifying tasks into multiple layers and applying
@@ -294,6 +299,12 @@ lazy_static! {
 ///
 /// - CmdJoin: Matches when the task uses pthread_setname_np to send a join/leave
 /// command to the scheduler. See examples/cmdjoin.c for more details.
+///
+/// - IsUsingGpu: Bool. When true, matches if the task is using a gpu
+///   as of the last time NVML was polled. When false, inverted.
+///
+/// - IsGroupLeader: Bool. When true, matches if the task has, since scheduler
+///   start, used a GPU. When false, inverted.
 ///
 /// While there are complexity limitations as the matches are performed in
 /// BPF, it is straightforward to add more types of matches.
@@ -534,6 +545,10 @@ struct Opts {
     /// Disable antistall
     #[clap(long, default_value = "false")]
     disable_antistall: bool,
+
+    /// Disable gpu support
+    #[clap(long, default_value = "false")]
+    enable_gpu_support: bool,
 
     /// Enable netdev IRQ balancing. This is experimental and should be used with caution.
     #[clap(long, default_value = "false")]
@@ -1116,6 +1131,7 @@ struct Scheduler<'a> {
     topo: Arc<Topology>,
     netdevs: BTreeMap<String, NetDev>,
     stats_server: StatsServer<StatsReq, StatsRes>,
+    opts: &'a Opts,
 }
 
 impl<'a> Scheduler<'a> {
@@ -1193,6 +1209,14 @@ impl<'a> Scheduler<'a> {
                         LayerMatch::IsGroupLeader(polarity) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_IS_GROUP_LEADER as i32;
                             mt.is_group_leader.write(*polarity);
+                        }
+                        LayerMatch::IsUsingGpu(polarity) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_USING_GPU as i32;
+                            mt.using_gpu.write(*polarity);
+                        }
+                        LayerMatch::IsOrHasUsedGpu(polarity) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_USED_GPU as i32;
+                            mt.used_gpu.write(*polarity);
                         }
                     }
                 }
@@ -1590,7 +1614,7 @@ impl<'a> Scheduler<'a> {
     }
 
     fn init(
-        opts: &Opts,
+        opts: &'a Opts,
         layer_specs: &[LayerSpec],
         open_object: &'a mut MaybeUninit<OpenObject>,
     ) -> Result<Self> {
@@ -1689,6 +1713,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.lo_fb_wait_ns = opts.lo_fb_wait_us * 1000;
         skel.maps.rodata_data.lo_fb_share_ppk = ((opts.lo_fb_share * 1024.0) as u32).clamp(1, 1024);
         skel.maps.rodata_data.enable_antistall = !opts.disable_antistall;
+        skel.maps.rodata_data.enable_gpu_support = opts.enable_gpu_support;
 
         for (cpu, sib) in topo.sibling_cpus().iter().enumerate() {
             skel.maps.rodata_data.__sibling_cpu[cpu] = *sib;
@@ -1811,6 +1836,7 @@ impl<'a> Scheduler<'a> {
             topo,
             netdevs,
             stats_server,
+            opts,
         };
 
         info!("Layered Scheduler Attached. Run `scx_layered --monitor` for metrics.");
@@ -1868,6 +1894,76 @@ impl<'a> Scheduler<'a> {
                 trace!("{} updating irq {} cpumask {:?}", iface, irq, irqmask);
             }
             netdev.apply_cpumasks()?;
+        }
+
+        Ok(())
+    }
+
+    fn update_gpu_pids(&mut self) -> Result<()> {
+        if !self.opts.enable_gpu_support {
+            return Ok(());
+        }
+
+        let nvml = NVML_CELL.get_or_try_init(|| Nvml::init())?;
+
+        let device_count = nvml.device_count()?;
+
+        let mut pids = HashSet::new();
+
+        // Iterate over all devices and gather running processes
+        for i in 0..device_count {
+            let device = nvml.device_by_index(i)?;
+
+            let procs = device.running_compute_processes()?;
+
+            for proc_info in procs {
+                pids.insert(proc_info.pid);
+            }
+        }
+
+        // ensure current pids only have current pids.
+        let zero = 0;
+        let all_pid_bpf_map = MapHandle::try_from(&self.skel.maps.all_gpu_pid)?;
+        let cur_pid_bpf_map = MapHandle::try_from(&self.skel.maps.cur_gpu_pid)?;
+
+        // get deletes for current, state of the world for all.
+        let mut cur_pid_bpf_set = HashSet::new();
+        let mut all_pid_bpf_set = HashSet::new();
+
+        for key in cur_pid_bpf_map.keys() {
+            let sized_bytes: [u8; 4] = key
+                .try_into()
+                .expect("failed to convert pid bytes to sized bytes");
+            let pid: u32 = u32::from_ne_bytes(sized_bytes);
+            cur_pid_bpf_set.insert(pid);
+        }
+        for key in all_pid_bpf_map.keys() {
+            let sized_bytes: [u8; 4] = key
+                .try_into()
+                .expect("failed to convert pid bytes to sized bytes");
+            let pid: u32 = u32::from_ne_bytes(sized_bytes);
+            all_pid_bpf_set.insert(pid);
+        }
+
+        let cur_delete_set = cur_pid_bpf_set.difference(&pids);
+        let cur_add_set = pids.difference(&pids);
+        let all_add_set = pids.difference(&all_pid_bpf_set);
+
+        let zero_bytes: &[u8; 4] = unsafe { std::mem::transmute(&zero) };
+        use libbpf_rs::MapFlags;
+        for pid in cur_add_set {
+            let pid_bytes: &[u8; 4] = unsafe { std::mem::transmute(&pid) };
+            cur_pid_bpf_map.update(pid_bytes, zero_bytes, MapFlags::ANY)?;
+        }
+
+        for pid in cur_delete_set {
+            let pid_bytes: &[u8; 4] = unsafe { std::mem::transmute(&pid) };
+            cur_pid_bpf_map.delete(pid_bytes)?;
+        }
+
+        for pid in all_add_set {
+            let pid_bytes: &[u8; 4] = unsafe { std::mem::transmute(&pid) };
+            all_pid_bpf_map.update(pid_bytes, zero_bytes, MapFlags::ANY)?;
         }
 
         Ok(())
@@ -2182,6 +2278,7 @@ impl<'a> Scheduler<'a> {
             self.processing_dur,
         )?;
         self.refresh_cpumasks()?;
+        self.update_gpu_pids()?;
         self.processing_dur += Instant::now().duration_since(started_at);
         Ok(())
     }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -300,7 +300,10 @@ static NVML_CELL: once_cell::sync::OnceCell<Nvml> = once_cell::sync::OnceCell::n
 /// - CmdJoin: Matches when the task uses pthread_setname_np to send a join/leave
 /// command to the scheduler. See examples/cmdjoin.c for more details.
 ///
-/// - IsUsingGpu: Bool. When true, matches if the task is using a gpu
+/// - UsingGpu: Bool. When true, matches if the task is using a gpu
+///   as of the last time NVML was polled. When false, inverted.
+///
+/// - UsedGpu: Bool. When true, matches if the task has ever used a gpu
 ///   as of the last time NVML was polled. When false, inverted.
 ///
 /// - IsGroupLeader: Bool. When true, matches if the task has, since scheduler
@@ -1210,11 +1213,11 @@ impl<'a> Scheduler<'a> {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_IS_GROUP_LEADER as i32;
                             mt.is_group_leader.write(*polarity);
                         }
-                        LayerMatch::IsUsingGpu(polarity) => {
+                        LayerMatch::UsingGpu(polarity) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_USING_GPU as i32;
                             mt.using_gpu.write(*polarity);
                         }
-                        LayerMatch::IsOrHasUsedGpu(polarity) => {
+                        LayerMatch::UsedGpu(polarity) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_USED_GPU as i32;
                             mt.used_gpu.write(*polarity);
                         }


### PR DESCRIPTION
scx_layered: initial attempt at adding gpu layer match filter

I figure once this works/we use it a bit, we'll know a decent interface (and impl. tbh) and can pull it out into scx_utils.

ATM I've got pids making it through to where I try to write it to the bpf.

I kind of wanted use user ringbuf's for this and started trying to use tests to figure out how to do that, but the docs scared me off a bit: https://docs.ebpf.io/linux/map-type/BPF_MAP_TYPE_USER_RINGBUF/

I'm not sure if how I'm doing this would work at all or if there's a bug in it atm causing pids to not get to bpf side (nor if this approach would be performant enough to be usable if it worked, tbh).
