### PR TITLE
scx_wd40: start simplifying

### DIFF
--- a/scheds/rust/scx_wd40/src/bpf/common.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/common.bpf.c
@@ -64,22 +64,3 @@ u32 dom_node_id(u32 dom_id)
 	}
 	return *nid_ptr;
 }
-
-__hidden
-struct task_ctx *try_lookup_task_ctx(struct task_struct *p)
-{
-	struct task_ctx __arena *taskc = sdt_task_data(p);
-	return (struct task_ctx *)taskc;
-}
-
-__hidden
-struct task_ctx *lookup_task_ctx(struct task_struct *p)
-{
-	struct task_ctx *taskc;
-
-	taskc = try_lookup_task_ctx(p);
-	if (!taskc)
-		scx_bpf_error("task_ctx lookup failed for task %p", p);
-
-	return taskc;
-}

--- a/scheds/rust/scx_wd40/src/bpf/cpumask.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/cpumask.bpf.c
@@ -114,6 +114,18 @@ int scx_bitmap_and(scx_bitmap_t __arg_arena dst, scx_bitmap_t __arg_arena src1, 
 }
 
 __weak
+int scx_bitmap_or(scx_bitmap_t __arg_arena dst, scx_bitmap_t __arg_arena src1, scx_bitmap_t __arg_arena src2)
+{
+	int i;
+
+	bpf_for(i, 0, mask_size) {
+		dst->bits[i] = src1->bits[i] | src2->bits[i];
+	}
+
+	return 0;
+}
+
+__weak
 bool scx_bitmap_empty(scx_bitmap_t __arg_arena mask)
 {
 	int i;

--- a/scheds/rust/scx_wd40/src/bpf/cpumask.h
+++ b/scheds/rust/scx_wd40/src/bpf/cpumask.h
@@ -33,6 +33,7 @@ bool scx_bitmap_test_cpu(u32 cpu, scx_bitmap_t __arg_arena mask);
 
 int scx_bitmap_clear(scx_bitmap_t __arg_arena mask);
 int scx_bitmap_and(scx_bitmap_t __arg_arena dst, scx_bitmap_t __arg_arena src1, scx_bitmap_t __arg_arena src2);
+int scx_bitmap_or(scx_bitmap_t __arg_arena dst, scx_bitmap_t __arg_arena src1, scx_bitmap_t __arg_arena src2);
 bool scx_bitmap_empty(scx_bitmap_t __arg_arena mask);
 int scx_bitmap_copy(scx_bitmap_t __arg_arena dst, scx_bitmap_t __arg_arena src);
 

--- a/scheds/rust/scx_wd40/src/bpf/deadline.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/deadline.bpf.c
@@ -72,7 +72,7 @@ static __noinline u64 sched_prio_to_latency_weight(u64 prio)
 	return sched_prio_to_weight[DL_MAX_LAT_PRIO - prio - 1];
 }
 
-static u64 task_compute_dl(struct task_struct *p, struct task_ctx *taskc,
+static u64 task_compute_dl(struct task_struct *p, task_ptr taskc,
 			   u64 enq_flags)
 {
 	u64 waker_freq, blocked_freq;
@@ -242,7 +242,7 @@ u64 update_freq(u64 freq, u64 interval)
 	return calc_avg(freq, new_freq);
 }
 
-static void clamp_task_vtime(struct task_struct *p, struct task_ctx *taskc, u64 enq_flags)
+static void clamp_task_vtime(struct task_struct *p, task_ptr taskc, u64 enq_flags)
 {
 	u64 dom_vruntime, min_vruntime;
 	dom_ptr domc;
@@ -268,7 +268,7 @@ static void clamp_task_vtime(struct task_struct *p, struct task_ctx *taskc, u64 
 }
 
 __hidden
-void place_task_dl(struct task_struct *p, struct task_ctx *taskc,
+void place_task_dl(struct task_struct *p, task_ptr taskc,
 			  u64 enq_flags)
 {
 	clamp_task_vtime(p, taskc, enq_flags);
@@ -277,14 +277,14 @@ void place_task_dl(struct task_struct *p, struct task_ctx *taskc,
 }
 
 __hidden
-void init_vtime(struct task_struct *p, struct task_ctx *taskc)
+void init_vtime(struct task_struct *p, task_ptr taskc)
 {
 	taskc->deadline = p->scx.dsq_vtime +
 			  scale_inverse_fair(taskc->avg_runtime, taskc->weight);
 }
 
 __hidden
-void running_update_vtime(struct task_struct *p, struct task_ctx *taskc,
+void running_update_vtime(struct task_struct *p, task_ptr taskc,
 				 dom_ptr domc)
 {
 	struct bpf_spin_lock * lock = lookup_dom_vtime_lock(domc);
@@ -302,8 +302,7 @@ void running_update_vtime(struct task_struct *p, struct task_ctx *taskc,
 
 
 __hidden
-void stopping_update_vtime(struct task_struct *p, struct task_ctx *taskc,
-				  dom_ptr domc)
+void stopping_update_vtime(struct task_struct *p, task_ptr taskc, dom_ptr domc)
 {
 	u64 now, delta;
 

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
@@ -393,8 +393,6 @@ __weak s32 create_dom(u32 dom_id)
 		domc->cpumask->bits[i] = dom_cpumasks[dom_id][i];
 	}
 
-	scx_bitmap_or(all_cpumask, all_cpumask, domc->cpumask);
-
 	if (node_id >= MAX_NUMA_NODES) {
 		scx_bpf_error("Invalid node%u", node_id);
 		return -ENOENT;

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
@@ -363,7 +363,7 @@ s32 create_node(u32 node_id)
 
 __weak s32 create_dom(u32 dom_id)
 {
-	u32 cpu, node_id, i;
+	u32 node_id, i;
 	dom_ptr domc;
 	s32 ret;
 

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
@@ -22,7 +22,6 @@
 #include <bpf/bpf_tracing.h>
 
 const volatile u64 dom_cpumasks[MAX_DOMS][MAX_CPUS / 64];
-const volatile u32 wd40_perf_mode;
 
 struct lock_wrapper {
 	struct bpf_spin_lock lock;
@@ -30,7 +29,6 @@ struct lock_wrapper {
 
 struct lb_domain {
 	union sdt_id		tid;
-
 	struct bpf_spin_lock vtime_lock;
 
 	dom_ptr domc;
@@ -379,7 +377,6 @@ __weak s32 create_dom(u32 dom_id)
 	scx_bitmap_t all_mask;
 	struct lb_domain *lb_domain;
 	u32 cpu, node_id;
-	int perf;
 	s32 ret;
 
 	if (dom_id >= MAX_DOMS) {
@@ -432,13 +429,6 @@ __weak s32 create_dom(u32 dom_id)
 		scx_bitmap_set_cpu(cpu, domc->cpumask);
 		scx_bitmap_set_cpu(cpu, all_mask);
 
-		/*
-		 * Perf has to be within [0, 1024]. Set it regardless
-		 * of value to clean up any previous settings, since
-		 * it persists even after removing the scheduler.
-		 */
-		perf = min(SCX_CPUPERF_ONE, wd40_perf_mode);
-		scx_bpf_cpuperf_set(cpu, perf);
 	}
 	bpf_rcu_read_unlock();
 	if (ret)

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.h
@@ -64,8 +64,7 @@ struct task_ctx *lookup_task_ctx_mask(struct task_struct *p, scx_bitmap_t *p_cpu
  */
 struct pcpu_ctx {
 	u32 dom_rr_cur; /* used when scanning other doms */
-	u32 dom_id;
-	struct bpf_cpumask __kptr *bpfmask;
+	dom_ptr domc;
 } __attribute__((aligned(CACHELINE_SIZE)));
 
 extern struct pcpu_ctx pcpu_ctx[MAX_CPUS];

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.h
@@ -23,8 +23,7 @@ extern volatile u64 slice_ns;
 extern const volatile u32 nr_doms;
 extern const volatile u32 nr_nodes;
 
-struct task_ctx *lookup_task_ctx(struct task_struct *p);
-struct task_ctx *try_lookup_task_ctx(struct task_struct *p);
+#define lookup_task_ctx(p) ((task_ptr) sdt_task_data(p))
 extern scx_bitmap_t all_cpumask;
 u32 dom_node_id(u32 dom_id);
 void dom_dcycle_adj(dom_ptr domc, u32 weight, u64 now, bool runnable);
@@ -40,25 +39,20 @@ static inline u64 dom_min_vruntime(dom_ptr domc)
 	return READ_ONCE_ARENA(u64, domc->min_vruntime);
 }
 
-void place_task_dl(struct task_struct *p, struct task_ctx *taskc,
-			  u64 enq_flags);
-
-void running_update_vtime(struct task_struct *p,
-				 struct task_ctx *taskc,
+void place_task_dl(struct task_struct *p, task_ptr taskc, u64 enq_flags);
+void running_update_vtime(struct task_struct *p, task_ptr taskc,
 				 dom_ptr domc);
-void stopping_update_vtime(struct task_struct *p, struct task_ctx *taskc,
+void stopping_update_vtime(struct task_struct *p, task_ptr taskc,
 				  dom_ptr domc);
 
 u64 update_freq(u64 freq, u64 interval);
-void init_vtime(struct task_struct *p, struct task_ctx *taskc);
-void task_pick_and_set_domain(struct task_ctx *taskc,
+void init_vtime(struct task_struct *p, task_ptr taskc);
+void task_pick_and_set_domain(task_ptr taskc,
 				     struct task_struct *p,
 				     const struct cpumask *cpumask,
 				     bool init_dsq_vtime);
 bool task_set_domain(struct task_struct *p __arg_trusted,
 			    u32 new_dom_id, bool init_dsq_vtime);
-struct task_ctx *lookup_task_ctx_mask(struct task_struct *p, scx_bitmap_t *p_cpumaskp);
-
 /*
  * Per-CPU context
  */

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.h
@@ -24,7 +24,6 @@ extern const volatile u32 nr_doms;
 extern const volatile u32 nr_nodes;
 
 #define lookup_task_ctx(p) ((task_ptr) sdt_task_data(p))
-extern scx_bitmap_t all_cpumask;
 u32 dom_node_id(u32 dom_id);
 void dom_dcycle_adj(dom_ptr domc, u32 weight, u64 now, bool runnable);
 

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -144,8 +144,7 @@ static struct pcpu_ctx *lookup_pcpu_ctx(s32 cpu)
 	return pcpuc;
 }
 
-static void task_load_adj(task_ptr taskc,
-			  u64 now, bool runnable)
+static void task_load_adj(task_ptr taskc, u64 now, bool runnable)
 {
 	struct ravg_data rdp;
 
@@ -609,8 +608,7 @@ dom_queue:
 	}
 }
 
-static bool
-dispatch_steal_local_numa(u32 curr_dom, struct pcpu_ctx *pcpuc)
+static bool dispatch_steal_local_numa(u32 curr_dom, struct pcpu_ctx *pcpuc)
 {
 	u32 my_node;
 	u32 dom;
@@ -632,8 +630,7 @@ dispatch_steal_local_numa(u32 curr_dom, struct pcpu_ctx *pcpuc)
 	return false;
 }
 
-static bool
-dispatch_steal_x_numa(u32 curr_dom, struct pcpu_ctx *pcpuc)
+static bool dispatch_steal_x_numa(u32 curr_dom, struct pcpu_ctx *pcpuc)
 {
 	u32 my_node;
 	u32 dom;
@@ -693,8 +690,7 @@ void BPF_STRUCT_OPS(wd40_dispatch, s32 cpu, struct task_struct *prev)
 	dispatch_steal_x_numa(curr_dom, pcpuc);
 }
 
-static void
-update_task_wake_freq(struct task_struct *p, u64 now)
+static void update_task_wake_freq(struct task_struct *p, u64 now)
 {
 	task_ptr taskc;
 	u64 interval;
@@ -725,8 +721,7 @@ void BPF_STRUCT_OPS(wd40_runnable, struct task_struct *p, u64 enq_flags)
 	update_task_wake_freq(bpf_get_current_task_btf(), now);
 }
 
-static
-void lb_record_run(task_ptr taskc)
+static void lb_record_run(task_ptr taskc)
 {
 	dom_ptr domc = taskc->domc;
 	u32 dap_gen;

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -90,22 +90,6 @@ const volatile u32 greedy_threshold_x_numa;
 
 struct pcpu_ctx pcpu_ctx[MAX_CPUS];
 
-static scx_bitmap_t scx_bitmap_get_idle_smtmask()
-{
-	scx_bitmap_t scx = scx_percpu_scx_bitmap();
-	const struct cpumask __kptr *bpf = scx_bpf_get_idle_smtmask();
-
-	if (!bpf) {
-		scx_bpf_error("failed to retrieve CPU-local storage");
-		return NULL;
-	}
-	scx_bitmap_from_bpf(scx, bpf);
-
-	scx_bpf_put_idle_cpumask(bpf);
-
-	return scx;
-}
-
 static s32 scx_bitmap_pick_idle_cpu(scx_bitmap_t mask __arg_arena, int flags)
 {
 	struct bpf_cpumask __kptr *bpf = scx_percpu_bpfmask();
@@ -149,34 +133,6 @@ static s32 scx_bitmap_any_and_distribute(scx_bitmap_t scx, const struct cpumask 
 	return cpu;
 }
 
-static scx_bitmap_t lookup_task_scx_bitmap(struct task_struct *p)
-{
-	struct task_ctx *taskc = try_lookup_task_ctx(p);
-
-	return taskc->cpumask;
-}
-
-__hidden
-struct task_ctx *lookup_task_ctx_mask(struct task_struct *p, scx_bitmap_t *p_cpumaskp)
-{
-	struct task_ctx *taskc;
-
-	if (p_cpumaskp == NULL) {
-		scx_bpf_error("no mask pointer provided");
-		return NULL;
-	}
-
-	taskc = lookup_task_ctx(p);
-	if (!taskc)
-		scx_bpf_error("task_ctx lookup failed for task %p", p);
-
-	*p_cpumaskp = lookup_task_scx_bitmap(p);
-	if (*p_cpumaskp == NULL)
-		scx_bpf_error("task mask lookup failed for task %p", p);
-
-	return taskc;
-}
-
 static struct pcpu_ctx *lookup_pcpu_ctx(s32 cpu)
 {
 	struct pcpu_ctx *pcpuc;
@@ -188,11 +144,17 @@ static struct pcpu_ctx *lookup_pcpu_ctx(s32 cpu)
 	return pcpuc;
 }
 
-static void task_load_adj(struct task_ctx *taskc,
+static void task_load_adj(task_ptr taskc,
 			  u64 now, bool runnable)
 {
+	struct ravg_data rdp;
+
+	rdp = taskc->dcyc_rd;
+
 	taskc->runnable = runnable;
-	ravg_accumulate(&taskc->dcyc_rd, taskc->runnable, now, load_half_life);
+	ravg_accumulate(&rdp, taskc->runnable, now, load_half_life);
+
+	taskc->dcyc_rd = rdp;
 }
 
 /*
@@ -270,7 +232,7 @@ static void refresh_tune_params(void)
 	}
 }
 
-static s32 try_sync_wakeup(struct task_struct *p, struct task_ctx *taskc,
+static s32 try_sync_wakeup(struct task_struct *p, task_ptr taskc,
 			   s32 prev_cpu)
 {
 	struct task_struct *current = (void *)bpf_get_current_task_btf();
@@ -314,7 +276,7 @@ out:
 }
 
 static
-int select_cpu_idle_x_numa(struct task_ctx *taskc, u32 prev_cpu, bool has_idle_cores, s32 *cpu)
+int select_cpu_idle_x_numa(task_ptr taskc, u32 prev_cpu, bool has_idle_cores, s32 *cpu)
 {
 
 	u32 dom_id = cpu_to_dom_id(prev_cpu);
@@ -474,15 +436,15 @@ s32 BPF_STRUCT_OPS(wd40_select_cpu, struct task_struct *p, s32 prev_cpu,
 		   u64 wake_flags)
 {
 	const struct cpumask *idle_smtmask = scx_bpf_get_idle_smtmask();
-	struct task_ctx *taskc;
+	task_ptr taskc;
 	bool prev_domestic, has_idle_cores;
 	scx_bitmap_t p_cpumask;
 	s32 cpu;
 
 	refresh_tune_params();
 
-	if (!(taskc = lookup_task_ctx_mask(p, &p_cpumask)) || !p_cpumask)
-		goto enoent;
+	taskc = lookup_task_ctx(p);
+	p_cpumask  = taskc->cpumask;
 
 	if (p->nr_cpus_allowed == 1) {
 		cpu = prev_cpu;
@@ -565,13 +527,13 @@ enoent:
 
 void BPF_STRUCT_OPS(wd40_enqueue, struct task_struct *p __arg_trusted, u64 enq_flags)
 {
-	struct task_ctx *taskc;
+	task_ptr taskc;
 	dom_ptr domc;
 	scx_bitmap_t p_cpumask;
 	s32 cpu = -1;
 
-	if (!(taskc = lookup_task_ctx_mask(p, &p_cpumask)) || !p_cpumask)
-		return;
+	taskc = lookup_task_ctx(p);
+	p_cpumask = taskc->cpumask;
 
 	domc = taskc->domc;
 	if (!domc)
@@ -635,21 +597,22 @@ dom_queue:
 	 * CPUs are highly loaded while KICK_GREEDY doesn't. Even under fairly
 	 * high utilization, KICK_GREEDY can slightly improve work-conservation.
 	 */
-	if (taskc->all_cpus) {
-		const struct cpumask *idle_cpumask;
+	if (!taskc->all_cpus)
+		return;
 
-		idle_cpumask = scx_bpf_get_idle_cpumask();
-		if (kick_greedy_cpumask) {
-			cpu = scx_bitmap_any_and_distribute(kick_greedy_cpumask, idle_cpumask);
-			if (cpu >= nr_cpu_ids)
-				cpu = -EBUSY;
-		}
-		scx_bpf_put_cpumask(idle_cpumask);
+	const struct cpumask *idle_cpumask;
 
-		if (cpu >= 0) {
-			stat_add(RUSTY_STAT_KICK_GREEDY, 1);
-			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
-		}
+	idle_cpumask = scx_bpf_get_idle_cpumask();
+	if (kick_greedy_cpumask) {
+		cpu = scx_bitmap_any_and_distribute(kick_greedy_cpumask, idle_cpumask);
+		if (cpu >= nr_cpu_ids)
+			cpu = -EBUSY;
+	}
+	scx_bpf_put_cpumask(idle_cpumask);
+
+	if (cpu >= 0) {
+		stat_add(RUSTY_STAT_KICK_GREEDY, 1);
+		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 	}
 }
 
@@ -740,11 +703,10 @@ void BPF_STRUCT_OPS(wd40_dispatch, s32 cpu, struct task_struct *prev)
 static void
 update_task_wake_freq(struct task_struct *p, u64 now)
 {
-	struct task_ctx *taskc;
+	task_ptr taskc;
 	u64 interval;
 
-	if (!(taskc = try_lookup_task_ctx(p)))
-		return;
+	taskc = lookup_task_ctx(p);
 
 	interval = now - taskc->last_woke_at;
 	taskc->waker_freq = update_freq(taskc->waker_freq, interval);
@@ -754,11 +716,9 @@ update_task_wake_freq(struct task_struct *p, u64 now)
 void BPF_STRUCT_OPS(wd40_runnable, struct task_struct *p, u64 enq_flags)
 {
 	u64 now = scx_bpf_now();
-	struct task_ctx *wakee_ctx;
+	task_ptr wakee_ctx;
 
-	if (!(wakee_ctx = lookup_task_ctx(p)))
-		return;
-
+	wakee_ctx = lookup_task_ctx(p);
 	wakee_ctx->is_kworker = p->flags & PF_WQ_WORKER;
 
 	task_load_adj(wakee_ctx, now, true);
@@ -773,7 +733,7 @@ void BPF_STRUCT_OPS(wd40_runnable, struct task_struct *p, u64 enq_flags)
 }
 
 static
-void lb_record_run(struct task_struct *p, dom_ptr domc, struct task_ctx *taskc)
+void lb_record_run(struct task_struct *p, dom_ptr domc, task_ptr taskc)
 {
 	task_ptr usrptr = (task_ptr)sdt_task_data(p);
 	u32 dap_gen;
@@ -804,7 +764,7 @@ void lb_record_run(struct task_struct *p, dom_ptr domc, struct task_ctx *taskc)
 
 void BPF_STRUCT_OPS(wd40_running, struct task_struct *p)
 {
-	struct task_ctx *taskc;
+	task_ptr taskc;
 	dom_ptr domc;
 
 	if (!(taskc = lookup_task_ctx(p)))
@@ -826,7 +786,7 @@ void BPF_STRUCT_OPS(wd40_running, struct task_struct *p)
 
 void BPF_STRUCT_OPS(wd40_stopping, struct task_struct *p, bool runnable)
 {
-	struct task_ctx *taskc;
+	task_ptr taskc;
 	dom_ptr domc;
 
 	if (fifo_sched)
@@ -844,7 +804,7 @@ void BPF_STRUCT_OPS(wd40_stopping, struct task_struct *p, bool runnable)
 void BPF_STRUCT_OPS(wd40_quiescent, struct task_struct *p, u64 deq_flags)
 {
 	u64 now = scx_bpf_now(), interval;
-	struct task_ctx *taskc;
+	task_ptr taskc;
 	dom_ptr domc;
 
 	if (!(taskc = lookup_task_ctx(p)))
@@ -866,7 +826,7 @@ void BPF_STRUCT_OPS(wd40_quiescent, struct task_struct *p, u64 deq_flags)
 
 void BPF_STRUCT_OPS(wd40_set_weight, struct task_struct *p, u32 weight)
 {
-	struct task_ctx *taskc;
+	task_ptr taskc;
 
 	if (!(taskc = lookup_task_ctx(p)))
 		return;
@@ -881,7 +841,7 @@ void BPF_STRUCT_OPS(wd40_set_weight, struct task_struct *p, u32 weight)
 void BPF_STRUCT_OPS(wd40_set_cpumask, struct task_struct *p __arg_trusted,
 		    const struct cpumask *cpumask __arg_trusted)
 {
-	struct task_ctx *taskc;
+	task_ptr taskc;
 
 	if (!(taskc = lookup_task_ctx(p)))
 		return;
@@ -895,13 +855,13 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(wd40_init_task, struct task_struct *p __arg_trusted
 		   struct scx_init_task_args *args)
 {
 	u64 now = scx_bpf_now();
-	struct task_ctx *taskc;
+	task_ptr taskc;
 
-	taskc = (struct task_ctx *)sdt_task_alloc(p);
+	taskc = (task_ptr)sdt_task_alloc(p);
 	if (!taskc)
 		return -ENOMEM;
 
-	*taskc = (struct task_ctx) {
+	*(struct task_ctx *)taskc = (struct task_ctx) {
 		.dom_active_tasks_gen = -1,
 		.last_blocked_at = now,
 		.last_woke_at = now,

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -285,9 +285,7 @@ static s32 try_sync_wakeup(struct task_struct *p, struct task_ctx *taskc,
 	if (!pcpuc)
 		return -ENOENT;
 
-	domc = lookup_dom_ctx(pcpuc->dom_id);
-	if (!domc)
-		return -ENOENT;
+	domc = pcpuc->domc;
 
 	idle_cpumask = scx_bpf_get_idle_cpumask();
 
@@ -960,7 +958,7 @@ static s32 initialize_cpu(s32 cpu)
 			return -ENOENT;
 
 		if (scx_bitmap_test_cpu(cpu, domc->cpumask)) {
-			pcpuc->dom_id = i;
+			pcpuc->domc = domc;
 			return 0;
 		}
 	}

--- a/scheds/rust/scx_wd40/src/bpf/types.h
+++ b/scheds/rust/scx_wd40/src/bpf/types.h
@@ -74,8 +74,4 @@ struct dom_ctx {
 	scx_bitmap_t node_cpumask;
 };
 
-struct node_ctx {
-	scx_bitmap_t cpumask;
-};
-
 #endif /* __TYPES_H */


### PR DESCRIPTION
Initial series of refactorings for scx_wd40. The two most important are:

- Domains now directly point to the CPU mask of their respective NUMA node instead of each having their own copy.
- Domain CPU masks are now directly in the dom_ctx struct, so the lb_domain is almost removed from the codebase.