### PR TITLE
scx_p2dq: Update kthread selection on task context

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -27,6 +27,7 @@
 #include "user_exit_info.h"
 #include "enum_defs.autogen.h"
 
+#define PF_IO_WORKER			0x00000010	/* Task is an IO worker */
 #define PF_WQ_WORKER			0x00000020	/* I'm a workqueue worker */
 #define PF_KTHREAD			0x00200000	/* I am a kernel thread */
 #define PF_EXITING			0x00000004

--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -782,7 +782,7 @@ static __always_inline void p2dq_runnable_impl(struct task_struct *p, u64 enq_fl
 	if (!(wakee_ctx = lookup_task_ctx(p)))
 		return;
 
-	wakee_ctx->is_kworker = p->flags & PF_WQ_WORKER;
+	wakee_ctx->is_kworker = p->flags & (PF_KTHREAD | PF_WQ_WORKER | PF_IO_WORKER);
 }
 
 


### PR DESCRIPTION
Update the is_kthread field on the task_context to include checks of if the task is a kworker, io, or wq worker.