### PR TITLE
scx_layered: Add idle qos config

### DIFF
--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -113,6 +113,8 @@ pub struct LayerCommon {
     #[serde(default)]
     pub perf: u64,
     #[serde(default)]
+    pub idle_resume_us: Option<u32>,
+    #[serde(default)]
     pub nodes: Vec<usize>,
     #[serde(default)]
     pub llcs: Vec<usize>,


### PR DESCRIPTION
Add per layer configuration that allows setting the idle QoS resume latency value. Using this configuration allows for better control of idle cstates. This allows layers to set the idle exit latency. From the docs:

> CPU idle time governors are expected to regard the minimum of the
> global (effective) CPU latency limit and the effective resume latency
> constraint for the given CPU as the upper limit for the exit latency of
> the idle states that they are allowed to select for that CPU. They
> should never select any idle states with exit latency beyond that limit.

See the kernel documentation for more details:
https://www.kernel.org/doc/html/latest/admin-guide/pm/cpuidle.html#power-management-quality-of-service-for-cpus