### PR TITLE
scx_flash: Always bounce tasks to ops.enqueue()

### DIFF
--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -478,6 +478,5 @@ SCX_OPS_DEFINE(flash_ops,
 	       .cpu_release		= (void *)flash_cpu_release,
 	       .init			= (void *)flash_init,
 	       .exit			= (void *)flash_exit,
-	       .flags			= SCX_OPS_ENQ_EXITING,
 	       .timeout_ms		= 5000U,
 	       .name			= "flash");

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -142,6 +142,15 @@ impl<'a> Scheduler<'a> {
             warn!("vfs_fsync_range symbol is missing")
         }
 
+        // Set scheduler flags.
+        skel.struct_ops.flash_ops_mut().flags = *compat::SCX_OPS_ENQ_EXITING
+            | *compat::SCX_OPS_ENQ_LAST
+            | *compat::SCX_OPS_ENQ_MIGRATION_DISABLED;
+        info!(
+            "scheduler flags: {:#x}",
+            skel.struct_ops.flash_ops_mut().flags
+        );
+
         // Load the BPF program for validation.
         let mut skel = scx_ops_load!(skel, flash_ops, uei)?;
 


### PR DESCRIPTION
Disable auto-dispatch of migration disabled tasks and ensure all tasks are always processed via ops.enqueue().

This seems to prevent stall scenarios where, under certain conditions, migration-disabled tasks are repeatedly rescheduled on the same CPU, leading to starvation of per-CPU tasks queued in the per-node DSQs (reported and tested by the CachyOS community).