### PR TITLE
ci: avoid synchronising scheduled jobs

### DIFF
--- a/.github/workflows/bpf-next-test.yml
+++ b/.github/workflows/bpf-next-test.yml
@@ -1,9 +1,9 @@
 name: bpf-next-test
 
 on:
-  # only runs on main, every 6 hours
-    schedule:
-      - cron: "0 */6 * * *"
+  # only runs on main, every 6 hours. specify hours explicitly so scheduled runs can be offset and use a random minute.
+  schedule:
+    - cron: "35 0,6,12,18 * * *"
 
 jobs:
   build-kernel:

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -1,12 +1,12 @@
 name: build-and-test
 
 on:
-  # only runs on main, hourly cache update used by all branches
-    schedule:
-      - cron: "0 * * * *"
-    push:
-    pull_request:
-    merge_group:
+  # only runs on main, hourly cache update used by all branches. random minute to avoid synchronised scheduled workflows.
+  schedule:
+    - cron: "8 * * * *"
+  push:
+  pull_request:
+  merge_group:
 
 jobs:
   lint:

--- a/.github/workflows/for-next-test.yml
+++ b/.github/workflows/for-next-test.yml
@@ -1,9 +1,9 @@
 name: for-next-test
 
 on:
-  # only runs on main, every 6 hours
-    schedule:
-      - cron: "0 */6 * * *"
+  # only runs on main, every 6 hours. specify hours explicitly so scheduled runs can be offset and use a random minute.
+  schedule:
+    - cron: "22 1,7,13,19 * * *"
 
 jobs:
   build-kernel:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,9 +1,9 @@
 name: stable-test
 
 on:
-  # only runs on main, every 6 hours
+  # only runs on main, every 6 hours. specify hours explicitly so scheduled runs can be offset and use a random minute.
   schedule:
-    - cron: "0 */6 * * *"
+    - cron: "40 2,8,14,20 * * *"
 
 jobs:
   build-kernel:


### PR DESCRIPTION

Every 6 hours 4 scheduled workflows trigger at exactly the same time, and because
each currently requires our full quantity of 20 scheduled runners in parallel
this guarantees a lot of queueing if you push a change just after.

Set each scheduled workflow to a random minute and manually specify the "every
6 hours" part with a rotation for the 3 jobs that run every 6 hours. This means
that there's a far better chance you'll be behind 1 job instead of 4 when you
push.

Drive by: make the alignment of the `on:` section consistent with the other
files and with the `jobs:` section.
