### PR TITLE
scx_utils: Fix tracepoint_exists()

### DIFF
--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -211,7 +211,7 @@ pub fn debugfs_mount() -> Result<std::path::PathBuf> {
 }
 
 pub fn tracepoint_exists(tracepoint: &str) -> Result<bool> {
-    let base_path = tracefs_mount().unwrap_or(debugfs_mount()?);
+    let base_path = tracefs_mount().unwrap_or_else(|_| debugfs_mount().unwrap().join("tracing"));
     let file = std::fs::File::open(base_path.join("available_events"))?;
     let reader = std::io::BufReader::new(file);
 


### PR DESCRIPTION
In tracepoint_exists(), unwrap_or() was used to get a result of either tracefs_mount() or debugfs_mount(). However, in Rust, unwrap_or() is eager so both tracefs_mount() and debugfs_mount() are evaluated. Hence, if one of them does not exist, an error is raised.

So, we replace unwrap_or() with unwrap_or_else(), which conducts lazy evaluation, meaning that if tracefs_mount() succeeds, debugfs_mount() is never evaluated.

Also, added "/tracing" to the debugfs mount point since the debugfs mount point is "/sys/kernel/debug" not "/sys/kernel/debug/tracing".

This should fix the following issue:
  https://github.com/sched-ext/scx/issues/1502