### PR TITLE
scx_utils: accessing GPU SMs (aka Streaming Multiprocessor).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,6 +2383,7 @@ dependencies = [
  "libc",
  "log",
  "nvml-wrapper",
+ "nvml-wrapper-sys",
  "paste",
  "regex",
  "scx_stats",

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -19,6 +19,7 @@ libbpf-cargo = "=0.25.0-beta.1"
 libbpf-rs = "=0.25.0-beta.1"
 log = "0.4.17"
 nvml-wrapper = { version = "0.10.0", optional = true }
+nvml-wrapper-sys = { version = "0.8.0", optional = true }
 paste = "1.0"
 regex = "1.11.1"
 scx_stats = { path = "../scx_stats", version = "1.0.9" }
@@ -44,7 +45,7 @@ walkdir = "2.4"
 
 [features]
 default = []
-gpu-topology = ["dep:nvml-wrapper"]
+gpu-topology = ["dep:nvml-wrapper", "dep:nvml-wrapper-sys"]
 autopower = ["dep:zbus"]
 
 [lints.clippy]

--- a/rust/scx_utils/src/gpu.rs
+++ b/rust/scx_utils/src/gpu.rs
@@ -83,6 +83,8 @@ pub fn create_gpus() -> BTreeMap<usize, Vec<Gpu>> {
                     Ok(()) => attrs.multiprocessorCount,
                     _ => 0,
                 };
+
+                let _ = std::mem::ManuallyDrop::new(lib);
             }
 
             // The NVML library doesn't return a PCIe bus ID compatible with sysfs. It includes


### PR DESCRIPTION
the rust wrapper, while binding it, does not expose it and the wrapper does lazy library call loadings.