### PR TITLE
ci: pin kernel revisions

### DIFF
--- a/.github/actions/restore-kernel-cache/action.yml
+++ b/.github/actions/restore-kernel-cache/action.yml
@@ -1,10 +1,7 @@
 name: 'Restore kernel cache'
 description: 'Restore a previously built kernel cache, failing if not available'
 inputs:
-  git-repo:
-    required: true
-    type: string
-  branch:
+  repo-name:
     required: true
     type: string
 
@@ -12,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Get hash from repo/branch
-      run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote ${{ inputs.git-repo }} heads/${{ inputs.branch }} | awk '{print $1}')" >> $GITHUB_ENV
+      run: echo "SCHED_EXT_KERNEL_COMMIT=$(jq -r '."${{ inputs.repo-name }}".commitHash' kernel-versions.json)" >> $GITHUB_ENV
       shell: bash
 
     - name: Load cache

--- a/.github/workflows/bpf-next-test.yml
+++ b/.github/workflows/bpf-next-test.yml
@@ -9,8 +9,7 @@ jobs:
   build-kernel:
     uses: ./.github/workflows/build-kernel.yml
     with:
-      git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git"
-      branch: for-next
+      repo-name: bpf/bpf-next
 
   integration-test:
     runs-on: ubuntu-24.04
@@ -24,8 +23,7 @@ jobs:
 
       - uses: ./.github/actions/restore-kernel-cache
         with:
-          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git"
-          branch: for-next
+          repo-name: bpf/bpf-next
 
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -1,10 +1,7 @@
 on:
   workflow_call:
     inputs:
-      git-repo:
-        required: true
-        type: string
-      branch:
+      repo-name:
         required: true
         type: string
 
@@ -16,14 +13,12 @@ jobs:
         if: ${{ runner.environment == 'github-hosted' }}
         uses: DeterminateSystems/nix-installer-action@main
 
-      # Make very basic dependencies available in PATH
-      - name: Install basic dependencies
-        run: |
-          nix profile install nixpkgs#{git,openssl,gawk,gnutar,zstd}
-          echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
+      - uses: actions/checkout@v4
 
-      # get latest head commit of sched_ext for-next
-      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(git ls-remote ${{ inputs.git-repo }} heads/${{ inputs.branch }} | awk '{print $1}')" >> $GITHUB_ENV
+      - name: Load minimal dependencies
+        run: nix run ./.github/workflows#nix-develop-gha -- ./.github/workflows#update-kernels
+
+      - run: echo "SCHED_EXT_KERNEL_COMMIT=$(jq -r '."${{ inputs.repo-name }}".commitHash' kernel-versions.json)" >> $GITHUB_ENV
 
       # check for cached kernel without downloading
       - name: Cache Kernel
@@ -37,13 +32,9 @@ jobs:
           key: kernel-build-${{ env.SCHED_EXT_KERNEL_COMMIT }}-7
           lookup-only: true
 
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v4
-
-      - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
-        uses: nicknovitski/nix-develop@v1
-        with:
-          arguments: ./.github/workflows#build-kernel
+      - name: Load dependencies
+        if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
+        run: nix run ./.github/workflows#nix-develop-gha -- ./.github/workflows#build-kernel
 
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
         name: Clone Kernel
@@ -51,7 +42,7 @@ jobs:
         with:
           retries: 10
           pause: 18
-          command: git clone --single-branch -b ${{ inputs.branch }} --depth 1 ${{ inputs.git-repo }} linux
+          command: git clone --single-branch -b $(jq -r '."${{ inputs.repo-name }}".branch' kernel-versions.json) --depth 100 $(jq -r '."${{ inputs.repo-name }}".repo' kernel-versions.json) linux
 
       - if: ${{ steps.cache-kernel.outputs.cache-hit != 'true' }}
         name: Select correct commit for cache hash

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -1,9 +1,6 @@
 name: build-and-test
 
 on:
-  # only runs on main, hourly cache update used by all branches. random minute to avoid synchronised scheduled workflows.
-  schedule:
-    - cron: "8 * * * *"
   push:
   pull_request:
   merge_group:
@@ -29,8 +26,7 @@ jobs:
   build-kernel:
     uses: ./.github/workflows/build-kernel.yml
     with:
-      git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
-      branch: for-next
+      repo-name: sched_ext/for-next
 
   integration-test:
     runs-on: ubuntu-24.04
@@ -44,8 +40,7 @@ jobs:
 
       - uses: ./.github/actions/restore-kernel-cache
         with:
-          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
-          branch: for-next
+          repo-name: sched_ext/for-next
 
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
@@ -121,8 +116,7 @@ jobs:
 
       - uses: ./.github/actions/restore-kernel-cache
         with:
-          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
-          branch: for-next
+          repo-name: sched_ext/for-next
 
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
@@ -186,8 +180,7 @@ jobs:
 
       - uses: ./.github/actions/restore-kernel-cache
         with:
-          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git"
-          branch: for-next
+          repo-name: sched_ext/for-next
 
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar

--- a/.github/workflows/flake.lock
+++ b/.github/workflows/flake.lock
@@ -18,6 +18,26 @@
         "type": "github"
       }
     },
+    "nix-develop-gha": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1740956892,
+        "narHash": "sha256-9MhGx2h0/iE2xF9SOw4QaQNfSM0KXvkUBNJZ5NYLb1I=",
+        "owner": "nicknovitski",
+        "repo": "nix-develop",
+        "rev": "5da6ac475f1ffbcf54ee562fa3056646e146be95",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nicknovitski",
+        "repo": "nix-develop",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1738086784,
@@ -37,6 +57,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nix-develop-gha": "nix-develop-gha",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/.github/workflows/flake.nix
+++ b/.github/workflows/flake.nix
@@ -4,17 +4,28 @@
   inputs = {
     nixpkgs.url = "github:JakeHillion/nixpkgs/virtme-ng";
     flake-utils.url = "github:numtide/flake-utils";
+
+    nix-develop-gha.url = "github:nicknovitski/nix-develop";
+    nix-develop-gha.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
+  outputs = { self, nixpkgs, flake-utils, nix-develop-gha, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ]
       (system: {
+        packages.nix-develop-gha = nix-develop-gha.packages."${system}".default;
+
         devShells =
           let
             pkgs = import nixpkgs { inherit system; };
             common = with pkgs; [ gnutar zstd ];
           in
           {
+            update-kernels = pkgs.mkShell {
+              buildInputs = with pkgs; common ++ [
+                jq
+              ];
+            };
+
             build-kernel = pkgs.mkShell {
               buildInputs = with pkgs; common ++ [
                 bc
@@ -23,6 +34,7 @@
                 elfutils
                 flex
                 git
+                jq
                 openssl
                 pahole
                 perl
@@ -31,8 +43,31 @@
               ];
             };
           };
-      }) // flake-utils.lib.eachDefaultSystem (system: {
-      formatter = nixpkgs.legacyPackages.${system}.nixpkgs-fmt;
-    });
+      }) // flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        formatter = pkgs.nixpkgs-fmt;
+
+        apps = {
+          update-kernels =
+            let
+              script = pkgs.python3Packages.buildPythonApplication {
+                pname = "update-kernels";
+                version = "git";
+
+                pyproject = false;
+                dontUnpack = true;
+
+                installPhase = "install -Dm755 ${./update-kernels.py} $out/bin/update-kernels";
+              };
+            in
+            {
+              type = "app";
+              program = "${script}/bin/update-kernels";
+            };
+        };
+      });
 }
 

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -9,8 +9,7 @@ jobs:
   build-kernel:
     uses: ./.github/workflows/build-kernel.yml
     with:
-      git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
-      branch: linux-rolling-stable
+      repo-name: stable/linux-rolling-stable
 
   integration-test:
     runs-on: ubuntu-24.04
@@ -24,8 +23,7 @@ jobs:
 
       - uses: ./.github/actions/restore-kernel-cache
         with:
-          git-repo: "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
-          branch: linux-rolling-stable
+          repo-name: stable/linux-rolling-stable
 
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar

--- a/.github/workflows/update-kernels.py
+++ b/.github/workflows/update-kernels.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+
+def get_hash_for_repo_branch(repo, branch):
+    result = subprocess.run(
+        ["git", "ls-remote", "--exit-code", repo, f"heads/{branch}"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.split("\t")[0]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Update kernel locks")
+    parser.add_argument(
+        "versions", nargs="*", help="Named version(s) to update (default=all)"
+    )
+    args = parser.parse_args()
+
+    try:
+        with open("kernel-versions.json", "r") as f:
+            data = json.load(f)
+    except FileNotFoundError as exc:
+        raise Exception(
+            "kernel-versions.json not found. Are you running this script from the root of the scx repo?"
+        ) from exc
+
+    diff = False
+
+    if args.versions:
+        versions_set = set(args.versions)
+
+    for k, v in data.items():
+        if args.versions and k not in versions_set:
+            continue
+
+        new_hash = get_hash_for_repo_branch(v["repo"], v["branch"])
+        old_hash = v.get("commitHash", "")
+        if new_hash == old_hash:
+            continue
+
+        print(f"Updating {k} from {old_hash} -> {new_hash}")
+
+        v["commitHash"] = new_hash
+        v["lastModified"] = int(time.time())
+
+        diff = True
+
+    if not diff:
+        print("No changes made, exiting.")
+        sys.exit(0)
+
+    content = json.dumps(data, indent=2)
+    with open("kernel-versions.json", "w") as f:
+        f.write(content)

--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -1,0 +1,72 @@
+name: update-kernels
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '23 3 * * *'
+
+jobs:
+  list-kernels:
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64" ]') || 'ubuntu-latest' }}
+    outputs:
+      matrix: ${{ steps.output.outputs.matrix }}
+    steps:
+      - name: Install Nix
+        if: ${{ runner.environment == 'github-hosted' }}
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: actions/checkout@v4
+
+      - name: Load dependencies
+        run: nix run ./.github/workflows#nix-develop-gha -- ./.github/workflows#update-kernels
+
+      - name: List kernels
+        id: output
+        run: |
+          matrix=$(jq -c 'keys' kernel-versions.json)
+          echo $matrix
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+  update-kernels:
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64" ]') || 'ubuntu-latest' }}
+    needs: list-kernels
+    strategy:
+      matrix:
+        version: ${{ fromJson(needs.list-kernels.outputs.matrix) }}
+
+    steps:
+      - name: Install Nix
+        if: ${{ runner.environment == 'github-hosted' }}
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+
+      - name: Load dependencies
+        run: nix run ./.github/workflows#nix-develop-gha -- ./.github/workflows#update-kernels
+
+      - name: Update kernel
+        run: |
+          git switch -c "deps/kernel/${{ matrix.version }}"
+          nix run ./.github/workflows#update-kernels -- ${{ matrix.version }}
+          git diff --exit-code || echo 'modified=true' >> $GITHUB_ENV
+
+      - name: Commit and open PR
+        if: env.modified == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+        run: |
+          git config --global user.email "ci@sched-ext.com"
+          git config --global user.name "sched-ext CI Bot"
+          git commit -am "chore(deps): update ${{ matrix.version }} kernel"
+
+          # we own these branches, force push is fine
+          git push --force origin "HEAD:deps/kernel/${{ matrix.version }}"
+
+          PR_IDS=$(gh pr list --head $(git rev-parse --abbrev-ref HEAD) --json id)
+          if echo $PR_IDS | jq -e '. == []'; then
+            gh pr create --fill
+          else
+            echo "PR already exists, skipping creation."
+          fi
+          gh pr merge --auto --merge --delete-branch

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -31,6 +31,25 @@ load between scheduling domains becomes a difficult problem. sched_ext has a
 common crate for calculating weights between scheduling domains. See the
 `infeasible` crate in `rust/scx_utils/src` for the implementation.
 
+## Development kernels
+This repository has a kernel lock file at `./kernel-versions.json` where we track
+several kernels important to development.
+
+If your change requires a new commit from a branch, you can update this file with:
+    nix run ./.github/workflows#update-kernels
+or with:
+    python3 ./.github/workflows/update-kernels.py
+
+Otherwise new changes will be picked up automatically. If the changes that are
+picked up automatically fail CI, you can fix this in a PR separately - the automatic
+updater will kick back in once things are green. Create a branch and PR as normal
+both updating the kernel lock and making necessary fixes to the codebase.
+
+We use `virtme-ng` for testing in the CI environment, and it should be possible
+to reproduce this locally with the same pinned kernels. Currently the most effective
+documentation for this will be to read the CI workflows. If this improves in the
+future we'll endeavour to update this documentation.
+
 ## Rust
 We use `cargo fmt` to ensure consistency in our Rust code. This runs on PRs in
 the CI and will fail with a patch if your code doesn't match. We currently need

--- a/kernel-versions.json
+++ b/kernel-versions.json
@@ -1,0 +1,20 @@
+{
+  "sched_ext/for-next": {
+    "repo": "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git",
+    "branch": "for-next",
+    "commitHash": "108963bba0853dc389177b12773f7e3b24308b7c",
+    "lastModified": 1741489170
+  },
+  "bpf/bpf-next": {
+    "repo": "https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git",
+    "branch": "master",
+    "commitHash": "bf5af299b51d2ae8fef6ec87ac7de0f9136f1512",
+    "lastModified": 1741671543
+  },
+  "stable/linux-rolling-stable": {
+    "repo": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-rolling-stable",
+    "commitHash": "0762dadc7cfbc0d547291bb24d48d0313f95a116",
+    "lastModified": 1741489170
+  }
+}


### PR DESCRIPTION
Currently we use unpinned kernels. We name a repo and branch and pull whatever is at the head of that at the time the GitHub workflow runs. This changeset proposes and implements locking kernel revision.

Advantages of pinning:
- Disambiguates between a commit that failed a GitHub run becuase of a code change and the kernel updating.
- Breakages in upstream kernels won't land in the repo until it is fixed, meaning people can keep developing.
- No race condition between the `build-kernel` CI job and the `restore-kernel-cache` CI steps. Currently they race because each checks the head cache individually, pinned they are guaranteed to use the same hash.
- Reduced reliance on git.kernel.org. Recently we saw failures because we query the head cache 10-20 times per PR. With this change we query git.kernel.org 0 times on a cache hit, which is very nearly always.
- Local reproducibility is improved (possible in follow up commits).

Disadvantages of pinning:
- There is more noise in the repo. A bot will occasionally commit updating the lock.
- Slight delay in picking up kernel changes. The `update-kernels` workflow needs to run, and if we run it too frequently there will be a lot of noise in the repo.
- With this setup if every branch has changed several CI runs will arrive at once, causing some unpleasant queuing, and undoing some spreading out of runs I made a while ago. I can't find a nice way to do this without spreading out the workflows. Mitigated by choosing the time of day with fewest user scheduled action runs.

This commit:
- Adds a script to update the kernel locks with `nix run ./.github/workflows#update-kernels`. This script is easily extensible if we need more information in the future.
- Adds a GitHub Action to automatically run this script, commit changes, and start PRs with auto merge for kernel updates.
- Uses the lock file in `build-kernel.yml` and the `restore-kernel-cache` action.
- Drops the scheduled run for `sched_ext/for-next`. This is now covered by the PR from the lock update or the PR with the scheduler change.

This commit DOES NOT:
- Test the `bpf/bpf-next` and `stable/linux-rolling-stable` versions before merging them, that happens at an unrelated time with the existing workflows. It does solve the polling git.kernel.org issue for them and is left in for consistency/to enable future work on making these push blocking where appropriate.

Test plan:
- Created a GitHub repository JakeHillion/scx-ci-staging. This can't be setup quite the same as the main repo but it successfully receives PRs from the bot, runs the actions, and auto merges when action conditions pass.
- Created a fork of Linux and broke the build. This change does not get pulled in.

I expect there to be a bit of noise landing this in the main repo, particularly around getting the `GH_TOKEN_FOR_UPDATES` secret right. This is necessary because standard actions can't trigger other actions on PRs, and we need a PR to run the merge queue (the whole point of this). The actual kernel builds are well tested.

[1] https://github.com/DeterminateSystems/update-flake-lock?tab=readme-ov-file#running-github-actions-ci