### PR TITLE
compat: add kprobe helper and update ksym helper

### DIFF
--- a/meson-scripts/stress_tests.ini
+++ b/meson-scripts/stress_tests.ini
@@ -30,7 +30,7 @@ timeout_sec: 15
 
 [scx_layered]
 sched: scx_layered
-sched_args: --run-example -v --stats 1
+sched_args: --run-example -v --stats 1 --enable-gpu-support
 stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
 timeout_sec: 15
 bpftrace_scripts: dsq_lat.bt,process_runqlat.bt


### PR DESCRIPTION
This adds a helper, `cond_kprobe_enable` to common. 

This will enable the passed in kprobe or print a warning if the symbol is missing. 

To support this, this switches `compat::ksym_exists` to using `/proc/kallsyms` (which, IIUC, will always work, vs the current approach which does not work with symbols in (some?) modules).

This also updates layered to use this for one conditional kprobe it has (nvidia_open) and updates stress-test config to have CI cover this code.

nvidia gpu machine (w/ symbol present) using this:
![image](https://github.com/user-attachments/assets/491f1af7-60c1-4e09-81d2-cdbfce8852a0)

amd gpu machine (w/ symbol missing) using this:
![image](https://github.com/user-attachments/assets/f38c7a73-6ff0-40fd-9ff6-1a4912f7ff49)
