### PR TITLE
scx_lavd: Do not proactively reserve overflow CPUs, and more. 

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -44,7 +44,6 @@ enum consts_internal  {
 	LAVD_CC_PER_CORE_MAX_CTUIL	= 500, /* maximum per-core CPU utilization */
 	LAVD_CC_PER_TURBO_CORE_MAX_CTUIL = 750, /* maximum per-core CPU utilization for a turbo core */
 	LAVD_CC_NR_ACTIVE_MIN		= 1, /* num of mininum active cores */
-	LAVD_CC_NR_OVRFLW		= 1, /* num of overflow cores */
 	LAVD_CC_CPU_PIN_INTERVAL	= (250ULL * NSEC_PER_MSEC),
 	LAVD_CC_CPU_PIN_INTERVAL_DIV	= (LAVD_CC_CPU_PIN_INTERVAL / LAVD_SYS_STAT_INTERVAL_NS),
 

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -48,8 +48,8 @@ enum consts_internal  {
 	LAVD_CC_CPU_PIN_INTERVAL	= (250ULL * NSEC_PER_MSEC),
 	LAVD_CC_CPU_PIN_INTERVAL_DIV	= (LAVD_CC_CPU_PIN_INTERVAL / LAVD_SYS_STAT_INTERVAL_NS),
 
-	LAVD_AP_HIGH_UTIL		= 700, /* balanced mode when 10% < cpu util <= 40%,
-						  performance mode when cpu util > 40% */
+	LAVD_AP_HIGH_UTIL		= 700, /* balanced mode when 10% < cpu util <= 70%,
+						  performance mode when cpu util > 70% */
 
 	LAVD_CPDOM_MIGRATION_SHIFT	= 3, /* 1/2**3 = +/- 12.5% */
 	LAVD_CPDOM_X_PROB_FT		= (LAVD_SYS_STAT_INTERVAL_NS /

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -756,10 +756,9 @@ static bool can_direct_dispatch(u64 dsq_id, s32 cpu, bool is_idle)
 
 void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 {
-	struct cpu_ctx *cpuc_cur;
 	struct task_ctx *taskc;
 	s32 task_cpu, cpu = -ENOENT;
-	u64 dsq_id, now;
+	u64 dsq_id;
 	bool is_idle = false;
 
 	taskc = get_task_ctx(p);

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -178,9 +178,6 @@ static bool is_kernel_task(struct task_struct *p)
 	return !!(p->flags & PF_KTHREAD);
 }
 
-#ifndef PF_IO_WORKER
-#define PF_IO_WORKER		0x00000010	/* Task is an IO worker */
-#endif
 static bool is_kernel_worker(struct task_struct *p)
 {
 	return !!(p->flags & (PF_WQ_WORKER | PF_IO_WORKER));

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -228,7 +228,7 @@ static u16 get_nice_prio(struct task_struct *p)
 
 static bool use_full_cpus(void)
 {
-	return (sys_stat.nr_active + LAVD_CC_NR_OVRFLW) >= nr_cpus_onln;
+	return sys_stat.nr_active >= nr_cpus_onln;
 }
 
 static s64 pick_any_bit(u64 bitmap, u64 nuance)


### PR DESCRIPTION
Previously, one overflow CPU was allocated by default to avoid overutilizing active CPUs proactively. However, it is not necessary in practice because there are almost always affinitized tasks, causing overflow CPUs to be assigned. So, drop proactive allocation of an overflow CPU and let's rely on the real overflow CPUs.

In addition, this PR contains code clean-ups without functional changes.