### PR TITLE
scx_utils: Fix the failure in tracepoint_exists() in some kernel configs.

### DIFF
--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -171,7 +171,10 @@ pub fn in_kallsyms(ksym: &str) -> Result<bool> {
 }
 
 pub fn tracepoint_exists(tracepoint: &str) -> Result<bool> {
-    let file = std::fs::File::open("/sys/kernel/tracing/available_events")?;
+    let mut file = match std::fs::File::open("/sys/kernel/tracing/available_events") {
+        Err(_) => std::fs::File::open("/sys/kernel/debug/tracing/available_events")?,
+        Ok(file) => file,
+    };
     let reader = std::io::BufReader::new(file);
 
     for line in reader.lines() {


### PR DESCRIPTION
tracepoint_exists() assumed that "/sys/kernel/tracing/available_events" always exists, which is not true in some kernel configurations. So let's check both "/sys/kernel/tracing/available_events" and "/sys/kernel/debug/tracing/available_events".

This fixes the following issue:
  https://github.com/sched-ext/scx/issues/1482