### PR TITLE
scx_rustland_core: bump up version to 2.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "scx_rustland_core"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "anyhow",
  "libbpf-rs 0.25.0-beta.1",

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland_core"
-version = "2.2.5"
+version = "2.2.6"
 edition = "2021"
 authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -13,11 +13,11 @@ ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "=0.25.0-beta.1"
 libc = "0.2.137"
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.5" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.6" }
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.5" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.6" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -20,12 +20,12 @@ serde = { version = "1.0", features = ["derive"] }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.8" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.8" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.5" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.6" }
 simplelog = "0.12"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.5" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.6" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION
Minor version bump to include the new backward-compatible changes.