### PR TITLE
scx_bpfland: Introduce --no-wake-sync

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -43,6 +43,11 @@ const volatile s64 slice_lag = 20ULL * NSEC_PER_MSEC;
 const volatile bool no_preempt;
 
 /*
+ * Ignore synchronous wakeup events.
+ */
+const volatile bool no_wake_sync;
+
+/*
  * When enabled always dispatch per-CPU kthreads directly.
  *
  * This allows to prioritize critical kernel threads that may potentially slow
@@ -473,6 +478,9 @@ static bool is_llc_busy(const struct cpumask *idle_cpumask, s32 cpu)
 static bool is_wake_sync(s32 prev_cpu, s32 this_cpu, u64 wake_flags)
 {
 	const struct task_struct *current = (void *)bpf_get_current_task_btf();
+
+	if (!no_wake_sync)
+		return false;
 
 	if ((wake_flags & SCX_WAKE_SYNC) && !(current->flags & PF_EXITING))
 		return true;

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -170,6 +170,15 @@ struct Opts {
     #[clap(short = 'k', long, action = clap::ArgAction::SetTrue)]
     local_kthreads: bool,
 
+    /// Disable direct dispatch during synchronous wakeups.
+    ///
+    /// Enabling this option can lead to a more uniform load distribution across available cores,
+    /// potentially improving performance in certain scenarios. However, it may come at the cost of
+    /// reduced efficiency for pipe-intensive workloads that benefit from tighter producer-consumer
+    /// coupling.
+    #[clap(short = 'w', long, action = clap::ArgAction::SetTrue)]
+    no_wake_sync: bool,
+
     /// Specifies the initial set of CPUs, represented as a bitmask in hex (e.g., 0xff), that the
     /// scheduler will use to dispatch tasks, until the system becomes saturated, at which point
     /// tasks may overflow to other available CPUs.
@@ -296,6 +305,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.local_pcpu = opts.local_pcpu;
         skel.maps.rodata_data.local_kthreads = opts.local_kthreads;
         skel.maps.rodata_data.no_preempt = opts.no_preempt;
+        skel.maps.rodata_data.no_wake_sync = opts.no_wake_sync;
         skel.maps.rodata_data.slice_max = opts.slice_us * 1000;
         skel.maps.rodata_data.slice_min = opts.slice_us_min * 1000;
         skel.maps.rodata_data.slice_lag = opts.slice_us_lag * 1000;


### PR DESCRIPTION
Certain workloads (especially games) seem to benefit from the synchronous wakeup optimization, which tries to dispatch a wakee on the waker’s CPU when both share the same LLC. This can improve cache locality and responsiveness in typical producer/consumer pipelines, where the same two tasks communicate frequently.

However, in other workloads, this behavior can lead to performance regressions and excessive CPU migrations. In particular, it can be detrimental in:

 - Mixed workloads with latency-sensitive and background pipe-intensive tasks (e.g., telemetry or logging daemons), where the latter are chatty but not performance-critical. Prioritizing them via direct dispatch skews fairness and may hurt important foreground tasks.

 - Many-to-one communication patterns, such as a centralized logger, being woken by many different producers. With the synchronous wakeup optimization, the consumer may bounce across CPUs trying to follow each producer, causing unnecessary migrations and disrupting CPU locality.

 - One-to-many patterns, such as a producer waking multiple consumers (e.g., multi-threaded services or a poll loop across many readers). Although each wakeup targets a single task, the aggregate behavior leads to similar instability and loss of locality when the waker is always favored.

 - Power-saving oriented cpufreq governors (e.g., balance_power with intel_pstate): disabling synchronous wakeups can promote a more balanced load across CPUs, helping to avoid overly aggressive frequency downscaling. This can lead to more consistent performance in interactive or graphics-intensive workloads.

To accommodate all these cases, introduce the --no-wake-sync option that allows to disable direct dispatch on synchronous wakeups. This can improve load distribution and overall performance in all these cases where prioritizing synchronous wakeups is counterproductive.

By default, the optimization remains enabled, as the majority of gaming and desktop workloads see clear gains from it, while the advantages of disabling it tend to be more rare and situational.