### PR TITLE
scx_utils: Fix cargo warning

### DIFF
--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -171,7 +171,7 @@ pub fn in_kallsyms(ksym: &str) -> Result<bool> {
 }
 
 pub fn tracepoint_exists(tracepoint: &str) -> Result<bool> {
-    let mut file = match std::fs::File::open("/sys/kernel/tracing/available_events") {
+    let file = match std::fs::File::open("/sys/kernel/tracing/available_events") {
         Err(_) => std::fs::File::open("/sys/kernel/debug/tracing/available_events")?,
         Ok(file) => file,
     };


### PR DESCRIPTION
Fix cargo linter warning for a variable being unnecessarily mutable.