### PR TITLE
scx_p2dq: Refactor idle cpu selection for LLC stickiness

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -501,12 +501,14 @@ static s32 pick_idle_cpu(struct task_struct *p, struct task_ctx *taskc,
 		goto out_put_cpumask;
 	}
 
-	// Greedy idle tries to grab any idle CPU in the LLC
-	if (greedy_idle && llcx->cpumask) {
+	// Try to keep interactive tasks local to the LLC and let non
+	// interactive tasks load balance via pick2.
+	if ((interactive || greedy_idle) && llcx->cpumask) {
 		cpu = scx_bpf_pick_idle_cpu(cast_mask(llcx->cpumask), 0);
 		if (cpu >= 0) {
+			if (greedy_idle)
+				stat_inc(P2DQ_STAT_GREEDY_IDLE);
 			*is_idle = true;
-			stat_inc(P2DQ_STAT_GREEDY_IDLE);
 			goto out_put_cpumask;
 		}
 	}
@@ -514,16 +516,18 @@ static s32 pick_idle_cpu(struct task_struct *p, struct task_ctx *taskc,
 	if (!nodec->cpumask)
 		goto out_put_cpumask;
 
-	cpu = scx_bpf_pick_idle_cpu(cast_mask(nodec->cpumask), SCX_PICK_IDLE_CORE);
-	if (cpu >= 0) {
-		*is_idle = true;
-		goto out_put_cpumask;
-	}
-
 	if (nr_llcs > 1) {
-		// Try to keep interactive tasks local to the LLC and let non
-		// interactive tasks load balance via pick2.
-		if (interactive && nodec->cpumask) {
+		// first try an idle core in the local node
+		cpu = scx_bpf_pick_idle_cpu(cast_mask(nodec->cpumask), SCX_PICK_IDLE_CORE);
+		if (cpu >= 0) {
+			*is_idle = true;
+			goto out_put_cpumask;
+		}
+
+		if (interactive) {
+			if (!nodec->cpumask)
+				goto out_put_cpumask;
+
 			cpu = scx_bpf_pick_idle_cpu(cast_mask(nodec->cpumask), 0);
 			if (cpu >= 0) {
 				*is_idle = true;
@@ -536,12 +540,21 @@ static s32 pick_idle_cpu(struct task_struct *p, struct task_ctx *taskc,
 				goto out_put_cpumask;
 			}
 		}
-	}
+	} else {
+		cpu = scx_bpf_pick_idle_cpu(cast_mask(nodec->cpumask), SCX_PICK_IDLE_CORE);
+		if (cpu >= 0) {
+			*is_idle = true;
+			goto out_put_cpumask;
+		}
 
-	cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
-	if (cpu >= 0) {
-		*is_idle = true;
-		goto out_put_cpumask;
+		if (!nodec->cpumask)
+			goto out_put_cpumask;
+
+		cpu = scx_bpf_pick_idle_cpu(cast_mask(nodec->cpumask), 0);
+		if (cpu >= 0) {
+			*is_idle = true;
+			goto out_put_cpumask;
+		}
 	}
 	cpu = prev_cpu;
 

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -118,7 +118,7 @@ struct Opts {
 
     /// Number of runs on the LLC before a task becomes eligbile for pick2 migration on the wakeup
     /// path.
-    #[clap(short = 'l', long, default_value = "3")]
+    #[clap(short = 'l', long, default_value = "1")]
     min_llc_runs_pick2: u64,
 
     /// Manual definition of slice intervals in microseconds for DSQs, must be equal to number of


### PR DESCRIPTION
Refactor idle CPU selection to make interactive tasks more sticky to LLCs. Update default value for eligible llc task migration to be less sticky for non interactive tasks.