### PR TITLE
scx_utils: topology: Add package_id to the LLC and Core keys

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -317,9 +317,9 @@ impl Topology {
 /// TopoCtx is a helper struct used to build a topology.
 struct TopoCtx {
     /// Mapping of NUMA node core ids
-    node_core_kernel_ids: BTreeMap<(usize, usize), usize>,
+    node_core_kernel_ids: BTreeMap<(usize, usize, usize), usize>,
     /// Mapping of NUMA node LLC ids
-    node_llc_kernel_ids: BTreeMap<(usize, usize), usize>,
+    node_llc_kernel_ids: BTreeMap<(usize, usize, usize), usize>,
     /// Mapping of L2 ids
     l2_ids: BTreeMap<String, usize>,
     /// Mapping of L3 ids
@@ -450,7 +450,7 @@ fn create_insert_cpu(
     let num_llcs = topo_ctx.node_llc_kernel_ids.len();
     let llc_id = topo_ctx
         .node_llc_kernel_ids
-        .entry((node.id, llc_kernel_id))
+        .entry((node.id, package_id, llc_kernel_id))
         .or_insert(num_llcs);
 
     let llc = node.llcs.entry(*llc_id).or_insert(Arc::new(Llc {
@@ -484,7 +484,7 @@ fn create_insert_cpu(
     let num_cores = topo_ctx.node_core_kernel_ids.len();
     let core_id = topo_ctx
         .node_core_kernel_ids
-        .entry((node.id, core_kernel_id))
+        .entry((node.id, package_id, core_kernel_id))
         .or_insert(num_cores);
 
     let core = llc_mut.cores.entry(*core_id).or_insert(Arc::new(Core {


### PR DESCRIPTION
In presence of multiple sockets with shared NUMA nodes the package_id must be considered to determine a unique key to identify cores / LLCs, otherwise some information may be missed due to key duplication.

For example, let's simulate a VM with 2 sockets, each one with a single SMT core and just one NUMA node, using virtme-ng:

  $ vng --cpu 4,sockets=2,cores=1,threads=2 -- lscpu -e
  CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE
    0    0      0    0 0:0:0:0          yes
    1    0      0    0 0:0:0:0          yes
    2    0      1    1 1:1:1:1          yes
    3    0      1    1 1:1:1:1          yes

And let's run the following test case inside the vng instance:

  let topo = Topology::new().unwrap();
  let smt_siblings = topo.sibling_cpus();
  info!("SMT sibling CPUs: {:?}", smt_siblings);

The result is the following:

  15:40:10 [INFO] SMT sibling CPUs: [-1, -1, 3, 2]

Which is incorect, as the first 2 CPUs don't map their SMT sibling correctly.

With this change applied the array of SMT siblings is correct:

  15:40:55 [INFO] SMT sibling CPUs: [1, 0, 3, 2]