### PR TITLE
scx_p2dq: Allow interactive task load balancing

### DIFF
--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -58,6 +58,10 @@ pub struct SchedulerOpts {
     #[clap(long, default_value = "75", value_parser = clap::value_parser!(u64).range(0..100))]
     pub dispatch_lb_busy: u64,
 
+    /// Enables pick2 load balancing on the dispatch path for interactive tasks.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub dispatch_lb_interactive: bool,
+
     /// Enable tasks to run beyond their timeslice if the CPU is idle.
     #[clap(long, action = clap::ArgAction::SetTrue)]
     pub keep_running: bool,
@@ -189,6 +193,7 @@ macro_rules! init_open_skel {
             $skel.maps.rodata_data.debug = verbose as u32;
             $skel.maps.rodata_data.dispatch_pick2_disable = opts.dispatch_pick2_disable;
             $skel.maps.rodata_data.dispatch_lb_busy = opts.dispatch_lb_busy;
+            $skel.maps.rodata_data.dispatch_lb_interactive = opts.dispatch_lb_interactive;
             $skel.maps.rodata_data.eager_load_balance = !opts.eager_load_balance;
             $skel.maps.rodata_data.has_little_cores = $crate::TOPO.has_little_cores();
             $skel.maps.rodata_data.interactive_sticky = opts.interactive_sticky;


### PR DESCRIPTION
Add an option to load balance interactive tasks. Depending on the workload this may greatly improve interactivity.

default:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (396749 total samples)
          50.0th: 11         (138184 samples)
          90.0th: 17         (140408 samples)
        * 99.0th: 22         (31329 samples)
          99.9th: 48         (2940 samples)
          min=1, max=4220
Request Latencies percentiles (usec) runtime 30 (s) (397615 total samples)
          50.0th: 6632       (115863 samples)
          90.0th: 10768      (158902 samples)
        * 99.0th: 12368      (35392 samples)
          99.9th: 18080      (3375 samples)
          min=5815, max=43930
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13072      (7 samples)
        * 50.0th: 13296      (9 samples)
          90.0th: 13488      (12 samples)
          min=12747, max=13638
average rps: 13253.83
```
with `--dispatch-lb-interactive`:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (390182 total samples)
          50.0th: 10         (106344 samples)
          90.0th: 16         (146284 samples)
        * 99.0th: 20         (27176 samples)
          99.9th: 34         (3518 samples)
          min=1, max=4035
Request Latencies percentiles (usec) runtime 30 (s) (391242 total samples)
          50.0th: 6632       (112534 samples)
          90.0th: 10896      (156370 samples)
        * 99.0th: 12336      (33520 samples)
          99.9th: 18784      (3429 samples)
          min=5863, max=50892
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 12784      (7 samples)
        * 50.0th: 13200      (11 samples)
          90.0th: 13488      (10 samples)
          min=10772, max=13707
average rps: 13041.40
```