### PR TITLE
scx_bpfland: NUMA-aware scheduling

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -70,6 +70,7 @@ void scx_bpf_dump_bstr(char *fmt, unsigned long long *data, u32 data_len) __ksym
 u32 scx_bpf_cpuperf_cap(s32 cpu) __ksym __weak;
 u32 scx_bpf_cpuperf_cur(s32 cpu) __ksym __weak;
 void scx_bpf_cpuperf_set(s32 cpu, u32 perf) __ksym __weak;
+u32 scx_bpf_nr_node_ids(void) __ksym __weak;
 u32 scx_bpf_nr_cpu_ids(void) __ksym __weak;
 int scx_bpf_cpu_node(s32 cpu) __ksym __weak;
 const struct cpumask *scx_bpf_get_possible_cpumask(void) __ksym __weak;

--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -189,6 +189,10 @@ static inline bool __COMPAT_is_enq_cpu_selected(u64 enq_flags)
  *
  * Preserve the following __COMPAT_scx_*_node macros until v6.17.
  */
+#define __COMPAT_scx_bpf_nr_node_ids()						\
+	(bpf_ksym_exists(scx_bpf_nr_node_ids) ?					\
+	 scx_bpf_nr_node_ids() : 1U)
+
 #define __COMPAT_scx_bpf_cpu_node(cpu)						\
 	(bpf_ksym_exists(scx_bpf_cpu_node) ?					\
 	 scx_bpf_cpu_node(cpu) : 0)

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -283,8 +283,18 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.slice_min = opts.slice_us_min * 1000;
         skel.maps.rodata_data.slice_lag = opts.slice_us_lag * 1000;
 
-        // Disable automatic dispatch of migration-disabled tasks.
-        skel.struct_ops.bpfland_ops_mut().flags |= *compat::SCX_OPS_ENQ_MIGRATION_DISABLED;
+        // Set scheduler compatibility flags.
+        skel.maps.rodata_data.__COMPAT_SCX_PICK_IDLE_IN_NODE = *compat::SCX_PICK_IDLE_IN_NODE;
+
+        // Set scheduler flags.
+        skel.struct_ops.bpfland_ops_mut().flags = *compat::SCX_OPS_ENQ_EXITING
+            | *compat::SCX_OPS_ENQ_LAST
+            | *compat::SCX_OPS_ENQ_MIGRATION_DISABLED
+            | *compat::SCX_OPS_BUILTIN_IDLE_PER_NODE;
+        info!(
+            "scheduler flags: {:#x}",
+            skel.struct_ops.bpfland_ops_mut().flags
+        );
 
         // Load the BPF program for validation.
         let mut skel = scx_ops_load!(skel, bpfland_ops, uei)?;


### PR DESCRIPTION
Use the new sched_ext node-aware APIs to account for NUMA topologies in the scheduling decisions.