### PR TITLE
build: Add script for pgo/lto builds

### DIFF
--- a/pgo-lto.sh
+++ b/pgo-lto.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+PGO_TMPDIR=${1:-/tmp/pgo-data}
+SCHED=${2:-scx_rustland}
+PGO_DUR=${3:-30}
+
+rm -rf "$PGO_TMPDIR"
+mkdir -p "$PGO_TMPDIR"
+
+RUSTFLAGS="-C profile-generate=$PGO_TMPDIR -C link-arg=-lgcov" \
+    cargo build --release --bin "$SCHED"
+
+echo "Running sched to generate PGO"
+for i in {0..3}; do
+	sudo "./target/release/$SCHED" &
+	sleep "$PGO_DUR"
+	sudo kill -9 $! || echo "$SCHED already dead"
+	sleep 1
+done
+
+# Merge the `.profraw` files into a `.profdata` file
+llvm-profdata merge --failure-mode=warn \
+	-o "$PGO_TMPDIR/merged.profdata" \
+	"$PGO_TMPDIR"
+
+# Use the `.profdata` file for guiding optimizations
+RUSTFLAGS="-Cprofile-use=$PGO_TMPDIR/merged.profdata" \
+    cargo build --release --bin "$SCHED"
+


### PR DESCRIPTION
Add a script to generate PGO/LTO builds. This may improve performance for some of the more userspace oriented schedulers.

If everything goes right and the toolchain supports it then a binary should be produced:
```
$ ./pgo-lto.sh /tmp/pgo-data scx_rustland 10
<lots of output>
   Compiling ordered-float v3.9.2
   Compiling simplelog v0.12.2
   Compiling scx_rustland_core v2.2.8 (/root/scx/rust/scx_rustland_core)
   Compiling fb_procfs v0.7.1
   Compiling scx_rustland v1.0.9 (/root/scx/scheds/rust/scx_rustland)
warning: scx_rustland_core.307c2d1e9a16060e-cgu.0: function control flow change detected (hash mismatch) __rust_realloc Hash = 2202711501531239 up to 467244 count discarded

warning: scx_rustland_core.307c2d1e9a16060e-cgu.0: function control flow change detected (hash mismatch) __rust_alloc_zeroed Hash = 2202711501531239 up to 198 count discarded

warning: `scx_rustland_core` (lib) generated 2 warnings
    Finished `release` profile [optimized] target(s) in 1m 59s
```