### PR TITLE
scx_layered: add HAS_BEEN_RENAMED matching rule

### DIFF
--- a/scheds/rust/scx_layered/examples/renamed.json
+++ b/scheds/rust/scx_layered/examples/renamed.json
@@ -1,0 +1,83 @@
+[
+  {
+    "name": "renamed_to_stress_ng",
+    "comment": "matches all tasks that have been renamed to 'stress-ng'",
+    "matches": [
+      [
+        {
+          "CommPrefix": "stress-ng"
+        },
+	{
+	  "HasBeenRenamed": true
+	}
+      ],
+      [
+        {
+          "PcommPrefix": "stress-ng"
+        },
+	{
+	  "HasBeenRenamed": true
+	}
+      ]
+    ],
+    "kind": {
+      "Confined": {
+        "util_range": [
+          0.4,
+          0.90
+        ]
+      }
+    }
+  },
+  {
+    "name": "other_renamed",
+    "comment": "all other renamed tasks",
+    "matches": [
+      [
+	{
+	  "HasBeenRenamed": true
+	}
+      ]
+    ],
+    "kind": {
+      "Confined": {
+        "util_range": [
+          0.4,
+          0.90
+        ]
+      }
+    }
+  },
+  {
+    "name": "non_renamed",
+    "comment": "all tasks that have not renamed themselves",
+    "matches": [
+      [
+	{
+	  "HasBeenRenamed": false
+	}
+      ]
+    ],
+    "kind": {
+      "Confined": {
+        "util_range": [
+          0.4,
+          0.90
+        ]
+      }
+    }
+  },
+  {
+    "name": "everything_else",
+    "comment": "the rest",
+    "matches":[[]],
+    "kind": {
+      "Grouped": {
+        "util_range": [
+          0.05,
+          0.60
+        ]
+      }
+    }
+  }
+]

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -242,6 +242,7 @@ enum layer_match_kind {
 	MATCH_NS_EQUALS,
 	MATCH_SCXCMD_JOIN,
 	MATCH_IS_GROUP_LEADER,
+	MATCH_HAS_BEEN_RENAMED,
 
 	NR_LAYER_MATCH_KINDS,
 };
@@ -259,6 +260,7 @@ struct layer_match {
 	u32		tgid;
 	u64		nsid;
 	bool		is_group_leader;
+	bool		has_been_renamed;
 };
 
 struct layer_match_ands {

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -75,6 +75,7 @@ pub enum LayerMatch {
     NSEquals(u32),
     CmdJoin(String),
     IsGroupLeader(bool),
+    HasBeenRenamed(bool),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -294,6 +294,8 @@ lazy_static! {
 ///
 /// - CmdJoin: Matches when the task uses pthread_setname_np to send a join/leave
 /// command to the scheduler. See examples/cmdjoin.c for more details.
+/// - HasBeenRenamed: Bool. Match tasks that have been renamed, or not been renamed. Useful, e.g.,
+/// for preventing a task from renaming itself to get a priority boost.
 ///
 /// While there are complexity limitations as the matches are performed in
 /// BPF, it is straightforward to add more types of matches.
@@ -1193,6 +1195,10 @@ impl<'a> Scheduler<'a> {
                         LayerMatch::IsGroupLeader(polarity) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_IS_GROUP_LEADER as i32;
                             mt.is_group_leader.write(*polarity);
+                        }
+                        LayerMatch::HasBeenRenamed(renamed) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_IS_GROUP_LEADER as i32;
+                            mt.has_been_renamed.write(*renamed);
                         }
                     }
                 }


### PR DESCRIPTION
Add a rule that tests whether a task has been renamed using pthread_rename_np() or through /proc. This has two uses:
- Using task renames to identify specific tasks in a large application, without requiring modifications for that application.
- Preventing tasks from renaming themselves to match into a more privileged layer for a performance boost.