### PR TITLE
lib/sdt_alloc: move sdt_static definition to sdt_task.h header

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -639,12 +639,6 @@ u64 sdt_alloc_internal(struct sdt_allocator *alloc)
  * having to define an allocator for each type.
  */
 
-struct sdt_static {
-	size_t max_alloc_bytes;
-	void __arena *memory;
-	size_t off;
-};
-
 struct sdt_static sdt_static;
 
 __hidden

--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -98,6 +98,12 @@ struct sdt_allocator {
 	sdt_desc_t	*root;
 };
 
+struct sdt_static {
+	size_t max_alloc_bytes;
+	void __arena *memory;
+	size_t off;
+};
+
 #ifdef __BPF__
 
 void __arena *sdt_task_data(struct task_struct *p);


### PR DESCRIPTION
The definition for the sdt_static allocator is currently in the lib/sdt_task.bpf.c. The definition is not picked up into the skeleton for scx_sdt, causing build failures. Move the definition of the struct into scheds/include/lib/sdt_task.h.