### PR TITLE
scx_lavd: Revise task affinity testing.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -72,7 +72,7 @@ struct pick_ctx {
 static __always_inline
 bool init_idle_i_mask(struct pick_ctx *ctx, const struct cpumask *idle_cpumask)
 {
-	if (!is_affinitized(ctx->taskc))
+	if (!ctx->taskc->is_affinitized)
 		ctx->i_mask = idle_cpumask;
 	else {
 		struct bpf_cpumask *_i_mask = ctx->cpuc_cur->tmp_i_mask;
@@ -102,7 +102,7 @@ bool init_ao_masks(struct pick_ctx *ctx)
 	if (!ctx->cpuc_cur)
 		return false;
 
-	if (!is_affinitized(ctx->taskc)) {
+	if (!ctx->taskc->is_affinitized) {
 		ctx->a_mask = ctx->active;
 		ctx->o_mask = ctx->ovrflw;
 		ctx->a_empty = ctx->o_empty = false;
@@ -300,7 +300,7 @@ bool can_run_on_cpu(struct pick_ctx *ctx, s32 cpu)
 	struct bpf_cpumask *a_mask;
 	struct bpf_cpumask *o_mask;
 
-	if (!is_affinitized(ctx->taskc))
+	if (!ctx->taskc->is_affinitized)
 		return true;
 
 	if (!bpf_cpumask_test_cpu(cpu, ctx->p->cpus_ptr))
@@ -321,7 +321,7 @@ bool can_run_on_domain(struct pick_ctx *ctx, s64 cpdom)
 	struct cpdom_ctx *cpdc;
 	struct bpf_cpumask *cpd_mask, *a_mask, *o_mask;
 
-	if (!is_affinitized(ctx->taskc))
+	if (!ctx->taskc->is_affinitized)
 		return true;
 
 	cpd_mask = MEMBER_VPTR(cpdom_cpumask, [cpdom]);

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -117,7 +117,6 @@ struct task_ctx {
 	/*
 	 * Task deadline and time slice
 	 */
-	u32	nr_cpus_allowed;	/* the number of allowed CPUs running on */
 	u32	lat_cri;		/* final context-aware latency criticality */
 	u32	lat_cri_waker;		/* waker's latency criticality */
 	u32	perf_cri;		/* performance criticality of a task */
@@ -130,6 +129,7 @@ struct task_ctx {
 	u8	slice_boost_prio;	/* how many times a task fully consumed the slice */
 	u8	on_big;			/* executable on a big core */
 	u8	on_little;		/* executable on a little core */
+	u8	is_affinitized;		/* is this task pinned to a subset of all CPUs? */
 };
 
 /*

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -207,11 +207,6 @@ static bool is_per_cpu_task(const struct task_struct *p)
 	return false;
 }
 
-static bool is_affinitized(const struct task_ctx *taskc)
-{
-	return taskc->nr_cpus_allowed != nr_cpu_ids;
-}
-
 static bool is_lat_cri(struct task_ctx *taskc, struct sys_stat *stat_cur)
 {
 	return taskc->lat_cri >= stat_cur->avg_lat_cri;


### PR DESCRIPTION
Instead of storing nr_cpus_allowed under task_ctx, let's directly store if a task is affinized or not (taskc->is_affinitized). That reduces the space in task_ctx and memory accesses in testing is_affinitized(). Also, remove is_affinitized() since now task_ctx has a field with the same name.