### PR TITLE
scx_layered: change sysinfo version to 0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2225,7 +2225,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
- "sysinfo",
+ "sysinfo 0.30.13",
 ]
 
 [[package]]
@@ -2239,7 +2239,7 @@ dependencies = [
  "log",
  "nix 0.29.0",
  "serde",
- "sysinfo",
+ "sysinfo 0.33.1",
  "tokio",
  "tokio-util",
  "toml",
@@ -2726,6 +2726,21 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
+]
+
+[[package]]
+name = "sysinfo"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
@@ -2735,7 +2750,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -3288,6 +3303,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows"

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0.133"
 simplelog = "0.12"
 nvml-wrapper = "0.10.0"
 once_cell = "1.20.2"
-sysinfo = "0.33.1"
+sysinfo = "0.30"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.11" }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1850,7 +1850,7 @@ impl<'a> Scheduler<'a> {
         let stats_server = StatsServer::new(stats::server_data()).launch()?;
         let gpu_mon_data = GpuMonData {
             sysinfo_sys: System::new_with_specifics(
-                sysinfo::RefreshKind::nothing()
+                sysinfo::RefreshKind::new()
                     .with_processes(sysinfo::ProcessRefreshKind::everything()),
             ),
             last_nvml_poll: std::time::SystemTime::now(),
@@ -1954,9 +1954,7 @@ impl<'a> Scheduler<'a> {
 
         if !self.opts.aggressive_nvml_polling {
             self.gpu_mon_data.sysinfo_sys.refresh_processes_specifics(
-                sysinfo::ProcessesToUpdate::All,
-                true,
-                sysinfo::ProcessRefreshKind::nothing(),
+                sysinfo::ProcessRefreshKind::new(),
             );
             let current_pidmap = self.gpu_mon_data.sysinfo_sys.processes();
             if self.gpu_mon_data.gpu_pidmap.is_empty() {
@@ -2050,9 +2048,7 @@ impl<'a> Scheduler<'a> {
             }
             // bookkeeping for non-agressive mode
             self.gpu_mon_data.sysinfo_sys.refresh_processes_specifics(
-                sysinfo::ProcessesToUpdate::All,
-                true,
-                sysinfo::ProcessRefreshKind::nothing(),
+                sysinfo::ProcessRefreshKind::new(),
             );
             self.gpu_mon_data.gpu_pidmap.clear();
             for x in pids {

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1953,9 +1953,9 @@ impl<'a> Scheduler<'a> {
         let mut missing_gpu_pid = false;
 
         if !self.opts.aggressive_nvml_polling {
-            self.gpu_mon_data.sysinfo_sys.refresh_processes_specifics(
-                sysinfo::ProcessRefreshKind::new(),
-            );
+            self.gpu_mon_data
+                .sysinfo_sys
+                .refresh_processes_specifics(sysinfo::ProcessRefreshKind::new());
             let current_pidmap = self.gpu_mon_data.sysinfo_sys.processes();
             if self.gpu_mon_data.gpu_pidmap.is_empty() {
                 missing_gpu_pid = true;
@@ -2047,9 +2047,9 @@ impl<'a> Scheduler<'a> {
                 all_pid_bpf_map.update(pid_bytes, zero_bytes, MapFlags::ANY)?;
             }
             // bookkeeping for non-agressive mode
-            self.gpu_mon_data.sysinfo_sys.refresh_processes_specifics(
-                sysinfo::ProcessRefreshKind::new(),
-            );
+            self.gpu_mon_data
+                .sysinfo_sys
+                .refresh_processes_specifics(sysinfo::ProcessRefreshKind::new());
             self.gpu_mon_data.gpu_pidmap.clear();
             for x in pids {
                 let x_pid = sysinfo::Pid::from_u32(x);


### PR DESCRIPTION
change sysinfo version to 0.30

this will make downstream consumption simpler in places with this version and less-flexible dep management than cargo.