### PR TITLE
scxtop: Set correct max on LLC sparkline view

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -592,7 +592,7 @@ impl<'a> App<'a> {
     }
 
     /// creates as sparkline for a llc.
-    fn llc_sparkline(&self, llc: usize, bottom_border: bool) -> Sparkline {
+    fn llc_sparkline(&self, llc: usize, max: u64, bottom_border: bool) -> Sparkline {
         let data = if self.llc_data.contains_key(&llc) {
             let llc_data = self.llc_data.get(&llc).unwrap();
             llc_data.event_data_immut(&self.active_event.event)
@@ -603,6 +603,7 @@ impl<'a> App<'a> {
 
         Sparkline::default()
             .data(&data)
+            .max(max)
             .direction(RenderDirection::RightToLeft)
             .style(self.theme().sparkline_style())
             .block(
@@ -756,7 +757,7 @@ impl<'a> App<'a> {
                 self.topo
                     .all_llcs
                     .keys()
-                    .map(|llc_id| self.llc_sparkline(*llc_id, *llc_id == num_llcs - 1))
+                    .map(|llc_id| self.llc_sparkline(*llc_id, stats.max, *llc_id == num_llcs - 1))
                     .enumerate()
                     .for_each(|(i, llc_sparkline)| {
                         frame.render_widget(llc_sparkline, llcs_verticle[i + 1]);


### PR DESCRIPTION
Set the max on the LLC sparkline view to be the maximum aggregated across all LLCs. This makes the TUI far more easier to intrepret across LLCs.

<img width="957" alt="image" src="https://github.com/user-attachments/assets/66d659e7-4b6c-4175-a164-8a4540509fca" />
