### PR TITLE
scxtop: concurrently await tui events and actions

### DIFF
--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -188,7 +188,6 @@ pub enum Action {
     Quit,
     RecordTrace(RecordTraceAction),
     ReloadStatsClient,
-    Render,
     SaveConfig,
     SchedCpuPerfSet(SchedCpuPerfSetAction),
     SchedReg,


### PR DESCRIPTION

scxtop currently waits for a TUI event, then try_recvs every waiting action. This
works okay when every action can be consumed in under one frame time, but
poorly when there is a large queue of actions. Bad behaviour shows up under a
large queue such as 'q' taking a long time to exit the application or render
events not getting through at all.

Changes the main wait loop to a `tokio::select!` which waits for both events.
This means events still get handled. It's not a complete solution given many of
those events get converted directly into actions, but it works for now. Also
cleans up `Action::Render` which doesn't have a clear use case.

To get the full interactivity win here we need to stop relying on Events
passing through `action_tx` quickly, but this is a start.

Test plan:
- Launched the TUI. Things look dynamic - it's refreshing counters and updating
  frames.
