### PR TITLE
scx_wd40: simplify BPF component

### DIFF
--- a/scheds/rust/scx_wd40/src/bpf/common.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/common.bpf.c
@@ -20,7 +20,7 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
-const volatile u32 dom_numa_id_map[MAX_DOMS];
+volatile u32 dom_numa_id_map[MAX_DOMS];
 const volatile u32 debug;
 const volatile u32 load_half_life = 1000000000	/* 1s */;
 const volatile u32 nr_doms = 32;	/* !0 for veristat, set during init */

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.h
@@ -12,13 +12,13 @@ dom_ptr try_lookup_dom_ctx(u32 dom_id);
 dom_ptr lookup_dom_ctx(u32 dom_id);
 struct bpf_spin_lock *lookup_dom_vtime_lock(dom_ptr domc);
 
-__weak s32 create_node(u32 node_id);
+__weak s32 alloc_dom(u32 dom_id);
 __weak s32 create_dom(u32 dom_id);
 int dom_xfer_task(struct task_struct *p __arg_trusted, u32 new_dom_id, u64 now);
 
+extern volatile scx_bitmap_t node_data[MAX_NUMA_NODES];
 extern const volatile u32 load_half_life;
 extern const volatile u32 debug;
-extern const volatile u64 numa_cpumasks[MAX_NUMA_NODES][MAX_CPUS / 64];
 extern volatile u64 slice_ns;
 extern const volatile u32 nr_doms;
 extern const volatile u32 nr_nodes;

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -905,9 +905,10 @@ static s32 initialize_cpu(s32 cpu)
 	return -ENOENT;
 }
 
-s32 BPF_STRUCT_OPS_SLEEPABLE(wd40_init)
+SEC("syscall")
+int wd40_arena_setup(void)
 {
-	s32 i, ret;
+	int ret;
 
 	ret = sdt_static_init(STATIC_ALLOC_PAGES_GRANULARITY);
 	if (ret)
@@ -940,6 +941,13 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(wd40_init)
 	ret = sdt_task_init(sizeof(struct task_ctx));
 	if (ret)
 		return ret;
+
+	return (0);
+}
+
+s32 BPF_STRUCT_OPS_SLEEPABLE(wd40_init)
+{
+	s32 i, ret;
 
 	bpf_for(i, 0, nr_nodes) {
 		ret = create_node(i);

--- a/scheds/rust/scx_wd40/src/main.rs
+++ b/scheds/rust/scx_wd40/src/main.rs
@@ -457,7 +457,8 @@ impl<'a> Scheduler<'a> {
                 let dom_cpumask_slice = unsafe{ &mut *domc.cpumask};
 
                 let raw_dom_slice = dom.mask_slice();
-                dom_cpumask_slice.bits.clone_from_slice(raw_dom_slice);
+                let (left, _) = dom_cpumask_slice.bits.split_at_mut(raw_numa_slice.len());
+                left.clone_from_slice(raw_dom_slice);
                 skel.maps.bss_data.dom_numa_id_map[dom.id()] =
                     numa.try_into().expect("NUMA ID could not fit into 32 bits");
 


### PR DESCRIPTION
Introduce 2 refactoring steps to simplify the code:

- Split arena allocation and kernel-side initialization into two steps to remove the intermediate masks we are currently using to communicate between userspace and BPF.
- Move the tuner completely in userspace by directly updating arena memory from the Rust module