### PR TITLE
scxtop: Fix max sparkline value across NUMA nodes

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -636,7 +636,7 @@ impl<'a> App<'a> {
     }
 
     /// creates as sparkline for a node.
-    fn node_sparkline(&self, node: usize, bottom_border: bool) -> Sparkline {
+    fn node_sparkline(&self, node: usize, max: u64, bottom_border: bool) -> Sparkline {
         let data = if self.llc_data.contains_key(&node) {
             let node_data = self.node_data.get(&node).unwrap();
             node_data.event_data_immut(&self.active_event.event)
@@ -647,6 +647,7 @@ impl<'a> App<'a> {
 
         Sparkline::default()
             .data(&data)
+            .max(max)
             .direction(RenderDirection::RightToLeft)
             .style(self.theme().sparkline_style())
             .block(
@@ -842,7 +843,9 @@ impl<'a> App<'a> {
                     .topo
                     .nodes
                     .keys()
-                    .map(|node_id| self.node_sparkline(*node_id, *node_id == num_nodes - 1))
+                    .map(|node_id| {
+                        self.node_sparkline(*node_id, stats.max, *node_id == num_nodes - 1)
+                    })
                     .collect();
 
                 let node_block = Block::bordered()


### PR DESCRIPTION
Use the max aggregated across all NUMA nodes when rendering NUMA sparklines. This makes it easier to make comparisons across NUMA nodes.

<img width="957" alt="image" src="https://github.com/user-attachments/assets/61659a57-4e43-42cb-ba78-cfcd7e45ed0b" />
