### PR TITLE
add linux .editorconfig for c and related files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+root = true
+
+[{*.{awk,c,dts,dtsi,dtso,h,mk,s,S},Kconfig,Makefile,Makefile.*}]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION

Add the `.editorconfig` used by Linux, only taking the section related to
C-like files. This lets contributors use their existing `vimrc` or whatever
other editorconfig while overriding the settings for consistent formatting in C
files. Often when you get a new contributor they insert tabs and don't view the
files with the correct indent size, this change fixes that in future.
