### PR TITLE
ci: remove --merge and --delete-branch in update-kernels

### DIFF
--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -69,4 +69,4 @@ jobs:
           else
             echo "PR already exists, skipping creation."
           fi
-          gh pr merge --auto --merge --delete-branch
+          gh pr merge --auto


### PR DESCRIPTION

Well, both pieces of this workflow that I couldn't test out of the main repo didn't work. Lucky me.

The `--delete-branch` argument is incompatible with merge queues. Remove it. We also don't need the `--merge` as that's the default.

Test plan:
- Ran locally: `cd scx-git && gh pr pull 1527 && gh pr merge --auto` - pressed the "Enable auto merge" button in the UI as expected.
