### PR TITLE
scxtop: Add checks when updating DSQ latency

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -2317,7 +2317,7 @@ impl<'a> App<'a> {
             self.max_cpu_events,
         ));
 
-        if *next_dsq_id != scx_enums.SCX_DSQ_INVALID {
+        if *next_dsq_id != scx_enums.SCX_DSQ_INVALID && *next_dsq_lat_us > 0 {
             cpu_data.add_event_data("dsq_lat_us", *next_dsq_lat_us);
             let next_dsq_data = self
                 .dsq_data
@@ -2340,7 +2340,7 @@ impl<'a> App<'a> {
             }
         }
 
-        if *prev_dsq_id != scx_enums.SCX_DSQ_INVALID {
+        if *prev_dsq_id != scx_enums.SCX_DSQ_INVALID && *prev_used_slice_ns > 0 {
             let prev_dsq_data = self
                 .dsq_data
                 .entry(*prev_dsq_id)

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -294,6 +294,7 @@ static int on_dsq_move(struct task_struct *p, u64 dsq)
 	if (!(tctx = try_lookup_task_ctx(p)))
 		return -ENOENT;
 
+	tctx->dsq_insert_time = bpf_ktime_get_ns();
 	tctx->dsq_id = dsq;
 	tctx->dsq_vtime = 0;
 
@@ -324,6 +325,7 @@ static int on_dsq_move_vtime(struct task_struct *p, u64 dsq)
 	if (!(tctx = try_lookup_task_ctx(p)))
 		return -ENOENT;
 
+	tctx->dsq_insert_time = bpf_ktime_get_ns();
 	tctx->dsq_id = dsq;
 	bpf_core_read(&tctx->dsq_vtime, sizeof(u64), &p->scx.dsq_vtime);
 


### PR DESCRIPTION
Add additional sanity checks for when DSQ latency is added in the TUI. DSQ latency of 0 should not be considered valid.