### PR TITLE
scxtop: Fill render area by setting max events

### DIFF
--- a/tools/scxtop/src/event_data.rs
+++ b/tools/scxtop/src/event_data.rs
@@ -45,6 +45,14 @@ impl EventData {
         }
     }
 
+    /// Sets the max size and truncates events greater than the max.
+    pub fn set_max_size(&mut self, max_data_size: usize) {
+        self.max_data_size = max_data_size;
+        for event_data in self.data.values_mut() {
+            event_data.truncate(self.max_data_size);
+        }
+    }
+
     /// Clears an event.
     pub fn clear_event(&mut self, event: String) {
         self.data.remove(&event);


### PR DESCRIPTION
Scale the max number of events by setting the max number of events based on the rendered area. This ensures that events fill the window space when rendering. fixes #1167

<img width="1913" alt="image" src="https://github.com/user-attachments/assets/855232cc-f89f-46c0-a64d-14880015596d" />
