### PR TITLE
scx_layered: expand kprobes used for gpu support

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -192,7 +192,6 @@ struct {
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 } gpu_tid SEC(".maps");
 
-SEC("?kprobe/nvidia_open")
 int save_gpu_tgid_pid() {
 	if (!enable_gpu_support)
 		return 0;
@@ -206,6 +205,21 @@ int save_gpu_tgid_pid() {
 	bpf_map_update_elem(&gpu_tid, &tid, &zero, BPF_ANY);
 	bpf_map_update_elem(&gpu_tgid, &pid, &zero, BPF_ANY);
 	return 0;
+}
+
+SEC("?kprobe/nvidia_poll")
+int kprobe_nvidia_poll() {
+	return save_gpu_tgid_pid();
+}
+
+SEC("?kprobe/nvidia_open")
+int kprobe_nvidia_open() {
+	return save_gpu_tgid_pid();
+}
+
+SEC("?kprobe/nvidia_mmap")
+int kprobe_nvidia_mmap() {
+	return save_gpu_tgid_pid();
 }
 
 // XXX - Converting this to bss array triggers verifier bugs. See

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1704,7 +1704,9 @@ impl<'a> Scheduler<'a> {
         // enable autoloads for conditionally loaded things
         // immediately after creating skel (because this is always before loading)
         if opts.enable_gpu_support {
-            compat::cond_kprobe_enable("nvidia_open", &skel.progs.save_gpu_tgid_pid)?;
+            compat::cond_kprobe_enable("nvidia_open", &skel.progs.kprobe_nvidia_open)?;
+            compat::cond_kprobe_enable("nvidia_poll", &skel.progs.kprobe_nvidia_poll)?;
+            compat::cond_kprobe_enable("nvidia_mmap", &skel.progs.kprobe_nvidia_mmap)?;
         }
 
         skel.maps.rodata_data.slice_ns = scx_enums.SCX_SLICE_DFL;


### PR DESCRIPTION
add kprobes for nvidia_mmap, nvidia_poll, nvidia_open.

these in combination with IsGroupLeader seem to identify pids using gpus reasonably well (including when layered is started after the PIDs using GPUs are).