### PR TITLE
scx_layered: add debug logging for gpu support and fix UsingGpu matcher

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1837,7 +1837,7 @@ static __noinline bool match_one(struct layer_match *match,
 			bool pid_present = false;
 
 			if (!enable_gpu_support)
-				return match->used_gpu;
+				return match->using_gpu;
 
 			pid = p->pid;
 			gpu_pid = bpf_map_lookup_elem(&cur_gpu_pid, &pid) == 0;
@@ -1845,7 +1845,7 @@ static __noinline bool match_one(struct layer_match *match,
 			if (gpu_pid)
 				pid_present = true;
 
-			return pid_present == match->used_gpu;
+			return pid_present == match->using_gpu;
 	}
 	case MATCH_USED_GPU: {
 			u32 pid;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1963,9 +1963,9 @@ impl<'a> Scheduler<'a> {
                 missing_gpu_pid = true;
             } else {
                 for (k, v) in self.gpu_mon_data.gpu_pidmap.iter() {
-                    let k_pid = sysinfo::Pid::from_u32(k.clone());
+                    let k_pid = sysinfo::Pid::from_u32(*k);
                     if current_pidmap.contains_key(&k_pid) {
-                        if v.clone() < current_pidmap.get(&k_pid).unwrap().start_time() {
+                        if *v < current_pidmap.get(&k_pid).unwrap().start_time() {
                             missing_gpu_pid = true;
                             break;
                         }
@@ -2074,6 +2074,7 @@ impl<'a> Scheduler<'a> {
                     self.gpu_mon_data.gpu_pidmap.insert(x, 0);
                 }
             }
+            debug!("GPU PIDs are: {:#?}", self.gpu_mon_data.gpu_pidmap);
         }
         Ok(())
     }


### PR DESCRIPTION
scx_layered: add debug logging for gpu support and fix UsingGpu matcher.

add gpu pid debug logging:
![Screenshot from 2025-02-18 17-14-32](https://github.com/user-attachments/assets/4e2ae236-f799-499a-8b3f-6286fd986f3d)

UsingGpu works like it should now (cfg to constrain GPU processes to 2 cores):
![Screenshot from 2025-02-18 17-35-20](https://github.com/user-attachments/assets/1e6cb86a-9676-4d0d-a4f7-85acf6df6e71)
