### PR TITLE
ci: deduplicate rust test jobs and build more targets

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -262,13 +262,12 @@ jobs:
           # it's all txt files w/ 90 day retention, lets be nice.
           compression-level: 9
 
-
-  rust-test-core:
+  rust-tests:
     runs-on: ubuntu-24.04
     needs: build-kernel
     strategy:
       matrix:
-        component: [scx_loader, scx_rustland_core, scx_stats, scx_utils]
+        package: [ scx_loader, scx_rustland_core, scx_stats, scx_utils, scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
     steps:
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
@@ -302,50 +301,8 @@ jobs:
         name: exit if cache stale
         run: exit -1
 
-      - run: cargo build  --manifest-path rust/${{ matrix.component }}/Cargo.toml
-      - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --manifest-path rust/${{ matrix.component }}/Cargo.toml
-
-  rust-test-schedulers:
-    runs-on: ubuntu-24.04
-    needs: build-kernel
-    strategy:
-      matrix:
-        scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
-    steps:
-      # prevent cache permission errors
-      - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/install-deps-action
-      # cache virtiofsd (goes away w/ 24.04)
-      - name: Cache virtiofsd
-        id: cache-virtiofsd
-        uses: actions/cache@v4
-        with:
-          path: |
-            /usr/lib/virtiofsd
-          key: virtiofsd-binary
-      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
-        run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-6.13 | awk '{print $1}')" >> $GITHUB_ENV
-      # Cache Kernel alone for rust tests
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
-
-      # need to re-run job when kernel head changes between build and test running.
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: exit if cache stale
-        run: exit -1
-
-      - run: cargo build  --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml
-      - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml
+      - run: cargo build --all-targets --package ${{ matrix.package }}
+      - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --package ${{ matrix.package }}
 
   pages:
     runs-on: ubuntu-24.04

--- a/.github/workflows/for-next-test.yml
+++ b/.github/workflows/for-next-test.yml
@@ -156,12 +156,12 @@ jobs:
           compression-level: 9
 
 
-  rust-test-core:
+  rust-tests:
     runs-on: ubuntu-24.04
     needs: build-kernel
     strategy:
       matrix:
-        component: [scx_loader, scx_rustland_core, scx_stats, scx_utils]
+        package: [ scx_loader, scx_rustland_core, scx_stats, scx_utils, scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
     steps:
       - uses: actions/checkout@v4
 
@@ -184,39 +184,8 @@ jobs:
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
 
-      - run: cargo build  --manifest-path rust/${{ matrix.component }}/Cargo.toml
-      - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --manifest-path rust/${{ matrix.component }}/Cargo.toml
-
-  rust-test-schedulers:
-    runs-on: ubuntu-24.04
-    needs: build-kernel
-    strategy:
-      matrix:
-        scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/restore-kernel-cache
-        with:
-          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
-          branch: for-next
-
-      # prevent cache permission errors
-      - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: ./.github/actions/install-deps-action
-      # cache virtiofsd (goes away w/ 24.04)
-      - name: Cache virtiofsd
-        id: cache-virtiofsd
-        uses: actions/cache@v4
-        with:
-          path: |
-            /usr/lib/virtiofsd
-          key: virtiofsd-binary
-      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
-        run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      - run: cargo build  --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml
-      - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --manifest-path scheds/rust/${{ matrix.scheduler }}/Cargo.toml
+      - run: cargo build --all-targets --package ${{ matrix.package }}
+      - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --package ${{ matrix.package }}
 
   notify-job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently Rust test jobs are split between `rust-test-scheds` and `rust-test-core`. Other than a different `manifest-path` they're identical. Switch from `--manifest-path` to `--package` then unify these targets into `--rust-tests`.

Also add the `--all-targets` mode to the Cargo build so it builds examples/tests/bins/libs. There is still some weirdness here where the `virtme-ng` instance of Cargo test insists on rebuilding everything, I haven't finished debugging it yet but want to land this first to reduce code duplication/catch errors in examples and so on.

To land this I will need to change the required names for the CI. This will cause some temporary disruption, I'll keep an eye on any PRs that get held up. Will only do this once approved and it should be short.

Test plan:
- CI for `caching-build.yml`.
- Added a temporary `push:` trigger to `for-next`. It worked.