### PR TITLE
scx_lavd: Use tracepoints for futex for reliable tracing

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -116,7 +116,6 @@ struct task_ctx {
 	/*
 	 * Task deadline and time slice
 	 */
-	u32	*futex_uaddr;		/* futex uaddr */
 	u32	lat_cri;		/* final context-aware latency criticality */
 	u32	lat_cri_waker;		/* waker's latency criticality */
 	u32	perf_cri;		/* performance criticality of a task */

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -53,6 +53,8 @@ enum consts_internal  {
 	LAVD_CPDOM_MIGRATION_SHIFT	= 3, /* 1/2**3 = +/- 12.5% */
 	LAVD_CPDOM_X_PROB_FT		= (LAVD_SYS_STAT_INTERVAL_NS /
 					   (2 * LAVD_SLICE_MAX_NS_DFL)), /* roughly twice per interval */
+
+	LAVD_FUTEX_OP_INVALID		= -1,
 };
 
 /*
@@ -108,6 +110,7 @@ struct cpu_ctx {
 	 * Information of a current running task for preemption
 	 */
 	volatile u64	stopping_tm_est_ns; /* estimated stopping time */
+	volatile s32	futex_op;	/* futex op in futex V1 */
 	volatile u16	lat_cri;	/* latency criticality */
 	volatile u8	is_online;	/* is this CPU online? */
 	volatile u8	lock_holder;	/* is a lock holder running */

--- a/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
@@ -7,37 +7,52 @@
 /*
  * To be included to the main.bpf.c
  */
-
-static void inc_futex_boost(u32 *uaddr)
+static void __inc_futex_boost(struct cpu_ctx *cpuc)
 {
 	struct task_struct *p = bpf_get_current_task_btf();
 	struct task_ctx *taskc = try_get_task_ctx(p);
-	struct cpu_ctx *cpuc = get_cpu_ctx();
 
-	if (taskc && cpuc && (taskc->futex_uaddr != uaddr)) {
-		taskc->futex_boost++;
-		taskc->futex_uaddr = uaddr;
-		cpuc->lock_holder = is_lock_holder(taskc);
+	if (taskc) {
+		if (!cpuc)
+			cpuc = get_cpu_ctx();
+
+		if (cpuc) {
+			taskc->futex_boost = true;
+			cpuc->lock_holder = true;
+		}
 	}
 	/*
 	 * If taskc is null, the task is not under sched_ext so ignore the error.
 	 */
 }
 
-static void dec_futex_boost(u32 *uaddr)
+static void __dec_futex_boost(struct cpu_ctx *cpuc)
 {
 	struct task_struct *p = bpf_get_current_task_btf();
 	struct task_ctx *taskc = try_get_task_ctx(p);
-	struct cpu_ctx *cpuc = get_cpu_ctx();
 
-	if (p && taskc && cpuc && taskc->futex_boost > 0) {
-		taskc->futex_boost--;
-		taskc->futex_uaddr = NULL;
-		cpuc->lock_holder = is_lock_holder(taskc);
+	if (taskc && taskc->futex_boost) {
+		if (!cpuc)
+			cpuc = get_cpu_ctx();
+
+		if (cpuc) {
+			taskc->futex_boost = false;
+			cpuc->lock_holder = false;
+		}
 	}
 	/*
 	 * If taskc is null, the task is not under sched_ext so ignore the error.
 	 */
+}
+
+static void inc_futex_boost(void)
+{
+	__inc_futex_boost(NULL);
+}
+
+static void dec_futex_boost(void)
+{
+	__dec_futex_boost(NULL);
 }
 
 static void reset_lock_futex_boost(struct task_ctx *taskc, struct cpu_ctx *cpuc)
@@ -45,8 +60,7 @@ static void reset_lock_futex_boost(struct task_ctx *taskc, struct cpu_ctx *cpuc)
 	if (is_lock_holder(taskc))
 		taskc->need_lock_boost = true;
 
-	taskc->futex_boost = 0;
-	taskc->futex_uaddr = NULL;
+	taskc->futex_boost = false;
 	cpuc->lock_holder = false;
 }
 
@@ -78,108 +92,130 @@ static void reset_lock_futex_boost(struct task_ctx *taskc, struct cpu_ctx *cpuc)
  *   designed critical section is short enough and too long a critical section
  *   is not worth boosting. So when a futex_wake() is not called within a one
  *   time slice, we assume futex_wake() is skipped.
+ * - We do not distinguish futex user addresses to lower the tracing burden.
  *
- * We trace the folloing futex calls:
- * - int __futex_wait(u32 *uaddr, unsigned int flags, u32 val, struct hrtimer_sleeper *to, u32 bitset)
- * - int futex_wait_multiple(struct futex_vector *vs, unsigned int count, struct hrtimer_sleeper *to)
- * - int futex_wait_requeue_pi(u32 *uaddr, unsigned int flags, u32 val, ktime_t *abs_time, u32 bitset, u32 *uaddr2)
- *
- * - int futex_wake(u32 *uaddr, unsigned int flags, int nr_wake, u32 bitset)
- * - int futex_wake_op(u32 *uaddr1, unsigned int flags, u32 *uaddr2, int nr_wake, int nr_wake2, int op)
- *
- * - int futex_lock_pi(u32 *uaddr, unsigned int flags, ktime_t *time, int trylock)
- * - int futex_unlock_pi(u32 *uaddr, unsigned int flags)
+ * We trace the folloing futex tracepoints:
+ * - sys_exit_futex
+ * - sys_exit_futex_wait
+ * - sys_exit_futex_waitv
+ * - sys_exit_futex_wake
  */
-struct futex_vector;
-struct hrtimer_sleeper;
 
-SEC("fexit/__futex_wait")
-int BPF_PROG(fexit___futex_wait, u32 *uaddr, unsigned int flags, u32 val, struct hrtimer_sleeper *to, u32 bitset, int ret)
+/*
+ * The following defines are from 'linux/include/uapi/linux/futex.h'
+ */
+#define FUTEX_WAIT		0
+#define FUTEX_WAKE		1
+#define FUTEX_FD		2
+#define FUTEX_REQUEUE		3
+#define FUTEX_CMP_REQUEUE	4
+#define FUTEX_WAKE_OP		5
+#define FUTEX_LOCK_PI		6
+#define FUTEX_UNLOCK_PI		7
+#define FUTEX_TRYLOCK_PI	8
+#define FUTEX_WAIT_BITSET	9
+#define FUTEX_WAKE_BITSET	10
+#define FUTEX_WAIT_REQUEUE_PI	11
+#define FUTEX_CMP_REQUEUE_PI	12
+#define FUTEX_LOCK_PI2		13
+
+#define FUTEX_PRIVATE_FLAG	128
+#define FUTEX_CLOCK_REALTIME	256
+#define FUTEX_CMD_MASK		~(FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME)
+
+struct tp_syscall_enter_futex {
+	struct trace_entry ent;
+	int __syscall_nr;
+	u32 __attribute__((btf_type_tag("user"))) * uaddr;
+	int op;
+	u32 val;
+	struct __kernel_timespec __attribute__((btf_type_tag("user"))) * utime;
+	u32 __attribute__((btf_type_tag("user"))) * uaddr2;
+	u32 val3;
+};
+
+struct tp_syscall_exit {
+	struct trace_entry ent;
+	int __syscall_nr;
+	long ret;
+};
+
+SEC("tracepoint/syscalls/sys_enter_futex")
+int rtp_sys_enter_futex(struct tp_syscall_enter_futex *ctx)
 {
-	if (ret == 0) {
-		/*
-		 * A futex is acquired.
-		 */
-		inc_futex_boost(uaddr);
-	}
+	struct cpu_ctx *cpuc = get_cpu_ctx();
+
+	if (cpuc)
+		cpuc->futex_op = ctx->op;
 	return 0;
 }
 
-SEC("fexit/futex_wait_multiple")
-int BPF_PROG(fexit_futex_wait_multiple, struct futex_vector *vs, unsigned int count, struct hrtimer_sleeper *to, int ret)
+SEC("tracepoint/syscalls/sys_exit_futex")
+int rtp_sys_exit_futex(struct tp_syscall_exit *ctx)
 {
-	if (ret == 0) {
-		/*
-		 * All of futexes are acquired.
-		 *
-		 * We don't want to traverse futex_vector here since that's
-		 * a userspace address. Hence we just pass an invalid adderess
-		 * to consider all futex_waitv() calls are for the same address.
-		 * Thit is a conservative approximation boosting less.
-		 */
-		inc_futex_boost((u32 *)0xbeefcafe); 
+	struct cpu_ctx *cpuc;
+	int cmd;
+
+	if (ctx->ret < 0)
+		return 0;
+
+	cpuc = get_cpu_ctx();
+	if (!cpuc)
+		return 0;
+
+	cmd = cpuc->futex_op & FUTEX_CMD_MASK;
+	switch (cmd) {
+	case FUTEX_WAIT:
+	case FUTEX_WAIT_BITSET:
+	case FUTEX_WAIT_REQUEUE_PI:
+		if (ctx->ret == 0) /* 0 for wait success */
+			__inc_futex_boost(cpuc);
+		return 0;
+
+	case FUTEX_WAKE:
+	case FUTEX_WAKE_BITSET:
+	case FUTEX_WAKE_OP:
+		if (ctx->ret > 0) /* the number of waiters that were woken up */
+			__dec_futex_boost(cpuc);
+		return 0;
+
+	case FUTEX_LOCK_PI:
+	case FUTEX_LOCK_PI2:
+	case FUTEX_TRYLOCK_PI:
+		if (ctx->ret == 0) /* 0 for successful locking */
+			__inc_futex_boost(cpuc);
+		return 0;
+
+	case FUTEX_UNLOCK_PI:
+		if (ctx->ret == 0) /* 0 for successful unlocking */
+			__dec_futex_boost(cpuc);
+		return 0;
 	}
+
 	return 0;
 }
 
-SEC("fexit/futex_wait_requeue_pi")
-int BPF_PROG(fexit_futex_wait_requeue_pi, u32 *uaddr, unsigned int flags, u32 val, ktime_t *abs_time, u32 bitset, u32 *uaddr2, int ret)
+SEC("tracepoint/syscalls/sys_exit_futex_wait")
+int rtp_sys_exit_futex_wait(struct tp_syscall_exit *ctx)
 {
-	if (ret == 0) {
-		/*
-		 * A futex is acquired.
-		 */
-		inc_futex_boost(uaddr);
-	}
+	if (ctx->ret == 0) /* 0 for wait success */
+		inc_futex_boost();
 	return 0;
 }
 
-SEC("fexit/futex_wake")
-int BPF_PROG(fexit_futex_wake, u32 *uaddr, unsigned int flags, int nr_wake, u32 bitset, int ret)
+SEC("tracepoint/syscalls/sys_exit_futex_waitv")
+int rtp_sys_exit_futex_waitv(struct tp_syscall_exit *ctx)
 {
-	if (ret >= 0) {
-		/*
-		 * A futex is released.
-		 */
-		dec_futex_boost(uaddr);
-	}
+	if (ctx->ret >= 0) /* array index of one of the woken futexes */
+		inc_futex_boost();
 	return 0;
 }
 
-
-SEC("fexit/futex_wake_op")
-int BPF_PROG(fexit_futex_wake_op, u32 *uaddr1, unsigned int flags, u32 *uaddr2, int nr_wake, int nr_wake2, int op, int ret)
+SEC("tracepoint/syscalls/sys_exit_futex_wake")
+int rtp_sys_exit_futex_wake(struct tp_syscall_exit *ctx)
 {
-	if (ret >= 0) {
-		/*
-		 * A futex is released.
-		 */
-		dec_futex_boost(uaddr1);
-	}
-	return 0;
-}
-
-SEC("fexit/futex_lock_pi")
-int BPF_PROG(fexit_futex_lock_pi, u32 *uaddr, unsigned int flags, ktime_t *time, int trylock, int ret)
-{
-	if (ret == 0) {
-		/*
-		 * A futex is acquired.
-		 */
-		inc_futex_boost(uaddr);
-	}
-	return 0;
-}
-
-SEC("fexit/futex_unlock_pi")
-int BPF_PROG(fexit_futex_unlock_pi, u32 *uaddr, unsigned int flags, int ret)
-{
-	if (ret == 0) {
-		/*
-		 * A futex is released.
-		 */
-		dec_futex_boost(uaddr);
-	}
+	if (ctx->ret > 0) /* the number of waiters that were woken up */
+		dec_futex_boost();
 	return 0;
 }
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -2032,6 +2032,7 @@ static s32 init_per_cpu_ctx(u64 now)
 		cpuc->offline_clk = now;
 		cpuc->cpdom_poll_pos = cpu % LAVD_CPDOM_MAX_NR;
 		cpuc->min_perf_cri = 1000;
+		cpuc->futex_op = LAVD_FUTEX_OP_INVALID;
 
 		if (cpuc->capacity > 0) {
 			sum_capacity += cpuc->capacity;

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -246,7 +246,7 @@ static bool is_eligible(struct task_ctx *taskc)
 
 static bool is_lock_holder(struct task_ctx *taskc)
 {
-	return taskc->futex_boost > 0;
+	return taskc->futex_boost;
 }
 
 static bool have_scheduled(struct task_ctx *taskc)


### PR DESCRIPTION
Using ftrace is handy. However, it could be unreliable across kernel versions and kernel configs because ftraced-functions can be renamed or inlined. Thus, for reliable tracing, replace ftrace to tracepoint. With tracepoint, there is no easy/efficient way to get arguments and return values, so drop tracking uaddr was used to distinguish indivisual futexes.