### PR TITLE
scxtop: make event_data faster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,6 +2516,7 @@ dependencies = [
  "directories",
  "futures",
  "glob",
+ "hashbrown 0.15.2",
  "json5",
  "lazy_static",
  "libbpf-rs",

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -53,6 +53,7 @@ tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "serde"] }
 xdg = "2.5.2"
 log-panics = { version = "2", features = ["with-backtrace"]}
+hashbrown = "0.15.2"
 
 [build-dependencies]
 protobuf-codegen = "3.7.1"

--- a/tools/scxtop/src/cpu_data.rs
+++ b/tools/scxtop/src/cpu_data.rs
@@ -6,6 +6,8 @@
 use crate::EventData;
 use crate::PerfEvent;
 
+use std::collections::VecDeque;
+
 /// Container for per CPU data.
 #[derive(Clone, Debug)]
 pub struct CpuData {
@@ -22,7 +24,7 @@ impl CpuData {
     pub fn new(cpu: usize, core: usize, llc: usize, node: usize, max_data_size: usize) -> CpuData {
         let mut data = EventData::new(max_data_size);
         for event in PerfEvent::default_events() {
-            data.event_data(event.event.clone());
+            data.event_data(&event.event);
         }
         Self {
             llc,
@@ -35,22 +37,22 @@ impl CpuData {
     }
 
     /// Initializes events with default values.
-    pub fn initialize_events(&mut self, events: &Vec<String>) {
+    pub fn initialize_events(&mut self, events: &[&str]) {
         self.data.initialize_events(events);
     }
 
     /// Returns the data for an event and updates if no entry is present.
-    pub fn event_data(&mut self, event: String) -> &Vec<u64> {
+    pub fn event_data(&mut self, event: &str) -> &VecDeque<u64> {
         self.data.event_data(event)
     }
 
     /// Returns the data for an event and updates if no entry is present.
-    pub fn event_data_immut(&self, event: String) -> Vec<u64> {
+    pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
         self.data.event_data_immut(event)
     }
 
     /// Adds data for an event.
-    pub fn add_event_data(&mut self, event: String, val: u64) {
+    pub fn add_event_data(&mut self, event: &str, val: u64) {
         self.data.add_event_data(event, val)
     }
 }

--- a/tools/scxtop/src/event_data.rs
+++ b/tools/scxtop/src/event_data.rs
@@ -3,45 +3,68 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
-use std::collections::BTreeMap;
+// This crate provides basically the same map as `std::collections::HashMap`. However, the raw
+// entry API isn't gated behind an unstable flag that requires a nightly compiler. When (if) the
+// raw entry API stabilises, this should be switched to the standard map.
+use hashbrown::HashMap;
+
+use std::collections::VecDeque;
 
 /// Container for event data.
 #[derive(Clone, Debug)]
 pub struct EventData {
-    pub data: BTreeMap<String, Vec<u64>>,
+    pub data: HashMap<String, VecDeque<u64>>,
     pub max_data_size: usize,
+}
+
+fn vec_deque_truncate_extend_with_zeros(vd: &mut VecDeque<u64>, len: usize) {
+    vd.truncate(len);
+    vd.reserve(len);
+    while vd.len() < len {
+        vd.push_front(0);
+    }
 }
 
 impl EventData {
     /// Creates a new EventData.
     pub fn new(max_data_size: usize) -> EventData {
         Self {
-            data: BTreeMap::new(),
+            data: HashMap::new(),
             max_data_size,
         }
     }
 
     /// Initializes events with default values.
-    pub fn initialize_events(&mut self, events: &Vec<String>) {
+    pub fn initialize_events(&mut self, events: &[&str]) {
         for event in events {
-            self.event_data(event.to_string());
+            self.event_data(event);
         }
     }
 
     /// Returns the data for an event and updates if no entry is present.
-    pub fn event_data(&mut self, event: String) -> &Vec<u64> {
-        self.data.entry(event).or_insert(vec![
-            0,
-            self.max_data_size
-                .try_into()
-                .expect("invalid max data size"),
-        ])
+    pub fn event_data_mut(&mut self, event: &str) -> &mut VecDeque<u64> {
+        self.data
+            .raw_entry_mut()
+            .from_key(event)
+            .or_insert_with(|| {
+                (event.to_string(), {
+                    let mut vd = VecDeque::new();
+                    vec_deque_truncate_extend_with_zeros(&mut vd, self.max_data_size);
+                    vd
+                })
+            })
+            .1
+    }
+
+    /// Returns the data for an event and updates if no entry is present.
+    pub fn event_data(&mut self, event: &str) -> &VecDeque<u64> {
+        self.event_data_mut(event)
     }
 
     /// Zeros out values for an event.
-    pub fn zero_event(&mut self, event: String) {
-        for ref mut val in self.event_data(event) {
-            *val = &0;
+    pub fn zero_event(&mut self, event: &str) {
+        for val in self.event_data_mut(event) {
+            *val = 0;
         }
     }
 
@@ -49,13 +72,13 @@ impl EventData {
     pub fn set_max_size(&mut self, max_data_size: usize) {
         self.max_data_size = max_data_size;
         for event_data in self.data.values_mut() {
-            event_data.truncate(self.max_data_size);
+            vec_deque_truncate_extend_with_zeros(event_data, self.max_data_size);
         }
     }
 
     /// Clears an event.
-    pub fn clear_event(&mut self, event: String) {
-        self.data.remove(&event);
+    pub fn clear_event(&mut self, event: &str) {
+        self.data.remove(event);
     }
 
     /// Clears out all values
@@ -64,12 +87,9 @@ impl EventData {
     }
 
     /// Returns the data for an event and updates if no entry is present.
-    pub fn event_data_immut(&self, event: String) -> Vec<u64> {
-        if self.data.contains_key(&event.clone()) {
-            self.data
-                .get(&event.clone())
-                .expect("failed to get vec")
-                .to_vec()
+    pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
+        if let Some(vs) = self.data.get(event) {
+            vs.iter().copied().collect()
         } else {
             vec![
                 0,
@@ -81,17 +101,12 @@ impl EventData {
     }
 
     /// Adds data for an event.
-    pub fn add_event_data(&mut self, event: String, val: u64) {
-        let size = self.max_data_size - 1;
-        self.data
-            .entry(event.clone())
-            .or_insert(vec![0, size.try_into().expect("invalid max data size")])
-            .push(val);
-        // XXX: make this efficient
-        if let Some(values) = self.data.get_mut(&event.clone()) {
-            if values.len() >= self.max_data_size {
-                values.remove(0);
-            }
+    pub fn add_event_data(&mut self, event: &str, val: u64) {
+        let size = self.max_data_size;
+        let data = self.event_data_mut(event);
+        if data.len() == size {
+            data.pop_front();
         }
+        data.push_back(val);
     }
 }

--- a/tools/scxtop/src/llc_data.rs
+++ b/tools/scxtop/src/llc_data.rs
@@ -6,6 +6,8 @@
 use crate::EventData;
 use crate::PerfEvent;
 
+use std::collections::VecDeque;
+
 /// Container for per LLC data.
 #[derive(Clone, Debug)]
 pub struct LlcData {
@@ -20,7 +22,7 @@ impl LlcData {
     pub fn new(llc: usize, node: usize, max_data_size: usize) -> LlcData {
         let mut data = EventData::new(max_data_size);
         for event in PerfEvent::default_events() {
-            data.event_data(event.event.clone());
+            data.event_data(&event.event);
         }
 
         Self {
@@ -32,35 +34,29 @@ impl LlcData {
     }
 
     /// Initializes events with default values.
-    pub fn initialize_events(&mut self, events: &Vec<String>) {
+    pub fn initialize_events(&mut self, events: &[&str]) {
         self.data.initialize_events(events);
     }
 
     /// Returns the data for an event and updates if no entry is present.
-    pub fn event_data(&mut self, event: String) -> &Vec<u64> {
+    pub fn event_data(&mut self, event: &str) -> &VecDeque<u64> {
         self.data.event_data(event)
     }
 
     /// Returns the data for an event and updates if no entry is present.
-    pub fn event_data_immut(&self, event: String) -> Vec<u64> {
+    pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
         self.data.event_data_immut(event)
     }
 
     /// Adds data for an event.
-    pub fn add_event_data(&mut self, event: String, val: u64) {
+    pub fn add_event_data(&mut self, event: &str, val: u64) {
         self.data.add_event_data(event, val);
     }
 
     /// Adds data for a cpu by updating the first value.
-    pub fn add_cpu_event_data(&mut self, event: String, val: u64) {
-        let size = self.max_data_size - 1;
-        self.data
-            .data
-            .entry(event.clone())
-            .and_modify(|x| {
-                let len = x.len();
-                x[len - 1] += val
-            })
-            .or_insert(vec![0, size.try_into().unwrap()]);
+    pub fn add_cpu_event_data(&mut self, event: &str, val: u64) {
+        let data = self.data.event_data_mut(event);
+        let len = data.len();
+        data[len - 1] += val;
     }
 }

--- a/tools/scxtop/src/node_data.rs
+++ b/tools/scxtop/src/node_data.rs
@@ -6,6 +6,8 @@
 use crate::EventData;
 use crate::PerfEvent;
 
+use std::collections::VecDeque;
+
 /// Container for per NUMA node data.
 #[derive(Clone, Debug)]
 pub struct NodeData {
@@ -19,7 +21,7 @@ impl NodeData {
     pub fn new(node: usize, max_data_size: usize) -> NodeData {
         let mut data = EventData::new(max_data_size);
         for event in PerfEvent::default_events() {
-            data.event_data(event.event.clone());
+            data.event_data(&event.event);
         }
         Self {
             node,
@@ -29,35 +31,29 @@ impl NodeData {
     }
 
     /// Initializes events with default values.
-    pub fn initialize_events(&mut self, events: &Vec<String>) {
+    pub fn initialize_events(&mut self, events: &[&str]) {
         self.data.initialize_events(events);
     }
 
     /// Returns the data for an event and updates if no entry is present.
-    pub fn event_data(&mut self, event: String) -> &Vec<u64> {
+    pub fn event_data(&mut self, event: &str) -> &VecDeque<u64> {
         self.data.event_data(event)
     }
 
     /// Returns the data for an event and updates if no entry is present.
-    pub fn event_data_immut(&self, event: String) -> Vec<u64> {
+    pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
         self.data.event_data_immut(event)
     }
 
     /// Adds data for an event.
-    pub fn add_event_data(&mut self, event: String, val: u64) {
+    pub fn add_event_data(&mut self, event: &str, val: u64) {
         self.data.add_event_data(event, val)
     }
 
     /// Adds data for a cpu by updating the first value.
-    pub fn add_cpu_event_data(&mut self, event: String, val: u64) {
-        let size = self.max_data_size - 1;
-        self.data
-            .data
-            .entry(event.clone())
-            .and_modify(|x| {
-                let len = x.len();
-                x[len - 1] += val
-            })
-            .or_insert(vec![0, size.try_into().unwrap()]);
+    pub fn add_cpu_event_data(&mut self, event: &str, val: u64) {
+        let data = self.data.event_data_mut(event);
+        let len = data.len();
+        data[len - 1] += val;
     }
 }


### PR DESCRIPTION

EventData has a lot of string copies and a `Vec::remove(0)`.

Changes made:
- Replace the `std::collections::BTreeMap` with a `hashbrown::HashMap`. This is
  very similar to `std::collections::HashMap` now but has the benefit of not
  needing a nightly compiler to use the `raw_entry_mut` API.
- Use the `event_data_mut` API to avoid cloning the `String` in the common
  (hit) case.
- Proliferate that String change everywhere.
- Change the `Vec` to a `std::collections::VecDeque` to make popping from the
  front cheap.
