### PR TITLE
stress_tests: increase timeout_sec to 45s

### DIFF
--- a/meson-scripts/stress_tests.ini
+++ b/meson-scripts/stress_tests.ini
@@ -2,53 +2,53 @@
 sched: scx_lavd
 sched_args: -v
 stress_cmd: stress-ng -t 31 --aggressive -M -c `nproc` -f `nproc` --affinity 1 --affinity-delay 1 --affinity-pin
-timeout_sec: 35
+timeout_sec: 45
 
 [scx_rusty]
 sched: scx_rusty
 sched_args: -v
 stress_cmd: stress-ng -t 31 --aggressive -M -c `nproc` -f `nproc` --affinity 1 --affinity-delay 1 --affinity-pin
-timeout_sec: 35
+timeout_sec: 45
 
 [scx_rustland]
 sched: scx_rustland
 sched_args: -v
 stress_cmd: stress-ng -t 31 --aggressive -M -c `nproc` -f `nproc` --affinity 1 --affinity-delay 1 --affinity-pin
-timeout_sec: 35
+timeout_sec: 45
 
 [scx_bpfland]
 sched: scx_bpfland
 sched_args: -v
 stress_cmd: stress-ng -t 31 --aggressive -M -c `nproc` -f `nproc` --affinity 1 --affinity-delay 1 --affinity-pin
-timeout_sec: 35
+timeout_sec: 45
 
 [scx_flash]
 sched: scx_flash
 sched_args:
 stress_cmd: stress-ng -t 31 --aggressive -M -c `nproc` -f `nproc` --affinity 1 --affinity-delay 1 --affinity-pin
-timeout_sec: 35
+timeout_sec: 45
 
 [scx_layered]
 sched: scx_layered
 sched_args: --run-example -v --stats 1 --enable-gpu-support
 stress_cmd: stress-ng -t 31 --aggressive -M -c `nproc` -f `nproc` --affinity 1 --affinity-delay 1 --affinity-pin
-timeout_sec: 35
+timeout_sec: 45
 bpftrace_scripts: dsq_lat.bt,process_runqlat.bt
 
 [scx_p2dq]
 sched: scx_p2dq
 sched_args:
 stress_cmd: stress-ng -t 31 --aggressive -M -c `nproc` -f `nproc` --affinity 1 --affinity-delay 1 --affinity-pin
-timeout_sec: 35
+timeout_sec: 45
 
 [scx_chaos]
 sched: scx_chaos
 sched_args:
 stress_cmd: stress-ng -t 31 --aggressive -M -c `nproc` -f `nproc` --affinity 1 --affinity-delay 1 --affinity-pin
-timeout_sec: 35
+timeout_sec: 45
 
 [scx_tickless]
 sched: scx_tickless
 sched_args: -v
 stress_cmd: stress-ng -t 31 --aggressive -M -c `nproc` -f `nproc` --affinity 1 --affinity-delay 1 --affinity-pin
-timeout_sec: 35
+timeout_sec: 45


### PR DESCRIPTION

The stress-ng commands in stress tests were recently bumped to 31s. The timeout_sec, the time for the VM to complete, was left at 35s. This leaves very little time for the VM to boot. Bump this to 45s as sometimes it hits timeouts in the CI.

Test plan:
- CI
