### PR TITLE
scxtop: Update build script to not recompile protos

### DIFF
--- a/tools/scxtop/build.rs
+++ b/tools/scxtop/build.rs
@@ -4,6 +4,7 @@
 // GNU General Public License version 2.
 
 fn main() {
+    println!("cargo::rerun-if-changed=src/protos/perfetto_scx.proto");
     protobuf_codegen::Codegen::new()
         .pure()
         .cargo_out_dir("protos_gen/")


### PR DESCRIPTION
Update the build script to be less aggressive about recompiling protobuf files. This should improve build times.