### PR TITLE
scxtop: better naming for kernel workqueue threads

### DIFF
--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -50,6 +50,7 @@ pub use plain::Plain;
 unsafe impl Plain for crate::bpf_skel::types::bpf_event {}
 
 use smartstring::alias::String as SsoString;
+use std::ffi::CStr;
 
 pub const APP: &str = "scxtop";
 pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
@@ -365,13 +366,10 @@ impl TryFrom<&bpf_event> for Action {
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_SCHED_WAKEUP => {
                 let wakeup = unsafe { event.event.wakeup };
-                let comm = unsafe {
-                    std::str::from_utf8(std::slice::from_raw_parts(
-                        event.event.wakeup.comm.as_ptr() as *const u8,
-                        16,
-                    ))
-                    .unwrap()
-                };
+                let comm = unsafe { CStr::from_ptr(event.event.wakeup.comm.as_ptr()) }
+                    .to_string_lossy()
+                    .to_string();
+
                 Ok(Action::SchedWakeup(SchedWakeupAction {
                     ts: event.ts,
                     cpu: event.cpu,
@@ -384,10 +382,9 @@ impl TryFrom<&bpf_event> for Action {
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_SCHED_WAKING => {
                 let waking = unsafe { &event.event.waking };
-                let comm = std::str::from_utf8(unsafe {
-                    std::slice::from_raw_parts(waking.comm.as_ptr() as *const u8, 16)
-                })
-                .unwrap();
+                let comm = unsafe { CStr::from_ptr(waking.comm.as_ptr()) }
+                    .to_string_lossy()
+                    .to_string();
 
                 Ok(Action::SchedWaking(SchedWakingAction {
                     ts: event.ts,
@@ -406,13 +403,10 @@ impl TryFrom<&bpf_event> for Action {
             })),
             bpf_intf::event_type_EXIT => {
                 let exit = unsafe { &event.event.exit };
-                let comm = unsafe {
-                    std::str::from_utf8(std::slice::from_raw_parts(
-                        exit.comm.as_ptr() as *const u8,
-                        exit.comm.len(),
-                    ))
-                    .unwrap()
-                };
+                let comm = unsafe { CStr::from_ptr(exit.comm.as_ptr()) }
+                    .to_string_lossy()
+                    .to_string();
+
                 Ok(Action::Exit(ExitAction {
                     ts: event.ts,
                     cpu: event.cpu,
@@ -425,20 +419,13 @@ impl TryFrom<&bpf_event> for Action {
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_FORK => {
                 let fork = unsafe { &event.event.fork };
-                let parent_comm = unsafe {
-                    std::str::from_utf8(std::slice::from_raw_parts(
-                        fork.parent_comm.as_ptr() as *const u8,
-                        fork.parent_comm.len(),
-                    ))
-                    .unwrap()
-                };
-                let child_comm = unsafe {
-                    std::str::from_utf8(std::slice::from_raw_parts(
-                        fork.child_comm.as_ptr() as *const u8,
-                        fork.child_comm.len(),
-                    ))
-                    .unwrap()
-                };
+                let parent_comm = unsafe { CStr::from_ptr(fork.parent_comm.as_ptr()) }
+                    .to_string_lossy()
+                    .to_string();
+                let child_comm = unsafe { CStr::from_ptr(fork.child_comm.as_ptr()) }
+                    .to_string_lossy()
+                    .to_string();
+
                 Ok(Action::Fork(ForkAction {
                     ts: event.ts,
                     cpu: event.cpu,
@@ -451,20 +438,12 @@ impl TryFrom<&bpf_event> for Action {
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_SCHED_SWITCH => {
                 let sched_switch = unsafe { &event.event.sched_switch };
-                let prev_comm = unsafe {
-                    std::str::from_utf8(std::slice::from_raw_parts(
-                        sched_switch.prev_comm.as_ptr() as *const u8,
-                        sched_switch.prev_comm.len(),
-                    ))
-                    .unwrap()
-                };
-                let next_comm = unsafe {
-                    std::str::from_utf8(std::slice::from_raw_parts(
-                        sched_switch.next_comm.as_ptr() as *const u8,
-                        sched_switch.next_comm.len(),
-                    ))
-                    .unwrap()
-                };
+                let prev_comm = unsafe { CStr::from_ptr(sched_switch.prev_comm.as_ptr()) }
+                    .to_string_lossy()
+                    .to_string();
+                let next_comm = unsafe { CStr::from_ptr(sched_switch.next_comm.as_ptr()) }
+                    .to_string_lossy()
+                    .to_string();
 
                 Ok(Action::SchedSwitch(SchedSwitchAction {
                     ts: event.ts,


### PR DESCRIPTION
Kernel workqueue threads have a comm field that always begins with "kworker/" and this isn't helpful at all for identifying the actual function of the thread which is super useful when analysing workloads. This change identifies workqueue threads and replaces the comm field we stash with the description of the thread that was provided when it was created. This idea and the bpf code was shamelessly stolen from the [systing](https://github.com/josefbacik/systing) project.

Just a note on the lib.rs changes (which @JakeHillion knows all about as he basically came up with them :-) ): the current lib.rs implementation pulls 16 bytes from the passed in event struct and uses `std::str::from_utf8()`  to construct a string which asserts if any of the bytes are not utf8. Using `bpf_probe_read_kernel_str()` to copy the comm value from a kernel worker struct exposes the fact that the target event struct may contain random garbage sometimes as it only copies up to and including the NULL terminator. We never previously hit this if we memcpy from a processes comm area as it is 0 filled in creation and therefore we always copy valid characters in the 16 bytes comm area. The fix is to switch to a CStr based solution that allows us to deal with invalid unicode bytes.

Workqueue threads before showed up like:

![Screenshot 2025-04-16 at 19 09 14](https://github.com/user-attachments/assets/1c437073-74f8-49e3-8a7b-a9251c5e66ba)


The now look like:

![Screenshot 2025-04-16 at 18 43 47](https://github.com/user-attachments/assets/68d4726e-3a8a-42c5-8299-22e649b035f3)

