### PR TITLE
scx_p2dq: Update default load balancing config

### DIFF
--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -109,7 +109,7 @@ struct Opts {
     idle_resume_us: Option<u32>,
 
     /// Only pick2 load balance from the max DSQ.
-    #[clap(long, default_value = "true", action = clap::ArgAction::Set)]
+    #[clap(long, default_value="false", action = clap::ArgAction::Set)]
     max_dsq_pick2: bool,
 
     /// Scheduling min slice duration in microseconds.


### PR DESCRIPTION
Update the default load balancing config to allow load balancing from all non interactive DSQs by default. This provides better load balancing characteristics on workloads that have a mix of interactive and CPU bound tasks.

Example from running `schbench` with `scxtop` to show load:
<img width="952" alt="image" src="https://github.com/user-attachments/assets/9ce82d1a-aa6d-4e12-b3e9-1f243e559f96" />
