### PR TITLE
scx_layered: add same_over_idle

### DIFF
--- a/scheds/rust/scx_layered/examples/same_over_idle.json
+++ b/scheds/rust/scx_layered/examples/same_over_idle.json
@@ -1,0 +1,60 @@
+[
+    {
+      "name": "same_over_idle",
+      "comment": "same_over_idle",
+      "matches": [
+        [{"CommPrefix": "stress-ng"}],
+        [{"PcommPrefix": "stress-ng"}]
+      ],
+      "kind": {
+        "Confined": {
+          "cpus_range_frac": [0.25,0.25],
+          "min_exec_us": 100,
+          "growth_algo": "NodeSpreadReverse",
+          "same_over_idle": true,
+          "util_range": [
+            0.8,
+            0.9
+          ]
+        }
+      }
+    },
+    {
+      "name": "not_same_over_idle",
+      "comment": "not_same_over_idle",
+      "matches": [
+        [{"CommPrefix": "stress"}],
+        [{"PcommPrefix": "stress"}]
+      ],
+      "kind": {
+        "Confined": {
+          "cpus_range_frac": [0.25,0.25],
+          "min_exec_us": 100,
+          "growth_algo": "NodeSpread",
+          "util_range": [
+            0.8,
+            0.9
+          ],
+          "same_over_idle": false
+        }
+      }
+    },
+    {
+      "name": "normal",
+      "comment": "the rest",
+      "matches": [
+        []
+      ],
+      "kind": {
+        "Open": {
+          "util_range": [
+            0.8,
+            0.9
+          ],
+          "min_exec_us": 100,
+          "allow_node_aligned": true
+        }
+      }
+    }
+  ]
+

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -310,6 +310,7 @@ struct layer {
 	bool			preempt_first;
 	bool			exclusive;
 	bool			allow_node_aligned;
+	bool			same_over_idle;
 	int			growth_algo;
 
 	u64			nr_tasks;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -751,7 +751,7 @@ static void maybe_refresh_layered_cpus_unprotected(struct task_struct *p, struct
 }
 
 static s32 pick_idle_cpu_from(const struct cpumask *cand_cpumask, s32 prev_cpu,
-			      const struct cpumask *idle_smtmask)
+			      const struct cpumask *idle_smtmask, const struct layer *layer)
 {
 	bool prev_in_cand;
 	s32 cpu;
@@ -765,7 +765,7 @@ static s32 pick_idle_cpu_from(const struct cpumask *cand_cpumask, s32 prev_cpu,
 	 * If CPU has SMT, any wholly idle CPU is likely a better pick than
 	 * partially idle @prev_cpu.
 	 */
-	if (smt_enabled) {
+	if (smt_enabled && !layer->same_over_idle) {
 		if (prev_in_cand &&
 		    bpf_cpumask_test_cpu(prev_cpu, idle_smtmask) &&
 		    scx_bpf_test_and_clear_cpu_idle(prev_cpu))
@@ -830,7 +830,7 @@ s32 pick_idle_big_little(struct layer *layer, struct task_ctx *taskc,
 		bpf_cpumask_and(tmp_cpumask, cast_mask(taskc->layered_mask),
 				cast_mask(big_cpumask));
 		cpu = pick_idle_cpu_from(cast_mask(tmp_cpumask),
-					 prev_cpu, idle_smtmask);
+					 prev_cpu, idle_smtmask, layer);
 		goto out_put;
 	}
 	case GROWTH_ALGO_LITTLE_BIG: {
@@ -844,7 +844,7 @@ s32 pick_idle_big_little(struct layer *layer, struct task_ctx *taskc,
 		bpf_cpumask_and(tmp_cpumask, cast_mask(taskc->layered_mask),
 				cast_mask(tmp_cpumask));
 		cpu = pick_idle_cpu_from(cast_mask(tmp_cpumask),
-					 prev_cpu, idle_smtmask);
+					 prev_cpu, idle_smtmask, layer);
 		goto out_put;
 	}
 	default:
@@ -963,7 +963,7 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 			cpu = -1;
 			goto out_put;
 		}
-		if ((cpu = pick_idle_cpu_from(cpumask, prev_cpu, idle_smtmask)) >= 0)
+		if ((cpu = pick_idle_cpu_from(cpumask, prev_cpu, idle_smtmask, layer)) >= 0)
 			goto out_put;
 
 		if (!(prev_llcc = lookup_llc_ctx(prev_cpuc->llc_id)) ||
@@ -984,11 +984,11 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 			cpu = -1;
 			goto out_put;
 		}
-		if ((cpu = pick_idle_cpu_from(cpumask, prev_cpu, idle_smtmask)) >= 0)
+		if ((cpu = pick_idle_cpu_from(cpumask, prev_cpu, idle_smtmask, layer)) >= 0)
 			goto out_put;
 	}
 
-	if ((cpu = pick_idle_cpu_from(layered_cpumask, prev_cpu, idle_smtmask)) >= 0)
+	if ((cpu = pick_idle_cpu_from(layered_cpumask, prev_cpu, idle_smtmask, layer)) >= 0)
 		goto out_put;
 
 	/*
@@ -1000,7 +1000,7 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 	    if (!unprot_mask)
 		    unprot_mask = unprotected_cpumask;
 
-	    if ((cpu = pick_idle_cpu_from(cast_mask(unprot_mask), prev_cpu, idle_smtmask)) >= 0) {
+	    if ((cpu = pick_idle_cpu_from(cast_mask(unprot_mask), prev_cpu, idle_smtmask, layer)) >= 0) {
 		lstat_inc(LSTAT_OPEN_IDLE, layer, cpuc);
 		goto out_put;
 	    }
@@ -1174,7 +1174,7 @@ static void layer_kick_idle_cpu(struct layer *layer)
 	    !(idle_smtmask = scx_bpf_get_idle_smtmask()))
 		return;
 
-	if ((cpu = pick_idle_cpu_from(layer_cpumask, 0, idle_smtmask)) >= 0)
+	if ((cpu = pick_idle_cpu_from(layer_cpumask, 0, idle_smtmask, layer)) >= 0)
 		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 
 	scx_bpf_put_idle_cpumask(idle_smtmask);

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -101,6 +101,8 @@ pub struct LayerCommon {
     #[serde(default)]
     pub allow_node_aligned: bool,
     #[serde(default)]
+    pub same_over_idle: bool,
+    #[serde(default)]
     pub weight: u32,
     #[serde(default)]
     pub disallow_open_after_us: Option<u64>,

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -110,6 +110,7 @@ lazy_static! {
                         preempt_first: false,
                         exclusive: false,
                         allow_node_aligned: false,
+                        same_over_idle: false,
                         idle_smt: None,
                         slice_us: 20000,
                         fifo: false,
@@ -140,6 +141,7 @@ lazy_static! {
                         preempt_first: false,
                         exclusive: true,
                         allow_node_aligned: true,
+                        same_over_idle: true,
                         idle_smt: None,
                         slice_us: 20000,
                         fifo: false,
@@ -174,6 +176,7 @@ lazy_static! {
                         preempt_first: false,
                         exclusive: false,
                         allow_node_aligned: false,
+                        same_over_idle: false,
                         idle_smt: None,
                         slice_us: 800,
                         fifo: false,
@@ -205,6 +208,7 @@ lazy_static! {
                         preempt_first: false,
                         exclusive: false,
                         allow_node_aligned: false,
+                        same_over_idle: false,
                         idle_smt: None,
                         slice_us: 20000,
                         fifo: false,
@@ -373,6 +377,10 @@ lazy_static! {
 ///   fallback. This is a hack to support node-affine tasks without making
 ///   the whole scheduler node aware and should only be used with open
 ///   layers on non-saturated machines to avoid possible stalls.
+///
+/// - same_over_idle: On SMT enabled systems, prefer using the same CPU
+///   when picking a CPU for tasks on this layer, even if that CPUs SMT
+///   sibling is processing a task.
 ///
 /// - weight: Weight of the layer, which is a range from 1 to 10000 with a
 ///   default of 100. Layer weights are used during contention to prevent
@@ -1324,6 +1332,7 @@ impl<'a> Scheduler<'a> {
                     preempt_first,
                     exclusive,
                     allow_node_aligned,
+                    same_over_idle,
                     growth_algo,
                     nodes,
                     slice_us,
@@ -1352,6 +1361,7 @@ impl<'a> Scheduler<'a> {
                 layer.preempt_first.write(*preempt_first);
                 layer.exclusive.write(*exclusive);
                 layer.allow_node_aligned.write(*allow_node_aligned);
+                layer.same_over_idle.write(*same_over_idle);
                 layer.growth_algo = growth_algo.as_bpf_enum();
                 layer.weight = *weight;
                 layer.disallow_open_after_ns = match disallow_open_after_us.unwrap() {


### PR DESCRIPTION
Add the layer property same_over_idle. When a layer has this property on it set to `true` and a machine has SMT enabled, tasks on this layer will be scheduled to use the same CPU even if that CPU's SMT sibling is not idle.

When this property is false, things will work as they do without this change. That is, tasks such as those in the example above would be scheduler to a CPU with an idle SMT sibling, if any such CPU exists.

the thing to note in these gif's the delta in how utilized CPUs are bouncing around:
disabled:
![Kooha-2025-03-28-18-06-51-opt](https://github.com/user-attachments/assets/df2328d0-e7f7-4cd8-bd4f-cb151ac3b8d1)

enabled:
![Kooha-2025-03-28-18-08-12-opt](https://github.com/user-attachments/assets/c5a1ad1a-add2-41d5-8893-c72537602ca0)