### PR TITLE
scx_utils: Introduce is_enq_cpu_selected() for BPF compatibility

### DIFF
--- a/scheds/c/scx_qmap.bpf.c
+++ b/scheds/c/scx_qmap.bpf.c
@@ -231,7 +231,7 @@ void BPF_STRUCT_OPS(qmap_enqueue, struct task_struct *p, u64 enq_flags)
 	}
 
 	/* if select_cpu() wasn't called, try direct dispatch */
-	if (!(enq_flags & SCX_ENQ_CPU_SELECTED) &&
+	if (!is_enq_cpu_selected(enq_flags) &&
 	    (cpu = pick_direct_dispatch_cpu(p, scx_bpf_task_cpu(p))) >= 0) {
 		__sync_fetch_and_add(&nr_ddsp_from_enq, 1);
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, slice_ns, enq_flags);

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -529,6 +529,23 @@ static inline bool time_in_range_open(u64 a, u64 b, u64 c)
  * Other helpers
  */
 
+static inline bool is_enq_cpu_selected(u64 enq_flags)
+{
+	u64 flag;
+
+	/*
+	 * When the kernel did not have SCX_ENQ_CPU_SELECTED,
+	 * select_task_rq_scx() has never been skipped. Thus, this case
+	 * should be considered that the CPU has already been selected.
+	 */
+	if (!bpf_core_enum_value_exists(enum scx_enq_flags,
+					SCX_ENQ_CPU_SELECTED))
+		return true;
+
+	flag = bpf_core_enum_value(enum scx_enq_flags, SCX_ENQ_CPU_SELECTED);
+	return enq_flags & flag;
+}
+
 /* useful compiler attributes */
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -708,7 +708,7 @@ static bool try_direct_dispatch(struct task_struct *p, struct task_ctx *tctx,
 	/*
 	 * If ops.select_cpu() has been skipped, try direct dispatch.
 	 */
-	if (!(enq_flags & SCX_ENQ_CPU_SELECTED)) {
+	if (!is_enq_cpu_selected(enq_flags)) {
 		s32 prev_cpu = scx_bpf_task_cpu(p);
 		struct rq *rq = scx_bpf_cpu_rq(prev_cpu);
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1059,14 +1059,10 @@ static bool can_direct_dispatch(struct task_struct *p, u64 enq_flags,
 	 * migratable, check whether the CPU is idle. If the CPU is idle,
 	 * dispatch the task to the local DSQ directly.
 	 */
-	if (bpf_core_enum_value_exists(enum scx_enq_flags, SCX_ENQ_CPU_SELECTED)) {
-		u64 flag = bpf_core_enum_value(enum scx_enq_flags,
-					       SCX_ENQ_CPU_SELECTED);
-		if (!(enq_flags & flag)) {
-			if (!scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | prev_cpu) &&
-				bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr))
-				return true;
-		}
+	if (!is_enq_cpu_selected(enq_flags)) {
+		if (!scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | prev_cpu) &&
+		    bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr))
+			return true;
 	}
 
 	return false;


### PR DESCRIPTION
Introduce a helper function, is_enq_cpu_selected(), to test SCX_ENQ_CPU_SELECTED in a compatible way.

BPF schedulers that directly use SCX_ENQ_CPU_SELECTED would have a compatibility bug if the schedulers are compiled against vmlinux.h that has SCX_ENQ_CPU_SELECTED but run on an old kernel that does not have SCX_ENQ_CPU_SELECTED. 

is_enq_cpu_selected() addresses such a problem using BPF CO-RE. Also, this PR changes BPF schedulers -- scx_qmap, scx_bpfland, and scx_lavd -- to use is_enq_cpu_selected().