### PR TITLE
scx_lavd: Enable SCX_OPS_ALLOW_QUEUED_WAKEUP and misc.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -188,9 +188,7 @@ static bool consume_task(struct cpu_ctx *cpuc)
 
 	/*
 	 * Task migration across compute domains happens.
-	 * Update the statistics.
 	 */
 x_domain_migration_out:
-	cpuc->nr_x_migration++;
 	return true;
 }

--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -16,7 +16,7 @@ struct pick_ctx {
 	s32 prev_cpu;
 	u64 wake_flags;
 	/*
-	 * Additional output arguments for find_idle_cpu().
+	 * Additional output arguments for pick_idle_cpu().
 	 */
 	u64 cpdom_id;
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -112,6 +112,7 @@ struct task_ctx {
 	u64	wait_freq;		/* waiting frequency in a second */
 	u64	wake_freq;		/* waking-up frequency in a second */
 	u64	svc_time;		/* total CPU time consumed for this task */
+	u64	dsq_id;			/* DSQ id where a task run for statistics */
 
 	/*
 	 * Task deadline and time slice

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -602,6 +602,11 @@ static void update_stat_for_running(struct task_struct *p,
 	if (is_perf_cri(taskc, stat_cur))
 		cpuc->nr_perf_cri++;
 
+	if (taskc->dsq_id != cpuc->cpdom_id) {
+		taskc->dsq_id = cpuc->cpdom_id;
+		cpuc->nr_x_migration++;
+	}
+
 	/*
 	 * It is clear there is no need to consider the suspended duration
 	 * while running a task, so reset the suspended duration to zero.

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -392,7 +392,7 @@ static u64 calc_adj_runtime(u64 runtime)
 {
 	/*
 	 * Convert highly skewed runtime distribution to
-	 * mildlyskewed distribution.
+	 * mildly skewed distribution.
 	 */
 	u64 adj_runtime = log2_u64(runtime + 1);
 	return adj_runtime * adj_runtime;
@@ -507,11 +507,12 @@ static void advance_cur_logical_clk(struct task_struct *p)
 	struct sys_stat *stat_cur = get_sys_stat_cur();
 	u64 vlc, clc, ret_clc;
 	u64 nr_queued, delta, new_clk;
+	int i;
 
 	vlc = READ_ONCE(p->scx.dsq_vtime);
 	clc = READ_ONCE(cur_logical_clk);
 
-	for (int i = 0; i < LAVD_MAX_RETRY; ++i) {
+	bpf_for(i, 0, LAVD_MAX_RETRY) {
 		/*
 		 * The clock should not go backward, so do nothing.
 		 */

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1722,9 +1722,9 @@ SCX_OPS_DEFINE(lavd_ops,
 	       .init_task		= (void *)lavd_init_task,
 	       .init			= (void *)lavd_init,
 	       .exit			= (void *)lavd_exit,
-	       .flags			= SCX_OPS_ENQ_LAST |
-					  SCX_OPS_KEEP_BUILTIN_IDLE |
-					  SCX_OPS_ENQ_EXITING,
+	       .flags			= SCX_OPS_ENQ_EXITING |
+					  SCX_OPS_ENQ_LAST |
+					  SCX_OPS_KEEP_BUILTIN_IDLE,
 	       .timeout_ms		= 30000U,
 	       .name			= "lavd");
 

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -647,6 +647,11 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.verbose = opts.verbose;
         skel.maps.rodata_data.slice_max_ns = opts.slice_max_us * 1000;
         skel.maps.rodata_data.slice_min_ns = opts.slice_min_us * 1000;
+
+        match *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP {
+            0 => info!("Kernel does not support queued wakeup optimization."),
+            v => skel.struct_ops.lavd_ops_mut().flags |= v,
+        }
     }
 
     fn get_msg_seq_id() -> u64 {


### PR DESCRIPTION
This PR contains the following changes:
- Enable SCX_OPS_ALLOW_QUEUED_WAKEUP when supported.
- Correctly account cross-domain migration.
- Replace the for loop to bpf_for loop.