### PR TITLE
scx_utils: remove test dependency on a sched_ext kernel

### DIFF
--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -270,7 +270,7 @@ mod tests {
 
     #[test]
     fn test_ksym_exists() {
-        assert!(super::ksym_exists("scx_bpf_consume").unwrap());
+        assert!(super::ksym_exists("bpf_task_acquire").unwrap());
         assert!(!super::ksym_exists("NO_SUCH_KFUNC").unwrap());
     }
 }


### PR DESCRIPTION

The test function `test_ksym_exists` in `scx_utils` currently requires
`scx_bpf_consume` which means Linux kernel >=6.12 <6.15 (as that function has
been renamed to be removed). The function, however, is testing whether a valid
and invalid ksym exist.

This change changes the ksym to `bpf_task_acquire` which should work on any
kernel >6.1, which means `cargo test` can run on more machine kernels. This
includes our CI machines which opens up the possibility of not running our CI
tests in a VM (change not made here).

Test plan:
- `cargo test` - Linux 6.13.1 machine
- `cargo test` - Ubuntu 24.04 machine, Linux 6.8.0-53
