### PR TITLE
scxtop: track number of dropped events and render it

### DIFF
--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -18,6 +18,11 @@ enum consts {
 	MAX_COMM	= 16,
 };
 
+enum stat_id {
+	STAT_DROPPED_EVENTS,
+	NR_SCXTOP_STATS,
+};
+
 enum event_type {
 	CPU_PERF_SET,
 	SCHED_REG,

--- a/tools/scxtop/src/bpf_stats.rs
+++ b/tools/scxtop/src/bpf_stats.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use crate::bpf_intf;
+use crate::bpf_skel::BpfSkel;
+
+use libbpf_rs::MapCore;
+
+const STAT_DROPPED_EVENTS: usize = bpf_intf::stat_id_STAT_DROPPED_EVENTS as usize;
+
+#[derive(Default)]
+pub struct BpfStats {
+    pub dropped_events: u64,
+}
+
+impl BpfStats {
+    pub fn get_from_skel(skel: &BpfSkel<'_>) -> anyhow::Result<BpfStats> {
+        let all_cpus = skel
+            .maps
+            .stats
+            .lookup_percpu(&(0 as u32).to_ne_bytes(), libbpf_rs::MapFlags::ANY)?
+            .expect("BPF_MAP_TYPE_PERCPU_ARRAY");
+
+        let read_stat = |idx| {
+            all_cpus
+                .iter()
+                .map(|pcpu| {
+                    // pcpu comes in as unaligned u8s. stride over 8 of them for each stat index.
+                    let val = &pcpu[idx * 8..];
+                    u64::from_ne_bytes(val.try_into().expect("all stats are u64s"))
+                })
+                .sum()
+        };
+
+        Ok(BpfStats {
+            dropped_events: read_stat(STAT_DROPPED_EVENTS),
+        })
+    }
+}

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -6,6 +6,7 @@
 mod app;
 pub mod bpf_intf;
 pub mod bpf_skel;
+mod bpf_stats;
 mod cpu_data;
 mod event_data;
 mod keymap;


### PR DESCRIPTION

Adds a stat to track events which can't be inserted into the ringbuf. I can't
get this to hit on my big AMD machines which is a good sign. I've tried a
couple of prod services and some stress-ng configurations. Seems like dropping
events isn't an issue at the minute, but we should keep an eye on it.

There are likely better ways to render this, but at least this way we keep
track of it and can render it more appropriately in the future.

Test plan:
- Artificially added failures on the BPF side. They render as expected in
  `scxtop` during a trace.
