### PR TITLE
scxtop: add process and thread descriptors

### DIFF
--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -74,6 +74,7 @@ struct sched_switch_event {
 
 struct wakeup_event {
 	u32		pid;
+	u32		tgid;
 	int		prio;
 	char		comm[MAX_COMM];
 };

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -427,6 +427,7 @@ static __always_inline int __on_sched_wakeup(struct task_struct *p)
 	event->ts = now;
 	event->cpu = bpf_get_smp_processor_id();
 	event->event.wakeup.pid = p->pid;
+	event->event.wakeup.tgid = p->tgid;
 	event->event.wakeup.prio = (int)p->prio;
 	__builtin_memcpy_inline(&event->event.wakeup.comm, &p->comm, MAX_COMM);
 	bpf_ringbuf_submit(event, 0);
@@ -461,6 +462,7 @@ int BPF_PROG(on_sched_waking, struct task_struct *p)
 	event->ts = bpf_ktime_get_ns();
 	event->cpu = bpf_get_smp_processor_id();
 	event->event.wakeup.pid = p->pid;
+	event->event.wakeup.tgid = p->tgid;
 	event->event.wakeup.prio = (int)p->prio;
 	__builtin_memcpy(&event->event.wakeup.comm, &p->comm, MAX_COMM);
 

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -166,6 +166,7 @@ pub struct SchedWakeActionCtx {
     pub ts: u64,
     pub cpu: u32,
     pub pid: u32,
+    pub tgid: u32,
     pub prio: i32,
     pub comm: SsoString,
 }
@@ -375,6 +376,7 @@ impl TryFrom<&bpf_event> for Action {
                     ts: event.ts,
                     cpu: event.cpu,
                     pid: wakeup.pid,
+                    tgid: wakeup.tgid,
                     prio: wakeup.prio,
                     comm: comm.into(),
                 }))
@@ -386,10 +388,12 @@ impl TryFrom<&bpf_event> for Action {
                     std::slice::from_raw_parts(waking.comm.as_ptr() as *const u8, 16)
                 })
                 .unwrap();
+
                 Ok(Action::SchedWaking(SchedWakingAction {
                     ts: event.ts,
                     cpu: event.cpu,
                     pid: waking.pid,
+                    tgid: waking.tgid,
                     prio: waking.prio,
                     comm: comm.into(),
                 }))


### PR DESCRIPTION
This change establishes relationships between a thread group leader (the main thread in a process) and its children. This therefore enables us to aggregate various attributes to the process which is very necessary for analysis of workloads.

At a perfetto UI level we now get what appear to be correct groupings of threads within their process groups (the attached image shows this). We still don't label all processes with their comm as we rely on having seen the main thread during capture for that. This is annoying and I'll see if there is a way to fix that.

![Screenshot 2025-04-14 at 16 25 13](https://github.com/user-attachments/assets/e1cbc88f-55d5-4443-969a-282aeb53c90f)


