### PR TITLE
scx_layered: remove extra call to test_and_clear_cpu in pick_idle_from

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -776,11 +776,11 @@ static s32 pick_idle_cpu_from(const struct cpumask *cand_cpumask, s32 prev_cpu,
 		}
 
 		// try prev if smt sibling empty
-		if (prev_in_cand &&
-			bpf_cpumask_test_cpu(prev_cpu, idle_smtmask) &&
-			scx_bpf_test_and_clear_cpu_idle(prev_cpu))
-			return prev_cpu;
-		prev_in_cand = false;
+		if (prev_in_cand && bpf_cpumask_test_cpu(prev_cpu, idle_smtmask)) {
+			if (scx_bpf_test_and_clear_cpu_idle(prev_cpu))
+				return prev_cpu;
+			prev_in_cand = false;
+		}
 
 		// try any idle core
 		cpu = scx_bpf_pick_idle_cpu(cand_cpumask, SCX_PICK_IDLE_CORE);

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -766,27 +766,32 @@ static s32 pick_idle_cpu_from(const struct cpumask *cand_cpumask, s32 prev_cpu,
 	 * partially idle @prev_cpu.
 	 */
 	if (smt_enabled) {
-
-		// if layer is prev_over_idle_core, try prev
-		if (prev_in_cand && layer->prev_over_idle_core &&
-				scx_bpf_test_and_clear_cpu_idle(prev_cpu))
-				return prev_cpu;
-
-		// try prev if layers smt sibling is idle
 		if (prev_in_cand &&
-		    bpf_cpumask_test_cpu(prev_cpu, idle_smtmask) &&
-		    scx_bpf_test_and_clear_cpu_idle(prev_cpu))
+			layer->prev_over_idle_core) {
+			// try prev if prev_over_idle_core
+			if (scx_bpf_test_and_clear_cpu_idle(prev_cpu))
+				return prev_cpu;
+			prev_in_cand = false;
+		}
+
+		// try prev if smt sibling is empty
+		if (prev_in_cand &&
+			bpf_cpumask_test_cpu(prev_cpu, idle_smtmask) &&
+			scx_bpf_test_and_clear_cpu_idle(prev_cpu))
 			return prev_cpu;
 
 		// try a wholly idle cpu
 		cpu = scx_bpf_pick_idle_cpu(cand_cpumask, SCX_PICK_IDLE_CORE);
 		if (cpu >= 0)
 			return cpu;
+
+	} else {
+		// if not SMT, try prev
+		if (prev_in_cand &&
+			scx_bpf_test_and_clear_cpu_idle(prev_cpu))
+			return prev_cpu;
 	}
-
-	if (prev_in_cand && scx_bpf_test_and_clear_cpu_idle(prev_cpu))
-		return prev_cpu;
-
+	// return any idle cpu
 	return scx_bpf_pick_idle_cpu(cand_cpumask, 0);
 }
 


### PR DESCRIPTION
Remove extra call to scx_bpf_test_and_clear_cpu_idle in pick_idle_cpu_from which would happen if smt_enabled and prev_over_idle_core when prev_cpu is busy and sibling_cpu is idle.