### PR TITLE
scxtop: track sched_waking events

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -21,7 +21,9 @@ use crate::ViewState;
 use crate::APP;
 use crate::LICENSE;
 use crate::SCHED_NAME_PATH;
-use crate::{Action, SchedCpuPerfSetAction, SchedSwitchAction, SchedWakeupAction};
+use crate::{
+    Action, SchedCpuPerfSetAction, SchedSwitchAction, SchedWakeupAction, SchedWakingAction,
+};
 
 use anyhow::Result;
 use glob::glob;
@@ -1977,6 +1979,12 @@ impl<'a> App<'a> {
         }
     }
 
+    fn on_sched_waking(&mut self, action: &SchedWakingAction) {
+        if self.state == AppState::Tracing {
+            self.trace_manager.on_sched_waking(action);
+        }
+    }
+
     /// Updates the app when a task is scheduled.
     fn on_sched_switch(&mut self, action: &SchedSwitchAction) {
         let SchedSwitchAction {
@@ -2095,6 +2103,9 @@ impl<'a> App<'a> {
             }
             Action::SchedWakeup(a) => {
                 self.on_sched_wakeup(&a);
+            }
+            Action::SchedWaking(a) => {
+                self.on_sched_waking(&a);
             }
             Action::ClearEvent => self.stop_perf_events(),
             Action::ChangeTheme => {

--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -24,6 +24,7 @@ enum event_type {
 	SCHED_UNREG,
 	SCHED_SWITCH,
 	SCHED_WAKEUP,
+	SCHED_WAKING,
 	EVENT_MAX,
 };
 
@@ -65,6 +66,7 @@ struct bpf_event {
 	u32		cpu;
 	union {
 		struct	sched_switch_event sched_switch;
+		struct	wakeup_event waking;
 		struct	wakeup_event wakeup;
 		struct	set_perf_event perf;
 	} event;

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -125,7 +125,7 @@ pub struct SchedSwitchAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct SchedWakeupAction {
+pub struct SchedWakeActionCtx {
     pub ts: u64,
     pub cpu: u32,
     pub pid: u32,
@@ -133,14 +133,9 @@ pub struct SchedWakeupAction {
     pub comm: String,
 }
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct SchedWakeupNewAction {
-    pub ts: u64,
-    pub cpu: u32,
-    pub pid: u32,
-    pub prio: i32,
-    pub comm: String,
-}
+pub type SchedWakeupNewAction = SchedWakeActionCtx;
+pub type SchedWakingAction = SchedWakeActionCtx;
+pub type SchedWakeupAction = SchedWakeActionCtx;
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Action {
@@ -167,6 +162,7 @@ pub enum Action {
     SchedSwitch(SchedSwitchAction),
     SchedWakeup(SchedWakeupAction),
     SchedWakeupNew(SchedWakeupNewAction),
+    SchedWaking(SchedWakingAction),
     SetState(AppState),
     NextViewState,
     RecordTrace,


### PR DESCRIPTION
Trace sched_waking and output them in the scxtop perfetto traces. This fills in
the per-process timelines with "Uninterruptible Sleep" and "Runnable".

It has the annoying side effect of sometimes putting "Wake Kill" at the end of
the trace. I think this is because we see the thread as not-runnable for the
last time then the trace terminates, but am unsure.

Drive by: removes the `run` function that is wrapped by `main` in favour of
calling it `main`.

Test plan:

Now some processes show states like this in places that fit the timeline:

<img width="1497" alt="image" src="https://github.com/user-attachments/assets/0a3d453f-d14c-4790-866f-5c842d24c90d" />

I think we may be dropping some events because of this. I'm adding monitoring for it and hopefully have some solutions in follow up PRs.
