### PR TITLE
ci: add missing dependencies for update-kernels

### DIFF
--- a/.github/workflows/flake.nix
+++ b/.github/workflows/flake.nix
@@ -22,6 +22,8 @@
           {
             update-kernels = pkgs.mkShell {
               buildInputs = with pkgs; common ++ [
+                gh
+                git
                 jq
               ];
             };


### PR DESCRIPTION

Add a couple of dependencies missed when running on GitHub Hosted runners instead of the self-hosted one.
