### PR TITLE
scxtop: adding cpu hotplug (enter) event tracepoint.

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -24,8 +24,8 @@ use crate::APP;
 use crate::LICENSE;
 use crate::SCHED_NAME_PATH;
 use crate::{
-    Action, GpuMemAction, IPIAction, RecordTraceAction, SchedCpuPerfSetAction, SchedSwitchAction,
-    SchedWakeupAction, SchedWakingAction, SoftIRQAction,
+    Action, CpuhpAction, GpuMemAction, IPIAction, RecordTraceAction, SchedCpuPerfSetAction,
+    SchedSwitchAction, SchedWakeupAction, SchedWakingAction, SoftIRQAction,
 };
 
 use anyhow::Result;
@@ -2270,6 +2270,13 @@ impl<'a> App<'a> {
         }
     }
 
+    /// Handles cpu hotplug events.
+    pub fn on_cpu_hp(&mut self, action: &CpuhpAction) {
+        if self.trace_tick > self.config.trace_tick_warmup() {
+            self.trace_manager.on_cpu_hp(action);
+        }
+    }
+
     /// Updates the bpf bpf sampling rate.
     pub fn update_bpf_sample_rate(&mut self, sample_rate: u32) {
         self.skel.maps.data_data.sample_rate = sample_rate;
@@ -2343,6 +2350,9 @@ impl<'a> App<'a> {
             }
             Action::GpuMem(a) => {
                 self.on_gpu_mem(a);
+            }
+            Action::Cpuhp(a) => {
+                self.on_cpu_hp(a);
             }
             Action::ClearEvent => self.stop_perf_events(),
             Action::ChangeTheme => {

--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -24,6 +24,7 @@ enum stat_id {
 };
 
 enum event_type {
+	CPU_HP,
 	CPU_PERF_SET,
 	GPU_MEM,
 	IPI,
@@ -87,12 +88,21 @@ struct gpu_mem_event {
 	u32             pid;
 };
 
+struct cpuhp_event {
+	u32             cpu;
+	u32             pid;
+	int             target;
+	int             state;
+	u64             fun;
+};
+
 struct bpf_event {
 	int		type;
 	u64		ts;
 	u32		cpu;
 	union {
 		struct  gpu_mem_event gm;
+		struct  cpuhp_event chp;
 		struct	ipi_event ipi;
 		struct	sched_switch_event sched_switch;
 		struct	set_perf_event perf;

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -681,7 +681,6 @@ SEC("tp_bpf/gpu_memory_total")
 int BPF_PROG(on_gpu_memory_total, u32 gpu, u32 pid, u64 size)
 {
 	struct bpf_event *event;
-	struct task_struct *p;
 
 	if (!enable_bpf_events || !should_sample())
 		return 0;
@@ -695,6 +694,37 @@ int BPF_PROG(on_gpu_memory_total, u32 gpu, u32 pid, u64 size)
 	event->event.gm.gpu = gpu;
 	event->event.gm.pid = pid;
 	event->event.gm.size = size;
+
+	bpf_ringbuf_submit(event, 0);
+
+	return 0;
+}
+
+SEC("tp_bpf/cpuhp_enter")
+int BPF_PROG(on_cpuhp_enter, u32 cpu, int target, int state, int(*fun)(u32))
+{
+	struct bpf_event *event;
+	struct task_struct *p;
+
+	if (!enable_bpf_events || !should_sample())
+		return 0;
+
+	if (!(event = try_reserve_event()))
+		return -ENOMEM;
+
+	event->type = CPU_HP;
+	event->cpu = bpf_get_smp_processor_id();
+	event->ts = bpf_ktime_get_ns();
+	event->event.chp.cpu = cpu;
+	event->event.chp.target = target;
+	event->event.chp.state = state;
+	event->event.chp.fun = (u64)fun;
+	p = (struct task_struct *)bpf_get_current_task();
+	if (p)
+		event->event.chp.pid = BPF_CORE_READ(p, pid);
+	else
+		event->event.chp.pid = 0;
+
 	bpf_ringbuf_submit(event, 0);
 
 	return 0;

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -177,9 +177,20 @@ pub struct GpuMemAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CpuhpAction {
+    pub ts: u64,
+    pub cpu: u32,
+    pub target: i32,
+    pub state: i32,
+    pub fun: u64,
+    pub pid: u32,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Action {
     ChangeTheme,
     ClearEvent,
+    Cpuhp(CpuhpAction),
     DecBpfSampleRate,
     DecTickRate,
     Down,
@@ -257,6 +268,15 @@ impl TryFrom<&bpf_event> for Action {
                 pid: unsafe { event.event.gm.pid },
                 gpu: unsafe { event.event.gm.gpu },
                 size: unsafe { event.event.gm.size },
+            })),
+            #[allow(non_upper_case_globals)]
+            bpf_intf::event_type_CPU_HP => Ok(Action::Cpuhp(CpuhpAction {
+                ts: event.ts,
+                pid: unsafe { event.event.chp.pid },
+                cpu: unsafe { event.event.chp.cpu },
+                state: unsafe { event.event.chp.state },
+                target: unsafe { event.event.chp.target },
+                fun: unsafe { event.event.chp.fun },
             })),
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_SOFTIRQ => {


### PR DESCRIPTION
For a given cpu, we capture its activity, e.g. online/offline, some states more in between like about to be teardown, before full activation.