### PR TITLE
ci: move caching-build to nix built kernel

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -26,74 +26,11 @@ jobs:
       - run: cargo fmt
       - run: git diff --exit-code
 
-  build-kernel-nix:
+  build-kernel:
     uses: ./.github/workflows/build-kernel.yml
     with:
       git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
       branch: for-6.13
-
-  build-kernel:
-    runs-on: ubuntu-24.04
-    steps:
-      # prevent cache permission errors
-      - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      # redundancy to exit fast
-      - run: echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y git --no-install-recommends
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-6.13 | awk '{print $1}')" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
-
-      # use cached kernel if available, create after job if not
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        uses: ./.github/actions/install-deps-action
-
-      # cache virtiofsd (goes away w/ 24.04)
-      - name: Cache virtiofsd
-        id: cache-virtiofsd
-        uses: actions/cache@v4
-        with:
-          path: |
-            /usr/lib/virtiofsd
-          key: virtiofsd-binary
-      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' && steps.cache-kernel.outputs.cache-hit != 'true' }}
-        run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: Clone Kernel
-        uses: cytopia/shell-command-retry-action@v0.1.2
-        with:
-          retries: 10
-          pause: 18
-          command: git clone --single-branch -b for-6.13 --depth 1 https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git linux
-
-      # guard rail because we are caching
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        run: cd linux && git checkout ${{ env.SCHED_EXT_KERNEL_COMMIT }}
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-      # Print the latest commit of the checked out sched-ext kernel
-        run: cd linux && git log -1 --pretty=format:"%h %ad %s" --date=short
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-      # Build a minimal kernel (with sched-ext enabled) using virtme-ng
-        run: cd linux && vng -v --build --config ../.github/workflows/sched-ext.config
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-      # Generate kernel headers
-        run: cd linux && make headers
 
   integration-test:
     runs-on: ubuntu-24.04
@@ -103,9 +40,15 @@ jobs:
             scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
           fail-fast: false
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/restore-kernel-cache
+        with:
+          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
+          branch: for-6.13
+
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.scheduler }}
@@ -121,24 +64,6 @@ jobs:
           key: virtiofsd-binary
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-6.13 | awk '{print $1}')" >> $GITHUB_ENV
-
-      # use cached kernel if available, create after job if not
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
-
-      # need to re-run job when kernel head changes between build and test running.
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: exit if cache stale
-        run: exit -1
 
       # veristat
       - run: wget https://github.com/libbpf/veristat/releases/download/v0.3.2/veristat-v0.3.2-amd64.tar.gz
@@ -192,9 +117,15 @@ jobs:
             antistall: ['', '--disable-antistall']
           fail-fast: false
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/restore-kernel-cache
+        with:
+          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
+          branch: for-6.13
+
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.scheduler }}
@@ -210,24 +141,6 @@ jobs:
           key: virtiofsd-binary
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-6.13 | awk '{print $1}')" >> $GITHUB_ENV
-
-      # use cached kernel if available, create after job if not
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
-
-      # need to re-run job when kernel head changes between build and test running.
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: exit if cache stale
-        run: exit -1
 
       # The actual build:
       - run: meson setup build -Dkernel=../linux/arch/x86/boot/bzImage -Dkernel_headers=../linux -Denable_stress=true -Dvng_rw_mount=true -Dextra_sched_args=" ${{ matrix.topo }} ${{ matrix.antistall }}"
@@ -269,9 +182,15 @@ jobs:
       matrix:
         package: [ scx_loader, scx_rustland_core, scx_stats, scx_utils, scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/restore-kernel-cache
+        with:
+          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
+          branch: for-6.13
+
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-deps-action
       # cache virtiofsd (goes away w/ 24.04)
       - name: Cache virtiofsd
@@ -283,23 +202,6 @@ jobs:
           key: virtiofsd-binary
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git heads/for-6.13 | awk '{print $1}')" >> $GITHUB_ENV
-
-      - name: Cache Kernel
-        id: cache-kernel
-        uses: actions/cache@v4
-        with:
-          path: |
-            linux/arch/x86/boot/bzImage
-            linux/usr/include
-            linux/**/*.h
-          key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-5
-
-      # need to re-run job when kernel head changes between build and test running.
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        name: exit if cache stale
-        run: exit -1
 
       - run: cargo build --all-targets --package ${{ matrix.package }}
       - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --package ${{ matrix.package }}


### PR DESCRIPTION
This has been building for a while and is stable, and now has been running on the scheduled jobs for a day or so. Merging to enable the `caching-build` workflow which covers push/PRs/merge queue events, and removes the non-nix non-self-hosted kernel build from the final workflow.

Test plan:
- CI