### PR TITLE
scx_layered: Automatically disable stats if not being collected

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -64,6 +64,7 @@ private(big_cpumask) struct bpf_cpumask __kptr *big_cpumask;
 struct layer layers[MAX_LAYERS];
 u32 fallback_cpu;
 u32 layered_root_tgid = 0;
+bool stats_disabled = false;
 
 u32 empty_layer_ids[MAX_LAYERS];
 u32 nr_empty_layer_ids;
@@ -241,6 +242,8 @@ static void gstat_add(u32 id, struct cpu_ctx *cpuc, s64 delta)
 		scx_bpf_error("invalid global stat id %d", id);
 		return;
 	}
+	if (stats_disabled)
+		return;
 
 	cpuc->gstats[id] += delta;
 }
@@ -253,6 +256,9 @@ static void gstat_inc(u32 id, struct cpu_ctx *cpuc)
 static void lstat_add(u32 id, struct layer *layer, struct cpu_ctx *cpuc, s64 delta)
 {
 	u64 *vptr;
+
+	if (stats_disabled)
+		return;
 
 	if ((vptr = MEMBER_VPTR(*cpuc, .lstats[layer->id][id])))
 		(*vptr) += delta;


### PR DESCRIPTION
Save some overhead in map lookups for updating stats by automatically disabling stat updates if stats are not being collected.


Tested using the same technique in #1319 using this patch on `p2dq_running`:
```
@@ -570,21 +570,21 @@ void BPF_STRUCT_OPS(p2dq_running, struct task_struct *p)
        struct task_ctx *taskc;
        struct cpu_ctx *cpuc;
        struct llc_ctx *llcx;
        s32 task_cpu = scx_bpf_task_cpu(p);

        if (!(taskc = lookup_task_ctx(p)) ||
           !(cpuc = lookup_cpu_ctx(task_cpu)) ||
           !(llcx = lookup_llc_ctx(cpuc->llc_id)))
                return;

-       if (taskc->llc_id != cpuc->llc_id)
+       // if (taskc->llc_id != cpuc->llc_id)
                stat_inc(P2DQ_STAT_LLC_MIGRATION);
```

`bpftop` stats disabled:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/bda7e58f-0ba8-4e20-863e-30f5c7f8889d" />
`bpftop` stats enabled:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/145d6f4e-45eb-4f35-9466-f4ae56bc7244" />

For `scx_layered` I ran a bunch of benchmarks using `stress-ng` and looked at the top 15 results with stats disabled having a slight edge in performance:
```
$ grep -A1 '(real' stats_disabled.log | grep -v real | grep -v '\--' | tr -s ' ' ' ' | cut -d ' ' -f 7 | sort -nr | head -n 15
2244.02
2243.97
2243.96
2243.94
2243.94
2243.94
2243.91
2243.91
2243.90
2243.90
2243.90
2243.90
2243.89
2243.89
2243.89
```
stats enabled:
```
$ grep -A1 '(real' stats_enabled.log | grep -v real | grep -v '\--' | tr -s ' ' ' ' | cut -d ' ' -f 7 | sort -nr | head -n 15
2243.99
2243.91
2243.89
2243.89
2243.88
2243.87
2243.86
2243.85
2243.85
2243.85
2243.85
2243.84
2243.83
2243.83
2243.83
```