### PR TITLE
scx_p2dq: Add CLI args for tuning load balancing

### DIFF
--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -57,6 +57,10 @@ pub struct SchedulerOpts {
     #[clap(long, action = clap::ArgAction::SetTrue)]
     pub keep_running: bool,
 
+    /// Minimum load for load balancing on the wakeup path, 0 to disable.
+    #[clap(long, default_value = "0", value_parser = clap::value_parser!(u64).range(0..99))]
+    pub wakeup_lb_busy: u64,
+
     /// Set idle QoS resume latency based in microseconds.
     #[clap(long)]
     pub idle_resume_us: Option<u32>,
@@ -176,6 +180,7 @@ macro_rules! init_open_skel {
             $skel.maps.rodata_data.max_dsq_pick2 = opts.max_dsq_pick2;
             $skel.maps.rodata_data.smt_enabled = $crate::TOPO.smt_enabled;
             $skel.maps.rodata_data.select_idle_in_enqueue = true;
+            $skel.maps.rodata_data.wakeup_lb_busy = opts.wakeup_lb_busy;
 
             Ok(())
         }


### PR DESCRIPTION
Add CLI parameters for tuning load balancing on the select_cpu/enqueue path. It's now disabled by default as doing load balancing in the select/enqueue path seems to regress wakeup latencies, but I figured it's worth making it configurable.

Tested on EPYC 9D64 with 11 LLCs and `schbench -t 100` to partially load the system.

`schbench` 30s run:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (403491 total samples)
          50.0th: 10         (108393 samples)
          90.0th: 15         (133389 samples)
        * 99.0th: 23         (35247 samples)
          99.9th: 146        (3236 samples)
          min=1, max=4191
Request Latencies percentiles (usec) runtime 30 (s) (404316 total samples)
          50.0th: 6584       (116445 samples)
          90.0th: 10768      (157308 samples)
        * 99.0th: 12368      (35623 samples)
          99.9th: 17824      (3451 samples)
          min=5861, max=41178
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13424      (7 samples)
        * 50.0th: 13584      (11 samples)
          90.0th: 13648      (13 samples)
          min=12088, max=13660
average rps: 13477.20
```
`eevdf`:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (397777 total samples)
          50.0th: 11         (136283 samples)
          90.0th: 17         (133950 samples)
        * 99.0th: 25         (26058 samples)
          99.9th: 128        (3333 samples)
          min=1, max=4168
Request Latencies percentiles (usec) runtime 30 (s) (398576 total samples)
          50.0th: 6584       (115990 samples)
          90.0th: 10800      (158852 samples)
        * 99.0th: 12304      (35107 samples)
          99.9th: 18272      (3492 samples)
          min=5825, max=49618
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 12944      (7 samples)
        * 50.0th: 13520      (9 samples)
          90.0th: 13584      (12 samples)
          min=11276, max=13619
average rps: 13285.87
```
