### PR TITLE
scxtop: clamp gauge ratio

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -2020,8 +2020,9 @@ impl<'a> App<'a> {
             .block(block)
             .gauge_style(self.theme().text_important_color())
             .ratio(
-                self.trace_tick as f64
-                    / (self.config.trace_ticks() + self.config.trace_tick_warmup()) as f64,
+                (self.trace_tick as f64
+                    / (self.config.trace_ticks() + self.config.trace_tick_warmup()) as f64)
+                    .clamp(0.0_f64, 1.0_f64),
             )
             .label(label);
         frame.render_widget(gauge, frame.area());


### PR DESCRIPTION

Received a panic using the new logging feature:

```
16:04:06 [ERROR] thread 'main' panicked at 'Ratio should be between 0 and 1 inclusively.': /home/jakehillion/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ratatui-0.29.0/src/widgets/gauge.rs:95
   0: <backtrace::capture::Backtrace as core::default::Default>::default
   1: log_panics::Config::install_panic_hook::{{closure}}
   2: std::panicking::rust_panic_with_hook
   3: std::panicking::begin_panic_handler::{{closure}}
   4: std::sys::backtrace::__rust_end_short_backtrace
   5: rust_begin_unwind
   6: core::panicking::panic_fmt
   7: scxtop::app::App::render
   8: ratatui::terminal::terminal::Terminal<B>::draw
   9: tokio::runtime::runtime::Runtime::block_on
  10: scxtop::main
  11: std::sys::backtrace::__rust_begin_short_backtrace
  12: main
  13: __libc_start_call_main
  14: __libc_start_main@GLIBC_2.2.5
  15: _start
```

The only Gauge in scxtop is this one. As it's just a progress bar and accuracy
isn't super important, clamp the float. It's not clear why it goes above 1,
probably a race condition somewhere.
