### PR TITLE
scxtop: Add fork event tracing

### DIFF
--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -32,6 +32,7 @@ enum mode {
 enum event_type {
 	CPU_HP,
 	CPU_PERF_SET,
+	FORK,
 	GPU_MEM,
 	HW_PRESSURE,
 	IPI,
@@ -85,6 +86,13 @@ struct softirq_event {
 	int		softirq_nr;
 };
 
+struct fork_event {
+	u32		parent_pid;
+	u32		child_pid;
+	char		parent_comm[MAX_COMM];
+	char		child_comm[MAX_COMM];
+};
+
 struct ipi_event {
 	u32		pid;
 	u32		target_cpu;
@@ -118,6 +126,7 @@ struct bpf_event {
 	u64		ts;
 	u32		cpu;
 	union {
+		struct  fork_event fork;
 		struct  hw_pressure_event hwp;
 		struct  gpu_mem_event gm;
 		struct  cpuhp_event chp;

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -171,7 +171,8 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
             skel.maps.data_data.sample_rate = 1;
 
             let mut skel = skel.load()?;
-            let links = attach_progs(&mut skel)?;
+            let mut links = attach_progs(&mut skel)?;
+            links.push(skel.progs.on_sched_fork.attach()?);
 
             let trace_dur = std::time::Duration::from_millis(trace_args.trace_ms);
             let bpf_publisher = BpfEventActionPublisher::new(action_tx.clone());


### PR DESCRIPTION
Add bpf event tracing for fork events and collect fork events into perfetto traces.
![2025-03-19-20:46:22](https://github.com/user-attachments/assets/c62ca765-bbc7-49cd-a475-66de58e04de3)
