### PR TITLE
scx_p2dq: Refactor eager load balancing

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -474,9 +474,9 @@ static s32 pick_idle_cpu(struct task_struct *p, struct task_ctx *taskc,
 	}
 
 	if (eager_load_balance && nr_llcs > 1) {
-		llcx = pick_two_llc_ctx(rand_llc_ctx(), rand_llc_ctx(), false);
-		if (!llcx) {
-			cpu = prev_cpu;
+		cpu = pick_two_cpu(taskc, is_idle);
+		if (cpu >= 0) {
+			stat_inc(P2DQ_STAT_SELECT_PICK2);
 			goto out_put_cpumask;
 		}
 	}


### PR DESCRIPTION
Refactor the eager load balancing path to use the pick_two_cpu method for load balancing. This makes the code easier to understand as the llc_ctx is not being updated to the load balanced llc.