### PR TITLE
ci: pass through rust test paths to prevent a rebuild

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -302,7 +302,13 @@ jobs:
         run: exit -1
 
       - run: cargo build --all-targets --package ${{ matrix.package }}
-      - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --package ${{ matrix.package }}
+
+      # virtme-ng runs as a different user than the runner, so loses the rustup and cargo roots. specify them explicitly to avoid a rebuild.
+      - run: |
+          vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- \
+            RUSTUP_HOME=$(realpath ~/.rustup) \
+            CARGO_HOME=$(realpath ~/.cargo) \
+            cargo test --package ${{ matrix.package }}
 
   pages:
     runs-on: ubuntu-24.04

--- a/.github/workflows/for-next-test.yml
+++ b/.github/workflows/for-next-test.yml
@@ -185,7 +185,13 @@ jobs:
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
 
       - run: cargo build --all-targets --package ${{ matrix.package }}
-      - run: vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- cargo test --package ${{ matrix.package }}
+
+      # virtme-ng runs as a different user than the runner, so loses the rustup and cargo roots. specify them explicitly to avoid a rebuild.
+      - run: |
+          vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- \
+            RUSTUP_HOME=$(realpath ~/.rustup) \
+            CARGO_HOME=$(realpath ~/.cargo) \
+            cargo test --package ${{ matrix.package }}
 
   notify-job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a fun one that's been bothering me for a while. The Rust test jobs in the CI have been completely rebuilding the test targets in the VM really slowly even though they are built before the vng VM is entered.

I thought this was something to do with the virtual filesystem before, but it turned out to be much more mundane. The caches for rustup and cargo are stored in $HOME/.rustup and $HOME/.cargo, and vng runs under a different user in the VM (root I assume) so is looking in the wrong place.

Pass through `RUSTUP_HOME` and `CARGO_HOME` to the `cargo test` call in the VM. This prevents the re-sync and download of the rustup components and prevents the rebuild/redownload of the Rust crates.

This makes the performance of the CI drastically better. Comparing [this PR](https://github.com/sched-ext/scx/actions/runs/13143680044/usage) to the last finished scheduled [build-and-test](https://github.com/sched-ext/scx/actions/runs/13143169572/usage) we reduce from 2h13m of usage to 1h5m, or roughly a 51% reduction in runner time.

Test plan:
- CI