### PR TITLE
common: include file and line number in scx_bpf_error

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -105,6 +105,9 @@ void scx_bpf_events(struct scx_event_stats *events, size_t events__sz) __ksym __
 static inline __attribute__((format(printf, 1, 2)))
 void ___scx_bpf_bstr_format_checker(const char *fmt, ...) {}
 
+#define SCX_STRINGIFY(x) #x
+#define SCX_TOSTRING(x) SCX_STRINGIFY(x)
+
 /*
  * Helper macro for initializing the fmt and variadic argument inputs to both
  * bstr exit kfuncs. Callers to this function should use ___fmt and ___param to
@@ -139,13 +142,15 @@ void ___scx_bpf_bstr_format_checker(const char *fmt, ...) {}
  * scx_bpf_error() wraps the scx_bpf_error_bstr() kfunc with variadic arguments
  * instead of an array of u64. Invoking this macro will cause the scheduler to
  * exit in an erroneous state, with diagnostic information being passed to the
- * user.
+ * user. It appends the file and line number to aid debugging.
  */
 #define scx_bpf_error(fmt, args...)						\
 ({										\
-	scx_bpf_bstr_preamble(fmt, args)					\
+	scx_bpf_bstr_preamble(							\
+		__FILE__ ":" SCX_TOSTRING(__LINE__) ": " fmt, ##args)		\
 	scx_bpf_error_bstr(___fmt, ___param, sizeof(___param));			\
-	___scx_bpf_bstr_format_checker(fmt, ##args);				\
+	___scx_bpf_bstr_format_checker(						\
+		__FILE__ ":" SCX_TOSTRING(__LINE__) ": " fmt, ##args);		\
 })
 
 /*


### PR DESCRIPTION

scx_bpf_error takes a user provided format string and args to exit the scheduler
with an error. When deploying a scheduler at scale this can be tricky to convert
back to a line of code. Add the `__FILE__` and `__LINE__` macros to give us a
fighting chance of finding the line the error occurred on.

Uses string literal concatenation rather than printf parameters to avoid using
up the 6 argument limit in BPF-C. This string should end up as a compile time
constant instead of on the BPF stack, and is passed directly to the kfunc.

Test plan:
- Built everything (local for Rust & CI for all).

Tested by injecting a failure into p2dq. Before:

    Error: EXIT: scx_bpf_error (failed)

After:

    Error: EXIT: scx_bpf_error (src/bpf/main.bpf.c:1047: failed)
