### PR TITLE
scx_layered: Implement layer option skip_remote_node

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -136,6 +136,7 @@ enum layer_stat_id {
 	LSTAT_XLAYER_REWAKE,
 	LSTAT_LLC_DRAIN_TRY,
 	LSTAT_LLC_DRAIN,
+	LSTAT_SKIP_REMOTE_NODE,
 	NR_LSTATS,
 };
 
@@ -311,6 +312,7 @@ struct layer {
 	bool			preempt_first;
 	bool			exclusive;
 	bool			allow_node_aligned;
+	bool			skip_remote_node;
 	bool			prev_over_idle_core;
 	int			growth_algo;
 

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -101,6 +101,8 @@ pub struct LayerCommon {
     #[serde(default)]
     pub allow_node_aligned: bool,
     #[serde(default)]
+    pub skip_remote_node: bool,
+    #[serde(default)]
     pub prev_over_idle_core: bool,
     #[serde(default)]
     pub weight: u32,

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -110,6 +110,7 @@ lazy_static! {
                         preempt_first: false,
                         exclusive: false,
                         allow_node_aligned: false,
+                        skip_remote_node: false,
                         prev_over_idle_core: false,
                         idle_smt: None,
                         slice_us: 20000,
@@ -141,6 +142,7 @@ lazy_static! {
                         preempt_first: false,
                         exclusive: true,
                         allow_node_aligned: true,
+                        skip_remote_node: false,
                         prev_over_idle_core: true,
                         idle_smt: None,
                         slice_us: 20000,
@@ -176,6 +178,7 @@ lazy_static! {
                         preempt_first: false,
                         exclusive: false,
                         allow_node_aligned: false,
+                        skip_remote_node: false,
                         prev_over_idle_core: false,
                         idle_smt: None,
                         slice_us: 800,
@@ -208,6 +211,7 @@ lazy_static! {
                         preempt_first: false,
                         exclusive: false,
                         allow_node_aligned: false,
+                        skip_remote_node: false,
                         prev_over_idle_core: false,
                         idle_smt: None,
                         slice_us: 20000,
@@ -1309,6 +1313,7 @@ impl<'a> Scheduler<'a> {
                     preempt_first,
                     exclusive,
                     allow_node_aligned,
+                    skip_remote_node,
                     prev_over_idle_core,
                     growth_algo,
                     nodes,
@@ -1338,6 +1343,7 @@ impl<'a> Scheduler<'a> {
                 layer.preempt_first.write(*preempt_first);
                 layer.exclusive.write(*exclusive);
                 layer.allow_node_aligned.write(*allow_node_aligned);
+                layer.skip_remote_node.write(*skip_remote_node);
                 layer.prev_over_idle_core.write(*prev_over_idle_core);
                 layer.growth_algo = growth_algo.as_bpf_enum();
                 layer.weight = *weight;

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -69,6 +69,7 @@ const LSTAT_XLAYER_WAKE: usize = bpf_intf::layer_stat_id_LSTAT_XLAYER_WAKE as us
 const LSTAT_XLAYER_REWAKE: usize = bpf_intf::layer_stat_id_LSTAT_XLAYER_REWAKE as usize;
 const LSTAT_LLC_DRAIN_TRY: usize = bpf_intf::layer_stat_id_LSTAT_LLC_DRAIN_TRY as usize;
 const LSTAT_LLC_DRAIN: usize = bpf_intf::layer_stat_id_LSTAT_LLC_DRAIN as usize;
+const LSTAT_SKIP_REMOTE_NODE: usize = bpf_intf::layer_stat_id_LSTAT_SKIP_REMOTE_NODE as usize;
 
 const LLC_LSTAT_LAT: usize = bpf_intf::llc_layer_stat_id_LLC_LSTAT_LAT as usize;
 const LLC_LSTAT_CNT: usize = bpf_intf::llc_layer_stat_id_LLC_LSTAT_CNT as usize;
@@ -183,6 +184,8 @@ pub struct LayerStats {
     pub llc_drain_try: f64,
     #[stat(desc = "% LLC draining succeeded")]
     pub llc_drain: f64,
+    #[stat(desc = "% skip LLC dispatch on remote node")]
+    pub skip_remote_node: f64,
     #[stat(desc = "mask of allocated CPUs", _om_skip)]
     pub cpus: Vec<u64>,
     #[stat(desc = "count of CPUs assigned")]
@@ -275,6 +278,7 @@ impl LayerStats {
             xllc_migration_skip: lstat_pct(LSTAT_XLLC_MIGRATION_SKIP),
             llc_drain_try: lstat_pct(LSTAT_LLC_DRAIN_TRY),
             llc_drain: lstat_pct(LSTAT_LLC_DRAIN),
+            skip_remote_node: lstat_pct(LSTAT_SKIP_REMOTE_NODE),
             cpus: layer.cpus.as_raw_slice().to_vec(),
             cur_nr_cpus: layer.cpus.weight() as u32,
             min_nr_cpus: nr_cpus_range.0 as u32,
@@ -366,12 +370,13 @@ impl LayerStats {
 
         writeln!(
             w,
-            "  {:<width$}  xlayer_wake/re={}/{} llc_drain/try={}/{}",
+            "  {:<width$}  xlayer_wake/re={}/{} llc_drain/try={}/{} skip_rnode={}",
             "",
             fmt_pct(self.xlayer_wake),
             fmt_pct(self.xlayer_rewake),
             fmt_pct(self.llc_drain),
             fmt_pct(self.llc_drain_try),
+            fmt_pct(self.skip_remote_node),
             width = header_width,
         )?;
 


### PR DESCRIPTION
This prevents the layer's dispatch path from trying to dispatch from DSQs in remote NUMA nodes which should reduce cross-node traffic and hopefully help machines that are more constrained in terms of cross-node bandwidth.