### PR TITLE
scxtop: Disable bpf conditional attachment

### DIFF
--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -242,13 +242,13 @@ int BPF_KPROBE(on_sched_cpu_perf, s32 cpu, u32 perf)
 	return 0;
 }
 
-SEC("?kprobe/scx_bpf_dsq_insert_vtime")
+SEC("kprobe/scx_bpf_dsq_insert_vtime")
 int BPF_KPROBE(scx_insert_vtime, struct task_struct *p, u64 dsq, u64 slice_ns, u64 vtime)
 {
 	return update_task_ctx(p, dsq, vtime, slice_ns);
 }
 
-SEC("?kprobe/scx_bpf_dispatch_vtime")
+SEC("kprobe/scx_bpf_dispatch_vtime")
 int BPF_KPROBE(scx_dispatch_vtime, struct task_struct *p, u64 dsq, u64 slice_ns, u64 vtime)
 {
 	return update_task_ctx(p, dsq, vtime, slice_ns);
@@ -272,13 +272,13 @@ static int on_insert(struct task_struct *p, u64 dsq)
 }
 
 
-SEC("?kprobe/scx_bpf_dsq_insert")
+SEC("kprobe/scx_bpf_dsq_insert")
 int BPF_KPROBE(scx_insert, struct task_struct *p, u64 dsq)
 {
 	return on_insert(p, dsq);
 }
 
-SEC("?kprobe/scx_bpf_dispatch")
+SEC("kprobe/scx_bpf_dispatch")
 int BPF_KPROBE(scx_dispatch, struct task_struct *p, u64 dsq)
 {
 	return on_insert(p, dsq);
@@ -300,14 +300,14 @@ static int on_dsq_move(struct task_struct *p, u64 dsq)
 	return 0;
 }
 
-SEC("?kprobe/scx_bpf_dsq_move")
+SEC("kprobe/scx_bpf_dsq_move")
 int BPF_KPROBE(scx_dsq_move, struct bpf_iter_scx_dsq *it__iter,
 	       struct task_struct *p, u64 dsq_id, u64 enq_flags)
 {
 	return on_dsq_move(p, dsq_id);
 }
 
-SEC("?kprobe/scx_bpf_dispatch_from_dsq")
+SEC("kprobe/scx_bpf_dispatch_from_dsq")
 int BPF_KPROBE(scx_dispatch_from_dsq, struct bpf_iter_scx_dsq *it__iter,
 	       struct task_struct *p, u64 dsq_id, u64 enq_flags)
 {
@@ -330,14 +330,14 @@ static int on_dsq_move_vtime(struct task_struct *p, u64 dsq)
 	return 0;
 }
 
-SEC("?kprobe/scx_bpf_dsq_move_vtime")
+SEC("kprobe/scx_bpf_dsq_move_vtime")
 int BPF_KPROBE(scx_dsq_move_vtime, struct bpf_iter_scx_dsq *it__iter,
 	       struct task_struct *p, u64 dsq_id, u64 enq_flags)
 {
 	return on_dsq_move_vtime(p, dsq_id);
 }
 
-SEC("?kprobe/scx_bpf_dispatch_vtime_from_dsq")
+SEC("kprobe/scx_bpf_dispatch_vtime_from_dsq")
 int BPF_KPROBE(scx_dispatch_vtime_from_dsq, struct bpf_iter_scx_dsq *it__iter,
 	       struct task_struct *p, u64 dsq_id, u64 enq_flags)
 {
@@ -359,14 +359,14 @@ static int on_move_set_slice(struct task_struct *p, u64 slice)
 	return 0;
 }
 
-SEC("?kprobe/scx_bpf_dsq_move_set_slice")
+SEC("kprobe/scx_bpf_dsq_move_set_slice")
 int BPF_KPROBE(scx_dsq_move_set_slice, struct bpf_iter_scx_dsq *it__iter, u64 slice)
 {
 	// TODO: figure out how to return task from iterator without consuming.
 	return on_move_set_slice(NULL, slice);
 }
 
-SEC("?kprobe/scx_bpf_dispatch_from_dsq_set_slice")
+SEC("kprobe/scx_bpf_dispatch_from_dsq_set_slice")
 int BPF_KPROBE(scx_dispatch_from_dsq_set_slice, struct bpf_iter_scx_dsq *it__iter,
 	       u64 slice)
 {
@@ -389,14 +389,14 @@ static int on_move_set_vtime(struct task_struct *p, u64 vtime)
 	return 0;
 }
 
-SEC("?kprobe/scx_bpf_dsq_move_set_vtime")
+SEC("kprobe/scx_bpf_dsq_move_set_vtime")
 int BPF_KPROBE(scx_dsq_move_set_vtime, struct bpf_iter_scx_dsq *it__iter, u64 vtime)
 {
 	// TODO: figure out how to return task from iterator without consuming.
 	return on_move_set_vtime(NULL, vtime);
 }
 
-SEC("?kprobe/scx_bpf_dispatch_from_dsq_set_vtime")
+SEC("kprobe/scx_bpf_dispatch_from_dsq_set_vtime")
 int BPF_KPROBE(scx_dispatch_from_dsq_set_vtime, struct bpf_iter_scx_dsq *it__iter, u64 vtime)
 {
 	// TODO: figure out how to return task from iterator without consuming.


### PR DESCRIPTION
Userspace correctly handles conditional attachment based on available kfuncs so no need to conditionally attach on the bpf side.

DSQ stats render properly:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/5353d7f2-1f9d-4665-843e-c57a4d0d717b" />
