### PR TITLE
scx_layered: refactor gpu support to workaround nvml issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,6 +2237,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
+ "sysinfo 0.33.1",
 ]
 
 [[package]]
@@ -2250,7 +2251,7 @@ dependencies = [
  "log",
  "nix 0.29.0",
  "serde",
- "sysinfo",
+ "sysinfo 0.31.4",
  "tokio",
  "tokio-util",
  "toml",
@@ -2717,6 +2718,20 @@ name = "sysinfo"
 version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0"
 simplelog = "0.12"
 nvml-wrapper = "0.10.0"
 once_cell = "1.20.2"
+sysinfo = "0.33.1"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.10" }


### PR DESCRIPTION
Refactor gpu support to workaround nvml issues.

This changes default behavior when `--enable-gpu-support` is set to use NVML less. It also adds a flag `--aggressive-nvml-polling` to restore prior behavior (poll NVML on each iteration of the userspace update loop).

By default, NVML will now be called super conservatively. In addition to only initializing NVML once  (which is done either way), the existence of PIDs seen previously by NVML will be used to limit updates to the map of GPU pids (and, more importantly, reading PIDs using GPUs via NVML).

The ruleset is now as follows:
* If all previously seen PIDs using GPUs are not dead, check NVML again in 10 minutes.
* If no PIDs were previously seen using GPUs, check NVML every 30 seconds.
* When a PID using a GPU dies, check NVML.
* "dead" wrt/ PIDs in this context means start_time > previous start time or the PID is gone.

The goal of this is to reduce NVML calls to avoid issues with concurrent calls (on occasion) crashing systems.

The GPU pinning works the same as last time, this just controls when it's done. Seems to work fine, the following screenshot shows a 30 second interval check being skipped (while test job was running), a NVML update after I killed the test job, and another NVML update after that (when no GPU jobs were running).

![Screenshot from 2025-02-01 00-47-13](https://github.com/user-attachments/assets/f8bb6e21-ff6c-4a9b-95f1-2c37f73a918c)

cc @valentinandrei