### PR TITLE
scxctl: Add version to scx_loader dependency

### DIFF
--- a/cargo-publish.py
+++ b/cargo-publish.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 import sys
 
-priority=['scx_stats', 'scx_stats_derive', 'scx_utils', 'scx_rustland_core']
+priority=['scx_stats', 'scx_stats_derive', 'scx_utils', 'scx_rustland_core', 'scx_p2dq']
 skip=['scx_mitosis']
 publish_args={'scx_rlfifo': ['--no-verify'],
               'scx_rustland': ['--no-verify']}

--- a/tools/scxctl/Cargo.toml
+++ b/tools/scxctl/Cargo.toml
@@ -18,4 +18,4 @@ rust-version = "1.81"
 clap = { version = "4.5.28", features = ["derive"] }
 colored = "3.0.0"
 zbus = "5.3.1"
-scx_loader = { path = "../../rust/scx_loader" }
+scx_loader = { path = "../../rust/scx_loader", version="1.0.11" }


### PR DESCRIPTION
The crate can't be published otherwise.