### PR TITLE
scxtop: scx_utils: Correctly handle signed values in CPU topology files

### DIFF
--- a/rust/scx_utils/src/gpu.rs
+++ b/rust/scx_utils/src/gpu.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "gpu-topology")]
 
-use crate::misc::read_file_usize;
+use crate::misc::read_from_file;
 use crate::{Cpumask, NR_CPU_IDS};
 use nvml_wrapper::bitmasks::InitFlags;
 use nvml_wrapper::enum_wrappers::device::{Clock, TopologyLevel};
@@ -99,7 +99,7 @@ pub fn create_gpus() -> BTreeMap<usize, Vec<Gpu>> {
             let bus_id = pci_info.bus_id.to_lowercase();
             let fixed_bus_id = bus_id.strip_prefix("0000").unwrap_or("");
             let numa_path = format!("/sys/bus/pci/devices/{}/numa_node", fixed_bus_id);
-            let numa_node = read_file_usize(Path::new(&numa_path)).unwrap_or(0);
+            let numa_node = read_from_file(Path::new(&numa_path)).unwrap_or(0_usize);
 
             let gpu = Gpu {
                 index: GpuIndex::Nvidia { nvml_id: index },

--- a/rust/scx_utils/src/misc.rs
+++ b/rust/scx_utils/src/misc.rs
@@ -79,7 +79,17 @@ pub fn set_rlimit_infinity() {
     };
 }
 
-pub fn read_file_usize(path: &Path) -> Result<usize> {
+/// Read a file and parse its content into the specified type.
+///
+/// Trims whitespace before parsing.
+///
+/// # Errors
+/// Returns an error if reading or parsing fails.
+pub fn read_from_file<T>(path: &Path) -> Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::error::Error + Send + Sync + 'static,
+{
     let val = match std::fs::read_to_string(path) {
         Ok(val) => val,
         Err(_) => {
@@ -87,10 +97,10 @@ pub fn read_file_usize(path: &Path) -> Result<usize> {
         }
     };
 
-    match val.trim().parse::<usize>() {
+    match val.trim().parse::<T>() {
         Ok(parsed) => Ok(parsed),
         Err(_) => {
-            bail!("Failed to parse {}", val);
+            bail!("Failed to parse content '{}' from {:?}", val.trim(), path);
         }
     }
 }

--- a/rust/scx_utils/src/netdev.rs
+++ b/rust/scx_utils/src/netdev.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-use crate::misc::read_file_usize;
+use crate::misc::read_from_file;
 use crate::Cpumask;
 use anyhow::Result;
 
@@ -55,7 +55,7 @@ pub fn read_netdevs() -> Result<BTreeMap<String, NetDev>> {
         let iface = entry.file_name().to_string_lossy().into_owned();
         let iface_path_raw = format!("/sys/class/net/{}/device/enable", iface);
         let iface_path = Path::new(&iface_path_raw);
-        let is_enabled = read_file_usize(iface_path).unwrap_or(0);
+        let is_enabled = read_from_file(iface_path).unwrap_or(0_usize);
         if is_enabled < 1 {
             continue;
         }
@@ -67,7 +67,7 @@ pub fn read_netdevs() -> Result<BTreeMap<String, NetDev>> {
 
         let node_path_raw = format!("/sys/class/net/{}/device/numa_node", iface);
         let node_path = Path::new(&node_path_raw);
-        let node = read_file_usize(node_path).unwrap_or(0);
+        let node = read_from_file(node_path).unwrap_or(0_usize);
         let mut irqs = BTreeMap::new();
         let mut irq_hints = BTreeMap::new();
 

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -69,8 +69,8 @@
 //! hierarchy are entirely read-only. If the host topology were to change (due
 //! to e.g. hotplug), a new Topology object should be created.
 
-use crate::misc::read_file_usize;
 use crate::misc::read_file_usize_vec;
+use crate::misc::read_from_file;
 use crate::Cpumask;
 use anyhow::bail;
 use anyhow::Result;
@@ -130,7 +130,7 @@ pub struct Cpu {
     pub llc_id: usize,
     pub node_id: usize,
     pub package_id: usize,
-    pub cluster_id: usize,
+    pub cluster_id: isize,
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -139,7 +139,7 @@ pub struct Core {
     pub id: usize,
     /// The sysfs value of core_id
     pub kernel_id: usize,
-    pub cluster_id: usize,
+    pub cluster_id: isize,
     pub cpus: BTreeMap<usize, Arc<Cpu>>,
     /// Cpumask of all CPUs in this core.
     pub span: Cpumask,
@@ -393,7 +393,7 @@ fn get_cache_id(topo_ctx: &mut TopoCtx, cache_level_path: &PathBuf, cache_level:
     }
 
     // In case of a cache miss, try to get the id from the sysfs first.
-    let id = read_file_usize(&cache_level_path.join("id")).unwrap_or(usize::MAX);
+    let id = read_from_file(&cache_level_path.join("id")).unwrap_or(usize::MAX);
     if id != usize::MAX {
         // Keep the id in the map
         id_map.insert(key, id);
@@ -429,9 +429,9 @@ fn create_insert_cpu(
 
     // Physical core ID
     let top_path = cpu_path.join("topology");
-    let core_kernel_id = read_file_usize(&top_path.join("core_id"))?;
-    let package_id = read_file_usize(&top_path.join("physical_package_id"))?;
-    let cluster_id = read_file_usize(&top_path.join("cluster_id"))?;
+    let core_kernel_id = read_from_file(&top_path.join("core_id"))?;
+    let package_id = read_from_file(&top_path.join("physical_package_id"))?;
+    let cluster_id = read_from_file(&top_path.join("cluster_id"))?;
 
     // Evaluate L2, L3 and LLC cache IDs.
     //
@@ -452,21 +452,22 @@ fn create_insert_cpu(
     // Min and max frequencies. If the kernel is not compiled with
     // CONFIG_CPU_FREQ, just assume 0 for both frequencies.
     let freq_path = cpu_path.join("cpufreq");
-    let min_freq = read_file_usize(&freq_path.join("scaling_min_freq")).unwrap_or(0);
-    let max_freq = read_file_usize(&freq_path.join("scaling_max_freq")).unwrap_or(0);
-    let base_freq = read_file_usize(&freq_path.join("base_frequency")).unwrap_or(max_freq);
-    let trans_lat_ns = read_file_usize(&freq_path.join("cpuinfo_transition_latency")).unwrap_or(0);
+    let min_freq = read_from_file(&freq_path.join("scaling_min_freq")).unwrap_or(0_usize);
+    let max_freq = read_from_file(&freq_path.join("scaling_max_freq")).unwrap_or(0_usize);
+    let base_freq = read_from_file(&freq_path.join("base_frequency")).unwrap_or(max_freq);
+    let trans_lat_ns =
+        read_from_file(&freq_path.join("cpuinfo_transition_latency")).unwrap_or(0_usize);
 
     // Cpu capacity
     let (cap_suffix, _avg_rcap, max_rcap) = capacity_src.unwrap_or(("".to_string(), 1024, 1024));
     let cap_path = cpu_path.join(cap_suffix);
-    let rcap = read_file_usize(&cap_path).unwrap_or(max_rcap);
+    let rcap = read_from_file(&cap_path).unwrap_or(max_rcap);
     let cpu_capacity = (rcap * 1024) / max_rcap;
 
     // Power management
     let power_path = cpu_path.join("power");
     let pm_qos_resume_latency_us =
-        read_file_usize(&power_path.join("pm_qos_resume_latency_us")).unwrap_or(0);
+        read_from_file(&power_path.join("pm_qos_resume_latency_us")).unwrap_or(0_usize);
 
     let num_llcs = topo_ctx.node_llc_kernel_ids.len();
     let llc_id = topo_ctx
@@ -588,7 +589,7 @@ fn cpu_capacity_source() -> Option<(String, usize, usize)> {
     for src in sources {
         let path_str = [prefix, src].join("/");
         let path = Path::new(&path_str);
-        raw_capacity = read_file_usize(&path).unwrap_or(0);
+        raw_capacity = read_from_file(&path).unwrap_or(0_usize);
         if raw_capacity > 0 {
             suffix = src;
             break;
@@ -604,7 +605,7 @@ fn cpu_capacity_source() -> Option<(String, usize, usize)> {
     let mut nr_cpus = 0;
     let cpu_paths = glob("/sys/devices/system/cpu/cpu[0-9]*").ok()?;
     for cpu_path in cpu_paths.filter_map(Result::ok) {
-        let raw_capacity = read_file_usize(&cpu_path.join(suffix)).unwrap_or(0);
+        let raw_capacity = read_from_file(&cpu_path.join(suffix)).unwrap_or(0_usize);
         if max_raw_capacity < raw_capacity {
             max_raw_capacity = raw_capacity;
         }
@@ -630,8 +631,8 @@ fn avg_cpu_freq() -> Option<(usize, usize)> {
     let cpu_paths = glob("/sys/devices/system/cpu/cpu[0-9]*").ok()?;
     for cpu_path in cpu_paths.filter_map(Result::ok) {
         let freq_path = cpu_path.join("cpufreq");
-        let max_freq = read_file_usize(&freq_path.join("scaling_max_freq")).unwrap_or(0);
-        let base_freq = read_file_usize(&freq_path.join("base_frequency")).unwrap_or(max_freq);
+        let max_freq = read_from_file(&freq_path.join("scaling_max_freq")).unwrap_or(0_usize);
+        let base_freq = read_from_file(&freq_path.join("base_frequency")).unwrap_or(max_freq);
         if base_freq > 0 {
             if max_freq > top_max_freq {
                 top_max_freq = max_freq;
@@ -652,7 +653,7 @@ fn has_big_little() -> Option<bool> {
     let cpu_paths = glob("/sys/devices/system/cpu/cpu[0-9]*").ok()?;
     for cpu_path in cpu_paths.filter_map(Result::ok) {
         let top_path = cpu_path.join("topology");
-        let cluster_id = read_file_usize(&top_path.join("cluster_id")).unwrap_or(0);
+        let cluster_id = read_from_file(&top_path.join("cluster_id")).unwrap_or(-1);
         clusters.insert(cluster_id);
     }
 
@@ -660,7 +661,7 @@ fn has_big_little() -> Option<bool> {
 }
 
 fn is_smt_active() -> Option<bool> {
-    let smt_on = read_file_usize(Path::new("/sys/devices/system/cpu/smt/active")).ok()?;
+    let smt_on: u8 = read_from_file(Path::new("/sys/devices/system/cpu/smt/active")).ok()?;
     Some(smt_on == 1)
 }
 

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -50,7 +50,7 @@ use ratatui::{
 };
 use regex::Regex;
 use scx_stats::prelude::StatsClient;
-use scx_utils::misc::read_file_usize;
+use scx_utils::misc::read_from_file;
 use scx_utils::scx_enums;
 use scx_utils::Topology;
 use serde_json::Value as JsonValue;
@@ -329,7 +329,7 @@ impl<'a> App<'a> {
                 *cpu_id
             );
             let path = Path::new(&file);
-            let freq = read_file_usize(path).unwrap_or(0);
+            let freq = read_from_file(path).unwrap_or(0_usize);
             let cpu_data = self.cpu_data.entry(*cpu_id).or_insert(CpuData::new(
                 *cpu_id,
                 0,
@@ -360,7 +360,7 @@ impl<'a> App<'a> {
                     re.captures(raw_path.to_str().expect("failed to get str from path"))
                 {
                     let package_id: usize = caps[1].parse().unwrap();
-                    let uncore_freq = read_file_usize(path).unwrap_or(0);
+                    let uncore_freq = read_from_file(path).unwrap_or(0_usize);
                     for cpu in self.topo.all_cpus.values() {
                         if cpu.package_id != package_id {
                             continue;


### PR DESCRIPTION
On some systems, the file `/sys/devices/system/cpu/cpu<N>/topology/cluster_id` may contain `-1` to indicate the lack of a defined cluster ID for a given CPU.

The existing code assumes unsigned integers, which causes parsing failures (e.g., `parse::<usize>()`) when reading such values.

Introduce a generic `read_from_file<T>()` function that supports any type implementing `FromStr`, including `isize`. Update the topology code to use `read_from_file::<isize>()` when reading `cluster_id` to correctly handle negative values.

While we are here, slightly improve the message in `bail()` statement in `read_from_file()`.

Signed-off-by: Metin Kaya <metin.kaya@arm.com>