### PR TITLE
scx_layered: add antistall_aggressiveness

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -509,6 +509,10 @@ struct Opts {
     #[clap(long, default_value = "0")]
     exit_dump_len: u32,
 
+    /// Antistall agressiveness. How many CPUs antistall claims per run.
+    #[clap(long, default_value = "1")]
+    antistall_aggressiveness: u32,
+
     /// Enable verbose output, including libbpf details. Specify multiple
     /// times to increase verbosity.
     #[clap(short = 'v', long, action = clap::ArgAction::Count)]
@@ -1819,6 +1823,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.has_little_cores = topo.has_little_cores();
         skel.maps.rodata_data.xnuma_preemption = opts.xnuma_preemption;
         skel.maps.rodata_data.antistall_sec = opts.antistall_sec;
+        skel.maps.rodata_data.antistall_aggressiveness = opts.antistall_aggressiveness;
         skel.maps.rodata_data.monitor_disable = opts.monitor_disable;
         skel.maps.rodata_data.lo_fb_wait_ns = opts.lo_fb_wait_us * 1000;
         skel.maps.rodata_data.lo_fb_share_ppk = ((opts.lo_fb_share * 1024.0) as u32).clamp(1, 1024);

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -513,6 +513,11 @@ struct Opts {
     #[clap(long, default_value = "1")]
     antistall_aggressiveness: u32,
 
+    /// Antistall slice override. When non-zero, override slice size for tasks
+    /// in DSQs being processed by antistall.
+    #[clap(long, default_value = "0")]
+    antistall_slice_override: u64,
+
     /// Enable verbose output, including libbpf details. Specify multiple
     /// times to increase verbosity.
     #[clap(short = 'v', long, action = clap::ArgAction::Count)]
@@ -1824,6 +1829,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.xnuma_preemption = opts.xnuma_preemption;
         skel.maps.rodata_data.antistall_sec = opts.antistall_sec;
         skel.maps.rodata_data.antistall_aggressiveness = opts.antistall_aggressiveness;
+        skel.maps.rodata_data.antistall_slice_override = opts.antistall_slice_override;
         skel.maps.rodata_data.monitor_disable = opts.monitor_disable;
         skel.maps.rodata_data.lo_fb_wait_ns = opts.lo_fb_wait_us * 1000;
         skel.maps.rodata_data.lo_fb_share_ppk = ((opts.lo_fb_share * 1024.0) as u32).clamp(1, 1024);


### PR DESCRIPTION
Add flag `--antistall-aggressiveness`, which takes a uint.

This flag sets a multiplier on the number of CPUs anti-stall dedicates to clearing stuck DSQs each pass.

By default, anti-stall selects 1 CPU per stuck DSQ each pass, and each pass happens every second. This is fine for smaller systems with more well-behaved workloads (i.e. workloads w/ a few affined tasks), but falls over on huge systems with less well-behaved workloads (i.e. workloads with enough affined tasks that much, much more CPU time than lo frac provides *may* be needed to prevent any task from triggering a stall watchdog).

This is kind-of a half-way measure vs increasing lo frac. 

Not sure about the name (it is kind of long).