### PR TITLE
scx_utils, scx_lavd: Add a new option, "--cpu-pref-order".

### DIFF
--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -140,8 +140,8 @@ impl Cpumask {
 
     pub fn from_cpulist(cpulist: &str) -> Result<Cpumask> {
         let mut mask = Cpumask::new();
-        for cpu_id in read_cpulist(cpulist).unwrap() {
-            mask.set_cpu(cpu_id);
+        for cpu_id in read_cpulist(cpulist)? {
+            let _ = mask.set_cpu(cpu_id);
         }
 
         Ok(mask)

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -76,6 +76,7 @@ pub use energy_model::PerfDomain;
 pub use energy_model::PerfState;
 
 mod cpumask;
+pub use cpumask::read_cpulist;
 pub use cpumask::Cpumask;
 
 mod gpu;


### PR DESCRIPTION
Add a new option, "--cpu-pref-order", to `scx_lavd` to easily experiment with various CPU allocation policies.
Additionally, refactor `scx_utils::cpumaks` to make `cpumask::read_cpulist()` public.