### PR TITLE
sdt_alloc: mark allocation functions as weak

### DIFF
--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -107,7 +107,9 @@ void sdt_task_free(struct task_struct *p);
 void sdt_subprog_init_arena(void);
 
 int sdt_alloc_init(struct sdt_allocator *alloc, __u64 data_size);
-struct sdt_data __arena *sdt_alloc(struct sdt_allocator *alloc);
-void sdt_free_idx(struct sdt_allocator *alloc, __u64 idx);
+u64 sdt_alloc_internal(struct sdt_allocator *alloc);
+int sdt_free_idx(struct sdt_allocator *alloc, __u64 idx);
+
+#define sdt_alloc(alloc) ((struct sdt_data __arena *)sdt_alloc_internal((alloc)))
 
 #endif /* __BPF__ */


### PR DESCRIPTION
The arena allocation functions are currently marked as __hidden, so the verifier treats them as static even if they are in a separate compilation unit from their caller. However, the allocation functions are relatively complex and lead to verification failures if called multiple times from the same function. The __weak keyword prevents the verifier from verifying the function on every call site, preventing this problem.