### PR TITLE
scx_p2dq: Avoid aggressive return on cpu selection

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -436,7 +436,7 @@ static s32 pick_idle_cpu(struct task_struct *p, struct task_ctx *taskc,
 	idle_cpumask = scx_bpf_get_idle_cpumask();
 	idle_smtmask = scx_bpf_get_idle_smtmask();
 
-	if (!idle_cpumask || !idle_smtmask || bpf_cpumask_empty(idle_cpumask))
+	if (!idle_cpumask || !idle_smtmask)
 		goto found_cpu;
 
 	if (!(prev_cpuc = lookup_cpu_ctx(prev_cpu)) ||


### PR DESCRIPTION
Avoid returning early if there are no idle CPUs. Returning the previous CPU if there are no idle CPUs is overly aggressive and causes affinitized tasks to hang if there are no idle CPUs.