### PR TITLE
[RFC] scx_utils: Add idle power management helpers

### DIFF
--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -79,6 +79,10 @@ mod infeasible;
 pub use infeasible::LoadAggregator;
 pub use infeasible::LoadLedger;
 
+pub mod pm;
+pub use pm::update_cpu_idle_resume_latency;
+pub use pm::update_global_idle_resume_latency;
+
 pub mod misc;
 pub use misc::monitor_stats;
 pub use misc::normalize_load_metric;

--- a/rust/scx_utils/src/pm.rs
+++ b/rust/scx_utils/src/pm.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use anyhow::{anyhow, Result};
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+
+/// Updates the global idle resume latency. When the returned file is closed the request is
+/// dropped. See the following kernel docs for more details:
+/// https://www.kernel.org/doc/html/latest/admin-guide/pm/cpuidle.html#power-management-quality-of-service-for-cpus
+pub fn update_global_idle_resume_latency(value_us: i32) -> Result<File> {
+    if value_us < 0 {
+        return Err(anyhow!("Latency value must be non-negative"));
+    }
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .open("/dev/cpu_dma_latency")?;
+    let bytes = value_us.to_le_bytes(); // Convert to little-endian bytes
+    file.write_all(&bytes)?;
+    Ok(file) // return file descriptor so it can be closed later
+}
+
+/// Updates per cpu idle resume latency.
+pub fn update_cpu_idle_resume_latency(cpu_num: usize, value_us: i32) -> Result<()> {
+    if value_us < 0 {
+        return Err(anyhow!("Latency value must be non-negative"));
+    }
+
+    let path = format!(
+        "/sys/devices/system/cpu/cpu{}/power/pm_qos_resume_latency_us",
+        cpu_num
+    );
+
+    let mut file = File::create(Path::new(&path))?;
+    write!(file, "{}", value_us)?;
+    Ok(())
+}


### PR DESCRIPTION
Add a set of idle power management helpers to scx_utils. This is an initial userspace implementation and if the interface shows promising results then similar idle power management helpers can be exposed via kfuncs. See the kernel docs for information on the userspace API:

https://www.kernel.org/doc/html/latest/admin-guide/pm/cpuidle.html#power-management-quality-of-service-for-cpus


Tested with [`p2dq-idle`](https://github.com/sched-ext/scx/compare/main...hodgesds:scx:p2dq-idle) branch:
```
./target/release/scx_p2dq --idle-qos
02:25:19 [INFO] Setting idle QoS to 100us
02:25:19 [INFO] Running scx_p2dq (build ID: 1.0.10-g8545a626-dirty x86_64-unknown-linux-gnu)
02:25:20 [INFO] DSQ[0] slice_ns 100000
02:25:20 [INFO] DSQ[1] slice_ns 3200000
02:25:20 [INFO] DSQ[2] slice_ns 6400000
02:25:20 [INFO] P2DQ scheduler started! Run `scx_p2dq --monitor` for metrics.
```
Verified update via:
```
cat /sys/devices/system/cpu/cpu*/power/pm_qos_resume_latency_us
100
100
100
100
100
100
100
100
100
100
100
100
100
100
100
100
```