### PR TITLE
scx: Don't panic on missing enums in C schedulers

### DIFF
--- a/scheds/include/scx/enums.h
+++ b/scheds/include/scx/enums.h
@@ -14,7 +14,8 @@ static inline void __ENUM_set(u64 *val, char *type, char *name)
 	bool res;
 
 	res = __COMPAT_read_enum(type, name, val);
-	SCX_BUG_ON(!res, "enum not found(%s)", name);
+	if (!res)
+		*val = 0;
 }
 
 #define SCX_ENUM_SET(skel, type, name) do {			\


### PR DESCRIPTION
Similar to commit 42ec582b ("scx_utils/enums: Don't panic on missing enums"), avoid panics when an enum is not found also in the C schedulers and default to 0, consistent with the Rust schedulers.