### PR TITLE
scx_bpfland; use scx_bpf_now() consistently

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -1022,7 +1022,7 @@ void BPF_STRUCT_OPS(bpfland_stopping, struct task_struct *p, bool runnable)
 	/*
 	 * Evaluate the time slice used by the task.
 	 */
-	slice = bpf_ktime_get_ns() - tctx->last_run_at;
+	slice = scx_bpf_now() - tctx->last_run_at;
 
 	/*
 	 * Update task's execution time (exec_runtime), but never account


### PR DESCRIPTION
Always use scx_bpf_now() to track time consistently. This fixes a bad regression with the 6.14 kernel, as scx_bpf_now() is no longer redirected to bpf_ktime_get_ns() and comparing the TSC timestamp with the timestamp cached in struct rq can lead to inaccurate time measurements.

Fixes: 97495ced ("scx_bpfland: Replace bpf_ktime_get_ns() to scx_bpf_now()")