### PR TITLE
ci: enable running on github runners when outside of repository

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -10,11 +10,11 @@ on:
 
 jobs:
   build-kernel:
-    runs-on: [ "self-hosted", "linux", "x64" ]
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64" ]') || 'ubuntu-latest' }}
     steps:
-      # Uncomment these if reverting to GitHub hosted runners
-      # - name: Install Nix
-      #   uses: DeterminateSystems/nix-installer-action@main
+      - name: Install Nix
+        if: ${{ runner.environment == 'github-hosted' }}
+        uses: DeterminateSystems/nix-installer-action@main
 
       # Make very basic dependencies available in PATH
       - name: Install basic dependencies


### PR DESCRIPTION
The build Nix kernel jobs currently fail in external forks because they expect access to the self-hosted runner. Change this to dynamically selecting the self-hosted runner when running in a repo owned by "sched-ext" (the only repos with access to our runner) and "ubuntu-latest" otherwise. Install Nix on GitHub runners but not on self-hosted runners (assume it's already there for now).

This involves

Test plan:
- Pushed to my fork and (after re-enabling actions) both builds passed.
- Runs in the CI on this PR. Will check it hits the right machine.