### PR TITLE
add hooks to notify when periodic jobs fail

### DIFF
--- a/.github/workflows/bpf-next-test.yml
+++ b/.github/workflows/bpf-next-test.yml
@@ -155,4 +155,19 @@ jobs:
           path: ./log_save/*.ci.log
           # it's all txt files w/ 90 day retention, lets be nice.
           compression-level: 9
+  notify-job:
+    runs-on: ubuntu-latest
+    if: ${{ (needs.integration-test.result == 'failure' || needs.integration-test.result == 'cancelled') }}
+    needs:
+      - integration-test
+    steps:
+    - uses: actions/checkout@v2
+    - name: Slack Notification
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_USERNAME: ci
+        SLACK_TITLE: Workflow ${{ needs.integration-test.result }}
+        MSG_MINIMAL: bpf-next ci job failed.
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+
 

--- a/.github/workflows/for-next-test.yml
+++ b/.github/workflows/for-next-test.yml
@@ -344,3 +344,19 @@ jobs:
 
       - run: cargo build  --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml
       - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml
+
+  notify-job:
+    runs-on: ubuntu-latest
+    if: ${{ (needs.integration-test.result == 'failure' || needs.integration-test.result == 'cancelled') }}
+    needs:
+      - integration-test
+    steps:
+    - uses: actions/checkout@v2
+    - name: Slack Notification
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_USERNAME: ci
+        SLACK_TITLE: Workflow ${{ needs.integration-test.result }}
+        MSG_MINIMAL: for-next ci job failed.
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+    

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -156,3 +156,18 @@ jobs:
           # it's all txt files w/ 90 day retention, lets be nice.
           compression-level: 9
 
+  notify-job:
+    runs-on: ubuntu-latest
+    if: ${{ (needs.integration-test.result == 'failure' || needs.integration-test.result == 'cancelled') }}
+    needs:
+      - integration-test
+    steps:
+    - uses: actions/checkout@v2
+    - name: Slack Notification
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_USERNAME: ci
+        SLACK_TITLE: Workflow ${{ needs.integration-test.result }}
+        MSG_MINIMAL: stable ci job failed.
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        


### PR DESCRIPTION
add hooks to notify when periodic jobs fail

i think this is a decent way to be notified of CI failures from the periodic jobs, lmk thoughts

this will probably take a few tries to get right