### PR TITLE
scx_utils: Bump up version to 1.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "scx_rustland_core"
-version = "2.2.6"
+version = "2.2.7"
 dependencies = [
  "anyhow",
  "libbpf-rs 0.25.0-beta.1",
@@ -2380,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "scx_utils"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland_core"
-version = "2.2.6"
+version = "2.2.7"
 edition = "2021"
 authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"
@@ -12,12 +12,12 @@ anyhow = "1.0.65"
 plain = "0.2.3"
 libbpf-rs = "=0.25.0-beta.1"
 libc = "0.2.137"
-scx_utils = { path = "../scx_utils", version = "1.0.9" }
+scx_utils = { path = "../scx_utils", version = "1.0.10" }
 
 [build-dependencies]
 tar = "0.4"
 walkdir = "2.4"
-scx_utils = { path = "../scx_utils", version = "1.0.9" }
+scx_utils = { path = "../scx_utils", version = "1.0.10" }
 
 [lib]
 name = "scx_rustland_core"

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_utils"
-version = "1.0.9"
+version = "1.0.10"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_bpfland/Cargo.toml
+++ b/scheds/rust/scx_bpfland/Cargo.toml
@@ -15,12 +15,12 @@ libbpf-rs = "=0.25.0-beta.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.8" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.8" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9", features = ["autopower"] }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10", features = ["autopower"] }
 serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_flash/Cargo.toml
+++ b/scheds/rust/scx_flash/Cargo.toml
@@ -15,12 +15,12 @@ libbpf-rs = "=0.25.0-beta.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.8" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.8" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
 serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4.17"
 ordered-float = "3.4.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.8" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.8" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9", features = ["autopower"] }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10", features = ["autopower"] }
 serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
 static_assertions = "1.1.0"
@@ -29,7 +29,7 @@ plain = "0.2.3"
 gpoint = "0.2"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -21,7 +21,7 @@ libc = "0.2.137"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.8" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.8" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.12"
@@ -29,7 +29,7 @@ nvml-wrapper = "0.10.0"
 once_cell = "1.20.2"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_mitosis/Cargo.toml
+++ b/scheds/rust/scx_mitosis/Cargo.toml
@@ -19,13 +19,13 @@ libbpf-rs = "=0.25.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 maplit = "1.0.2"
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -12,12 +12,12 @@ plain = "0.2.3"
 ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "=0.25.0-beta.1"
 libc = "0.2.137"
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.7" }
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.7" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -19,13 +19,13 @@ ordered-float = "3.4.0"
 serde = { version = "1.0", features = ["derive"] }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.8" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.8" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.7" }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.6" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.7" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -19,14 +19,14 @@ log = "0.4.17"
 ordered-float = "3.4.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.8" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.8" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
 serde = { version = "1.0", features = ["derive"] }
 simplelog = "0.12"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.9" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }
 
 [features]
 enable_backtrace = []

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "4.1", features = [
     "unstable-styles",
 ] }
 libbpf-rs = "=0.24.8"
-scx_utils = { path = "../../rust/scx_utils", version = "1.0.8" }
+scx_utils = { path = "../../rust/scx_utils", version = "1.0.10" }
 scx_stats = { path = "../../rust/scx_stats", version = "1.0.8" }
 config = "0.14.1"
 crossterm = { version = "0.28.1", features = ["serde", "event-stream"] }
@@ -50,6 +50,6 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter", "serde"] }
 protobuf = "3.7.1"
 
 [build-dependencies]
-scx_utils = { path = "../../rust/scx_utils", version = "1.0.8" }
+scx_utils = { path = "../../rust/scx_utils", version = "1.0.10" }
 scx_stats = { path = "../../rust/scx_stats", version = "1.0.8" }
 protobuf-codegen = "3.7.1"


### PR DESCRIPTION
Release a new scx_utils to fix scx_rustland_core dependency.