### PR TITLE
wd40: fixups for getting single unit compilation working

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -8,8 +8,6 @@
 #include <scx/common.bpf.h>
 #include <lib/sdt_task.h>
 
-char _license[] SEC("license") = "GPL";
-
 struct {
 	__uint(type, BPF_MAP_TYPE_ARENA);
 	__uint(map_flags, BPF_F_MMAPABLE);

--- a/scheds/include/scx/ravg_impl.bpf.h
+++ b/scheds/include/scx/ravg_impl.bpf.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /* to be included in the main bpf.c file */
 #include "ravg.bpf.h"
 

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.h
@@ -1,3 +1,4 @@
+#pragma once
 
 #include <lib/sdt_task.h>
 


### PR DESCRIPTION
Compilation times for WD40 have become unreasonable, often reaching above a minute. One way to reduce them is compiling the scheduler as a single compilation unit using the "include all *.c files in main.bpf.c" hack. To get this working with WD40:

1) Add #pragma once to headers from which it is missing so that we can safely include them multiple times
2) Remove the GPL license string from the allocator library. The license is still present in the beginning of the file, and the scheduler code has its own copy of the license string.