### PR TITLE
ci: move rust tests out of vms onto dedicated server

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -26,6 +26,46 @@ jobs:
       - run: cargo fmt
       - run: git diff --exit-code
 
+  rust-tests:
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64" ]') || 'ubuntu-latest' }}
+    needs: build-kernel
+    steps:
+      - name: Install Nix
+        if: ${{ runner.environment == 'github-hosted' }}
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: actions/checkout@v4
+
+      - name: Load dependencies
+        uses: JakeHillion/nix-develop@2b6707695e9a29665e4756b84b169208d1f8109b # Get openssl from Nix if not available in path: https://github.com/nicknovitski/nix-develop/pull/26
+        with:
+          arguments: ./.github/workflows#rust-tests
+
+      - uses: ./.github/actions/restore-kernel-cache
+        with:
+          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
+          branch: for-next
+
+      - name: Build
+        # pure devshell is required to work on GHA runners that pollute path, but we need to pass through $HOME on self-hosted
+        shell: nix develop ./.github/workflows#rust-tests -i -k HOME --command bash -e {0}
+        run: cargo build --all-targets
+
+      - name: Clippy
+        shell: nix develop ./.github/workflows#rust-tests -i -k HOME --command bash -e {0}
+        run: |
+          CLIPPY_PACKAGES=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.metadata.scx.ci.use_clippy == true) | .name')
+          echo $CLIPPY_PACKAGES | xargs -I{} cargo clippy --all-targets --no-deps -p {} -- -Dwarnings
+
+      # virtme-ng runs as a different user than the runner, so loses the rustup and cargo roots. specify them explicitly to avoid a rebuild.
+      - name: Test
+        shell: nix develop ./.github/workflows#rust-tests -i -k HOME --command bash -e {0}
+        run: |
+          vng -v --rw --memory 10G --cpu $(nproc) -r linux/arch/x86/boot/bzImage -- \
+            RUSTUP_HOME=$(realpath ~/.rustup) \
+            CARGO_HOME=$(realpath ~/.cargo) \
+            cargo test --frozen
+
   build-kernel:
     uses: ./.github/workflows/build-kernel.yml
     with:
@@ -174,47 +214,6 @@ jobs:
           path: ./log_save/*.ci.log
           # it's all txt files w/ 90 day retention, lets be nice.
           compression-level: 9
-
-  rust-tests:
-    runs-on: ubuntu-24.04
-    needs: build-kernel
-    strategy:
-      matrix:
-        package: [ scx_loader, scx_rustland_core, scx_stats, scx_utils, scxtop, scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty, scx_p2dq ]
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/restore-kernel-cache
-        with:
-          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
-          branch: for-next
-
-      # prevent cache permission errors
-      - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: ./.github/actions/install-deps-action
-      # cache virtiofsd (goes away w/ 24.04)
-      - name: Cache virtiofsd
-        id: cache-virtiofsd
-        uses: actions/cache@v4
-        with:
-          path: |
-            /usr/lib/virtiofsd
-          key: virtiofsd-binary
-      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
-        run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      - run: cargo build --all-targets --package ${{ matrix.package }}
-
-      - name: Clippy
-        if: contains(fromJSON('["scxtop"]'), matrix.package)
-        run: cargo clippy --no-deps -p ${{ matrix.package }} -- -Dwarnings
-
-      # virtme-ng runs as a different user than the runner, so loses the rustup and cargo roots. specify them explicitly to avoid a rebuild.
-      - run: |
-          vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- \
-            RUSTUP_HOME=$(realpath ~/.rustup) \
-            CARGO_HOME=$(realpath ~/.cargo) \
-            cargo test --package ${{ matrix.package }}
 
   pages:
     runs-on: ubuntu-24.04

--- a/.github/workflows/flake.lock
+++ b/.github/workflows/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738086784,
-        "narHash": "sha256-S55TBVValODQ3jb3g0IE+KQuWqpINoo5gdJ3yhRbuP4=",
+        "lastModified": 1741127887,
+        "narHash": "sha256-wjvXLT5DJqBg+KDDdx/R/LhroGZr6OpE+n+l/AnNJc8=",
         "owner": "JakeHillion",
         "repo": "nixpkgs",
-        "rev": "c1613ab9aa510bd571ba01a1e74a41496327d545",
+        "rev": "f72326a3a7770ec2b85c832fbfa8051346e21515",
         "type": "github"
       },
       "original": {

--- a/.github/workflows/flake.nix
+++ b/.github/workflows/flake.nix
@@ -12,7 +12,7 @@
         devShells =
           let
             pkgs = import nixpkgs { inherit system; };
-            common = with pkgs; [ gnutar zstd ];
+            common = with pkgs; [ git gnutar zstd ];
           in
           {
             build-kernel = pkgs.mkShell {
@@ -28,6 +28,29 @@
                 perl
                 virtme-ng
                 zlib
+              ];
+            };
+
+            rust-tests = pkgs.mkShellNoCC {
+              buildInputs = with pkgs; common ++ [
+                cargo
+                clang
+                clippy
+                elfutils
+                jq
+                llvmPackages.libclang
+                llvmPackages.libllvm
+                pkg-config
+                rustfmt
+                virtme-ng
+                zlib
+              ];
+
+              LIBCLANG_PATH = "${pkgs.lib.getLib pkgs.llvmPackages.libclang}/lib";
+
+              hardeningDisable = [
+                "stackprotector"
+                "zerocallusedregs"
               ];
             };
           };

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -7,6 +7,9 @@ license = "GPL-2.0-only"
 repository = "https://github.com/sched-ext/scx"
 description = "sched_ext scheduler tool for observability"
 
+[package.metadata.scx]
+ci.use_clippy = true
+
 [lints.rust]
 unused_imports = "allow"
 

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -327,7 +327,7 @@ mod tests {
 
         assert_eq!(merged.theme(), &AppTheme::MidnightGreen);
         assert_eq!(merged.tick_rate_ms(), 114);
-        assert_eq!(merged.debug(), true);
-        assert_eq!(merged.exclude_bpf(), false);
+        assert!(merged.debug());
+        assert!(!merged.exclude_bpf());
     }
 }


### PR DESCRIPTION
Move Rust tests out of VMs as they don't need to run with a specific kernel, and should run on any dev's machine. Nix'ify the build process and move them to the large machine.

Specific changes:
- Move `rust-tests` to the big self-hosted machine when in the `sched-ext` org.
- Nix'ify the dependencies. This uses a fixed version of `cargo`, `rustc` and `clippy` rather than the moving target of `rust-toolchain.toml`, but it is still `stable`.
- Remove the dependency on `build-kernel` so the tests start sooner.
- Add a new `package.metadata.scx` section to describe whether to run clippy, moving this out of the GitHub actions spec and into each package's spec.
- Run for the entire workspace instead of a set of named packages. This means we can require `rust-tests` in the CI instead of requiring each individual package's matrix entry, reducing errors. It also significantly reduces duplicated work.

This runs much faster in repo and avoids repeated work. It takes longer out of repo on the smaller GitHub runners, but still takes far less machine time which seems like a fair compromise.

If we do require a specific kernel for cargo tests in the future, we should either implement this in the test or add a Cargo `package.metadata` field to opt into that behaviour where necessary, given how much slower tests in a VM run.

Test plan:
- This PR's CI.
- Ran in my fork with the usual GitHub Actions runners. It works.