### PR TITLE
scxtop: Add exit event tracing

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -25,9 +25,9 @@ use crate::APP;
 use crate::LICENSE;
 use crate::SCHED_NAME_PATH;
 use crate::{
-    Action, CpuhpAction, ExecAction, ForkAction, GpuMemAction, HwPressureAction, IPIAction,
-    SchedCpuPerfSetAction, SchedSwitchAction, SchedWakeupAction, SchedWakingAction, SoftIRQAction,
-    TraceStartedAction, TraceStoppedAction,
+    Action, CpuhpAction, ExecAction, ExitAction, ForkAction, GpuMemAction, HwPressureAction,
+    IPIAction, SchedCpuPerfSetAction, SchedSwitchAction, SchedWakeupAction, SchedWakingAction,
+    SoftIRQAction, TraceStartedAction, TraceStoppedAction,
 };
 
 use anyhow::Result;
@@ -2150,6 +2150,7 @@ impl<'a> App<'a> {
             self.skel.progs.on_ipi_send_cpu.attach()?,
             self.skel.progs.on_sched_fork.attach()?,
             self.skel.progs.on_sched_exec.attach()?,
+            self.skel.progs.on_sched_exit.attach()?,
         ];
 
         Ok(())
@@ -2279,6 +2280,12 @@ impl<'a> App<'a> {
     fn on_exec(&mut self, action: &ExecAction) {
         if self.state == AppState::Tracing && action.ts > self.trace_start {
             self.trace_manager.on_exec(action);
+        }
+    }
+
+    fn on_exit(&mut self, action: &ExitAction) {
+        if self.state == AppState::Tracing && action.ts > self.trace_start {
+            self.trace_manager.on_exit(action);
         }
     }
 
@@ -2485,6 +2492,9 @@ impl<'a> App<'a> {
             }
             Action::Exec(a) => {
                 self.on_exec(a);
+            }
+            Action::Exit(a) => {
+                self.on_exit(a);
             }
             Action::Fork(a) => {
                 self.on_fork(a);

--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -33,6 +33,7 @@ enum event_type {
 	CPU_HP,
 	CPU_PERF_SET,
 	EXEC,
+	EXIT,
 	FORK,
 	GPU_MEM,
 	HW_PRESSURE,
@@ -87,6 +88,13 @@ struct softirq_event {
 	int		softirq_nr;
 };
 
+struct exit_event {
+	u32		pid;
+	u32		prio;
+	u32		tgid;
+	char		comm[MAX_COMM];
+};
+
 struct fork_event {
 	u32		parent_pid;
 	u32		child_pid;
@@ -132,6 +140,7 @@ struct bpf_event {
 	u64		ts;
 	u32		cpu;
 	union {
+		struct  exit_event exit;
 		struct  fork_event fork;
 		struct  exec_event exec;
 		struct  hw_pressure_event hwp;

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -782,6 +782,30 @@ int BPF_PROG(on_ipi_send_cpu, u32 cpu, void *callsite, void *callback)
 	return 0;
 }
 
+SEC("tp_btf/sched_process_exit")
+int BPF_PROG(on_sched_exit, struct task_struct *task)
+{
+  struct bpf_event *event;
+
+  if (!enable_bpf_events || !should_sample())
+    return 0;
+
+	if (!(event = try_reserve_event()))
+		return -ENOMEM;
+
+	event->type = EXIT;
+	event->cpu = bpf_get_smp_processor_id();
+	event->ts = bpf_ktime_get_ns();
+	event->event.exit.pid = BPF_CORE_READ(task, pid);
+	event->event.exit.tgid = BPF_CORE_READ(task, tgid);
+	event->event.exit.prio = BPF_CORE_READ(task, prio);
+	__builtin_memcpy_inline(&event->event.exit.comm, &task->comm, MAX_COMM);
+
+	bpf_ringbuf_submit(event, 0);
+
+	return 0;
+}
+
 SEC("tp_btf/sched_process_fork")
 int BPF_PROG(on_sched_fork, struct task_struct *parent, struct task_struct *child)
 {

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -173,6 +173,7 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
             let mut skel = skel.load()?;
             let mut links = attach_progs(&mut skel)?;
             links.push(skel.progs.on_sched_fork.attach()?);
+            links.push(skel.progs.on_sched_exit.attach()?);
 
             let trace_dur = std::time::Duration::from_millis(trace_args.trace_ms);
             let bpf_publisher = BpfEventActionPublisher::new(action_tx.clone());


### PR DESCRIPTION
Adds the exit ftrace event to the perfetto trace which is a nice (semi useful) pairing for the fork event recently added by #1535 .

<img width="1740" alt="Screenshot 2025-03-24 at 13 46 38" src="https://github.com/user-attachments/assets/dbf3488c-cc4a-48aa-bbb4-0baad4c1debe" />
