### PR TITLE
scx_rustland: write generated files only when needed

### DIFF
--- a/rust/scx_rustland_core/src/rustland_builder.rs
+++ b/rust/scx_rustland_core/src/rustland_builder.rs
@@ -5,11 +5,11 @@
 
 use anyhow::Result;
 
+use scx_utils::BpfBuilder;
+use std::fs;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
-
-use scx_utils::BpfBuilder;
 
 pub struct RustLandBuilder {
     inner_builder: BpfBuilder,
@@ -24,6 +24,14 @@ impl RustLandBuilder {
 
     fn create_file(&self, file_name: &str, content: &[u8]) {
         let path = Path::new(file_name);
+
+        // Limit file writing to when file contents differ (for caching)
+        if let Ok(bytes_there) = fs::read(path) {
+            if bytes_there == content {
+                return;
+            }
+        }
+
         let mut file = File::create(path).expect("Unable to create file");
         file.write_all(content).expect("Unable to write to file");
     }


### PR DESCRIPTION
This enables caches to cache the builds for rustland and rlfifo. 

Build times were getting a bit iffy locally for me, so I set up sccache and using mold as linker in addition to ccache.

This matters less for builds where -p scheduler_i_want_to_build can be passed, but matters more for LSP (i.e. startup time before go to definition/hover info etc. works).

This change enables a cache within all of those to cache better (making build times instant when no changes).

These are warm cache build times before and after this change:

![Screenshot from 2025-03-08 02-24-59](https://github.com/user-attachments/assets/62423ed5-277f-44f7-a132-55293b0b71d2)
