### PR TITLE
scx_bpfland: Improve NUMA node locality

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -745,11 +745,11 @@ static bool try_direct_dispatch(struct task_struct *p, struct task_ctx *tctx,
 		}
 
 		/*
-		 * If local_pcpu is enabled always dispatch tasks that can only run
-		 * on one CPU directly.
+		 * If local_pcpu is enabled always dispatch tasks that can
+		 * only run on one CPU directly.
 		 *
-		 * This can help to improve I/O workloads (like large parallel
-		 * builds).
+		 * This can help to improve I/O workloads (like large
+		 * parallel builds).
 		 */
 		if (local_pcpu && p->nr_cpus_allowed == 1) {
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, slice, enq_flags);
@@ -766,8 +766,29 @@ static bool try_direct_dispatch(struct task_struct *p, struct task_ctx *tctx,
 			return false;
 
 		/*
-		 * If the previously used CPU is still a full-idle SMT
-		 * core, perform a direct dispatch.
+		 * If the task can only run on a single CPU and that CPU is
+		 * idle, perform a direct dispatch.
+		 */
+		if (p->nr_cpus_allowed == 1) {
+			if (scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
+				scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | prev_cpu,
+						   slice_max, enq_flags);
+				__sync_fetch_and_add(&nr_direct_dispatches, 1);
+
+				return true;
+			}
+
+			/*
+			 * No need to check for other CPUs if the task can
+			 * only run on a single one.
+			 */
+			return false;
+		}
+
+		/*
+		 * For tasks that are not limited to run on a single CPU,
+		 * check if their previously used CPU is a full-idle SMT
+		 * core and in that case perform a direct dispatch.
 		 */
 		if (is_fully_idle(prev_cpu)) {
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | prev_cpu,

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -544,8 +544,8 @@ impl<'a> Scheduler<'a> {
 
         // Update the BPF cpumasks for the cache domains.
         for (cache_id, cpus) in cache_id_map {
-            // Ignore the cache domain if it includes a single CPU or all the CPUs.
-            if cpus.len() <= 1 || cpus.len() == *NR_CPU_IDS {
+            // Ignore the cache domain if it includes a single CPU.
+            if cpus.len() <= 1 {
                 continue;
             }
 


### PR DESCRIPTION
With these changes, bpfland tries more aggressively to keep tasks running within the same node, prioritizing partially idle SMT cores before considering cross-node migrations.

Moreover, it tries more aggressively to perform migrations + direct dispatch attempts from ops.enqueue() to reduce pressure on the shared per-node DSQs.