### PR TITLE
scxtop: Filter sched_switch events less aggressively

### DIFF
--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -480,14 +480,14 @@ int BPF_PROG(on_sched_switch, bool preempt, struct task_struct *prev,
 		return 0;
 
 	next_tctx = try_lookup_task_ctx(next);
-	if (!next_tctx || next_tctx->dsq_id == SCX_DSQ_INVALID || next_tctx->dsq_insert_time == 0) {
+	if (!next_tctx || next_tctx->dsq_insert_time == 0) {
 		if (sample_rate == 1)
 			return on_sched_switch_non_scx(preempt, prev, next, prev_state);
 		return -ENOENT;
 	}
 
 	prev_tctx = try_lookup_task_ctx(prev);
-	if (!prev_tctx || prev_tctx->dsq_id == SCX_DSQ_INVALID) {
+	if (!prev_tctx) {
 		if (sample_rate == 1)
 			return on_sched_switch_non_scx(preempt, prev, next, prev_state);
 		return -ENOENT;


### PR DESCRIPTION
On sched_switch there can be tasks that aren't handled by sched_ext schedulers. Be less aggressive in filtering tasks without a recorded DSQ.

This makes kthreads get collected properly: 
![2025-03-01-21:47:37](https://github.com/user-attachments/assets/f60dabd8-0e90-4155-89b2-b70859e10b24)
