### PR TITLE
scx_lavd: Fix a verifier error on ARM64.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -50,7 +50,7 @@ extern void bpf_iter_task_destroy(struct bpf_iter_task *it) __weak __ksym;
 enum {
 	LAVD_CPU_ID_MAX			= 512,
 
-	LAVD_CPDOM_MAX_NR		= 32, /* maximum number of compute domain */
+	LAVD_CPDOM_MAX_NR		= 16, /* maximum number of compute domain */
 	LAVD_CPDOM_MAX_DIST		= 4,  /* maximum distance from one compute domain to another */
 
 	LAVD_STATUS_STR_LEN		= 4, /* {LR: Latency-critical, Regular}


### PR DESCRIPTION
On ARM64, the BPF verifier complains that the program is too large. So, let's reduce LAVD_CPDOM_MAX_NR to 16, which is a more realistic maximum.