### PR TITLE
scx_lavd: Use BPF CO-RE for SCX_ENQ_CPU_SELECTED

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1059,10 +1059,14 @@ static bool can_direct_dispatch(struct task_struct *p, u64 enq_flags,
 	 * migratable, check whether the CPU is idle. If the CPU is idle,
 	 * dispatch the task to the local DSQ directly.
 	 */
-	if (!(enq_flags & SCX_ENQ_CPU_SELECTED)) {
-		if (!scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | prev_cpu) &&
-		    bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr))
-			return true;
+	if (bpf_core_enum_value_exists(enum scx_enq_flags, SCX_ENQ_CPU_SELECTED)) {
+		u64 flag = bpf_core_enum_value(enum scx_enq_flags,
+					       SCX_ENQ_CPU_SELECTED);
+		if (!(enq_flags & flag)) {
+			if (!scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | prev_cpu) &&
+				bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr))
+				return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
There could be a case such that the scheduler is compiled against the latest vmlinux.h, which has SCX_ENQ_CPU_SELECTED, but runs on the old kernel, which does not have SCX_ENQ_CPU_SELECTED. In this case, !(enq_flags & SCX_ENQ_CPU_SELECTED) will be always true, which is unintended. So use BPF CO-RE to check if SCX_ENQ_CPU_SELECTED exists in runtime.