### PR TITLE
scx_utils: Fix kernels without CONFIG_DEBUG_FS

### DIFF
--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -171,7 +171,7 @@ pub fn in_kallsyms(ksym: &str) -> Result<bool> {
 }
 
 pub fn tracepoint_exists(tracepoint: &str) -> Result<bool> {
-    let file = std::fs::File::open("/sys/kernel/debug/tracing/available_events")?;
+    let file = std::fs::File::open("/sys/kernel/tracing/available_events")?;
     let reader = std::io::BufReader::new(file);
 
     for line in reader.lines() {

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -211,7 +211,7 @@ struct Opts {
     #[clap(long)]
     monitor: Option<f64>,
 
-    /// Enable BPF debugging via /sys/kernel/debug/tracing/trace_pipe.
+    /// Enable BPF debugging via /sys/kernel/tracing/trace_pipe.
     #[clap(short = 'd', long, action = clap::ArgAction::SetTrue)]
     debug: bool,
 

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -94,7 +94,7 @@ struct Opts {
     exit_dump_len: u32,
 
     /// Enable verbose output, including libbpf details. Moreover, BPF scheduling events will be
-    /// reported in debugfs (e.g., /sys/kernel/debug/tracing/trace_pipe).
+    /// reported in tracefs (e.g., /sys/kernel/tracing/trace_pipe).
     #[clap(short = 'v', long, action = clap::ArgAction::SetTrue)]
     verbose: bool,
 

--- a/scripts/sched_ftrace.py
+++ b/scripts/sched_ftrace.py
@@ -6,7 +6,7 @@ import time
 
 HEADER = "TASK-PID"
 BUFF_STARTED = "buffer started ###"
-TRACING_PATH = "/sys/kernel/debug/tracing"
+TRACING_PATH = "/sys/kernel/tracing"
 TRACE_PIPE_PATH = os.path.join(TRACING_PATH, "trace_pipe")
 
 


### PR DESCRIPTION
tracefs is usually mounted on both /sys/kernel/tracing and /sys/kernel/debug/tracing, I guess for compatibility reasons.

On kernels without CONFIG_DEBUG_FS, /sys/kernel/debug doesn't exist, so we should use /sys/kernel/tracing instead to avoid errors such as "Error: No such file or directory (os error 2)" from scx_lavd with the default futex holder boosting enabled.