### PR TITLE
[scx-layered] misc. lsp cleanup

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1,9 +1,9 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
+
 #ifdef LSP
 #ifndef __bpf__
 #define __bpf__
 #endif
-#define LSP_INC
 #include "../../../../include/scx/common.bpf.h"
 #include "../../../../include/scx/namespace_impl.bpf.h"
 #else

--- a/scheds/rust/scx_layered/src/bpf/timer.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/timer.bpf.c
@@ -1,10 +1,9 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
 
 #ifdef LSP
+#ifndef __bpf__
 #define __bpf__
 #endif
-
-#if defined LSP && defined LSP_INC
 #include "../../../../include/scx/common.bpf.h"
 #else
 #include <scx/common.bpf.h>

--- a/scheds/rust/scx_layered/src/bpf/timer.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/timer.bpf.h
@@ -1,12 +1,16 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
 #ifndef __LAYERED_TIMER_H
 #define __LAYERED_TIMER_H
+
 #ifdef LSP
+#ifndef __bpf__
 #define __bpf__
-#ifndef LSP_INC
+#endif
 #include "../../../../include/scx/common.bpf.h"
+#else
+#include <scx/common.bpf.h>
 #endif
-#endif
+
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>

--- a/scheds/rust/scx_layered/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/util.bpf.c
@@ -1,8 +1,8 @@
+
 #ifdef LSP
 #ifndef __bpf__
 #define __bpf__
 #endif
-#define LSP_INC
 #include "../../../../include/scx/common.bpf.h"
 #else
 #include <scx/common.bpf.h>

--- a/scheds/rust/scx_layered/src/bpf/util.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/util.bpf.h
@@ -1,12 +1,16 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
 #ifndef __LAYERED_UTIL_H
 #define __LAYERED_UTIL_H
+
 #ifdef LSP
+#ifndef __bpf__
 #define __bpf__
-#ifndef LSP_INC
+#endif
 #include "../../../../include/scx/common.bpf.h"
+#else
+#include <scx/common.bpf.h>
 #endif
-#endif
+
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>


### PR DESCRIPTION
Misc cleanup to keep LSP nice. I think how this works is a lot more flexible now that we have object linking. 

Keeping the "everything is included as text" approach working is good though because it enables LSP etc. to work nice w/o additional effort and it enables using bindgen manually (which is fantastic wrt/ alternative build systems).
