### PR TITLE
scx_p2dq: Revert SCX_DSQ_LOCAL_ON in select_cpu

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -586,7 +586,7 @@ s32 BPF_STRUCT_OPS(p2dq_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wak
 	if (is_idle) {
 		stat_inc(P2DQ_STAT_IDLE);
 		u64 slice_ns = dsq_time_slice(taskc->dsq_index);
-		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, slice_ns, 0);
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, slice_ns, 0);
 	}
 
 	return cpu;


### PR DESCRIPTION
After enabling `SCX_DSQ_LOCAL_ON` in the select path p2dq would sometimes get kicked:

```
[2427581.529156] sched_ext: BPF scheduler "p2dq" disabled (runtime error) [2427581.543695] sched_ext: p2dq: SCX_DSQ_LOCAL[_ON] verdict target cpu 21 not allowed for rcu_exp_par_gp_[313]
[2427581.565551]    task_can_run_on_remote_rq+0x6e/0x80
[2427581.576607]    dispatch_to_local_dsq+0x66/0x170
[2427581.587074]    run_deferred+0x7c/0xa0
[2427581.595631]    wake_up_process+0x65b/0xbe0
[2427581.605141]    kthread_queue_work+0x3f/0x60
[2427581.605147]    rcu_exp_sel_wait_wake+0x32d/0xe40
[2427581.625499]    kthread_worker_fn+0xcc/0x250
[2427581.635211]    kthread+0xdd/0x120
[2427581.642980]    ret_from_fork+0x2f/0x40
[2427581.651707]    ret_from_fork_asm+0x11/0x20
```

Revert back to using SCX_DSQ_LOCAL in the select_cpu path.