### PR TITLE
scxtop: Add scx_stats support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,7 @@ dependencies = [
  "plain",
  "ratatui",
  "regex",
+ "scx_stats",
  "scx_utils",
  "serde",
  "serde_json",

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4.1", features = [
 ] }
 libbpf-rs = "=0.24.8"
 scx_utils = { path = "../../rust/scx_utils", version = "1.0.8" }
+scx_stats = { path = "../../rust/scx_stats", version = "1.0.8" }
 config = "0.14.1"
 crossterm = { version = "0.28.1", features = ["serde", "event-stream"] }
 derive_deref = "1.1.1"
@@ -45,3 +46,4 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter", "serde"] }
 
 [build-dependencies]
 scx_utils = { path = "../../rust/scx_utils", version = "1.0.8" }
+scx_stats = { path = "../../rust/scx_stats", version = "1.0.8" }

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -39,6 +39,7 @@ pub use plain::Plain;
 // Generate serialization types for handling events from the bpf ring buffer.
 unsafe impl Plain for crate::bpf_skel::types::bpf_event {}
 
+pub const STATS_SOCKET_PATH: &'static str = "/var/run/scx/root/stats";
 pub const APP: &'static str = "scxtop";
 pub const LICENSE: &'static str = "Copyright (c) Meta Platforms, Inc. and affiliates. 
 
@@ -110,6 +111,9 @@ pub enum Action {
     SchedCpuPerfSet {
         cpu: u32,
         perf: u32,
+    },
+    SchedStats {
+        raw: String,
     },
     SchedSwitch {
         cpu: u32,

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -20,6 +20,7 @@ use scxtop::KeyMap;
 use scxtop::Tui;
 use scxtop::APP;
 use scxtop::SCHED_NAME_PATH;
+use scxtop::STATS_SOCKET_PATH;
 use std::mem::MaybeUninit;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
@@ -39,7 +40,10 @@ struct Args {
     debug: bool,
     /// Exclude bpf event tracking.
     #[arg(short, long, default_value_t = false)]
-    excluse_bpf: bool,
+    exclude_bpf: bool,
+    /// Stats unix socket path.
+    #[arg(short, long, default_value_t = STATS_SOCKET_PATH.to_string())]
+    stats_socket_path: String,
 }
 
 fn get_action(_app: &App, keymap: &KeyMap, event: Event) -> Action {
@@ -157,6 +161,7 @@ async fn run() -> Result<()> {
     let scheduler = read_file_string(SCHED_NAME_PATH).unwrap_or("none".to_string());
 
     let mut app = App::new(
+        args.stats_socket_path,
         scheduler,
         keymap.clone(),
         100,


### PR DESCRIPTION
Add scx_stats support for scxtop to the scheduler view. Implements #1238 

Right now the stats rendering is super basic and just prints the json, but this can be made into more structured output in the future. For schedulers with few numbers of stats the output is reasonable:
<img width="1918" alt="image" src="https://github.com/user-attachments/assets/dfe07b79-d62e-431e-b045-54c9803734e7" />
