### PR TITLE
lib/sdt_alloc: remove sdt_* prefix from most of the allocator

### DIFF
--- a/lib/cpumask.bpf.c
+++ b/lib/cpumask.bpf.c
@@ -43,7 +43,7 @@ u64 scx_bitmap_alloc_internal(void)
 __weak
 int scx_bitmap_free(scx_bitmap_t __arg_arena mask)
 {
-	sdt_subprog_init_arena();
+	scx_arena_subprog_init();
 
 	scx_alloc_free_idx(&scx_bitmap_allocator, mask->tid.idx);
 	return 0;

--- a/lib/cpumask.bpf.c
+++ b/lib/cpumask.bpf.c
@@ -4,7 +4,7 @@
 #include <lib/cpumask.h>
 #include <lib/percpu.h>
 
-static struct sdt_allocator scx_bitmap_allocator;
+static struct scx_allocator scx_bitmap_allocator;
 size_t mask_size;
 
 __weak
@@ -12,7 +12,7 @@ int scx_bitmap_init(__u64 total_mask_size)
 {
 	mask_size = div_round_up(total_mask_size, 8);
 
-	return sdt_alloc_init(&scx_bitmap_allocator, mask_size * 8 + sizeof(union sdt_id));
+	return scx_alloc_init(&scx_bitmap_allocator, mask_size * 8 + sizeof(union sdt_id));
 }
 
 __weak
@@ -22,7 +22,7 @@ u64 scx_bitmap_alloc_internal(void)
 	scx_bitmap_t mask;
 	int i;
 
-	data = sdt_alloc(&scx_bitmap_allocator);
+	data = scx_alloc(&scx_bitmap_allocator);
 	if (unlikely(!data))
 		return (u64)(NULL);
 
@@ -45,7 +45,7 @@ int scx_bitmap_free(scx_bitmap_t __arg_arena mask)
 {
 	sdt_subprog_init_arena();
 
-	sdt_free_idx(&scx_bitmap_allocator, mask->tid.idx);
+	scx_alloc_free_idx(&scx_bitmap_allocator, mask->tid.idx);
 	return 0;
 }
 

--- a/lib/include/lib
+++ b/lib/include/lib
@@ -1,1 +1,0 @@
-../../scheds/include/lib

--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -47,8 +47,6 @@ static __u64 zero = 0;
  */
 static bool sdt_verify_once;
 
-#define SDT_TASK_FN_ATTRS	inline __attribute__((unused, always_inline))
-
 __hidden void sdt_subprog_init_arena(void)
 {
 	if (sdt_verify_once)
@@ -69,7 +67,7 @@ struct sdt_pool sdt_chunk_pool;
 /* Protected by sdt_lock. */
 struct sdt_stats sdt_stats;
 
-static SDT_TASK_FN_ATTRS int sdt_ffs(__u64 word)
+static int sdt_ffs(__u64 word)
 {
 	unsigned int num = 0;
 
@@ -107,7 +105,7 @@ static SDT_TASK_FN_ATTRS int sdt_ffs(__u64 word)
 }
 
 /* find the first empty slot */
-static SDT_TASK_FN_ATTRS __u64 sdt_chunk_find_empty(sdt_desc_t *desc)
+static __u64 sdt_chunk_find_empty(sdt_desc_t *desc)
 {
 	__u64 freeslots;
 	__u64 i;
@@ -123,7 +121,7 @@ static SDT_TASK_FN_ATTRS __u64 sdt_chunk_find_empty(sdt_desc_t *desc)
 	return SDT_TASK_ENTS_PER_CHUNK;
 }
 
-static SDT_TASK_FN_ATTRS
+static
 void __arena *scx_alloc_stack_pop(struct scx_alloc_stack __arena *stack)
 {
 	void __arena *slab;
@@ -139,7 +137,7 @@ void __arena *scx_alloc_stack_pop(struct scx_alloc_stack __arena *stack)
 	return slab;
 }
 
-static SDT_TASK_FN_ATTRS
+static
 int scx_alloc_stack(struct scx_alloc_stack __arena *stack)
 {
 	void __arena *slab;
@@ -199,7 +197,7 @@ int scx_alloc_attempt(struct scx_alloc_stack __arena *stack)
 }
 
 /* Allocate element from the pool. Must be called with a then pool lock held. */
-static SDT_TASK_FN_ATTRS
+static
 void __arena *scx_alloc_from_pool(struct sdt_pool *pool,
 	struct scx_alloc_stack __arena *stack)
 {
@@ -228,7 +226,7 @@ void __arena *scx_alloc_from_pool(struct sdt_pool *pool,
 }
 
 /* Allocate element from the pool. Must be called with a then pool lock held. */
-static SDT_TASK_FN_ATTRS
+static
 void __arena *scx_alloc_from_pool_sleepable(struct sdt_pool *pool)
 {
 	__u64 elem_size, max_elems;
@@ -253,8 +251,7 @@ void __arena *scx_alloc_from_pool_sleepable(struct sdt_pool *pool)
 }
 
 /* Alloc desc and associated chunk. Called with the task spinlock held. */
-static SDT_TASK_FN_ATTRS
-sdt_desc_t *scx_alloc_chunk(struct scx_alloc_stack __arena *stack)
+static sdt_desc_t *scx_alloc_chunk(struct scx_alloc_stack __arena *stack)
 {
 	struct sdt_chunk __arena *chunk;
 	sdt_desc_t *desc;
@@ -273,7 +270,7 @@ sdt_desc_t *scx_alloc_chunk(struct scx_alloc_stack __arena *stack)
 	return out;
 }
 
-static SDT_TASK_FN_ATTRS int sdt_pool_set_size(struct sdt_pool *pool, __u64 data_size, __u64 nr_pages)
+static int sdt_pool_set_size(struct sdt_pool *pool, __u64 data_size, __u64 nr_pages)
 {
 	if (unlikely(data_size % 8)) {
 		scx_bpf_error("%s: allocation size %llu not word aligned", __func__, data_size);
@@ -340,7 +337,7 @@ scx_alloc_init(struct scx_allocator *alloc, __u64 data_size)
 	return 0;
 }
 
-static SDT_TASK_FN_ATTRS
+static
 int sdt_set_idx_state(sdt_desc_t *desc, __u64 pos, bool state)
 {
 	__u64 __arena *allocated = desc->allocated;
@@ -476,8 +473,7 @@ int scx_alloc_free_idx(struct scx_allocator *alloc, __u64 idx)
  * Find and return an available idx on the allocator.
  * Called with the task spinlock held.
  */
-static SDT_TASK_FN_ATTRS
-sdt_desc_t * sdt_find_empty(sdt_desc_t *desc,
+static sdt_desc_t * sdt_find_empty(sdt_desc_t *desc,
 	struct scx_alloc_stack __arena *stack,
 	__u64 *idxp)
 {
@@ -539,8 +535,7 @@ sdt_desc_t * sdt_find_empty(sdt_desc_t *desc,
 	return desc;
 }
 
-static SDT_TASK_FN_ATTRS
-void scx_alloc_finish(struct sdt_data __arena *data, __u64 idx)
+static void scx_alloc_finish(struct sdt_data __arena *data, __u64 idx)
 {
 	bpf_spin_lock(&sdt_lock);
 

--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -45,15 +45,15 @@ static __u64 zero = 0;
  * statement that triggers at most once to generate an LD.IMM instruction
  * to access the arena and help the verifier.
  */
-static bool sdt_verify_once;
+static bool scx_arena_verify_once;
 
-__hidden void sdt_subprog_init_arena(void)
+__hidden void scx_arena_subprog_init(void)
 {
-	if (sdt_verify_once)
+	if (scx_arena_verify_once)
 		return;
 
 	bpf_printk("%s: arena pointer %p", __func__, &arena);
-	sdt_verify_once = true;
+	scx_arena_verify_once = true;
 }
 
 
@@ -396,7 +396,7 @@ int scx_alloc_free_idx(struct scx_allocator *alloc, __u64 idx)
 	int ret;
 	int i;
 
-	sdt_subprog_init_arena();
+	scx_arena_subprog_init();
 
 	if (!alloc)
 		return 0;

--- a/lib/sdt_task.bpf.c
+++ b/lib/sdt_task.bpf.c
@@ -12,7 +12,7 @@
  * Task BPF map entry recording the task's assigned ID and pointing to the data
  * area allocated in arena.
  */
-struct sdt_task_map_val {
+struct scx_task_map_val {
 	union sdt_id		tid;
 	__u64			tptr;
 	struct sdt_data __arena	*data;
@@ -22,23 +22,23 @@ struct {
 	__uint(type, BPF_MAP_TYPE_TASK_STORAGE);
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 	__type(key, int);
-	__type(value, struct sdt_task_map_val);
-} sdt_task_map SEC(".maps");
+	__type(value, struct scx_task_map_val);
+} scx_task_map SEC(".maps");
 
-struct scx_allocator sdt_task_allocator;
+struct scx_allocator scx_task_allocator;
 
 __hidden
-void __arena *sdt_task_alloc(struct task_struct *p)
+void __arena *scx_task_alloc(struct task_struct *p)
 {
 	struct sdt_data __arena *data = NULL;
-	struct sdt_task_map_val *mval;
+	struct scx_task_map_val *mval;
 
-	mval = bpf_task_storage_get(&sdt_task_map, p, 0,
+	mval = bpf_task_storage_get(&scx_task_map, p, 0,
 				    BPF_LOCAL_STORAGE_GET_F_CREATE);
 	if (!mval)
 		return NULL;
 
-	data = scx_alloc(&sdt_task_allocator);
+	data = scx_alloc(&scx_task_allocator);
 
 	mval->tid = data->tid;
 	mval->tptr = (__u64) p;
@@ -48,20 +48,20 @@ void __arena *sdt_task_alloc(struct task_struct *p)
 }
 
 __hidden
-int sdt_task_init(__u64 data_size)
+int scx_task_init(__u64 data_size)
 {
-	return scx_alloc_init(&sdt_task_allocator, data_size);
+	return scx_alloc_init(&scx_task_allocator, data_size);
 }
 
 __hidden
-void __arena *sdt_task_data(struct task_struct *p)
+void __arena *scx_task_data(struct task_struct *p)
 {
 	struct sdt_data __arena *data;
-	struct sdt_task_map_val *mval;
+	struct scx_task_map_val *mval;
 
 	sdt_subprog_init_arena();
 
-	mval = bpf_task_storage_get(&sdt_task_map, p, 0, 0);
+	mval = bpf_task_storage_get(&scx_task_map, p, 0, 0);
 	if (!mval)
 		return NULL;
 
@@ -71,17 +71,17 @@ void __arena *sdt_task_data(struct task_struct *p)
 }
 
 __hidden
-void sdt_task_free(struct task_struct *p)
+void scx_task_free(struct task_struct *p)
 {
-	struct sdt_task_map_val *mval;
+	struct scx_task_map_val *mval;
 
 	sdt_subprog_init_arena();
 
-	mval = bpf_task_storage_get(&sdt_task_map, p, 0, 0);
+	mval = bpf_task_storage_get(&scx_task_map, p, 0, 0);
 	if (!mval)
 		return;
 
-	scx_alloc_free_idx(&sdt_task_allocator, mval->tid.idx);
+	scx_alloc_free_idx(&scx_task_allocator, mval->tid.idx);
 	mval->data = NULL;
 	mval->tptr = 0;
 }

--- a/lib/sdt_task.bpf.c
+++ b/lib/sdt_task.bpf.c
@@ -25,7 +25,7 @@ struct {
 	__type(value, struct sdt_task_map_val);
 } sdt_task_map SEC(".maps");
 
-struct sdt_allocator sdt_task_allocator;
+struct scx_allocator sdt_task_allocator;
 
 __hidden
 void __arena *sdt_task_alloc(struct task_struct *p)
@@ -38,7 +38,7 @@ void __arena *sdt_task_alloc(struct task_struct *p)
 	if (!mval)
 		return NULL;
 
-	data = sdt_alloc(&sdt_task_allocator);
+	data = scx_alloc(&sdt_task_allocator);
 
 	mval->tid = data->tid;
 	mval->tptr = (__u64) p;
@@ -50,7 +50,7 @@ void __arena *sdt_task_alloc(struct task_struct *p)
 __hidden
 int sdt_task_init(__u64 data_size)
 {
-	return sdt_alloc_init(&sdt_task_allocator, data_size);
+	return scx_alloc_init(&sdt_task_allocator, data_size);
 }
 
 __hidden
@@ -81,7 +81,7 @@ void sdt_task_free(struct task_struct *p)
 	if (!mval)
 		return;
 
-	sdt_free_idx(&sdt_task_allocator, mval->tid.idx);
+	scx_alloc_free_idx(&sdt_task_allocator, mval->tid.idx);
 	mval->data = NULL;
 	mval->tptr = 0;
 }

--- a/lib/sdt_task.bpf.c
+++ b/lib/sdt_task.bpf.c
@@ -59,7 +59,7 @@ void __arena *scx_task_data(struct task_struct *p)
 	struct sdt_data __arena *data;
 	struct scx_task_map_val *mval;
 
-	sdt_subprog_init_arena();
+	scx_arena_subprog_init();
 
 	mval = bpf_task_storage_get(&scx_task_map, p, 0, 0);
 	if (!mval)
@@ -75,7 +75,7 @@ void scx_task_free(struct task_struct *p)
 {
 	struct scx_task_map_val *mval;
 
-	sdt_subprog_init_arena();
+	scx_arena_subprog_init();
 
 	mval = bpf_task_storage_get(&scx_task_map, p, 0, 0);
 	if (!mval)

--- a/scheds/c/scx_sdt.bpf.c
+++ b/scheds/c/scx_sdt.bpf.c
@@ -43,7 +43,7 @@ s32 BPF_STRUCT_OPS(sdt_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wake
 	bool is_idle = false;
 	s32 cpu;
 
-	stats = sdt_task_data(p);
+	stats = scx_task_data(p);
 	if (!stats) {
 		scx_bpf_error("%s: no stats for pid %d", __func__, p->pid);
 		return 0;
@@ -64,7 +64,7 @@ void BPF_STRUCT_OPS(sdt_enqueue, struct task_struct *p, u64 enq_flags)
 {
 	struct scx_stats __arena *stats;
 
-	stats = sdt_task_data(p);
+	stats = scx_task_data(p);
 	if (!stats) {
 		scx_bpf_error("%s: no stats for pid %d", __func__, p->pid);
 		return;
@@ -85,7 +85,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(sdt_init_task, struct task_struct *p,
 {
 	struct scx_stats __arena *stats;
 
-	stats = sdt_task_alloc(p);
+	stats = scx_task_alloc(p);
 	if (!stats) {
 		scx_bpf_error("arena allocator out of memory");
 		return -ENOMEM;
@@ -103,7 +103,7 @@ void BPF_STRUCT_OPS(sdt_exit_task, struct task_struct *p,
 {
 	struct scx_stats __arena *stats;
 
-	stats = sdt_task_data(p);
+	stats = scx_task_data(p);
 	if (!stats) {
 		scx_bpf_error("%s: no stats for pid %d", __func__, p->pid);
 		return;
@@ -112,14 +112,14 @@ void BPF_STRUCT_OPS(sdt_exit_task, struct task_struct *p,
 	stat_inc_exit(stats);
 	scx_stat_global_update(stats);
 
-	sdt_task_free(p);
+	scx_task_free(p);
 }
 
 s32 BPF_STRUCT_OPS_SLEEPABLE(sdt_init)
 {
 	int ret;
 
-	ret = sdt_task_init(sizeof(struct scx_stats));
+	ret = scx_task_init(sizeof(struct scx_stats));
 	if (ret < 0) {
 		scx_bpf_error("%s: failed with %d", __func__, ret);
 		return ret;

--- a/scheds/c/scx_sdt.c
+++ b/scheds/c/scx_sdt.c
@@ -77,12 +77,12 @@ restart:
 		printf("\n");
 
 		printf("====ALLOCATION STATS====\n");
-		printf("chunk allocs=%llu\t", skel->bss->sdt_stats.chunk_allocs);
-		printf("data_allocs=%llu\n", skel->bss->sdt_stats.data_allocs);
-		printf("alloc_ops=%llu\t", skel->bss->sdt_stats.alloc_ops);
-		printf("free_ops=%llu\t", skel->bss->sdt_stats.free_ops);
-		printf("active_allocs=%llu\t", skel->bss->sdt_stats.active_allocs);
-		printf("arena_pages_used=%llu\t", skel->bss->sdt_stats.arena_pages_used);
+		printf("chunk allocs=%llu\t", skel->bss->alloc_stats.chunk_allocs);
+		printf("data_allocs=%llu\n", skel->bss->alloc_stats.data_allocs);
+		printf("alloc_ops=%llu\t", skel->bss->alloc_stats.alloc_ops);
+		printf("free_ops=%llu\t", skel->bss->alloc_stats.free_ops);
+		printf("active_allocs=%llu\t", skel->bss->alloc_stats.active_allocs);
+		printf("arena_pages_used=%llu\t", skel->bss->alloc_stats.arena_pages_used);
 		printf("\n\n");
 
 		fflush(stdout);

--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -72,7 +72,7 @@ struct sdt_chunk {
  * to drop the lock to allocate pages from the arena in the middle of the
  * top-level alloc. This in turn prevents races and simplifies the code.
  */
-struct sdt_alloc_stack {
+struct scx_alloc_stack {
 	__u64 idx;
 	void __arena	*stack[SDT_TASK_ALLOC_STACK_MAX];
 };
@@ -93,7 +93,7 @@ struct sdt_stats {
 	__u64		arena_pages_used;
 };
 
-struct sdt_allocator {
+struct scx_allocator {
 	struct sdt_pool	pool;
 	sdt_desc_t	*root;
 };
@@ -112,11 +112,11 @@ void __arena *sdt_task_alloc(struct task_struct *p);
 void sdt_task_free(struct task_struct *p);
 void sdt_subprog_init_arena(void);
 
-int sdt_alloc_init(struct sdt_allocator *alloc, __u64 data_size);
-u64 sdt_alloc_internal(struct sdt_allocator *alloc);
-int sdt_free_idx(struct sdt_allocator *alloc, __u64 idx);
+int scx_alloc_init(struct scx_allocator *alloc, __u64 data_size);
+u64 scx_alloc_internal(struct scx_allocator *alloc);
+int scx_alloc_free_idx(struct scx_allocator *alloc, __u64 idx);
 
-#define sdt_alloc(alloc) ((struct sdt_data __arena *)sdt_alloc_internal((alloc)))
+#define scx_alloc(alloc) ((struct sdt_data __arena *)scx_alloc_internal((alloc)))
 
 void __arena *scx_static_alloc(size_t bytes);
 int scx_static_init(size_t max_alloc_pages);

--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -110,7 +110,7 @@ void __arena *scx_task_data(struct task_struct *p);
 int scx_task_init(__u64 data_size);
 void __arena *scx_task_alloc(struct task_struct *p);
 void scx_task_free(struct task_struct *p);
-void sdt_subprog_init_arena(void);
+void scx_arena_subprog_init(void);
 
 int scx_alloc_init(struct scx_allocator *alloc, __u64 data_size);
 u64 scx_alloc_internal(struct scx_allocator *alloc);

--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -106,10 +106,10 @@ struct scx_static {
 
 #ifdef __BPF__
 
-void __arena *sdt_task_data(struct task_struct *p);
-int sdt_task_init(__u64 data_size);
-void __arena *sdt_task_alloc(struct task_struct *p);
-void sdt_task_free(struct task_struct *p);
+void __arena *scx_task_data(struct task_struct *p);
+int scx_task_init(__u64 data_size);
+void __arena *scx_task_alloc(struct task_struct *p);
+void scx_task_free(struct task_struct *p);
 void sdt_subprog_init_arena(void);
 
 int scx_alloc_init(struct scx_allocator *alloc, __u64 data_size);

--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -84,7 +84,7 @@ struct sdt_pool {
 	__u64		idx;
 };
 
-struct sdt_stats {
+struct scx_alloc_stats {
 	__u64		chunk_allocs;
 	__u64		data_allocs;
 	__u64		alloc_ops;

--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -98,7 +98,7 @@ struct sdt_allocator {
 	sdt_desc_t	*root;
 };
 
-struct sdt_static {
+struct scx_static {
 	size_t max_alloc_bytes;
 	void __arena *memory;
 	size_t off;
@@ -118,7 +118,7 @@ int sdt_free_idx(struct sdt_allocator *alloc, __u64 idx);
 
 #define sdt_alloc(alloc) ((struct sdt_data __arena *)sdt_alloc_internal((alloc)))
 
-void __arena *sdt_static_alloc(size_t bytes);
-int sdt_static_init(size_t max_alloc_pages);
+void __arena *scx_static_alloc(size_t bytes);
+int scx_static_init(size_t max_alloc_pages);
 
 #endif /* __BPF__ */

--- a/scheds/rust/scx_rusty/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_rusty/src/bpf/lb_domain.h
@@ -1,6 +1,6 @@
 #include <scx/common.bpf.h>
 
-#include <lib/sdt_task.h>
+#include "sdt_task.h"
 
 struct lb_domain {
 	union sdt_id		tid;

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -43,9 +43,9 @@
 #else
 #include <scx/common.bpf.h>
 #include <scx/ravg_impl.bpf.h>
-#include <lib/sdt_task.h>
 #endif
 
+#include "sdt_task.h"
 #include "intf.h"
 #include "types.h"
 #include "lb_domain.h"

--- a/scheds/rust/scx_rusty/src/bpf/sdt_alloc.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/sdt_alloc.bpf.c
@@ -6,7 +6,8 @@
  */
 
 #include <scx/common.bpf.h>
-#include <lib/sdt_task.h>
+
+#include "sdt_task.h"
 
 char _license[] SEC("license") = "GPL";
 

--- a/scheds/rust/scx_rusty/src/bpf/sdt_task.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/sdt_task.bpf.c
@@ -6,7 +6,8 @@
  */
 
 #include <scx/common.bpf.h>
-#include <lib/sdt_task.h>
+
+#include "sdt_task.h"
 
 /*
  * Task BPF map entry recording the task's assigned ID and pointing to the data

--- a/scheds/rust/scx_rusty/src/bpf/sdt_task.h
+++ b/scheds/rust/scx_rusty/src/bpf/sdt_task.h
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright (c) 2024 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2024 Tejun Heo <tj@kernel.org>
+ * Copyright (c) 2024 Emil Tsalapatis <etsal@meta.com>
+ */
+#pragma once
+#include <scx/bpf_arena_common.h>
+
+#ifndef div_round_up
+#define div_round_up(a, b) (((a) + (b) - 1) / (b))
+#endif
+
+typedef struct sdt_desc __arena sdt_desc_t;
+
+enum sdt_consts {
+	SDT_TASK_ENTS_PER_PAGE_SHIFT	= 9,
+	SDT_TASK_LEVELS			= 3,
+	SDT_TASK_ENTS_PER_CHUNK		= 1 << SDT_TASK_ENTS_PER_PAGE_SHIFT,
+	SDT_TASK_CHUNK_BITMAP_U64S	= div_round_up(SDT_TASK_ENTS_PER_CHUNK, 64),
+	SDT_TASK_ALLOC_STACK_MIN	= 2 * SDT_TASK_LEVELS,
+	SDT_TASK_ALLOC_STACK_MAX	= SDT_TASK_ALLOC_STACK_MIN * 5,
+	SDT_TASK_MIN_ELEM_PER_ALLOC = 8,
+	SDT_TASK_ALLOC_ATTEMPTS		= 32,
+};
+
+union sdt_id {
+	__s64				val;
+	struct {
+		__s32			idx;	/* index in the radix tree */
+		__s32			gen;	/* ++'d on recycle so that it forms unique'ish 64bit ID */
+	};
+};
+
+struct sdt_chunk;
+
+/*
+ * Each index page is described by the following descriptor which carries the
+ * bitmap. This way the actual index can host power-of-two numbers of entries
+ * which makes indexing cheaper.
+ */
+struct sdt_desc {
+	__u64				allocated[SDT_TASK_CHUNK_BITMAP_U64S];
+	__u64				nr_free;
+	struct sdt_chunk __arena	*chunk;
+};
+
+/*
+ * Leaf node containing per-task data.
+ */
+struct sdt_data {
+	union sdt_id			tid;
+	__u64				payload[];
+};
+
+/*
+ * Intermediate node pointing to another intermediate node or leaf node.
+ */
+struct sdt_chunk {
+	union {
+		sdt_desc_t * descs[SDT_TASK_ENTS_PER_CHUNK];
+		struct sdt_data __arena *data[SDT_TASK_ENTS_PER_CHUNK];
+	};
+};
+
+/*
+ * Stack structure to avoid chunk allocations/frees while under lock. The
+ * allocator preallocates enough arena pages before any operation to satisfy
+ * the maximum amount of chunk allocations:(2 * SDT_TASK_LEVELS + 1), two
+ * allocations per tree level, and one for the data itself. Preallocating
+ * ensures that the stack can satisfy these allocations, so we do not need
+ * to drop the lock to allocate pages from the arena in the middle of the
+ * top-level alloc. This in turn prevents races and simplifies the code.
+ */
+struct sdt_alloc_stack {
+	__u64 idx;
+	void __arena	*stack[SDT_TASK_ALLOC_STACK_MAX];
+};
+
+struct sdt_pool {
+	void __arena	*slab;
+	__u64		elem_size;
+	__u64		max_elems;
+	__u64		idx;
+};
+
+struct sdt_stats {
+	__u64		chunk_allocs;
+	__u64		data_allocs;
+	__u64		alloc_ops;
+	__u64		free_ops;
+	__u64		active_allocs;
+	__u64		arena_pages_used;
+};
+
+struct sdt_allocator {
+	struct sdt_pool	pool;
+	sdt_desc_t	*root;
+};
+
+struct sdt_static {
+	size_t max_alloc_bytes;
+	void __arena *memory;
+	size_t off;
+};
+
+#ifdef __BPF__
+
+void __arena *sdt_task_data(struct task_struct *p);
+int sdt_task_init(__u64 data_size);
+void __arena *sdt_task_alloc(struct task_struct *p);
+void sdt_task_free(struct task_struct *p);
+void sdt_subprog_init_arena(void);
+
+int sdt_alloc_init(struct sdt_allocator *alloc, __u64 data_size);
+u64 sdt_alloc_internal(struct sdt_allocator *alloc);
+int sdt_free_idx(struct sdt_allocator *alloc, __u64 idx);
+
+#define sdt_alloc(alloc) ((struct sdt_data __arena *)sdt_alloc_internal((alloc)))
+
+void __arena *sdt_static_alloc(size_t bytes);
+int sdt_static_init(size_t max_alloc_pages);
+
+#endif /* __BPF__ */

--- a/scheds/rust/scx_wd40/Cargo.lock
+++ b/scheds/rust/scx_wd40/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "scx_stats"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "scx_stats_derive"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "scx_utils"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "scx_wd40"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
@@ -37,12 +37,12 @@ struct {
 volatile scx_bitmap_t node_data[MAX_NUMA_NODES];
 
 volatile dom_ptr dom_ctxs[MAX_DOMS];
-struct sdt_allocator lb_domain_allocator;
+struct scx_allocator lb_domain_allocator;
 
 __weak
 int lb_domain_init(void)
 {
-	return sdt_alloc_init(&lb_domain_allocator, sizeof(struct dom_ctx));
+	return scx_alloc_init(&lb_domain_allocator, sizeof(struct dom_ctx));
 }
 
 __hidden
@@ -51,7 +51,7 @@ dom_ptr lb_domain_alloc(u32 dom_id)
 	struct sdt_data __arena *data = NULL;
 	dom_ptr domc;
 
-	data = sdt_alloc(&lb_domain_allocator);
+	data = scx_alloc(&lb_domain_allocator);
 
 	domc = (dom_ptr)data->payload;
 	domc->tid = data->tid;
@@ -89,7 +89,7 @@ void lb_domain_free(dom_ptr domc)
 	scx_bitmap_free(domc->direct_greedy_cpumask);
 	scx_bitmap_free(domc->cpumask);
 
-	sdt_free_idx(&lb_domain_allocator, domc->tid.idx);
+	scx_alloc_free_idx(&lb_domain_allocator, domc->tid.idx);
 }
 
 __hidden

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
@@ -83,7 +83,7 @@ dom_ptr lb_domain_alloc(u32 dom_id)
 __hidden
 void lb_domain_free(dom_ptr domc)
 {
-	sdt_subprog_init_arena();
+	scx_arena_subprog_init();
 
 	scx_bitmap_free(domc->node_cpumask);
 	scx_bitmap_free(domc->direct_greedy_cpumask);

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
@@ -266,7 +266,7 @@ int dom_xfer_task(struct task_struct *p __arg_trusted, u32 new_dom_id, u64 now)
 	dom_ptr from_domc, to_domc;
 	task_ptr taskc;
 
-	taskc = (task_ptr)sdt_task_data(p);
+	taskc = (task_ptr)scx_task_data(p);
 	if (!taskc)
 		return 0;
 

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.h
@@ -21,7 +21,7 @@ extern volatile u64 slice_ns;
 extern const volatile u32 nr_doms;
 extern const volatile u32 nr_nodes;
 
-#define lookup_task_ctx(p) ((task_ptr) sdt_task_data(p))
+#define lookup_task_ctx(p) ((task_ptr) scx_task_data(p))
 u32 dom_node_id(u32 dom_id);
 void dom_dcycle_adj(dom_ptr domc, u32 weight, u64 now, bool runnable);
 

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.h
@@ -2,7 +2,7 @@
 #include <lib/sdt_task.h>
 
 extern volatile dom_ptr dom_ctxs[MAX_DOMS];
-extern struct sdt_allocator lb_domain_allocator;
+extern struct scx_allocator lb_domain_allocator;
 
 int lb_domain_init(void);
 dom_ptr lb_domain_alloc(u32 dom_id);

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -779,7 +779,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(wd40_init_task, struct task_struct *p __arg_trusted
 	u64 now = scx_bpf_now();
 	task_ptr taskc;
 
-	taskc = (task_ptr)sdt_task_alloc(p);
+	taskc = (task_ptr)scx_task_alloc(p);
 	if (!taskc)
 		return -ENOMEM;
 
@@ -797,7 +797,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(wd40_init_task, struct task_struct *p __arg_trusted
 
 	taskc->cpumask = scx_bitmap_alloc();
 	if (!taskc->cpumask) {
-		sdt_task_free(p);
+		scx_task_free(p);
 		return -ENOMEM;
 	}
 
@@ -811,7 +811,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(wd40_init_task, struct task_struct *p __arg_trusted
 void BPF_STRUCT_OPS(wd40_exit_task, struct task_struct *p,
 		    struct scx_exit_task_args *args)
 {
-	sdt_task_free(p);
+	scx_task_free(p);
 }
 
 static s32 initialize_cpu(s32 cpu)
@@ -886,7 +886,7 @@ int wd40_arena_setup(void)
 	if (ret)
 		return ret;
 
-	ret = sdt_task_init(sizeof(struct task_ctx));
+	ret = scx_task_init(sizeof(struct task_ctx));
 	if (ret)
 		return ret;
 

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -857,7 +857,7 @@ int wd40_arena_setup(void)
 {
 	int ret, i;
 
-	ret = sdt_static_init(STATIC_ALLOC_PAGES_GRANULARITY);
+	ret = scx_static_init(STATIC_ALLOC_PAGES_GRANULARITY);
 	if (ret)
 		return ret;
 

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -821,7 +821,7 @@ static s32 initialize_cpu(s32 cpu)
 	int perf;
 	u32 i;
 
-	sdt_subprog_init_arena();
+	scx_arena_subprog_init();
 
 	if (!pcpuc)
 		return -ENOENT;


### PR DESCRIPTION
The allocator code currently uses the sdt_* prefix that initially stood for "scx data task", as it was used exclusively for task contexts. However, the allocator is now used for more data structures and the prefix has become more confusing than helpful. Even worse, we still have a task allocator in sdt_task.c, where we expand the sdt_* prefix to sdt_task to avoid a namespace conflict with the generic allocator code. Go through the common allocator code and replace or remove the sdt_* prefix as needed. 

The resulting code still uses the sdt_* prefix for pools, descriptors, and chunks. These are data structures that will be used exclusively for the task allocator in the future and will be moved into sdt_task.c, so we leave them as-is.