### PR TITLE
ci: add nixed script to cover rust part of ci

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from typing import List, Optional
+import random
+
+
+def run_command(
+    cmd: List[str], check: bool = True, env: Optional[dict] = None
+) -> subprocess.CompletedProcess:
+    """Run a command and return the result."""
+    print(f"Running: {' '.join(cmd)}", flush=True)
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    return subprocess.run(cmd, check=check, env=merged_env)
+
+
+def get_clippy_packages() -> List[str]:
+    """Get list of packages that should be linted with clippy."""
+    result = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    metadata = json.loads(result.stdout)
+
+    clippy_packages = []
+    for pkg in metadata.get("packages", []):
+        pkg_metadata = pkg.get("metadata")
+        if pkg_metadata:
+            scx_metadata = pkg_metadata.get("scx")
+            if scx_metadata and scx_metadata.get("ci", {}).get("use_clippy") == True:
+                clippy_packages.append(pkg["name"])
+
+    return clippy_packages
+
+
+def test_binary_has_tests(binary_path: str) -> bool:
+    """Test whether a test binary contains any tests."""
+    result = subprocess.run(
+        [binary_path, "--list"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    return result.stdout.strip() != "0 tests, 0 benchmarks"
+
+
+def run_format():
+    """Format all targets."""
+    print("Running format...", flush=True)
+
+    run_command(["cargo", "fmt"])
+    run_command(["git", "diff", "--exit-code"])
+    print("✓ Format completed successfully", flush=True)
+
+
+def run_build():
+    """Build all targets."""
+    print("Running build...", flush=True)
+
+    run_command(["cargo", "build", "--all-targets"])
+    print("✓ Build completed successfully", flush=True)
+
+
+def run_clippy():
+    """Run clippy on packages marked for CI linting."""
+    print("Running clippy...", flush=True)
+
+    clippy_packages = get_clippy_packages()
+    for package in clippy_packages:
+        run_command(["cargo", "clippy", "--no-deps", "-p", package, "--", "-Dwarnings"])
+
+    print("✓ Clippy checks passed", flush=True)
+
+
+def run_tests():
+    """Run the test suite."""
+    print("Running tests...", flush=True)
+
+    result = subprocess.run(
+        ["cargo", "test", "--no-run", "--message-format", "json"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=sys.stderr,
+        text=True,
+    )
+    cargo_results = [
+        json.loads(line) for line in result.stdout.splitlines() if line.strip()
+    ]
+    test_binaries = [
+        x["executable"]
+        for x in cargo_results
+        if x["reason"] == "compiler-artifact"
+        if x["profile"].get("test", False)
+        if x["executable"] is not None
+    ]
+
+    test_binaries = [x for x in test_binaries if test_binary_has_tests(x)]
+    random.shuffle(test_binaries)
+
+    # If vng needs to traverse a path that's inaccessible to the user (like
+    # /var/cache/private/...) it can't run these binaries with their absolute
+    # paths. Make them relative to CWD to solve this.
+    test_binaries = [os.path.relpath(x) for x in test_binaries]
+
+    # Get CPU count
+    cpu_count = min(os.cpu_count(), 8)
+
+    # Find kernel image
+    kernel_path = "linux/arch/x86/boot/bzImage"
+    if not os.path.exists(kernel_path):
+        print(f"Error: Kernel image not found at {kernel_path}")
+        print("Make sure to run the build-kernel job first")
+        sys.exit(1)
+
+    cmd = [
+        "vng",
+        "--memory",
+        "10G",
+        "--cpu",
+        str(cpu_count),
+        "-r",
+        kernel_path,
+    ]
+    if os.environ.get("CI") == "true":
+        # verbose in CI but not locally
+        cmd += ["-v"]
+
+        # CI runs in /var/cache/private which fails the usual cwd stuff. mount
+        # it elsewhere and use that as the root.
+        cmd += [
+            "--overlay-rwdir=/tmp",
+            "--rodir=/tmp/workspace=.",
+            "--cwd=/tmp/workspace",
+        ]
+
+    cmd += [
+        "--",
+        sys.argv[0],
+        "test-in-vm",
+    ]
+    cmd += test_binaries
+
+    # Run tests in VM
+    run_command(cmd)
+
+    print("✓ Tests completed successfully", flush=True)
+
+
+def run_tests_in_vm(test_bins):
+    """Run tests when already inside the VM."""
+
+    for cmd in test_bins:
+        run_command([cmd])
+
+
+def run_all():
+    """Run all CI steps in the correct order."""
+    run_format()
+    run_build()
+    run_clippy()
+    run_tests()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SCX CI Script")
+
+    subparsers = parser.add_subparsers(
+        dest="command", description="Command to run (default: all)"
+    )
+    subparsers.required = True
+
+    parser_format = subparsers.add_parser("format", help="Perform formatting checks")
+    parser_build = subparsers.add_parser("build", help="Build Rust crates")
+    parser_clippy = subparsers.add_parser(
+        "clippy", help="Run Clippy on crates that request it"
+    )
+    parser_test = subparsers.add_parser("test", help="Run Rust tests")
+
+    parser_all = subparsers.add_parser("all", help="Run all commands")
+
+    parser_test_in_vm = subparsers.add_parser(
+        "test-in-vm",
+        help="Run Rust tests in VM (intended to be invoked by this script)",
+    )
+    parser_test_in_vm.add_argument(
+        "test_bins", nargs="*", help="Test binaries to execute in order"
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "format":
+        run_format()
+    elif args.command == "build":
+        run_build()
+    elif args.command == "clippy":
+        run_clippy()
+    elif args.command == "test":
+        run_tests()
+    elif args.command == "test-in-vm":
+        run_tests_in_vm(args.test_bins)
+    elif args.command == "all":
+        run_all()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/include/flake.lock
+++ b/.github/include/flake.lock
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738086784,
-        "narHash": "sha256-S55TBVValODQ3jb3g0IE+KQuWqpINoo5gdJ3yhRbuP4=",
+        "lastModified": 1741127887,
+        "narHash": "sha256-wjvXLT5DJqBg+KDDdx/R/LhroGZr6OpE+n+l/AnNJc8=",
         "owner": "JakeHillion",
         "repo": "nixpkgs",
-        "rev": "c1613ab9aa510bd571ba01a1e74a41496327d545",
+        "rev": "f72326a3a7770ec2b85c832fbfa8051346e21515",
         "type": "github"
       },
       "original": {

--- a/.github/include/flake.nix
+++ b/.github/include/flake.nix
@@ -14,34 +14,45 @@
       (system:
         let
           pkgs = import nixpkgs { inherit system; };
+          lib = pkgs.lib;
         in
         {
-          devShells = let common = with pkgs; [ gnutar zstd ]; in {
-            update-kernels = pkgs.mkShell {
-              buildInputs = with pkgs; common ++ [
-                gh
-                git
-                jq
-              ];
-            };
+          devShells =
+            let
+              common = with pkgs; [ git gnutar zstd ];
+            in
+            {
+              restore-kernels = pkgs.mkShellNoCC {
+                buildInputs = with pkgs; common ++ [
+                  jq
+                ];
+              };
 
-            build-kernel = pkgs.mkShell {
-              buildInputs = with pkgs; common ++ [
-                bc
-                bison
-                cpio
-                elfutils
-                flex
-                git
-                jq
-                openssl
-                pahole
-                perl
-                virtme-ng
-                zlib
-              ];
+              update-kernels = pkgs.mkShell {
+                buildInputs = with pkgs; common ++ [
+                  gh
+                  git
+                  jq
+                ];
+              };
+
+              build-kernel = pkgs.mkShell {
+                buildInputs = with pkgs; common ++ [
+                  bc
+                  bison
+                  cpio
+                  elfutils
+                  flex
+                  git
+                  jq
+                  openssl
+                  pahole
+                  perl
+                  virtme-ng
+                  zlib
+                ];
+              };
             };
-          };
 
           packages = {
             nix-develop-gha = nix-develop-gha.packages."${system}".default;
@@ -53,6 +64,76 @@
                 version = details.kernelVersion;
               }))
               (builtins.fromJSON (builtins.readFile ./../../kernel-versions.json));
+
+            ci =
+              pkgs.python3Packages.buildPythonApplication rec {
+                pname = "ci";
+                version = "git";
+
+                pyproject = false;
+                dontUnpack = true;
+
+                propagatedBuildInputs = with pkgs; [
+                  bash
+                  binutils
+                  cargo
+                  clang
+                  clippy
+                  coreutils
+                  gcc
+                  git
+                  gnugrep
+                  gnumake
+                  gnused
+                  jq
+                  llvmPackages.libclang
+                  llvmPackages.libllvm
+                  pkg-config
+                  protobuf
+                  rustc
+                  rustfmt
+                  virtme-ng
+
+                  elfutils.dev
+                  zlib.dev
+                  zstd.dev
+                ];
+
+                makeWrapperArgs = lib.lists.flatten [
+                  [ "--set" "CC" "gcc" ]
+                  [ "--set" "LD" "ld" ]
+
+                  [ "--set" "BPF_CLANG" (lib.getExe pkgs.llvmPackages.clang) ]
+                  [ "--set" "LIBCLANG_PATH" "${lib.getLib pkgs.llvmPackages.libclang}/lib" ]
+
+                  [ "--set" "PKG_CONFIG_PATH" "${lib.makeSearchPath "lib/pkgconfig" propagatedBuildInputs}" ]
+
+                  [ "--set" "RUSTFLAGS" "'-C relocation-model=pic -C link-args=-lelf -C link-args=-lz -C link-args=-lzstd'" ]
+
+                  [ "--set" "NIX_BINTOOLS" pkgs.binutils ]
+                  [ "--set" "NIX_CC" pkgs.gcc ]
+
+                  (
+                    let system = builtins.replaceStrings [ "-" ] [ "_" ] pkgs.stdenv.hostPlatform.config; in [
+                      [ "--set" "NIX_BINTOOLS_WRAPPER_TARGET_HOST_${system}" "1" ]
+                      [ "--set" "NIX_CC_WRAPPER_TARGET_HOST_${system}" "1" ]
+                      [ "--set" "NIX_PKG_CONFIG_WRAPPER_TARGET_HOST_${system}" "1" ]
+                    ]
+                  )
+
+                  [
+                    "--set"
+                    "NIX_LDFLAGS"
+                    ("'" + (lib.concatStringsSep " " (builtins.map (drv: "-L${drv}/lib") (with pkgs; [
+                      elfutils.out
+                      zlib
+                      zstd.out
+                    ]))) + "'")
+                  ]
+                ];
+
+                installPhase = "install -Dm755 ${../include/ci.py} $out/bin/ci";
+              };
           };
         }) // flake-utils.lib.eachDefaultSystem (system:
       let
@@ -80,7 +161,7 @@
                   nix
                 ];
 
-                installPhase = "install -Dm755 ${./update-kernels.py} $out/bin/update-kernels";
+                installPhase = "install -Dm755 ${../include/update-kernels.py} $out/bin/update-kernels";
               };
             in
             {

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -15,8 +15,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Load minimal dependencies
-        run: nix run ./.github/include#nix-develop-gha -- ./.github/include#update-kernels
+      - name: Load dependencies
+        run: nix run ./.github/include#nix-develop-gha -- ./.github/include#restore-kernels
 
       - run: echo "SCHED_EXT_KERNEL_COMMIT=$(jq -r '."${{ inputs.repo-name }}".commitHash' kernel-versions.json)" >> $GITHUB_ENV
 

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -6,27 +6,39 @@ on:
   merge_group:
 
 jobs:
-  lint:
-    runs-on: ubuntu-24.04
-    steps:
-      # prevent cache permission errors
-      - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - name: Install deps
-        run: |
-          curl https://sh.rustup.rs -sSf | RUSTUP_INIT_SKIP_PATH_CHECK=yes sh -s -- -y
-          rustup show  # installs the toolchain from rust-toolchain.toml
-          export PATH="~/.cargo/bin:$PATH"
-
-      - uses: actions/checkout@v4
-
-      # Lint code
-      - run: cargo fmt
-      - run: git diff --exit-code
-
   build-kernel:
     uses: ./.github/workflows/build-kernel.yml
     with:
       repo-name: sched_ext/for-next
+
+  rust-tests:
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64" ]') || 'ubuntu-latest' }}
+    needs: build-kernel
+    steps:
+      - name: Install Nix
+        if: ${{ runner.environment == 'github-hosted' }}
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: actions/checkout@v4
+
+      - name: Load dependencies
+        run: nix run ./.github/include#nix-develop-gha -- ./.github/include#restore-kernels
+
+      - uses: ./.github/actions/restore-kernel-cache
+        with:
+          repo-name: sched_ext/for-next
+
+      - name: Format
+        run: nix run ./.github/include#ci -- format
+
+      - name: Build
+        run: nix run ./.github/include#ci -- build
+
+      - name: Clippy
+        run: nix run ./.github/include#ci -- clippy
+
+      - name: Test
+        run: nix run ./.github/include#ci -- test
 
   integration-test:
     runs-on: ubuntu-24.04
@@ -168,46 +180,6 @@ jobs:
           path: ./log_save/*.ci.log
           # it's all txt files w/ 90 day retention, lets be nice.
           compression-level: 9
-
-  rust-tests:
-    runs-on: ubuntu-24.04
-    needs: build-kernel
-    strategy:
-      matrix:
-        package: [ scx_loader, scx_rustland_core, scx_stats, scx_utils, scxtop, scx_bpfland, scx_chaos, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty, scx_p2dq, scx_tickless ]
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/restore-kernel-cache
-        with:
-          repo-name: sched_ext/for-next
-
-      # prevent cache permission errors
-      - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-      - uses: ./.github/actions/install-deps-action
-      # cache virtiofsd (goes away w/ 24.04)
-      - name: Cache virtiofsd
-        id: cache-virtiofsd
-        uses: actions/cache@v4
-        with:
-          path: |
-            /usr/lib/virtiofsd
-          key: virtiofsd-binary
-      - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
-        run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      - run: cargo build --all-targets --package ${{ matrix.package }}
-
-      - name: Clippy
-        if: contains(fromJSON('["scxtop", "scx_chaos"]'), matrix.package)
-        run: cargo clippy --no-deps -p ${{ matrix.package }} -- -Dwarnings
-
-      # virtme-ng runs as a different user than the runner, so loses the rustup and cargo roots. specify them explicitly to avoid a rebuild.
-      - run: |
-          vng -v --rw --memory 10G --cpu 8 -r linux/arch/x86/boot/bzImage  --network user -- \
-            RUSTUP_HOME=$(realpath ~/.rustup) \
-            CARGO_HOME=$(realpath ~/.cargo) \
-            cargo test --package ${{ matrix.package }}
 
   pages:
     runs-on: ubuntu-24.04

--- a/scheds/rust/scx_chaos/Cargo.toml
+++ b/scheds/rust/scx_chaos/Cargo.toml
@@ -3,6 +3,9 @@ name = "scx_chaos"
 version = "1.0.11"
 edition = "2021"
 
+[package.metadata.scx]
+ci.use_clippy = true
+
 [dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.13" }
 scx_p2dq = { path = "../../../scheds/rust/scx_p2dq", version = "1.0.12" }

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -7,6 +7,9 @@ license = "GPL-2.0-only"
 repository = "https://github.com/sched-ext/scx"
 description = "sched_ext scheduler tool for observability"
 
+[package.metadata.scx]
+ci.use_clippy = true
+
 [dependencies]
 anyhow = "1.0.65"
 clap = { version = "4.5.28", features = [

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -327,7 +327,7 @@ mod tests {
 
         assert_eq!(merged.theme(), &AppTheme::MidnightGreen);
         assert_eq!(merged.tick_rate_ms(), 114);
-        assert_eq!(merged.debug(), true);
-        assert_eq!(merged.exclude_bpf(), false);
+        assert!(merged.debug());
+        assert!(!merged.exclude_bpf());
     }
 }


### PR DESCRIPTION
Nix'ify the build process for Rust tests and move them to the large machine when in org. Remove the test matrix, as the overhead here is mostly contained in starting the VM and it's inefficient to start many/repeat the build.

The new CI script, which only coveres Rust tests for now, doesn't require Nix to run. Nix enables it to run more reproducibly, and is required for the CI as that's how the self hosted runner handles dependencies, but is not required to run the script locally.

Specific changes:
- Move `rust-tests` to the big self-hosted machine when in the `sched-ext` org.
- Nix'ify the dependencies. This uses a fixed version of `cargo`, `rustc` and `clippy` rather than the moving target of `rust-toolchain.toml`, but it is still `stable`. We can pull more speciifc versions using a tool like fenix[0] in the future, but this is fine for now.
- Add a new `package.metadata.scx` section to describe whether to run clippy, moving this out of the GitHub actions spec and into each package's spec.
- Run for the entire workspace instead of a set of named packages. This means we can require `rust-tests` in the CI instead of requiring each individual package's matrix entry, reducing errors. It also significantly reduces duplicated work.

This new rust-tests step takes approximately the same amount of time as `rust-tests (scxtop)` on the hosted runners, but instead of using 14 runners it uses one slot on the self-hosted runner. Out of repo it takes longer, but still takes less machine time which seems like a fair compromise - forks are lower priority here.

Test plan:
- This PR's CI.
- Ran in my fork with the usual GitHub Actions runners. It works.

```
$ mkdir -p linux/arch/x86/boot
$ ln -s $(nix build --no-link --print-out-paths ./.github/include#kernels.sched_ext/for-next)/bzImage linux/arch/x86/boot/bzImage
$ nix run ./.github/include#ci all
```

Follow ups:
- The actual `vng` step is slower on the NixOS self hosted runner than the Ubuntu GitHub hosted runner (the Rust builds are faster). It is exactly the same binary with the same arguments, both using the slow bash script for now, so I'm guessing there's something missing to make it go faster. It's still faster than not having this change for now so can address later.

[0] https://github.com/nix-community/fenix