### PR TITLE
scx_bpfland: Skip migration attempts for migration-disabled tasks

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -853,7 +853,7 @@ static bool try_direct_dispatch(struct task_struct *p, struct task_ctx *tctx,
 		 * If the task can only run on a single CPU and that CPU is
 		 * idle, perform a direct dispatch.
 		 */
-		if (p->nr_cpus_allowed == 1) {
+		if (p->nr_cpus_allowed == 1 || is_migration_disabled(p)) {
 			if (scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
 				scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL,
 						   slice_max, enq_flags);


### PR DESCRIPTION
Skip migration when performing a direct dispatch in ops.enqueue() for per-CPU and migration-disabled tasks.