### PR TITLE
scx_lavd: Change type in clamp_time_slice_ns().

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -228,7 +228,7 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 	}
 }
 
-static u32 clamp_time_slice_ns(u32 slice)
+static u64 clamp_time_slice_ns(u64 slice)
 {
 	if (slice < slice_min_ns)
 		slice = slice_min_ns;


### PR DESCRIPTION
Let's use u64 clamp_time_slice_ns() for consistency since u64 is used for all the other slice-related code.