### PR TITLE
scx_utils: Add helper for cpu idle qos support

### DIFF
--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -79,10 +79,6 @@ mod infeasible;
 pub use infeasible::LoadAggregator;
 pub use infeasible::LoadLedger;
 
-pub mod pm;
-pub use pm::update_cpu_idle_resume_latency;
-pub use pm::update_global_idle_resume_latency;
-
 pub mod misc;
 pub use misc::monitor_stats;
 pub use misc::normalize_load_metric;
@@ -91,6 +87,8 @@ pub use misc::set_rlimit_infinity;
 mod netdev;
 pub use netdev::read_netdevs;
 pub use netdev::NetDev;
+
+pub mod pm;
 
 pub mod enums;
 pub use enums::scx_enums;

--- a/rust/scx_utils/src/pm.rs
+++ b/rust/scx_utils/src/pm.rs
@@ -39,3 +39,8 @@ pub fn update_cpu_idle_resume_latency(cpu_num: usize, value_us: i32) -> Result<(
     write!(file, "{}", value_us)?;
     Ok(())
 }
+
+/// Returns if idle resume latency is supported.
+pub fn cpu_idle_resume_latency_supported() -> bool {
+    std::fs::exists("/sys/devices/system/cpu/cpu0/power/pm_qos_resume_latency_us").unwrap_or(false)
+}

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -28,13 +28,13 @@ use scx_stats::prelude::*;
 use scx_utils::build_id;
 use scx_utils::import_enums;
 use scx_utils::init_libbpf_logging;
+use scx_utils::pm::{cpu_idle_resume_latency_supported, update_cpu_idle_resume_latency};
 use scx_utils::scx_enums;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
 use scx_utils::uei_exited;
 use scx_utils::uei_report;
-use scx_utils::update_cpu_idle_resume_latency;
 use scx_utils::CoreType;
 use scx_utils::Topology;
 use scx_utils::UserExitInfo;
@@ -390,10 +390,14 @@ fn main() -> Result<()> {
     }
 
     if let Some(idle_resume_us) = opts.idle_resume_us {
-        if idle_resume_us > 0 {
-            info!("Setting idle QoS to {}us", idle_resume_us);
-            for cpu in TOPO.all_cpus.values() {
-                update_cpu_idle_resume_latency(cpu.id, idle_resume_us.try_into().unwrap())?;
+        if !cpu_idle_resume_latency_supported() {
+            warn!("idle resume latency not supported");
+        } else {
+            if idle_resume_us > 0 {
+                info!("Setting idle QoS to {}us", idle_resume_us);
+                for cpu in TOPO.all_cpus.values() {
+                    update_cpu_idle_resume_latency(cpu.id, idle_resume_us.try_into().unwrap())?;
+                }
             }
         }
     }


### PR DESCRIPTION
Add a helper to check if idle qos is supported and use the helpering in scx_layered/scx_p2dq to emit warnings when the functionality is not supported.

`scx_p2dq` test:
```
$ sudo ./target/release/scx_p2dq --idle-resume-us 500
13:08:46 [WARN] idle resume latency not supported
13:08:46 [INFO] Running scx_p2dq (build ID: 1.0.10-g0206c6b1-dirty x86_64-unknown-linux-gnu)
13:08:46 [INFO] DSQ[0] slice_ns 100000
13:08:46 [INFO] DSQ[1] slice_ns 3200000
13:08:46 [INFO] DSQ[2] slice_ns 6400000
13:08:47 [INFO] P2DQ scheduler started! Run `scx_p2dq --monitor` for metrics.
^CEXIT: unregistered from user space
```
`scx_layered` test:
```
$ sudo ./target/release/scx_layered f:/home/hodgesd/user2.json
13:13:21 [INFO] Topology awareness not specified, selecting enabled based on hardware
13:13:21 [INFO] CPUs: online/possible=176/176 nr_cores=88
13:13:21 [INFO] Kernel does not support queued wakeup optimization
13:13:22 [WARN] idle_resume_us not supported, ignoring
13:13:23 [INFO] Layered Scheduler Attached. Run `scx_layered --monitor` for metrics.
```