### PR TITLE
scx_p2dq: Allow disabling pick2 load balancing on dispatch

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -48,6 +48,7 @@ const volatile bool autoslice = true;
 const volatile bool interactive_sticky = false;
 const volatile bool keep_running_enabled = true;
 const volatile bool eager_load_balance = true;
+const volatile bool dispatch_pick2_disable = false;
 const volatile bool smt_enabled = true;
 const volatile bool greedy_idle = false;
 const volatile bool has_little_cores = false;
@@ -811,7 +812,7 @@ void BPF_STRUCT_OPS(p2dq_dispatch, s32 cpu, struct task_struct *prev)
 	}
 
 	// If on a single LLC there isn't anything left to try.
-	if (nr_llcs == 1)
+	if (nr_llcs == 1 || dispatch_pick2_disable)
 		return;
 
 	// Last ditch effort try consuming from the most loaded DSQ.

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -101,6 +101,10 @@ struct Opts {
     #[clap(short = 'y', long, action = clap::ArgAction::SetTrue)]
     interactive_sticky: bool,
 
+    /// Disables pick2 load balancing on the dispatch path.
+    #[clap(short = 'd', long, action = clap::ArgAction::SetTrue)]
+    dispatch_pick2_disable: bool,
+
     /// Enable tasks to run beyond their timeslice if the CPU is idle.
     #[clap(long, action = clap::ArgAction::SetTrue)]
     keep_running: bool,
@@ -232,7 +236,9 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.init_dsq_index = opts.init_dsq_index as i32;
         skel.maps.rodata_data.nr_llcs = TOPO.all_llcs.clone().keys().len() as u32;
         skel.maps.rodata_data.nr_nodes = TOPO.nodes.clone().keys().len() as u32;
+
         skel.maps.rodata_data.eager_load_balance = !opts.eager_load_balance;
+        skel.maps.rodata_data.dispatch_pick2_disable = opts.dispatch_pick2_disable;
         skel.maps.rodata_data.greedy_idle = !opts.greedy_idle_disable;
         skel.maps.rodata_data.has_little_cores = TOPO.has_little_cores();
         skel.maps.rodata_data.interactive_sticky = opts.interactive_sticky;


### PR DESCRIPTION
Add a config to allow disabling pick2 load balancing on the dispatch path.