### PR TITLE
scxtop: adding gpu_mem_total tracepoint.

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -24,7 +24,7 @@ use crate::APP;
 use crate::LICENSE;
 use crate::SCHED_NAME_PATH;
 use crate::{
-    Action, IPIAction, RecordTraceAction, SchedCpuPerfSetAction, SchedSwitchAction,
+    Action, GpuMemAction, IPIAction, RecordTraceAction, SchedCpuPerfSetAction, SchedSwitchAction,
     SchedWakeupAction, SchedWakingAction, SoftIRQAction,
 };
 
@@ -2261,6 +2261,12 @@ impl<'a> App<'a> {
         }
     }
 
+    pub fn on_gpu_mem(&mut self, action: &GpuMemAction) {
+        if self.trace_tick > self.config.trace_tick_warmup() {
+            self.trace_manager.on_gpu_mem(action);
+        }
+    }
+
     /// Updates the bpf bpf sampling rate.
     pub fn update_bpf_sample_rate(&mut self, sample_rate: u32) {
         self.skel.maps.data_data.sample_rate = sample_rate;
@@ -2331,6 +2337,9 @@ impl<'a> App<'a> {
             }
             Action::IPI(a) => {
                 self.on_ipi(a);
+            }
+            Action::GpuMem(a) => {
+                self.on_gpu_mem(a);
             }
             Action::ClearEvent => self.stop_perf_events(),
             Action::ChangeTheme => {

--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -25,6 +25,7 @@ enum stat_id {
 
 enum event_type {
 	CPU_PERF_SET,
+	GPU_MEM,
 	IPI,
 	SCHED_REG,
 	SCHED_SWITCH,
@@ -80,11 +81,18 @@ struct ipi_event {
 	u32		target_cpu;
 };
 
+struct gpu_mem_event {
+	u64             size;
+	u32             gpu;
+	u32             pid;
+};
+
 struct bpf_event {
 	int		type;
 	u64		ts;
 	u32		cpu;
 	union {
+		struct  gpu_mem_event gm;
 		struct	ipi_event ipi;
 		struct	sched_switch_event sched_switch;
 		struct	set_perf_event perf;

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -168,6 +168,15 @@ pub struct IPIAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct GpuMemAction {
+    pub ts: u64,
+    pub size: u64,
+    pub cpu: u32,
+    pub gpu: u32,
+    pub pid: u32,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Action {
     ChangeTheme,
     ClearEvent,
@@ -176,6 +185,7 @@ pub enum Action {
     Down,
     Enter,
     Event,
+    GpuMem(GpuMemAction),
     Help,
     IncBpfSampleRate,
     IncTickRate,
@@ -239,6 +249,14 @@ impl TryFrom<&bpf_event> for Action {
                 cpu: event.cpu,
                 pid: unsafe { event.event.ipi.pid },
                 target_cpu: unsafe { event.event.ipi.target_cpu },
+            })),
+            #[allow(non_upper_case_globals)]
+            bpf_intf::event_type_GPU_MEM => Ok(Action::GpuMem(GpuMemAction {
+                ts: event.ts,
+                cpu: event.cpu,
+                pid: unsafe { event.event.gm.pid },
+                gpu: unsafe { event.event.gm.gpu },
+                size: unsafe { event.event.gm.size },
             })),
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_SOFTIRQ => {


### PR DESCRIPTION
when for a given GPU, its memory activity fluctuates, this event is triggered. Could be on a process basis or globally.