### PR TITLE
scx_layered: add exclude match rule

### DIFF
--- a/scheds/rust/scx_layered/examples/exclude.json
+++ b/scheds/rust/scx_layered/examples/exclude.json
@@ -1,0 +1,27 @@
+[
+	{
+		"name": "not stress-ng",
+		"matches": [
+			[{ "CommPrefixExclude": "stress-ng" }]
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range":  [5, 5],
+				"util_range": [0.01, 0.99],
+				"growth_algo": "RandomTopo",
+				"protected": true
+			}
+		}
+	},
+	{
+		"name": "stress-ng",
+		"matches": [
+			[]
+		],
+		"kind": {
+			"Open": {
+				"growth_algo": "RandomTopo"
+			}
+		}
+	}
+]

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -268,6 +268,7 @@ struct layer_match {
 	bool		is_kthread;
 	bool		used_gpu_tid;
 	bool		used_gpu_pid;
+	bool		exclude;
 };
 
 struct layer_match_ands {

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2044,7 +2044,7 @@ int match_layer(u32 layer_id, pid_t pid, const char *cgrp_path)
 				goto err;
 
 			match = &ands->matches[and_id];
-			if (!match_one(match, p, cgrp_path)) {
+			if (!(match_one(match, p, cgrp_path) == !match->exclude)) {
 				matched = false;
 				break;
 			}

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -62,7 +62,9 @@ impl LayerSpec {
 pub enum LayerMatch {
     CgroupPrefix(String),
     CommPrefix(String),
+    CommPrefixExclude(String),
     PcommPrefix(String),
+    PcommPrefixExclude(String),
     NiceAbove(i32),
     NiceBelow(i32),
     NiceEquals(i32),

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1298,6 +1298,9 @@ impl<'a> Scheduler<'a> {
                             mt.used_gpu_pid.write(*polarity);
                         }
                     }
+
+                    // Rules are allowlist-based by default
+                    mt.exclude.write(false);
                 }
                 layer.matches[or_i].nr_match_ands = or.len() as i32;
             }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1223,6 +1223,10 @@ impl<'a> Scheduler<'a> {
             for (or_i, or) in spec.matches.iter().enumerate() {
                 for (and_i, and) in or.iter().enumerate() {
                     let mt = &mut layer.matches[or_i].matches[and_i];
+
+                    // Rules are allowlist-based by default
+                    mt.exclude.write(false);
+
                     match and {
                         LayerMatch::CgroupPrefix(prefix) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_CGROUP_PREFIX as i32;
@@ -1232,8 +1236,18 @@ impl<'a> Scheduler<'a> {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_COMM_PREFIX as i32;
                             copy_into_cstr(&mut mt.comm_prefix, prefix.as_str());
                         }
+                        LayerMatch::CommPrefixExclude(prefix) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_COMM_PREFIX as i32;
+                            mt.exclude.write(true);
+                            copy_into_cstr(&mut mt.comm_prefix, prefix.as_str());
+                        }
                         LayerMatch::PcommPrefix(prefix) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_PCOMM_PREFIX as i32;
+                            copy_into_cstr(&mut mt.pcomm_prefix, prefix.as_str());
+                        }
+                        LayerMatch::PcommPrefixExclude(prefix) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_PCOMM_PREFIX as i32;
+                            mt.exclude.write(true);
                             copy_into_cstr(&mut mt.pcomm_prefix, prefix.as_str());
                         }
                         LayerMatch::NiceAbove(nice) => {
@@ -1298,9 +1312,6 @@ impl<'a> Scheduler<'a> {
                             mt.used_gpu_pid.write(*polarity);
                         }
                     }
-
-                    // Rules are allowlist-based by default
-                    mt.exclude.write(false);
                 }
                 layer.matches[or_i].nr_match_ands = or.len() as i32;
             }


### PR DESCRIPTION
Add matching rules for excluding tasks/processes/cgroups with a given name from a layer. This lets us more finely specify task membership for a layer without overly depending on the order we specify the layers.