### PR TITLE
meson: Cross-compiling with cargo

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -310,6 +310,11 @@ if get_option('kernel') != ''
   kernel = get_option('kernel')
 endif
 
+if meson.is_cross_build()
+  cargo_target = host_machine.cpu_family() + '-unknown-' + host_machine.kernel() + '-gnu'
+  cargo_build_args += ['--target', cargo_target]
+endif
+
 if enable_rust
   cargo = find_program(get_option('cargo'))
   cargo_fetch = find_program(join_paths(meson.current_source_dir(),

--- a/rust/scx_utils/src/clang_info.rs
+++ b/rust/scx_utils/src/clang_info.rs
@@ -37,9 +37,15 @@ pub struct ClangInfo {
 
 impl ClangInfo {
     pub fn new() -> Result<ClangInfo> {
+        let mut clang_args = vec!["--version".to_string()];
+
+        if let Ok(target) = env::var("TARGET") {
+            clang_args.push(format!("--target={}", target));
+        }
+
         let clang = env::var("BPF_CLANG").unwrap_or("clang".into());
         let output = Command::new(&clang)
-            .args(["--version"])
+            .args(clang_args)
             .output()
             .with_context(|| format!("Failed to run \"{} --version\"", &clang))?;
 


### PR DESCRIPTION
This PR uses the [cross-compilation](https://mesonbuild.com/Cross-compilation.html) features of meson to pass the correct `--target` to cargo.

We also need to pass target to clang when compiling bpf programs using scx_util to include the correct `vmlinux.h` headers.

Cross-compilation also needs a `.cargo/config.toml`, the following is from an openSUSE machine:

```toml
[target.aarch64-unknown-linux-gnu]
linker = "/usr/bin/aarch64-suse-linux-gcc"
ar = "/usr/bin/aarch64-suse-linux-ar"
```

And a cross-file (with a corresponding sys-root with libbpf installed):

```toml
[binaries]
c = 'aarch64-suse-linux-gcc'
cpp = 'aarch64-suse-linux-g++'
strip = 'aarch64-suse-linux-strip'
pkg-config = '/usr/bin/pkg-config'
cmake = '/usr/bin/cmake'

[properties]
sys_root = '/usr/aarch64-suse-linux/sys-root'

[host_machine]
system = 'unknown'
cpu = 'aarch64'
cpu_family = 'aarch64'
kernel = 'linux'
endian = 'little'
```

This can then be built using meson:

```sh
$ meson setup --reconfigure -Dbpftool=/usr/sbin/bpftool -Dlibbpf_a=disabled -Dopenrc=disabled -Dlibalpm=disabled --cross-file=aarch64 build-aarch64
$ meson compile -C build-aarch64
```

Which produces artifacts for the specified architecture.