### PR TITLE
scxtop: trace (part of) pstate_sample

### DIFF
--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -39,6 +39,7 @@ enum event_type {
 	GPU_MEM,
 	HW_PRESSURE,
 	IPI,
+	PSTATE_SAMPLE,
 	SCHED_REG,
 	SCHED_SWITCH,
 	SCHED_UNREG,
@@ -145,6 +146,10 @@ struct trace_started_event {
 	bool		stop_scheduled;
 };
 
+struct pstate_sample_event {
+	u32             busy;
+};
+
 struct bpf_event {
 	int		type;
 	u64		ts;
@@ -158,6 +163,7 @@ struct bpf_event {
 		struct  cpuhp_enter_event chp;
 		struct  cpuhp_exit_event cxp;
 		struct	ipi_event ipi;
+		struct  pstate_sample_event pstate;
 		struct	sched_switch_event sched_switch;
 		struct	set_perf_event perf;
 		struct	softirq_event softirq;

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -978,6 +978,27 @@ int BPF_PROG(on_hw_pressure_update, u32 cpu, u64 hw_pressure)
 	return 0;
 }
 
+SEC("tp_btf/pstate_sample")
+int BPF_PROG(on_pstate_sample, u32 core_busy, u32 scaled_busy, u32 from, u32 to, u64 mperf, u64 aperf, u64 tsc, u32 freq, u32 io_boost)
+{
+	struct bpf_event *event;
+
+	if (!enable_bpf_events || !should_sample())
+		return 0;
+
+	if (!(event = try_reserve_event()))
+		return -ENOMEM;
+
+	event->type = PSTATE_SAMPLE;
+	event->cpu = bpf_get_smp_processor_id();
+	event->ts = bpf_ktime_get_ns();
+	event->event.pstate.busy = scaled_busy;
+
+	bpf_ringbuf_submit(event, 0);
+
+	return 0;
+}
+
 SEC("syscall")
 int BPF_PROG(scxtop_init)
 {

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -240,6 +240,12 @@ pub struct HwPressureAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PstateSampleAction {
+    pub cpu: u32,
+    pub busy: u32,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Action {
     ChangeTheme,
     ClearEvent,
@@ -264,6 +270,7 @@ pub enum Action {
     PageDown,
     PageUp,
     PrevEvent,
+    PstateSample(PstateSampleAction),
     Quit,
     RequestTrace,
     TraceStarted(TraceStartedAction),
@@ -435,6 +442,11 @@ impl TryFrom<&bpf_event> for Action {
                     child_comm: child_comm.into(),
                 }))
             }
+            #[allow(non_upper_case_globals)]
+            bpf_intf::event_type_PSTATE_SAMPLE => Ok(Action::PstateSample(PstateSampleAction {
+                cpu: event.cpu,
+                busy: unsafe { event.event.pstate.busy },
+            })),
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_SCHED_SWITCH => {
                 let sched_switch = unsafe { &event.event.sched_switch };

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -113,6 +113,9 @@ fn attach_progs(skel: &mut BpfSkel) -> Result<Vec<Link>> {
     if let Ok(link) = skel.progs.on_cpuhp_exit.attach() {
         links.push(link);
     }
+    if let Ok(link) = skel.progs.on_pstate_sample.attach() {
+        links.push(link);
+    }
 
     Ok(links)
 }


### PR DESCRIPTION
scaled_busy represents the performance state "final score", i.e. scaled frequency used by the CPU.