### PR TITLE
scxtop: add logging to file with panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "log-panics"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
+dependencies = [
+ "backtrace",
+ "log",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,6 +2521,7 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "log",
+ "log-panics",
  "num-format",
  "perf-event-open-sys",
  "plain",
@@ -2524,6 +2535,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
+ "simplelog",
  "strip-ansi-escapes",
  "tokio",
  "tokio-util",

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -40,6 +40,7 @@ ratatui = { version = "0.29.0", features = ["serde", "macros"] }
 regex = "1.11.1"
 scx_stats = { path = "../../rust/scx_stats", version = "1.0.9" }
 scx_utils = { path = "../../rust/scx_utils", version = "1.0.11" }
+simplelog = "0.12"
 serde_json = "1.0.133"
 serde = { version = "1.0.215", features = ["derive"] }
 signal-hook = "0.3.17"
@@ -51,6 +52,7 @@ tracing = "0.1.41"
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "serde"] }
 xdg = "2.5.2"
+log-panics = { version = "2", features = ["with-backtrace"]}
 
 [build-dependencies]
 protobuf-codegen = "3.7.1"


### PR DESCRIPTION

scxtop logs, including panics, are currently lost because the TUI overwrites
them. Add environment variables to write the log to a file and control the log
level.

Test plan:
- Caught a panic that was lost before. It works.
- Handles bad levels correctly.
