### PR TITLE
ci: disable DEBUG_INFO_REDUCED for arm64

### DIFF
--- a/.github/workflows/sched-ext.config
+++ b/.github/workflows/sched-ext.config
@@ -8,6 +8,10 @@ CONFIG_BPF_JIT_ALWAYS_ON=y
 CONFIG_BPF_JIT_DEFAULT_ON=y
 CONFIG_SCHED_CLASS_EXT=y
 
+# Required on arm64
+#
+# CONFIG_DEBUG_INFO_REDUCED is not set
+
 # Enable scheduling debugging
 #
 CONFIG_SCHED_DEBUG=y


### PR DESCRIPTION
Disable CONFIG_DEBUG_INFO_REDUCED, as it blocks CONFIG_DEBUG_INFO_BTF, preventing BTF from being generated.