### PR TITLE
build: Add release-fast build mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,11 @@ resolver = "2"
 
 [profile.release]
 lto = true
+
+[profile.release-fast]
+inherits = "release"
+target-cpu = "native"
+lto = false
+incremental = true
+opt-level = 0
+debuginfo = 0


### PR DESCRIPTION
Add `release-fast` build mode for fast local builds for testing.

`release` build:
<img width="436" alt="image" src="https://github.com/user-attachments/assets/96780576-9289-451b-bc04-24838d940058" />

`release-quick` build:
<img width="436" alt="image" src="https://github.com/user-attachments/assets/983b9d72-2df3-4f05-b37b-bd5f36c62673" />

Build timings generated with:
```
cargo build --timings --profile release
```