### PR TITLE
scx_lavd: Revert "scx_lavd: Preemption when ops.select_cpu() was skipped"

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -70,17 +70,6 @@ static bool can_cpu1_kick_cpu2(struct preemption_info *prm_cpu1,
 	return comp_preemption_info(prm_cpu1, prm_cpu2) < 0;
 }
 
-static bool can_task1_kick_cpu2(struct task_ctx *taskc1, struct cpu_ctx *cpuc2,
-				u64 now)
-{
-	struct preemption_info prm_task1, prm_cpu2;
-
-	prm_task1.stopping_tm_est_ns = get_est_stopping_time(taskc1, now);
-	prm_task1.lat_cri = taskc1->lat_cri;
-
-	return can_cpu1_kick_cpu2(&prm_task1, &prm_cpu2, cpuc2);
-}
-
 static bool is_worth_kick_other_task(struct task_ctx *taskc)
 {
 	/*


### PR DESCRIPTION
This reverts commit 22057be29a4308861e0c05759fcc80c00a915e47

That particular commit has more harm than good. It causes latency spikes and performance drops in many workloads, including WebGL Aquarium, osu-wine, Bitwig, and slowroads.io. Thus revert the commit.
