### PR TITLE
chaos: store p2dq vtime and restore it before enqueue

### DIFF
--- a/scheds/rust/scx_chaos/src/bpf/intf.h
+++ b/scheds/rust/scx_chaos/src/bpf/intf.h
@@ -25,6 +25,7 @@ struct chaos_task_ctx {
 
 	enum chaos_trait_kind	next_trait;
 	u64			enq_flags;
+	u64			p2dq_vtime;
 };
 
 #endif /* __CHAOS_INTF_H */


### PR DESCRIPTION

scx_chaos uses a different vtime timeline in its delay queues, where vtime is
in the same timeline as bpf_ktime_get_ns(). Existing behaviour is to run p2dq's
enqueue for the second time after removing the task from its delay queue. This
is incorrect as the task goes into enqueue with an incorrect vtime.

Save the p2dq vtime into `chaos_task_ctx` before the first enqueue attempt and
restore it before the second enqueue attempt. This is still imperfect as if the
task has been delayed for a long time it will have a much lower vtime and
therefore always hit the:

    vtime = vtime_now - slice_ns;

Case in p2dq's enqueue, but for short delays it should be much more accurate.

Test plan:
- `sudo target/release/scx_chaos --random-delay-frequency 0.1 --random-delay-max-us 500000 --random-delay-min-us 500000`
