### PR TITLE
scx_lavd: Simplify CPU frequency scaling.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
@@ -37,7 +37,7 @@ int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc, u32 cpu_id)
 	m->taskc_x.pid = p->pid;
 	__builtin_memcpy_inline(m->taskc_x.comm, p->comm, TASK_COMM_LEN);
 	m->taskc_x.static_prio = get_nice_prio(p);
-	m->taskc_x.cpu_util = cpuc->util / 10;
+	m->taskc_x.cpu_util = cpuc->avg_util / 10;
 	m->taskc_x.cpu_id = cpu_id;
 	m->taskc_x.avg_lat_cri = stat_cur->avg_lat_cri;
 	m->taskc_x.thr_perf_cri = stat_cur->thr_perf_cri;

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -88,7 +88,8 @@ struct cpu_ctx {
 	/* 
 	 * Information used to keep track of CPU utilization
 	 */
-	volatile u64	util;		/* average of the CPU utilization */
+	volatile u32	avg_util;	/* average of the CPU utilization */
+	volatile u32	cur_util;	/* CPU utilization of the current interval */
 	volatile u64	idle_total;	/* total idle time so far */
 	volatile u64	idle_start_clk;	/* when the CPU becomes idle */
 
@@ -124,8 +125,6 @@ struct cpu_ctx {
 	 * Information for CPU frequency scaling
 	 */
 	u32		cpuperf_cur;	/* CPU's current performance target */
-	u32		cpuperf_task;	/* task's CPU performance target */
-	u32		cpuperf_avg;	/* EWMA of task's CPU performance target */
 
 	/*
 	 * Fields for core compaction

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -48,7 +48,7 @@ struct sys_stat_ctx {
 	u64		max_perf_cri;
 	u64		sum_perf_cri;
 	u32		thr_perf_cri;
-	u64		new_util;
+	u32		cur_util;
 	u32		nr_violation;
 };
 
@@ -212,15 +212,15 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 		if (c->duration > cpuc->idle_total)
 			compute = c->duration - cpuc->idle_total;
 
-		c->new_util = (compute * LAVD_CPU_UTIL_MAX) / c->duration;
-		cpuc->util = calc_avg(cpuc->util, c->new_util);
+		cpuc->cur_util = (compute * LAVD_CPU_UTIL_MAX) / c->duration;
+		cpuc->avg_util = calc_avg(cpuc->avg_util, cpuc->cur_util);
 
 		if (cpuc->turbo_core) {
-			if (cpuc->util > LAVD_CC_PER_TURBO_CORE_MAX_CTUIL)
+			if (cpuc->avg_util > LAVD_CC_PER_TURBO_CORE_MAX_CTUIL)
 				c->nr_violation += 1000;
 		}
 		else {
-			if (cpuc->util > LAVD_CC_PER_CORE_MAX_CTUIL)
+			if (cpuc->avg_util > LAVD_CC_PER_CORE_MAX_CTUIL)
 				c->nr_violation += 1000;
 		}
 
@@ -239,7 +239,7 @@ static void calc_sys_stat(struct sys_stat_ctx *c)
 		c->compute_total = c->duration_total - c->idle_total;
 	else
 		c->compute_total = 0;
-	c->new_util = (c->compute_total * LAVD_CPU_UTIL_MAX)/c->duration_total;
+	c->cur_util = (c->compute_total * LAVD_CPU_UTIL_MAX)/c->duration_total;
 
 	if (c->nr_sched == 0) {
 		/*
@@ -274,7 +274,7 @@ static void update_sys_stat_next(struct sys_stat_ctx *c)
 	struct sys_stat *stat_next = c->stat_next;
 
 	stat_next->util =
-		calc_avg(stat_cur->util, c->new_util);
+		calc_avg(stat_cur->util, c->cur_util);
 
 	stat_next->max_lat_cri =
 		calc_avg32(stat_cur->max_lat_cri, c->max_lat_cri);


### PR DESCRIPTION
Simplify CPU frequency scaling to decide the frequency based on CPU utilization without considering the task's performance criticality. The running average of tasks' performance criticality converges to a constant, making no significant difference. To respond quickly upon load spikes, use the bigger one between the running average and the recent utilization. When the utilization is greater than LAVD_CPU_UTIL_MAX_FOR_CPUPERF (85%), ceil to 100%.