### PR TITLE
scx_p2dq: Add config for min runs for pick2

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/intf.h
+++ b/scheds/rust/scx_p2dq/src/bpf/intf.h
@@ -77,6 +77,7 @@ struct task_ctx {
 	u64			last_dsq_id;
 	int			last_dsq_index;
 	u64 			last_run_at;
+	u64			llc_runs; /* how many runs on the current LLC */
 
 	/* The task is a workqueue worker thread */
 	bool			is_kworker;

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -109,6 +109,11 @@ struct Opts {
     #[clap(short = 's', long, default_value = "100")]
     min_slice_us: u64,
 
+    /// Number of runs on the LLC before a task becomes eligbile for pick2 migration on the wakeup
+    /// path.
+    #[clap(short = 'l', long, default_value = "3")]
+    min_llc_runs_pick2: u64,
+
     /// Manual definition of slice intervals in microseconds for DSQs, must be equal to number of
     /// dumb_queues.
     #[clap(short = 't', long, value_parser = clap::value_parser!(u64), default_values_t = [0;0])]
@@ -218,6 +223,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.interactive_ratio = opts.interactive_ratio as u32;
         skel.maps.rodata_data.min_slice_us = opts.min_slice_us;
         skel.maps.rodata_data.min_nr_queued_pick2 = opts.min_nr_queued_pick2;
+        skel.maps.rodata_data.min_llc_runs_pick2 = opts.min_llc_runs_pick2;
         skel.maps.rodata_data.dsq_shift = opts.dsq_shift as u64;
         skel.maps.rodata_data.kthreads_local = !opts.disable_kthreads_local;
         skel.maps.rodata_data.debug = opts.verbose as u32;


### PR DESCRIPTION
Add a config that tracks the number of runs the task has run on the local LLC and do not consider tasks below the threshold available to pick2 load balance on the wakeup path.

Test on 80 core dual socket (40 CPUs per socket) machine with `stress-ng`:
```
$ stress-ng -c 60
```

Run with 100 slices before migrating on the local LLC to make tasks sticky:
```
$ scx_p2dq --stats 1  -g -l 100
direct/idle/greedy 208/29342/0
        dsq same/migrate 30415/3400
        keep 0 pick2 4
        migrations llc/node: 1559/1559
direct/idle/greedy 194/31168/0
        dsq same/migrate 32933/3320
        keep 0 pick2 3
        migrations llc/node: 2433/2433
direct/idle/greedy 321/28467/0
        dsq same/migrate 29682/3378
        keep 0 pick2 31
        migrations llc/node: 1467/1467
```
<img width="862" alt="image" src="https://github.com/user-attachments/assets/6e1a3610-38e0-4e3a-9ab2-ad4f8859aee5" />

<img width="862" alt="image" src="https://github.com/user-attachments/assets/464b0fca-7638-42f0-840e-dc1a6db8d1ca" />

Run with 1 slice for thrashing:
```
$ scx_p2dq --stats 1  -g -l 1
direct/idle/greedy 143/28412/0
        dsq same/migrate 29553/3158
        keep 0 pick2 727
        migrations llc/node: 1125/1125
direct/idle/greedy 268/30955/0
        dsq same/migrate 32142/4230
        keep 0 pick2 804
        migrations llc/node: 1823/1823
direct/idle/greedy 331/37811/0
        dsq same/migrate 38857/5179
        keep 0 pick2 1036
        migrations llc/node: 1448/1448
```
<img width="862" alt="image" src="https://github.com/user-attachments/assets/79b20d1c-32de-4b2a-9df7-87786e43e4e7" />
<img width="862" alt="image" src="https://github.com/user-attachments/assets/548837da-f4c7-4925-92cb-e2d68ae8b1b9" />
