### PR TITLE
scx_bpfland: Fix is_wake_sync()

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -377,7 +377,7 @@ static bool is_wake_sync(const struct task_struct *p,
 	 * kthread, which has now finished, making the wakeup effectively
 	 * synchronous. An example of this behavior is seen in IO completions.
 	 */
-	if (is_kthread(current) && (p->nr_cpus_allowed == 1) &&
+	if (is_kthread(current) && (current->nr_cpus_allowed == 1) &&
 	    (prev_cpu == cpu))
 		return true;
 


### PR DESCRIPTION
In is_wake_sync() we want to check if the waker is a per-CPU kthread, but instead we're checking the number of allowed CPU of the wakee.

Fix this by properly check if the waker is a per-CPU kthread.