### PR TITLE
scx_wd40: remove unnecessary argument to vtime update functions

### DIFF
--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.h
@@ -37,10 +37,8 @@ static inline u64 dom_min_vruntime(dom_ptr domc)
 }
 
 void place_task_dl(struct task_struct *p, task_ptr taskc, u64 enq_flags);
-void running_update_vtime(struct task_struct *p, task_ptr taskc,
-				 dom_ptr domc);
-void stopping_update_vtime(struct task_struct *p, task_ptr taskc,
-				  dom_ptr domc);
+void running_update_vtime(struct task_struct *p, task_ptr taskc);
+void stopping_update_vtime(struct task_struct *p);
 
 u64 update_freq(u64 freq, u64 interval);
 void init_vtime(struct task_struct *p, task_ptr taskc);

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -704,34 +704,24 @@ static void lb_record_run(task_ptr taskc)
 void BPF_STRUCT_OPS(wd40_running, struct task_struct *p)
 {
 	task_ptr taskc;
-	dom_ptr domc;
 
-	taskc = lookup_task_ctx(p);
-	domc = taskc->domc;
+	if (!(taskc = lookup_task_ctx(p)))
+		return;
 
 	lb_record_run(taskc);
 
 	if (fifo_sched)
 		return;
 
-	running_update_vtime(p, taskc, domc);
+	running_update_vtime(p, taskc);
 }
 
 void BPF_STRUCT_OPS(wd40_stopping, struct task_struct *p, bool runnable)
 {
-	task_ptr taskc;
-	dom_ptr domc;
-
 	if (fifo_sched)
 		return;
 
-	if (!(taskc = lookup_task_ctx(p)))
-		return;
-
-	if (!(domc = taskc->domc))
-		return;
-
-	stopping_update_vtime(p, taskc, domc);
+	stopping_update_vtime(p);
 }
 
 void BPF_STRUCT_OPS(wd40_quiescent, struct task_struct *p, u64 deq_flags)


### PR DESCRIPTION
The vtime update functions in WD40 take the task's domain context as an argument, but the domain is already accessible through the task context. Remove the  unnecessary arguments to shorten the function signatures.