### PR TITLE
scx_utils: make cpumask example no_run

### DIFF
--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -16,10 +16,10 @@
 //! Empty Cpumasks can be created directly, or they can be created from a
 //! hexadecimal string:
 //!
-//!```
+//!```no_run
 //!     use scx_utils::Cpumask;
 //!     let all_zeroes = Cpumask::new();
-//!     let from_str_mask = Cpumask::from_str(&String::from("0xf0"));
+//!     let from_str_mask = Cpumask::from_str("0xf0");
 //!```
 //!
 //! The hexadecimal string also supports the special values "none" and "all",


### PR DESCRIPTION

This example creates a Cpumask from an explicit string which required certain
CPUs to be present. Previously this succeeded on machines with 2/3 CPUs but not
4/5/6/7. This wasn't testing anything useful and reduced the number of machines
that can cleanly run these tests, so stop running it. Use `no_run` instead of
`ignore` so the snippet still gets compiled.

Drive-by: remove unnecessary String and use a str literal instead.
