### PR TITLE
scxtop: Add localization on number formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +307,28 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bindgen"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 1.0.109",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
@@ -311,7 +342,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "shlex",
  "syn 2.0.95",
 ]
@@ -1326,6 +1357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libbpf-cargo"
 version = "0.25.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,6 +1599,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "encoding_rs",
+ "itoa",
+ "lazy_static",
+ "libc",
+ "num-format-windows",
+ "serde",
+ "widestring",
+ "winapi",
+]
+
+[[package]]
+name = "num-format-windows"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1e07f67225c1eb911d16c2f72492669c1fb08212dbfaa1f6cfbeb119152cfa"
+dependencies = [
+ "bindgen 0.63.0",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,6 +1781,12 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "perf-event-open-sys"
@@ -2097,6 +2167,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
@@ -2395,7 +2471,7 @@ name = "scx_utils"
 version = "1.0.11"
 dependencies = [
  "anyhow",
- "bindgen",
+ "bindgen 0.71.1",
  "bitvec",
  "glob",
  "hex",
@@ -2435,6 +2511,7 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "log",
+ "num-format",
  "perf-event-open-sys",
  "plain",
  "protobuf",
@@ -3272,6 +3349,12 @@ dependencies = [
  "once_cell",
  "rustix",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -20,9 +20,6 @@ clap = { version = "4.1", features = [
     "string",
     "unstable-styles",
 ] }
-libbpf-rs = "=0.25.0-beta.1"
-scx_utils = { path = "../../rust/scx_utils", version = "1.0.11" }
-scx_stats = { path = "../../rust/scx_stats", version = "1.0.9" }
 config = "0.14.1"
 crossterm = { version = "0.28.1", features = ["serde", "event-stream"] }
 derive_deref = "1.1.1"
@@ -31,25 +28,29 @@ futures = "0.3.31"
 glob = "0.3.2"
 json5 = "0.4.1"
 lazy_static = "1.5.0"
+libbpf-rs = "=0.25.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
+num-format = { version = "0.4.3", features = ["with-serde", "with-system-locale"] }
 perf-event-open-sys = "4.0.0"
 plain = "0.2.3"
+protobuf = "3.7.1"
 rand = "0.8.5"
 ratatui = { version = "0.29.0", features = ["serde", "macros"] }
 regex = "1.11.1"
-serde = { version = "1.0.215", features = ["derive"] }
+scx_stats = { path = "../../rust/scx_stats", version = "1.0.9" }
+scx_utils = { path = "../../rust/scx_utils", version = "1.0.11" }
 serde_json = "1.0.133"
+serde = { version = "1.0.215", features = ["derive"] }
 signal-hook = "0.3.17"
 strip-ansi-escapes = "0.2.0"
-tokio = { version = "1.42.0", features = ["full"] }
 tokio-util = "0.7.13"
+tokio = { version = "1.42.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "serde"] }
-protobuf = "3.7.1"
 
 [build-dependencies]
-scx_utils = { path = "../../rust/scx_utils", version = "1.0.11" }
-scx_stats = { path = "../../rust/scx_stats", version = "1.0.9" }
 protobuf-codegen = "3.7.1"
+scx_stats = { path = "../../rust/scx_stats", version = "1.0.9" }
+scx_utils = { path = "../../rust/scx_utils", version = "1.0.11" }

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -36,6 +36,7 @@ impl Default for KeyMap {
         bindings.insert(Key::Char('e'), Action::SetState(AppState::Event));
         bindings.insert(Key::Char('f'), Action::ToggleCpuFreq);
         bindings.insert(Key::Char('u'), Action::ToggleUncoreFreq);
+        bindings.insert(Key::Char('L'), Action::ToggleLocalization);
         bindings.insert(Key::Char('h'), Action::SetState(AppState::Help));
         bindings.insert(Key::Char('?'), Action::SetState(AppState::Help));
         bindings.insert(Key::Char('l'), Action::SetState(AppState::Llc));

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -190,6 +190,7 @@ pub enum Action {
     NextViewState,
     RecordTrace(RecordTraceAction),
     ToggleCpuFreq,
+    ToggleLocalization,
     ToggleUncoreFreq,
     TickRateChange(std::time::Duration),
     IncTickRate,


### PR DESCRIPTION
I might put this as a runtime option because it makes the output rather verbose:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/27ebd63f-a961-49be-852d-e33ce95fa1fd" />
