### PR TITLE
scx_p2dq: Adjust max vtime calculation

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -691,10 +691,10 @@ static __always_inline void async_p2dq_enqueue(struct enqueue_promise *ret,
 	u64 vtime = p->scx.dsq_vtime;
 
 	/*
-	 * Limit the amount of budget that an idling task can accumulate
-	 * to one slice for the dsq.
+	 * Limit the amount of budget that an idling task can accumulate to the
+	 * max possible slice.
 	 */
-	if (time_before(vtime, vtime_now - slice_ns))
+	if (time_before(vtime, vtime_now - dsq_time_slice(nr_dsqs_per_llc - 1)))
 		vtime = vtime_now - slice_ns;
 
 	p->scx.dsq_vtime = vtime;


### PR DESCRIPTION
Adjust max vtime so that the maximum amount of vtime accumulated is equal to the max slice size rather than the max current assigned DSQ slice. This yields better prioritization when tasks move between layers and lowers wakeup latencies.

`main` branch:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (92266 total samples)
          50.0th: 18         (27791 samples)
          90.0th: 189        (34882 samples)
        * 99.0th: 997        (8362 samples)
          99.9th: 1622       (772 samples)
          min=1, max=4165
Request Latencies percentiles (usec) runtime 30 (s) (92429 total samples)
          50.0th: 6552       (27942 samples)
          90.0th: 8056       (36773 samples)
        * 99.0th: 13040      (8309 samples)
          99.9th: 17696      (834 samples)
          min=3317, max=24260
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 3076       (7 samples)
        * 50.0th: 3092       (9 samples)
          90.0th: 3124       (13 samples)
          min=2642, max=3130
average rps: 3080.97
```
PR:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (93941 total samples)
          50.0th: 17         (29873 samples)
          90.0th: 47         (33055 samples)
        * 99.0th: 825        (8442 samples)
          99.9th: 1622       (841 samples)
          min=1, max=4129
Request Latencies percentiles (usec) runtime 30 (s) (94117 total samples)
          50.0th: 6472       (28281 samples)
          90.0th: 7832       (37537 samples)
        * 99.0th: 12976      (8456 samples)
          99.9th: 17568      (844 samples)
          min=3321, max=22710
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 3124       (8 samples)
        * 50.0th: 3148       (10 samples)
          90.0th: 3196       (10 samples)
          min=2730, max=3232
average rps: 3137.23
```