### PR TITLE
scx_p2dq: enqueue to selected_cpu

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -576,7 +576,7 @@ s32 BPF_STRUCT_OPS(p2dq_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wak
 	if (is_idle) {
 		stat_inc(P2DQ_STAT_IDLE);
 		u64 slice_ns = dsq_time_slice(taskc->dsq_index);
-		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, slice_ns, 0);
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, slice_ns, 0);
 	}
 
 	return cpu;
@@ -638,7 +638,7 @@ void BPF_STRUCT_OPS(p2dq_enqueue, struct task_struct *p __arg_trusted, u64 enq_f
 		return;
 	}
 
-	/* 
+	/*
 	 * Affinitized tasks just get dispatched directly, need to handle this
 	 * better.
 	 */


### PR DESCRIPTION
The .select_cpu() method always enqueues on the local CPU even if another one is selected because it uses SCX_DSQ_LOCAL. Use SCX_DSQ_LOCAL_ON | cpu instead to enqueue to the CPU picked by pick_idle_cpu().