### PR TITLE
scxtop: clean up unused imports

### DIFF
--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -7,9 +7,6 @@ license = "GPL-2.0-only"
 repository = "https://github.com/sched-ext/scx"
 description = "sched_ext scheduler tool for observability"
 
-[lints.rust]
-unused_imports = "allow"
-
 [dependencies]
 anyhow = "1.0.65"
 clap = { version = "4.5.28", features = [

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -35,7 +35,6 @@ use glob::glob;
 use libbpf_rs::Link;
 use libbpf_rs::ProgramInput;
 use num_format::{SystemLocale, ToFormattedString};
-use protobuf::Message;
 use ratatui::prelude::Constraint;
 use ratatui::{
     layout::{Alignment, Direction, Layout, Rect},

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -14,7 +14,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use xdg;
 
 /// `scxtop` can use a configuration file, which can be generated using the `S` key

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -4,29 +4,21 @@
 // GNU General Public License version 2.
 
 use scx_utils::compat;
-use scxtop::bpf_intf::*;
 use scxtop::bpf_skel::types::bpf_event;
 use scxtop::bpf_skel::*;
 use scxtop::cli::{generate_completions, Cli, Commands, TraceArgs, TuiArgs};
-use scxtop::config::get_config_path;
 use scxtop::config::Config;
 use scxtop::edm::{ActionHandler, BpfEventActionPublisher, BpfEventHandler, EventDispatchManager};
 use scxtop::read_file_string;
 use scxtop::tracer::Tracer;
+use scxtop::Action;
 use scxtop::App;
 use scxtop::Event;
 use scxtop::Key;
 use scxtop::KeyMap;
-use scxtop::PerfEvent;
 use scxtop::PerfettoTraceManager;
 use scxtop::Tui;
-use scxtop::APP;
 use scxtop::SCHED_NAME_PATH;
-use scxtop::STATS_SOCKET_PATH;
-use scxtop::{
-    Action, IPIAction, SchedCpuPerfSetAction, SchedSwitchAction, SchedWakeupAction,
-    SchedWakingAction, SoftIRQAction,
-};
 
 use anyhow::anyhow;
 use anyhow::Result;
@@ -39,7 +31,6 @@ use libbpf_rs::RingBufferBuilder;
 use libbpf_rs::UprobeOpts;
 use log::debug;
 use log::info;
-use log::trace;
 use ratatui::crossterm::event::KeyCode::Char;
 use simplelog::{
     ColorChoice, Config as SimplelogConfig, LevelFilter, TermLogger, TerminalMode, WriteLogger,
@@ -47,13 +38,11 @@ use simplelog::{
 use std::sync::atomic::AtomicBool;
 use tokio::sync::mpsc;
 
-use std::fs;
 use std::fs::File;
 use std::mem::MaybeUninit;
-use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::Ordering;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 fn get_action(_app: &App, keymap: &KeyMap, event: Event) -> Action {

--- a/tools/scxtop/src/perf_event.rs
+++ b/tools/scxtop/src/perf_event.rs
@@ -10,7 +10,6 @@ use anyhow::Context;
 use anyhow::Result;
 use libc::{close, read};
 use perf_event_open_sys as perf;
-use scx_utils::compat::get_fs_mount;
 use scx_utils::compat::tracefs_mount;
 
 use std::collections::{BTreeMap, HashSet};
@@ -19,7 +18,6 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::mem;
 use std::path::Path;
-use std::path::PathBuf;
 use std::str::FromStr;
 
 #[allow(dead_code)]

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -3,7 +3,7 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
-use anyhow::{Error, Result};
+use anyhow::Result;
 use protobuf::Message;
 use rand::rngs::StdRng;
 use rand::RngCore;
@@ -14,12 +14,10 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::bpf_skel::types::bpf_event;
-use crate::edm::{ActionHandler, BpfEventHandler};
+use crate::edm::ActionHandler;
 use crate::{
     Action, CpuhpEnterAction, CpuhpExitAction, ExecAction, ExitAction, ForkAction, GpuMemAction,
-    HwPressureAction, IPIAction, SchedSwitchAction, SchedWakeupAction, SchedWakingAction,
-    SoftIRQAction,
+    IPIAction, SchedSwitchAction, SchedWakeupAction, SchedWakingAction, SoftIRQAction,
 };
 
 use crate::protos_gen::perfetto_scx::clock_snapshot::Clock;


### PR DESCRIPTION

scxtop has `unused_imports = allow`, I'm guessing because it was copy/pasted
from somewhere. Remove this and cleanup the unused imports. Will be checked in
the CI under the clippy step in future.

Test plan:
- CI
