### PR TITLE
scx_lavd: Further prioritize kworkers and a few more.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -534,7 +534,7 @@ s32 pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle)
 	 * to set an anchor for proximity.
 	 */
 	ctx->waker_cpu = -ENOENT;
-	ctx->is_task_big = is_perf_cri(ctx->taskc, get_sys_stat_cur());
+	ctx->is_task_big = is_perf_cri(ctx->taskc);
 	sticky_cpu = find_sticky_cpu_and_domain(ctx, &sticky_cpdom);
 
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -68,6 +68,7 @@ struct sys_stat {
 
 	volatile u64	avg_svc_time;	/* average service time per task */
 	volatile u64	nr_queued_task;
+	volatile u64	slice;		/* base time slice */
 
 	volatile u32	avg_lat_cri;	/* average latency criticality (LC) */
 	volatile u32	max_lat_cri;	/* maximum latency criticality (LC) */

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -63,33 +63,33 @@ enum {
  * System-wide stats
  */
 struct sys_stat {
-	volatile u64	last_update_clk;
-	volatile u64	util;		/* average of the CPU utilization */
+	u64	last_update_clk;
+	u64	util;		/* average of the CPU utilization */
 
-	volatile u64	avg_svc_time;	/* average service time per task */
-	volatile u64	nr_queued_task;
-	volatile u64	slice;		/* base time slice */
+	u64	avg_svc_time;	/* average service time per task */
+	u64	nr_queued_task;
+	u64	slice;		/* base time slice */
 
-	volatile u32	avg_lat_cri;	/* average latency criticality (LC) */
-	volatile u32	max_lat_cri;	/* maximum latency criticality (LC) */
-	volatile u32	thr_lat_cri;	/* latency criticality threshold for kicking */
+	u32	avg_lat_cri;	/* average latency criticality (LC) */
+	u32	max_lat_cri;	/* maximum latency criticality (LC) */
+	u32	thr_lat_cri;	/* latency criticality threshold for kicking */
 
-	volatile u32	min_perf_cri;	/* minimum performance criticality */
-	volatile u32	avg_perf_cri;	/* average performance criticality */
-	volatile u32	max_perf_cri;	/* maximum performance criticality */
-	volatile u32	thr_perf_cri;	/* performance criticality threshold */
+	u32	min_perf_cri;	/* minimum performance criticality */
+	u32	avg_perf_cri;	/* average performance criticality */
+	u32	max_perf_cri;	/* maximum performance criticality */
+	u32	thr_perf_cri;	/* performance criticality threshold */
 
-	volatile u32	nr_stealee;	/* number of compute domains to be migrated */
-	volatile u32	nr_violation;	/* number of utilization violation */
-	volatile u32	nr_active;	/* number of active cores */
+	u32	nr_stealee;	/* number of compute domains to be migrated */
+	u32	nr_violation;	/* number of utilization violation */
+	u32	nr_active;	/* number of active cores */
 
-	volatile u64	nr_sched;	/* total scheduling so far */
-	volatile u64	nr_perf_cri;	/* number of performance-critical tasks scheduled */
-	volatile u64	nr_lat_cri;	/* number of latency-critical tasks scheduled */
-	volatile u64	nr_x_migration; /* number of cross domain migration */
-	volatile u64	nr_big;		/* scheduled on big core */
-	volatile u64	nr_pc_on_big;	/* performance-critical tasks scheduled on big core */
-	volatile u64	nr_lc_on_big;	/* latency-critical tasks scheduled on big core */
+	u64	nr_sched;	/* total scheduling so far */
+	u64	nr_perf_cri;	/* number of performance-critical tasks scheduled */
+	u64	nr_lat_cri;	/* number of latency-critical tasks scheduled */
+	u64	nr_x_migration; /* number of cross domain migration */
+	u64	nr_big;		/* scheduled on big core */
+	u64	nr_pc_on_big;	/* performance-critical tasks scheduled on big core */
+	u64	nr_lc_on_big;	/* latency-critical tasks scheduled on big core */
 };
 
 /*

--- a/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
@@ -21,7 +21,6 @@ struct {
 static __always_inline
 int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc, u32 cpu_id)
 {
-	struct sys_stat *stat_cur = get_sys_stat_cur();
 	struct cpu_ctx *cpuc;
 	struct msg_task_ctx *m;
 
@@ -39,13 +38,13 @@ int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc, u32 cpu_id)
 	m->taskc_x.static_prio = get_nice_prio(p);
 	m->taskc_x.cpu_util = cpuc->avg_util / 10;
 	m->taskc_x.cpu_id = cpu_id;
-	m->taskc_x.avg_lat_cri = stat_cur->avg_lat_cri;
-	m->taskc_x.thr_perf_cri = stat_cur->thr_perf_cri;
-	m->taskc_x.nr_active = stat_cur->nr_active;
+	m->taskc_x.avg_lat_cri = sys_stat.avg_lat_cri;
+	m->taskc_x.thr_perf_cri = sys_stat.thr_perf_cri;
+	m->taskc_x.nr_active = sys_stat.nr_active;
 	m->taskc_x.cpuperf_cur = cpuc->cpuperf_cur;
 
-	m->taskc_x.stat[0] = is_lat_cri(taskc, stat_cur) ? 'L' : 'R';
-	m->taskc_x.stat[1] = is_perf_cri(taskc, stat_cur) ? 'H' : 'I';
+	m->taskc_x.stat[0] = is_lat_cri(taskc) ? 'L' : 'R';
+	m->taskc_x.stat[1] = is_perf_cri(taskc) ? 'H' : 'I';
 	m->taskc_x.stat[2] = cpuc->big_core ? 'B' : 'T';
 	m->taskc_x.stat[3] = is_greedy(taskc) ? 'G' : 'E';
 	m->taskc_x.stat[4] = '\0';

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -289,6 +289,12 @@ static u64 calc_weight_factor(struct task_struct *p, struct task_ctx *taskc)
 		weight_boost += LAVD_LC_WEIGHT_BOOST;
 
 	/*
+	 * Further prioritize kworkers.
+	 */
+	if (is_kernel_worker(p))
+		weight_boost += LAVD_LC_WEIGHT_BOOST;
+
+	/*
 	 * Prioritize an affinitized task since it has restrictions
 	 * in placement so it tends to be delayed.
 	 */

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -78,9 +78,7 @@ static bool is_worth_kick_other_task(struct task_ctx *taskc)
 	 * trying to victimize another CPU as the current task is urgent
 	 * enough.
 	 */
-	struct sys_stat *stat_cur = get_sys_stat_cur();
-
-	return (taskc->lat_cri >= stat_cur->thr_lat_cri);
+	return (taskc->lat_cri >= sys_stat.thr_lat_cri);
 }
 
 static bool can_cpu_be_kicked(u64 now, struct cpu_ctx *cpuc)

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -117,13 +117,6 @@ static struct cpu_ctx *find_victim_cpu(const struct cpumask *cpumask,
 	cur_cpu = cpuc->cpu_id;
 
 	/*
-	 * First check if it is worth to try to kick other CPU
-	 * at the expense of IPI.
-	 */
-	if (!is_worth_kick_other_task(taskc))
-		goto null_out;
-
-	/*
 	 * Randomly find _two_ CPUs that run lower-priority tasks than @p. To
 	 * traverse CPUs in a random order, we start from a random CPU ID in a
 	 * random direction (left or right). The random-order traversal helps
@@ -238,6 +231,12 @@ static bool try_find_and_kick_victim_cpu(struct task_struct *p,
 	 * Don't even try to perform expensive preemption for greedy tasks.
 	 */
 	if (!is_eligible(taskc))
+		return false;
+
+	/*
+	 * Check if it is worth to try to kick other CPU at the expense of IPI.
+	 */
+	if (!is_worth_kick_other_task(taskc))
 		return false;
 
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -23,8 +23,6 @@ struct {
 } update_timer SEC(".maps");
 
 struct sys_stat_ctx {
-	struct sys_stat *stat_cur;
-	struct sys_stat	*stat_next;
 	u64		now;
 	u64		duration;
 	u64		duration_total;
@@ -56,12 +54,10 @@ static void init_sys_stat_ctx(struct sys_stat_ctx *c)
 {
 	__builtin_memset(c, 0, sizeof(*c));
 
-	c->stat_cur = get_sys_stat_cur();
-	c->stat_next = get_sys_stat_next();
 	c->min_perf_cri = 1000;
 	c->now = scx_bpf_now();
-	c->duration = c->now - c->stat_cur->last_update_clk;
-	c->stat_next->last_update_clk = c->now;
+	c->duration = c->now - sys_stat.last_update_clk;
+	sys_stat.last_update_clk = c->now;
 }
 
 static void plan_x_cpdom_migration(struct sys_stat_ctx *c)
@@ -232,8 +228,20 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 	}
 }
 
+static u32 clamp_time_slice_ns(u32 slice)
+{
+	if (slice < slice_min_ns)
+		slice = slice_min_ns;
+	else if (slice > slice_max_ns)
+		slice = slice_max_ns;
+	return slice;
+}
+
 static void calc_sys_stat(struct sys_stat_ctx *c)
 {
+	static int cnt = 0;
+	u64 avg_svc_time = 0, nr_queued, slice;
+
 	c->duration_total = c->duration * nr_cpus_onln;
 	if (c->duration_total > c->idle_total)
 		c->compute_total = c->duration_total - c->idle_total;
@@ -246,13 +254,13 @@ static void calc_sys_stat(struct sys_stat_ctx *c)
 		 * When a system is completely idle, it is indeed possible
 		 * nothing scheduled for an interval.
 		 */
-		c->max_lat_cri = c->stat_cur->max_lat_cri;
-		c->avg_lat_cri = c->stat_cur->avg_lat_cri;
+		c->max_lat_cri = sys_stat.max_lat_cri;
+		c->avg_lat_cri = sys_stat.avg_lat_cri;
 
 		if (have_little_core) {
-			c->min_perf_cri = c->stat_cur->min_perf_cri;
-			c->max_perf_cri = c->stat_cur->max_perf_cri;
-			c->avg_perf_cri = c->stat_cur->avg_perf_cri;
+			c->min_perf_cri = sys_stat.min_perf_cri;
+			c->max_perf_cri = sys_stat.max_perf_cri;
+			c->avg_perf_cri = sys_stat.avg_perf_cri;
 		}
 	}
 	else {
@@ -260,61 +268,33 @@ static void calc_sys_stat(struct sys_stat_ctx *c)
 		if (have_little_core)
 			c->avg_perf_cri = c->sum_perf_cri / c->nr_sched;
 	}
-}
-
-static u32 clamp_time_slice_ns(u32 slice)
-{
-	if (slice < slice_min_ns)
-		slice = slice_min_ns;
-	else if (slice > slice_max_ns)
-		slice = slice_max_ns;
-	return slice;
-}
-
-static void update_sys_stat_next(struct sys_stat_ctx *c)
-{
-	static int cnt = 0;
-	u64 avg_svc_time = 0, nr_queued, slice;
 
 	/*
 	 * Update the CPU utilization to the next version.
 	 */
-	struct sys_stat *stat_cur = c->stat_cur;
-	struct sys_stat *stat_next = c->stat_next;
-
-	stat_next->util =
-		calc_avg(stat_cur->util, c->cur_util);
-
-	stat_next->max_lat_cri =
-		calc_avg32(stat_cur->max_lat_cri, c->max_lat_cri);
-	stat_next->avg_lat_cri =
-		calc_avg32(stat_cur->avg_lat_cri, c->avg_lat_cri);
-	stat_next->thr_lat_cri = stat_next->max_lat_cri -
-		((stat_next->max_lat_cri - stat_next->avg_lat_cri) >> 1);
+	sys_stat.util = calc_avg(sys_stat.util, c->cur_util);
+	sys_stat.max_lat_cri = calc_avg32(sys_stat.max_lat_cri, c->max_lat_cri);
+	sys_stat.avg_lat_cri = calc_avg32(sys_stat.avg_lat_cri, c->avg_lat_cri);
+	sys_stat.thr_lat_cri = sys_stat.max_lat_cri - ((sys_stat.max_lat_cri -
+				sys_stat.avg_lat_cri) >> 1);
 
 	if (have_little_core) {
-		stat_next->min_perf_cri =
-			calc_avg32(stat_cur->min_perf_cri, c->min_perf_cri);
-		stat_next->avg_perf_cri =
-			calc_avg32(stat_cur->avg_perf_cri, c->avg_perf_cri);
-		stat_next->max_perf_cri =
-			calc_avg32(stat_cur->max_perf_cri, c->max_perf_cri);
-		stat_next->thr_perf_cri =
-			c->stat_cur->thr_perf_cri; /* will be updated later */
+		sys_stat.min_perf_cri =
+			calc_avg32(sys_stat.min_perf_cri, c->min_perf_cri);
+		sys_stat.avg_perf_cri =
+			calc_avg32(sys_stat.avg_perf_cri, c->avg_perf_cri);
+		sys_stat.max_perf_cri =
+			calc_avg32(sys_stat.max_perf_cri, c->max_perf_cri);
 	}
 
-	stat_next->nr_stealee = c->nr_stealee;
+	sys_stat.nr_stealee = c->nr_stealee;
 
-	stat_next->nr_violation =
-		calc_avg32(stat_cur->nr_violation, c->nr_violation);
+	sys_stat.nr_violation = calc_avg32(sys_stat.nr_violation, c->nr_violation);
 
 	if (c->nr_sched > 0)
 		avg_svc_time = c->tot_svc_time / c->nr_sched;
-	stat_next->avg_svc_time =
-		calc_avg(stat_cur->avg_svc_time, avg_svc_time);
-
-	stat_next->nr_queued_task =
-		calc_avg(stat_cur->nr_queued_task, c->nr_queued_task);
+	sys_stat.avg_svc_time = calc_avg(sys_stat.avg_svc_time, avg_svc_time);
+	sys_stat.nr_queued_task = calc_avg(sys_stat.nr_queued_task, c->nr_queued_task);
 
 	/*
 	 * Given the updated state, recalculate the time slice for the next
@@ -322,10 +302,10 @@ static void update_sys_stat_next(struct sys_stat_ctx *c)
 	 * runnable tasks at least once within a targeted latency using the
 	 * active CPUs.
 	 */
-	nr_queued = stat_next->nr_queued_task + 1;
-	slice = (LAVD_TARGETED_LATENCY_NS * stat_next->nr_active) / nr_queued;
+	nr_queued = sys_stat.nr_queued_task + 1;
+	slice = (LAVD_TARGETED_LATENCY_NS * sys_stat.nr_active) / nr_queued;
 	slice = clamp_time_slice_ns(slice);
-	stat_next->slice = calc_avg(stat_cur->slice, slice);
+	sys_stat.slice = calc_avg(sys_stat.slice, slice);
 
 	/*
 	 * Half the statistics every minitue so the statistics hold the
@@ -333,26 +313,26 @@ static void update_sys_stat_next(struct sys_stat_ctx *c)
 	 */
 	if (cnt++ == LAVD_SYS_STAT_DECAY_TIMES) {
 		cnt = 0;
-		stat_next->nr_sched >>= 1;
-		stat_next->nr_perf_cri >>= 1;
-		stat_next->nr_lat_cri >>= 1;
-		stat_next->nr_x_migration >>= 1;
-		stat_next->nr_big >>= 1;
-		stat_next->nr_pc_on_big >>= 1;
-		stat_next->nr_lc_on_big >>= 1;
+		sys_stat.nr_sched >>= 1;
+		sys_stat.nr_perf_cri >>= 1;
+		sys_stat.nr_lat_cri >>= 1;
+		sys_stat.nr_x_migration >>= 1;
+		sys_stat.nr_big >>= 1;
+		sys_stat.nr_pc_on_big >>= 1;
+		sys_stat.nr_lc_on_big >>= 1;
 
 		__sync_fetch_and_sub(&performance_mode_ns, performance_mode_ns/2);
 		__sync_fetch_and_sub(&balanced_mode_ns, balanced_mode_ns/2);
 		__sync_fetch_and_sub(&powersave_mode_ns, powersave_mode_ns/2);
 	}
 
-	stat_next->nr_sched += c->nr_sched;
-	stat_next->nr_perf_cri += c->nr_perf_cri;
-	stat_next->nr_lat_cri += c->nr_lat_cri;
-	stat_next->nr_x_migration += c->nr_x_migration;
-	stat_next->nr_big += c->nr_big;
-	stat_next->nr_pc_on_big += c->nr_pc_on_big;
-	stat_next->nr_lc_on_big += c->nr_lc_on_big;
+	sys_stat.nr_sched += c->nr_sched;
+	sys_stat.nr_perf_cri += c->nr_perf_cri;
+	sys_stat.nr_lat_cri += c->nr_lat_cri;
+	sys_stat.nr_x_migration += c->nr_x_migration;
+	sys_stat.nr_big += c->nr_big;
+	sys_stat.nr_pc_on_big += c->nr_pc_on_big;
+	sys_stat.nr_lc_on_big += c->nr_lc_on_big;
 
 	update_power_mode_time();
 }
@@ -361,19 +341,10 @@ static void do_update_sys_stat(void)
 {
 	struct sys_stat_ctx c;
 
-	/*
-	 * Collect and prepare the next version of stat.
-	 */
 	init_sys_stat_ctx(&c);
 	plan_x_cpdom_migration(&c);
 	collect_sys_stat(&c);
 	calc_sys_stat(&c);
-	update_sys_stat_next(&c);
-
-	/*
-	 * Make the next version atomically visible.
-	 */
-	flip_sys_stat();
 }
 
 static void update_sys_stat(void)
@@ -413,11 +384,10 @@ static s32 init_sys_stat(u64 now)
 	u32 key = 0;
 	int err;
 
-	__builtin_memset(__sys_stats, 0, sizeof(__sys_stats));
-	__sys_stats[0].last_update_clk = now;
-	__sys_stats[1].last_update_clk = now;
-	__sys_stats[0].nr_active = nr_cpus_big;
-	__sys_stats[1].nr_active = nr_cpus_big;
+	sys_stat.last_update_clk = now;
+	sys_stat.last_update_clk = now;
+	sys_stat.nr_active = nr_cpus_big;
+	sys_stat.nr_active = nr_cpus_big;
 
 	timer = bpf_map_lookup_elem(&update_timer, &key);
 	if (!timer) {

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -385,9 +385,7 @@ static s32 init_sys_stat(u64 now)
 	int err;
 
 	sys_stat.last_update_clk = now;
-	sys_stat.last_update_clk = now;
-	sys_stat.nr_active = nr_cpus_big;
-	sys_stat.nr_active = nr_cpus_big;
+	sys_stat.nr_active = nr_cpus_onln;
 
 	timer = bpf_map_lookup_elem(&update_timer, &key);
 	if (!timer) {

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -199,6 +199,14 @@ static bool is_kernel_task(struct task_struct *p)
 	return !!(p->flags & PF_KTHREAD);
 }
 
+#ifndef PF_IO_WORKER
+#define PF_IO_WORKER		0x00000010	/* Task is an IO worker */
+#endif
+static bool is_kernel_worker(struct task_struct *p)
+{
+	return !!(p->flags & (PF_WQ_WORKER | PF_IO_WORKER));
+}
+
 static bool is_per_cpu_task(const struct task_struct *p)
 {
 	if (p->nr_cpus_allowed == 1 || is_migration_disabled(p))

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -776,7 +776,7 @@ impl<'a> Scheduler<'a> {
                 self.mseq_id += 1;
 
                 let bss_data = &self.skel.maps.bss_data;
-                let st = bss_data.__sys_stats[0];
+                let st = bss_data.sys_stat;
 
                 let mseq = self.mseq_id;
                 let nr_queued_task = st.nr_queued_task;


### PR DESCRIPTION
The main changes of this PR is 1) prioritizing kworkers to improve IO performance, 2) reducing the cost of preemption, and 3) reducing the cost of switching to the performance mode.

Besides these main changes, the PR includes code clean-ups -- including removing unused function args, caching repeatedly calculated time slices to sys_stat,  and relaxing the atomic visibility of sys_stat. Note that there is no functional change in the code clean-ups.