### PR TITLE
compat: Provide a compatible helper for scx_bpf_events()

### DIFF
--- a/scheds/c/scx_qmap.bpf.c
+++ b/scheds/c/scx_qmap.bpf.c
@@ -774,7 +774,7 @@ static int monitor_timerfn(void *map, int *key, struct bpf_timer *timer)
 	if (print_shared_dsq)
 		dump_shared_dsq();
 
-	scx_bpf_events(&events, sizeof(events));
+	__COMPAT_scx_bpf_events(&events, sizeof(events));
 
 	bpf_printk("%35s: %llu", "SCX_EV_SELECT_CPU_FALLBACK",
 		   scx_read_event(&events, SCX_EV_SELECT_CPU_FALLBACK));

--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -183,7 +183,15 @@ static inline bool __COMPAT_is_enq_cpu_selected(u64 enq_flags)
 	 bpf_ktime_get_ns())
 
 /*
+ * v6.15: Introduce event counters.
  *
+ * Preserve the following macro until v6.17.
+ */
+#define __COMPAT_scx_bpf_events(events, size)					\
+	(bpf_ksym_exists(scx_bpf_events) ?					\
+	 scx_bpf_events(events, size) : ({}))
+
+/*
  * v6.15: Introduce NUMA-aware kfuncs to operate with per-node idle
  * cpumasks.
  *


### PR DESCRIPTION
Introduce __COMPAT_scx_bpf_events() to use scx_bpf_events() in a compatible way also with kernels that don't provide this kfunc.

This also fixes the following error with scx_qmap when running on a kernel that does not provide scx_bpf_events():

 ; scx_bpf_events(&events, sizeof(events)); @ scx_qmap.bpf.c:777
 318: (b7) r2 = 72                     ; R2_w=72 async_cb
 319: <invalid kfunc call>
 kfunc 'scx_bpf_events' is referenced but wasn't resolved

Fixes: d3844539 ("kernel: Sync at ad3b301aa05a ("sched_ext: Provides a sysfs 'events' to expose core event counters")")