### PR TITLE
scxtop: Add config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,8 +2291,8 @@ dependencies = [
  "fb_procfs",
  "lazy_static",
  "libbpf-rs",
+ "libc",
  "log",
- "nix 0.29.0",
  "nvml-wrapper",
  "once_cell",
  "scx_stats",
@@ -2527,9 +2527,11 @@ dependencies = [
  "strip-ansi-escapes",
  "tokio",
  "tokio-util",
+ "toml",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+ "xdg",
 ]
 
 [[package]]
@@ -3647,6 +3649,12 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xdg-home"

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -46,9 +46,11 @@ signal-hook = "0.3.17"
 strip-ansi-escapes = "0.2.0"
 tokio-util = "0.7.13"
 tokio = { version = "1.42.0", features = ["full"] }
+toml = "0.8"
 tracing = "0.1.41"
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "serde"] }
+xdg = "2.5.2"
 
 [build-dependencies]
 protobuf-codegen = "3.7.1"

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -6,6 +6,8 @@
 use crate::available_perf_events;
 use crate::bpf_skel::BpfSkel;
 use crate::bpf_stats::BpfStats;
+use crate::config::get_config_path;
+use crate::config::Config;
 use crate::format_hz;
 use crate::read_file_string;
 use crate::AppState;
@@ -49,8 +51,8 @@ use scx_stats::prelude::StatsClient;
 use scx_utils::misc::read_file_usize;
 use scx_utils::Topology;
 use serde_json::Value as JsonValue;
+use std::sync::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::RwLock;
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -62,10 +64,10 @@ const DSQ_VTIME_CUTOFF: u64 = 1_000_000_000_000_000;
 
 /// App is the struct for scxtop application state.
 pub struct App<'a> {
+    config: Config,
     localize: bool,
     locale: SystemLocale,
     stats_client: Arc<RwLock<StatsClient>>,
-    stats_socket_path: String,
     sched_stats_raw: String,
 
     keymap: KeyMap,
@@ -74,9 +76,7 @@ pub struct App<'a> {
     max_sched_events: usize,
     state: AppState,
     prev_state: AppState,
-    theme: AppTheme,
     view_state: ViewState,
-    pub tick_rate_ms: usize,
     pub should_quit: Arc<AtomicBool>,
     pub action_tx: UnboundedSender<Action>,
     pub skel: BpfSkel<'a>,
@@ -108,10 +108,8 @@ pub struct App<'a> {
     non_hw_event_active: bool,
 
     // trace releated
-    trace_manager: PerfettoTraceManager<'a>,
+    trace_manager: PerfettoTraceManager,
     trace_tick: usize,
-    trace_tick_warmup: usize,
-    max_trace_ticks: usize,
     prev_bpf_sample_rate: u32,
     process_id: i32,
     trace_links: Vec<Link>,
@@ -121,14 +119,10 @@ impl<'a> App<'a> {
     /// Creates a new appliation.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        stats_socket_path: String,
-        trace_file_prefix: &'a str,
+        config: Config,
         scheduler: String,
         keymap: KeyMap,
         max_cpu_events: usize,
-        tick_rate_ms: usize,
-        trace_ticks: usize,
-        trace_tick_warmup: usize,
         process_id: i32,
         action_tx: UnboundedSender<Action>,
         skel: BpfSkel<'a>,
@@ -174,33 +168,34 @@ impl<'a> App<'a> {
             .collect();
         let num_perf_events: u16 = available_perf_events_list.len() as u16;
         let mut stats_client = StatsClient::new();
+        let stats_socket_path = config.stats_socket_path();
         if !stats_socket_path.is_empty() {
-            stats_client = stats_client.set_path(stats_socket_path.clone());
+            stats_client = stats_client.set_path(stats_socket_path);
         }
         stats_client = stats_client.connect().unwrap_or_else(|_| {
             let mut client = StatsClient::new();
             if !stats_socket_path.is_empty() {
-                client = client.set_path(stats_socket_path.clone());
+                client = client.set_path(stats_socket_path);
             }
             client
         });
         let sample_rate = skel.maps.data_data.sample_rate;
+        let trace_file_prefix = config.trace_file_prefix().to_string();
+        let trace_manager = PerfettoTraceManager::new(trace_file_prefix, None);
 
         let app = Self {
+            config,
             localize: true,
             locale: SystemLocale::default()?,
             stats_client: Arc::new(RwLock::new(stats_client)),
             sched_stats_raw: "".to_string(),
-            stats_socket_path: stats_socket_path.clone(),
             scheduler,
             max_cpu_events,
             max_sched_events: max_cpu_events,
             keymap,
-            theme: AppTheme::Default,
             state: AppState::Default,
             view_state: ViewState::BarChart,
             prev_state: AppState::Default,
-            tick_rate_ms,
             should_quit: Arc::new(AtomicBool::new(false)),
             action_tx,
             skel,
@@ -225,9 +220,7 @@ impl<'a> App<'a> {
             non_hw_event_active: false,
             prev_bpf_sample_rate: sample_rate,
             trace_tick: 0,
-            trace_tick_warmup,
-            max_trace_ticks: trace_ticks,
-            trace_manager: PerfettoTraceManager::new(trace_file_prefix, None),
+            trace_manager,
             bpf_stats: Default::default(),
             process_id,
             trace_links: vec![],
@@ -248,13 +241,13 @@ impl<'a> App<'a> {
     }
 
     /// Returns the current theme of the application
-    pub fn theme(&self) -> AppTheme {
-        self.theme.clone()
+    pub fn theme(&self) -> &AppTheme {
+        self.config.theme()
     }
 
     /// Sets the theme of the application.
     pub fn set_theme(&mut self, theme: AppTheme) {
-        self.theme = theme
+        self.config.set_theme(theme)
     }
 
     /// Stop all active perf events.
@@ -408,9 +401,26 @@ impl<'a> App<'a> {
         self.max_cpu_events = max_events;
     }
 
+    /// Saves the current config.
+    fn on_save_config(&mut self) -> Result<()> {
+        self.config.save()
+    }
+
     /// Handles when scheduler stats are received.
     fn on_sched_stats(&mut self, stats_raw: String) {
         self.sched_stats_raw = stats_raw;
+    }
+
+    /// Reloads stats client
+    fn reload_stats_client(&mut self) -> Result<()> {
+        let stats_socket_path = self.config.stats_socket_path();
+        let mut new_client = StatsClient::new();
+        new_client = new_client.connect()?;
+        new_client = new_client.set_path(stats_socket_path);
+        let mut client = self.stats_client.write().unwrap();
+        *client = new_client;
+
+        Ok(())
     }
 
     /// Runs callbacks to update application state on tick.
@@ -422,10 +432,9 @@ impl<'a> App<'a> {
             AppState::Scheduler => {
                 if !self.scheduler.is_empty() {
                     let stats_client_read = self.stats_client.clone();
-                    let stats_socket_path = self.stats_socket_path.clone();
                     let tx = self.action_tx.clone();
                     tokio::spawn(async move {
-                        let mut client = stats_client_read.write().await;
+                        let mut client = stats_client_read.write().unwrap();
 
                         let result = client.request::<JsonValue>("stats", vec![]);
                         match result {
@@ -436,14 +445,7 @@ impl<'a> App<'a> {
                                 .unwrap();
                             }
                             Err(_) => {
-                                // On error it could be the scheduler was loaded/unloaded so try
-                                // reconnecting.
-                                let mut new_client = StatsClient::new();
-                                new_client = new_client.connect()?;
-                                if !stats_socket_path.is_empty() {
-                                    new_client = new_client.set_path(stats_socket_path);
-                                }
-                                *client = new_client;
+                                tx.send(Action::ReloadStatsClient).unwrap();
                             }
                         }
                         Ok::<(), anyhow::Error>(())
@@ -453,7 +455,7 @@ impl<'a> App<'a> {
             AppState::Tracing => {
                 self.trace_tick += 1;
                 // trace for max ticks and then exit tracing mode
-                if self.trace_tick > self.max_trace_ticks + self.trace_tick_warmup {
+                if self.trace_tick > self.config.trace_ticks() + self.config.trace_tick_warmup() {
                     return self.record_trace();
                 }
             }
@@ -569,7 +571,7 @@ impl<'a> App<'a> {
             .data(&data)
             .max(max)
             .direction(RenderDirection::RightToLeft)
-            .style(self.theme.sparkline_style())
+            .style(self.theme().sparkline_style())
             .bar_set(if small { THREE_LEVELS } else { NINE_LEVELS })
             .block(
                 Block::new()
@@ -589,7 +591,7 @@ impl<'a> App<'a> {
                     ))
                     .borders(borders)
                     .border_type(BorderType::Rounded)
-                    .style(self.theme.border_style()),
+                    .style(self.theme().border_style()),
             )
     }
 
@@ -606,7 +608,7 @@ impl<'a> App<'a> {
         Sparkline::default()
             .data(&data)
             .direction(RenderDirection::RightToLeft)
-            .style(self.theme.sparkline_style())
+            .style(self.theme().sparkline_style())
             .block(
                 Block::new()
                     .borders(if bottom_border {
@@ -614,7 +616,7 @@ impl<'a> App<'a> {
                     } else {
                         Borders::LEFT | Borders::RIGHT
                     })
-                    .style(self.theme.border_style())
+                    .style(self.theme().border_style())
                     .border_type(BorderType::Rounded)
                     .title_top(
                         Line::from(if self.localize {
@@ -631,7 +633,7 @@ impl<'a> App<'a> {
                                 llc, stats.avg, stats.max, stats.min
                             )
                         })
-                        .style(self.theme.title_style())
+                        .style(self.theme().title_style())
                         .left_aligned(),
                     ),
             )
@@ -650,7 +652,7 @@ impl<'a> App<'a> {
         Sparkline::default()
             .data(&data)
             .direction(RenderDirection::RightToLeft)
-            .style(self.theme.sparkline_style())
+            .style(self.theme().sparkline_style())
             .block(
                 Block::new()
                     .borders(if bottom_border {
@@ -659,7 +661,7 @@ impl<'a> App<'a> {
                         Borders::LEFT | Borders::RIGHT
                     })
                     .border_type(BorderType::Rounded)
-                    .style(self.theme.border_style())
+                    .style(self.theme().border_style())
                     .title_top(
                         Line::from(if self.collect_uncore_freq {
                             "uncore ".to_string()
@@ -675,7 +677,7 @@ impl<'a> App<'a> {
                         } else {
                             "".to_string()
                         })
-                        .style(self.theme.text_important_color())
+                        .style(self.theme().text_important_color())
                         .right_aligned(),
                     )
                     .title_top(
@@ -693,7 +695,7 @@ impl<'a> App<'a> {
                                 node, stats.avg, stats.max, stats.min,
                             )
                         })
-                        .style(self.theme.title_style())
+                        .style(self.theme().title_style())
                         .left_aligned(),
                     ),
             )
@@ -741,16 +743,16 @@ impl<'a> App<'a> {
                                 self.active_event.event, stats.avg, stats.max, stats.min,
                             )
                         })
-                        .style(self.theme.title_style())
+                        .style(self.theme().title_style())
                         .centered(),
                     )
                     .border_type(BorderType::Rounded)
                     .title_top(
-                        Line::from(format!("{}ms", self.tick_rate_ms))
-                            .style(self.theme.text_important_color())
+                        Line::from(format!("{}ms", self.config.tick_rate_ms()))
+                            .style(self.theme().text_important_color())
                             .right_aligned(),
                     )
-                    .style(self.theme.border_style());
+                    .style(self.theme().border_style());
 
                 frame.render_widget(llc_block, llcs_verticle[0]);
 
@@ -780,15 +782,15 @@ impl<'a> App<'a> {
                                 self.active_event.event, stats.avg, stats.max, stats.min,
                             )
                         })
-                        .style(self.theme.title_style())
+                        .style(self.theme().title_style())
                         .centered(),
                     )
                     .title_top(
-                        Line::from(format!("{}ms", self.tick_rate_ms))
-                            .style(self.theme.text_important_color())
+                        Line::from(format!("{}ms", self.config.tick_rate_ms()))
+                            .style(self.theme().text_important_color())
                             .right_aligned(),
                     )
-                    .style(self.theme.border_style())
+                    .style(self.theme().border_style())
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded);
 
@@ -799,7 +801,7 @@ impl<'a> App<'a> {
                     .block(llc_block)
                     .max(stats.max)
                     .direction(Direction::Horizontal)
-                    .bar_style(self.theme.sparkline_style())
+                    .bar_style(self.theme().sparkline_style())
                     .bar_gap(0)
                     .bar_width(1);
 
@@ -862,16 +864,16 @@ impl<'a> App<'a> {
                                 self.active_event.event, stats.avg, stats.max, stats.min,
                             )
                         })
-                        .style(self.theme.title_style())
+                        .style(self.theme().title_style())
                         .centered(),
                     )
                     .title_top(
-                        Line::from(format!("{}ms", self.tick_rate_ms))
-                            .style(self.theme.text_important_color())
+                        Line::from(format!("{}ms", self.config.tick_rate_ms()))
+                            .style(self.theme().text_important_color())
                             .right_aligned(),
                     )
                     .border_type(BorderType::Rounded)
-                    .style(self.theme.border_style());
+                    .style(self.theme().border_style());
 
                 frame.render_widget(node_block, nodes_verticle[0]);
                 node_sparklines
@@ -898,15 +900,15 @@ impl<'a> App<'a> {
                                 self.active_event.event, stats.avg, stats.max, stats.min,
                             )
                         })
-                        .style(self.theme.title_style())
+                        .style(self.theme().title_style())
                         .centered(),
                     )
                     .title_top(
-                        Line::from(format!("{}ms", self.tick_rate_ms))
-                            .style(self.theme.text_important_color())
+                        Line::from(format!("{}ms", self.config.tick_rate_ms()))
+                            .style(self.theme().text_important_color())
                             .right_aligned(),
                     )
-                    .style(self.theme.border_style())
+                    .style(self.theme().border_style())
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded);
 
@@ -917,7 +919,7 @@ impl<'a> App<'a> {
                     .block(node_block)
                     .max(stats.max)
                     .direction(Direction::Horizontal)
-                    .bar_style(self.theme.sparkline_style())
+                    .bar_style(self.theme().sparkline_style())
                     .bar_gap(0)
                     .bar_width(1);
 
@@ -951,25 +953,25 @@ impl<'a> App<'a> {
             .data(&data)
             .max(stats.max)
             .direction(RenderDirection::RightToLeft)
-            .style(self.theme.sparkline_style())
+            .style(self.theme().sparkline_style())
             .block(
                 Block::new()
                     .borders(borders)
                     .border_type(BorderType::Rounded)
-                    .style(self.theme.border_style())
+                    .style(self.theme().border_style())
                     .title_top(if render_sample_rate {
                         Line::from(format!(
                             "sample rate {}",
                             self.skel.maps.data_data.sample_rate
                         ))
-                        .style(self.theme.text_important_color())
+                        .style(self.theme().text_important_color())
                         .right_aligned()
                     } else {
                         Line::from("".to_string())
                     })
                     .title_top(if render_title {
                         Line::from(format!("{} ", event.clone()))
-                            .style(self.theme.title_style())
+                            .style(self.theme().title_style())
                             .left_aligned()
                     } else {
                         Line::from("".to_string())
@@ -989,7 +991,7 @@ impl<'a> App<'a> {
                                 dsq_id, stats.avg, stats.max, stats.min,
                             )
                         })
-                        .style(self.theme.title_style())
+                        .style(self.theme().title_style())
                         .centered(),
                     ),
             )
@@ -1110,15 +1112,15 @@ impl<'a> App<'a> {
         let block = Block::bordered()
             .title_top(
                 Line::from(self.scheduler.clone())
-                    .style(self.theme.title_style())
+                    .style(self.theme().title_style())
                     .centered(),
             )
             .title_top(
-                Line::from(format!("{}ms", self.tick_rate_ms))
-                    .style(self.theme.text_important_color())
+                Line::from(format!("{}ms", self.config.tick_rate_ms()))
+                    .style(self.theme().text_important_color())
                     .right_aligned(),
             )
-            .style(self.theme.border_style())
+            .style(self.theme().border_style())
             .border_type(BorderType::Rounded);
 
         frame.render_widget(paragraph.block(block), area);
@@ -1152,10 +1154,10 @@ impl<'a> App<'a> {
             let block = Block::default()
                 .title_top(
                     Line::from(self.scheduler.clone())
-                        .style(self.theme.title_style())
+                        .style(self.theme().title_style())
                         .centered(),
                 )
-                .style(self.theme.border_style())
+                .style(self.theme().border_style())
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded);
             frame.render_widget(block, area);
@@ -1195,10 +1197,10 @@ impl<'a> App<'a> {
             let block = Block::default()
                 .title_top(
                     Line::from(self.scheduler.clone())
-                        .style(self.theme.title_style())
+                        .style(self.theme().title_style())
                         .centered(),
                 )
-                .style(self.theme.border_style())
+                .style(self.theme().border_style())
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded);
             frame.render_widget(block, area);
@@ -1238,10 +1240,10 @@ impl<'a> App<'a> {
             let block = Block::default()
                 .title_top(
                     Line::from(self.scheduler.clone())
-                        .style(self.theme.title_style())
+                        .style(self.theme().title_style())
                         .centered(),
                 )
-                .style(self.theme.border_style())
+                .style(self.theme().border_style())
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded);
             frame.render_widget(block, area);
@@ -1278,17 +1280,17 @@ impl<'a> App<'a> {
                         self.scheduler, event, stats.avg, stats.max, stats.min,
                     )
                 })
-                .style(self.theme.title_style())
+                .style(self.theme().title_style())
                 .centered(),
             )
             .title_top(if render_sample_rate {
                 Line::from(format!("sample rate {}", sample_rate))
-                    .style(self.theme.text_important_color())
+                    .style(self.theme().text_important_color())
                     .right_aligned()
             } else {
                 Line::from("")
             })
-            .style(self.theme.border_style())
+            .style(self.theme().border_style())
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded);
 
@@ -1299,7 +1301,7 @@ impl<'a> App<'a> {
             .block(bar_block)
             .max(stats.max)
             .direction(Direction::Horizontal)
-            .bar_style(self.theme.sparkline_style())
+            .bar_style(self.theme().sparkline_style())
             .bar_gap(0)
             .bar_width(1);
 
@@ -1320,10 +1322,10 @@ impl<'a> App<'a> {
             let block = Block::default()
                 .title_top(
                     Line::from(self.scheduler.clone())
-                        .style(self.theme.title_style())
+                        .style(self.theme().title_style())
                         .centered(),
                 )
-                .style(self.theme.border_style())
+                .style(self.theme().border_style())
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded);
             frame.render_widget(block, area);
@@ -1357,17 +1359,17 @@ impl<'a> App<'a> {
                         self.scheduler, event, stats.avg, stats.max, stats.min,
                     )
                 })
-                .style(self.theme.title_style())
+                .style(self.theme().title_style())
                 .centered(),
             )
             .title_top(if render_sample_rate {
                 Line::from(format!("sample rate {}", sample_rate))
-                    .style(self.theme.text_important_color())
+                    .style(self.theme().text_important_color())
                     .right_aligned()
             } else {
                 Line::from("")
             })
-            .style(self.theme.border_style())
+            .style(self.theme().border_style())
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded);
 
@@ -1378,7 +1380,7 @@ impl<'a> App<'a> {
             .block(bar_block)
             .max(stats.max)
             .direction(Direction::Horizontal)
-            .bar_style(self.theme.sparkline_style())
+            .bar_style(self.theme().sparkline_style())
             .bar_gap(0)
             .bar_width(1);
 
@@ -1503,12 +1505,12 @@ impl<'a> App<'a> {
                                     stats.min,
                                 )
                             })
-                            .style(self.theme.title_style())
+                            .style(self.theme().title_style())
                             .centered(),
                         )
                         .title_top(if i == 0 {
-                            Line::from(format!("{}ms", self.tick_rate_ms))
-                                .style(self.theme.text_important_color())
+                            Line::from(format!("{}ms", self.config.tick_rate_ms()))
+                                .style(self.theme().text_important_color())
                                 .right_aligned()
                         } else {
                             Line::from("")
@@ -1528,11 +1530,11 @@ impl<'a> App<'a> {
                             } else {
                                 "".to_string()
                             })
-                            .style(self.theme.text_important_color())
+                            .style(self.theme().text_important_color())
                             .left_aligned(),
                         )
                         .border_type(BorderType::Rounded)
-                        .style(self.theme.border_style());
+                        .style(self.theme().border_style());
 
                     frame.render_widget(node_block, top);
 
@@ -1623,12 +1625,12 @@ impl<'a> App<'a> {
                                     stats.min,
                                 )
                             })
-                            .style(self.theme.title_style())
+                            .style(self.theme().title_style())
                             .centered(),
                         )
                         .title_top(if i == 0 {
-                            Line::from(format!("{}ms", self.tick_rate_ms))
-                                .style(self.theme.text_important_color())
+                            Line::from(format!("{}ms", self.config.tick_rate_ms()))
+                                .style(self.theme().text_important_color())
                                 .right_aligned()
                         } else {
                             Line::from("")
@@ -1648,11 +1650,11 @@ impl<'a> App<'a> {
                             } else {
                                 "".to_string()
                             })
-                            .style(self.theme.text_important_color())
+                            .style(self.theme().text_important_color())
                             .left_aligned(),
                         )
                         .border_type(BorderType::Rounded)
-                        .style(self.theme.border_style());
+                        .style(self.theme().border_style());
 
                     let mut bar_col_data: Vec<Vec<Bar>> = vec![Vec::new(); 4];
                     let _: Vec<_> = node
@@ -1679,13 +1681,13 @@ impl<'a> App<'a> {
                                 },
                             )
                             .border_type(BorderType::Rounded)
-                            .style(self.theme.border_style());
+                            .style(self.theme().border_style());
                         let bar_chart = BarChart::default()
                             .block(cpu_block)
                             .data(BarGroup::default().bars(col_data))
                             .max(stats.max)
                             .direction(Direction::Horizontal)
-                            .bar_style(self.theme.sparkline_style())
+                            .bar_style(self.theme().sparkline_style())
                             .bar_gap(0)
                             .bar_width(1);
                         frame.render_widget(bar_chart, cpus_areas[j % col_scale as usize]);
@@ -1749,7 +1751,7 @@ impl<'a> App<'a> {
                 format!(
                     "{}: decrease tick rate ({}ms)",
                     self.keymap.action_keys_string(Action::DecTickRate),
-                    self.tick_rate_ms
+                    self.config.tick_rate_ms()
                 ),
                 Style::default(),
             )),
@@ -1757,7 +1759,7 @@ impl<'a> App<'a> {
                 format!(
                     "{}: increase tick rate ({}ms)",
                     self.keymap.action_keys_string(Action::IncTickRate),
-                    self.tick_rate_ms
+                    self.config.tick_rate_ms()
                 ),
                 Style::default(),
             )),
@@ -1881,16 +1883,24 @@ impl<'a> App<'a> {
                 ),
                 Style::default(),
             )),
+            Line::from(Span::styled(
+                format!(
+                    "{}: Saves the current config ({})",
+                    self.keymap.action_keys_string(Action::SaveConfig),
+                    get_config_path()?.to_string_lossy()
+                ),
+                Style::default(),
+            )),
         ];
         frame.render_widget(
             Paragraph::new(text)
                 .block(
                     Block::default()
-                        .title_top(Line::from(APP).style(self.theme.title_style()).centered())
+                        .title_top(Line::from(APP).style(self.theme().title_style()).centered())
                         .borders(Borders::ALL)
                         .border_type(BorderType::Rounded),
                 )
-                .style(self.theme.border_style())
+                .style(self.theme().border_style())
                 .alignment(Alignment::Left),
             area,
         );
@@ -1900,7 +1910,7 @@ impl<'a> App<'a> {
     /// Renders the event list TUI.
     fn render_event_list(&mut self, frame: &mut Frame) -> Result<()> {
         let area = frame.area();
-        let default_style = Style::default().fg(self.theme.text_color());
+        let default_style = Style::default().fg(self.theme().text_color());
         let chunks = Layout::vertical([Constraint::Min(1), Constraint::Percentage(99)]).split(area);
 
         let height = if area.height > 0 { area.height - 1 } else { 1 };
@@ -1914,9 +1924,9 @@ impl<'a> App<'a> {
             .enumerate()
             .map(|(i, event)| {
                 if i == self.selected_event {
-                    Line::from(event.clone()).fg(self.theme.text_important_color())
+                    Line::from(event.clone()).fg(self.theme().text_important_color())
                 } else {
-                    Line::from(event.clone()).fg(self.theme.text_color())
+                    Line::from(event.clone()).fg(self.theme().text_color())
                 }
             })
             .collect();
@@ -1956,12 +1966,12 @@ impl<'a> App<'a> {
         let block = Block::new()
             .title_top(
                 Line::from(self.scheduler.clone())
-                    .style(self.theme.title_style())
+                    .style(self.theme().title_style())
                     .centered(),
             )
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .style(self.theme.border_style());
+            .style(self.theme().border_style());
 
         let label = Span::styled(
             format!(
@@ -1969,12 +1979,15 @@ impl<'a> App<'a> {
                 self.trace_manager.trace_file(),
                 self.bpf_stats.dropped_events
             ),
-            self.theme.title_style(),
+            self.theme().title_style(),
         );
         let gauge = Gauge::default()
             .block(block)
-            .gauge_style(self.theme.text_important_color())
-            .ratio(self.trace_tick as f64 / (self.max_trace_ticks + self.trace_tick_warmup) as f64)
+            .gauge_style(self.theme().text_important_color())
+            .ratio(
+                self.trace_tick as f64
+                    / (self.config.trace_ticks() + self.config.trace_tick_warmup()) as f64,
+            )
             .label(label);
         frame.render_widget(gauge, frame.area());
 
@@ -2091,7 +2104,11 @@ impl<'a> App<'a> {
     fn start_trace(&mut self, immediate: bool) -> Result<()> {
         self.prev_state = self.state.clone();
         self.state = AppState::Tracing;
-        self.trace_tick = if immediate { self.trace_tick_warmup } else { 0 };
+        self.trace_tick = if immediate {
+            self.config.trace_tick_warmup()
+        } else {
+            0
+        };
         self.trace_manager.start()?;
 
         // set bpf sampling to every event
@@ -2135,13 +2152,13 @@ impl<'a> App<'a> {
 
     /// Updates the app when a task wakes.
     fn on_sched_wakeup(&mut self, action: &SchedWakeupAction) {
-        if self.state == AppState::Tracing && self.trace_tick > self.trace_tick_warmup {
+        if self.state == AppState::Tracing && self.trace_tick > self.config.trace_tick_warmup() {
             self.trace_manager.on_sched_wakeup(action);
         }
     }
 
     fn on_sched_waking(&mut self, action: &SchedWakingAction) {
-        if self.state == AppState::Tracing && self.trace_tick > self.trace_tick_warmup {
+        if self.state == AppState::Tracing && self.trace_tick > self.config.trace_tick_warmup() {
             self.trace_manager.on_sched_waking(action);
         }
     }
@@ -2159,7 +2176,7 @@ impl<'a> App<'a> {
         } = action;
 
         if self.state == AppState::Tracing {
-            if self.trace_tick > self.trace_tick_warmup {
+            if self.trace_tick > self.config.trace_tick_warmup() {
                 self.trace_manager.on_sched_switch(action);
             }
             return;
@@ -2205,14 +2222,14 @@ impl<'a> App<'a> {
 
     /// Handles softirq events.
     pub fn on_softirq(&mut self, action: &SoftIRQAction) {
-        if self.trace_tick > self.trace_tick_warmup {
+        if self.trace_tick > self.config.trace_tick_warmup() {
             self.trace_manager.on_softirq(action);
         }
     }
 
     /// Handles IPI events.
     pub fn on_ipi(&mut self, action: &IPIAction) {
-        if self.trace_tick > self.trace_tick_warmup {
+        if self.trace_tick > self.config.trace_tick_warmup() {
             self.trace_manager.on_ipi(action);
         }
     }
@@ -2267,6 +2284,12 @@ impl<'a> App<'a> {
             Action::RecordTrace(RecordTraceAction { immediate }) => {
                 self.start_trace(*immediate)?;
             }
+            Action::ReloadStatsClient => {
+                self.reload_stats_client()?;
+            }
+            Action::SaveConfig => {
+                self.on_save_config()?;
+            }
             Action::SchedSwitch(a) => {
                 self.on_sched_switch(a);
             }
@@ -2287,7 +2310,8 @@ impl<'a> App<'a> {
                 self.set_theme(self.theme().next());
             }
             Action::TickRateChange(dur) => {
-                self.tick_rate_ms = dur.as_millis().try_into().unwrap();
+                self.config
+                    .set_tick_rate_ms(dur.as_millis().try_into().unwrap());
             }
             Action::ToggleCpuFreq => self.collect_cpu_freq = !self.collect_cpu_freq,
             Action::ToggleUncoreFreq => self.collect_uncore_freq = !self.collect_uncore_freq,

--- a/tools/scxtop/src/cli.rs
+++ b/tools/scxtop/src/cli.rs
@@ -1,0 +1,58 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+use crate::APP;
+use crate::STATS_SOCKET_PATH;
+use crate::TRACE_FILE_PREFIX;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(about = APP)]
+pub struct Cli {
+    /// App tick rate in milliseconds.
+    #[arg(short = 'r', long, default_missing_value = "250")]
+    pub tick_rate_ms: Option<usize>,
+    /// Extra verbose output.
+    #[arg(short, long, default_missing_value = "false")]
+    pub debug: Option<bool>,
+    /// Exclude bpf event tracking.
+    #[arg(short, long, default_missing_value = "false")]
+    pub exclude_bpf: Option<bool>,
+    /// Stats unix socket path.
+    #[arg(short, long, default_missing_value = STATS_SOCKET_PATH.to_string())]
+    pub stats_socket_path: Option<String>,
+    /// Trace file prefix for perfetto traces.
+    #[arg(short, long, default_missing_value = TRACE_FILE_PREFIX.to_string())]
+    pub trace_file_prefix: Option<String>,
+    /// Number of ticks for traces.
+    #[arg(long, default_missing_value = "5")]
+    pub trace_ticks: Option<usize>,
+    /// Number of worker threads.
+    #[arg(long, default_missing_value = "4", value_parser = clap::value_parser!(u16).range(2..128))]
+    pub worker_threads: Option<u16>,
+    /// Number of ticks to warmup before collecting traces.
+    #[arg(long, default_missing_value = "3")]
+    pub trace_tick_warmup: Option<usize>,
+    /// Process to monitor or all.
+    #[arg(long, default_value_t = -1)]
+    pub process_id: i32,
+
+    /// Automatically start a trace when a function takes too long to return.
+    #[arg(
+        long,
+        default_value_t = false,
+        requires("experimental_long_tail_tracing_symbol"),
+        requires("experimental_long_tail_tracing_binary")
+    )]
+    pub experimental_long_tail_tracing: bool,
+    /// Symbol to automatically trace the long tail of.
+    #[arg(long)]
+    pub experimental_long_tail_tracing_symbol: Option<String>,
+    /// Binary to attach the uprobe and uretprobe to.
+    #[arg(long)]
+    pub experimental_long_tail_tracing_binary: Option<String>,
+    /// Minimum latency to trigger a trace.
+    #[arg(long, default_value_t = 100000000)]
+    pub experimental_long_tail_tracing_min_latency_ns: u64,
+}

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -1,0 +1,194 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use crate::cli::Cli;
+use crate::AppTheme;
+use crate::STATS_SOCKET_PATH;
+use crate::TRACE_FILE_PREFIX;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use xdg;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Config {
+    /// TUI theme.
+    theme: Option<AppTheme>,
+    /// App tick rate in milliseconds.
+    tick_rate_ms: Option<usize>,
+    /// Extra verbose output.
+    debug: Option<bool>,
+    /// Exclude bpf event tracking.
+    exclude_bpf: Option<bool>,
+    /// Stats unix socket path.
+    stats_socket_path: Option<String>,
+    /// Trace file prefix for perfetto traces.
+    trace_file_prefix: Option<String>,
+    /// Number of ticks for traces.
+    trace_ticks: Option<usize>,
+    /// Number of worker threads
+    worker_threads: Option<u16>,
+    /// Number of ticks to warmup before collecting traces.
+    trace_tick_warmup: Option<usize>,
+}
+
+pub fn get_config_path() -> Result<PathBuf> {
+    let xdg_dirs = xdg::BaseDirectories::with_prefix("scxtop")?;
+    let config_path = xdg_dirs.get_config_file("scxtop.toml");
+    Ok(config_path)
+}
+
+impl Config {
+    /// App theme.
+    pub fn theme(&self) -> &AppTheme {
+        match &self.theme {
+            Some(theme) => theme,
+            None => &AppTheme::Default,
+        }
+    }
+
+    /// Set the app theme.
+    pub fn set_theme(&mut self, theme: AppTheme) {
+        self.theme = Some(theme);
+    }
+
+    /// App tick rate in milliseconds.
+    pub fn tick_rate_ms(&self) -> usize {
+        self.tick_rate_ms.unwrap_or(250)
+    }
+
+    /// Set app tick rate in milliseconds.
+    pub fn set_tick_rate_ms(&mut self, tick_rate_ms: usize) {
+        self.tick_rate_ms = Some(tick_rate_ms);
+    }
+
+    /// Extra verbose output.
+    pub fn debug(&self) -> bool {
+        self.debug.unwrap_or(false)
+    }
+
+    /// Exclude bpf event tracking.
+    pub fn exclude_bpf(&self) -> bool {
+        self.exclude_bpf.unwrap_or(false)
+    }
+
+    /// Stats unix socket path.
+    pub fn stats_socket_path(&self) -> &str {
+        match &self.stats_socket_path {
+            Some(stats_socket_path) => stats_socket_path,
+            None => STATS_SOCKET_PATH,
+        }
+    }
+
+    /// Trace file prefix for perfetto traces.
+    pub fn trace_file_prefix(&self) -> &str {
+        match &self.trace_file_prefix {
+            Some(trace_file_prefix) => trace_file_prefix,
+            None => TRACE_FILE_PREFIX,
+        }
+    }
+
+    /// Number of ticks for traces.
+    pub fn trace_ticks(&self) -> usize {
+        self.trace_ticks.unwrap_or(5)
+    }
+
+    /// Number of worker threads
+    pub fn worker_threads(&self) -> u16 {
+        self.worker_threads.unwrap_or(4)
+    }
+
+    /// Number of ticks to warmup before collecting traces.
+    pub fn trace_tick_warmup(&self) -> usize {
+        self.trace_tick_warmup.unwrap_or(3)
+    }
+
+    /// Returns a config with nothing set.
+    pub fn empty_config() -> Config {
+        Config {
+            theme: None,
+            tick_rate_ms: None,
+            debug: None,
+            exclude_bpf: None,
+            stats_socket_path: None,
+            trace_file_prefix: None,
+            trace_ticks: None,
+            worker_threads: None,
+            trace_tick_warmup: None,
+        }
+    }
+
+    /// Returns the default config.
+    pub fn default_config() -> Config {
+        let mut config = Config {
+            theme: None,
+            tick_rate_ms: None,
+            debug: None,
+            exclude_bpf: None,
+            stats_socket_path: None,
+            trace_file_prefix: None,
+            trace_ticks: None,
+            worker_threads: None,
+            trace_tick_warmup: None,
+        };
+        config.tick_rate_ms = Some(config.tick_rate_ms());
+        config.debug = Some(config.debug());
+        config.exclude_bpf = Some(config.exclude_bpf());
+
+        config
+    }
+
+    /// Loads the config from XDG configuration.
+    pub fn load() -> Result<Config> {
+        let config_path = get_config_path()?;
+        let contents = fs::read_to_string(config_path)?;
+        let config: Config = toml::from_str(&contents)?;
+        Ok(config)
+    }
+
+    /// Merges a Config with a Cli config.
+    pub fn merge_cli(config: &Config, cli: &Cli) -> Config {
+        Config {
+            theme: config.theme.clone(),
+            tick_rate_ms: Some(cli.tick_rate_ms.unwrap_or(config.tick_rate_ms())),
+            debug: Some(cli.debug.unwrap_or(config.debug())),
+            exclude_bpf: Some(cli.exclude_bpf.unwrap_or(config.exclude_bpf())),
+            stats_socket_path: match &cli.stats_socket_path {
+                Some(s) => {
+                    if !s.is_empty() {
+                        Some(s.to_string())
+                    } else {
+                        config.stats_socket_path.clone()
+                    }
+                }
+                None => config.stats_socket_path.clone(),
+            },
+            trace_file_prefix: match &cli.trace_file_prefix {
+                Some(s) => {
+                    if !s.is_empty() {
+                        Some(s.to_string())
+                    } else {
+                        config.trace_file_prefix.clone()
+                    }
+                }
+                None => config.trace_file_prefix.clone(),
+            },
+            trace_ticks: Some(cli.trace_ticks.unwrap_or(config.trace_ticks())),
+            worker_threads: Some(cli.worker_threads.unwrap_or(config.worker_threads())),
+            trace_tick_warmup: Some(cli.trace_tick_warmup.unwrap_or(config.trace_tick_warmup())),
+        }
+    }
+
+    /// Saves the current config.
+    pub fn save(&mut self) -> Result<()> {
+        let config_path = get_config_path()?;
+        if !config_path.exists() {
+            fs::create_dir_all(config_path.parent().map(PathBuf::from).unwrap())?;
+        }
+        let config_str = toml::to_string(&self)?;
+        Ok(fs::write(&config_path, config_str)?)
+    }
+}

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -42,6 +42,7 @@ impl Default for KeyMap {
         bindings.insert(Key::Char('l'), Action::SetState(AppState::Llc));
         bindings.insert(Key::Char('n'), Action::SetState(AppState::Node));
         bindings.insert(Key::Char('s'), Action::SetState(AppState::Scheduler));
+        bindings.insert(Key::Char('S'), Action::SaveConfig);
         bindings.insert(
             Key::Char('a'),
             Action::RecordTrace(RecordTraceAction { immediate: false }),

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -7,6 +7,8 @@ mod app;
 pub mod bpf_intf;
 pub mod bpf_skel;
 mod bpf_stats;
+pub mod cli;
+pub mod config;
 mod cpu_data;
 mod event_data;
 mod keymap;
@@ -44,8 +46,9 @@ pub use plain::Plain;
 // Generate serialization types for handling events from the bpf ring buffer.
 unsafe impl Plain for crate::bpf_skel::types::bpf_event {}
 
-pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const APP: &str = "scxtop";
+pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
+pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
 This software may be used and distributed according to the terms of the 
@@ -162,40 +165,42 @@ pub struct IPIAction {
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Action {
-    Tick,
-    Quit,
-    Help,
-    IPI(IPIAction),
-    Event,
-    ClearEvent,
-    NextEvent,
-    PrevEvent,
     ChangeTheme,
-    Up,
+    ClearEvent,
+    DecBpfSampleRate,
+    DecTickRate,
     Down,
-    PageUp,
-    PageDown,
     Enter,
+    Event,
+    Help,
+    IncBpfSampleRate,
+    IncTickRate,
+    IPI(IPIAction),
+    NextEvent,
+    NextViewState,
+    PageDown,
+    PageUp,
+    PrevEvent,
+    Quit,
+    RecordTrace(RecordTraceAction),
+    ReloadStatsClient,
     Render,
-    SchedReg,
-    SchedUnreg,
+    SaveConfig,
     SchedCpuPerfSet(SchedCpuPerfSetAction),
+    SchedReg,
     SchedStats(String),
     SchedSwitch(SchedSwitchAction),
-    SchedWakeup(SchedWakeupAction),
+    SchedUnreg,
     SchedWakeupNew(SchedWakeupNewAction),
+    SchedWakeup(SchedWakeupAction),
     SchedWaking(SchedWakingAction),
     SetState(AppState),
     SoftIRQ(SoftIRQAction),
-    NextViewState,
-    RecordTrace(RecordTraceAction),
+    Tick,
+    TickRateChange(std::time::Duration),
     ToggleCpuFreq,
     ToggleLocalization,
     ToggleUncoreFreq,
-    TickRateChange(std::time::Duration),
-    IncTickRate,
-    DecTickRate,
-    IncBpfSampleRate,
-    DecBpfSampleRate,
+    Up,
     None,
 }

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -30,14 +30,14 @@ use crate::protos_gen::perfetto_scx::{
 /// Handler for perfetto traces. For details on data flow in perfetto see:
 /// https://perfetto.dev/docs/concepts/buffers and
 /// https://perfetto.dev/docs/reference/trace-packet-proto
-pub struct PerfettoTraceManager<'a> {
+pub struct PerfettoTraceManager {
     // proto fields
     trace: Trace,
 
     trace_id: u32,
     trusted_pid: i32,
     rng: StdRng,
-    output_file_prefix: &'a str,
+    output_file_prefix: String,
 
     // per cpu ftrace events
     ftrace_events: BTreeMap<u32, Vec<FtraceEvent>>,
@@ -48,9 +48,9 @@ pub struct PerfettoTraceManager<'a> {
     dsq_uuids: BTreeMap<u64, u64>,
 }
 
-impl<'a> PerfettoTraceManager<'a> {
+impl PerfettoTraceManager {
     /// Returns a PerfettoTraceManager that is ready to start tracing.
-    pub fn new(output_file_prefix: &'a str, seed: Option<u64>) -> Self {
+    pub fn new(output_file_prefix: String, seed: Option<u64>) -> Self {
         let trace_uuid = seed.unwrap_or(
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
Add option to load default values from a config file defined following XDG base directory specification. This will allow for custom keymaps to be defined in config files. The handling between the clap CLI args and the config file is a little awkward, but that can be cleaned up in the future.

After running `scxtop` the default config file will be created:
```
$ cat $HOME/.config/scxtop/scxtop.toml
tick_rate_ms = 250
debug = false
exclude_bpf = false
stats_socket_path = "/var/run/scx/root/stats"
trace_file_prefix = "scxtop_trace"
trace_ticks = 5
worker_threads = 4
trace_tick_warmup = 3
```