### PR TITLE
scxtop: attach sched_waking porgram

### DIFF
--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -451,9 +451,11 @@ int BPF_PROG(on_sched_waking, struct task_struct *p)
 {
 	struct bpf_event *event;
 
-	event = bpf_ringbuf_reserve(&events, sizeof(struct bpf_event), 0);
-	if (!event)
-		return 0;
+        if (!enable_bpf_events || !should_sample())
+                return 0;
+
+        if (!(event = try_reserve_event()))
+                return -ENOMEM;
 
 	event->type = SCHED_WAKING;
 	event->ts = bpf_ktime_get_ns();

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -81,6 +81,7 @@ fn attach_progs(skel: &mut BpfSkel) -> Result<Vec<Link>> {
         skel.progs.on_sched_switch.attach()?,
         skel.progs.on_sched_wakeup.attach()?,
         skel.progs.on_sched_wakeup_new.attach()?,
+        skel.progs.on_sched_waking.attach()?,
     ];
 
     // 6.13 compatibility


### PR DESCRIPTION
Owing to a simple omission we weren't attaching to the `sched_waking` tracepoint and therefore no corresponding ftrace events were being captured in the perfetto traces.

I've also made the `on_sched_waking` bpf program follow the same pattern as the other programs as it was non-standard. There are some other minor bpf inconsistencies around here but I'll fix those in a follow up diff.

The image below shows that the perfetto trace now contains `sched_waking` ftrace events.

![Screenshot 2025-04-08 at 21 12 34](https://github.com/user-attachments/assets/a8f3e927-5063-4ab8-9957-94d35d1e1ba9)


