### PR TITLE
scx_lavd: Don't try preemption for greedy tasks

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1068,7 +1068,8 @@ bool can_direct_dispatch(struct task_struct *p, struct task_ctx *taskc,
 		if (!scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | cpu_id))
 			return true;
 
-		if (can_task1_kick_cpu2(taskc, cpuc_task, now)) {
+		if (is_eligible(taskc) &&
+		    can_task1_kick_cpu2(taskc, cpuc_task, now)) {
 			*enq_flags |= SCX_ENQ_PREEMPT;
 			return true;
 		}

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -278,6 +278,12 @@ static bool try_find_and_kick_victim_cpu(struct task_struct *p,
 	bool ret = false;
 
 	/*
+	 * Don't even try to perform expensive preemption for greedy tasks.
+	 */
+	if (!is_eligible(taskc))
+		return false;
+
+	/*
 	 * Prepare a cpumak so we find a victim in @p's compute domain.
 	 */
 	cpumask = cpuc_cur->tmp_t_mask;


### PR DESCRIPTION
Don't try to perform preemption for greedy tasks. This improves the fairnes.