### PR TITLE
scx_bpfland: Enable SCX_OPS_ALLOW_QUEUED_WAKEUP

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -281,7 +281,8 @@ impl<'a> Scheduler<'a> {
         skel.struct_ops.bpfland_ops_mut().flags = *compat::SCX_OPS_ENQ_EXITING
             | *compat::SCX_OPS_ENQ_LAST
             | *compat::SCX_OPS_ENQ_MIGRATION_DISABLED
-            | *compat::SCX_OPS_BUILTIN_IDLE_PER_NODE;
+            | *compat::SCX_OPS_BUILTIN_IDLE_PER_NODE
+            | *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP;
         info!(
             "scheduler flags: {:#x}",
             skel.struct_ops.bpfland_ops_mut().flags


### PR DESCRIPTION
Enable ttwu_queue optimization (SCX_OPS_ALLOW_QUEUED_WAKEUP) if the kernel supports it.

This optimization allows to process a task wakeup on the wakee's CPU (via IPI), saving some locking overhead on the waker's CPU, which can be expensive on large machines, due to cache and node boundaries.

This results in ops.select_cpu() being skipped when this path is taken; however, scx_bpfland explicitly checks whether ops.select_cpu() is skipped and still provides the task an opportunity to be directly dispatched from ops.enqueue(), so it is fair to enable this optimization.