### PR TITLE
lib/sdt_alloc: introduce typeless init-time arena allocator

### DIFF
--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -112,4 +112,7 @@ int sdt_free_idx(struct sdt_allocator *alloc, __u64 idx);
 
 #define sdt_alloc(alloc) ((struct sdt_data __arena *)sdt_alloc_internal((alloc)))
 
+void __arena *sdt_static_alloc(size_t bytes);
+int sdt_static_init(size_t max_alloc_pages);
+
 #endif /* __BPF__ */

--- a/scheds/rust/scx_rusty/src/bpf/intf.h
+++ b/scheds/rust/scx_rusty/src/bpf/intf.h
@@ -64,6 +64,8 @@ enum consts {
 	 * anyway and will be retried until loads are balanced.
 	 */
 	MAX_DOM_ACTIVE_TPTRS	= 1024,
+
+	STATIC_ALLOC_PAGES_GRANULARITY = 1,
 };
 
 /* Statistics */

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -1909,6 +1909,10 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rusty_init)
 {
 	s32 i, ret;
 
+	ret = sdt_static_init(STATIC_ALLOC_PAGES_GRANULARITY);
+	if (ret)
+		return ret;
+
 	ret = sdt_task_init(sizeof(struct task_ctx));
 	if (ret)
 		return ret;


### PR DESCRIPTION
Add a simple typeless, single threaded arena allocator to be used at initialization time. This is useful because:

1) Arena allocators are currently typed. We have to create a new allocator for each new type we want to add into the arena.
2) The existing allocator's retry and tree traversal logic is complex enough that naively making too many allocator calls in a single function can cause verification to fail, e.g., allocating an array of structs in a loop.

With this new allocator we avoid these problems for initialization-time struct instances.