### PR TITLE
scx_lavd: Improve preemption for non-migratable tasks

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -116,7 +116,6 @@ struct task_ctx {
 	/*
 	 * Task deadline and time slice
 	 */
-	u64	vdeadline_log_clk;	/* logical clock of the deadilne */
 	u32	*futex_uaddr;		/* futex uaddr */
 	u32	lat_cri;		/* final context-aware latency criticality */
 	u32	lat_cri_waker;		/* waker's latency criticality */

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -268,8 +268,7 @@ static u64 calc_freq_factor(u64 freq, u64 weight_ft)
 	return (ft * weight_ft * LAVD_LC_FREQ_OVER_RUNTIME) + 1;
 }
 
-static u64 calc_weight_factor(struct task_struct *p, struct task_ctx *taskc,
-			      u64 enq_flags)
+static u64 calc_weight_factor(struct task_struct *p, struct task_ctx *taskc)
 {
 	u64 weight_boost = 1;
 	u64 weight_ft;
@@ -278,7 +277,6 @@ static u64 calc_weight_factor(struct task_struct *p, struct task_ctx *taskc,
 	 * Prioritize a wake-up task since this is a clear sign of immediate
 	 * consumer. If it is a synchronous wakeup, double the prioritization.
 	 */
-	taskc->wakeup_ft += !!(enq_flags & SCX_ENQ_WAKEUP);
 	weight_boost += taskc->wakeup_ft * LAVD_LC_WEIGHT_BOOST;
 
 	/*
@@ -336,8 +334,7 @@ static void calc_perf_cri(struct task_struct *p, struct task_ctx *taskc)
 	taskc->perf_cri = perf_cri;
 }
 
-static void calc_lat_cri(struct task_struct *p, struct task_ctx *taskc,
-			 u64 enq_flags)
+static void calc_lat_cri(struct task_struct *p, struct task_ctx *taskc)
 {
 	u64 weight_ft, wait_freq_ft, wake_freq_ft, runtime_ft;
 	u64 lat_cri;
@@ -346,7 +343,7 @@ static void calc_lat_cri(struct task_struct *p, struct task_ctx *taskc,
 	 * Adjust task's weight based on the scheduling context, such as
 	 * if it is a kernel task, lock holder, etc.
 	 */
-	weight_ft = calc_weight_factor(p, taskc, enq_flags);
+	weight_ft = calc_weight_factor(p, taskc);
 
 	/*
 	 * A task is more latency-critical as its wait or wake frequencies
@@ -393,8 +390,7 @@ static u64 calc_adj_runtime(u64 runtime)
 }
 
 static u64 calc_virtual_deadline_delta(struct task_struct *p,
-					struct task_ctx *taskc,
-					u64 enq_flags)
+					struct task_ctx *taskc)
 {
 	u64 deadline, adj_runtime;
 	u32 greedy_ratio, greedy_ft;
@@ -404,7 +400,7 @@ static u64 calc_virtual_deadline_delta(struct task_struct *p,
 	 * latency criticality, and greedy ratio.
 	 */
 	calc_perf_cri(p, taskc);
-	calc_lat_cri(p, taskc, enq_flags);
+	calc_lat_cri(p, taskc);
 	greedy_ratio = calc_greedy_ratio(taskc);
 	greedy_ft = calc_greedy_factor(greedy_ratio);
 	adj_runtime = calc_adj_runtime(taskc->run_time_ns);
@@ -497,13 +493,13 @@ static void update_stat_for_runnable(struct task_struct *p,
 	taskc->acc_run_time_ns = 0;
 }
 
-static void advance_cur_logical_clk(struct task_ctx *taskc)
+static void advance_cur_logical_clk(struct task_struct *p)
 {
 	struct sys_stat *stat_cur = get_sys_stat_cur();
 	u64 vlc, clc, ret_clc;
 	u64 nr_queued, delta, new_clk;
 
-	vlc = READ_ONCE(taskc->vdeadline_log_clk);
+	vlc = READ_ONCE(p->scx.dsq_vtime);
 	clc = READ_ONCE(cur_logical_clk);
 
 	for (int i = 0; i < LAVD_MAX_RETRY; ++i) {
@@ -542,7 +538,7 @@ static void update_stat_for_running(struct task_struct *p,
 	/*
 	 * Update the current logical clock.
 	 */
-	advance_cur_logical_clk(taskc);
+	advance_cur_logical_clk(p);
 
 	/*
 	 * Since this is the start of a new schedule for @p, we update run
@@ -962,34 +958,16 @@ out:
 	return cpu_id;
 }
 
-static void update_task_log_clk(struct task_ctx *taskc, u64 deadline_ns)
+static u64 calc_when_to_run(struct task_struct *p, struct task_ctx *taskc)
 {
-	/*
-	 * Update the logical clock of the virtual deadline.
-	 */
-	u64 vlc = READ_ONCE(cur_logical_clk) + deadline_ns;
-	WRITE_ONCE(taskc->vdeadline_log_clk, vlc);
-}
-
-static void direct_dispatch(struct task_struct *p, struct task_ctx *taskc,
-			    u64 enq_flags)
-{
-	/*
-	 * Calculate latency criticality for preemptability test.
-	 */
-	calc_lat_cri(p, taskc, enq_flags);
+	u64 deadline_delta;
 
 	/*
-	 * Update the task's logical clock.
+	 * Before enqueueing a task to a run queue, we should decide when a
+	 * task should be scheduled.
 	 */
-	update_task_log_clk(taskc, 0);
-
-	/*
-	 * Calculate the duration to run.
-	 */
-	p->scx.slice = calc_time_slice(p, taskc);
-
-	scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, p->scx.slice, enq_flags);
+	deadline_delta = calc_virtual_deadline_delta(p, taskc);
+	return READ_ONCE(cur_logical_clk) + deadline_delta;
 }
 
 s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
@@ -1014,7 +992,9 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 		 * If there is an idle cpu,
 		 * disptach the task to the idle cpu right now.
 		 */
-		direct_dispatch(p, taskc, 0);
+		p->scx.dsq_vtime = calc_when_to_run(p, taskc);
+		p->scx.slice = calc_time_slice(p, taskc);
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, p->scx.slice, 0);
 		scx_bpf_kick_cpu(cpu_id, SCX_KICK_IDLE);
 		return cpu_id;
 	}
@@ -1023,19 +1003,6 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 	 * Even if there is no idle cpu, still repect the chosen cpu.
 	 */
 	return cpu_id >= 0 ? cpu_id : prev_cpu;
-}
-
-static void calc_when_to_run(struct task_struct *p, struct task_ctx *taskc,
-			     u64 enq_flags)
-{
-	u64 deadline_ns;
-
-	/*
-	 * Before enqueueing a task to a run queue, we should decide when a
-	 * task should be scheduled.
-	 */
-	deadline_ns = calc_virtual_deadline_delta(p, taskc, enq_flags);
-	update_task_log_clk(taskc, deadline_ns);
 }
 
 static u64 find_proper_dsq(struct task_ctx *taskc, struct cpu_ctx *cpuc)
@@ -1127,13 +1094,10 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 		return;
 
 	/*
-	 * Calculate when a task can be scheduled.
+	 * Calculate when a task can be scheduled for how long.
 	 */
-	calc_when_to_run(p, taskc, enq_flags);
-
-	/*
-	 * Calculate the task's time slice.
-	 */
+	taskc->wakeup_ft += !!(enq_flags & SCX_ENQ_WAKEUP);
+	p->scx.dsq_vtime = calc_when_to_run(p, taskc);
 	p->scx.slice = calc_time_slice(p, taskc);
 
 	/*
@@ -1146,7 +1110,7 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 				   p->scx.slice, enq_flags);
 	} else {
 		scx_bpf_dsq_insert_vtime(p, dsq_id, p->scx.slice,
-					 taskc->vdeadline_log_clk, enq_flags);
+					 p->scx.dsq_vtime, enq_flags);
 	}
 
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -32,8 +32,8 @@ static int comp_preemption_info(struct preemption_info *prm_a,
 	return 0;
 }
 
-static  bool can_task1_kick_task2(struct preemption_info *prm_task1,
-				  struct preemption_info *prm_task2)
+static bool can_task1_kick_task2(struct preemption_info *prm_task1,
+				 struct preemption_info *prm_task2)
 {
 	/*
 	 * A caller should ensure that task2 is not a lock holder.
@@ -46,9 +46,9 @@ static  bool can_task1_kick_task2(struct preemption_info *prm_task1,
 	return comp_preemption_info(prm_task1, prm_task2) < 0;
 }
 
-static  bool can_cpu1_kick_cpu2(struct preemption_info *prm_cpu1,
-				struct preemption_info *prm_cpu2,
-				struct cpu_ctx *cpuc2)
+static bool can_cpu1_kick_cpu2(struct preemption_info *prm_cpu1,
+			       struct preemption_info *prm_cpu2,
+			       struct cpu_ctx *cpuc2)
 {
 	/*
 	 * Set a CPU information
@@ -68,6 +68,17 @@ static  bool can_cpu1_kick_cpu2(struct preemption_info *prm_cpu1,
 	 * candidate.
 	 */
 	return comp_preemption_info(prm_cpu1, prm_cpu2) < 0;
+}
+
+static bool can_task1_kick_cpu2(struct task_ctx *taskc1, struct cpu_ctx *cpuc2,
+				u64 now)
+{
+	struct preemption_info prm_task1, prm_cpu2;
+
+	prm_task1.stopping_tm_est_ns = get_est_stopping_time(taskc1, now);
+	prm_task1.lat_cri = taskc1->lat_cri;
+
+	return can_cpu1_kick_cpu2(&prm_task1, &prm_cpu2, cpuc2);
 }
 
 static bool is_worth_kick_other_task(struct task_ctx *taskc)


### PR DESCRIPTION
This PR improves the preemption of in the following two ways:
- Perform preemption when ops.select_cpu() was skipped
- Clean up taskc->vdeadline_log_clk and replace it to p->scx.dsq_vtime