### PR TITLE
ci: add build-kernel-nix job using dedicated server

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -26,6 +26,65 @@ jobs:
       - run: cargo fmt
       - run: git diff --exit-code
 
+  build-kernel-nix:
+    runs-on: [ "self-hosted", "linux", "x64" ]
+    steps:
+      # Uncomment these if reverting to GitHub hosted runners
+      # - name: Install Nix
+      #   uses: DeterminateSystems/nix-installer-action@main
+
+      # Make very basic dependencies available in PATH
+      - name: Install basic dependencies
+        run: |
+          nix profile install nixpkgs#{git,openssl,gawk,gnutar,zstd}
+          echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
+
+      # get latest head commit of sched_ext for-next
+      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-6.13 | awk '{print $1}')" >> $GITHUB_ENV
+
+      # check for cached kernel without downloading
+      - name: Cache Kernel
+        id: cache-kernel
+        uses: actions/cache@v4
+        with:
+          path: |
+            linux/arch/x86/boot/bzImage
+            linux/usr/include
+            linux/**/*.h
+          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-7
+          lookup-only: true
+
+      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
+        uses: actions/checkout@v4
+
+      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
+        uses: nicknovitski/nix-develop@v1
+        with:
+          arguments: ./.github/workflows#build-kernel
+
+      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
+        name: Clone Kernel
+        uses: cytopia/shell-command-retry-action@v0.1.2
+        with:
+          retries: 10
+          pause: 18
+          command: git clone --single-branch -b for-6.13 --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
+
+      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
+        name: Select correct commit for cache hash
+        run: |
+          cd linux
+          git switch --detach ${{ env.SCHED_EXT_KERNEL_COMMIT }}
+          git log -1 --pretty=format:"%h %ad %s" --date=short
+
+      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
+      # Build a minimal kernel (with sched-ext enabled) using virtme-ng
+        run: cd linux && virtme-ng -v --build --config ../.github/workflows/sched-ext.config
+
+      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
+      # Generate kernel headers
+        run: cd linux && make headers
+
   build-kernel:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/flake.lock
+++ b/.github/workflows/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738086784,
+        "narHash": "sha256-S55TBVValODQ3jb3g0IE+KQuWqpINoo5gdJ3yhRbuP4=",
+        "owner": "JakeHillion",
+        "repo": "nixpkgs",
+        "rev": "c1613ab9aa510bd571ba01a1e74a41496327d545",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JakeHillion",
+        "ref": "virtme-ng",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/.github/workflows/flake.nix
+++ b/.github/workflows/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "Nix flake for the scx CI environment.";
+
+  inputs = {
+    nixpkgs.url = "github:JakeHillion/nixpkgs/virtme-ng";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" ]
+      (system: {
+        devShells =
+          let
+            pkgs = import nixpkgs { inherit system; };
+            common = with pkgs; [ gnutar zstd ];
+          in
+          {
+            build-kernel = pkgs.mkShell {
+              buildInputs = with pkgs; common ++ [
+                bc
+                bison
+                cpio
+                elfutils
+                flex
+                git
+                openssl
+                pahole
+                perl
+                virtme-ng
+                zlib
+              ];
+            };
+          };
+      }) // flake-utils.lib.eachDefaultSystem (system: {
+      formatter = nixpkgs.legacyPackages.${system}.nixpkgs-fmt;
+    });
+}
+


### PR DESCRIPTION
Begin migration of CPU heavy tasks from GitHub free runners to self hosted dedicated Linux runners. Start with the build-kernel job as it's pretty simple and doesn't run very often. Will come back for the other copies of `build-kernel` once this is proven.

Changes to enable this:
- Set `runs-on` correctly for this job.
- Switch dependency management to a Nix develop shell for this job. This means we get the same dependencies whether we stay on a self-hosted runner or switch back to GitHub. This is much easier than chasing the ever moving target of software installed on the GitHub runners, and has the added benefit of pinning dependencies.
- Use my branch of nixpkgs with `virtme-ng` packaged. Will upstream this once `virtme-ng` is confirmed working for all of our use cases.
- Bump the cache version number. This isn't really necessary but will mean if this does cause any problems that a revert is cleaner.
- Enables `lookup-only` for the cache kernel step. This means that the cache is never downloaded, which is a good idea given the dedicated server will likely take longer to download the cache. It has the added benefit of being much faster on a hit, and has the same behaviour on a miss.

On request, landing this as an additional job and not using the cache artifacts in this initial merge. Will leave this running for a short time before switching.

|||
|-|-|
|Old cache miss| [13m2s](https://github.com/sched-ext/scx/actions/runs/13000153631/job/36256954083) |
|New cache miss| [2m55s](https://github.com/sched-ext/scx/actions/runs/13021263130/job/36322236211) |
|Old cache hit | [12s  ](https://github.com/sched-ext/scx/actions/runs/13016947090/job/36308397960) |
|New cache hit | [6s   ](https://github.com/sched-ext/scx/actions/runs/13021532927/job/36323025625) |


Test plan:
- Performance looks good.
- If CI passes we're good (excl rusty at the minute). Already checked the hit and miss cases separately.