### PR TITLE
scxtop: Add event to default list after selection

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -1714,6 +1714,7 @@ impl<'a> App<'a> {
                     let prev_state = self.prev_state.clone();
                     self.prev_state = self.state.clone();
                     self.state = prev_state;
+                    self.available_events.push(perf_event.clone());
                 }
             }
             _ => {}


### PR DESCRIPTION
When an event is selected add it to the default set of events to quicky scroll through events using the j/k keybindings by default.