### PR TITLE
scxtop: make q exit help if in help instead of quitting

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -2132,9 +2132,14 @@ impl<'a> App<'a> {
                     self.update_bpf_sample_rate(if new_rate >= 8 { new_rate } else { 0 });
                 }
             }
-            Action::Quit => {
-                self.should_quit.store(true, Ordering::Relaxed);
-            }
+            Action::Quit => match self.state {
+                AppState::Help => {
+                    self.handle_action(Action::SetState(AppState::Help))?;
+                }
+                _ => {
+                    self.should_quit.store(true, Ordering::Relaxed);
+                }
+            },
             _ => {}
         };
         Ok(())


### PR DESCRIPTION

I cannot wrap my head around not pressing 'q' to close the help screen. Make
pressing 'q' while help is open quit the help screen rather than the
application.

Test plan:
- Opened help, pressed q, help closed. Pressed q again and the app quit.
- Pressed q without opening help, app quit.
