### PR TITLE
scx_p2dq: Fix vtime handling and cleanup

### DIFF
--- a/scheds/rust/scx_p2dq/Cargo.toml
+++ b/scheds/rust/scx_p2dq/Cargo.toml
@@ -3,7 +3,7 @@ name = "scx_p2dq"
 version = "1.0.8"
 authors = ["Daniel Hodges <hodges.daniel.scott@gmail.com>"]
 edition = "2021"
-description = ""
+description = "scx_p2dq A simple pick two load balancing scheduler in BPF"
 license = "GPL-2.0-only"
 
 [dependencies]

--- a/scheds/rust/scx_p2dq/README.md
+++ b/scheds/rust/scx_p2dq/README.md
@@ -11,3 +11,6 @@ consume more than half the slice are moved to shorter slice DSQs. The DSQs with
 the shortest slice lengths are then determined to be "interactive". All DSQs on
 the same LLC share the same vtime and there is special handling for
 (non)interactive tasks.
+
+The scheduler handles all scheduling decisions in BPF and the userspace
+component is only for metric reporting.

--- a/scheds/rust/scx_p2dq/src/bpf/intf.h
+++ b/scheds/rust/scx_p2dq/src/bpf/intf.h
@@ -19,12 +19,6 @@ typedef unsigned int u32;
 typedef unsigned long long u64;
 #endif
 
-#ifdef LSP
-#define __bpf__
-#include "../../../../include/scx/ravg.bpf.h"
-#else
-#include <scx/ravg.bpf.h>
-#endif
 
 enum consts {
 	MAX_CPUS		= 512,
@@ -34,9 +28,12 @@ enum consts {
 };
 
 enum stat_idx {
+	P2DQ_STAT_DIRECT,
 	P2DQ_STAT_DSQ_SAME,
 	P2DQ_STAT_DSQ_CHANGE,
+	P2DQ_STAT_IDLE,
 	P2DQ_STAT_LLC_MIGRATION,
+	P2DQ_STAT_NODE_MIGRATION,
 	P2DQ_STAT_KEEP,
 	P2DQ_STAT_PICK2,
 	P2DQ_NR_STATS,
@@ -51,6 +48,7 @@ struct task_ctx {
 	int			dsq_index;
 	u32			cpu;
 	u32			llc_id;
+	u32			node_id;
 	bool			runnable;
 	u32			weight;
 	u64			last_dsq_id;
@@ -78,7 +76,6 @@ struct cpu_ctx {
 	u64				dsqs[MAX_DSQS_PER_LLC];
 	u64				dsq_load[MAX_DSQS_PER_LLC];
 	u64				max_load_dsq;
-	struct bpf_cpumask __kptr	*tmp_cpumask;
 };
 
 struct llc_ctx {

--- a/scheds/rust/scx_p2dq/src/stats.rs
+++ b/scheds/rust/scx_p2dq/src/stats.rs
@@ -27,25 +27,41 @@ pub struct Metrics {
     pub pick2: u64,
     #[stat(desc = "Number of times a task migrated LLCs")]
     pub llc_migrations: u64,
+    #[stat(desc = "Number of times a task migrated NUMA nodes")]
+    pub node_migrations: u64,
+    #[stat(desc = "Number of times tasks have directly been dispatched to local per CPU DSQs")]
+    pub direct: u64,
+    #[stat(desc = "Number of times tasks have dispatched to an idle local per CPU DSQs")]
+    pub idle: u64,
 }
 
 impl Metrics {
     fn format<W: Write>(&self, w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "same_dsq: {} dsq_change: {} keep: {} pick2: {}\n\tllc_migrations: {}",
-            self.same_dsq, self.dsq_change, self.keep, self.pick2, self.llc_migrations
+            "direct/idle {}/{}\n\tdsq same/migrate {}/{}\n\tkeep {} pick2 {}\n\tmigrations llc/node: {}/{}",
+            self.direct,
+            self.idle,
+            self.same_dsq,
+            self.dsq_change,
+            self.keep,
+            self.pick2,
+            self.llc_migrations,
+            self.node_migrations
         )?;
         Ok(())
     }
 
     fn delta(&self, rhs: &Self) -> Self {
         Self {
+            direct: self.direct - rhs.direct,
+            idle: self.idle - rhs.idle,
             dsq_change: self.dsq_change - rhs.dsq_change,
             same_dsq: self.same_dsq - rhs.same_dsq,
             keep: self.keep - rhs.keep,
             pick2: self.pick2 - rhs.pick2,
             llc_migrations: self.llc_migrations - rhs.llc_migrations,
+            node_migrations: self.node_migrations - rhs.node_migrations,
             ..self.clone()
         }
     }


### PR DESCRIPTION
- Fix vtime handling so that it progresses properly and tasks get vtime initialized.

- Remove workaround logic in dispatch for broken vtime handling.

- Add variable to control whether or not to store stats. If metric collection is disabled then stat collection is paused.

- Cleanup unused/unimplemented code.