### PR TITLE
scx_bpfland: update default options and performance profiles

### DIFF
--- a/rust/scx_loader/README.md
+++ b/rust/scx_loader/README.md
@@ -27,9 +27,9 @@
 
 * **Start a Scheduler with Arguments:**
   ```bash
-  dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.StartSchedulerWithArgs string:scx_bpfland array:string:"-k","-c","0"
+  dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.StartSchedulerWithArgs string:scx_bpfland array:string:"-p","-s","5000"
   ```
-  (This starts `scx_bpfland` with arguments `-k -c 0`)
+  (This starts `scx_bpfland` with arguments `-p -s 5000`)
 
 * **Stop the Current Scheduler:**
   ```bash
@@ -44,9 +44,9 @@
 
 * **Switch Scheduler with Arguments:**
   ```bash
-  dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.SwitchSchedulerWithArgs string:scx_bpfland array:string:"-k","-c","0"
+  dbus-send --system --print-reply --dest=org.scx.Loader /org/scx/Loader org.scx.Loader.SwitchSchedulerWithArgs string:scx_bpfland array:string:"-p","-s","5000"
   ```
-  (This switches to `scx_bpfland` with arguments `-k -c 0`)
+  (This switches to `scx_bpfland` with arguments `-p -s 5000`)
 
 * **Get the Currently Active Scheduler:**
   ```bash

--- a/rust/scx_loader/configuration.md
+++ b/rust/scx_loader/configuration.md
@@ -22,7 +22,7 @@ default_mode = "Auto"
 [scheds.scx_bpfland]
 auto_mode = []
 gaming_mode = ["-m", "performance"]
-lowlatency_mode = ["-k", "-s", "5000", "-l", "5000"]
+lowlatency_mode = ["-s", "5000", "-S", "500", "-l", "5000", "-m", "performance"]
 powersave_mode = ["-m", "powersave"]
 
 [scheds.scx_rusty]
@@ -72,7 +72,7 @@ The example configuration above shows how to set custom flags for different sche
 
 * For `scx_bpfland`:
     * Gaming mode: `-m performance`
-    * Low Latency mode: `-k -s 5000 -l 5000`
+    * Low Latency mode: `-s 5000 -S 500 -l 5000`
     * Power Save mode: `-m powersave`
 * For `scx_rusty`:
     * No custom flags are defined, so the default flags for each mode will be used.

--- a/rust/scx_loader/src/config.rs
+++ b/rust/scx_loader/src/config.rs
@@ -177,9 +177,11 @@ fn get_default_scx_flags_for_mode(scx_sched: &SupportedSched, sched_mode: SchedM
     match scx_sched {
         SupportedSched::Bpfland => match sched_mode {
             SchedMode::Gaming => vec!["-m", "performance"],
-            SchedMode::LowLatency => vec!["-k", "-s", "5000", "-l", "5000"],
+            SchedMode::LowLatency => {
+                vec!["-s", "5000", "-S", "500", "-l", "5000", "-m", "performance"]
+            }
             SchedMode::PowerSave => vec!["-m", "powersave"],
-            SchedMode::Server => vec!["-c", "0"],
+            SchedMode::Server => vec!["-p"],
             SchedMode::Auto => vec![],
         },
         SupportedSched::Lavd => match sched_mode {
@@ -207,9 +209,9 @@ default_mode = "Auto"
 [scheds.scx_bpfland]
 auto_mode = []
 gaming_mode = ["-m", "performance"]
-lowlatency_mode = ["-k", "-s", "5000", "-l", "5000"]
+lowlatency_mode = ["-s", "5000", "-S", "500", "-l", "5000", "-m", "performance"]
 powersave_mode = ["-m", "powersave"]
-server_mode = ["-c", "0"]
+server_mode = ["-p"]
 
 [scheds.scx_rusty]
 auto_mode = []

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -148,11 +148,14 @@ struct Opts {
     #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
     local_pcpu: bool,
 
-    /// Enable kthreads prioritization.
+    /// Enable kthreads prioritization (EXPERIMENTAL).
     ///
-    /// Enabling this can improve system performance, but it may also introduce interactivity
-    /// issues or unfairness in scenarios with high kthread activity, such as heavy I/O or network
-    /// traffic.
+    /// Enabling this can improve system performance, but it may also introduce noticeable
+    /// interactivity issues or unfairness in scenarios with high kthread activity, such as heavy
+    /// I/O or network traffic.
+    ///
+    /// Use it only when conducting specific experiments or if you have a clear understanding of
+    /// its implications.
     #[clap(short = 'k', long, action = clap::ArgAction::SetTrue)]
     local_kthreads: bool,
 

--- a/services/scx
+++ b/services/scx
@@ -2,4 +2,4 @@
 SCX_SCHEDULER=scx_bpfland
 
 # Set custom flags for each scheduler, below is an example of how to use
-#SCX_FLAGS='-k -m performance'
+#SCX_FLAGS='-p -m performance'


### PR DESCRIPTION
Update doc and default options for the different performance profiles in scx_bpfland to align with the recent changes.