### PR TITLE
rustscheds: add common SCX_TIMEOUT_MS env var to set stall watchdog limit

### DIFF
--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -324,6 +324,18 @@ macro_rules! scx_ops_open {
                 }
             };
 
+            if let Ok(s) = ::std::env::var("SCX_TIMEOUT_MS") {
+                skel.struct_ops.[<$ops _mut>]().timeout_ms = match s.parse::<u32>() {
+                    Ok(ms) => {
+                        ::scx_utils::info!("Setting timeout_ms to {} based on environment", ms);
+                        ms
+                    },
+                    Err(e) => {
+                        break 'block anyhow::Result::Err(e).context("SCX_TIMEOUT_MS has invalid value");
+                    },
+                };
+            }
+
             $crate::import_enums!(skel);
 
             let result = ::anyhow::Result::Ok(skel);

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -30,6 +30,7 @@
 //! Utility modules which can be useful for userspace component of sched_ext
 //! schedulers.
 
+pub use log::info;
 pub use log::warn;
 pub use paste::paste;
 


### PR DESCRIPTION

Currently the stall watchdog timer is either hardcoded into each scheduler's
struct_ops or left at the kernel default of 30s. This is inconvenient
particularly when performing testing as 30s is an incredibly long time.

Add an environment variable SCX_TIMEOUT_MS that dictates `timeout_ms` when set.
`scx_ops_open` is quite opinionated already, so we add it there and this variable
will propagate to all schedulers that use that. Will propose a similar change to
C-schedulers in the future.

Test plan:
- `cargo build --release && sudo SCX_TIMEOUT_MS=5000 target/release/scx_chaos --random-delay-frequency 0.1 --random-delay-min-us 5000000 --random-delay-max-us 5000000` - kicked for stalling with the environment variable, stays without.
