### PR TITLE
scxtop: always send bpf event to terminate trace

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -26,7 +26,7 @@ use crate::LICENSE;
 use crate::SCHED_NAME_PATH;
 use crate::{
     Action, CpuhpAction, GpuMemAction, IPIAction, SchedCpuPerfSetAction, SchedSwitchAction,
-    SchedWakeupAction, SchedWakingAction, SoftIRQAction, TraceStartedAction,
+    SchedWakeupAction, SchedWakingAction, SoftIRQAction, TraceStartedAction, TraceStoppedAction,
 };
 
 use anyhow::Result;
@@ -2134,10 +2134,10 @@ impl<'a> App<'a> {
     }
 
     /// Records the trace to perfetto output.
-    fn stop_recording_trace(&mut self) -> Result<()> {
+    fn stop_recording_trace(&mut self, ts: u64) -> Result<()> {
         self.skel.maps.data_data.sample_rate = self.prev_bpf_sample_rate;
         self.state = self.prev_state.clone();
-        self.trace_manager.stop()?;
+        self.trace_manager.stop(Some(ts))?;
         self.trace_links.clear();
 
         Ok(())
@@ -2408,8 +2408,8 @@ impl<'a> App<'a> {
             }) => {
                 self.start_recording_trace(*start_immediately, *ts, *stop_scheduled)?;
             }
-            Action::TraceStopped => {
-                self.stop_recording_trace()?;
+            Action::TraceStopped(TraceStoppedAction { ts }) => {
+                self.stop_recording_trace(*ts)?;
             }
             Action::ReloadStatsClient => {
                 self.reload_stats_client()?;

--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -26,6 +26,7 @@ enum stat_id {
 enum mode {
 	MODE_NORMAL,
 	MODE_TRACING,
+	MODE_TRACE_STOPPING,
 };
 
 enum event_type {

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -162,6 +162,11 @@ pub struct TraceStartedAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TraceStoppedAction {
+    pub ts: u64,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct IPIAction {
     pub ts: u64,
     pub cpu: u32,
@@ -210,7 +215,7 @@ pub enum Action {
     Quit,
     RequestTrace,
     TraceStarted(TraceStartedAction),
-    TraceStopped,
+    TraceStopped(TraceStoppedAction),
     ReloadStatsClient,
     SaveConfig,
     SchedCpuPerfSet(SchedCpuPerfSetAction),
@@ -375,7 +380,10 @@ impl TryFrom<&bpf_event> for Action {
                 }))
             }
             #[allow(non_upper_case_globals)]
-            bpf_intf::event_type_TRACE_STOPPED => Ok(Action::TraceStopped),
+            bpf_intf::event_type_TRACE_STOPPED => {
+                let action = Action::TraceStopped(TraceStoppedAction { ts: event.ts });
+                Ok(action)
+            }
             _ => Err(()),
         }
     }
@@ -396,7 +404,7 @@ impl std::fmt::Display for Action {
             Action::SaveConfig => write!(f, "SaveConfig"),
             Action::RequestTrace => write!(f, "RequestTrace"),
             Action::TraceStarted(_) => write!(f, "TraceStarted"),
-            Action::TraceStopped => write!(f, "TraceStopped"),
+            Action::TraceStopped(_) => write!(f, "TraceStopped"),
             Action::ClearEvent => write!(f, "ClearEvent"),
             Action::PrevEvent => write!(f, "PrevEvent"),
             Action::NextEvent => write!(f, "NextEvent"),


### PR DESCRIPTION

Although this BPF timer work started with the intention of making sure the
trace always terminated, the initial implementation makes it less likely to
terminate. This is because the userspace ticks are guaranteed to happen since
#1433, but the single timer callback cannot guarantee it will insert into the ring
buffer.

Add an additional mode called TRACE_STOPPING for the case where there was a
previous trace that should have stopped but userspace hasn't been informed yet.
Retrigger the timer every 5ms until it manages to enter the ringbuf, which is
made more likely by having already reduced the sample rate from BPF side.
Finally, clean up any events that came after the true end of the trace in
userspace, as these events will be partial due to the sample rate.

There's an exceedingly unlikely case where practically all events are being
dropped that means the trace takes a very long time to terminate. This will
have the previous issue of consuming an unbounded amount of userspace memory,
and will probably result in something (hopefully scxtop) getting OOM killed.
If this shows up we should solve it by having a userspace cutoff too that stops
storing events, but I haven't seen it yet.

Closes #1317

Test plan:
- Tested on a busy machine with lots of dropped events. The trace terminates.
- Artificially introduced a large amount of latency into `TryFrom<&bpf_event for Action>`.
  The trace eventually terminates.
