### PR TITLE
scx_utils: explicitly reference scx_utils::import_enums

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -35,7 +35,6 @@ use libc::{pthread_self, pthread_setschedparam, sched_param};
 use libc::timespec;
 
 use scx_utils::compat;
-use scx_utils::import_enums;
 use scx_utils::scx_enums;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -322,7 +322,7 @@ macro_rules! scx_ops_open {
                 }
             };
 
-            import_enums!(skel);
+            $crate::import_enums!(skel);
 
             let result : Result<OpenBpfSkel<'_>, anyhow::Error> = Ok(skel);
 

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -35,7 +35,6 @@ use scx_stats::prelude::*;
 use scx_utils::autopower::{fetch_power_profile, PowerProfile};
 use scx_utils::build_id;
 use scx_utils::compat;
-use scx_utils::import_enums;
 use scx_utils::scx_enums;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -32,7 +32,6 @@ use log::warn;
 use scx_stats::prelude::*;
 use scx_utils::build_id;
 use scx_utils::compat;
-use scx_utils::import_enums;
 use scx_utils::scx_enums;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -49,7 +49,6 @@ use scx_stats::prelude::*;
 use scx_utils::autopower::{fetch_power_profile, PowerProfile};
 use scx_utils::build_id;
 use scx_utils::compat;
-use scx_utils::import_enums;
 use scx_utils::scx_enums;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -41,7 +41,6 @@ use log::warn;
 use scx_layered::*;
 use scx_stats::prelude::*;
 use scx_utils::compat;
-use scx_utils::import_enums;
 use scx_utils::init_libbpf_logging;
 use scx_utils::pm::{cpu_idle_resume_latency_supported, update_cpu_idle_resume_latency};
 use scx_utils::read_netdevs;

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -36,7 +36,6 @@ use log::trace;
 use maplit::btreemap;
 use maplit::hashmap;
 use scx_utils::compat;
-use scx_utils::import_enums;
 use scx_utils::init_libbpf_logging;
 use scx_utils::ravg::ravg_read;
 use scx_utils::scx_enums;

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -26,7 +26,6 @@ use libbpf_rs::OpenObject;
 use log::{debug, info, warn};
 use scx_stats::prelude::*;
 use scx_utils::build_id;
-use scx_utils::import_enums;
 use scx_utils::init_libbpf_logging;
 use scx_utils::pm::{cpu_idle_resume_latency_supported, update_cpu_idle_resume_latency};
 use scx_utils::scx_enums;

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -48,7 +48,6 @@ use log::info;
 use scx_stats::prelude::*;
 use scx_utils::build_id;
 use scx_utils::compat;
-use scx_utils::import_enums;
 use scx_utils::init_libbpf_logging;
 use scx_utils::scx_enums;
 use scx_utils::scx_ops_attach;

--- a/scheds/rust/scx_tickless/src/main.rs
+++ b/scheds/rust/scx_tickless/src/main.rs
@@ -34,7 +34,6 @@ use log::warn;
 use log::{debug, info};
 use scx_stats::prelude::*;
 use scx_utils::build_id;
-use scx_utils::import_enums;
 use scx_utils::scx_enums;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;


### PR DESCRIPTION

Rust macros aren't scoped the same as functions, and this `import_enums` reference
expects you to have it already imported. Reference this with the full reference
to the crate and remove the now unnecessary imports from all the usage sites.

Test plan:
- `cargo build`
- CI
