### PR TITLE
scx_p2dq: Refactor wakeup logic

### DIFF
--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -61,6 +61,10 @@ pub struct SchedulerOpts {
     #[clap(long, default_value = "0", value_parser = clap::value_parser!(u64).range(0..99))]
     pub wakeup_lb_busy: u64,
 
+    /// Allow LLC migrations on the wakeup path.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub wakeup_llc_migrations: bool,
+
     /// Set idle QoS resume latency based in microseconds.
     #[clap(long)]
     pub idle_resume_us: Option<u32>,
@@ -187,6 +191,7 @@ macro_rules! init_open_skel {
             $skel.maps.rodata_data.smt_enabled = $crate::TOPO.smt_enabled;
             $skel.maps.rodata_data.select_idle_in_enqueue = true;
             $skel.maps.rodata_data.wakeup_lb_busy = opts.wakeup_lb_busy;
+            $skel.maps.rodata_data.wakeup_llc_migrations = opts.wakeup_llc_migrations;
 
             Ok(())
         }


### PR DESCRIPTION
Refactor wakup logic with configuration to control migrating across LLCs. Keep interactive tasks sticky to the local LLC when waking.