### PR TITLE
scxtop: add experimental_long_tail_tracing

### DIFF
--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -31,6 +31,7 @@ enum event_type {
 	SCHED_WAKEUP,
 	SCHED_WAKING,
 	SOFTIRQ,
+	START_TRACE,
 	EVENT_MAX,
 };
 

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -3,8 +3,8 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
-use crate::Action;
 use crate::AppState;
+use crate::{Action, RecordTraceAction};
 use crossterm::event::KeyCode;
 use std::collections::HashMap;
 
@@ -41,8 +41,14 @@ impl Default for KeyMap {
         bindings.insert(Key::Char('l'), Action::SetState(AppState::Llc));
         bindings.insert(Key::Char('n'), Action::SetState(AppState::Node));
         bindings.insert(Key::Char('s'), Action::SetState(AppState::Scheduler));
-        bindings.insert(Key::Char('a'), Action::RecordTrace);
-        bindings.insert(Key::Char('P'), Action::RecordTrace);
+        bindings.insert(
+            Key::Char('a'),
+            Action::RecordTrace(RecordTraceAction { immediate: false }),
+        );
+        bindings.insert(
+            Key::Char('P'),
+            Action::RecordTrace(RecordTraceAction { immediate: false }),
+        );
         bindings.insert(Key::Char('x'), Action::ClearEvent);
         bindings.insert(Key::Char('j'), Action::PrevEvent);
         bindings.insert(Key::Char('k'), Action::NextEvent);

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -148,6 +148,11 @@ pub struct SoftIRQAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct RecordTraceAction {
+    pub immediate: bool,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Action {
     Tick,
     Increment,
@@ -176,7 +181,7 @@ pub enum Action {
     SetState(AppState),
     SoftIRQ(SoftIRQAction),
     NextViewState,
-    RecordTrace,
+    RecordTrace(RecordTraceAction),
     ToggleCpuFreq,
     ToggleUncoreFreq,
     TickRateChange(std::time::Duration),


### PR DESCRIPTION

Adding an experimental feature to automatically start a perfetto trace when a
named function takes a specified long time to return. This can be used to get a
trace of an event when a group of long tail events happen together.

Prefacing this all with experimental as the implementation is a little funky.

Implementation notes:
- Starts the trace entirely from BPF space and relies on ordering of the
  ringbuffer to make sure userspace notices before the first events come
  through.
- Misses early softirq events because they require userspace to attach the
  programs.
- Starts the trace from `trace_tick_warmup` ticks to events aren't dropped.
- Extends the trace if another such event comes from, meaning this can generate
  an infinitely long trace and probably get scxtop OOM killed if you get the
  parameters wrong.

The concept here is that many traces can be recorded by leaving scxtop running,
but currently it doesn't seem to be able to get more than 2 without the TUI
crashing and leaving it in a terminal output that needs Ctrl+C'ing.

Test plan:
- Attached to a production binary and it hits when expected, gathering traces
  that look reasonable.
