### PR TITLE
scx_p2dq: Add config for minimum queue size for pick2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,6 +2393,7 @@ dependencies = [
  "crossbeam",
  "ctrlc",
  "fb_procfs",
+ "lazy_static",
  "libbpf-rs",
  "libc",
  "log",

--- a/scheds/rust/scx_p2dq/Cargo.toml
+++ b/scheds/rust/scx_p2dq/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7"
+lazy_static = "1.5.0"
 libbpf-rs = "=0.25.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"

--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -41,6 +41,7 @@ const volatile u64 dsq_shift = 2;
 const volatile int init_dsq_index = 0;
 const volatile u64 min_slice_us = 100;
 const volatile u32 interactive_ratio = 10;
+const volatile u32 min_nr_queued_pick2 = 10;
 
 const volatile bool autoslice = true;
 const volatile bool interactive_sticky = false;
@@ -287,11 +288,15 @@ static struct llc_ctx *pick_two_llc_ctx(struct llc_ctx *left, struct llc_ctx *ri
 		right_load += *MEMBER_VPTR(right->dsq_load, [i]);
 	}
 
+	if (min_nr_queued_pick2 > 0 &&
+	    (left_queued < min_nr_queued_pick2 && right_queued < min_nr_queued_pick2))
+		return NULL;
+
 	if (((left_queued > 0 || right_queued > 0) && left_queued < right_queued) ||
 	    left_load > right_load)
 		return most_loaded ? right : left;
 
-	return most_loaded ? left : right;
+	return NULL;
 }
 
 static s32 pick_two_cpu(struct task_ctx *taskc, bool *is_idle)


### PR DESCRIPTION
Add a config option for requiring a minimum number of enqueued tasks before attempting to do pick2 migrations. This option allows tuning the stickiness of a tasks to their local LLC. This is just a rough first pass, will try to add a more comprehensive pick2 handling later.

Example: run `stress-ng` using 60 CPUs on a 80 CPU (dual 40 core sockets) NUMA machine. This provides an imbalanced load.

Running with `-m 0` to aggressively pick2 can cause thrashing
```
scx_p2dq --stats 1  -g -m 0
...
direct/idle/greedy 374/31710/0
        dsq same/migrate 52837/6578
        keep 0 pick2 130
        migrations llc/node: 386/386
```
<img width="860" alt="image" src="https://github.com/user-attachments/assets/9c89ba07-27ef-4b05-82ea-84f66b3e5fdb" />


As `-m` increases pick2 runs less frequent:
```
sudo ./target/release/scx_p2dq --stats 1  -g -m 5
direct/idle/greedy 206/13502/0
        dsq same/migrate 32798/1929
        keep 0 pick2 6
        migrations llc/node: 582/582
```
<img width="860" alt="image" src="https://github.com/user-attachments/assets/7a6ebfe7-2f53-4333-a0be-a5e98eafd90c" />

As `-m` increases migrations decrease and there is less balance between NUMAs
```
sudo ./target/release/scx_p2dq --stats 1  -g -m 10
...
direct/idle/greedy 205/14917/0
        dsq same/migrate 35876/2838
        keep 0 pick2 0
        migrations llc/node: 101/101
```
<img width="860" alt="image" src="https://github.com/user-attachments/assets/4116b721-bc16-486e-a81d-bb774d981756" />
