### PR TITLE
scx_layered: revamp gpu support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,7 +2312,6 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "log",
- "nvml-wrapper",
  "once_cell",
  "scx_stats",
  "scx_stats_derive",
@@ -2320,7 +2319,6 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
- "sysinfo 0.30.13",
 ]
 
 [[package]]
@@ -2334,7 +2332,7 @@ dependencies = [
  "log",
  "nix 0.29.0",
  "serde",
- "sysinfo 0.33.1",
+ "sysinfo",
  "tokio",
  "tokio-util",
  "toml",
@@ -2841,21 +2839,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "windows 0.52.0",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
@@ -2865,7 +2848,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows 0.57.0",
+ "windows",
 ]
 
 [[package]]
@@ -3424,16 +3407,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "windows"

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -25,9 +25,7 @@ scx_utils = { path = "../../../rust/scx_utils", version = "1.0.11" }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 simplelog = "0.12"
-nvml-wrapper = "0.10.0"
 once_cell = "1.20.2"
-sysinfo = "0.30"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.11" }

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -243,8 +243,8 @@ enum layer_match_kind {
 	MATCH_NS_EQUALS,
 	MATCH_SCXCMD_JOIN,
 	MATCH_IS_GROUP_LEADER,
-	MATCH_USING_GPU,
-	MATCH_USED_GPU,
+	MATCH_USED_GPU_TID,
+	MATCH_USED_GPU_PID,
 
 	NR_LAYER_MATCH_KINDS,
 };
@@ -262,8 +262,8 @@ struct layer_match {
 	u32		tgid;
 	u64		nsid;
 	bool		is_group_leader;
-	bool	using_gpu;
-	bool	used_gpu;
+	bool	used_gpu_tid;
+	bool	used_gpu_pid;
 };
 
 struct layer_match_ands {

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -75,8 +75,8 @@ pub enum LayerMatch {
     NSEquals(u32),
     CmdJoin(String),
     IsGroupLeader(bool),
-    UsingGpu(bool),
-    UsedGpu(bool),
+    UsedGpuTid(bool),
+    UsedGpuPid(bool),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -7,7 +7,6 @@ mod stats;
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::ffi::CString;
 use std::fs;
 use std::io::Write;
@@ -29,18 +28,18 @@ pub use bpf_skel::*;
 use clap::Parser;
 use crossbeam::channel::RecvTimeoutError;
 use lazy_static::lazy_static;
+use libbpf_rs::libbpf_sys::bpf_program__set_autoload;
 use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::Skel;
 use libbpf_rs::skel::SkelBuilder;
+use libbpf_rs::AsRawLibbpf;
 use libbpf_rs::MapCore as _;
-use libbpf_rs::MapHandle;
 use libbpf_rs::OpenObject;
 use libbpf_rs::ProgramInput;
 use log::debug;
 use log::info;
 use log::trace;
 use log::warn;
-use nvml_wrapper::Nvml;
 use scx_layered::*;
 use scx_stats::prelude::*;
 use scx_utils::compat;
@@ -65,7 +64,8 @@ use stats::LayerStats;
 use stats::StatsReq;
 use stats::StatsRes;
 use stats::SysStats;
-use sysinfo::System;
+use std::collections::HashSet;
+use std::io::BufRead;
 
 const MAX_PATH: usize = bpf_intf::consts_MAX_PATH as usize;
 const MAX_COMM: usize = bpf_intf::consts_MAX_COMM as usize;
@@ -221,8 +221,6 @@ lazy_static! {
     };
 }
 
-static NVML_CELL: once_cell::sync::OnceCell<Nvml> = once_cell::sync::OnceCell::new();
-
 /// scx_layered: A highly configurable multi-layer sched_ext scheduler
 ///
 /// scx_layered allows classifying tasks into multiple layers and applying
@@ -301,11 +299,11 @@ static NVML_CELL: once_cell::sync::OnceCell<Nvml> = once_cell::sync::OnceCell::n
 /// - CmdJoin: Matches when the task uses pthread_setname_np to send a join/leave
 /// command to the scheduler. See examples/cmdjoin.c for more details.
 ///
-/// - UsingGpu: Bool. When true, matches if the task is using a gpu
-///   as of the last time NVML was polled. When false, inverted.
+/// - UsedGpuTid: Bool. When true, matches if the tasks which have used
+///   gpus by tid.
 ///
-/// - UsedGpu: Bool. When true, matches if the task has ever used a gpu
-///   as of the last time NVML was polled. When false, inverted.
+/// - UsedGpuPid: Bool. When true, matches if the tasks which have used gpu
+///   by tgid/pid.
 ///
 /// While there are complexity limitations as the matches are performed in
 /// BPF, it is straightforward to add more types of matches.
@@ -555,19 +553,6 @@ struct Opts {
     #[clap(long, default_value = "false")]
     enable_gpu_support: bool,
 
-    /// GPU Pid Poll Short Interval, if gpu support enabled.
-    #[clap(long, default_value = "180")]
-    gpu_poll_short_interval: u64,
-
-    /// On each user space update loop, use NVML to update GPU pids.
-    /// The alternative (and default) is to use loose heuristics
-    /// (i.e. start_time/existence of prior gpu process) to
-    /// reduce NVML calls (at the expense of scheduling accuracy).
-    /// This is to reduce the odds of taking systems offline due to NVML
-    /// triggering crashes when concurrently called.
-    #[clap(long, default_value = "false")]
-    aggressive_nvml_polling: bool,
-
     /// Enable netdev IRQ balancing. This is experimental and should be used with caution.
     #[clap(long, default_value = "false")]
     netdev_irq_balance: bool,
@@ -600,6 +585,20 @@ fn read_total_cpu(reader: &procfs::ProcReader) -> Result<procfs::CpuStat> {
         .context("Failed to read procfs")?
         .total_cpu
         .ok_or_else(|| anyhow!("Could not read total cpu stat in proc"))
+}
+
+fn sym_exists(sym: &str) -> bool {
+    let file = std::fs::File::open("/proc/kallsyms").expect("kallsyms missing");
+    let reader = std::io::BufReader::new(file);
+    let mut syms_present: HashSet<String> = HashSet::new();
+
+    for line in reader.lines() {
+        for sym in line.unwrap().split_whitespace() {
+            syms_present.insert(sym.into());
+        }
+    }
+
+    syms_present.contains(sym)
 }
 
 fn calc_util(curr: &procfs::CpuStat, prev: &procfs::CpuStat) -> Result<f64> {
@@ -788,13 +787,6 @@ impl<'a, 'b> Sub<&'b BpfStats> for &'a BpfStats {
                 .collect(),
         }
     }
-}
-
-#[derive(Debug)]
-struct GpuMonData {
-    sysinfo_sys: sysinfo::System,
-    last_nvml_poll: std::time::SystemTime,
-    gpu_pid_to_start_time: HashMap<u32, u64>,
 }
 
 #[derive(Clone, Debug)]
@@ -1156,8 +1148,6 @@ struct Scheduler<'a> {
     topo: Arc<Topology>,
     netdevs: BTreeMap<String, NetDev>,
     stats_server: StatsServer<StatsReq, StatsRes>,
-    opts: &'a Opts,
-    gpu_mon_data: GpuMonData,
 }
 
 impl<'a> Scheduler<'a> {
@@ -1236,13 +1226,13 @@ impl<'a> Scheduler<'a> {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_IS_GROUP_LEADER as i32;
                             mt.is_group_leader.write(*polarity);
                         }
-                        LayerMatch::UsingGpu(polarity) => {
-                            mt.kind = bpf_intf::layer_match_kind_MATCH_USING_GPU as i32;
-                            mt.using_gpu.write(*polarity);
+                        LayerMatch::UsedGpuTid(polarity) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_USED_GPU_TID as i32;
+                            mt.used_gpu_tid.write(*polarity);
                         }
-                        LayerMatch::UsedGpu(polarity) => {
-                            mt.kind = bpf_intf::layer_match_kind_MATCH_USED_GPU as i32;
-                            mt.used_gpu.write(*polarity);
+                        LayerMatch::UsedGpuPid(polarity) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_USED_GPU_PID as i32;
+                            mt.used_gpu_pid.write(*polarity);
                         }
                     }
                 }
@@ -1716,6 +1706,22 @@ impl<'a> Scheduler<'a> {
         skel_builder.obj_builder.debug(opts.verbose > 1);
         init_libbpf_logging(None);
         let mut skel = scx_ops_open!(skel_builder, open_object, layered)?;
+
+        // enable autoloads for conditionally loaded things
+        // immediately after creating skel (because this is always before loading)
+        if opts.enable_gpu_support {
+            if sym_exists("nvidia_open") {
+                unsafe {
+                    bpf_program__set_autoload(
+                        skel.progs.save_gpu_tgid_pid.as_libbpf_object().as_ptr(),
+                        true,
+                    );
+                }
+            } else {
+                warn!("--enable-gpu-support was set but nvidia_open symbol is missing.")
+            }
+        }
+
         skel.maps.rodata_data.slice_ns = scx_enums.SCX_SLICE_DFL;
         skel.maps.rodata_data.max_exec_ns = 20 * scx_enums.SCX_SLICE_DFL;
 
@@ -1837,6 +1843,7 @@ impl<'a> Scheduler<'a> {
             ..Default::default()
         };
         let prog = &mut skel.progs.initialize_pid_namespace;
+
         let _ = prog.test_run(input);
 
         // XXX If we try to refresh the cpumasks here before attaching, we
@@ -1848,14 +1855,6 @@ impl<'a> Scheduler<'a> {
         // Attach.
         let struct_ops = scx_ops_attach!(skel, layered)?;
         let stats_server = StatsServer::new(stats::server_data()).launch()?;
-        let gpu_mon_data = GpuMonData {
-            sysinfo_sys: System::new_with_specifics(
-                sysinfo::RefreshKind::new()
-                    .with_processes(sysinfo::ProcessRefreshKind::everything()),
-            ),
-            last_nvml_poll: std::time::SystemTime::now(),
-            gpu_pid_to_start_time: HashMap::new(),
-        };
 
         let sched = Self {
             struct_ops: Some(struct_ops),
@@ -1877,8 +1876,6 @@ impl<'a> Scheduler<'a> {
             topo,
             netdevs,
             stats_server,
-            opts,
-            gpu_mon_data,
         };
 
         info!("Layered Scheduler Attached. Run `scx_layered --monitor` for metrics.");
@@ -1938,141 +1935,6 @@ impl<'a> Scheduler<'a> {
             netdev.apply_cpumasks()?;
         }
 
-        Ok(())
-    }
-
-    fn update_gpu_pids(&mut self) -> Result<()> {
-        if !self.opts.enable_gpu_support {
-            return Ok(());
-        }
-
-        let nvml = NVML_CELL.get_or_try_init(|| {
-            Nvml::init().context("enabling GPU support requires a nvidia device")
-        })?;
-
-        let mut missing_gpu_pid = false;
-
-        if !self.opts.aggressive_nvml_polling {
-            self.gpu_mon_data
-                .sysinfo_sys
-                .refresh_processes_specifics(sysinfo::ProcessRefreshKind::new());
-            let current_pidmap = self.gpu_mon_data.sysinfo_sys.processes();
-            if self.gpu_mon_data.gpu_pid_to_start_time.is_empty() {
-                missing_gpu_pid = true;
-            } else {
-                for (k, v) in self.gpu_mon_data.gpu_pid_to_start_time.iter() {
-                    let k_pid = sysinfo::Pid::from_u32(*k);
-                    if current_pidmap.contains_key(&k_pid) {
-                        if *v < current_pidmap.get(&k_pid).unwrap().start_time() {
-                            missing_gpu_pid = true;
-                            break;
-                        }
-                    } else {
-                        missing_gpu_pid = true;
-                        break;
-                    }
-                }
-            }
-        }
-
-        let time_since_last_update = std::time::SystemTime::now()
-            .duration_since(self.gpu_mon_data.last_nvml_poll)?
-            .as_secs();
-        let since_last_update_short = time_since_last_update > self.opts.gpu_poll_short_interval;
-        let since_last_update_600s = time_since_last_update > 600;
-
-        if self.opts.aggressive_nvml_polling
-            || (missing_gpu_pid && since_last_update_short)
-            || (since_last_update_600s)
-        {
-            debug!("calling NVML to update GPU pids");
-            self.gpu_mon_data.last_nvml_poll = std::time::SystemTime::now();
-            let device_count = nvml.device_count()?;
-            let mut pids = HashSet::new();
-            // Iterate over all devices and gather running processes
-            for i in 0..device_count {
-                let device = nvml.device_by_index(i)?;
-                let procs = device.running_compute_processes()?;
-
-                for proc_info in procs {
-                    pids.insert(proc_info.pid);
-                }
-            }
-
-            // ensure current pids only have current pids.
-            let all_pid_bpf_map = MapHandle::try_from(&self.skel.maps.all_gpu_pid)?;
-            let cur_pid_bpf_map = MapHandle::try_from(&self.skel.maps.cur_gpu_pid)?;
-
-            // get deletes for current, state of the world for all.
-            let mut cur_pid_bpf_set = HashSet::new();
-            let mut all_pid_bpf_set = HashSet::new();
-
-            for key in cur_pid_bpf_map.keys() {
-                let sized_bytes: [u8; 4] = key
-                    .try_into()
-                    .expect("failed to convert pid bytes to sized bytes");
-                let pid: u32 = u32::from_ne_bytes(sized_bytes);
-                cur_pid_bpf_set.insert(pid);
-            }
-            for key in all_pid_bpf_map.keys() {
-                let sized_bytes: [u8; 4] = key
-                    .try_into()
-                    .expect("failed to convert pid bytes to sized bytes");
-                let pid: u32 = u32::from_ne_bytes(sized_bytes);
-                all_pid_bpf_set.insert(pid);
-            }
-
-            let cur_delete_set = cur_pid_bpf_set.difference(&pids);
-            let cur_add_set = pids.difference(&pids);
-            let all_add_set = pids.difference(&all_pid_bpf_set);
-
-            let zero_bytes = (0 as u32).to_ne_bytes();
-            use libbpf_rs::MapFlags;
-            for pid in cur_add_set.cloned() {
-                let pid_bytes = pid.to_ne_bytes();
-                cur_pid_bpf_map.update(&pid_bytes, &zero_bytes, MapFlags::ANY)?;
-            }
-
-            for pid in cur_delete_set.cloned() {
-                let pid_bytes = pid.to_ne_bytes();
-                cur_pid_bpf_map.delete(&pid_bytes)?;
-            }
-
-            for pid in all_add_set.cloned() {
-                let pid_bytes = pid.to_ne_bytes();
-                all_pid_bpf_map.update(&pid_bytes, &zero_bytes, MapFlags::ANY)?;
-            }
-            // bookkeeping for non-agressive mode
-            self.gpu_mon_data
-                .sysinfo_sys
-                .refresh_processes_specifics(sysinfo::ProcessRefreshKind::new());
-            self.gpu_mon_data.gpu_pid_to_start_time.clear();
-            for x in pids {
-                let x_pid = sysinfo::Pid::from_u32(x);
-                if self
-                    .gpu_mon_data
-                    .sysinfo_sys
-                    .processes()
-                    .contains_key(&x_pid)
-                {
-                    let proc = self
-                        .gpu_mon_data
-                        .sysinfo_sys
-                        .processes()
-                        .get(&x_pid)
-                        .unwrap();
-                    self.gpu_mon_data
-                        .gpu_pid_to_start_time
-                        .insert(x, proc.start_time());
-                } else {
-                    self.gpu_mon_data.gpu_pid_to_start_time.insert(x, 0);
-                }
-            }
-            debug!(
-                "GPU PIDs are: {:#?}",
-                self.gpu_mon_data.gpu_pid_to_start_time
-            );
-        }
         Ok(())
     }
 
@@ -2382,7 +2244,6 @@ impl<'a> Scheduler<'a> {
             self.processing_dur,
         )?;
         self.refresh_cpumasks()?;
-        self.update_gpu_pids()?;
         self.processing_dur += Instant::now().duration_since(started_at);
         Ok(())
     }


### PR DESCRIPTION
redo gpu support for layered

* remove the hacks to avoid using nvml and replace that with a kprobe on nvidia-open.
* have the kprobe be conditionally loaded such that layered loads/runs with and without the symbol nvidia_open present.
* remove no_prealloc from the gpu pid map and make the gpu pid map lru.

this seems to work better than the prior solution:

radeon machine:
![Pasted image](https://github.com/user-attachments/assets/c9b9d489-9883-46bd-91e2-656e7e6bf9fb)

nvidia machine:
![Pasted image (2)](https://github.com/user-attachments/assets/f7f201d0-e28e-48d7-a0b5-969b0a579633)
 
