### PR TITLE
ci: switch scheduled jobs to nix built kernel

### DIFF
--- a/.github/actions/restore-kernel-cache/action.yml
+++ b/.github/actions/restore-kernel-cache/action.yml
@@ -1,0 +1,26 @@
+name: 'Restore kernel cache'
+description: 'Restore a previously built kernel cache, failing if not available'
+inputs:
+  git-repo:
+    required: true
+    type: string
+  branch:
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get hash from repo/branch
+      run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote ${{ inputs.git-repo }} heads/${{ inputs.branch }} | awk '{print $1}')" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Load cache
+      uses: actions/cache/restore@v4
+      with:
+        fail-on-cache-miss: true
+        key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-7
+        path:  |
+          linux/arch/x86/boot/bzImage
+          linux/usr/include
+          linux/**/*.h

--- a/.github/workflows/bpf-next-test.yml
+++ b/.github/workflows/bpf-next-test.yml
@@ -6,73 +6,11 @@ on:
       - cron: "0 */6 * * *"
 
 jobs:
-  build-kernel-nix:
+  build-kernel:
     uses: ./.github/workflows/build-kernel.yml
     with:
       git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git"
       branch: for-next
-
-  build-kernel:
-    runs-on: ubuntu-24.04
-    steps:
-      # prevent cache permission errors
-      - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      # redundancy to exit fast
-      - run: echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y git --no-install-recommends
-      # get latest head commit of sched_ext for-next
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
-
-      # use cached kernel if available, create after job if not
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-bpf-1
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        uses: ./.github/actions/install-deps-action
-
-      # cache virtiofsd (goes away w/ 24.04)
-      - name: Cache virtiofsd
-        id: cache-virtiofsd
-        uses: actions/cache@v4
-        with:
-          path: |
-            /usr/lib/virtiofsd
-          key: virtiofsd-binary
-      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' && steps.cache-kernel.outputs.cache-hit != 'true' }}
-        run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: Clone Kernel
-        # Get the latest sched-ext enabled kernel directly from the korg
-        # for-next branch
-        run: git clone --single-branch -b for-next --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git linux
-
-      # guard rail because we are caching
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        run: cd linux && git checkout ${{ env.SCHED_EXT_KERNEL_COMMIT }}
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-      # Print the latest commit of the checked out sched-ext kernel
-        run: cd linux && git log -1 --pretty=format:"%h %ad %s" --date=short
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-      # Build a minimal kernel (with sched-ext enabled) using virtme-ng
-        run: cd linux && vng -v --build --config ../.github/workflows/sched-ext.config
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-      # Generate kernel headers
-        run: cd linux && make headers
 
   integration-test:
     runs-on: ubuntu-24.04
@@ -82,9 +20,15 @@ jobs:
             scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
           fail-fast: false
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/restore-kernel-cache
+        with:
+          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git"
+          branch: for-next
+
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.scheduler }}
@@ -100,25 +44,6 @@ jobs:
           key: virtiofsd-binary
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      # get latest head commit of sched_ext for-next
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
-
-      # use cached kernel if available, create after job if not
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-bpf-1
-
-      # need to re-run job when kernel head changes between build and test running.
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: exit if cache stale
-        run: exit -1
 
       # veristat
       - run: wget https://github.com/libbpf/veristat/releases/download/v0.3.2/veristat-v0.3.2-amd64.tar.gz

--- a/.github/workflows/for-next-test.yml
+++ b/.github/workflows/for-next-test.yml
@@ -6,94 +6,11 @@ on:
       - cron: "0 */6 * * *"
 
 jobs:
-  build-kernel-nix:
+  build-kernel:
     uses: ./.github/workflows/build-kernel.yml
     with:
       git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
       branch: for-next
-
-  lint:
-    runs-on: ubuntu-24.04
-    steps:
-      # prevent cache permission errors
-      - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - name: Install deps
-        run: |
-          curl https://sh.rustup.rs -sSf | RUSTUP_INIT_SKIP_PATH_CHECK=yes sh -s -- -y
-          rustup show  # installs the toolchain from rust-toolchain.toml
-          export PATH="~/.cargo/bin:$PATH"
-
-      - uses: actions/checkout@v4
-
-      # Lint code
-      - run: cargo fmt
-      - run: git diff --exit-code
-
-  build-kernel:
-    runs-on: ubuntu-24.04
-    steps:
-      # prevent cache permission errors
-      - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      # redundancy to exit fast
-      - run: echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y git --no-install-recommends
-      # get latest head commit of sched_ext for-next
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
-
-      # use cached kernel if available, create after job if not
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        uses: ./.github/actions/install-deps-action
-
-      # cache virtiofsd (goes away w/ 24.04)
-      - name: Cache virtiofsd
-        id: cache-virtiofsd
-        uses: actions/cache@v4
-        with:
-          path: |
-            /usr/lib/virtiofsd
-          key: virtiofsd-binary
-      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' && steps.cache-kernel.outputs.cache-hit != 'true' }}
-        run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: Clone Kernel
-        # Get the latest sched-ext enabled kernel directly from the korg
-        # for-next branch
-        uses: cytopia/shell-command-retry-action@v0.1.2
-        with:
-          retries: 10
-          pause: 18
-          command: git clone --single-branch -b for-next --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
-
-      # guard rail because we are caching
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        run: cd linux && git checkout ${{ env.SCHED_EXT_KERNEL_COMMIT }}
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-      # Print the latest commit of the checked out sched-ext kernel
-        run: cd linux && git log -1 --pretty=format:"%h %ad %s" --date=short
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-      # Build a minimal kernel (with sched-ext enabled) using virtme-ng
-        run: cd linux && vng -v --build --config ../.github/workflows/sched-ext.config
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-      # Generate kernel headers
-        run: cd linux && make headers
 
   integration-test:
     runs-on: ubuntu-24.04
@@ -103,9 +20,15 @@ jobs:
             scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
           fail-fast: false
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/restore-kernel-cache
+        with:
+          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
+          branch: for-next
+
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.scheduler }}
@@ -121,25 +44,6 @@ jobs:
           key: virtiofsd-binary
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      # get latest head commit of sched_ext for-next
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
-
-      # use cached kernel if available, create after job if not
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
-
-      # need to re-run job when kernel head changes between build and test running.
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: exit if cache stale
-        run: exit -1
 
       # veristat
       - run: wget https://github.com/libbpf/veristat/releases/download/v0.3.2/veristat-v0.3.2-amd64.tar.gz
@@ -193,9 +97,15 @@ jobs:
             antistall: ['', '--disable-antistall']
           fail-fast: false
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/restore-kernel-cache
+        with:
+          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
+          branch: for-next
+
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.scheduler }}
@@ -211,25 +121,6 @@ jobs:
           key: virtiofsd-binary
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      # get latest head commit of sched_ext for-next
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
-
-      # use cached kernel if available, create after job if not
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
-
-      # need to re-run job when kernel head changes between build and test running.
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: exit if cache stale
-        run: exit -1
 
       # The actual build:
       - run: meson setup build -Dkernel=../linux/arch/x86/boot/bzImage -Dkernel_headers=../linux -Denable_stress=true -Dvng_rw_mount=true -Dextra_sched_args=" ${{ matrix.topo }} ${{ matrix.antistall }}"
@@ -272,9 +163,15 @@ jobs:
       matrix:
         component: [scx_loader, scx_rustland_core, scx_stats, scx_utils]
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/restore-kernel-cache
+        with:
+          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
+          branch: for-next
+
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-deps-action
       # cache virtiofsd (goes away w/ 24.04)
       - name: Cache virtiofsd
@@ -286,24 +183,6 @@ jobs:
           key: virtiofsd-binary
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      # get latest head commit of sched_ext for-next
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
-
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
-
-      # need to re-run job when kernel head changes between build and test running.
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: exit if cache stale
-        run: exit -1
 
       - run: cargo build  --manifest-path rust/${{ matrix.component }}/Cargo.toml
       - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --manifest-path rust/${{ matrix.component }}/Cargo.toml
@@ -315,9 +194,15 @@ jobs:
       matrix:
         scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/restore-kernel-cache
+        with:
+          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
+          branch: for-next
+
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-deps-action
       # cache virtiofsd (goes away w/ 24.04)
       - name: Cache virtiofsd
@@ -329,24 +214,6 @@ jobs:
           key: virtiofsd-binary
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      # get latest head commit of sched_ext for-next
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-next | awk '{print $1}')" >> $GITHUB_ENV
-      # Cache Kernel alone for rust tests
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
-
-      # need to re-run job when kernel head changes between build and test running.
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: exit if cache stale
-        run: exit -1
 
       - run: cargo build  --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml
       - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -6,73 +6,11 @@ on:
     - cron: "0 */6 * * *"
 
 jobs:
-  build-kernel-nix:
+  build-kernel:
     uses: ./.github/workflows/build-kernel.yml
     with:
       git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
       branch: linux-rolling-stable
-
-  build-kernel:
-    runs-on: ubuntu-24.04
-    steps:
-      # prevent cache permission errors
-      - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      # redundancy to exit fast
-      - run: echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y git --no-install-recommends
-      # get latest head commit of sched_ext linux-rolling-stable
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git heads/linux-rolling-stable | awk '{print $1}')" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
-
-      # use cached kernel if available, create after job if not
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-stable-1
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        uses: ./.github/actions/install-deps-action
-
-      # cache virtiofsd (goes away w/ 24.04)
-      - name: Cache virtiofsd
-        id: cache-virtiofsd
-        uses: actions/cache@v4
-        with:
-          path: |
-            /usr/lib/virtiofsd
-          key: virtiofsd-binary
-      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' && steps.cache-kernel.outputs.cache-hit != 'true' }}
-        run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: Clone Kernel
-        # Get the latest sched-ext enabled kernel directly from the korg
-        # linux-rolling-stable branch
-        run: git clone --single-branch -b linux-rolling-stable --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git linux
-
-      # guard rail because we are caching
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        run: cd linux && git checkout ${{ env.SCHED_EXT_KERNEL_COMMIT }}
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-      # Print the latest commit of the checked out sched-ext kernel
-        run: cd linux && git log -1 --pretty=format:"%h %ad %s" --date=short
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-      # Build a minimal kernel (with sched-ext enabled) using virtme-ng
-        run: cd linux && vng -v --build --config ../.github/workflows/sched-ext.config
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-      # Generate kernel headers
-        run: cd linux && make headers
 
   integration-test:
     runs-on: ubuntu-24.04
@@ -82,9 +20,15 @@ jobs:
             scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
           fail-fast: false
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/restore-kernel-cache
+        with:
+          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
+          branch: linux-rolling-stable
+
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.scheduler }}
@@ -100,25 +44,6 @@ jobs:
           key: virtiofsd-binary
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      # get latest head commit of linux-rolling-stable
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git heads/linux-rolling-stable | awk '{print $1}')" >> $GITHUB_ENV
-
-      # use cached kernel if available, create after job if not
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-stable-1
-
-      # need to re-run job when kernel head changes between build and test running.
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: exit if cache stale
-        run: exit -1
 
       # veristat
       - run: wget https://github.com/libbpf/veristat/releases/download/v0.3.2/veristat-v0.3.2-amd64.tar.gz


### PR DESCRIPTION
Create a reusable GitHub action to restore the kernel cache. This takes an
argument for `git-repo` and `branch`, like the equivalent reusable workflow for
building a Nix kernel. Enable this action for the Nix built kernels in the
scheduled runs.

This reduces the possibility for a mis-copy and significantly simplifies the
files compared to duplicating the code.

Note that this is deliberately ordered before the `tar` setuid bit in the
actions, as the new cache and that change don't interact well. Will drop that
setuid step in future changes but leaving it there for now to load the other
caches.

Drive by: remove lint from the for-next scheduled run. It's already checked on
PRs, in the merge queue, and on the scheduled main run.

Test plan:
- Changed one of the cache loads to the `master` branch to guarantee a miss.
    Workflow fails as expected.
- Tested scheduled workflows by enabling them temporarily on `push`. They pass.