### PR TITLE
scxtop: run clippy and implement fixes

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -180,7 +180,7 @@ jobs:
     needs: build-kernel
     strategy:
       matrix:
-        package: [ scx_loader, scx_rustland_core, scx_stats, scx_utils, scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
+        package: [ scx_loader, scx_rustland_core, scx_stats, scx_utils, scxtop, scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty ]
     steps:
       - uses: actions/checkout@v4
 
@@ -204,6 +204,10 @@ jobs:
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
 
       - run: cargo build --all-targets --package ${{ matrix.package }}
+
+      - name: Clippy
+        if: contains(fromJSON('["scxtop"]'), matrix.package)
+        run: cargo clippy --no-deps -p ${{ matrix.package }} -- -Dwarnings
 
       # virtme-ng runs as a different user than the runner, so loses the rustup and cargo roots. specify them explicitly to avoid a rebuild.
       - run: |

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -45,7 +45,6 @@ use regex::Regex;
 use scx_stats::prelude::StatsClient;
 use scx_utils::misc::read_file_usize;
 use scx_utils::Topology;
-use serde_json;
 use serde_json::Value as JsonValue;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::RwLock;
@@ -114,6 +113,7 @@ pub struct App<'a> {
 
 impl<'a> App<'a> {
     /// Creates a new appliation.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         stats_socket_path: String,
         trace_file_prefix: &'a str,
@@ -219,7 +219,7 @@ impl<'a> App<'a> {
             trace_tick: 0,
             trace_tick_warmup,
             max_trace_ticks: trace_ticks,
-            trace_manager: PerfettoTraceManager::new(&trace_file_prefix, None),
+            trace_manager: PerfettoTraceManager::new(trace_file_prefix, None),
             bpf_stats: Default::default(),
         };
 
@@ -637,23 +637,20 @@ impl<'a> App<'a> {
                     .border_type(BorderType::Rounded)
                     .style(self.theme.border_style())
                     .title_top(
-                        Line::from(format!(
-                            "{}",
-                            if self.collect_uncore_freq {
-                                "uncore ".to_string()
-                                    + &format_hz(
-                                        self.node_data
-                                            .get(&node)
-                                            .unwrap()
-                                            .event_data_immut("uncore_freq".to_string())
-                                            .last()
-                                            .copied()
-                                            .unwrap_or(0_u64),
-                                    )
-                            } else {
-                                "".to_string()
-                            }
-                        ))
+                        Line::from(if self.collect_uncore_freq {
+                            "uncore ".to_string()
+                                + &format_hz(
+                                    self.node_data
+                                        .get(&node)
+                                        .unwrap()
+                                        .event_data_immut("uncore_freq".to_string())
+                                        .last()
+                                        .copied()
+                                        .unwrap_or(0_u64),
+                                )
+                        } else {
+                            "".to_string()
+                        })
                         .style(self.theme.text_important_color())
                         .right_aligned(),
                     )
@@ -713,15 +710,10 @@ impl<'a> App<'a> {
 
                 frame.render_widget(llc_block, llcs_verticle[0]);
 
-                let llc_sparklines: Vec<Sparkline> = self
-                    .topo
+                self.topo
                     .all_llcs
                     .keys()
-                    .map(|llc_id| self.llc_sparkline(llc_id.clone(), *llc_id == num_llcs - 1))
-                    .collect();
-
-                let _ = llc_sparklines
-                    .iter()
+                    .map(|llc_id| self.llc_sparkline(*llc_id, *llc_id == num_llcs - 1))
                     .enumerate()
                     .for_each(|(i, llc_sparkline)| {
                         frame.render_widget(llc_sparkline, llcs_verticle[i + 1]);
@@ -797,7 +789,7 @@ impl<'a> App<'a> {
                     .topo
                     .nodes
                     .keys()
-                    .map(|node_id| self.node_sparkline(node_id.clone(), *node_id == num_nodes - 1))
+                    .map(|node_id| self.node_sparkline(*node_id, *node_id == num_nodes - 1))
                     .collect();
 
                 let node_block = Block::bordered()
@@ -818,7 +810,7 @@ impl<'a> App<'a> {
                     .style(self.theme.border_style());
 
                 frame.render_widget(node_block, nodes_verticle[0]);
-                let _ = node_sparklines
+                node_sparklines
                     .iter()
                     .enumerate()
                     .for_each(|(i, node_sparkline)| {
@@ -933,7 +925,7 @@ impl<'a> App<'a> {
             .map(|(j, (dsq_id, _data))| {
                 self.dsq_sparkline(
                     event.clone(),
-                    dsq_id.clone(),
+                    *dsq_id,
                     Borders::ALL,
                     j == 0 && render_title,
                     j == 0 && render_sample_rate,
@@ -1069,8 +1061,7 @@ impl<'a> App<'a> {
         }
         let dsqs_verticle = Layout::vertical(dsq_constraints).split(area);
 
-        let _ = self
-            .dsq_sparklines(event.clone(), render_title, render_sample_rate)
+        self.dsq_sparklines(event.clone(), render_title, render_sample_rate)
             .iter()
             .enumerate()
             .for_each(|(j, dsq_sparkline)| {
@@ -1114,8 +1105,7 @@ impl<'a> App<'a> {
         }
         let dsqs_verticle = Layout::vertical(dsq_constraints).split(area);
 
-        let _ = self
-            .dsq_sparklines(event.clone(), render_title, render_sample_rate)
+        self.dsq_sparklines(event.clone(), render_title, render_sample_rate)
             .iter()
             .enumerate()
             .for_each(|(j, dsq_sparkline)| {
@@ -1381,23 +1371,20 @@ impl<'a> App<'a> {
                             Line::from("")
                         })
                         .title_top(
-                            Line::from(format!(
-                                "{}",
-                                if self.collect_uncore_freq {
-                                    "uncore ".to_string()
-                                        + &format_hz(
-                                            self.node_data
-                                                .get(&node.id)
-                                                .unwrap()
-                                                .event_data_immut("uncore_freq".to_string())
-                                                .last()
-                                                .copied()
-                                                .unwrap_or(0_u64),
-                                        )
-                                } else {
-                                    "".to_string()
-                                }
-                            ))
+                            Line::from(if self.collect_uncore_freq {
+                                "uncore ".to_string()
+                                    + &format_hz(
+                                        self.node_data
+                                            .get(&node.id)
+                                            .unwrap()
+                                            .event_data_immut("uncore_freq".to_string())
+                                            .last()
+                                            .copied()
+                                            .unwrap_or(0_u64),
+                                    )
+                            } else {
+                                "".to_string()
+                            })
                             .style(self.theme.text_important_color())
                             .left_aligned(),
                         )
@@ -1414,7 +1401,7 @@ impl<'a> App<'a> {
                         .enumerate()
                         .map(|(j, cpu)| {
                             self.cpu_sparkline(
-                                cpu.id.clone(),
+                                cpu.id,
                                 stats.max,
                                 if j > col_scale && j == node_cpus - col_scale {
                                     Borders::LEFT | Borders::BOTTOM
@@ -1434,7 +1421,7 @@ impl<'a> App<'a> {
                         })
                         .collect();
 
-                    let _ = cpu_sparklines
+                    cpu_sparklines
                         .iter()
                         .enumerate()
                         .for_each(|(j, cpu_sparkline)| {
@@ -1489,23 +1476,20 @@ impl<'a> App<'a> {
                             Line::from("")
                         })
                         .title_top(
-                            Line::from(format!(
-                                "{}",
-                                if self.collect_uncore_freq {
-                                    "uncore ".to_string()
-                                        + &format_hz(
-                                            self.node_data
-                                                .get(&node.id)
-                                                .unwrap()
-                                                .event_data_immut("uncore_freq".to_string())
-                                                .last()
-                                                .copied()
-                                                .unwrap_or(0_u64),
-                                        )
-                                } else {
-                                    "".to_string()
-                                }
-                            ))
+                            Line::from(if self.collect_uncore_freq {
+                                "uncore ".to_string()
+                                    + &format_hz(
+                                        self.node_data
+                                            .get(&node.id)
+                                            .unwrap()
+                                            .event_data_immut("uncore_freq".to_string())
+                                            .last()
+                                            .copied()
+                                            .unwrap_or(0_u64),
+                                    )
+                            } else {
+                                "".to_string()
+                            })
                             .style(self.theme.text_important_color())
                             .left_aligned(),
                         )
@@ -1540,7 +1524,7 @@ impl<'a> App<'a> {
                             .style(self.theme.border_style());
                         let bar_chart = BarChart::default()
                             .block(cpu_block)
-                            .data(BarGroup::default().bars(&col_data))
+                            .data(BarGroup::default().bars(col_data))
                             .max(stats.max)
                             .direction(Direction::Horizontal)
                             .bar_style(self.theme.sparkline_style())
@@ -1857,78 +1841,59 @@ impl<'a> App<'a> {
 
     /// Updates app state when the down arrow or mapped key is pressed.
     fn on_down(&mut self) {
-        match self.state {
-            AppState::Event => {
-                if self.event_scroll <= self.num_perf_events {
-                    self.event_scroll += 1;
-                    self.selected_event += 1
-                }
-            }
-            _ => {}
+        if self.state == AppState::Event && self.event_scroll <= self.num_perf_events {
+            self.event_scroll += 1;
+            self.selected_event += 1
         }
     }
 
     /// Updates app state when the up arrow or mapped key is pressed.
     fn on_up(&mut self) {
-        match self.state {
-            AppState::Event => {
-                if self.event_scroll > 0 {
-                    self.event_scroll -= 1;
-                    self.selected_event -= 1
-                }
-            }
-            _ => {}
+        if self.state == AppState::Event && self.event_scroll > 0 {
+            self.event_scroll -= 1;
+            self.selected_event -= 1
         }
     }
 
     /// Updates app state when page down or mapped key is pressed.
     fn on_pg_down(&mut self) {
-        match self.state {
-            AppState::Event => {
-                if self.event_scroll <= self.num_perf_events - self.events_list_size {
-                    self.event_scroll += self.events_list_size - 1;
-                    self.selected_event += (self.events_list_size - 1) as usize;
-                }
-            }
-            _ => {}
+        if self.state == AppState::Event
+            && self.event_scroll <= self.num_perf_events - self.events_list_size
+        {
+            self.event_scroll += self.events_list_size - 1;
+            self.selected_event += (self.events_list_size - 1) as usize;
         }
     }
 
     /// Updates app state when page up or mapped key is pressed.
     fn on_pg_up(&mut self) {
-        match self.state {
-            AppState::Event => {
-                if self.event_scroll > self.events_list_size {
-                    self.event_scroll -= self.events_list_size - 1;
-                    self.selected_event -= (self.events_list_size - 1) as usize;
-                } else {
-                    self.event_scroll = 0;
-                    self.selected_event = 0;
-                }
+        if self.state == AppState::Event {
+            if self.event_scroll > self.events_list_size {
+                self.event_scroll -= self.events_list_size - 1;
+                self.selected_event -= (self.events_list_size - 1) as usize;
+            } else {
+                self.event_scroll = 0;
+                self.selected_event = 0;
             }
-            _ => {}
         }
     }
 
     /// Updates app state when the enter key is pressed.
     fn on_enter(&mut self) {
-        match self.state {
-            AppState::Event => {
-                if let Some((subsystem, event)) =
-                    self.available_perf_events_list[self.selected_event].split_once(":")
-                {
-                    let perf_event = PerfEvent::new(subsystem.to_string(), event.to_string(), 0);
-                    self.active_perf_events.clear();
-                    self.active_event = perf_event.clone();
-                    let _ = self.activate_perf_event(&perf_event);
-                    self.non_hw_event_active = true;
-                    let prev_state = self.prev_state.clone();
-                    self.prev_state = self.state.clone();
-                    self.state = prev_state;
-                    self.available_events.push(perf_event.clone());
-                }
+        if self.state == AppState::Event {
+            if let Some((subsystem, event)) =
+                self.available_perf_events_list[self.selected_event].split_once(":")
+            {
+                let perf_event = PerfEvent::new(subsystem.to_string(), event.to_string(), 0);
+                self.active_perf_events.clear();
+                self.active_event = perf_event.clone();
+                let _ = self.activate_perf_event(&perf_event);
+                self.non_hw_event_active = true;
+                let prev_state = self.prev_state.clone();
+                self.prev_state = self.state.clone();
+                self.state = prev_state;
+                self.available_events.push(perf_event.clone());
             }
-            _ => {}
         }
     }
 

--- a/tools/scxtop/src/bpf_stats.rs
+++ b/tools/scxtop/src/bpf_stats.rs
@@ -20,7 +20,7 @@ impl BpfStats {
         let all_cpus = skel
             .maps
             .stats
-            .lookup_percpu(&(0 as u32).to_ne_bytes(), libbpf_rs::MapFlags::ANY)?
+            .lookup_percpu(&0_u32.to_ne_bytes(), libbpf_rs::MapFlags::ANY)?
             .expect("BPF_MAP_TYPE_PERCPU_ARRAY");
 
         let read_stat = |idx| {

--- a/tools/scxtop/src/cpu_data.rs
+++ b/tools/scxtop/src/cpu_data.rs
@@ -36,7 +36,7 @@ impl CpuData {
 
     /// Initializes events with default values.
     pub fn initialize_events(&mut self, events: &Vec<String>) {
-        self.data.initialize_events(&events);
+        self.data.initialize_events(events);
     }
 
     /// Returns the data for an event and updates if no entry is present.

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -28,9 +28,9 @@ pub struct KeyMap {
     bindings: HashMap<Key, Action>,
 }
 
-impl KeyMap {
+impl Default for KeyMap {
     /// Returns the default keymap.
-    pub fn default() -> Self {
+    fn default() -> Self {
         let mut bindings = HashMap::new();
         bindings.insert(Key::Char('d'), Action::SetState(AppState::Default));
         bindings.insert(Key::Char('e'), Action::SetState(AppState::Event));
@@ -61,7 +61,9 @@ impl KeyMap {
 
         Self { bindings }
     }
+}
 
+impl KeyMap {
     /// Maps the Key to an Action.
     pub fn action(&self, key: &Key) -> Action {
         self.bindings.get(key).cloned().unwrap_or(Action::None)
@@ -81,13 +83,10 @@ impl KeyMap {
     /// Returns a String of the keys for an Action.
     pub fn action_keys_string(&self, action: Action) -> String {
         let action_keys = self.action_keys(action);
-        format!(
-            "{}",
-            action_keys
-                .iter()
-                .map(|k| k.to_string())
-                .collect::<Vec<_>>()
-                .join("/")
-        )
+        action_keys
+            .iter()
+            .map(|k| k.to_string())
+            .collect::<Vec<_>>()
+            .join("/")
     }
 }

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -44,13 +44,13 @@ pub use plain::Plain;
 // Generate serialization types for handling events from the bpf ring buffer.
 unsafe impl Plain for crate::bpf_skel::types::bpf_event {}
 
-pub const STATS_SOCKET_PATH: &'static str = "/var/run/scx/root/stats";
-pub const APP: &'static str = "scxtop";
-pub const LICENSE: &'static str = "Copyright (c) Meta Platforms, Inc. and affiliates. 
+pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
+pub const APP: &str = "scxtop";
+pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
 This software may be used and distributed according to the terms of the 
 GNU General Public License version 2.";
-pub const SCHED_NAME_PATH: &'static str = "/sys/kernel/sched_ext/root/ops";
+pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum AppState {

--- a/tools/scxtop/src/llc_data.rs
+++ b/tools/scxtop/src/llc_data.rs
@@ -33,7 +33,7 @@ impl LlcData {
 
     /// Initializes events with default values.
     pub fn initialize_events(&mut self, events: &Vec<String>) {
-        self.data.initialize_events(&events);
+        self.data.initialize_events(events);
     }
 
     /// Returns the data for an event and updates if no entry is present.

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 use ratatui::crossterm::event::KeyCode::Char;
 use tokio::sync::mpsc;
 
-const TRACE_FILE_PREFIX: &'static str = "scxtop_trace";
+const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 
 #[derive(Parser, Debug)]
 #[command(about = APP)]

--- a/tools/scxtop/src/node_data.rs
+++ b/tools/scxtop/src/node_data.rs
@@ -30,7 +30,7 @@ impl NodeData {
 
     /// Initializes events with default values.
     pub fn initialize_events(&mut self, events: &Vec<String>) {
-        self.data.initialize_events(&events);
+        self.data.initialize_events(events);
     }
 
     /// Returns the data for an event and updates if no entry is present.

--- a/tools/scxtop/src/perf_event.rs
+++ b/tools/scxtop/src/perf_event.rs
@@ -24,9 +24,9 @@ const PERF_FORMAT_TOTAL_TIME_ENABLED: u64 = 1 << 0;
 #[allow(dead_code)]
 const PERF_FORMAT_TOTAL_TIME_RUNNING: u64 = 1 << 1;
 #[allow(dead_code)]
-const DEBUGFS: &'static str = "debugfs";
-const TRACEFS: &'static str = "tracefs";
-const PROCFS_MOUNTS: &'static str = "/proc/mounts";
+const DEBUGFS: &str = "debugfs";
+const TRACEFS: &str = "tracefs";
+const PROCFS_MOUNTS: &str = "/proc/mounts";
 
 /// Returns the mount point for a filesystem type.
 fn get_fs_mount(mount_type: &str) -> Result<Vec<PathBuf>> {
@@ -110,88 +110,30 @@ impl PerfEvent {
 
     /// Returns the set of default hardware events.
     pub fn default_hw_events() -> Vec<PerfEvent> {
-        let mut avail_events = Vec::new();
-        avail_events.push(PerfEvent::new("hw".to_string(), "cycles".to_string(), 0));
-        avail_events.push(PerfEvent::new("hw".to_string(), "branches".to_string(), 0));
-        avail_events.push(PerfEvent::new(
-            "hw".to_string(),
-            "branch-misses".to_string(),
-            0,
-        ));
-        avail_events.push(PerfEvent::new(
-            "hw".to_string(),
-            "cache-misses".to_string(),
-            0,
-        ));
-        avail_events.push(PerfEvent::new(
-            "hw".to_string(),
-            "cache-references".to_string(),
-            0,
-        ));
-        avail_events.push(PerfEvent::new(
-            "hw".to_string(),
-            "instructions".to_string(),
-            0,
-        ));
-        avail_events.push(PerfEvent::new(
-            "hw".to_string(),
-            "ref-cycles".to_string(),
-            0,
-        ));
-        avail_events.push(PerfEvent::new(
-            "hw".to_string(),
-            "stalled-cycles-backend".to_string(),
-            0,
-        ));
-        avail_events.push(PerfEvent::new(
-            "hw".to_string(),
-            "stalled-cycles-frontend".to_string(),
-            0,
-        ));
-        avail_events.push(PerfEvent::new(
-            "hw".to_string(),
-            "bus-cycles".to_string(),
-            0,
-        ));
-        avail_events.push(PerfEvent::new(
-            "hw".to_string(),
-            "L1-dcache-load-misses".to_string(),
-            0,
-        ));
-
-        avail_events
+        vec![
+            PerfEvent::new("hw".to_string(), "cycles".to_string(), 0),
+            PerfEvent::new("hw".to_string(), "branches".to_string(), 0),
+            PerfEvent::new("hw".to_string(), "branch-misses".to_string(), 0),
+            PerfEvent::new("hw".to_string(), "cache-misses".to_string(), 0),
+            PerfEvent::new("hw".to_string(), "cache-references".to_string(), 0),
+            PerfEvent::new("hw".to_string(), "instructions".to_string(), 0),
+            PerfEvent::new("hw".to_string(), "ref-cycles".to_string(), 0),
+            PerfEvent::new("hw".to_string(), "stalled-cycles-backend".to_string(), 0),
+            PerfEvent::new("hw".to_string(), "stalled-cycles-frontend".to_string(), 0),
+            PerfEvent::new("hw".to_string(), "bus-cycles".to_string(), 0),
+            PerfEvent::new("hw".to_string(), "L1-dcache-load-misses".to_string(), 0),
+        ]
     }
 
     /// Returns the set of default software events.
     pub fn default_sw_events() -> Vec<PerfEvent> {
-        let mut avail_events = Vec::new();
-        avail_events.push(PerfEvent::new(
-            "sw".to_string(),
-            "context-switches".to_string(),
-            0,
-        ));
-        avail_events.push(PerfEvent::new(
-            "sw".to_string(),
-            "page-faults".to_string(),
-            0,
-        ));
-        avail_events.push(PerfEvent::new(
-            "sw".to_string(),
-            "minor-faults".to_string(),
-            0,
-        ));
-        avail_events.push(PerfEvent::new(
-            "sw".to_string(),
-            "major-faults".to_string(),
-            0,
-        ));
-        avail_events.push(PerfEvent::new(
-            "sw".to_string(),
-            "migrations".to_string(),
-            0,
-        ));
-
-        avail_events
+        vec![
+            PerfEvent::new("sw".to_string(), "context-switches".to_string(), 0),
+            PerfEvent::new("sw".to_string(), "page-faults".to_string(), 0),
+            PerfEvent::new("sw".to_string(), "minor-faults".to_string(), 0),
+            PerfEvent::new("sw".to_string(), "major-faults".to_string(), 0),
+            PerfEvent::new("sw".to_string(), "migrations".to_string(), 0),
+        ]
     }
 
     /// Returns the set of default hardware and software events.
@@ -204,9 +146,10 @@ impl PerfEvent {
 
     /// Attaches a PerfEvent struct.
     pub fn attach(&mut self) -> Result<()> {
-        let mut attrs = perf::bindings::perf_event_attr::default();
-
-        attrs.size = std::mem::size_of::<perf::bindings::perf_event_attr>() as u32;
+        let mut attrs = perf::bindings::perf_event_attr {
+            size: std::mem::size_of::<perf::bindings::perf_event_attr>() as u32,
+            ..Default::default()
+        };
 
         match self.subsystem.to_lowercase().as_str() {
             "hw" | "hardware" => {

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -153,7 +153,7 @@ impl<'a> PerfettoTraceManager<'a> {
 
         // dsq latency tracks
         for dsq in &trace_dsqs {
-            self.dsq_lat_events.remove(&dsq).map(|events| {
+            if let Some(events) = self.dsq_lat_events.remove(dsq) {
                 for dsq_lat_event in events {
                     let ts: u64 = dsq_lat_event.timestamp_absolute_us() as u64 / 1_000;
                     let mut packet = TracePacket::new();
@@ -162,12 +162,12 @@ impl<'a> PerfettoTraceManager<'a> {
                     packet.set_timestamp(ts);
                     self.trace.packet.push(packet);
                 }
-            });
+            }
         }
 
         // dsq nr_queued tracks
         for dsq in &trace_dsqs {
-            self.dsq_nr_queued_events.remove(&dsq).map(|events| {
+            if let Some(events) = self.dsq_nr_queued_events.remove(dsq) {
                 for dsq_lat_event in events {
                     let ts: u64 = dsq_lat_event.timestamp_absolute_us() as u64 / 1_000;
                     let mut packet = TracePacket::new();
@@ -177,7 +177,7 @@ impl<'a> PerfettoTraceManager<'a> {
                     packet.set_timestamp(ts);
                     self.trace.packet.push(packet);
                 }
-            });
+            }
         }
 
         // ftrace events
@@ -185,11 +185,11 @@ impl<'a> PerfettoTraceManager<'a> {
             let mut packet = TracePacket::new();
             let mut bundle = FtraceEventBundle::new();
 
-            self.ftrace_events.remove(&cpu).map(|mut events| {
+            if let Some(mut events) = self.ftrace_events.remove(cpu) {
                 // sort by timestamp just to make sure.
                 events.sort_by_key(|event| event.timestamp());
                 bundle.event = events;
-            });
+            }
             bundle.set_cpu(*cpu);
             packet.set_ftrace_events(bundle);
             packet.trusted_pid = Some(self.trusted_pid);
@@ -214,27 +214,23 @@ impl<'a> PerfettoTraceManager<'a> {
             comm,
         } = action;
 
-        let _ = self
-            .ftrace_events
-            .entry(*cpu)
-            .or_insert_with(Vec::new)
-            .push({
-                let mut ftrace_event = FtraceEvent::new();
-                let mut wakeup_event = SchedWakeupFtraceEvent::new();
-                let pid = *pid as u32;
-                let cpu = *cpu as i32;
+        self.ftrace_events.entry(*cpu).or_default().push({
+            let mut ftrace_event = FtraceEvent::new();
+            let mut wakeup_event = SchedWakeupFtraceEvent::new();
+            let pid = *pid;
+            let cpu = *cpu as i32;
 
-                wakeup_event.set_pid(pid.try_into().unwrap());
-                wakeup_event.set_prio(*prio);
-                wakeup_event.set_comm(comm.clone());
-                wakeup_event.set_target_cpu(cpu);
+            wakeup_event.set_pid(pid.try_into().unwrap());
+            wakeup_event.set_prio(*prio);
+            wakeup_event.set_comm(comm.clone());
+            wakeup_event.set_target_cpu(cpu);
 
-                ftrace_event.set_timestamp(*ts);
-                ftrace_event.set_sched_wakeup(wakeup_event);
-                ftrace_event.set_pid(pid);
+            ftrace_event.set_timestamp(*ts);
+            ftrace_event.set_sched_wakeup(wakeup_event);
+            ftrace_event.set_pid(pid);
 
-                ftrace_event
-            });
+            ftrace_event
+        });
     }
 
     /// Adds events for on sched_wakeup_new.
@@ -252,27 +248,23 @@ impl<'a> PerfettoTraceManager<'a> {
             comm,
         } = action;
 
-        let _ = self
-            .ftrace_events
-            .entry(*cpu)
-            .or_insert_with(Vec::new)
-            .push({
-                let mut ftrace_event = FtraceEvent::new();
-                let mut waking_event = SchedWakingFtraceEvent::new();
-                let pid = *pid as u32;
-                let cpu = *cpu as i32;
+        self.ftrace_events.entry(*cpu).or_default().push({
+            let mut ftrace_event = FtraceEvent::new();
+            let mut waking_event = SchedWakingFtraceEvent::new();
+            let pid = *pid;
+            let cpu = *cpu as i32;
 
-                waking_event.set_pid(pid.try_into().unwrap());
-                waking_event.set_prio(*prio);
-                waking_event.set_comm(comm.clone());
-                waking_event.set_target_cpu(cpu);
+            waking_event.set_pid(pid.try_into().unwrap());
+            waking_event.set_prio(*prio);
+            waking_event.set_comm(comm.clone());
+            waking_event.set_target_cpu(cpu);
 
-                ftrace_event.set_timestamp(*ts);
-                ftrace_event.set_sched_waking(waking_event);
-                ftrace_event.set_pid(pid);
+            ftrace_event.set_timestamp(*ts);
+            ftrace_event.set_sched_waking(waking_event);
+            ftrace_event.set_pid(pid);
 
-                ftrace_event
-            });
+            ftrace_event
+        });
     }
 
     /// Adds events for the sched_switch event.
@@ -293,29 +285,25 @@ impl<'a> PerfettoTraceManager<'a> {
             ..
         } = action;
 
-        let _ = self
-            .ftrace_events
-            .entry(*cpu)
-            .or_insert_with(Vec::new)
-            .push({
-                let mut ftrace_event = FtraceEvent::new();
-                let mut switch_event = SchedSwitchFtraceEvent::new();
-                let prev_pid: i32 = *prev_pid as i32;
-                let next_pid: i32 = *next_pid as i32;
+        self.ftrace_events.entry(*cpu).or_default().push({
+            let mut ftrace_event = FtraceEvent::new();
+            let mut switch_event = SchedSwitchFtraceEvent::new();
+            let prev_pid: i32 = *prev_pid as i32;
+            let next_pid: i32 = *next_pid as i32;
 
-                switch_event.set_next_pid(next_pid);
-                switch_event.set_next_comm(next_comm.clone());
-                switch_event.set_next_prio(*next_prio);
-                switch_event.set_prev_pid(prev_pid);
-                switch_event.set_prev_prio(*prev_prio);
-                switch_event.set_prev_comm(prev_comm.clone());
-                switch_event.set_prev_state(*prev_state as i64);
-                ftrace_event.set_timestamp(*ts);
-                ftrace_event.set_sched_switch(switch_event);
-                ftrace_event.set_pid(prev_pid.try_into().unwrap());
+            switch_event.set_next_pid(next_pid);
+            switch_event.set_next_comm(next_comm.clone());
+            switch_event.set_next_prio(*next_prio);
+            switch_event.set_prev_pid(prev_pid);
+            switch_event.set_prev_prio(*prev_prio);
+            switch_event.set_prev_comm(prev_comm.clone());
+            switch_event.set_prev_state(*prev_state as i64);
+            ftrace_event.set_timestamp(*ts);
+            ftrace_event.set_sched_switch(switch_event);
+            ftrace_event.set_pid(prev_pid.try_into().unwrap());
 
-                ftrace_event
-            });
+            ftrace_event
+        });
 
         // Skip handling DSQ data if the sched_switch event didn't have
         // any DSQ data.
@@ -327,24 +315,19 @@ impl<'a> PerfettoTraceManager<'a> {
             .dsq_uuids
             .entry(*next_dsq_id)
             .or_insert_with(|| self.rng.next_u64());
-        let _ = self
-            .dsq_lat_events
-            .entry(*next_dsq_id)
-            .or_insert_with(Vec::new)
-            .push({
-                let mut event = TrackEvent::new();
-                let ts: i64 = (*ts).try_into().unwrap();
-                event.set_type(TrackEventType::TYPE_COUNTER);
-                event.set_track_uuid(*next_dsq_uuid);
-                event.set_counter_value((*next_dsq_lat_us).try_into().unwrap());
-                event.set_timestamp_absolute_us(ts / 1000);
+        self.dsq_lat_events.entry(*next_dsq_id).or_default().push({
+            let mut event = TrackEvent::new();
+            let ts: i64 = (*ts).try_into().unwrap();
+            event.set_type(TrackEventType::TYPE_COUNTER);
+            event.set_track_uuid(*next_dsq_uuid);
+            event.set_counter_value((*next_dsq_lat_us).try_into().unwrap());
+            event.set_timestamp_absolute_us(ts / 1000);
 
-                event
-            });
-        let _ = self
-            .dsq_nr_queued_events
+            event
+        });
+        self.dsq_nr_queued_events
             .entry(*next_dsq_id)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push({
                 let mut event = TrackEvent::new();
                 let ts: i64 = (*ts).try_into().unwrap();

--- a/tools/scxtop/src/stats.rs
+++ b/tools/scxtop/src/stats.rs
@@ -110,7 +110,7 @@ impl VecStats {
                     }
                 }
                 Self {
-                    avg: if calc_avg && vec.len() > 0 {
+                    avg: if calc_avg && !vec.is_empty() {
                         sum / vec.len() as u64
                     } else {
                         0
@@ -121,7 +121,7 @@ impl VecStats {
                 }
             }
             None => Self {
-                avg: if calc_avg && vec.len() > 0 {
+                avg: if calc_avg && !vec.is_empty() {
                     sum / vec.len() as u64
                 } else {
                     0


### PR DESCRIPTION

Ran `clippy` against `scxtop` and kept iterating until no more warnings. I was
very happy with the quality of these warnings.

The main change to the code is things are less indented because of some
restructuring. This is another PR to review with GitHub set to not show
whitespace changes.

Test plan:
- Build scxtop and run any tests we write in the CI in the future.
- Run `cargo clippy` only for scxtop in the CI too to keep things clean.
