### PR TITLE
scxtop: adding hw_pressure event trace.

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -25,8 +25,9 @@ use crate::APP;
 use crate::LICENSE;
 use crate::SCHED_NAME_PATH;
 use crate::{
-    Action, CpuhpAction, GpuMemAction, IPIAction, SchedCpuPerfSetAction, SchedSwitchAction,
-    SchedWakeupAction, SchedWakingAction, SoftIRQAction, TraceStartedAction, TraceStoppedAction,
+    Action, CpuhpAction, GpuMemAction, HwPressureAction, IPIAction, SchedCpuPerfSetAction,
+    SchedSwitchAction, SchedWakeupAction, SchedWakingAction, SoftIRQAction, TraceStartedAction,
+    TraceStoppedAction,
 };
 
 use anyhow::Result;
@@ -500,21 +501,23 @@ impl<'a> App<'a> {
 
     /// Generates a CPU bar chart.
     fn cpu_bar(&self, cpu: usize, event: &str) -> Bar {
-        let value = self
-            .cpu_data
-            .get(&cpu)
-            .unwrap()
+        let cpu_data = self.cpu_data.get(&cpu).unwrap();
+        let value = cpu_data
             .event_data_immut(event)
             .last()
             .copied()
             .unwrap_or(0_u64);
+        let hw_pressure = cpu_data
+            .event_data_immut("hw_pressure")
+            .last()
+            .copied()
+            .unwrap_or(0);
         Bar::default()
             .value(value)
             .label(Line::from(format!(
-                "{}{}",
+                "{}{}{}",
                 cpu,
                 if self.collect_cpu_freq {
-                    let cpu_data = self.cpu_data.get(&cpu).unwrap();
                     format!(
                         " {}",
                         format_hz(
@@ -525,6 +528,11 @@ impl<'a> App<'a> {
                                 .unwrap_or(0)
                         )
                     )
+                } else {
+                    "".to_string()
+                },
+                if hw_pressure > 0 {
+                    format!("{}", hw_pressure)
                 } else {
                     "".to_string()
                 }
@@ -540,6 +548,7 @@ impl<'a> App<'a> {
     fn cpu_sparkline(&self, cpu: usize, max: u64, borders: Borders, small: bool) -> Sparkline {
         let mut perf: u64 = 0;
         let mut cpu_freq: u64 = 0;
+        let mut hw_pressure: u64 = 0;
         let data = if self.cpu_data.contains_key(&cpu) {
             let cpu_data = self.cpu_data.get(&cpu).unwrap();
             perf = cpu_data
@@ -554,6 +563,11 @@ impl<'a> App<'a> {
                     .copied()
                     .unwrap_or(0);
             }
+            hw_pressure = cpu_data
+                .event_data_immut("hw_pressure")
+                .last()
+                .copied()
+                .unwrap_or(0);
             cpu_data.event_data_immut(self.active_event.event_name())
         } else {
             Vec::new()
@@ -567,7 +581,7 @@ impl<'a> App<'a> {
             .block(
                 Block::new()
                     .title(format!(
-                        "{} perf({}){}",
+                        "{} perf({}){}{}",
                         cpu,
                         if perf == 0 {
                             "".to_string()
@@ -576,6 +590,11 @@ impl<'a> App<'a> {
                         },
                         if self.collect_cpu_freq {
                             format!(" {}", format_hz(cpu_freq))
+                        } else {
+                            "".to_string()
+                        },
+                        if hw_pressure > 0 {
+                            format!(" hw_pressure({})", hw_pressure)
                         } else {
                             "".to_string()
                         }
@@ -2351,6 +2370,21 @@ impl<'a> App<'a> {
         }
     }
 
+    /// Handles hardware pressure events.
+    pub fn on_hw_pressure(&mut self, action: &HwPressureAction) {
+        let HwPressureAction { cpu, hw_pressure } = action;
+
+        let cpu_data = self.cpu_data.entry(*cpu as usize).or_insert(CpuData::new(
+            *cpu as usize,
+            0,
+            0,
+            0,
+            self.max_cpu_events,
+        ));
+
+        cpu_data.add_event_data("hw_pressure", *hw_pressure);
+    }
+
     /// Updates the bpf bpf sampling rate.
     pub fn update_bpf_sample_rate(&mut self, sample_rate: u32) {
         self.skel.maps.data_data.sample_rate = sample_rate;
@@ -2437,6 +2471,9 @@ impl<'a> App<'a> {
             }
             Action::Cpuhp(a) => {
                 self.on_cpu_hp(a);
+            }
+            Action::HwPressure(a) => {
+                self.on_hw_pressure(a);
             }
             Action::ClearEvent => self.stop_perf_events(),
             Action::ChangeTheme => {

--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -33,6 +33,7 @@ enum event_type {
 	CPU_HP,
 	CPU_PERF_SET,
 	GPU_MEM,
+	HW_PRESSURE,
 	IPI,
 	SCHED_REG,
 	SCHED_SWITCH,
@@ -102,6 +103,11 @@ struct cpuhp_event {
 	int             state;
 };
 
+struct hw_pressure_event {
+	u64             hw_pressure;
+	u32             cpu;
+};
+
 struct trace_started_event {
 	bool		start_immediately;
 	bool		stop_scheduled;
@@ -112,6 +118,7 @@ struct bpf_event {
 	u64		ts;
 	u32		cpu;
 	union {
+		struct  hw_pressure_event hwp;
 		struct  gpu_mem_event gm;
 		struct  cpuhp_event chp;
 		struct	ipi_event ipi;

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -194,6 +194,12 @@ pub struct CpuhpAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct HwPressureAction {
+    pub hw_pressure: u64,
+    pub cpu: u32,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Action {
     ChangeTheme,
     ClearEvent,
@@ -205,6 +211,7 @@ pub enum Action {
     Event,
     GpuMem(GpuMemAction),
     Help,
+    HwPressure(HwPressureAction),
     IncBpfSampleRate,
     IncTickRate,
     IPI(IPIAction),
@@ -285,6 +292,11 @@ impl TryFrom<&bpf_event> for Action {
                 cpu: unsafe { event.event.chp.cpu },
                 state: unsafe { event.event.chp.state },
                 target: unsafe { event.event.chp.target },
+            })),
+            #[allow(non_upper_case_globals)]
+            bpf_intf::event_type_HW_PRESSURE => Ok(Action::HwPressure(HwPressureAction {
+                cpu: event.cpu,
+                hw_pressure: unsafe { event.event.hwp.hw_pressure },
             })),
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_SOFTIRQ => {

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -122,6 +122,11 @@ fn attach_progs(skel: &mut BpfSkel) -> Result<Vec<Link>> {
             links.push(link);
         }
     }
+    if compat::ksym_exists("hw_pressure_update").is_ok() {
+        if let Ok(link) = skel.progs.on_hw_pressure_update.attach() {
+            links.push(link);
+        }
+    }
 
     Ok(links)
 }

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -17,8 +17,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::bpf_skel::types::bpf_event;
 use crate::edm::{ActionHandler, BpfEventHandler};
 use crate::{
-    Action, CpuhpAction, GpuMemAction, IPIAction, SchedSwitchAction, SchedWakeupAction,
-    SchedWakingAction, SoftIRQAction,
+    Action, CpuhpAction, GpuMemAction, HwPressureAction, IPIAction, SchedSwitchAction,
+    SchedWakeupAction, SchedWakingAction, SoftIRQAction,
 };
 
 use crate::protos_gen::perfetto_scx::counter_descriptor::Unit::UNIT_COUNT;


### PR DESCRIPTION
tracks hardware related contention in a cpu scheduling context. could cpu frequency related, high cpu cache miss rate, poor cpu locality
 but also memory ; thermal throttling.