### PR TITLE
scx_lavd: Do not extend the overflow set for migration-disabled tasks.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -503,10 +503,11 @@ s32 pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle)
 	 */
 	if (!init_active_ovrflw_masks(ctx))
 		goto err_out;
-	if (is_per_cpu_task(ctx->p)) {
+	if (is_pinned(ctx->p) || is_migration_disabled(ctx->p)) {
 		cpu = ctx->prev_cpu;
 		if (!bpf_cpumask_test_cpu(cpu, cast_mask(ctx->active))) {
-			bpf_cpumask_test_and_set_cpu(cpu, ctx->ovrflw);
+			if (is_pinned(ctx->p))
+				bpf_cpumask_test_and_set_cpu(cpu, ctx->ovrflw);
 		}
 		*is_idle = scx_bpf_test_and_clear_cpu_idle(cpu);
 		goto unlock_out;

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -183,12 +183,9 @@ static bool is_kernel_worker(struct task_struct *p)
 	return !!(p->flags & (PF_WQ_WORKER | PF_IO_WORKER));
 }
 
-static bool is_per_cpu_task(const struct task_struct *p)
+static bool is_pinned(const struct task_struct *p)
 {
-	if (p->nr_cpus_allowed == 1 || is_migration_disabled(p))
-		return true;
-
-	return false;
+	return p->nr_cpus_allowed == 1;
 }
 
 static bool is_lat_cri(struct task_ctx *taskc)


### PR DESCRIPTION
It is necessary to pinned tasks (nr_allowed_cpus == 1) and migration-disabled tasks (migration_disabled == ture) differently. The pinned tasks are pinned by the program so they are very likely to run on the pinned CPU for a while. However, disabling migration is temporary for the sake of kernel implementation (e.g., running a BPF code). 

Therefore, let's extend the overflow set only for the pinned tasks.