### PR TITLE
chaos: guarantee dispatch of tasks on quiet cpus

### DIFF
--- a/scheds/rust/scx_chaos/src/lib.rs
+++ b/scheds/rust/scx_chaos/src/lib.rs
@@ -127,8 +127,8 @@ impl<'a> TryFrom<Builder<'a>> for Pin<Box<Scheduler>> {
                 } => {
                     open_skel.maps.rodata_data.random_delays_freq_frac32 =
                         (frequency * 2_f64.powf(32_f64)) as u32;
-                    open_skel.maps.rodata_data.random_delays_min_ns = (min_us * 1000) as u32;
-                    open_skel.maps.rodata_data.random_delays_max_ns = (max_us * 1000) as u32;
+                    open_skel.maps.rodata_data.random_delays_min_ns = min_us * 1000;
+                    open_skel.maps.rodata_data.random_delays_max_ns = max_us * 1000;
                 }
             }
         }


### PR DESCRIPTION

scx_chaos uses dispatch to perform delayed enqueue of tasks. If dispatch doesn't
run for an arbitrarily long time, these tasks sit in the queue. This doesn't
appear to cause stalls on a system where all CPUs are online, but it does mean
the tasks get delayed for a long time, particularly when the CPU goes idle.

Add a timer that walks each per-CPU delay queue and kicks the CPU if the task is
due an enqueue. Use a slack factor to kick the CPU gently for a couple of milliseconds,
then preempt if the queue still hasn't been dealt with.

The numbers for this timer probably need tuning on smaller systems, but leaving
them hardcoded for now. They're const volatiles so easy to add CLI args for in
the future.

Drive by:
- Correct random_delays_{min,max}_ns from u32->u64.
- Add a macro for the number of tasks dealt with in dispatch and fix off by one error.

Test plan:
- Ran `sudo target/release/scx_chaos --random-delay-frequency 0.1 --random-delay-max-us 500000 --random-delay-min-us 500000`.
  System feels much more responsive than before.
