### PR TITLE
ci: only trigger slack notification on failure of main for scheduled runs

### DIFF
--- a/.github/workflows/bpf-next-test.yml
+++ b/.github/workflows/bpf-next-test.yml
@@ -157,7 +157,7 @@ jobs:
           compression-level: 9
   notify-job:
     runs-on: ubuntu-latest
-    if: ${{ always() && (needs.integration-test.result == 'failure' || needs.integration-test.result == 'cancelled') }}
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
     needs:
       - integration-test
     steps:
@@ -167,7 +167,7 @@ jobs:
       env:
         SLACK_USERNAME: ci
         SLACK_ICON: https://www.dictionary.com/e/wp-content/uploads/2018/03/thisisfine-1.jpg
-        SLACK_TITLE: Workflow ${{ needs.integration-test.result }}
+        SLACK_TITLE: Workflow failed
         SLACK_MESSAGE: bpf-next ci job failed.
         SLACK_COLOR: failure
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/for-next-test.yml
+++ b/.github/workflows/for-next-test.yml
@@ -347,7 +347,7 @@ jobs:
 
   notify-job:
     runs-on: ubuntu-latest
-    if: ${{ always() && (needs.integration-test.result == 'failure' || needs.integration-test.result == 'cancelled') }}
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
     needs:
       - integration-test
     steps:
@@ -357,7 +357,7 @@ jobs:
       env:
         SLACK_USERNAME: ci
         SLACK_ICON: https://www.dictionary.com/e/wp-content/uploads/2018/03/thisisfine-1.jpg
-        SLACK_TITLE: Workflow ${{ needs.integration-test.result }}
+        SLACK_TITLE: Workflow failed
         SLACK_MESSAGE: sched_ext/for-next ci job failed.
         SLACK_COLOR: failure
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -158,7 +158,7 @@ jobs:
 
   notify-job:
     runs-on: ubuntu-latest
-    if: ${{ always() && (needs.integration-test.result == 'failure' || needs.integration-test.result == 'cancelled') }}
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
     needs:
       - integration-test
     steps:
@@ -168,7 +168,7 @@ jobs:
       env:
         SLACK_USERNAME: ci
         SLACK_ICON: https://www.dictionary.com/e/wp-content/uploads/2018/03/thisisfine-1.jpg
-        SLACK_TITLE: Workflow ${{ needs.integration-test.result }}
+        SLACK_TITLE: Workflow failed
         SLACK_MESSAGE: stable ci job failed.
         SLACK_COLOR: failure
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION

Currently the Slack notification gets sent even if the failing branch is not
`main`. This means that any testing done on these workflows (by temporarily
enabling `push`) triggers the notification if they fail or are cancelled.

Replace the `always()` condition with `failure()`. This omits the previous
`cancelled()` case, but that should be fine. Will add it back if there are
objections. Also add the same filter as the `pages` job to only run on `main`.

Test plan:
- __shrugs__
