### PR TITLE
scx_p2dq: Fix vtime accounting

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -728,7 +728,7 @@ void BPF_STRUCT_OPS(p2dq_stopping, struct task_struct *p, bool runnable)
 	}
 
 	used = now - taskc->last_run_at;
-	p->scx.dsq_vtime = scale_by_task_weight(p, used);
+	p->scx.dsq_vtime += scale_by_task_weight_inverse(p, used);
 	taskc->last_dsq_id = taskc->dsq_id;
 	taskc->last_dsq_index = dsq_index;
 	__sync_fetch_and_add(&llcx->vtime, used);


### PR DESCRIPTION
When a task stops running fix the fix time by adding the weighted vtime to the current vtime.

Reported-by: Changwoo Min <changwoo@igalia.com>