### PR TITLE
scx_lavd: Revert "scx_lavd: Kick an idle cpu as early as possible on ops.select_cpu()"

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -995,7 +995,6 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 		p->scx.dsq_vtime = calc_when_to_run(p, taskc);
 		p->scx.slice = calc_time_slice(p, taskc);
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, p->scx.slice, 0);
-		scx_bpf_kick_cpu(cpu_id, SCX_KICK_IDLE);
 		return cpu_id;
 	}
 


### PR DESCRIPTION
Kicking a CPU at ops.select_cpu() causes performance regression in some scenarios. The reported case is as follows:

  - Game: Space Marine 2
  - Kernel:  6.13.1-2-cachyos
  - CPU: i9-13900KF
  - GPU: RTX 3700 Ti 570 drivers closed source GSP disabled
  - KDE Plasma Wayland with VRR Automatic

Since kicking a CPU at ops.select_cpu() is redundant -- after the ops.select_cpu(), the kernel will kick the CPU if necessary, it is safe to drop the kick CPU here.

Tested-by: Eric Naim <dnaim@cachyos.org>