### PR TITLE
scx_layered: fix gpu matcher bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,15 +1465,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -1519,19 +1510,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
- "pin-utils",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
  "pin-utils",
 ]
 
@@ -2239,7 +2217,6 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "log",
- "nix 0.26.4",
  "nvml-wrapper",
  "once_cell",
  "scx_stats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,6 +1465,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -1510,6 +1519,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
  "pin-utils",
 ]
 
@@ -2217,6 +2239,7 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "log",
+ "nix 0.26.4",
  "nvml-wrapper",
  "once_cell",
  "scx_stats",

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -54,7 +54,7 @@ const volatile u32 lo_fb_share_ppk = 128;	/* !0 for veristat */
 
 /* Flag to enable or disable antistall feature */
 const volatile bool enable_antistall = true;
-const volatile bool enable_gpu_support = true;
+const volatile bool enable_gpu_support = false;
 /* Delay permitted, in seconds, before antistall activates */
 const volatile u64 antistall_sec = 3;
 const u32 zero_u32 = 0;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -54,7 +54,7 @@ const volatile u32 lo_fb_share_ppk = 128;	/* !0 for veristat */
 
 /* Flag to enable or disable antistall feature */
 const volatile bool enable_antistall = true;
-const volatile bool enable_gpu_support = false;
+const volatile bool enable_gpu_support = true;
 /* Delay permitted, in seconds, before antistall activates */
 const volatile u64 antistall_sec = 3;
 const u32 zero_u32 = 0;
@@ -1833,32 +1833,32 @@ static __noinline bool match_one(struct layer_match *match,
 	}
 	case MATCH_USING_GPU: {
 			u32 pid;
-			u32 gpu_pid;
+			u32 *gpu_pid;
 			bool pid_present = false;
 
 			if (!enable_gpu_support)
 				return match->using_gpu;
+			
+			pid = (u32) p->tgid;
+			gpu_pid = bpf_map_lookup_elem(&cur_gpu_pid, &pid);
 
-			pid = p->pid;
-			gpu_pid = bpf_map_lookup_elem(&cur_gpu_pid, &pid) == 0;
-
-			if (gpu_pid)
+			if (gpu_pid && *gpu_pid == 0)
 				pid_present = true;
 
 			return pid_present == match->using_gpu;
 	}
 	case MATCH_USED_GPU: {
 			u32 pid;
-			u32 gpu_pid;
+			u32 *gpu_pid;
 			bool pid_present = false;
 
 			if (!enable_gpu_support)
 				return match->used_gpu;
 
-			pid = p->pid;
-			gpu_pid = bpf_map_lookup_elem(&all_gpu_pid, &pid) == 0;
+			pid = (u32) p->tgid;
+			gpu_pid = bpf_map_lookup_elem(&all_gpu_pid, &pid);
 
-			if (gpu_pid)
+			if (gpu_pid && *gpu_pid == 0)
 				pid_present = true;
 
 			return pid_present == match->used_gpu;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -2064,21 +2064,21 @@ impl<'a> Scheduler<'a> {
             let cur_add_set = pids.difference(&pids);
             let all_add_set = pids.difference(&all_pid_bpf_set);
 
-            let zero_bytes: &[u8; 4] = unsafe { std::mem::transmute(&zero) };
+            let zero_bytes = (0 as u32).to_ne_bytes();
             use libbpf_rs::MapFlags;
-            for pid in cur_add_set {
-                let pid_bytes: &[u8; 4] = unsafe { std::mem::transmute(&pid) };
-                cur_pid_bpf_map.update(pid_bytes, zero_bytes, MapFlags::ANY)?;
+            for pid in cur_add_set.cloned() {
+                let pid_bytes = pid.to_ne_bytes();
+                cur_pid_bpf_map.update(&pid_bytes, &zero_bytes, MapFlags::ANY)?;
             }
 
-            for pid in cur_delete_set {
-                let pid_bytes: &[u8; 4] = unsafe { std::mem::transmute(&pid) };
-                cur_pid_bpf_map.delete(pid_bytes)?;
+            for pid in cur_delete_set.cloned() {
+                let pid_bytes = pid.to_ne_bytes();
+                cur_pid_bpf_map.delete(&pid_bytes)?;
             }
 
-            for pid in all_add_set {
-                let pid_bytes: &[u8; 4] = unsafe { std::mem::transmute(&pid) };
-                all_pid_bpf_map.update(pid_bytes, zero_bytes, MapFlags::ANY)?;
+            for pid in all_add_set.cloned() {
+                let pid_bytes = pid.to_ne_bytes();
+                all_pid_bpf_map.update(&pid_bytes, &zero_bytes, MapFlags::ANY)?;
             }
             // bookkeeping for non-agressive mode
             self.gpu_mon_data

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -2026,12 +2026,13 @@ impl<'a> Scheduler<'a> {
                         let cpu_set = self
                             .gpu_mon_data
                             .gpu_to_affinity
-                            .get(&i)
-                            .expect("missing gpu numa data");
-                        sched_setaffinity(
-                            nix::unistd::Pid::from_raw(proc_info.pid.try_into()?),
-                            cpu_set,
-                        )?;
+                            .get(&i);
+                        if let Some(cpu_set) = cpu_set {
+                            sched_setaffinity(
+                                nix::unistd::Pid::from_raw(proc_info.pid.try_into()?),
+                                cpu_set,
+                            )?;
+                        }
                     }
                 }
             }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -2023,10 +2023,7 @@ impl<'a> Scheduler<'a> {
                     if self.opts.affinitize_gpu_tasks
                         && !self.gpu_mon_data.gpu_to_affinity.is_empty()
                     {
-                        let cpu_set = self
-                            .gpu_mon_data
-                            .gpu_to_affinity
-                            .get(&i);
+                        let cpu_set = self.gpu_mon_data.gpu_to_affinity.get(&i);
                         if let Some(cpu_set) = cpu_set {
                             sched_setaffinity(
                                 nix::unistd::Pid::from_raw(proc_info.pid.try_into()?),


### PR DESCRIPTION
scx_layered: fix gpu matcher bugs ~and add flag to enable affinitizing gpu tasks~

this fixes pid serialization across ffi, confirmed via bpftool that the gpu pid map has all GPU pids in it:
```
[{
        "key": 558103,
        "value": 0
    },{
        "key": 558106,
        "value": 0
    },{
...
```

~this also adds a flag, ` --affinitize-gpu-tasks`, which has the scheduler grab some topo info when it uses nvml and affine gpu processes to those CPUs nvml recommends as ideal.~

I think this tested well (it looked like there was enough load for the results to be valid),