### PR TITLE
scxtop: use smartstr with SSO for comms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,6 +2537,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "simplelog",
+ "smartstring",
  "strip-ansi-escapes",
  "tokio",
  "tokio-util",
@@ -2701,6 +2702,18 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "serde",
+ "static_assertions",
+ "version_check",
+]
 
 [[package]]
 name = "socket2"

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -54,6 +54,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter", "serde"] }
 xdg = "2.5.2"
 log-panics = { version = "2", features = ["with-backtrace"]}
 hashbrown = "0.15.2"
+smartstring = { version = "1.0.1", features = ["serde"] }
 
 [build-dependencies]
 protobuf-codegen = "3.7.1"

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -661,7 +661,7 @@ impl<'a> App<'a> {
                     .title_top(
                         Line::from(if self.collect_uncore_freq {
                             "uncore ".to_string()
-                                + &format_hz(
+                                + format_hz(
                                     self.node_data
                                         .get(&node)
                                         .unwrap()
@@ -670,6 +670,7 @@ impl<'a> App<'a> {
                                         .copied()
                                         .unwrap_or(0_u64),
                                 )
+                                .as_str()
                         } else {
                             "".to_string()
                         })
@@ -1509,7 +1510,7 @@ impl<'a> App<'a> {
                         .title_top(
                             Line::from(if self.collect_uncore_freq {
                                 "uncore ".to_string()
-                                    + &format_hz(
+                                    + format_hz(
                                         self.node_data
                                             .get(&node.id)
                                             .unwrap()
@@ -1518,6 +1519,7 @@ impl<'a> App<'a> {
                                             .copied()
                                             .unwrap_or(0_u64),
                                     )
+                                    .as_str()
                             } else {
                                 "".to_string()
                             })
@@ -1627,7 +1629,7 @@ impl<'a> App<'a> {
                         .title_top(
                             Line::from(if self.collect_uncore_freq {
                                 "uncore ".to_string()
-                                    + &format_hz(
+                                    + format_hz(
                                         self.node_data
                                             .get(&node.id)
                                             .unwrap()
@@ -1636,6 +1638,7 @@ impl<'a> App<'a> {
                                             .copied()
                                             .unwrap_or(0_u64),
                                     )
+                                    .as_str()
                             } else {
                                 "".to_string()
                             })

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -46,6 +46,8 @@ pub use plain::Plain;
 // Generate serialization types for handling events from the bpf ring buffer.
 unsafe impl Plain for crate::bpf_skel::types::bpf_event {}
 
+use smartstring::alias::String as SsoString;
+
 pub const APP: &str = "scxtop";
 pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
@@ -117,14 +119,14 @@ pub struct SchedSwitchAction {
     pub next_pid: u32,
     pub next_tgid: u32,
     pub next_prio: i32,
-    pub next_comm: String,
+    pub next_comm: SsoString,
     pub prev_dsq_id: u64,
     pub prev_used_slice_ns: u64,
     pub prev_slice_ns: u64,
     pub prev_pid: u32,
     pub prev_tgid: u32,
     pub prev_prio: i32,
-    pub prev_comm: String,
+    pub prev_comm: SsoString,
     pub prev_state: u64,
 }
 
@@ -134,7 +136,7 @@ pub struct SchedWakeActionCtx {
     pub cpu: u32,
     pub pid: u32,
     pub prio: i32,
-    pub comm: String,
+    pub comm: SsoString,
 }
 
 pub type SchedWakeupNewAction = SchedWakeActionCtx;

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -224,7 +224,7 @@ impl PerfettoTraceManager {
 
             wakeup_event.set_pid(pid.try_into().unwrap());
             wakeup_event.set_prio(*prio);
-            wakeup_event.set_comm(comm.clone());
+            wakeup_event.set_comm(comm.to_string());
             wakeup_event.set_target_cpu(cpu);
 
             ftrace_event.set_timestamp(*ts);
@@ -258,7 +258,7 @@ impl PerfettoTraceManager {
 
             waking_event.set_pid(pid.try_into().unwrap());
             waking_event.set_prio(*prio);
-            waking_event.set_comm(comm.clone());
+            waking_event.set_comm(comm.to_string());
             waking_event.set_target_cpu(cpu);
 
             ftrace_event.set_timestamp(*ts);
@@ -337,11 +337,11 @@ impl PerfettoTraceManager {
             let next_pid: i32 = *next_pid as i32;
 
             switch_event.set_next_pid(next_pid);
-            switch_event.set_next_comm(next_comm.clone());
+            switch_event.set_next_comm(next_comm.to_string());
             switch_event.set_next_prio(*next_prio);
             switch_event.set_prev_pid(prev_pid);
             switch_event.set_prev_prio(*prev_prio);
-            switch_event.set_prev_comm(prev_comm.clone());
+            switch_event.set_prev_comm(prev_comm.to_string());
             switch_event.set_prev_state(*prev_state as i64);
             ftrace_event.set_timestamp(*ts);
             ftrace_event.set_sched_switch(switch_event);


### PR DESCRIPTION

We pass around a bunch of Comm strings in scxtop that comfortably fit in the
allocation of the string, but were each doing an allocation/deallocation and
being copied multiple times.

Use a crate `smartstr` to get a string with Small String Optimization. This
string fits 23 bytes in the string itself without a heap allocation.

Test plan:
- Took a perfetto trace, comms look good.
