### PR TITLE
scx_p2dq: Fix vtime handling in enqueue path

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -692,12 +692,6 @@ void BPF_STRUCT_OPS(p2dq_enqueue, struct task_struct *p __arg_trusted, u64 enq_f
 		return;
 	}
 
-	if (vtime > llcx->dsq_max_vtime[taskc->dsq_index]) {
-		llcx->dsq_max_vtime[taskc->dsq_index] = vtime;
-		trace("LLC[%d]DSQ[%d] max_vtime %llu", llcx->id, dsq_id, vtime);
-	}
-
-
 	llc_mask = cast_mask(llcx->cpumask);
 	if (!llc_mask) {
 		scx_bpf_error("invalid llc cpumask");


### PR DESCRIPTION
vtime should not be adjusted for the DSQ in the enqueue path. Adding vtime during enqueue could change the order of DSQ consumption during dispatch. Only update DSQ vtime during stopping for consistency.

`schbench` on `main`:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (43931 total samples)
          50.0th: 7          (17897 samples)
          90.0th: 16         (6023 samples)
        * 99.0th: 871        (3945 samples)
          99.9th: 1630       (396 samples)
          min=1, max=4205
Request Latencies percentiles (usec) runtime 30 (s) (43951 total samples)
          50.0th: 10768      (15361 samples)
          90.0th: 11152      (14859 samples)
        * 99.0th: 19168      (3836 samples)
          99.9th: 29856      (395 samples)
          min=4565, max=44194
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 1438       (7 samples)
        * 50.0th: 1450       (9 samples)
          90.0th: 1470       (12 samples)
          min=1426, max=1767
average rps: 1465.03
```
PR:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (44153 total samples)
          50.0th: 6          (0 samples)
          90.0th: 15         (16110 samples)
        * 99.0th: 717        (3669 samples)
          99.9th: 1550       (395 samples)
          min=1, max=6995
Request Latencies percentiles (usec) runtime 30 (s) (44171 total samples)
          50.0th: 10704      (13117 samples)
          90.0th: 11088      (16082 samples)
        * 99.0th: 19040      (3944 samples)
          99.9th: 28832      (387 samples)
          min=4726, max=42821
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 1450       (9 samples)
        * 50.0th: 1462       (10 samples)
          90.0th: 1474       (9 samples)
          min=1438, max=1794
average rps: 1472.37
```