### PR TITLE
scxtop: fix exec event handling when tracing

### DIFF
--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -841,7 +841,7 @@ int BPF_PROG(on_sched_exec, struct task_struct *p, u32 old_pid, struct linux_bin
 	if (!(event = try_reserve_event()))
 		return -ENOMEM;
 
-	event->type = FORK;
+	event->type = EXEC;
 	event->cpu = bpf_get_smp_processor_id();
 	event->ts = bpf_ktime_get_ns();
 	event->event.exec.old_pid = old_pid;

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -173,6 +173,7 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
             let mut skel = skel.load()?;
             let mut links = attach_progs(&mut skel)?;
             links.push(skel.progs.on_sched_fork.attach()?);
+            links.push(skel.progs.on_sched_exec.attach()?);
             links.push(skel.progs.on_sched_exit.attach()?);
 
             let trace_dur = std::time::Duration::from_millis(trace_args.trace_ms);


### PR DESCRIPTION
Change #1543 added the `sched_process_exec` event. However, the bpf program wasn't being attached when executing a trace (scxtop trace ...) and, more importantly, when it was attached sxctop panicked. This is owing to the fact that event payload for the exec event was being marked as a FORK and not and EXEC.

To test this I simply ensured we now attach the program using `bpftool`:

```
<elided>
56269: raw_tracepoint  prog 512134
        tp 'sched_process_fork'
        pids scxtop(604902)
56270: raw_tracepoint  prog 512135
        tp 'sched_process_exec'
        pids scxtop(604902)
56271: raw_tracepoint  prog 512133
        tp 'sched_process_exit'
        pids scxtop(604902)
<elided>
```

As a side note, I think that the way bpf program attaches are done could be reworked to make this kind of oversight much more difficult to do. I'll try and get around to this some time.