### PR TITLE
common: Rename scale_task_fair and scale_task_inverse_fair

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -641,17 +641,17 @@ static inline u32 log2_u64(u64 v)
 }
 
 /*
- * Return a value proportionally scaled to the task's priority.
+ * Return a value proportionally scaled to the task's weight.
  */
-static inline u64 scale_task_fair(const struct task_struct *p, u64 value)
+static inline u64 scale_by_task_weight(const struct task_struct *p, u64 value)
 {
 	return (value * p->scx.weight) / 100;
 }
 
 /*
- * Return a value inversely proportional to the task's priority.
+ * Return a value inversely proportional to the task's weight.
  */
-static inline u64 scale_task_inverse_fair(const struct task_struct *p, u64 value)
+static inline u64 scale_by_task_weight_inverse(const struct task_struct *p, u64 value)
 {
 	return value * 100 / p->scx.weight;
 }

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -279,7 +279,7 @@ static u64 task_deadline(const struct task_struct *p, struct task_ctx *tctx)
 	/*
 	 * Add the execution vruntime to the deadline.
 	 */
-	tctx->deadline += scale_task_inverse_fair(p, tctx->exec_runtime);
+	tctx->deadline += scale_by_task_weight_inverse(p, tctx->exec_runtime);
 
 	return tctx->deadline;
 }
@@ -1020,7 +1020,7 @@ void BPF_STRUCT_OPS(bpfland_stopping, struct task_struct *p, bool runnable)
 	/*
 	 * Update task's vruntime.
 	 */
-	tctx->deadline += scale_task_inverse_fair(p, slice);
+	tctx->deadline += scale_by_task_weight_inverse(p, slice);
 }
 
 void BPF_STRUCT_OPS(bpfland_runnable, struct task_struct *p, u64 enq_flags)

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -171,7 +171,7 @@ static u64 task_deadline(const struct task_struct *p, struct task_ctx *tctx)
 	/*
 	 * Add the execution vruntime to the deadline.
 	 */
-	return tctx->deadline + scale_task_inverse_fair(p, tctx->exec_runtime);
+	return tctx->deadline + scale_by_task_weight_inverse(p, tctx->exec_runtime);
 }
 
 /*
@@ -186,7 +186,7 @@ static u64 task_slice(const struct task_struct *p,
 	 * proportional to the total amount of tasks that are waiting to be
 	 * scheduled.
 	 */
-	return scale_task_fair(p, slice_max / nr_tasks_waiting(node));
+	return scale_by_task_weight(p, slice_max / nr_tasks_waiting(node));
 }
 
 /*
@@ -335,7 +335,7 @@ void BPF_STRUCT_OPS(flash_stopping, struct task_struct *p, bool runnable)
 	/*
 	 * Update task's vruntime.
 	 */
-	tctx->deadline += scale_task_inverse_fair(p, slice);
+	tctx->deadline += scale_by_task_weight_inverse(p, slice);
 }
 
 void BPF_STRUCT_OPS(flash_quiescent, struct task_struct *p, u64 deq_flags)

--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -749,7 +749,7 @@ void BPF_STRUCT_OPS(p2dq_stopping, struct task_struct *p, bool runnable)
 	}
 
 	used = now - taskc->last_run_at;
-	p->scx.dsq_vtime = scale_task_fair(p, used);
+	p->scx.dsq_vtime = scale_by_task_weight(p, used);
 	taskc->last_dsq_id = taskc->dsq_id;
 	taskc->last_dsq_index = dsq_index;
 	__sync_fetch_and_add(&llcx->vtime, used);

--- a/scheds/rust/scx_tickless/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_tickless/src/bpf/main.bpf.c
@@ -183,7 +183,7 @@ static u64 task_deadline(const struct task_struct *p, struct task_ctx *tctx)
 	/*
 	 * Add the execution vruntime to the deadline.
 	 */
-	return tctx->deadline + scale_task_inverse_fair(p, tctx->exec_runtime);
+	return tctx->deadline + scale_by_task_weight_inverse(p, tctx->exec_runtime);
 }
 
 /*
@@ -556,7 +556,7 @@ void BPF_STRUCT_OPS(tickless_stopping, struct task_struct *p, bool runnable)
 	/*
 	 * Update task's vruntime.
 	 */
-	tctx->deadline += scale_task_inverse_fair(p, slice);
+	tctx->deadline += scale_by_task_weight_inverse(p, slice);
 }
 
 /*


### PR DESCRIPTION
Rename scale_task_fair and scale_task_inverse_fair to scale_by_task_weight and scale_by_task_weight_inverse to have more precise naming. Follow up from #1485.