### PR TITLE
scx_bpfland: Rework preemption behavior

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -145,8 +145,8 @@ struct Opts {
 
     /// Disable preemption.
     ///
-    /// Never allow tasks to preempt others before their assigned time slice expires. This can help
-    /// to increase system throughput over responsiveness.
+    /// Never allow tasks to be directly dispatched. This can help to increase fairness
+    /// over responsiveness.
     #[clap(short = 'n', long, action = clap::ArgAction::SetTrue)]
     no_preempt: bool,
 


### PR DESCRIPTION
Allowing tasks to interrupt others before their time slice expires is often introducing more issues than benefits, specifically when the system is overloaded we may trigger a storm of context switches, that are never beneficial and can lead to massive system lags.

Therefore, rework preemption by tying it to the concept of direct dispatch: tasks are always allowed to run for their entire assigned time slice and the --no-preempt option effectively disables direct dispatching.

In this context, preemption can be interpreted as the ability to interrupt or bypass the regular scheduling flow.

Disabling direct dispatches (now controllable via --no-preempt) can help to improve fairness at the cost of system responsiveness, which can be an acceptable trade-off for certain server workloads.

Tested-by: Piotr Gorski <piotrgorski@cachyos.org>