### PR TITLE
scx/common.bpf.h: Add helper to check task migration state

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -419,7 +419,7 @@ static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu)
 	 * For tasks that can run only on a single CPU, we can simply verify if
 	 * their only allowed CPU is still idle.
 	 */
-	if (p->nr_cpus_allowed == 1 || p->migration_disabled) {
+	if (p->nr_cpus_allowed == 1 || is_migration_disabled(p)) {
 		if (scx_bpf_test_and_clear_cpu_idle(prev_cpu))
 			return prev_cpu;
 

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -416,6 +416,17 @@ static __always_inline const struct cpumask *cast_mask(struct bpf_cpumask *mask)
 	return (const struct cpumask *)mask;
 }
 
+/*
+ * Return true if task @p cannot migrate to a different CPU, false
+ * otherwise.
+ */
+static inline bool is_migration_disabled(const struct task_struct *p)
+{
+	if (bpf_core_field_exists(p->migration_disabled))
+		return p->migration_disabled;
+	return false;
+}
+
 /* rcu */
 void bpf_rcu_read_lock(void) __ksym;
 void bpf_rcu_read_unlock(void) __ksym;

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -326,17 +326,6 @@ static inline bool is_kthread(const struct task_struct *p)
 }
 
 /*
- * Return true if the task can only run on its assigned CPU, false
- * otherwise.
- */
-static bool is_migration_disabled(const struct task_struct *p)
-{
-	if (bpf_core_field_exists(p->migration_disabled))
-		return p->migration_disabled;
-	return false;
-}
-
-/*
  * Return the amount of tasks that are waiting to run.
  */
 static inline u64 nr_tasks_waiting(void)

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -292,7 +292,7 @@ static u64 calc_weight_factor(struct task_struct *p, struct task_ctx *taskc,
 	 * Prioritize a migration-disabled task since it has restrictions
 	 * in placement so it tends to be delayed.
 	 */
-	if (is_migration_disabled(p))
+	if (is_per_cpu_task(p))
 		weight_boost += LAVD_LC_WEIGHT_BOOST;
 
 	/*
@@ -740,7 +740,7 @@ s32 find_idle_cpu(struct task_struct *p, struct task_ctx *taskc, s32 prev_cpu,
 	 * If a task can run only on a single CPU (e.g., per-CPU kworker), we
 	 * simply check if a task is still pinned on the prev_cpu and go.
 	 */
-	if (is_migration_disabled(p) &&
+	if (is_per_cpu_task(p) &&
 	    bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr)) {
 		if (test_and_clear_cpu_idle(prev_cpu, idle_mask, reserve_cpu))
 			*is_idle = true;

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -216,13 +216,10 @@ static bool is_kernel_task(struct task_struct *p)
 	return !!(p->flags & PF_KTHREAD);
 }
 
-static bool is_migration_disabled(const struct task_struct *p)
+static bool is_per_cpu_task(const struct task_struct *p)
 {
-	if (p->nr_cpus_allowed == 1)
+	if (p->nr_cpus_allowed == 1 || is_migration_disabled(p))
 		return true;
-
-	if (bpf_core_field_exists(p->migration_disabled))
-		return p->migration_disabled;
 
 	return false;
 }


### PR DESCRIPTION
Introduce a new helper for BPF schedulers to determine whether a task can migrate or not (supporting both SMP and UP systems).

This re-aligns the code with kernel commit 5f52bbf2f6e0 ("tools/sched_ext: Add helper to check task migration state").

Moreover, update the schedulers that are relying on p->migration_disabled to use the common helper instead.