### PR TITLE
scxtop: adding one perf event type `L1-dcache-load-misses`.

### DIFF
--- a/tools/scxtop/src/perf_event.rs
+++ b/tools/scxtop/src/perf_event.rs
@@ -153,6 +153,11 @@ impl PerfEvent {
             "bus-cycles".to_string(),
             0,
         ));
+        avail_events.push(PerfEvent::new(
+            "hw".to_string(),
+            "L1-dcache-load-misses".to_string(),
+            0,
+        ));
 
         avail_events
     }
@@ -236,6 +241,9 @@ impl PerfEvent {
                     }
                     "bus-cycles" | "bus_cycles" => {
                         attrs.config = perf::bindings::PERF_COUNT_HW_BUS_CYCLES as u64;
+                    }
+                    "L1-dcache-load-misses" => {
+                        attrs.config = perf::bindings::PERF_COUNT_HW_CACHE_RESULT_MISS as u64;
                     }
                     _ => {
                         return Err(anyhow!("unknown event"));

--- a/tools/scxtop/src/protos/perfetto_scx.proto
+++ b/tools/scxtop/src/protos/perfetto_scx.proto
@@ -926,7 +926,7 @@ message PerfEvents {
     // emulation-faults
     SW_EMULATION_FAULTS = 9;
     // dummy
-    SW_DUMMY = 20;
+    SW_DUMMY = 21;
 
     // cpu-cycles, cycles
     HW_CPU_CYCLES = 10;
@@ -948,6 +948,8 @@ message PerfEvents {
     HW_STALLED_CYCLES_BACKEND = 18;
     // ref-cycles
     HW_REF_CPU_CYCLES = 19;
+    // l1-dcache-load-misses
+    HW_CACHE_RESULT_MISS = 20;
   }
 
   message Tracepoint {


### PR DESCRIPTION
Gives a hint if the there is a suboptimal CPU cache locality, forcing
 to slower CPU levels.