### PR TITLE
scxtop: propose to give the ability to focus on one process.

### DIFF
--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -16,6 +16,7 @@ use scxtop::App;
 use scxtop::Event;
 use scxtop::Key;
 use scxtop::KeyMap;
+use scxtop::PerfEvent;
 use scxtop::Tui;
 use scxtop::APP;
 use scxtop::SCHED_NAME_PATH;
@@ -58,6 +59,9 @@ struct Args {
     /// Number of ticks to warmup before collecting traces.
     #[arg(long, default_value_t = 3)]
     trace_tick_warmup: usize,
+    /// Process to monitor or all.
+    #[arg(long, default_value_t = -1)]
+    process_id: i32,
 }
 
 fn get_action(_app: &App, keymap: &KeyMap, event: Event) -> Action {
@@ -87,6 +91,8 @@ async fn main() -> Result<()> {
     if args.debug {
         builder.obj_builder.debug(true);
     }
+    PerfEvent::set_process_id(args.process_id)
+        .expect("perf event process_id init failed or invalid value");
 
     let open_skel = builder.open(&mut open_object)?;
     let skel = open_skel.load()?;

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -91,8 +91,6 @@ async fn main() -> Result<()> {
     if args.debug {
         builder.obj_builder.debug(true);
     }
-    PerfEvent::set_process_id(args.process_id)
-        .expect("perf event process_id init failed or invalid value");
 
     let open_skel = builder.open(&mut open_object)?;
     let skel = open_skel.load()?;
@@ -260,6 +258,7 @@ async fn main() -> Result<()> {
         args.tick_rate_ms,
         args.trace_ticks,
         args.trace_tick_warmup,
+        args.process_id,
         action_tx.clone(),
         skel,
     )?;


### PR DESCRIPTION
checking if scheduler A fits well with a specific application. In that case, it is probably fair to think that child processes created (e.g. web servers) should be included.