### PR TITLE
make ci use a stable branch for MRs etc.

### DIFF
--- a/.github/workflows/bpf-next-test.yml
+++ b/.github/workflows/bpf-next-test.yml
@@ -5,10 +5,6 @@ on:
     schedule:
       - cron: "0 */6 * * *"
 
-  # if development becomes intertwined,
-  # fold this into a matrix on the main job
-  # bpf-next == do everything the same but w/
-  # bpf-next bzImage.
 jobs:
   build-kernel:
     runs-on: ubuntu-24.04

--- a/.github/workflows/for-next-test.yml
+++ b/.github/workflows/for-next-test.yml
@@ -1,12 +1,9 @@
-name: build-and-test
+name: for-next-test
 
 on:
-  # only runs on main, hourly cache update used by all branches
+  # only runs on main, every 6 hours
     schedule:
-      - cron: "0 * * * *"
-    push:
-    pull_request:
-    merge_group:
+      - cron: "0 */6 * * *"
 
 jobs:
   lint:
@@ -35,7 +32,8 @@ jobs:
       - run: echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
       - run: sudo apt-get update
       - run: sudo apt-get install -y git --no-install-recommends
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-6.13 | awk '{print $1}')" >> $GITHUB_ENV
+      # get latest head commit of sched_ext for-next
+      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
 
@@ -67,11 +65,13 @@ jobs:
 
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
         name: Clone Kernel
+        # Get the latest sched-ext enabled kernel directly from the korg
+        # for-next branch
         uses: cytopia/shell-command-retry-action@v0.1.2
         with:
           retries: 10
           pause: 18
-          command: git clone --single-branch -b for-6.13 --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
+          command: git clone --single-branch -b for-next --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
 
       # guard rail because we are caching
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
@@ -116,7 +116,8 @@ jobs:
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
 
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-6.13 | awk '{print $1}')" >> $GITHUB_ENV
+      # get latest head commit of sched_ext for-next
+      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
 
       # use cached kernel if available, create after job if not
       - name: Cache Kernel
@@ -205,7 +206,8 @@ jobs:
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
 
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-6.13 | awk '{print $1}')" >> $GITHUB_ENV
+      # get latest head commit of sched_ext for-next
+      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
 
       # use cached kernel if available, create after job if not
       - name: Cache Kernel
@@ -279,7 +281,8 @@ jobs:
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
 
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-6.13 | awk '{print $1}')" >> $GITHUB_ENV
+      # get latest head commit of sched_ext for-next
+      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
 
       - name: Cache Kernel
         id: cache-kernel
@@ -321,7 +324,8 @@ jobs:
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
 
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-6.13 | awk '{print $1}')" >> $GITHUB_ENV
+      # get latest head commit of sched_ext for-next
+      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
       # Cache Kernel alone for rust tests
       - name: Cache Kernel
         id: cache-kernel
@@ -340,41 +344,3 @@ jobs:
 
       - run: cargo build  --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml
       - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml
-
-  pages:
-    runs-on: ubuntu-24.04
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: write  # To push a branch
-      pages: write  # To push to a GitHub Pages site
-      id-token: write # To update the deployment status
-    steps:
-      # prevent cache permission errors
-      - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/install-deps-action
-      - name: Build Book and Linux Docs
-        run: |
-          cd / && rustup component add rustfmt && cd $OLDPWD
-          RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --workspace --no-deps --bins --lib --examples --document-private-items
-          sudo apt install build-essential graphviz sphinx-doc python3-sphinx-rtd-theme texlive-latex-recommended python3-yaml -y
-          cargo install htmlq
-          git clone --single-branch -b for-6.13 --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
-          cd linux
-          make DOCS_THEME=sphinx_rtd_theme SPHINXDIRS=scheduler htmldocs
-          make DOCS_THEME=sphinx_rtd_theme SPHINXDIRS=bpf htmldocs
-          cd ..
-          cp -a linux/Documentation/output/scheduler target/doc/
-          cp -a linux/Documentation/output/bpf target/doc/
-          sed -i 's%<li><a href="server/index.html">server</a></li>%<li><a href="server/index.html">server</a></li><li><a href="scheduler/sched-ext.html">Kernel Sched Ext Docs</a></li><li><a href="bpf/helpers.html">Kernel Bpf Helpers Docs</a></li>%' target/doc/index.html
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: 'target/doc'
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4


### PR DESCRIPTION
make ci use a stable branch for MRs etc.

this changes CI such that:
* every 6 hours sched_ext for-next is used for a job
* every 6 hours bpf for-next is used for a job
* for everything else, for-6.13 is used (i.e. it uses for-6.13 as stable).

We need to update that as releases are cut etc. . An alternative is to have CI use a git repo which always has the latest upstream stable on some branch, but I think this should work fine for now.
