### PR TITLE
scx_layered: making unexpected gpu error smoother.

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1935,7 +1935,10 @@ impl<'a> Scheduler<'a> {
             return Ok(());
         }
 
-        let nvml = NVML_CELL.get_or_try_init(|| Nvml::init())?;
+        let nvml = NVML_CELL.get_or_try_init(|| {
+            Nvml::init().context("enabling GPU support requires a nvidia device")
+        })?;
+
         let mut missing_gpu_pid = false;
 
         if !self.opts.aggressive_nvml_polling {


### PR DESCRIPTION
nvml attempts to load the C library being, but scx_layered exits in a AMD setting.