### PR TITLE
scx_utils, scx_lavd: Add cpu_capacity to Topology and use it in scx_lavd.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -535,7 +535,7 @@ static u16 get_cputurbo_cap(void)
 	int nr_turbo = 0, cpu;
 
 	/*
-	 * Find the maximum CPU frequency
+	 * Find the maximum CPU capacity
 	 */
 	for (cpu = 0; cpu < nr_cpu_ids && cpu < LAVD_CPU_ID_MAX; cpu++) {
 		if (__cpu_capacity_hint[cpu] > turbo_cap) {
@@ -545,7 +545,7 @@ static u16 get_cputurbo_cap(void)
 	}
 
 	/*
-	 * If all CPU's frequencies are the same, ignore the turbo.
+	 * If all CPU's capacities are the same, ignore the turbo.
 	 */
 	if (nr_turbo <= 1)
 		turbo_cap = 0;


### PR DESCRIPTION
There are various sysfs sources that somehow represent each CPU's capacity even if the kernel does not properly implement arch_scale_cpu_capacity(), which is used for scx_bpf_cpuperf_cap().

This PR tries to make a best guess about CPU capacity based on available sysfs entries by checking the most precise (e.g., vendor-specific information) to the least precise (CPU max frequency).

Also, scx_lavd is changed to use cpu_capacity exposed by Topology.