### PR TITLE
scxtop: add config merging interface

### DIFF
--- a/tools/scxtop/src/cli.rs
+++ b/tools/scxtop/src/cli.rs
@@ -25,7 +25,7 @@ pub struct Cli {
     pub tui: TuiArgs,
 }
 
-#[derive(Parser, Debug)]
+#[derive(Clone, Parser, Debug)]
 #[command(about = APP)]
 pub struct TuiArgs {
     /// App tick rate in milliseconds.

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -78,8 +78,10 @@ fn run_tui(tui_args: &TuiArgs) -> Result<()> {
             .install_panic_hook();
     };
 
-    let mut config = Config::load().unwrap_or(Config::default_config());
-    config = Config::merge_tui_args(&config, tui_args);
+    let config = Config::merge([
+        Config::from(tui_args.clone()),
+        Config::load().unwrap_or(Config::default_config()),
+    ]);
     let keymap = config.active_keymap.clone();
 
     tokio::runtime::Builder::new_multi_thread()


### PR DESCRIPTION

The `Config::merge_tui_args` method is quite complicated and needs modifying
each time. It leaves the `Config` in a mostly-Some state, meaning combining
more than one `TuiArgs` for whatever reason wouldn't work.

Generalise this into a `Config::merge` method which prefers the left-most
value. This is done with an extension of the `Option::or` method for all fields
in the config struct, meaning the left-most set value will win. We can then
replace `Config::merge_tui_args` with a combination of `From<TuiArgs> for Config`
and `Config::merge`. This turns the quite complicated function into two simple
ones.

Test plan:
- Wrote a test to confirm fields get merged as expected.
