### PR TITLE
scx_utils: Topology: Provide smt_enabled

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -184,6 +184,8 @@ pub struct Topology {
     pub nodes: BTreeMap<usize, Node>,
     /// Cpumask all CPUs in the system.
     pub span: Cpumask,
+    /// True if SMT is enabled in the system, false otherwise.
+    pub smt_enabled: bool,
 
     /// Skip indices to access lower level members easily.
     pub all_llcs: BTreeMap<usize, Arc<Llc>>,
@@ -241,6 +243,7 @@ impl Topology {
         Ok(Topology {
             nodes,
             span,
+            smt_enabled: is_smt_active().unwrap_or(false),
             all_llcs: topo_llcs,
             all_cores: topo_cores,
             all_cpus: topo_cpus,
@@ -644,6 +647,11 @@ fn has_big_little() -> Option<bool> {
     }
 
     Some(clusters.len() > 1)
+}
+
+fn is_smt_active() -> Option<bool> {
+    let smt_on = read_file_usize(Path::new("/sys/devices/system/cpu/smt/active")).ok()?;
+    Some(smt_on == 1)
 }
 
 fn create_default_node(

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -14,8 +14,6 @@ mod stats;
 use std::collections::BTreeMap;
 use std::ffi::c_int;
 use std::fmt::Write;
-use std::fs::File;
-use std::io::Read;
 use std::mem::MaybeUninit;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -228,16 +226,6 @@ struct Opts {
     help_stats: bool,
 }
 
-fn is_smt_active() -> std::io::Result<i32> {
-    let mut file = File::open("/sys/devices/system/cpu/smt/active")?;
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)?;
-
-    let smt_active: i32 = contents.trim().parse().unwrap_or(0);
-
-    Ok(smt_active)
-}
-
 struct Scheduler<'a> {
     skel: BpfSkel<'a>,
     struct_ops: Option<libbpf_rs::Link>,
@@ -254,16 +242,19 @@ impl<'a> Scheduler<'a> {
         // Validate command line arguments.
         assert!(opts.slice_us >= opts.slice_us_min);
 
+        // Initialize CPU topology.
+        let topo = Topology::new().unwrap();
+
         // Check host topology to determine if we need to enable SMT capabilities.
-        let smt_enabled = match is_smt_active() {
-            Ok(value) => value == 1,
-            Err(_) => false,
-        };
         info!(
             "{} {} {}",
             SCHEDULER_NAME,
             build_id::full_version(env!("CARGO_PKG_VERSION")),
-            if smt_enabled { "SMT on" } else { "SMT off" }
+            if topo.smt_enabled {
+                "SMT on"
+            } else {
+                "SMT off"
+            }
         );
 
         // Initialize BPF connector.
@@ -275,7 +266,7 @@ impl<'a> Scheduler<'a> {
 
         // Override default BPF scheduling parameters.
         skel.maps.rodata_data.debug = opts.debug;
-        skel.maps.rodata_data.smt_enabled = smt_enabled;
+        skel.maps.rodata_data.smt_enabled = topo.smt_enabled;
         skel.maps.rodata_data.local_pcpu = opts.local_pcpu;
         skel.maps.rodata_data.local_kthreads = opts.local_kthreads;
         skel.maps.rodata_data.no_preempt = opts.no_preempt;
@@ -299,9 +290,6 @@ impl<'a> Scheduler<'a> {
         // Load the BPF program for validation.
         let mut skel = scx_ops_load!(skel, bpfland_ops, uei)?;
 
-        // Initialize CPU topology.
-        let topo = Topology::new().unwrap();
-
         // Initialize the primary scheduling domain and the preferred domain.
         let power_profile = fetch_power_profile(false);
         if let Err(err) = Self::init_energy_domain(&mut skel, &opts.primary_domain, power_profile) {
@@ -315,7 +303,7 @@ impl<'a> Scheduler<'a> {
         }
 
         // Initialize SMT domains.
-        if smt_enabled {
+        if topo.smt_enabled {
             Self::init_smt_domains(&mut skel, &topo)?;
         }
 

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -34,7 +34,7 @@ volatile bool		no_prefer_turbo_core;
 volatile bool		is_powersave_mode;
 volatile bool		reinit_cpumask_for_performance;
 const volatile bool	is_autopilot_on;
-const volatile u32 	is_smt_active;
+const volatile bool	is_smt_active;
 const volatile u8	verbose;
 
 /*

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1740,7 +1740,7 @@ impl<'a> Scheduler<'a> {
         };
         skel.maps.rodata_data.nr_cpu_ids = *NR_CPU_IDS as u32;
         skel.maps.rodata_data.nr_possible_cpus = *NR_CPUS_POSSIBLE as u32;
-        skel.maps.rodata_data.smt_enabled = topo.all_cpus.len() > topo.all_cores.len();
+        skel.maps.rodata_data.smt_enabled = topo.smt_enabled;
         skel.maps.rodata_data.has_little_cores = topo.has_little_cores();
         skel.maps.rodata_data.xnuma_preemption = opts.xnuma_preemption;
         skel.maps.rodata_data.antistall_sec = opts.antistall_sec;

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -9,7 +9,6 @@ pub mod stats;
 use stats::Metrics;
 
 use std::mem::MaybeUninit;
-use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -29,7 +28,6 @@ use scx_stats::prelude::*;
 use scx_utils::build_id;
 use scx_utils::import_enums;
 use scx_utils::init_libbpf_logging;
-use scx_utils::misc::read_file_usize;
 use scx_utils::scx_enums;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
@@ -249,8 +247,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.interactive_sticky = opts.interactive_sticky;
         skel.maps.rodata_data.keep_running_enabled = opts.keep_running;
         skel.maps.rodata_data.max_dsq_pick2 = opts.max_dsq_pick2;
-        skel.maps.rodata_data.smt_enabled =
-            read_file_usize(Path::new("/sys/devices/system/cpu/smt/active")).unwrap_or(0) == 1;
+        skel.maps.rodata_data.smt_enabled = TOPO.smt_enabled;
 
         let mut skel = scx_ops_load!(skel, p2dq, uei)?;
 


### PR DESCRIPTION
Add the new property smt_enabled in Topology that can be used by the schedulers to check if SMT is enabled in the system.

Also change all the schedulers to use this property and get rid of all the duplicate code.