### PR TITLE
scxtop: Fix handling non scx scheduled switch events

### DIFF
--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -372,8 +372,8 @@ int BPF_PROG(on_sched_wakeup_new, struct task_struct *p)
 }
 
 
-static int on_sched_switch_non_scx(bool preempt, struct task_struct *prev,
-				   struct task_struct *next, u64 prev_state)
+static __always_inline int on_sched_switch_non_scx(bool preempt, struct task_struct *prev,
+						   struct task_struct *next, u64 prev_state)
 {
 	struct bpf_event *event;
 
@@ -384,6 +384,10 @@ static int on_sched_switch_non_scx(bool preempt, struct task_struct *prev,
 	if (!event)
 		return -ENOENT;
 
+	u64 now = bpf_ktime_get_ns();
+	event->type = SCHED_SWITCH;
+	event->cpu = bpf_get_smp_processor_id();
+	event->ts = now;
 	event->event.sched_switch.preempt = preempt;
 	event->event.sched_switch.next_pid = next->pid;
 	event->event.sched_switch.next_tgid = next->tgid;


### PR DESCRIPTION
Fix handling non scx handling sched_switch events by properly setting the header on the event so that it can be processed by userspace correctly. Remove the use of tokio for ringbuffer callbacks . Will add some counters later for collecting dropped events.

traces are now working for when a scheduler is loaded or when eevdf is running.

no scheduler:
![2025-01-29-20:14:12](https://github.com/user-attachments/assets/12e2b99f-a230-4d4c-9580-8197e6c35cd0)
layered:
![2025-01-29-20:15:21](https://github.com/user-attachments/assets/bb6f74a6-c691-4e6b-8e3f-593abb585a41)

example trace:
[scxtop_trace_0.log](https://github.com/user-attachments/files/18596118/scxtop_trace_0.log)

