### PR TITLE
scx_layered: enable creating scx appimage

### DIFF
--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -34,3 +34,7 @@ scx_utils = { path = "../../../rust/scx_utils", version = "1.0.11" }
 
 [features]
 enable_backtrace = []
+
+[package.metadata.appimage]
+auto_link = true
+


### PR DESCRIPTION
this change enables using cargo appimage to make running sched_ext in less supported places simpler

how to use this:
1) https://github.com/AppImage/appimagetool/releases/tag/continuous -- put that appimage, renamed as appimagetool and chmod +x'ed, on your path.
2) install cargo-appimage.
3) cargo appimage from the scx_layered directory.

runs fine and the appimage contents looks right:
![image](https://github.com/user-attachments/assets/3884d5c1-97a0-4ad4-a560-e042c3a9462b)
