### PR TITLE
scxtop: Conditionally attach GPU probes

### DIFF
--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -677,7 +677,7 @@ int BPF_PROG(on_ipi_send_cpu, u32 cpu, void *callsite, void *callback)
 	return 0;
 }
 
-SEC("tp_bpf/gpu_memory_total")
+SEC("?tp_btf/gpu_mem_total")
 int BPF_PROG(on_gpu_memory_total, u32 gpu, u32 pid, u64 size)
 {
 	struct bpf_event *event;

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -3,6 +3,7 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
+use scx_utils::compat;
 use scxtop::bpf_intf::*;
 use scxtop::bpf_skel::types::bpf_event;
 use scxtop::bpf_skel::*;
@@ -149,6 +150,11 @@ fn run_tui(tui_args: &TuiArgs) -> Result<()> {
             }
             if let Ok(link) = skel.progs.on_cpuhp_enter.attach() {
                 links.push(link);
+            }
+            if compat::ksym_exists("gpu_memory_total").is_ok() {
+                if let Ok(link) = skel.progs.on_gpu_memory_total.attach() {
+                    links.push(link);
+                }
             }
 
             if tui_args.experimental_long_tail_tracing {


### PR DESCRIPTION
Only attempt to attach GPU probes if the symbol exists. Fixes failure to launch on systems without GPU tracepoints.

Happy trace:
![2025-02-27-20:19:55](https://github.com/user-attachments/assets/8317cb9d-e0f9-4b76-aec7-95b0799c45f1)
