### PR TITLE
scx_wd40: remove lb_domain map

### DIFF
--- a/scheds/rust/scx_wd40/Cargo.lock
+++ b/scheds/rust/scx_wd40/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "scx_stats"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "scx_stats_derive"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "scx_utils"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "scx_wd40"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,8 +959,8 @@ dependencies = [
  "ctrlc",
  "fb_procfs",
  "libbpf-rs",
- "libc",
  "log",
+ "nix 0.29.0",
  "ordered-float",
  "scx_stats",
  "scx_stats_derive",

--- a/scheds/rust/scx_wd40/src/bpf/bpf_experimental.h
+++ b/scheds/rust/scx_wd40/src/bpf/bpf_experimental.h
@@ -352,6 +352,19 @@ l_true:												\
        })
 #endif
 
+/* Override the definitions from scx/common.bpf.h. */
+#ifdef cond_break
+#undef cond_break
+#endif
+
+#ifdef READ_ONCE
+#undef READ_ONCE
+#endif
+
+#ifdef WRITE_ONCE
+#undef WRITE_ONCE
+#endif
+
 /*
  * Note that cond_break can only be portably used in the body of a breakable
  * construct, whereas can_loop can be used anywhere.

--- a/scheds/rust/scx_wd40/src/bpf/common.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/common.bpf.c
@@ -10,6 +10,8 @@
 
 #include "cpumask.h"
 
+#include "bpf_arena_spin_lock.h"
+
 #include "intf.h"
 #include "types.h"
 #include "lb_domain.h"

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
@@ -10,6 +10,8 @@
 
 #include "cpumask.h"
 
+#include "bpf_arena_spin_lock.h"
+
 #include "intf.h"
 #include "types.h"
 #include "lb_domain.h"
@@ -27,7 +29,6 @@ struct lock_wrapper {
 
 struct lb_domain {
 	union sdt_id		tid;
-	struct bpf_spin_lock vtime_lock;
 
 	dom_ptr domc;
 };
@@ -156,20 +157,6 @@ dom_ptr lookup_dom_ctx(u32 dom_id)
 		scx_bpf_error("Failed to lookup dom[%u]", dom_id);
 
 	return domc;
-}
-
-__hidden
-struct bpf_spin_lock *lookup_dom_vtime_lock(dom_ptr domc)
-{
-	struct lb_domain *lb_domain;
-
-	lb_domain = lb_domain_get(domc->id);
-	if (!lb_domain) {
-		scx_bpf_error("Failed to lookup dom map value");
-		return NULL;
-	}
-
-	return &lb_domain->vtime_lock;
 }
 
 static inline u32 weight_to_bucket_idx(u32 weight)

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.h
@@ -10,7 +10,6 @@ void lb_domain_free(dom_ptr domc);
 struct lb_domain *lb_domain_get(u32 dom_id);
 dom_ptr try_lookup_dom_ctx(u32 dom_id);
 dom_ptr lookup_dom_ctx(u32 dom_id);
-struct bpf_spin_lock *lookup_dom_vtime_lock(dom_ptr domc);
 
 __weak s32 alloc_dom(u32 dom_id);
 __weak s32 create_dom(u32 dom_id);

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.h
@@ -7,7 +7,6 @@ extern struct sdt_allocator lb_domain_allocator;
 int lb_domain_init(void);
 dom_ptr lb_domain_alloc(u32 dom_id);
 void lb_domain_free(dom_ptr domc);
-struct lb_domain *lb_domain_get(u32 dom_id);
 dom_ptr try_lookup_dom_ctx(u32 dom_id);
 dom_ptr lookup_dom_ctx(u32 dom_id);
 

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -50,6 +50,7 @@
 #endif
 
 #include "cpumask.h"
+#include "bpf_arena_spin_lock.h"
 
 #include "intf.h"
 #include "types.h"

--- a/scheds/rust/scx_wd40/src/bpf/placement.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/placement.bpf.c
@@ -10,6 +10,8 @@
 
 #include "cpumask.h"
 
+#include "bpf_arena_spin_lock.h"
+
 #include "intf.h"
 #include "types.h"
 #include "lb_domain.h"

--- a/scheds/rust/scx_wd40/src/bpf/types.h
+++ b/scheds/rust/scx_wd40/src/bpf/types.h
@@ -64,6 +64,8 @@ struct dom_active_tasks {
 };
 
 struct dom_ctx {
+	union sdt_id		tid;
+
 	u32 id;
 	u64 min_vruntime;
 

--- a/scheds/rust/scx_wd40/src/bpf/types.h
+++ b/scheds/rust/scx_wd40/src/bpf/types.h
@@ -4,6 +4,8 @@
 typedef struct dom_ctx __arena *dom_ptr;
 struct dom_ctx;
 
+#define arena_lock_t arena_spinlock_t __arena *
+
 struct task_ctx {
 	/* The domains this task can run on */
 	u64 dom_mask;
@@ -72,6 +74,8 @@ struct dom_ctx {
 	scx_bitmap_t cpumask;
 	scx_bitmap_t direct_greedy_cpumask;
 	scx_bitmap_t node_cpumask;
+
+	arena_lock_t vtime_lock;
 };
 
 #endif /* __TYPES_H */


### PR DESCRIPTION
Use arena spinlocks to replace the BPF ones for WD40's load balancing domains on the BPF side. Having removed the spinlocks from the domains, move the entire domain structure into arenas and remove the associated BPF map data structure.