### PR TITLE
scx_chaos: init with basic functionality

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build-kernel
     strategy:
           matrix:
-            scheduler: [ scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty, scx_p2dq, scx_tickless ]
+            scheduler: [ scx_bpfland, scx_chaos, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty, scx_p2dq, scx_tickless ]
           fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -174,7 +174,7 @@ jobs:
     needs: build-kernel
     strategy:
       matrix:
-        package: [ scx_loader, scx_rustland_core, scx_stats, scx_utils, scxtop, scx_bpfland, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty, scx_p2dq, scx_tickless ]
+        package: [ scx_loader, scx_rustland_core, scx_stats, scx_utils, scxtop, scx_bpfland, scx_chaos, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty, scx_p2dq, scx_tickless ]
     steps:
       - uses: actions/checkout@v4
 
@@ -199,7 +199,7 @@ jobs:
       - run: cargo build --all-targets --package ${{ matrix.package }}
 
       - name: Clippy
-        if: contains(fromJSON('["scxtop"]'), matrix.package)
+        if: contains(fromJSON('["scxtop", "scx_chaos"]'), matrix.package)
         run: cargo clippy --no-deps -p ${{ matrix.package }} -- -Dwarnings
 
       # virtme-ng runs as a different user than the runner, so loses the rustup and cargo roots. specify them explicitly to avoid a rebuild.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,6 +2276,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "scx_chaos"
+version = "1.0.10"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ctrlc",
+ "libbpf-rs",
+ "log",
+ "scx_p2dq",
+ "scx_utils",
+ "simplelog",
+]
+
+[[package]]
 name = "scx_flash"
 version = "1.0.8"
 dependencies = [
@@ -2386,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "scx_p2dq"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = ["rust/scx_stats",
            "scheds/rust/scx_p2dq",
            "scheds/rust/scx_tickless",
            "scheds/rust/scx_layered",
-           "scheds/rust/scx_mitosis"]
+           "scheds/rust/scx_mitosis", "scheds/rust/scx_chaos"]
 resolver = "2"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ repo](https://mesonbuild.com/Quick-guide.html#installation-from-source) and call
 - `clang`: >=16 required, >=17 recommended
 - `libbpf`: >=1.2.2 required, >=1.3 recommended (`RESIZE_ARRAY` support is
   new in 1.3). It's preferred to link statically against the source from the libbpf git repo, which is cloned during setup.
-- Rust toolchain: >=1.81
+- Rust toolchain: >=1.82
 - `libelf`, `libz`, `libzstd` if linking against staic `libbpf.a`
 - `bpftool` By default this is cloned and built as part of the default build process. Alternatively it's usually available in `linux-tools-common`.
 

--- a/meson-scripts/stress_tests.ini
+++ b/meson-scripts/stress_tests.ini
@@ -41,6 +41,12 @@ sched_args:
 stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
 timeout_sec: 15
 
+[scx_chaos]
+sched: scx_chaos
+sched_args:
+stress_cmd: stress-ng -t 14 --aggressive -M -c `nproc` -f `nproc`
+timeout_sec: 15
+
 [scx_tickless]
 sched: scx_tickless
 sched_args: -v

--- a/meson.build
+++ b/meson.build
@@ -357,7 +357,7 @@ if enable_rust
 
   rust_scheds = ['scx_lavd', 'scx_bpfland', 'scx_rustland', 'scx_rlfifo',
                  'scx_flash', 'scx_rusty', 'scx_p2dq',
-                 'scx_layered', 'scx_mitosis', 'scx_tickless']
+                 'scx_layered', 'scx_mitosis', 'scx_tickless', 'scx_chaos']
   rust_misc = ['scx_stats', 'scx_stats_derive', 'scx_utils',
                'scx_rustland_core',
                'scx_loader']

--- a/scheds/rust/scx_chaos/Cargo.toml
+++ b/scheds/rust/scx_chaos/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "scx_chaos"
+version = "1.0.10"
+edition = "2021"
+
+[dependencies]
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.12" }
+scx_p2dq = { path = "../../../scheds/rust/scx_p2dq", version = "1.0.11" }
+
+anyhow = "1.0.65"
+clap = { version = "4.1", features = ["derive", "env", "unicode", "wrap_help"] }
+ctrlc = { version = "3.1", features = ["termination"] }
+libbpf-rs = "=0.25.0-beta.1"
+log = "0.4.17"
+simplelog = "0.12"
+
+[build-dependencies]
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.12" }

--- a/scheds/rust/scx_chaos/build.rs
+++ b/scheds/rust/scx_chaos/build.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+fn main() {
+    // TODO: The BpfBuilder appears to assume only files in the crate are relevant to building,
+    // meaning chaos won't rebuild if p2dq sources change. This is fine for now as the CI should
+    // catch anything obvious with a clean build.
+    scx_utils::BpfBuilder::new()
+        .unwrap()
+        .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
+        .enable_skel("src/bpf/main.bpf.c", "bpf")
+        .compile_link_gen()
+        .unwrap();
+}

--- a/scheds/rust/scx_chaos/src/bpf/intf.h
+++ b/scheds/rust/scx_chaos/src/bpf/intf.h
@@ -1,0 +1,30 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+#ifndef __CHAOS_INTF_H
+#define __CHAOS_INTF_H
+
+#ifndef __KERNEL__
+typedef unsigned long long u64;
+#endif
+
+enum chaos_consts {
+	CHAOS_DSQ_BASE_SHIFT	= 16,
+	CHAOS_DSQ_BASE		= 1 << CHAOS_DSQ_BASE_SHIFT,
+};
+
+enum chaos_trait_kind {
+	CHAOS_TRAIT_NONE,
+	CHAOS_TRAIT_RANDOM_DELAYS,
+	CHAOS_TRAIT_MAX,
+};
+
+struct chaos_task_ctx {
+	// chaos_task_ctx is initialised zero'd
+
+	enum chaos_trait_kind	next_trait;
+	u64			enq_flags;
+};
+
+#endif /* __CHAOS_INTF_H */

--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -1,0 +1,224 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This software may be used and distributed according to the terms of the
+ * GNU General Public License version 2.
+ */
+
+#define P2DQ_CREATE_STRUCT_OPS 0
+#include "../../../scx_p2dq/src/bpf/main.bpf.c"
+
+#include "intf.h"
+
+#include <stdbool.h>
+
+const volatile u32 random_delays_freq_frac32 = 1; /* for veristat */
+const volatile u32 random_delays_min_ns = 1; /* for veristat */
+const volatile u32 random_delays_max_ns = 2; /* for veristat */
+
+struct {
+	__uint(type, BPF_MAP_TYPE_TASK_STORAGE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__type(key, int);
+	__type(value, struct chaos_task_ctx);
+} chaos_task_ctxs SEC(".maps");
+
+struct chaos_task_ctx *lookup_create_chaos_task_ctx(struct task_struct *p)
+{
+	return bpf_task_storage_get(&chaos_task_ctxs, p, NULL, BPF_LOCAL_STORAGE_GET_F_CREATE);
+}
+
+static __always_inline enum chaos_trait_kind choose_chaos()
+{
+	if (bpf_get_prandom_u32() < random_delays_freq_frac32)
+		return CHAOS_TRAIT_RANDOM_DELAYS;
+
+	return CHAOS_TRAIT_NONE;
+}
+
+static __always_inline u32 get_current_cpu_delay_dsq()
+{
+	// use current processor so enqueue runs here next time too
+	// TODO: this assumes CPU IDs are linear, and probably needs to be mapped
+	// into linear IDs with topology information passed from userspace
+	u32 cpu = bpf_get_smp_processor_id();
+
+	return CHAOS_DSQ_BASE | cpu;
+}
+
+__weak s32 enqueue_random_delay(struct task_struct *p __arg_trusted, u64 enq_flags,
+				struct chaos_task_ctx *taskc __arg_nonnull)
+{
+	u64 rand64 = ((u64)bpf_get_prandom_u32() << 32) | bpf_get_prandom_u32();
+
+	u64 vtime = bpf_ktime_get_ns() + random_delays_min_ns;
+	if (random_delays_min_ns != random_delays_max_ns) {
+		vtime += rand64 % (random_delays_max_ns - random_delays_min_ns);
+	}
+
+	scx_bpf_dsq_insert_vtime(p, get_current_cpu_delay_dsq(), 0, vtime, enq_flags);
+
+	return true;
+}
+
+__weak s32 enqueue_chaotic(struct task_struct *p __arg_trusted, u64 enq_flags,
+			   struct chaos_task_ctx *taskc __arg_nonnull)
+{
+	bool out;
+
+	switch (taskc->next_trait) {
+	case CHAOS_TRAIT_RANDOM_DELAYS:
+		out = enqueue_random_delay(p, enq_flags, taskc);
+		break;
+
+	case CHAOS_TRAIT_NONE:
+	case CHAOS_TRAIT_MAX:
+		out = false;
+		break;
+	}
+
+	taskc->next_trait = CHAOS_TRAIT_NONE;
+	return out;
+}
+
+s32 BPF_STRUCT_OPS_SLEEPABLE(chaos_init)
+{
+	struct llc_ctx *llcx;
+	struct cpu_ctx *cpuc;
+	int i, ret;
+
+	bpf_for(i, 0, nr_cpus) {
+		if (!(cpuc = lookup_cpu_ctx(i)) ||
+		    !(llcx = lookup_llc_ctx(cpuc->llc_id)))
+			return -EINVAL;
+
+		ret = scx_bpf_create_dsq(CHAOS_DSQ_BASE | i, llcx->node_id);
+		if (ret < 0)
+			return ret;
+	}
+
+	return p2dq_init_impl();
+}
+
+static __always_inline void complete_p2dq_enqueue_move(struct enqueue_promise *pro,
+						       struct bpf_iter_scx_dsq *it__iter,
+						       struct task_struct *p)
+{
+	switch (pro->kind) {
+	case P2DQ_ENQUEUE_PROMISE_COMPLETE:
+		goto out;
+	case P2DQ_ENQUEUE_PROMISE_FIFO:
+		scx_bpf_dsq_move_set_slice(it__iter, *MEMBER_VPTR(pro->fifo, .slice_ns));
+		scx_bpf_dsq_move(it__iter, p, pro->fifo.dsq_id, pro->fifo.enq_flags);
+		goto out;
+	case P2DQ_ENQUEUE_PROMISE_VTIME:
+		scx_bpf_dsq_move_set_slice(it__iter, pro->vtime.slice_ns);
+		scx_bpf_dsq_move_set_vtime(it__iter, pro->vtime.vtime);
+		scx_bpf_dsq_move_vtime(it__iter, p, pro->vtime.dsq_id, pro->vtime.enq_flags);
+		goto out;
+	}
+
+out:
+	pro->kind = P2DQ_ENQUEUE_PROMISE_COMPLETE;
+}
+
+void BPF_STRUCT_OPS(chaos_dispatch, s32 cpu, struct task_struct *prev)
+{
+	struct enqueue_promise promise;
+	struct chaos_task_ctx *taskc;
+	struct task_struct *p;
+	u64 now = bpf_ktime_get_ns();
+
+	int i = 0;
+	bpf_for_each(scx_dsq, p, get_current_cpu_delay_dsq(), 0) {
+		if (++i >= 8)
+			break; // the verifier can't handle this loop, so limit it
+
+		p = bpf_task_from_pid(p->pid);
+		if (!p)
+			continue;
+
+		if (!(taskc = lookup_create_chaos_task_ctx(p))) {
+			scx_bpf_error("couldn't find task context");
+			bpf_task_release(p);
+			break;
+		}
+
+		if (p->scx.dsq_vtime > now) {
+			bpf_task_release(p);
+			break; // this is the DSQ's key so we're done
+		}
+
+		async_p2dq_enqueue(&promise, p, taskc->enq_flags);
+		complete_p2dq_enqueue_move(&promise, BPF_FOR_EACH_ITER, p);
+		bpf_task_release(p);
+	}
+
+	return p2dq_dispatch_impl(cpu, prev);
+}
+
+void BPF_STRUCT_OPS(chaos_enqueue, struct task_struct *p __arg_trusted, u64 enq_flags)
+{
+	struct enqueue_promise promise;
+	struct chaos_task_ctx *taskc;
+
+	if (!(taskc = lookup_create_chaos_task_ctx(p))) {
+		scx_bpf_error("failed to lookup task context in enqueue");
+		return;
+	}
+
+	async_p2dq_enqueue(&promise, p, enq_flags);
+	if (promise.kind == P2DQ_ENQUEUE_PROMISE_COMPLETE)
+		return;
+
+	if (taskc->next_trait != CHAOS_TRAIT_NONE &&
+	    enqueue_chaotic(p, enq_flags, taskc))
+		return;
+
+	complete_p2dq_enqueue(&promise, p);
+}
+
+void BPF_STRUCT_OPS(chaos_runnable, struct task_struct *p, u64 enq_flags)
+{
+	enum chaos_trait_kind t = choose_chaos();
+	if (t == CHAOS_TRAIT_NONE)
+		goto p2dq;
+
+	struct chaos_task_ctx *wakee_ctx;
+	if (!(wakee_ctx = lookup_create_chaos_task_ctx(p)))
+		goto p2dq;
+
+	wakee_ctx->next_trait = t;
+p2dq:
+	return p2dq_runnable_impl(p, enq_flags);
+}
+
+s32 BPF_STRUCT_OPS(chaos_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wake_flags)
+{
+	struct chaos_task_ctx *wakee_ctx;
+	if (!(wakee_ctx = lookup_create_chaos_task_ctx(p)))
+		goto p2dq;
+
+	// don't allow p2dq to select_cpu if we plan chaos to ensure we hit enqueue
+	if (wakee_ctx->next_trait != CHAOS_TRAIT_NONE)
+		return prev_cpu;
+
+p2dq:
+	return p2dq_select_cpu_impl(p, prev_cpu, wake_flags);
+}
+
+SCX_OPS_DEFINE(chaos,
+	       .select_cpu		= (void *)chaos_select_cpu,
+	       .enqueue			= (void *)chaos_enqueue,
+	       .runnable		= (void *)chaos_runnable,
+	       .init			= (void *)chaos_init,
+	       .dispatch		= (void *)chaos_dispatch,
+
+	       .running			= (void *)p2dq_running,
+	       .stopping		= (void *)p2dq_stopping,
+	       .set_cpumask		= (void *)p2dq_set_cpumask,
+	       .init_task		= (void *)p2dq_init_task,
+	       .exit			= (void *)p2dq_exit,
+
+	       .timeout_ms		= 30000,
+	       .name			= "chaos");

--- a/scheds/rust/scx_chaos/src/bpf_intf.rs
+++ b/scheds/rust/scx_chaos/src/bpf_intf.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+
+include!(concat!(env!("OUT_DIR"), "/bpf_intf.rs"));

--- a/scheds/rust/scx_chaos/src/bpf_skel.rs
+++ b/scheds/rust/scx_chaos/src/bpf_skel.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+include!(concat!(env!("OUT_DIR"), "/bpf_skel.rs"));

--- a/scheds/rust/scx_chaos/src/lib.rs
+++ b/scheds/rust/scx_chaos/src/lib.rs
@@ -1,0 +1,156 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+mod bpf_intf;
+mod bpf_skel;
+
+use bpf_skel::BpfSkel;
+
+use scx_p2dq::SchedulerOpts as P2dqOpts;
+use scx_utils::init_libbpf_logging;
+use scx_utils::scx_ops_attach;
+use scx_utils::scx_ops_load;
+use scx_utils::scx_ops_open;
+use scx_utils::uei_exited;
+use scx_utils::uei_report;
+
+use anyhow::Result;
+use libbpf_rs::OpenObject;
+use log::debug;
+
+use std::marker::PhantomPinned;
+use std::mem::MaybeUninit;
+use std::pin::Pin;
+use std::sync::Condvar;
+use std::sync::Mutex;
+use std::time::Duration;
+use std::time::Instant;
+
+#[derive(Debug)]
+pub enum Trait {
+    RandomDelays {
+        frequency: f64,
+        min_us: u64,
+        max_us: u64,
+    },
+}
+
+#[derive(Debug)]
+/// State required to build a Scheduler configuration.
+pub struct Builder<'a> {
+    pub traits: Vec<Trait>,
+    pub verbose: u8,
+    pub p2dq_opts: &'a P2dqOpts,
+}
+
+pub struct Scheduler {
+    open_object: MaybeUninit<OpenObject>,
+    skel: BpfSkel<'static>,
+    struct_ops: libbpf_rs::Link,
+
+    // Skel holds a reference to the OpenObject, so the address must not change.
+    _pin: PhantomPinned,
+}
+
+impl Scheduler {
+    pub fn observe(
+        &self,
+        shutdown: &(Mutex<bool>, Condvar),
+        timeout: Option<Duration>,
+    ) -> Result<()> {
+        let (lock, cvar) = shutdown;
+
+        let start_time = Instant::now();
+
+        let mut guard = lock.lock().unwrap();
+        while !*guard {
+            if uei_exited!(&self.skel, uei) {
+                return uei_report!(&self.skel, uei)
+                    .and_then(|_| Err(anyhow::anyhow!("scheduler exited unexpectedly")));
+            }
+
+            if timeout.is_some_and(|x| Instant::now().duration_since(start_time) >= x) {
+                break;
+            }
+
+            guard = cvar
+                .wait_timeout(guard, Duration::from_millis(500))
+                .unwrap()
+                .0;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> TryFrom<Builder<'a>> for Pin<Box<Scheduler>> {
+    type Error = anyhow::Error;
+
+    fn try_from(builder: Builder<'a>) -> Result<Pin<Box<Scheduler>>> {
+        let mut out = Box::<Scheduler>::new_uninit();
+
+        let open_object = &mut unsafe {
+            // SAFETY: We're extracting a MaybeUninit field from a MaybeUninit which is always
+            // safe.
+            let ptr = out.as_mut_ptr();
+            (&raw mut (*ptr).open_object).as_mut().unwrap()
+        };
+
+        let open_object = unsafe {
+            // SAFETY: Scheduler is pinned so this reference will not be invalidated for the
+            // lifetime of Scheduler. Dropping MaybeUninit is a no-op, so it doesn't matter who
+            // gets first. The use site (BpfSkel) is also in Scheduler and has the same lifetime.
+            // Therefore it is safe to treat this reference as 'static from BpfSkel's perspective.
+            std::mem::transmute::<&mut MaybeUninit<OpenObject>, &'static mut MaybeUninit<OpenObject>>(
+                open_object,
+            )
+        };
+
+        let mut skel_builder = bpf_skel::BpfSkelBuilder::default();
+        skel_builder.obj_builder.debug(builder.verbose > 1);
+        init_libbpf_logging(None);
+
+        let mut open_skel = scx_ops_open!(skel_builder, open_object, chaos)?;
+        scx_p2dq::init_open_skel!(&mut open_skel, builder.p2dq_opts, builder.verbose)?;
+
+        // TODO: figure out how to abstract waking a CPU in enqueue properly, but for now disable
+        // this codepath
+        open_skel.maps.rodata_data.select_idle_in_enqueue = false;
+
+        for tr in builder.traits {
+            match tr {
+                Trait::RandomDelays {
+                    frequency,
+                    min_us,
+                    max_us,
+                } => {
+                    open_skel.maps.rodata_data.random_delays_freq_frac32 =
+                        (frequency * 2_f64.powf(32_f64)) as u32;
+                    open_skel.maps.rodata_data.random_delays_min_ns = (min_us * 1000) as u32;
+                    open_skel.maps.rodata_data.random_delays_max_ns = (max_us * 1000) as u32;
+                }
+            }
+        }
+
+        let mut skel = scx_ops_load!(open_skel, chaos, uei)?;
+        scx_p2dq::init_skel!(&mut skel);
+
+        let struct_ops = scx_ops_attach!(skel, chaos)?;
+
+        let out = unsafe {
+            // SAFETY: initialising field by field. open_object is already "initialised" (it's
+            // permanently MaybeUninit so any state is fine), hence the structure will be
+            // initialised after initialising `skel` and `struct_ops`.
+            let ptr = out.as_mut_ptr();
+
+            (&raw mut (*ptr).skel).write(skel);
+            (&raw mut (*ptr).struct_ops).write(struct_ops);
+
+            out.assume_init()
+        };
+
+        debug!("scx_chaos scheduler started");
+        Ok(Box::into_pin(out))
+    }
+}

--- a/scheds/rust/scx_chaos/src/main.rs
+++ b/scheds/rust/scx_chaos/src/main.rs
@@ -1,0 +1,239 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+use scx_chaos::Builder;
+use scx_chaos::Scheduler;
+use scx_chaos::Trait;
+
+use scx_p2dq::SchedulerOpts as P2dqOpts;
+
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+use log::info;
+
+use std::panic;
+use std::pin::Pin;
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::Condvar;
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+
+/// Randomly delay a process.
+#[derive(Debug, Parser)]
+pub struct RandomDelayArgs {
+    /// Chance of randomly delaying a process.
+    #[clap(long, requires = "random_delay_min_us")]
+    pub random_delay_frequency: Option<f64>,
+
+    /// Minimum time to add for random delay.
+    #[clap(long, requires = "random_delay_max_us")]
+    pub random_delay_min_us: Option<u64>,
+
+    /// Maximum time to add for random delay.
+    #[clap(long, requires = "random_delay_frequency")]
+    pub random_delay_max_us: Option<u64>,
+}
+
+/// scx_chaos: A general purpose sched_ext scheduler designed to amplify race conditions
+///
+/// WARNING: This scheduler is a very early alpha, and hasn't been production tested yet. The CLI
+/// in particular is likely very unstable and does not guarantee compatibility between versions.
+///
+/// scx_chaos is a general purpose scheduler designed to run apps with acceptable performance. It
+/// has a series of features designed to add latency in paths in an application. All control is
+/// through the CLI. Running without arguments will not attempt to introduce latency and can set a
+/// baseline for performance impact. The other command line arguments allow for specifying latency
+/// inducing behaviours which attempt to induce a crash.
+///
+/// Unlike most other schedulers, you can also run scx_chaos with a named target. For example:
+///     scx_chaos -- ./app_that_might_crash --arg1 --arg2
+/// In this mode the scheduler will automatically detach after the application exits, unless run
+/// with `--repeat-failure` where it will restart the application on failure.
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// Whether to continue on failure of the command under test.
+    #[clap(long, action = clap::ArgAction::SetTrue, requires = "args")]
+    pub repeat_failure: bool,
+
+    /// Whether to continue on successful exit of the command under test.
+    #[clap(long, action = clap::ArgAction::SetTrue, requires = "args")]
+    pub repeat_success: bool,
+
+    /// Enable verbose output, including libbpf details. Specify multiple
+    /// times to increase verbosity.
+    #[clap(short = 'v', long, action = clap::ArgAction::Count)]
+    pub verbose: u8,
+
+    #[command(flatten, next_help_heading = "Random Delays")]
+    pub random_delay: RandomDelayArgs,
+
+    #[command(flatten, next_help_heading = "General Scheduling")]
+    pub p2dq: P2dqOpts,
+
+    /// Stop the scheduler if specified process terminates
+    #[arg(
+        long,
+        short = 'p',
+        help_heading = "Test Command",
+        conflicts_with = "args"
+    )]
+    pub pid: Option<u64>,
+
+    /// Program to run under the chaos scheduler
+    ///
+    /// Runs a program under test and tracks when it terminates, similar to most debuggers. Note
+    /// that the scheduler still attaches for every process on the system.
+    #[arg(
+        trailing_var_arg = true,
+        allow_hyphen_values = true,
+        help_heading = "Test Command"
+    )]
+    pub args: Vec<String>,
+}
+
+struct BuilderIterator<'a> {
+    args: &'a Args,
+    idx: u32,
+}
+
+impl<'a> From<&'a Args> for BuilderIterator<'a> {
+    fn from(args: &'a Args) -> BuilderIterator<'a> {
+        BuilderIterator { args, idx: 0 }
+    }
+}
+
+impl<'a> Iterator for BuilderIterator<'a> {
+    type Item = Builder<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.idx += 1;
+
+        if self.idx > 1 {
+            None
+        } else {
+            let mut traits = vec![];
+
+            if let RandomDelayArgs {
+                random_delay_frequency: Some(frequency),
+                random_delay_min_us: Some(min_us),
+                random_delay_max_us: Some(max_us),
+            } = self.args.random_delay
+            {
+                traits.push(Trait::RandomDelays {
+                    frequency,
+                    min_us,
+                    max_us,
+                });
+            };
+
+            Some(Builder {
+                traits,
+                verbose: self.args.verbose,
+                p2dq_opts: &self.args.p2dq,
+            })
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let args = Arc::new(Args::parse());
+
+    let llv = match &args.verbose {
+        0 => simplelog::LevelFilter::Info,
+        1 => simplelog::LevelFilter::Debug,
+        _ => simplelog::LevelFilter::Trace,
+    };
+    simplelog::TermLogger::init(
+        llv,
+        simplelog::ConfigBuilder::new()
+            .set_time_level(simplelog::LevelFilter::Error)
+            .set_location_level(simplelog::LevelFilter::Off)
+            .set_target_level(simplelog::LevelFilter::Off)
+            .set_thread_level(simplelog::LevelFilter::Off)
+            .build(),
+        simplelog::TerminalMode::Stderr,
+        simplelog::ColorChoice::Auto,
+    )?;
+
+    if args.pid.is_some() {
+        return Err(anyhow!("args.pid is not yet implemented"));
+    }
+
+    let shutdown = Arc::new((Mutex::new(false), Condvar::new()));
+
+    ctrlc::set_handler({
+        let shutdown = shutdown.clone();
+        move || {
+            let (lock, cvar) = &*shutdown;
+            *lock.lock().unwrap() = true;
+            cvar.notify_all();
+        }
+    })
+    .context("Error setting Ctrl-C handler")?;
+
+    let scheduler_thread = thread::spawn({
+        let args = args.clone();
+        let shutdown = shutdown.clone();
+
+        move || -> Result<()> {
+            for builder in BuilderIterator::from(&*args) {
+                info!("{:?}", &builder);
+
+                let sched: Pin<Box<Scheduler>> = builder.try_into()?;
+
+                sched.observe(&shutdown, None)?;
+            }
+
+            Ok(())
+        }
+    });
+
+    let mut should_run_app = !args.args.is_empty();
+    while should_run_app {
+        let (cmd, vargs) = args.args.split_first().unwrap();
+
+        let mut child = Command::new(cmd).args(vargs).spawn()?;
+        loop {
+            should_run_app &= !*shutdown.0.lock().unwrap();
+
+            if scheduler_thread.is_finished() {
+                child.kill()?;
+                break;
+            }
+            if let Some(s) = child.try_wait()? {
+                if s.success() && args.repeat_success {
+                    should_run_app &= !*shutdown.0.lock().unwrap();
+                    if should_run_app {
+                        info!("app under test terminated successfully, restarting...");
+                    };
+                } else if s.success() {
+                    info!("app under test terminated successfully, exiting...");
+                    should_run_app = false;
+                } else {
+                    info!("TODO: report what the scheduler was doing when it crashed");
+                    should_run_app &= !*shutdown.0.lock().unwrap() && args.repeat_failure;
+                };
+
+                break;
+            };
+
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    if !args.args.is_empty() {
+        let (lock, cvar) = &*shutdown;
+        *lock.lock().unwrap() = true;
+        cvar.notify_all();
+    }
+
+    match scheduler_thread.join() {
+        Ok(_) => {}
+        Err(e) => panic::resume_unwind(e),
+    };
+
+    Ok(())
+}

--- a/scheds/rust/scx_p2dq/Cargo.toml
+++ b/scheds/rust/scx_p2dq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_p2dq"
-version = "1.0.10"
+version = "1.0.11"
 authors = ["Daniel Hodges <hodges.daniel.scott@gmail.com>"]
 edition = "2021"
 description = "scx_p2dq A simple pick two load balancing scheduler in BPF"

--- a/scheds/rust/scx_p2dq/src/bpf/intf.h
+++ b/scheds/rust/scx_p2dq/src/bpf/intf.h
@@ -2,8 +2,8 @@
 
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
-#ifndef __INTF_H
-#define __INTF_H
+#ifndef __P2DQ_INTF_H
+#define __P2DQ_INTF_H
 
 #include <stdbool.h>
 #ifndef __kptr
@@ -127,4 +127,31 @@ struct node_ctx {
 	struct bpf_cpumask __kptr	*big_cpumask;
 };
 
-#endif /* __INTF_H */
+enum enqueue_promise_kind {
+	P2DQ_ENQUEUE_PROMISE_COMPLETE,
+	P2DQ_ENQUEUE_PROMISE_VTIME,
+	P2DQ_ENQUEUE_PROMISE_FIFO,
+};
+
+struct enqueue_promise_vtime {
+	u64	dsq_id;
+	u64	enq_flags;
+	u64	slice_ns;
+	u64	vtime;
+};
+
+struct enqueue_promise_fifo {
+	u64	dsq_id;
+	u64	enq_flags;
+	u64	slice_ns;
+};
+
+struct enqueue_promise {
+	enum enqueue_promise_kind	kind;
+	union {
+		struct enqueue_promise_vtime	vtime;
+		struct enqueue_promise_fifo	fifo;
+	};
+};
+
+#endif /* __P2DQ_INTF_H */

--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -1,0 +1,199 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+pub use scx_utils::CoreType;
+use scx_utils::Topology;
+pub use scx_utils::NR_CPU_IDS;
+
+use clap::Parser;
+
+lazy_static::lazy_static! {
+        pub static ref TOPO: Topology = Topology::new().unwrap();
+}
+
+fn get_default_greedy_disable() -> bool {
+    TOPO.all_llcs.len() > 1
+}
+
+fn get_default_llc_runs() -> u64 {
+    let n_llcs = TOPO.all_llcs.len() as f64;
+    let llc_runs = n_llcs.log2();
+    llc_runs as u64
+}
+
+#[derive(Debug, Parser)]
+pub struct SchedulerOpts {
+    /// Disables per-cpu kthreads directly dispatched into local dsqs.
+    #[clap(short = 'k', long, action = clap::ArgAction::SetTrue)]
+    pub disable_kthreads_local: bool,
+
+    /// Enables autoslice tuning
+    #[clap(short = 'a', long, action = clap::ArgAction::SetTrue)]
+    pub autoslice: bool,
+
+    /// Ratio of interactive tasks for autoslice tuning, percent value from 1-99.
+    #[clap(short = 'r', long, default_value = "10")]
+    pub interactive_ratio: usize,
+
+    /// Disables eager pick2 load balancing.
+    #[clap(short = 'e', long, action = clap::ArgAction::SetTrue)]
+    pub eager_load_balance: bool,
+
+    /// Disables greedy idle CPU selection, may cause better load balancing on multi-LLC systems.
+    #[clap(short = 'g', long, default_value_t = get_default_greedy_disable(), action = clap::ArgAction::Set)]
+    pub greedy_idle_disable: bool,
+
+    /// Interactive tasks stay sticky to their CPU if no idle CPU is found.
+    #[clap(short = 'y', long, action = clap::ArgAction::SetTrue)]
+    pub interactive_sticky: bool,
+
+    /// Disables pick2 load balancing on the dispatch path.
+    #[clap(short = 'd', long, action = clap::ArgAction::SetTrue)]
+    pub dispatch_pick2_disable: bool,
+
+    /// Enable tasks to run beyond their timeslice if the CPU is idle.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub keep_running: bool,
+
+    /// Set idle QoS resume latency based in microseconds.
+    #[clap(long)]
+    pub idle_resume_us: Option<u32>,
+
+    /// Only pick2 load balance from the max DSQ.
+    #[clap(long, default_value="false", action = clap::ArgAction::Set)]
+    pub max_dsq_pick2: bool,
+
+    /// Scheduling min slice duration in microseconds.
+    #[clap(short = 's', long, default_value = "100")]
+    pub min_slice_us: u64,
+
+    /// Number of runs on the LLC before a task becomes eligbile for pick2 migration on the wakeup
+    /// path.
+    #[clap(short = 'l', long, default_value_t = get_default_llc_runs())]
+    pub min_llc_runs_pick2: u64,
+
+    /// Manual definition of slice intervals in microseconds for DSQs, must be equal to number of
+    /// dumb_queues.
+    #[clap(short = 't', long, value_parser = clap::value_parser!(u64), default_values_t = [0;0])]
+    pub dsq_time_slices: Vec<u64>,
+
+    /// DSQ scaling shift, each queue min timeslice is shifted by the scaling shift.
+    #[clap(short = 'x', long, default_value = "4")]
+    pub dsq_shift: u64,
+
+    /// Minimum number of queued tasks to use pick2 balancing, 0 to always enabled.
+    #[clap(short = 'm', long, default_value = "0")]
+    pub min_nr_queued_pick2: u32,
+
+    /// Number of dumb DSQs.
+    #[clap(short = 'q', long, default_value = "3")]
+    pub dumb_queues: usize,
+
+    /// Initial DSQ for tasks.
+    #[clap(short = 'i', long, default_value = "0")]
+    pub init_dsq_index: usize,
+}
+
+pub fn dsq_slice_ns(dsq_index: u64, min_slice_us: u64, dsq_shift: u64) -> u64 {
+    let result = if dsq_index == 0 {
+        1000 * min_slice_us
+    } else {
+        1000 * (min_slice_us << (dsq_index as u32) << dsq_shift)
+    };
+    result
+}
+
+#[macro_export]
+macro_rules! init_open_skel {
+    ($skel: expr, $opts: expr, $verbose: expr) => {
+        'block: {
+            let opts: &$crate::SchedulerOpts = $opts;
+            let verbose: u8 = $verbose;
+
+            if opts.init_dsq_index > opts.dumb_queues - 1 {
+                break 'block ::anyhow::Result::Err(::anyhow::anyhow!(
+                    "Invalid init_dsq_index {}",
+                    opts.init_dsq_index
+                ));
+            }
+            if opts.dsq_time_slices.len() > 0 {
+                if opts.dsq_time_slices.len() != opts.dumb_queues {
+                    break 'block ::anyhow::Result::Err(::anyhow::anyhow!(
+                        "Invalid number of dsq_time_slices, got {} need {}",
+                        opts.dsq_time_slices.len(),
+                        opts.dumb_queues,
+                    ));
+                }
+                for vals in opts.dsq_time_slices.windows(2) {
+                    if vals[0] >= vals[1] {
+                        break 'block ::anyhow::Result::Err(::anyhow::anyhow!(
+                            "DSQ time slices must be in increasing order"
+                        ));
+                    }
+                }
+                for (i, slice) in opts.dsq_time_slices.iter().enumerate() {
+                    ::log::info!("DSQ[{}] slice_ns {}", i, slice * 1000);
+                    $skel.maps.bss_data.dsq_time_slices[i] = slice * 1000;
+                }
+            } else {
+                for i in 0..=opts.dumb_queues - 1 {
+                    let slice_ns =
+                        $crate::dsq_slice_ns(i as u64, opts.min_slice_us, opts.dsq_shift);
+                    ::log::info!("DSQ[{}] slice_ns {}", i, slice_ns);
+                    $skel.maps.bss_data.dsq_time_slices[i] = slice_ns;
+                }
+            }
+            if opts.autoslice {
+                if opts.interactive_ratio == 0 || opts.interactive_ratio > 99 {
+                    break 'block ::anyhow::Result::Err(::anyhow::anyhow!(
+                        "Invalid interactive_ratio {}, must be between 1-99",
+                        opts.interactive_ratio
+                    ));
+                }
+            }
+
+            $skel.maps.rodata_data.interactive_ratio = opts.interactive_ratio as u32;
+            $skel.maps.rodata_data.min_slice_us = opts.min_slice_us;
+            $skel.maps.rodata_data.min_nr_queued_pick2 = opts.min_nr_queued_pick2;
+            $skel.maps.rodata_data.min_llc_runs_pick2 = opts.min_llc_runs_pick2;
+            $skel.maps.rodata_data.dsq_shift = opts.dsq_shift as u64;
+            $skel.maps.rodata_data.kthreads_local = !opts.disable_kthreads_local;
+            $skel.maps.rodata_data.nr_cpus = *$crate::NR_CPU_IDS as u32;
+            $skel.maps.rodata_data.nr_dsqs_per_llc = opts.dumb_queues as u32;
+            $skel.maps.rodata_data.init_dsq_index = opts.init_dsq_index as i32;
+            $skel.maps.rodata_data.nr_llcs = $crate::TOPO.all_llcs.clone().keys().len() as u32;
+            $skel.maps.rodata_data.nr_nodes = $crate::TOPO.nodes.clone().keys().len() as u32;
+
+            $skel.maps.rodata_data.autoslice = opts.autoslice;
+            $skel.maps.rodata_data.debug = verbose as u32;
+            $skel.maps.rodata_data.dispatch_pick2_disable = opts.dispatch_pick2_disable;
+            $skel.maps.rodata_data.eager_load_balance = !opts.eager_load_balance;
+            $skel.maps.rodata_data.greedy_idle = !opts.greedy_idle_disable;
+            $skel.maps.rodata_data.has_little_cores = $crate::TOPO.has_little_cores();
+            $skel.maps.rodata_data.interactive_sticky = opts.interactive_sticky;
+            $skel.maps.rodata_data.keep_running_enabled = opts.keep_running;
+            $skel.maps.rodata_data.max_dsq_pick2 = opts.max_dsq_pick2;
+            $skel.maps.rodata_data.smt_enabled = $crate::TOPO.smt_enabled;
+            $skel.maps.rodata_data.select_idle_in_enqueue = true;
+
+            Ok(())
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! init_skel {
+    ($skel: expr) => {
+        for cpu in $crate::TOPO.all_cpus.values() {
+            $skel.maps.bss_data.big_core_ids[cpu.id] =
+                if cpu.core_type == ($crate::CoreType::Big { turbo: true }) {
+                    1
+                } else {
+                    0
+                };
+            $skel.maps.bss_data.cpu_llc_ids[cpu.id] = cpu.llc_id as u64;
+            $skel.maps.bss_data.cpu_node_ids[cpu.id] = cpu.node_id as u64;
+        }
+    };
+}

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -4,9 +4,13 @@
 // GNU General Public License version 2.
 mod bpf_skel;
 pub use bpf_skel::*;
+
 pub mod bpf_intf;
 pub mod stats;
 use stats::Metrics;
+
+use scx_p2dq::SchedulerOpts;
+use scx_p2dq::TOPO;
 
 use std::mem::MaybeUninit;
 use std::sync::atomic::AtomicBool;
@@ -31,10 +35,7 @@ use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
 use scx_utils::uei_exited;
 use scx_utils::uei_report;
-use scx_utils::CoreType;
-use scx_utils::Topology;
 use scx_utils::UserExitInfo;
-use scx_utils::NR_CPU_IDS;
 
 use crate::bpf_intf::stat_idx_P2DQ_NR_STATS;
 use crate::bpf_intf::stat_idx_P2DQ_STAT_DIRECT;
@@ -51,123 +52,33 @@ use crate::bpf_intf::stat_idx_P2DQ_STAT_WAKE_LLC;
 use crate::bpf_intf::stat_idx_P2DQ_STAT_WAKE_MIG;
 use crate::bpf_intf::stat_idx_P2DQ_STAT_WAKE_PREV;
 
-lazy_static::lazy_static! {
-        pub static ref TOPO: Topology = Topology::new().unwrap();
-}
-
-fn get_default_greedy_disable() -> bool {
-    TOPO.all_llcs.len() > 1
-}
-
-fn get_default_llc_runs() -> u64 {
-    let n_llcs = TOPO.all_llcs.len() as f64;
-    let llc_runs = n_llcs.log2();
-    llc_runs as u64
-}
-
 /// scx_p2dq: A pick 2 dumb queuing load balancing scheduler.
 ///
 /// The BPF part does simple vtime or round robin scheduling in each domain
 /// while tracking average load of each domain and duty cycle of each task.
 ///
 #[derive(Debug, Parser)]
-struct Opts {
-    /// Disables per-cpu kthreads directly dispatched into local dsqs.
-    #[clap(short = 'k', long, action = clap::ArgAction::SetTrue)]
-    disable_kthreads_local: bool,
-
-    /// Enables autoslice tuning
-    #[clap(short = 'a', long, action = clap::ArgAction::SetTrue)]
-    autoslice: bool,
-
-    /// Ratio of interactive tasks for autoslice tuning, percent value from 1-99.
-    #[clap(short = 'r', long, default_value = "10")]
-    interactive_ratio: usize,
-
-    /// Disables eager pick2 load balancing.
-    #[clap(short = 'e', long, action = clap::ArgAction::SetTrue)]
-    eager_load_balance: bool,
-
-    /// Disables greedy idle CPU selection, may cause better load balancing on multi-LLC systems.
-    #[clap(short = 'g', long, default_value_t = get_default_greedy_disable(), action = clap::ArgAction::Set)]
-    greedy_idle_disable: bool,
-
-    /// Interactive tasks stay sticky to their CPU if no idle CPU is found.
-    #[clap(short = 'y', long, action = clap::ArgAction::SetTrue)]
-    interactive_sticky: bool,
-
-    /// Disables pick2 load balancing on the dispatch path.
-    #[clap(short = 'd', long, action = clap::ArgAction::SetTrue)]
-    dispatch_pick2_disable: bool,
-
-    /// Enable tasks to run beyond their timeslice if the CPU is idle.
-    #[clap(long, action = clap::ArgAction::SetTrue)]
-    keep_running: bool,
-
-    /// Set idle QoS resume latency based in microseconds.
-    #[clap(long)]
-    idle_resume_us: Option<u32>,
-
-    /// Only pick2 load balance from the max DSQ.
-    #[clap(long, default_value="false", action = clap::ArgAction::Set)]
-    max_dsq_pick2: bool,
-
-    /// Scheduling min slice duration in microseconds.
-    #[clap(short = 's', long, default_value = "100")]
-    min_slice_us: u64,
-
-    /// Number of runs on the LLC before a task becomes eligbile for pick2 migration on the wakeup
-    /// path.
-    #[clap(short = 'l', long, default_value_t = get_default_llc_runs())]
-    min_llc_runs_pick2: u64,
-
-    /// Manual definition of slice intervals in microseconds for DSQs, must be equal to number of
-    /// dumb_queues.
-    #[clap(short = 't', long, value_parser = clap::value_parser!(u64), default_values_t = [0;0])]
-    dsq_time_slices: Vec<u64>,
-
-    /// DSQ scaling shift, each queue min timeslice is shifted by the scaling shift.
-    #[clap(short = 'x', long, default_value = "4")]
-    dsq_shift: u64,
-
-    /// Minimum number of queued tasks to use pick2 balancing, 0 to always enabled.
-    #[clap(short = 'm', long, default_value = "0")]
-    min_nr_queued_pick2: u32,
-
-    /// Number of dumb DSQs.
-    #[clap(short = 'q', long, default_value = "3")]
-    dumb_queues: usize,
-
-    /// Initial DSQ for tasks.
-    #[clap(short = 'i', long, default_value = "0")]
-    init_dsq_index: usize,
-
+struct CliOpts {
     /// Enable verbose output, including libbpf details. Specify multiple
     /// times to increase verbosity.
     #[clap(short = 'v', long, action = clap::ArgAction::Count)]
-    verbose: u8,
+    pub verbose: u8,
 
     /// Enable stats monitoring with the specified interval.
     #[clap(long)]
-    stats: Option<f64>,
+    pub stats: Option<f64>,
 
     /// Run in stats monitoring mode with the specified interval. Scheduler
     /// is not launched.
     #[clap(long)]
-    monitor: Option<f64>,
+    pub monitor: Option<f64>,
 
     /// Print version and exit.
     #[clap(long)]
-    version: bool,
-}
+    pub version: bool,
 
-fn dsq_slice_ns(dsq_index: u64, min_slice_us: u64, dsq_shift: u64) -> u64 {
-    let result = if dsq_index == 0 {
-        1000 * min_slice_us
-    } else {
-        1000 * (min_slice_us << (dsq_index as u32) << dsq_shift)
-    };
-    result
+    #[clap(flatten)]
+    pub sched: SchedulerOpts,
 }
 
 struct Scheduler<'a> {
@@ -178,93 +89,29 @@ struct Scheduler<'a> {
 }
 
 impl<'a> Scheduler<'a> {
-    fn init(opts: &Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
+    fn init(
+        opts: &SchedulerOpts,
+        open_object: &'a mut MaybeUninit<OpenObject>,
+        verbose: u8,
+    ) -> Result<Self> {
         // Open the BPF prog first for verification.
         let mut skel_builder = BpfSkelBuilder::default();
-        skel_builder.obj_builder.debug(opts.verbose > 1);
+        skel_builder.obj_builder.debug(verbose > 1);
         init_libbpf_logging(None);
         info!(
             "Running scx_p2dq (build ID: {})",
             build_id::full_version(env!("CARGO_PKG_VERSION"))
         );
-        let mut skel = scx_ops_open!(skel_builder, open_object, p2dq).unwrap();
-
-        if opts.init_dsq_index > opts.dumb_queues - 1 {
-            panic!("Invalid init_dsq_index {}", opts.init_dsq_index);
-        }
-        if opts.dsq_time_slices.len() > 0 {
-            if opts.dsq_time_slices.len() != opts.dumb_queues {
-                panic!(
-                    "Invalid number of dsq_time_slices, got {} need {}",
-                    opts.dsq_time_slices.len(),
-                    opts.dumb_queues,
-                )
-            }
-            for vals in opts.dsq_time_slices.windows(2) {
-                assert!(
-                    vals[0] < vals[1],
-                    "DSQ time slices must be in increasing order"
-                );
-            }
-            for (i, slice) in opts.dsq_time_slices.iter().enumerate() {
-                info!("DSQ[{}] slice_ns {}", i, slice * 1000);
-                skel.maps.bss_data.dsq_time_slices[i] = slice * 1000;
-            }
-        } else {
-            for i in 0..=opts.dumb_queues - 1 {
-                let slice_ns = dsq_slice_ns(i as u64, opts.min_slice_us, opts.dsq_shift);
-                info!("DSQ[{}] slice_ns {}", i, slice_ns);
-                skel.maps.bss_data.dsq_time_slices[i] = slice_ns;
-            }
-        }
-        if opts.autoslice {
-            if opts.interactive_ratio == 0 || opts.interactive_ratio > 99 {
-                panic!(
-                    "Invalid interactive_ratio {}, must be between 1-99",
-                    opts.interactive_ratio
-                );
-            }
-        }
-
-        skel.maps.rodata_data.interactive_ratio = opts.interactive_ratio as u32;
-        skel.maps.rodata_data.min_slice_us = opts.min_slice_us;
-        skel.maps.rodata_data.min_nr_queued_pick2 = opts.min_nr_queued_pick2;
-        skel.maps.rodata_data.min_llc_runs_pick2 = opts.min_llc_runs_pick2;
-        skel.maps.rodata_data.dsq_shift = opts.dsq_shift as u64;
-        skel.maps.rodata_data.kthreads_local = !opts.disable_kthreads_local;
-        skel.maps.rodata_data.nr_cpus = *NR_CPU_IDS as u32;
-        skel.maps.rodata_data.nr_dsqs_per_llc = opts.dumb_queues as u32;
-        skel.maps.rodata_data.init_dsq_index = opts.init_dsq_index as i32;
-        skel.maps.rodata_data.nr_llcs = TOPO.all_llcs.clone().keys().len() as u32;
-        skel.maps.rodata_data.nr_nodes = TOPO.nodes.clone().keys().len() as u32;
-
-        skel.maps.rodata_data.autoslice = opts.autoslice;
-        skel.maps.rodata_data.debug = opts.verbose as u32;
-        skel.maps.rodata_data.dispatch_pick2_disable = opts.dispatch_pick2_disable;
-        skel.maps.rodata_data.eager_load_balance = !opts.eager_load_balance;
-        skel.maps.rodata_data.greedy_idle = !opts.greedy_idle_disable;
-        skel.maps.rodata_data.has_little_cores = TOPO.has_little_cores();
-        skel.maps.rodata_data.interactive_sticky = opts.interactive_sticky;
-        skel.maps.rodata_data.keep_running_enabled = opts.keep_running;
-        skel.maps.rodata_data.max_dsq_pick2 = opts.max_dsq_pick2;
-        skel.maps.rodata_data.smt_enabled = TOPO.smt_enabled;
+        let mut open_skel = scx_ops_open!(skel_builder, open_object, p2dq).unwrap();
+        scx_p2dq::init_open_skel!(&mut open_skel, opts, verbose)?;
 
         match *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP {
             0 => info!("Kernel does not support queued wakeup optimization."),
-            v => skel.struct_ops.p2dq_mut().flags |= v,
-        }
-        let mut skel = scx_ops_load!(skel, p2dq, uei)?;
+            v => open_skel.struct_ops.p2dq_mut().flags |= v,
+        };
 
-        for cpu in TOPO.all_cpus.values() {
-            skel.maps.bss_data.big_core_ids[cpu.id] =
-                if cpu.core_type == (CoreType::Big { turbo: true }) {
-                    1
-                } else {
-                    0
-                };
-            skel.maps.bss_data.cpu_llc_ids[cpu.id] = cpu.llc_id as u64;
-            skel.maps.bss_data.cpu_node_ids[cpu.id] = cpu.node_id as u64;
-        }
+        let mut skel = scx_ops_load!(open_skel, p2dq, uei)?;
+        scx_p2dq::init_skel!(&mut skel);
 
         let struct_ops = Some(scx_ops_attach!(skel, p2dq)?);
 
@@ -336,7 +183,7 @@ impl Drop for Scheduler<'_> {
 }
 
 fn main() -> Result<()> {
-    let opts = Opts::parse();
+    let opts = CliOpts::parse();
 
     if opts.version {
         println!(
@@ -391,7 +238,7 @@ fn main() -> Result<()> {
         }
     }
 
-    if let Some(idle_resume_us) = opts.idle_resume_us {
+    if let Some(idle_resume_us) = opts.sched.idle_resume_us {
         if !cpu_idle_resume_latency_supported() {
             warn!("idle resume latency not supported");
         } else {
@@ -406,7 +253,7 @@ fn main() -> Result<()> {
 
     let mut open_object = MaybeUninit::uninit();
     loop {
-        let mut sched = Scheduler::init(&opts, &mut open_object)?;
+        let mut sched = Scheduler::init(&opts.sched, &mut open_object, opts.verbose)?;
         if !sched.run(shutdown.clone())?.should_restart() {
             break;
         }


### PR DESCRIPTION

This commit initialises scx_chaos, a sched_ext scheduler designed for concurrency
testing programs. It is extremely lightly tested at the minute, but should implement
most of the behaviour of concurrency-fuzz-scheduler[0].

scx_chaos uses scx_p2dq as a base, and rather than copy-pasting code it makes
some changes to the structure to be able to use it directly. It turns out this
is pretty simple as we load the scheduler from the skeleton by name. It is then
pretty easy to wrap methods in chaos's BPF side while still maintaining all of
the necessary functionality from p2dq. The biggest change to p2dq comes in
enqueue, where the structure is changed to return a "promise". This is a C
structure detailing either what happened or how to do it, allowing chaos to
choose not to execute the enqueue and delay it until later, as well as allowing
chaos to run the enqueue with `scx_bpf_dsq_move` rather than `scx_bpf_dsq_insert`.

The concurrency testing functionality in this commit is pretty basic, and I
intend to extend it much further with a variety of different algorithms/inference
based techniques. The current method uniformly selects tasks for delay in `enqueue`,
and if selected enqueues them in a special vtime queue where vtime is wall time.
The delay is selected uniformly between a minimum and maximum. This is currently
only tested in dispatch, which appears never to stall on my machine but does
sometimes have very large delays - will be addressed in follow up patches.

[0] https://github.com/parttimenerd/concurrency-fuzz-scheduler
