### PR TITLE
scx_lavd: Fix BPF verifier errors in old kernels.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
@@ -14,7 +14,7 @@ static void __inc_futex_boost(struct cpu_ctx *cpuc)
 
 	if (taskc) {
 		if (!cpuc)
-			cpuc = get_cpu_ctx();
+			cpuc = try_get_cpu_ctx();
 
 		if (cpuc) {
 			taskc->futex_boost = true;
@@ -33,7 +33,7 @@ static void __dec_futex_boost(struct cpu_ctx *cpuc)
 
 	if (taskc && taskc->futex_boost) {
 		if (!cpuc)
-			cpuc = get_cpu_ctx();
+			cpuc = try_get_cpu_ctx();
 
 		if (cpuc) {
 			taskc->futex_boost = false;
@@ -143,7 +143,7 @@ struct tp_syscall_exit {
 SEC("tracepoint/syscalls/sys_enter_futex")
 int rtp_sys_enter_futex(struct tp_syscall_enter_futex *ctx)
 {
-	struct cpu_ctx *cpuc = get_cpu_ctx();
+	struct cpu_ctx *cpuc = try_get_cpu_ctx();
 
 	if (cpuc)
 		cpuc->futex_op = ctx->op;
@@ -159,7 +159,7 @@ int rtp_sys_exit_futex(struct tp_syscall_exit *ctx)
 	if (ctx->ret < 0)
 		return 0;
 
-	cpuc = get_cpu_ctx();
+	cpuc = try_get_cpu_ctx();
 	if (!cpuc)
 		return 0;
 

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -156,6 +156,13 @@ static struct task_ctx *get_task_ctx(struct task_struct *p)
 	return taskc;
 }
 
+static struct cpu_ctx *try_get_cpu_ctx(void)
+{
+	const u32 idx = 0;
+
+	return bpf_map_lookup_elem(&cpu_ctx_stor, &idx);
+}
+
 static struct cpu_ctx *get_cpu_ctx(void)
 {
 	const u32 idx = 0;


### PR DESCRIPTION
Fixes: 9a67bd7f ("scx_lavd: Use tracepoints for futex for reliable tracing")