### PR TITLE
scx_rusty: use arena-based CPU masks

### DIFF
--- a/scheds/rust/scx_rusty/build.rs
+++ b/scheds/rust/scx_rusty/build.rs
@@ -8,6 +8,7 @@ fn main() {
         .unwrap()
         .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
         .enable_skel("src/bpf/main.bpf.c", "bpf")
+        .add_source("src/bpf/cpumask.bpf.c")
         .add_source("../../../lib/sdt_task.bpf.c")
         .add_source("../../../lib/sdt_alloc.bpf.c")
         .compile_link_gen()

--- a/scheds/rust/scx_rusty/src/bpf/cpumask.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/cpumask.bpf.c
@@ -1,0 +1,211 @@
+#include <scx/common.bpf.h>
+#include <lib/sdt_task.h>
+
+#include "cpumask.h"
+
+static struct sdt_allocator scx_mask_allocator;
+
+__weak
+int scx_mask_init(__u64 total_mask_size)
+{
+	mask_size = div_round_up(total_mask_size, 8);
+
+	return sdt_alloc_init(&scx_mask_allocator, mask_size * 8 + sizeof(union sdt_id));
+}
+
+__weak
+u64 scx_mask_alloc_internal(void)
+{
+	struct sdt_data __arena *data = NULL;
+	scx_cpumask_t mask;
+	int i;
+
+	data = sdt_alloc(&scx_mask_allocator);
+	cast_kern(data);
+	if (!data)
+		return (u64)(NULL);
+
+	mask = (scx_cpumask_t)data->payload;
+	mask->tid = data->tid;
+	bpf_for(i, 0, mask_size) {
+		mask->bits[i] = 0ULL;
+	}
+
+	return (u64)mask;
+}
+
+/*
+ * XXXETSAL: Ideally these functions would have a void return type,
+ * but as of 6.13 the verifier requires global functions to return a scalar.
+ */
+
+__weak
+int scx_mask_free(scx_cpumask_t __arg_arena mask)
+{
+	sdt_subprog_init_arena();
+
+	sdt_free_idx(&scx_mask_allocator, mask->tid.idx);
+	return 0;
+}
+
+__weak
+int scxmask_copy_to_stack(struct scx_cpumask *dst, scx_cpumask_t __arg_arena src)
+{
+	int i;
+
+	if (!src || !dst) {
+		scx_bpf_error("invalid pointer args to pointer copy");
+		return 0;
+	}
+
+	bpf_for(i, 0, mask_size) {
+		if (i >= SCXMASK_NLONG || i < 0)
+			return 0;
+		dst->bits[i] = src->bits[i];
+	}
+
+	return 0;
+}
+
+__weak
+int scxmask_set_cpu(u32 cpu, scx_cpumask_t __arg_arena mask)
+{
+	mask->bits[cpu / 64] |= 1 << (cpu % 64);
+	return 0;
+}
+
+__weak
+int scxmask_clear_cpu(u32 cpu, scx_cpumask_t __arg_arena mask)
+{
+	mask->bits[cpu / 64] &= 1 << ~(cpu % 64);
+	return 0;
+}
+
+__weak
+bool scxmask_test_cpu(u32 cpu, scx_cpumask_t __arg_arena mask)
+{
+	return mask->bits[cpu / 64] & (1 << (cpu % 64));
+}
+
+__weak
+int scxmask_clear(scx_cpumask_t __arg_arena mask)
+{
+	int i;
+
+	bpf_for(i, 0, mask_size) {
+		mask->bits[i] = 0;
+	}
+
+	return 0;
+}
+
+__weak
+int scxmask_and(scx_cpumask_t __arg_arena dst, scx_cpumask_t __arg_arena src1, scx_cpumask_t __arg_arena src2)
+{
+	int i;
+
+	bpf_for(i, 0, mask_size) {
+		dst->bits[i] = src1->bits[i] & src2->bits[i];
+	}
+
+	return 0;
+}
+
+__weak
+bool scxmask_empty(scx_cpumask_t __arg_arena mask)
+{
+	int i;
+
+	bpf_for(i, 0, mask_size) {
+		if (mask->bits[i])
+			return true;
+	}
+
+	return true;
+}
+
+cpumask_t tmpmask;
+
+__weak int
+scxmask_to_bpf(struct bpf_cpumask __kptr *bpfmask __arg_trusted,
+		   scx_cpumask_t __arg_arena scxmask)
+{
+	struct scx_cpumask tmp;
+	int ret, i;
+
+#if 0
+	if (bpf_ksym_exists(bpf_cpumask_from_bpf_mem)) {
+		scxmask_copy_to_stack(&tmp, scxmask);
+		ret = bpf_cpumask_from_bpf_mem(bpfmask, &tmp, sizeof(tmp));
+		if (ret)
+			scx_bpf_error("error");
+
+		return 0;
+	}
+#endif
+
+	bpf_for(i, 0, nr_cpu_ids) {
+		if (scxmask_test_cpu(i, scxmask))
+			bpf_cpumask_set_cpu(i, bpfmask);
+		else
+			bpf_cpumask_clear_cpu(i, bpfmask);
+	}
+
+	return 0;
+}
+
+
+__weak
+int scxmask_copy(scx_cpumask_t __arg_arena dst, scx_cpumask_t __arg_arena src)
+{
+	int i;
+
+	bpf_for(i, 0, mask_size) {
+		dst->bits[i] = src->bits[i];
+	}
+
+	return 0;
+}
+
+__weak
+bool scxmask_subset_cpumask(scx_cpumask_t __arg_arena big, const struct cpumask *small __arg_trusted)
+{
+	int i;
+
+	bpf_for(i, 0, nr_cpu_ids) {
+		if (!scxmask_test_cpu(i, big) && bpf_cpumask_test_cpu(i, small))
+			return false;
+	}
+
+	return true;
+}
+
+__weak
+bool scxmask_intersects_cpumask(scx_cpumask_t __arg_arena scx, const struct cpumask *cpu __arg_trusted)
+{
+	int i;
+
+	bpf_for(i, 0, nr_cpu_ids) {
+		if (scxmask_test_cpu(i, scx) && bpf_cpumask_test_cpu(i, cpu))
+			return true;
+	}
+
+	return false;
+}
+
+__weak
+int scxmask_and_cpumask(scx_cpumask_t dst __arg_arena,
+			       scx_cpumask_t scx __arg_arena,
+			       const struct cpumask *cpu __arg_trusted)
+{
+	int i;
+
+	bpf_for(i, 0, nr_cpu_ids) {
+		if (scxmask_test_cpu(i, scx) && bpf_cpumask_test_cpu(i, cpu))
+			scxmask_set_cpu(i, dst);
+		else
+			scxmask_clear_cpu(i, dst);
+	}
+
+	return 0;
+}

--- a/scheds/rust/scx_rusty/src/bpf/cpumask.h
+++ b/scheds/rust/scx_rusty/src/bpf/cpumask.h
@@ -1,242 +1,63 @@
-int bpf_cpumask_from_mem(struct bpf_cpumask *dst, void *src, size_t src__sz) __ksym __weak;
-int bpf_cpumask_to_mem(void *dst, size_t dst__sz, struct bpf_cpumask *src) __ksym __weak;
+#pragma once
+#include <scx/common.bpf.h>
+
+#include <lib/sdt_task.h>
+
+
+int bpf_cpumask_from_bpf_mem(struct bpf_cpumask *dst, void *src, size_t src__sz) __ksym __weak;
+
+#define SCXMASK_NLONG (512 / 8)
+
+/* XXX HACK hardcoded MAX_CPUS / 64 from src/bpf/intf.h, right now this header is a mess */
+struct scx_cpumask {
+	union sdt_id tid;
+	u64 bits[SCXMASK_NLONG];
+};
+
+typedef struct scx_cpumask __arena * __arg_arena scx_cpumask_t;
 
 extern const volatile u32 nr_cpu_ids;
 
 /* Mask size in 64-bit words. */
 static size_t mask_size;
 
-/* XXX HACK hardcoded MAX_CPUS / 64 from src/bpf/intf.h, right now this header is a mess */
-struct scx_cpumask {
-	union sdt_id tid;
-	u64 bits[8];
-};
+int scx_mask_init(__u64 total_mask_size);
+u64 scx_mask_alloc_internal(void);
+#define scx_mask_alloc() ( (scx_cpumask_t) scx_mask_alloc_internal() )
+int scx_mask_free(scx_cpumask_t __arg_arena mask);
 
-typedef struct scx_cpumask __arena * __arg_arena scx_cpumask_t;
+int scxmask_copy_to_stack(struct scx_cpumask *dst, scx_cpumask_t __arg_arena src);
+int scxmask_to_bpf(struct bpf_cpumask __kptr *bpfmask __arg_trusted, scx_cpumask_t __arg_arena scxmask);
 
-struct sdt_allocator scx_mask_allocator;
+int scxmask_set_cpu(u32 cpu, scx_cpumask_t __arg_arena mask);
+int scxmask_clear_cpu(u32 cpu, scx_cpumask_t __arg_arena mask);
+bool scxmask_test_cpu(u32 cpu, scx_cpumask_t __arg_arena mask);
 
-__weak
-int scx_mask_init(__u64 total_mask_size)
-{
-	mask_size = (total_mask_size + 7 / 8);
+int scxmask_clear(scx_cpumask_t __arg_arena mask);
+int scxmask_and(scx_cpumask_t __arg_arena dst, scx_cpumask_t __arg_arena src1, scx_cpumask_t __arg_arena src2);
+bool scxmask_empty(scx_cpumask_t __arg_arena mask);
+int scxmask_copy(scx_cpumask_t __arg_arena dst, scx_cpumask_t __arg_arena src);
 
-	return sdt_alloc_init(&scx_mask_allocator, mask_size * 8 + sizeof(union sdt_id));
-}
-
-static
-scx_cpumask_t scx_mask_alloc(void)
-{
-	struct sdt_data __arena *data = NULL;
-	scx_cpumask_t mask;
-	int i;
-
-	data = sdt_alloc(&scx_mask_allocator);
-	cast_kern(data);
-
-	mask = (scx_cpumask_t)data->payload;
-	mask->tid = data->tid;
-	bpf_for(i, 0, mask_size) {
-		mask->bits[i] = 0ULL;
-	}
-
-	return mask;
-}
+bool scxmask_intersects_cpumask(scx_cpumask_t __arg_arena scx, const struct cpumask *cpu);
+bool scxmask_subset_cpumask(scx_cpumask_t __arg_arena big, const struct cpumask *small);
+int scxmask_and_cpumask(scx_cpumask_t dst __arg_arena, scx_cpumask_t scx __arg_arena,
+			       const struct cpumask *cpu __arg_trusted);
 
 /*
- * XXXETSAL: Ideally these functions would have a void return type,
- * but as of 6.13 the verifier requires global functions to return a scalar.
+ * XXXETSAL Turning this nonstatic causes a verification failure. Investigate
+ * why - the verifier erroneously believes cpumask_t only has 8 elements.
  */
-
-__weak
-int scx_mask_free(scx_cpumask_t __arg_arena mask)
-{
-	sdt_subprog_init_arena();
-
-	sdt_free_idx(&scx_mask_allocator, mask->tid.idx);
-	return 0;
-}
-
-__weak
-int scxmask_copy_to_stack(struct scx_cpumask *dst, scx_cpumask_t __arg_arena src)
-{
-	int i;
-
-	if (!src || !dst) {
-		scx_bpf_error("invalid pointer args to pointer copy");
-		return 0;
-	}
-
-	bpf_for(i, 0, mask_size) {
-		if (i >= 8 || i < 0)
-			return 0;
-		dst->bits[i] = src->bits[i];
-	}
-
-	return 0;
-}
-
-__weak
-int scxmask_set_cpu(u32 cpu, scx_cpumask_t __arg_arena mask)
-{
-	mask->bits[cpu / 64] |= 1 << (cpu % 64);
-	return 0;
-}
-
-__weak
-int scxmask_clear_cpu(u32 cpu, scx_cpumask_t __arg_arena mask)
-{
-	mask->bits[cpu / 64] &= 1 << ~(cpu % 64);
-	return 0;
-}
-
-__weak
-bool scxmask_test_cpu(u32 cpu, scx_cpumask_t __arg_arena mask)
-{
-	return mask->bits[cpu / 64] & (1 << (cpu % 64));
-}
-
-__weak
-int scxmask_clear(scx_cpumask_t __arg_arena mask)
-{
-	int i;
-
-	bpf_for(i, 0, mask_size) {
-		mask->bits[i] = 0;
-	}
-
-	return 0;
-}
-
-__weak
-int scxmask_and(scx_cpumask_t __arg_arena dst, scx_cpumask_t __arg_arena src1, scx_cpumask_t __arg_arena src2)
-{
-	int i;
-
-	bpf_for(i, 0, mask_size) {
-		dst->bits[i] = src1->bits[i] & src2->bits[i];
-	}
-
-	return 0;
-}
-
-__weak
-bool scxmask_empty(scx_cpumask_t __arg_arena mask)
-{
-	int i;
-
-	bpf_for(i, 0, mask_size) {
-		if (mask->bits[i])
-			return true;
-	}
-
-	return true;
-}
-
-static void
-scxmask_to_bpf(struct bpf_cpumask __kptr *bpfmask __arg_trusted,
-		   scx_cpumask_t __arg_arena scxmask)
-{
-	struct scx_cpumask tmp;
-	int ret, i;
-
-	if (bpf_ksym_exists(bpf_cpumask_from_mem)) {
-		scxmask_copy_to_stack(&tmp, scxmask);
-		ret = bpf_cpumask_from_mem(bpfmask, &tmp, sizeof(tmp));
-		if (ret)
-			scx_bpf_error("error");
-
-		return;
-	}
-
-	bpf_for(i, 0, nr_cpu_ids) {
-		if (scxmask_test_cpu(i, scxmask))
-			bpf_cpumask_set_cpu(i, bpfmask);
-		else
-			bpf_cpumask_clear_cpu(i, bpfmask);
-	}
-}
-
-cpumask_t tmpmask;
-
-/*
- * XXX Terrible implementations. We require a kfunc pair to do this properly.
- */
-static void
-scxmask_from_bpf(scx_cpumask_t __arg_arena scxmask, const struct cpumask __kptr *bpfmask)
+static int
+scxmask_from_bpf(scx_cpumask_t __arg_arena scxmask, const struct cpumask __kptr *bpfmask __arg_trusted)
 {
 	size_t len = mask_size;
 	int i;
 
-	if (len > sizeof(tmpmask))
-		len = sizeof(tmpmask);
+	if (len > sizeof(cpumask_t) / 8)
+		len = sizeof(cpumask_t) / 8;
 
-	/*
-	 * We cannot access the BPF mask in a loop. Since we know its exact
-	 * size, but not that of our cpumask type, copy over the bpfmask into a
-	 * temporary buffer, then copy over the valid data from that buffer into
-	 * our cpumask.
-	 */
-	#pragma unroll
-	for (i = 0; i < (sizeof(tmpmask) / sizeof(tmpmask.bits[0])); i++)
-		tmpmask.bits[i] = bpfmask->bits[i];
-
-	bpf_for (i, 0, mask_size) {
-		scxmask->bits[i] = tmpmask.bits[i];
-	}
-}
-
-__weak
-int scxmask_copy(scx_cpumask_t __arg_arena dst, scx_cpumask_t __arg_arena src)
-{
-	int i;
-
-	bpf_for(i, 0, mask_size) {
-		dst->bits[i] = src->bits[i];
-	}
-
-	return 0;
-}
-
-static
-bool scxmask_subset_cpumask(scx_cpumask_t __arg_arena big, const struct cpumask *small)
-{
-	int i;
-
-	bpf_for(i, 0, nr_cpu_ids) {
-		if (!scxmask_test_cpu(i, big) && bpf_cpumask_test_cpu(i, small))
-			return false;
-	}
-
-	return true;
-}
-
-static
-bool scxmask_intersects_cpumask(scx_cpumask_t __arg_arena scx, const struct cpumask *cpu)
-{
-	int i;
-
-	bpf_for(i, 0, nr_cpu_ids) {
-		if (scxmask_test_cpu(i, scx) && bpf_cpumask_test_cpu(i, cpu))
-			return true;
-	}
-
-	return false;
-}
-
-static
-int scxmask_and_cpumask(scx_cpumask_t dst __arg_arena,
-			       scx_cpumask_t scx __arg_arena,
-			       const struct cpumask *cpu __arg_trusted)
-{
-	int i;
-
-	bpf_for(i, 0, nr_cpu_ids) {
-		if (scxmask_test_cpu(i, scx) && bpf_cpumask_test_cpu(i, cpu))
-			scxmask_set_cpu(i, dst);
-		else
-			scxmask_clear_cpu(i, dst);
-	}
+	for (i = 0; i < len && can_loop; i++)
+		scxmask->bits[i] = bpfmask->bits[i];
 
 	return 0;
 }

--- a/scheds/rust/scx_rusty/src/bpf/cpumask.h
+++ b/scheds/rust/scx_rusty/src/bpf/cpumask.h
@@ -1,0 +1,84 @@
+size_t mask_size;
+
+struct scx_cpumask {
+	u8 mask[(MAX_CPUS + 7) / 8];
+};
+
+typedef struct scx_cpumask __arena * scx_cpumask_t;
+
+static inline
+void scxmask_set_cpu(int cpu, scx_cpumask_t mask)
+{
+	mask->mask[cpu / 8] |= 1 << (cpu % 8);
+}
+
+static inline
+void scxmask_clear_cpu(int cpu, scx_cpumask_t mask)
+{
+	mask->mask[cpu / 8] &= 1 << ~(cpu % 8);
+}
+
+static inline
+bool scxmask_test_cpu(int cpu, scx_cpumask_t mask)
+{
+	return mask->mask[cpu / 8] & (1 << (cpu % 8));
+}
+
+static inline
+void scxmask_clear(scx_cpumask_t mask)
+{
+	int i;
+
+	bpf_for(i, 0, mask_size) {
+		mask->mask[i] = 0;
+	}
+}
+
+static inline
+void scxmask_and(scx_cpumask_t dst, scx_cpumask_t src1, scx_cpumask_t src2)
+{
+	int i;
+
+	bpf_for(i, 0, mask_size) {
+		dst->mask[i] = src1->mask[i] & src2->mask[i];
+	}
+}
+
+static inline
+bool scxmask_empty(scx_cpumask_t mask)
+{
+	int i;
+
+	bpf_for(i, 0, mask_size) {
+		if (mask->mask[i])
+			return true;
+	}
+
+	return true;
+}
+
+static inline
+bool scxmask_subset(scx_cpumask_t big, scx_cpumask_t small)
+{
+	int i;
+
+	bpf_for(i, 0, mask_size) {
+		if (big->mask[i] & ~small->mask[i])
+			return false;
+	}
+
+	return true;
+}
+
+static inline
+bool scxmask_intersects(scx_cpumask_t src1, scx_cpumask_t src2)
+{
+	int i;
+
+	bpf_for(i, 0, mask_size) {
+		if (src1->mask[i] & src2->mask[i])
+			return true;
+	}
+
+	return false;
+}

--- a/scheds/rust/scx_rusty/src/bpf/cpumask.h
+++ b/scheds/rust/scx_rusty/src/bpf/cpumask.h
@@ -3,12 +3,11 @@
 
 #include <lib/sdt_task.h>
 
-
 int bpf_cpumask_from_bpf_mem(struct bpf_cpumask *dst, void *src, size_t src__sz) __ksym __weak;
 
+/* XXX HACK hardcoded MAX_CPUS / 64 from src/bpf/intf.h, right now this header is a mess */
 #define SCXMASK_NLONG (512 / 8)
 
-/* XXX HACK hardcoded MAX_CPUS / 64 from src/bpf/intf.h, right now this header is a mess */
 struct scx_cpumask {
 	union sdt_id tid;
 	u64 bits[SCXMASK_NLONG];
@@ -19,7 +18,7 @@ typedef struct scx_cpumask __arena * __arg_arena scx_cpumask_t;
 extern const volatile u32 nr_cpu_ids;
 
 /* Mask size in 64-bit words. */
-static size_t mask_size;
+extern size_t mask_size;
 
 int scx_mask_init(__u64 total_mask_size);
 u64 scx_mask_alloc_internal(void);
@@ -38,26 +37,9 @@ int scxmask_and(scx_cpumask_t __arg_arena dst, scx_cpumask_t __arg_arena src1, s
 bool scxmask_empty(scx_cpumask_t __arg_arena mask);
 int scxmask_copy(scx_cpumask_t __arg_arena dst, scx_cpumask_t __arg_arena src);
 
-bool scxmask_intersects_cpumask(scx_cpumask_t __arg_arena scx, const struct cpumask *cpu);
-bool scxmask_subset_cpumask(scx_cpumask_t __arg_arena big, const struct cpumask *small);
+int scxmask_from_bpf(scx_cpumask_t __arg_arena scxmask, const cpumask_t *bpfmask __arg_trusted);
 int scxmask_and_cpumask(scx_cpumask_t dst __arg_arena, scx_cpumask_t scx __arg_arena,
-			       const struct cpumask *cpu __arg_trusted);
+			       const struct cpumask *bpf __arg_trusted);
 
-/*
- * XXXETSAL Turning this nonstatic causes a verification failure. Investigate
- * why - the verifier erroneously believes cpumask_t only has 8 elements.
- */
-static int
-scxmask_from_bpf(scx_cpumask_t __arg_arena scxmask, const struct cpumask __kptr *bpfmask __arg_trusted)
-{
-	size_t len = mask_size;
-	int i;
-
-	if (len > sizeof(cpumask_t) / 8)
-		len = sizeof(cpumask_t) / 8;
-
-	for (i = 0; i < len && can_loop; i++)
-		scxmask->bits[i] = bpfmask->bits[i];
-
-	return 0;
-}
+bool scxmask_intersects_cpumask(scx_cpumask_t __arg_arena scx, const struct cpumask *bpf __arg_trusted);
+bool scxmask_subset_cpumask(scx_cpumask_t __arg_arena big, const struct cpumask *small __arg_trusted);

--- a/scheds/rust/scx_rusty/src/bpf/cpumask.h
+++ b/scheds/rust/scx_rusty/src/bpf/cpumask.h
@@ -2,12 +2,14 @@ int bpf_cpumask_from_mem(struct bpf_cpumask *dst, void *src, size_t src__sz) __k
 int bpf_cpumask_to_mem(void *dst, size_t dst__sz, struct bpf_cpumask *src) __ksym __weak;
 
 extern const volatile u32 nr_cpu_ids;
-size_t mask_size;
 
-/* XXX HACK hardcoded MAX_CPUS / 8 from src/bpf/intf.h, right now this header is a mess */
+/* Mask size in 64-bit words. */
+static size_t mask_size;
+
+/* XXX HACK hardcoded MAX_CPUS / 64 from src/bpf/intf.h, right now this header is a mess */
 struct scx_cpumask {
 	union sdt_id tid;
-	u8 mask[64];
+	u64 bits[8];
 };
 
 typedef struct scx_cpumask __arena * __arg_arena scx_cpumask_t;
@@ -17,9 +19,9 @@ struct sdt_allocator scx_mask_allocator;
 __weak
 int scx_mask_init(__u64 total_mask_size)
 {
-	mask_size = total_mask_size;
+	mask_size = (total_mask_size + 7 / 8);
 
-	return sdt_alloc_init(&scx_mask_allocator, mask_size + sizeof(union sdt_id));
+	return sdt_alloc_init(&scx_mask_allocator, mask_size * 8 + sizeof(union sdt_id));
 }
 
 static
@@ -35,7 +37,7 @@ scx_cpumask_t scx_mask_alloc(void)
 	mask = (scx_cpumask_t)data->payload;
 	mask->tid = data->tid;
 	bpf_for(i, 0, mask_size) {
-		mask->mask[i] = 0ULL;
+		mask->bits[i] = 0ULL;
 	}
 
 	return mask;
@@ -66,9 +68,9 @@ int scxmask_copy_to_stack(struct scx_cpumask *dst, scx_cpumask_t __arg_arena src
 	}
 
 	bpf_for(i, 0, mask_size) {
-		if (i >= 64 || i < 0)
+		if (i >= 8 || i < 0)
 			return 0;
-		dst->mask[i] = src->mask[i];
+		dst->bits[i] = src->bits[i];
 	}
 
 	return 0;
@@ -77,21 +79,21 @@ int scxmask_copy_to_stack(struct scx_cpumask *dst, scx_cpumask_t __arg_arena src
 __weak
 int scxmask_set_cpu(u32 cpu, scx_cpumask_t __arg_arena mask)
 {
-	mask->mask[cpu / 8] |= 1 << (cpu % 8);
+	mask->bits[cpu / 64] |= 1 << (cpu % 64);
 	return 0;
 }
 
 __weak
 int scxmask_clear_cpu(u32 cpu, scx_cpumask_t __arg_arena mask)
 {
-	mask->mask[cpu / 8] &= 1 << ~(cpu % 8);
+	mask->bits[cpu / 64] &= 1 << ~(cpu % 64);
 	return 0;
 }
 
 __weak
 bool scxmask_test_cpu(u32 cpu, scx_cpumask_t __arg_arena mask)
 {
-	return mask->mask[cpu / 8] & (1 << (cpu % 8));
+	return mask->bits[cpu / 64] & (1 << (cpu % 64));
 }
 
 __weak
@@ -100,7 +102,7 @@ int scxmask_clear(scx_cpumask_t __arg_arena mask)
 	int i;
 
 	bpf_for(i, 0, mask_size) {
-		mask->mask[i] = 0;
+		mask->bits[i] = 0;
 	}
 
 	return 0;
@@ -112,7 +114,7 @@ int scxmask_and(scx_cpumask_t __arg_arena dst, scx_cpumask_t __arg_arena src1, s
 	int i;
 
 	bpf_for(i, 0, mask_size) {
-		dst->mask[i] = src1->mask[i] & src2->mask[i];
+		dst->bits[i] = src1->bits[i] & src2->bits[i];
 	}
 
 	return 0;
@@ -124,7 +126,7 @@ bool scxmask_empty(scx_cpumask_t __arg_arena mask)
 	int i;
 
 	bpf_for(i, 0, mask_size) {
-		if (mask->mask[i])
+		if (mask->bits[i])
 			return true;
 	}
 
@@ -155,23 +157,33 @@ scxmask_to_bpf(struct bpf_cpumask __kptr *bpfmask __arg_trusted,
 	}
 }
 
+cpumask_t tmpmask;
 
 /*
  * XXX Terrible implementations. We require a kfunc pair to do this properly.
  */
 static void
-scxmask_from_bpf(scx_cpumask_t __arg_arena scxmask,
-		     const struct cpumask *bpfmask __arg_trusted)
+scxmask_from_bpf(scx_cpumask_t __arg_arena scxmask, const struct cpumask __kptr *bpfmask)
 {
+	size_t len = mask_size;
 	int i;
 
-	bpf_for(i, 0, nr_cpu_ids) {
-		if (bpf_cpumask_test_cpu(i, bpfmask))
-			scxmask_set_cpu(i, scxmask);
-		else
-			scxmask_clear_cpu(i, scxmask);
-	}
+	if (len > sizeof(tmpmask))
+		len = sizeof(tmpmask);
 
+	/*
+	 * We cannot access the BPF mask in a loop. Since we know its exact
+	 * size, but not that of our cpumask type, copy over the bpfmask into a
+	 * temporary buffer, then copy over the valid data from that buffer into
+	 * our cpumask.
+	 */
+	#pragma unroll
+	for (i = 0; i < (sizeof(tmpmask) / sizeof(tmpmask.bits[0])); i++)
+		tmpmask.bits[i] = bpfmask->bits[i];
+
+	bpf_for (i, 0, mask_size) {
+		scxmask->bits[i] = tmpmask.bits[i];
+	}
 }
 
 __weak
@@ -180,7 +192,7 @@ int scxmask_copy(scx_cpumask_t __arg_arena dst, scx_cpumask_t __arg_arena src)
 	int i;
 
 	bpf_for(i, 0, mask_size) {
-		dst->mask[i] = src->mask[i];
+		dst->bits[i] = src->bits[i];
 	}
 
 	return 0;

--- a/scheds/rust/scx_rusty/src/bpf/cpumask.h
+++ b/scheds/rust/scx_rusty/src/bpf/cpumask.h
@@ -5,41 +5,40 @@
 
 int bpf_cpumask_from_bpf_mem(struct bpf_cpumask *dst, void *src, size_t src__sz) __ksym __weak;
 
-/* XXX HACK hardcoded MAX_CPUS / 64 from src/bpf/intf.h, right now this header is a mess */
 #define SCXMASK_NLONG (512 / 8)
 
-struct scx_cpumask {
+struct scx_bitmap {
 	union sdt_id tid;
 	u64 bits[SCXMASK_NLONG];
 };
 
-typedef struct scx_cpumask __arena * __arg_arena scx_cpumask_t;
+typedef struct scx_bitmap __arena * __arg_arena scx_bitmap_t;
 
 extern const volatile u32 nr_cpu_ids;
 
 /* Mask size in 64-bit words. */
 extern size_t mask_size;
 
-int scx_mask_init(__u64 total_mask_size);
-u64 scx_mask_alloc_internal(void);
-#define scx_mask_alloc() ( (scx_cpumask_t) scx_mask_alloc_internal() )
-int scx_mask_free(scx_cpumask_t __arg_arena mask);
+int scx_bitmap_init(__u64 total_mask_size);
+u64 scx_bitmap_alloc_internal(void);
+#define scx_bitmap_alloc() ( (scx_bitmap_t) scx_bitmap_alloc_internal() )
+int scx_bitmap_free(scx_bitmap_t __arg_arena mask);
 
-int scxmask_copy_to_stack(struct scx_cpumask *dst, scx_cpumask_t __arg_arena src);
-int scxmask_to_bpf(struct bpf_cpumask __kptr *bpfmask __arg_trusted, scx_cpumask_t __arg_arena scxmask);
+int scx_bitmap_copy_to_stack(struct scx_bitmap *dst, scx_bitmap_t __arg_arena src);
+int scx_bitmap_to_bpf(struct bpf_cpumask __kptr *bpfmask __arg_trusted, scx_bitmap_t __arg_arena scx_bitmap);
 
-int scxmask_set_cpu(u32 cpu, scx_cpumask_t __arg_arena mask);
-int scxmask_clear_cpu(u32 cpu, scx_cpumask_t __arg_arena mask);
-bool scxmask_test_cpu(u32 cpu, scx_cpumask_t __arg_arena mask);
+int scx_bitmap_set_cpu(u32 cpu, scx_bitmap_t __arg_arena mask);
+int scx_bitmap_clear_cpu(u32 cpu, scx_bitmap_t __arg_arena mask);
+bool scx_bitmap_test_cpu(u32 cpu, scx_bitmap_t __arg_arena mask);
 
-int scxmask_clear(scx_cpumask_t __arg_arena mask);
-int scxmask_and(scx_cpumask_t __arg_arena dst, scx_cpumask_t __arg_arena src1, scx_cpumask_t __arg_arena src2);
-bool scxmask_empty(scx_cpumask_t __arg_arena mask);
-int scxmask_copy(scx_cpumask_t __arg_arena dst, scx_cpumask_t __arg_arena src);
+int scx_bitmap_clear(scx_bitmap_t __arg_arena mask);
+int scx_bitmap_and(scx_bitmap_t __arg_arena dst, scx_bitmap_t __arg_arena src1, scx_bitmap_t __arg_arena src2);
+bool scx_bitmap_empty(scx_bitmap_t __arg_arena mask);
+int scx_bitmap_copy(scx_bitmap_t __arg_arena dst, scx_bitmap_t __arg_arena src);
 
-int scxmask_from_bpf(scx_cpumask_t __arg_arena scxmask, const cpumask_t *bpfmask __arg_trusted);
-int scxmask_and_cpumask(scx_cpumask_t dst __arg_arena, scx_cpumask_t scx __arg_arena,
+int scx_bitmap_from_bpf(scx_bitmap_t __arg_arena scx_bitmap, const cpumask_t *bpfmask __arg_trusted);
+int scx_bitmap_and_cpumask(scx_bitmap_t dst __arg_arena, scx_bitmap_t scx __arg_arena,
 			       const struct cpumask *bpf __arg_trusted);
 
-bool scxmask_intersects_cpumask(scx_cpumask_t __arg_arena scx, const struct cpumask *bpf __arg_trusted);
-bool scxmask_subset_cpumask(scx_cpumask_t __arg_arena big, const struct cpumask *small __arg_trusted);
+bool scx_bitmap_intersects_cpumask(scx_bitmap_t __arg_arena scx, const struct cpumask *bpf __arg_trusted);
+bool scx_bitmap_subset_cpumask(scx_bitmap_t __arg_arena big, const struct cpumask *small __arg_trusted);

--- a/scheds/rust/scx_rusty/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_rusty/src/bpf/lb_domain.h
@@ -6,9 +6,9 @@ struct lb_domain {
 	union sdt_id		tid;
 
 	struct bpf_spin_lock vtime_lock;
-	scx_cpumask_t cpumask;
-	scx_cpumask_t direct_greedy_cpumask;
-	scx_cpumask_t node_cpumask;
+	scx_bitmap_t cpumask;
+	scx_bitmap_t direct_greedy_cpumask;
+	scx_bitmap_t node_cpumask;
 
 	dom_ptr domc;
 };

--- a/scheds/rust/scx_rusty/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_rusty/src/bpf/lb_domain.h
@@ -6,9 +6,9 @@ struct lb_domain {
 	union sdt_id		tid;
 
 	struct bpf_spin_lock vtime_lock;
-	struct bpf_cpumask __kptr *cpumask;
-	struct bpf_cpumask __kptr *direct_greedy_cpumask;
-	struct bpf_cpumask __kptr *node_cpumask;
+	scx_cpumask_t cpumask;
+	scx_cpumask_t direct_greedy_cpumask;
+	scx_cpumask_t node_cpumask;
 
 	dom_ptr domc;
 };
@@ -24,7 +24,7 @@ struct {
 volatile dom_ptr dom_ctxs[MAX_DOMS];
 struct sdt_allocator lb_domain_allocator;
 
-__hidden __noinline
+__weak
 int lb_domain_init(void)
 {
 	return sdt_alloc_init(&lb_domain_allocator, sizeof(struct dom_ctx));

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -51,6 +51,7 @@
 #include "intf.h"
 #include "types.h"
 #include "lb_domain.h"
+#include "percpu.h"
 
 #include <scx/bpf_arena_common.h>
 #include <errno.h>
@@ -95,128 +96,6 @@ const volatile u32 debug;
 
 /* base slice duration */
 volatile u64 slice_ns;
-
-struct rusty_percpu_storage {
-	struct bpf_cpumask __kptr *bpfmask;
-	scx_cpumask_t scxmask;
-};
-
-/*
- * XXX Need protection against grabbing the same per-cpu temporary storage
- * twice, or this can lead to very nasty bugs.
- */
-struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__type(key, u32);
-	__type(value, struct rusty_percpu_storage);
-	__uint(max_entries, 1);
-} scx_percpu_storage_map SEC(".maps");
-
-static s32 create_save_scxmask(scx_cpumask_t *maskp)
-{
-	scx_cpumask_t mask;
-
-	mask = scx_mask_alloc();
-	if (!mask)
-		return -ENOMEM;
-
-	scxmask_clear(mask);
-
-	*maskp = mask;
-
-	return 0;
-}
-
-static s32 create_save_bpfmask(struct bpf_cpumask __kptr **kptr)
-{
-	struct bpf_cpumask *bpfmask;
-
-	bpfmask = bpf_cpumask_create();
-	if (!bpfmask) {
-		scx_bpf_error("Failed to create bpfmask");
-		return -ENOMEM;
-	}
-
-	bpfmask = bpf_kptr_xchg(kptr, bpfmask);
-	if (bpfmask) {
-		scx_bpf_error("kptr already had cpumask");
-		bpf_cpumask_release(bpfmask);
-	}
-
-	return 0;
-}
-
-__weak int scx_rusty__storage_init_single(u32 cpu)
-{
-	struct rusty_percpu_storage *storage;
-	void *map = &scx_percpu_storage_map;
-	const u32 zero = 0;
-	int ret;
-
-	storage = bpf_map_lookup_percpu_elem(map, &zero, cpu);
-	if (!storage) {
-		/* Should be impossible. */
-		scx_bpf_error("Did not find map entry");
-		return -EINVAL;
-	}
-
-	ret = create_save_bpfmask(&storage->bpfmask);
-	if (ret)
-		return ret;
-
-	return create_save_scxmask(&storage->scxmask);
-}
-
-__weak int scx_percpu_storage_init(void)
-{
-	int ret, i;
-
-	bpf_for(i, 0, nr_cpu_ids) {
-		ret = scx_rusty__storage_init_single(i);
-		if (ret != 0)
-			return ret;
-	}
-
-	return 0;
-}
-
-static struct bpf_cpumask *scx_percpu_bpfmask(void)
-{
-	struct rusty_percpu_storage *storage;
-	void *map = &scx_percpu_storage_map;
-	const u32 zero = 0;
-
-	storage = bpf_map_lookup_elem(map, &zero);
-	if (!storage) {
-		/* Should be impossible. */
-		scx_bpf_error("Did not find map entry");
-		return NULL;
-	}
-
-	if (!storage->bpfmask)
-		scx_bpf_error("Did not properly initialize singleton bpfmask");
-
-	return storage->bpfmask;
-}
-
-static scx_cpumask_t scx_percpu_scxmask(void)
-{
-	struct rusty_percpu_storage *storage;
-	void *map = &scx_percpu_storage_map;
-	const u32 zero = 0;
-
-	storage = bpf_map_lookup_elem(map, &zero);
-	if (!storage) {
-		/* Should be impossible. */
-		scx_bpf_error("Did not find map entry");
-		return NULL;
-	}
-
-	if (!storage->scxmask)
-		scx_bpf_error("Did not properly initialize singleton scxmask");
-
-	return storage->scxmask;
-}
 
 static scx_cpumask_t scxmask_get_idle_smtmask()
 {

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -221,7 +221,7 @@ static scx_cpumask_t scx_percpu_scxmask(void)
 static scx_cpumask_t scxmask_get_idle_smtmask()
 {
 	scx_cpumask_t scx = scx_percpu_scxmask();
-	const struct cpumask *bpf = scx_bpf_get_idle_smtmask();
+	const struct cpumask __kptr *bpf = scx_bpf_get_idle_smtmask();
 
 	if (!bpf) {
 		scx_bpf_error("failed to retrieve CPU-local storage");
@@ -237,7 +237,7 @@ static scx_cpumask_t scxmask_get_idle_smtmask()
 
 static s32 scxmask_pick_idle_cpu(scx_cpumask_t mask __arg_arena, int flags)
 {
-	struct bpf_cpumask *bpf = scx_percpu_bpfmask();
+	struct bpf_cpumask __kptr *bpf = scx_percpu_bpfmask();
 	s32 cpu;
 
 	if (!bpf)
@@ -247,7 +247,7 @@ static s32 scxmask_pick_idle_cpu(scx_cpumask_t mask __arg_arena, int flags)
 
 	cpu = scx_bpf_pick_idle_cpu(cast_mask(bpf), flags);
 
-	scxmask_from_bpf(mask, cast_mask(bpf));
+	scxmask_from_bpf(mask, (const cpumask_t __kptr *)bpf);
 
 	return cpu;
 }

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -122,11 +122,11 @@ static s32 scxmask_pick_idle_cpu(scx_cpumask_t mask __arg_arena, int flags)
 	if (!bpf)
 		return -1;
 
-	scxmask_to_bpf(bpf, mask);
+	scxmask_to_bpf(cast_mask(bpf), mask);
 
 	cpu = scx_bpf_pick_idle_cpu(cast_mask(bpf), flags);
 
-	scxmask_from_bpf(mask, (const cpumask_t __kptr *)bpf);
+	scxmask_from_bpf(mask, cast_mask(bpf));
 
 	return cpu;
 }
@@ -139,7 +139,7 @@ static s32 scxmask_any_distribute(scx_cpumask_t mask __arg_arena)
 	if (!bpf)
 		return -1;
 
-	scxmask_to_bpf(bpf, mask);
+	scxmask_to_bpf(cast_mask(bpf), mask);
 	cpu = bpf_cpumask_any_distribute(cast_mask(bpf));
 
 	return cpu;
@@ -153,7 +153,7 @@ static s32 scxmask_any_and_distribute(scx_cpumask_t scx, const struct cpumask *b
 	if (!bpf || !tmp)
 		return -1;
 
-	scxmask_to_bpf(tmp, scx);
+	scxmask_to_bpf(cast_mask(tmp), scx);
 	cpu = bpf_cpumask_any_and_distribute(cast_mask(tmp), bpf);
 
 	return cpu;
@@ -1434,7 +1434,7 @@ void BPF_STRUCT_OPS(rusty_running, struct task_struct *p)
 
 	domc = task_domain(taskc);
 	if (!domc) {
-		scx_bpf_error("Invalid dom ID");
+		scx_bpf_error("no domain for task");
 		return;
 	}
 
@@ -1852,11 +1852,11 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rusty_init)
 	if (ret)
 		return ret;
 
-	ret = sdt_task_init(sizeof(struct task_ctx));
+	ret = scx_mask_init(MAX_CPUS / 8);
 	if (ret)
 		return ret;
 
-	ret = scx_mask_init(MAX_CPUS / 8);
+	ret = sdt_task_init(sizeof(struct task_ctx));
 	if (ret)
 		return ret;
 

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -57,6 +57,8 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
+#include "cpumask.h"
+
 char _license[] SEC("license") = "GPL";
 
 UEI_DEFINE(uei);

--- a/scheds/rust/scx_rusty/src/bpf/percpu.h
+++ b/scheds/rust/scx_rusty/src/bpf/percpu.h
@@ -6,6 +6,7 @@ struct rusty_percpu_storage {
 	struct bpf_cpumask __kptr *bpfmask;
 	scx_cpumask_t scxmask;
 	cpumask_t cpumask;
+	struct scx_cpumask scxmask_stack;
 };
 
 /*
@@ -139,4 +140,20 @@ static cpumask_t *scx_percpu_cpumask(void)
 	}
 
 	return &storage->cpumask;
+}
+
+static struct scx_cpumask *scx_percpu_scxmask_stack(void)
+{
+	struct rusty_percpu_storage *storage;
+	void *map = &scx_percpu_storage_map;
+	const u32 zero = 0;
+
+	storage = bpf_map_lookup_elem(map, &zero);
+	if (!storage) {
+		/* Should be impossible. */
+		scx_bpf_error("Did not find map entry");
+		return NULL;
+	}
+
+	return &storage->scxmask_stack;
 }

--- a/scheds/rust/scx_rusty/src/bpf/percpu.h
+++ b/scheds/rust/scx_rusty/src/bpf/percpu.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <scx/common.bpf.h>
+
+struct rusty_percpu_storage {
+	struct bpf_cpumask __kptr *bpfmask;
+	scx_cpumask_t scxmask;
+	cpumask_t cpumask;
+};
+
+/*
+ * XXX Need protection against grabbing the same per-cpu temporary storage
+ * twice, or this can lead to very nasty bugs.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__type(key, u32);
+	__type(value, struct rusty_percpu_storage);
+	__uint(max_entries, 1);
+} scx_percpu_storage_map __weak SEC(".maps");
+
+static s32 create_save_scxmask(scx_cpumask_t *maskp)
+{
+	scx_cpumask_t mask;
+
+	mask = scx_mask_alloc();
+	if (!mask)
+		return -ENOMEM;
+
+	scxmask_clear(mask);
+
+	*maskp = mask;
+
+	return 0;
+}
+
+static s32 create_save_bpfmask(struct bpf_cpumask __kptr **kptr)
+{
+	struct bpf_cpumask *bpfmask;
+
+	bpfmask = bpf_cpumask_create();
+	if (!bpfmask) {
+		scx_bpf_error("Failed to create bpfmask");
+		return -ENOMEM;
+	}
+
+	bpfmask = bpf_kptr_xchg(kptr, bpfmask);
+	if (bpfmask) {
+		scx_bpf_error("kptr already had cpumask");
+		bpf_cpumask_release(bpfmask);
+	}
+
+	return 0;
+}
+
+__weak int scx_rusty__storage_init_single(u32 cpu)
+{
+	struct rusty_percpu_storage *storage;
+	void *map = &scx_percpu_storage_map;
+	const u32 zero = 0;
+	int ret;
+
+	storage = bpf_map_lookup_percpu_elem(map, &zero, cpu);
+	if (!storage) {
+		/* Should be impossible. */
+		scx_bpf_error("Did not find map entry");
+		return -EINVAL;
+	}
+
+	ret = create_save_bpfmask(&storage->bpfmask);
+	if (ret)
+		return ret;
+
+	return create_save_scxmask(&storage->scxmask);
+}
+
+__weak int scx_percpu_storage_init(void)
+{
+	int ret, i;
+
+	bpf_for(i, 0, nr_cpu_ids) {
+		ret = scx_rusty__storage_init_single(i);
+		if (ret != 0)
+			return ret;
+	}
+
+	return 0;
+}
+
+static struct bpf_cpumask *scx_percpu_bpfmask(void)
+{
+	struct rusty_percpu_storage *storage;
+	void *map = &scx_percpu_storage_map;
+	const u32 zero = 0;
+
+	storage = bpf_map_lookup_elem(map, &zero);
+	if (!storage) {
+		/* Should be impossible. */
+		scx_bpf_error("Did not find map entry");
+		return NULL;
+	}
+
+	if (!storage->bpfmask)
+		scx_bpf_error("Did not properly initialize singleton bpfmask");
+
+	return storage->bpfmask;
+}
+
+static scx_cpumask_t scx_percpu_scxmask(void)
+{
+	struct rusty_percpu_storage *storage;
+	void *map = &scx_percpu_storage_map;
+	const u32 zero = 0;
+
+	storage = bpf_map_lookup_elem(map, &zero);
+	if (!storage) {
+		/* Should be impossible. */
+		scx_bpf_error("Did not find map entry");
+		return NULL;
+	}
+
+	if (!storage->scxmask)
+		scx_bpf_error("Did not properly initialize singleton scxmask");
+
+	return storage->scxmask;
+}
+
+static cpumask_t *scx_percpu_cpumask(void)
+{
+	struct rusty_percpu_storage *storage;
+	void *map = &scx_percpu_storage_map;
+	const u32 zero = 0;
+
+	storage = bpf_map_lookup_elem(map, &zero);
+	if (!storage) {
+		/* Should be impossible. */
+		scx_bpf_error("Did not find map entry");
+		return NULL;
+	}
+
+	return &storage->cpumask;
+}

--- a/scheds/rust/scx_rusty/src/bpf/types.h
+++ b/scheds/rust/scx_rusty/src/bpf/types.h
@@ -64,7 +64,7 @@ struct task_ctx {
 
 	struct ravg_data dcyc_rd;
 
-	scx_cpumask_t cpumask;
+	scx_bitmap_t cpumask;
 };
 
 /* XXXETSAL Same rationale as for dom_ptr. Remove once we dump Clang 18.*/
@@ -97,7 +97,7 @@ struct dom_ctx {
 };
 
 struct node_ctx {
-	scx_cpumask_t cpumask;
+	scx_bitmap_t cpumask;
 };
 
 #endif /* __TYPES_H */

--- a/scheds/rust/scx_rusty/src/bpf/types.h
+++ b/scheds/rust/scx_rusty/src/bpf/types.h
@@ -63,6 +63,8 @@ struct task_ctx {
 	u32 pid;
 
 	struct ravg_data dcyc_rd;
+
+	scx_cpumask_t cpumask;
 };
 
 /* XXXETSAL Same rationale as for dom_ptr. Remove once we dump Clang 18.*/
@@ -95,7 +97,7 @@ struct dom_ctx {
 };
 
 struct node_ctx {
-	struct bpf_cpumask __kptr *cpumask;
+	scx_cpumask_t cpumask;
 };
 
 #endif /* __TYPES_H */


### PR DESCRIPTION
The scx_rusty scheduler currently represents domains and tasks with arena-based structs, but cannot embed cpumasks into these fields as they are represented as kptrs. Introduce a cpumask type that is implemented as a BPF library and so can be embedded/pointed to by arena structs. Also add wrappers around kfuncs that take struct bpf_cpumask * arguments to transparently translate between our new internal cpumask type and the bpf_cpumask type expected by the calls.

Note: This code currently has really suboptimal bpf_cpumask to scxmask conversions that I am in the process of fixing. We'll need a kfunc for that but the rest of the code compiles and verifies just fine so it's a matter of solving this one isolated issue.