### PR TITLE
scx_lavd, scx_top: inlining builtin copies.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
@@ -35,7 +35,7 @@ int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc, u32 cpu_id)
 
 	m->hdr.kind = LAVD_MSG_TASKC;
 	m->taskc_x.pid = p->pid;
-	__builtin_memcpy(m->taskc_x.comm, p->comm, TASK_COMM_LEN);
+	__builtin_memcpy_inline(m->taskc_x.comm, p->comm, TASK_COMM_LEN);
 	m->taskc_x.static_prio = get_nice_prio(p);
 	m->taskc_x.cpu_util = cpuc->util / 10;
 	m->taskc_x.cpu_id = cpu_id;
@@ -50,7 +50,7 @@ int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc, u32 cpu_id)
 	m->taskc_x.stat[3] = is_greedy(taskc) ? 'G' : 'E';
 	m->taskc_x.stat[4] = '\0';
 
-	__builtin_memcpy(&m->taskc, taskc, sizeof(m->taskc));
+	__builtin_memcpy_inline(&m->taskc, taskc, sizeof(m->taskc));
 
 	bpf_ringbuf_submit(m, 0);
 

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -353,7 +353,7 @@ static __always_inline int __on_sched_wakeup(struct task_struct *p)
 	event->cpu = bpf_get_smp_processor_id();
 	event->event.wakeup.pid = p->pid;
 	event->event.wakeup.prio = (int)p->prio;
-	__builtin_memcpy(&event->event.wakeup.comm, &p->comm, MAX_COMM);
+	__builtin_memcpy_inline(&event->event.wakeup.comm, &p->comm, MAX_COMM);
 	bpf_ringbuf_submit(event, 0);
 
 	return 0;
@@ -398,8 +398,8 @@ static __always_inline int on_sched_switch_non_scx(bool preempt, struct task_str
 	event->event.sched_switch.prev_prio = (int)prev->prio;
 	event->event.sched_switch.prev_dsq_id = SCX_DSQ_INVALID;
 	event->event.sched_switch.prev_state = prev_state;
-	__builtin_memcpy(&event->event.sched_switch.next_comm, &next->comm, MAX_COMM);
-	__builtin_memcpy(&event->event.sched_switch.prev_comm, &prev->comm, MAX_COMM);
+	__builtin_memcpy_inline(&event->event.sched_switch.next_comm, &next->comm, MAX_COMM);
+	__builtin_memcpy_inline(&event->event.sched_switch.prev_comm, &prev->comm, MAX_COMM);
 
 	bpf_ringbuf_submit(event, 0);
 


### PR DESCRIPTION
clang can still generate a memcpy call with __builtin_memcpy __builtin_memcpy_inline takes it a step further with compile time size value in exchange of a little binary size increase. supported since clang 15 and we want clang 16 min.