### PR TITLE
scx_utils: retain all BPF output files for multiple compilation units

### DIFF
--- a/scheds/rust/scx_wd40/build.rs
+++ b/scheds/rust/scx_wd40/build.rs
@@ -7,7 +7,7 @@ fn main() {
     scx_utils::BpfBuilder::new()
         .unwrap()
         .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
-        .enable_skel("src/bpf/main.bpf.c", "bpf")
+        .enable_skel("src/bpf/main.bpf.c", "main")
         .add_source("src/bpf/lb_domain.bpf.c")
         .add_source("src/bpf/common.bpf.c")
         .add_source("src/bpf/deadline.bpf.c")


### PR DESCRIPTION
The code in scx_utils responsible for compiling schedulers as separate compilation units currently does not retain separate output files for each file compiled, and instead only keeps the final combined object file produced by the linker. This happens because the code uses the same name for all object files, causing them to overwrite each other during compilation. However, the intermediate *.o files are useful for debugging.  Modify the code to properly name the object files so they are retained during compilation. Also change the name of the *.o file for main.bpf.c from bpf.bpf.o to main.bpf.o for consistency.