### PR TITLE
nix: add package to build pinned kernels

### DIFF
--- a/.github/workflows/build-kernel.nix
+++ b/.github/workflows/build-kernel.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchgit
+, virtme-ng
+, linuxManualConfig
+, linuxPackages_latest
+, name
+, repo
+, branch
+, commitHash
+, narHash
+, version
+}:
+
+let
+  src = fetchgit {
+    url = repo;
+    rev = commitHash;
+    branchName = branch;
+
+    hash = narHash;
+  };
+
+  configfile = stdenv.mkDerivation {
+    inherit src;
+    name = name + "-configfile";
+
+    buildInputs = linuxPackages_latest.kernel.buildInputs;
+    nativeBuildInputs = linuxPackages_latest.kernel.nativeBuildInputs;
+
+    buildPhase = ''
+      ${virtme-ng}/bin/virtme-ng -v --kconfig --config ${./sched-ext.config}
+    '';
+    installPhase = ''
+      mv .config $out
+    '';
+  };
+
+in
+linuxManualConfig {
+  inherit src version configfile;
+}

--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -70,3 +70,8 @@ jobs:
             echo "PR already exists, skipping creation."
           fi
           gh pr merge --auto
+
+      - name: Build Nix kernels
+        if: env.modified == 'true'
+        # Non-blocking step to track that these kernels build with Nix
+        run: nix build ./.github/workflows#kernels."${{ matrix.version }}"

--- a/kernel-versions.json
+++ b/kernel-versions.json
@@ -3,18 +3,24 @@
     "repo": "https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git",
     "branch": "for-next",
     "commitHash": "f0c6eab5e45c529f449fbc595873719e00de6d79",
-    "lastModified": 1743047221
+    "lastModified": 1743425107,
+    "narHash": "sha256-kbFxeHdDziJkYPWpTAQ+RNHqt6iRqEppce8LuZwGiWY=",
+    "kernelVersion": "6.14.0"
   },
   "bpf/bpf-next": {
     "repo": "https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git",
     "branch": "master",
     "commitHash": "4e82c87058f45e79eeaa4d5bcc3b38dd3dce7209",
-    "lastModified": 1743392808
+    "lastModified": 1743424196,
+    "narHash": "sha256-49BC0D0kPzcLU0aVSYaPCKUykVw6MF4bhtoCBJsvXss=",
+    "kernelVersion": "6.14.0"
   },
   "stable/linux-rolling-stable": {
     "repo": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
     "branch": "linux-rolling-stable",
     "commitHash": "dfc5f6de47b62aa45150d0b9ef1ffda99bb5112a",
-    "lastModified": 1743219799
+    "lastModified": 1743424196,
+    "narHash": "sha256-rAeUPoDSXoLfamCrUgRq0E8fjWgOqHPxXYHVxisndg4=",
+    "kernelVersion": "6.13.9"
   }
 }


### PR DESCRIPTION
This commit adds Nix infrastructure to build the tracked kernels easily on any machine with Nix installed. You can run:

    nix build ./.github/workflows#kernels."sched_ext/for-next"

To get a very similar kernel to that the CI is using locally, available at `result/bzImage`. It uses `virtme-ng` as the CI does to generate a valid config, then the existing `nixpkgs` build infrastructure to build the kernel from that.

This does not yet change the way the CI kernels are built, as I'm still working out the Nix caching story.

Also adds a step to `update-kernels.yml` to do the Nix build for updated kernels, simply to track whether the build stays working manually. It does not at this time block updating the kernel lock for the existing CI build.

Test plan:
- Merged into main of `JakeHillion/scx-ci-staging`, updated several kernels and they all built.
- `jq -r 'keys[]' kernel-versions.json | xargs -I{} nix build .github/workflows#kernels."{}"`. All built.