### PR TITLE
scx_utils: add retries and fallback path for autopower

### DIFF
--- a/rust/scx_utils/src/autopower.rs
+++ b/rust/scx_utils/src/autopower.rs
@@ -41,8 +41,8 @@ fn read_energy_profile() -> String {
         .to_string()
 }
 
-pub fn fetch_power_profile() -> String {
-    if std::env::var("SCX_NO_PPD").is_ok_and(|s| s == "1") {
+pub fn fetch_power_profile(no_ppd: bool) -> String {
+    if no_ppd || std::env::var("SCX_NO_PPD").is_ok_and(|s| s == "1") {
         return read_energy_profile();
     }
     let proxy = POWER_PROFILES_PROXY.get();
@@ -61,7 +61,7 @@ pub fn fetch_power_profile() -> String {
             })();
             if let Some(proxy) = proxy {
                 let _ = POWER_PROFILES_PROXY.set(proxy);
-                fetch_power_profile()
+                fetch_power_profile(false)
             } else {
                 warn!("failed to communicate with ppd: retry {retries}");
                 read_energy_profile()

--- a/rust/scx_utils/src/autopower.rs
+++ b/rust/scx_utils/src/autopower.rs
@@ -42,7 +42,7 @@ fn read_energy_profile() -> String {
 }
 
 pub fn fetch_power_profile(no_ppd: bool) -> String {
-    if no_ppd || std::env::var("SCX_NO_PPD").is_ok_and(|s| s == "1") {
+    if no_ppd {
         return read_energy_profile();
     }
     let proxy = POWER_PROFILES_PROXY.get();

--- a/rust/scx_utils/src/autopower.rs
+++ b/rust/scx_utils/src/autopower.rs
@@ -7,8 +7,6 @@ use zbus::blocking::Connection;
 use zbus::proxy;
 use zbus::Result;
 
-use crate::warn;
-
 #[proxy(
     interface = "net.hadess.PowerProfiles",
     default_service = "net.hadess.PowerProfiles",
@@ -76,7 +74,7 @@ pub fn fetch_power_profile(no_ppd: bool) -> PowerProfile {
     if let Some(proxy) = proxy {
         proxy.active_profile().map_or_else(
             |e| {
-                warn!("failed to fetch the active power profile from ppd: {e}");
+                log::debug!("failed to fetch the active power profile from ppd: {e}");
                 read_energy_profile()
             },
             |profile| parse_profile(&profile),
@@ -94,12 +92,12 @@ pub fn fetch_power_profile(no_ppd: bool) -> PowerProfile {
                         parse_profile(&profile)
                     }
                     Err(e) => {
-                        warn!("failed to communicate with ppd (retry {retries}): {e}");
+                        log::debug!("failed to communicate with ppd (retry {retries}): {e}");
                         read_energy_profile()
                     }
                 },
                 Err(e) => {
-                    warn!("failed to communicate with dbus (retry {retries}): {e}");
+                    log::debug!("failed to communicate with dbus (retry {retries}): {e}");
                     read_energy_profile()
                 }
             }

--- a/rust/scx_utils/src/autopower.rs
+++ b/rust/scx_utils/src/autopower.rs
@@ -42,6 +42,9 @@ fn read_energy_profile() -> String {
 }
 
 pub fn fetch_power_profile() -> String {
+    if std::env::var("SCX_NO_PPD").is_ok_and(|s| s == "1") {
+        return read_energy_profile();
+    }
     let proxy = POWER_PROFILES_PROXY.get();
     if let Some(proxy) = proxy {
         proxy.active_profile().unwrap_or_else(|e| {

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -162,8 +162,7 @@ struct Opts {
     /// tasks may overflow to other available CPUs.
     ///
     /// Special values:
-    ///  - "auto" = automatically detect the CPUs based on the active power profile;
-    ///     require power-profiles-daemon being running.
+    ///  - "auto" = automatically detect the CPUs based on the active power profile
     ///  - "performance" = automatically detect and prioritize the fastest CPUs
     ///  - "powersave" = automatically detect and prioritize the slowest CPUs
     ///  - "all" = all CPUs assigned to the primary domain

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -278,7 +278,7 @@ impl<'a> Scheduler<'a> {
         let topo = Topology::new().unwrap();
 
         // Initialize the primary scheduling domain and the preferred domain.
-        let power_profile = fetch_power_profile();
+        let power_profile = fetch_power_profile(false);
         if let Err(err) = Self::init_energy_domain(&mut skel, &opts.primary_domain, &power_profile)
         {
             warn!("failed to initialize primary domain: error {}", err);
@@ -407,7 +407,7 @@ impl<'a> Scheduler<'a> {
 
     fn refresh_sched_domain(&mut self) -> bool {
         if self.power_profile != "none" {
-            let power_profile = fetch_power_profile();
+            let power_profile = fetch_power_profile(false);
             if power_profile != self.power_profile {
                 self.power_profile = power_profile.clone();
 

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -81,7 +81,6 @@ struct Opts {
     autopilot: bool,
 
     /// Automatically decide the scheduler's power mode based on the system's active power profile.
-    /// Require power-profiles-daemon being running.
     #[clap(long = "autopower", action = clap::ArgAction::SetTrue)]
     autopower: bool,
 

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -833,7 +833,7 @@ impl<'a> Scheduler<'a> {
     }
 
     fn update_power_profile(&mut self, prev_profile: String) -> (bool, String) {
-        let profile = fetch_power_profile();
+        let profile = fetch_power_profile(false);
         if profile == prev_profile {
             // If the profile is the same, skip updaring the profile for BPF.
             return (true, profile);


### PR DESCRIPTION
This PR adds retries and fallback path for `fetch_power_profile()` to fix issues in the case ppd is not available or not started yet. This is generally a better solution than that in #1231. I also re-enable use of autopower in scx_bpfland.

@multics69 @arighi PTAL

