### PR TITLE
lib/sdt_alloc: introduce ring buffer-based arena allocator

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -665,6 +665,8 @@ void __arena *sdt_static_alloc(size_t bytes)
 	ptr = (void __arena *)((__u64) sdt_static.memory + sdt_static.off);
 	sdt_static.off += bytes;
 
+	bpf_spin_unlock(&sdt_lock);
+
 	return ptr;
 }
 

--- a/scheds/include/scx/bpf_arena_spin_lock.h
+++ b/scheds/include/scx/bpf_arena_spin_lock.h
@@ -44,7 +44,7 @@ struct arena_qnode {
  * 16-17: tail index
  * 18-31: tail cpu (+1)
  */
-#define _Q_MAX_CPUS		1024
+#define _Q_MAX_CPUS		16384
 
 #define	_Q_SET_MASK(type)	(((1U << _Q_ ## type ## _BITS) - 1)\
 				      << _Q_ ## type ## _OFFSET)
@@ -460,7 +460,7 @@ static __always_inline int arena_spin_lock(arena_spinlock_t __arena *lock)
 {
 	int val = 0;
 
-	if (CONFIG_NR_CPUS > 1024)
+	if (CONFIG_NR_CPUS > _Q_MAX_CPUS)
 		return -EOPNOTSUPP;
 
 	bpf_preempt_disable();

--- a/scheds/rust/scx_wd40/build.rs
+++ b/scheds/rust/scx_wd40/build.rs
@@ -7,7 +7,7 @@ fn main() {
     scx_utils::BpfBuilder::new()
         .unwrap()
         .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
-        .enable_skel("src/bpf/main.bpf.c", "bpf")
+        .enable_skel("src/bpf/main.bpf.c", "main")
         .add_source("src/bpf/lb_domain.bpf.c")
         .add_source("src/bpf/common.bpf.c")
         .add_source("src/bpf/deadline.bpf.c")

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
@@ -37,24 +37,26 @@ struct {
 volatile scx_bitmap_t node_data[MAX_NUMA_NODES];
 
 volatile dom_ptr dom_ctxs[MAX_DOMS];
-struct sdt_allocator lb_domain_allocator;
+struct scx_ringbuf lb_domain_allocator;
+
+#define LBALLOC_PAGES_PER_ALLOC (16)
 
 __weak
 int lb_domain_init(void)
 {
-	return sdt_alloc_init(&lb_domain_allocator, sizeof(struct dom_ctx));
+	return scx_ringbuf_init(&lb_domain_allocator,
+		sizeof(struct dom_ctx),
+		LBALLOC_PAGES_PER_ALLOC);
 }
 
 __hidden
 dom_ptr lb_domain_alloc(u32 dom_id)
 {
-	struct sdt_data __arena *data = NULL;
 	dom_ptr domc;
 
-	data = sdt_alloc(&lb_domain_allocator);
-
-	domc = (dom_ptr)data->payload;
-	domc->tid = data->tid;
+	domc = (dom_ptr)scx_ringbuf_alloc(&lb_domain_allocator);
+	if (!domc)
+		return NULL;
 
 	domc->cpumask = scx_bitmap_alloc();
 	if (!domc->cpumask) {
@@ -89,7 +91,7 @@ void lb_domain_free(dom_ptr domc)
 	scx_bitmap_free(domc->direct_greedy_cpumask);
 	scx_bitmap_free(domc->cpumask);
 
-	sdt_free_idx(&lb_domain_allocator, domc->tid.idx);
+	scx_ringbuf_free(&lb_domain_allocator, (void __arena *)domc);
 }
 
 __hidden

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.h
@@ -2,7 +2,6 @@
 #include <lib/sdt_task.h>
 
 extern volatile dom_ptr dom_ctxs[MAX_DOMS];
-extern struct sdt_allocator lb_domain_allocator;
 
 int lb_domain_init(void);
 dom_ptr lb_domain_alloc(u32 dom_id);

--- a/scheds/rust/scx_wd40/src/bpf/types.h
+++ b/scheds/rust/scx_wd40/src/bpf/types.h
@@ -64,8 +64,6 @@ struct dom_active_tasks {
 };
 
 struct dom_ctx {
-	union sdt_id		tid;
-
 	u32 id;
 	u64 min_vruntime;
 


### PR DESCRIPTION
The arena allocator currently uses a tree-based indexing structure that doubles as a key-value store for the allocated values. This is useful for data structures like task contexts that must be uniquely identified, but not for interchangeable structs like cpumask instances. For these structures we only need to allocate and free, and do not need to provide lookups for.

For interchangeable data structures, using a tree to back the allocator has the disadvantage that each allocated structure is permanently associated with a unique key, which is also used for freeing the struct. This has required embedding unique IDs to each data structure which is used solely by the allocator. 

Introduce a ring buffer-based allocator for arena memory that is more appropriate for these interchangeable data structures. The ring buffer holds preallocated instances of a data structure that get popped and pushed by allocation and free operations, respectively. The ring buffer expands as needed to accommodate the preallocated data structures. The ring buffer is designed for allocating large data structures, so the overhead caused by holding a pointer per struct instance is small relative to the total size of the data.

Also the new allocator for domain structs in the WD40 scheduler.