### PR TITLE
scx_lavd: Calculate scaled and invariant CPU utilization.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -145,6 +145,7 @@ struct task_ctx_x {
 	u16	static_prio;	/* nice priority */
 	u32	cpu_id;		/* where a task ran */
 	u64	cpu_util;	/* cpu utilization in [0..100] */
+	u64	cpu_sutil;	/* scaled cpu utilization in [0..100] */
 	u32	thr_perf_cri;	/* performance criticality threshold */
 	u32	avg_lat_cri;	/* average latency criticality */
 	u32	nr_active;	/* number of active cores */

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -64,7 +64,9 @@ enum {
  */
 struct sys_stat {
 	u64	last_update_clk;
-	u64	util;		/* average of the CPU utilization */
+	u64	avg_util;	/* average of the CPU utilization */
+	u64	avg_sc_util;	/* average of the scaled CPU utilization,
+				   which is capacity and frequency invariant */
 
 	u64	avg_svc_time;	/* average service time per task */
 	u64	nr_queued_task;
@@ -112,7 +114,7 @@ struct task_ctx {
 	u64	run_freq;		/* scheduling frequency in a second */
 	u64	wait_freq;		/* waiting frequency in a second */
 	u64	wake_freq;		/* waking-up frequency in a second */
-	u64	svc_time;		/* total CPU time consumed for this task */
+	u64	svc_time;		/* total CPU time consumed for this task scaled by task's weight */
 	u64	dsq_id;			/* DSQ id where a task run for statistics */
 
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
@@ -37,6 +37,7 @@ int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc, u32 cpu_id)
 	__builtin_memcpy_inline(m->taskc_x.comm, p->comm, TASK_COMM_LEN);
 	m->taskc_x.static_prio = get_nice_prio(p);
 	m->taskc_x.cpu_util = s2p(cpuc->avg_util);
+	m->taskc_x.cpu_sutil = s2p(cpuc->avg_sc_util);
 	m->taskc_x.cpu_id = cpu_id;
 	m->taskc_x.avg_lat_cri = sys_stat.avg_lat_cri;
 	m->taskc_x.thr_perf_cri = sys_stat.thr_perf_cri;

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -96,13 +96,17 @@ struct cpu_ctx {
 	 */
 	volatile u32	avg_util;	/* average of the CPU utilization */
 	volatile u32	cur_util;	/* CPU utilization of the current interval */
+	volatile u32	avg_sc_util;	/* average of the scaled CPU utilization, which is capacity and frequency invariant. */
+	volatile u32	cur_sc_util;	/* the scaled CPU utilization of the current interval, which is capacity and frequency invariant. */
 	volatile u64	idle_total;	/* total idle time so far */
 	volatile u64	idle_start_clk;	/* when the CPU becomes idle */
 
 	/*
 	 * Information used to keep track of load
 	 */
-	volatile u64	tot_svc_time;	/* total service time on a CPU */
+	volatile u64	tot_svc_time;	/* total service time on a CPU scaled by tasks' weights */
+	volatile u64	tot_sc_time;	/* total scaled CPU time, which is capacity and frequency invariant. */
+	volatile u64	cpu_release_clk; /* when the CPU is taken by higher-priority scheduler class */
 
 	/*
 	 * Information used to keep track of latency criticality

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -733,6 +733,7 @@ impl<'a> Scheduler<'a> {
             thr_perf_cri: tx.thr_perf_cri,
             cpuperf_cur: tx.cpuperf_cur,
             cpu_util: tx.cpu_util,
+            cpu_sutil: tx.cpu_sutil,
             nr_active: tx.nr_active,
         }) {
             Ok(()) | Err(TrySendError::Full(_)) => 0,

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -157,8 +157,10 @@ pub struct SchedSample {
     pub thr_perf_cri: u32,
     #[stat(desc = "Target performance level of this CPU")]
     pub cpuperf_cur: u32,
-    #[stat(desc = "CPU utilization of this particular CPU")]
+    #[stat(desc = "CPU utilization of this CPU")]
     pub cpu_util: u64,
+    #[stat(desc = "Scaled CPU utilization of this CPU")]
+    pub cpu_sutil: u64,
     #[stat(desc = "Number of active CPUs when core compaction is enabled")]
     pub nr_active: u32,
 }
@@ -167,7 +169,7 @@ impl SchedSample {
     pub fn format_header<W: Write>(w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "\x1b[93m| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:7} | {:8} | {:7} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:6} |\x1b[0m",
+            "\x1b[93m| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:7} | {:8} | {:7} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:6} |\x1b[0m",
             "MSEQ",
             "PID",
             "COMM",
@@ -186,6 +188,7 @@ impl SchedSample {
             "THR_PC",
             "CPUFREQ",
             "CPU_UTIL",
+            "CPU_SUTIL",
             "NR_ACT",
         )?;
         Ok(())
@@ -198,7 +201,7 @@ impl SchedSample {
 
         writeln!(
             w,
-            "| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:7} | {:8} | {:7} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:6} |",
+            "| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:7} | {:8} | {:7} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:6} |",
             self.mseq,
             self.pid,
             self.comm,
@@ -217,6 +220,7 @@ impl SchedSample {
             self.thr_perf_cri,
             self.cpuperf_cur,
             self.cpu_util,
+            self.cpu_sutil,
             self.nr_active,
         )?;
         Ok(())


### PR DESCRIPTION
Previously, neither CPU capacity nor frequency were considered when calculating CPU utilization. CPU utilization merely means the compute time ratio to a certain time duration. So, it is not possible to compare the utilization value of one CPU directly with that of another CPU.

The new scaled utilization (sys_stat.avg_sc_util and sys_stat.cur_sc_util) is normalized value to the highest frequency of the fastest CPU, so the scaled utilization values are safely compared across CPU types with different frequencies.

After this PR, the scaled, invariant utilization will be used for core compaction. 
