### PR TITLE
scxtop: use struct-in-tuples for Action enum instead of structs

### DIFF
--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -32,50 +32,15 @@ impl KeyMap {
     /// Returns the default keymap.
     pub fn default() -> Self {
         let mut bindings = HashMap::new();
-        bindings.insert(
-            Key::Char('d'),
-            Action::SetState {
-                state: AppState::Default,
-            },
-        );
-        bindings.insert(
-            Key::Char('e'),
-            Action::SetState {
-                state: AppState::Event,
-            },
-        );
+        bindings.insert(Key::Char('d'), Action::SetState(AppState::Default));
+        bindings.insert(Key::Char('e'), Action::SetState(AppState::Event));
         bindings.insert(Key::Char('f'), Action::ToggleCpuFreq);
         bindings.insert(Key::Char('u'), Action::ToggleUncoreFreq);
-        bindings.insert(
-            Key::Char('h'),
-            Action::SetState {
-                state: AppState::Help,
-            },
-        );
-        bindings.insert(
-            Key::Char('?'),
-            Action::SetState {
-                state: AppState::Help,
-            },
-        );
-        bindings.insert(
-            Key::Char('l'),
-            Action::SetState {
-                state: AppState::Llc,
-            },
-        );
-        bindings.insert(
-            Key::Char('n'),
-            Action::SetState {
-                state: AppState::Node,
-            },
-        );
-        bindings.insert(
-            Key::Char('s'),
-            Action::SetState {
-                state: AppState::Scheduler,
-            },
-        );
+        bindings.insert(Key::Char('h'), Action::SetState(AppState::Help));
+        bindings.insert(Key::Char('?'), Action::SetState(AppState::Help));
+        bindings.insert(Key::Char('l'), Action::SetState(AppState::Llc));
+        bindings.insert(Key::Char('n'), Action::SetState(AppState::Node));
+        bindings.insert(Key::Char('s'), Action::SetState(AppState::Scheduler));
         bindings.insert(Key::Char('a'), Action::RecordTrace);
         bindings.insert(Key::Char('P'), Action::RecordTrace);
         bindings.insert(Key::Char('x'), Action::ClearEvent);

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -95,6 +95,54 @@ impl std::fmt::Display for ViewState {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SchedCpuPerfSetAction {
+    pub cpu: u32,
+    pub perf: u32,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SchedSwitchAction {
+    pub ts: u64,
+    pub cpu: u32,
+    pub preempt: bool,
+    pub next_dsq_id: u64,
+    pub next_dsq_lat_us: u64,
+    pub next_dsq_nr_queued: u32,
+    pub next_dsq_vtime: u64,
+    pub next_slice_ns: u64,
+    pub next_pid: u32,
+    pub next_tgid: u32,
+    pub next_prio: i32,
+    pub next_comm: String,
+    pub prev_dsq_id: u64,
+    pub prev_used_slice_ns: u64,
+    pub prev_slice_ns: u64,
+    pub prev_pid: u32,
+    pub prev_tgid: u32,
+    pub prev_prio: i32,
+    pub prev_comm: String,
+    pub prev_state: u64,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SchedWakeupAction {
+    pub ts: u64,
+    pub cpu: u32,
+    pub pid: u32,
+    pub prio: i32,
+    pub comm: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SchedWakeupNewAction {
+    pub ts: u64,
+    pub cpu: u32,
+    pub pid: u32,
+    pub prio: i32,
+    pub comm: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Action {
     Tick,
     Increment,
@@ -114,59 +162,17 @@ pub enum Action {
     Render,
     SchedReg,
     SchedUnreg,
-    SchedCpuPerfSet {
-        cpu: u32,
-        perf: u32,
-    },
-    SchedStats {
-        raw: String,
-    },
-    SchedSwitch {
-        ts: u64,
-        cpu: u32,
-        preempt: bool,
-        next_dsq_id: u64,
-        next_dsq_lat_us: u64,
-        next_dsq_nr_queued: u32,
-        next_dsq_vtime: u64,
-        next_slice_ns: u64,
-        next_pid: u32,
-        next_tgid: u32,
-        next_prio: i32,
-        next_comm: String,
-        prev_dsq_id: u64,
-        prev_used_slice_ns: u64,
-        prev_slice_ns: u64,
-        prev_pid: u32,
-        prev_tgid: u32,
-        prev_prio: i32,
-        prev_comm: String,
-        prev_state: u64,
-    },
-    SchedWakeup {
-        ts: u64,
-        cpu: u32,
-        pid: u32,
-        prio: i32,
-        comm: String,
-    },
-    SchedWakeupNew {
-        ts: u64,
-        cpu: u32,
-        pid: u32,
-        prio: i32,
-        comm: String,
-    },
-    SetState {
-        state: AppState,
-    },
+    SchedCpuPerfSet(SchedCpuPerfSetAction),
+    SchedStats(String),
+    SchedSwitch(SchedSwitchAction),
+    SchedWakeup(SchedWakeupAction),
+    SchedWakeupNew(SchedWakeupNewAction),
+    SetState(AppState),
     NextViewState,
     RecordTrace,
     ToggleCpuFreq,
     ToggleUncoreFreq,
-    TickRateChange {
-        tick_rate_ms: u64,
-    },
+    TickRateChange(std::time::Duration),
     IncTickRate,
     DecTickRate,
     IncBpfSampleRate,


### PR DESCRIPTION

Currently we have a few functions that take an entire `&Action` but only match
on one specific case and `panic` otherwise. The invariant is that they're only
called with that case.

This can be checked by the type system, but unfortunately it's not possible to
specify that you're taking an `&Action::SetState`. To get the correct behaviour
here we can instead use tuple enum variants and place a named struct in there.
This gets rid of those ugly panics. Admittedly it's quite a noisy change, but
should make things better for when we inevitably forget those invariants.

Test plan:
- It builds.
