### PR TITLE
common: Add helpers for scaling by task weight

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -640,6 +640,23 @@ static inline u32 log2_u64(u64 v)
                 return log2_u32(v) + 1;
 }
 
+/*
+ * Return a value proportionally scaled to the task's priority.
+ */
+static inline u64 scale_task_fair(const struct task_struct *p, u64 value)
+{
+	return (value * p->scx.weight) / 100;
+}
+
+/*
+ * Return a value inversely proportional to the task's priority.
+ */
+static inline u64 scale_task_inverse_fair(const struct task_struct *p, u64 value)
+{
+	return value * 100 / p->scx.weight;
+}
+
+
 #include "compat.bpf.h"
 #include "enums.bpf.h"
 

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -258,14 +258,6 @@ static u64 nr_tasks_waiting(int node)
 }
 
 /*
- * Return a value inversely proportional to the task's priority.
- */
-static u64 scale_inverse_fair(const struct task_struct *p, u64 value)
-{
-	return value * 100 / p->scx.weight;
-}
-
-/*
  * Update and return the task's deadline.
  */
 static u64 task_deadline(const struct task_struct *p, struct task_ctx *tctx)
@@ -287,7 +279,7 @@ static u64 task_deadline(const struct task_struct *p, struct task_ctx *tctx)
 	/*
 	 * Add the execution vruntime to the deadline.
 	 */
-	tctx->deadline += scale_inverse_fair(p, tctx->exec_runtime);
+	tctx->deadline += scale_task_inverse_fair(p, tctx->exec_runtime);
 
 	return tctx->deadline;
 }
@@ -1028,7 +1020,7 @@ void BPF_STRUCT_OPS(bpfland_stopping, struct task_struct *p, bool runnable)
 	/*
 	 * Update task's vruntime.
 	 */
-	tctx->deadline += scale_inverse_fair(p, slice);
+	tctx->deadline += scale_task_inverse_fair(p, slice);
 }
 
 void BPF_STRUCT_OPS(bpfland_runnable, struct task_struct *p, u64 enq_flags)

--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -224,14 +224,6 @@ static inline void stat_inc(enum stat_idx idx)
 }
 
 /*
- * Return a value proportionally scaled to the task's priority.
- */
-static u64 scale_up_fair(const struct task_struct *p, u64 value)
-{
-	return (value * p->scx.weight) / 100;
-}
-
-/*
  * Returns if the task is interactive based on the tasks DSQ index.
  */
 static bool is_interactive(struct task_ctx *taskc)
@@ -757,7 +749,7 @@ void BPF_STRUCT_OPS(p2dq_stopping, struct task_struct *p, bool runnable)
 	}
 
 	used = now - taskc->last_run_at;
-	p->scx.dsq_vtime = scale_up_fair(p, used);
+	p->scx.dsq_vtime = scale_task_fair(p, used);
 	taskc->last_dsq_id = taskc->dsq_id;
 	taskc->last_dsq_index = dsq_index;
 	__sync_fetch_and_add(&llcx->vtime, used);

--- a/scheds/rust/scx_tickless/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_tickless/src/bpf/main.bpf.c
@@ -162,14 +162,6 @@ struct task_ctx *try_lookup_task_ctx(const struct task_struct *p)
 static u64 vtime_now;
 
 /*
- * Scale value inversely proportional to the weight of @p.
- */
-static u64 scale_inverse_fair(const struct task_struct *p, u64 value)
-{
-	return value * 100 / p->scx.weight;
-}
-
-/*
  * Update and return the task's deadline.
  */
 static u64 task_deadline(const struct task_struct *p, struct task_ctx *tctx)
@@ -191,7 +183,7 @@ static u64 task_deadline(const struct task_struct *p, struct task_ctx *tctx)
 	/*
 	 * Add the execution vruntime to the deadline.
 	 */
-	return tctx->deadline + scale_inverse_fair(p, tctx->exec_runtime);
+	return tctx->deadline + scale_task_inverse_fair(p, tctx->exec_runtime);
 }
 
 /*
@@ -564,7 +556,7 @@ void BPF_STRUCT_OPS(tickless_stopping, struct task_struct *p, bool runnable)
 	/*
 	 * Update task's vruntime.
 	 */
-	tctx->deadline += scale_inverse_fair(p, slice);
+	tctx->deadline += scale_task_inverse_fair(p, slice);
 }
 
 /*


### PR DESCRIPTION
Add scale_task_fair and scale_task_inverse_fair helpers and refactor schedulers to use shared helpers.