### PR TITLE
scx_rusty: turn off mempolicy setting for arm64 until we regen the headers

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -1279,6 +1279,7 @@ static u64 node_dom_mask(u32 node_id)
 	return mask;
 }
 
+#ifndef __TARGET_ARCH_arm64
 /*
  * Sets the preferred domain mask according to the mempolicy. See man(2)
  * set_mempolicy for more details on mempolicy.
@@ -1329,6 +1330,14 @@ static void task_set_preferred_mempolicy_dom_mask(struct task_struct *p,
 
 	return;
 }
+#else
+
+static void task_set_preferred_mempolicy_dom_mask(struct task_struct *p,
+                                                 struct task_ctx *taskc)
+{}
+
+#endif
+
 
 void BPF_STRUCT_OPS(rusty_dispatch, s32 cpu, struct task_struct *prev)
 {


### PR DESCRIPTION
Using BPF_CORE_READ() still fails for arm64 using our current vmlinux.h, because the macro still assumes the field exists. Temporarily turn off mempolicy setting for arm64 until we regenerate the arm64 header with NUMA support.