### PR TITLE
scx_p2dq: Fix affinitized task handling

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/intf.h
+++ b/scheds/rust/scx_p2dq/src/bpf/intf.h
@@ -86,8 +86,9 @@ struct task_ctx {
 	/* The task is a workqueue worker thread */
 	bool			is_kworker;
 
-	/* Allowed on all CPUs and eligible for DIRECT_GREEDY optimization */
+	/* Allowed to run on all CPUs */
 	bool			all_cpus;
+
 
 	struct bpf_cpumask __kptr *mask;
 };


### PR DESCRIPTION
Fix the definition of task_ctx->all_cpus to do a proper check of both p->cpus_ptr == &p->cpus_mask and p->nr_cpus_allowed == num_possible_cpus().