### PR TITLE
scx_lavd: Bump version for v1.0.9 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "scx_lavd"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_lavd"
-version = "1.0.8"
+version = "1.0.9"
 authors = ["Changwoo Min <changwoo@igalia.com>", "Igalia"]
 edition = "2021"
 description = "A Latency-criticality Aware Virtual Deadline (LAVD) scheduler based on sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"


### PR DESCRIPTION
Forgot to bump lavd version during v1.0.9 release.