### PR TITLE
scx_lavd: Fix incorrect task affinity testing and more.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -121,7 +121,7 @@ struct task_ctx {
 	u32	lat_cri_waker;		/* waker's latency criticality */
 	u32	perf_cri;		/* performance criticality of a task */
 	u32	slice_ns;		/* time slice */
-	s8	futex_boost;		/* futex boost count */
+	s8	futex_boost;		/* futex acquired or not */
 	u8	is_greedy;		/* task's overscheduling ratio compared to its nice priority */
 	u8	need_lock_boost;	/* need to boost lock for deadline calculation */
 	u8	lock_holder_xted;	/* slice is already extended for a lock holder task */

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -117,6 +117,7 @@ struct task_ctx {
 	/*
 	 * Task deadline and time slice
 	 */
+	u32	nr_cpus_allowed;	/* the number of allowed CPUs running on */
 	u32	lat_cri;		/* final context-aware latency criticality */
 	u32	lat_cri_waker;		/* waker's latency criticality */
 	u32	perf_cri;		/* performance criticality of a task */

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -207,9 +207,9 @@ static bool is_per_cpu_task(const struct task_struct *p)
 	return false;
 }
 
-static bool is_affinitized(const struct task_struct *p)
+static bool is_affinitized(const struct task_ctx *taskc)
 {
-	return p->nr_cpus_allowed != nr_cpu_ids;
+	return taskc->nr_cpus_allowed != nr_cpu_ids;
 }
 
 static bool is_lat_cri(struct task_ctx *taskc, struct sys_stat *stat_cur)


### PR DESCRIPTION
p->nr_cpus_allowed does not always tell the number of allowed CPUs when
p->cpus_ptr does not point to p->cpus_mask [1]. The previous implementation
of is_affinitized() didn't consider that.

So, track the number of allowed CPUs under task_ctx (taskc->nr_cpus_allowed)
and update it whenever task's cpumask is updated. Change is_affinitized() and
its callers accordingly.

[1] https://lore.kernel.org/lkml/Z-sOIwUNgrjbQJkx@slm.duckdns.org/

In addition to this, this PR contains a code cleanup without functional change.