### PR TITLE
scx_layered: fixes for MATCH_SCXCMD_JOIN

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -499,8 +499,6 @@ static int handle_cmd(struct task_ctx *taskc, struct scx_cmd *cmd)
 
 	_Static_assert(sizeof(*cmd) == MAX_COMM, "scx_cmd has wrong size");
 
-	bpf_printk("received cmd");
-
 	/* Is this a valid command? */
 	if (cmd->prefix != SCXCMD_PREFIX)
 		return 0;
@@ -2864,6 +2862,9 @@ static s32 init_layer(int layer_id)
 				break;
 			case MATCH_NS_EQUALS:
 				dbg("%s NSID %lld", header, match->nsid);
+				break;
+			case MATCH_SCXCMD_JOIN:
+				dbg("%s SCXCMD_JOIN \"%s\"", header, match->comm_prefix);
 				break;
 			case MATCH_IS_GROUP_LEADER:
 				dbg("%s PID %d", header, match->is_group_leader);

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1184,7 +1184,7 @@ impl<'a> Scheduler<'a> {
                             mt.nsid = *nsid as u64;
                         }
                         LayerMatch::CmdJoin(joincmd) => {
-                            mt.kind = bpf_intf::consts_SCXCMD_OP_JOIN as i32;
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_SCXCMD_JOIN as i32;
                             copy_into_cstr(&mut mt.comm_prefix, joincmd);
                         }
                         LayerMatch::IsGroupLeader(polarity) => {


### PR DESCRIPTION
Add three fixes for the MATCH_SCXCMD_JOIN command:

- Remove stray printf when processing a user command
- Add debug printf command for the layer type during layer initialization
- Use the right enum when initializing the layer from the Rust side