### PR TITLE
scx_lavd: Improve preemption at ops.tick() and ops.qneueue().

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1010,25 +1010,6 @@ consume_out:
 		prev->scx.slice = calc_time_slice(taskc);
 }
 
-void BPF_STRUCT_OPS(lavd_tick, struct task_struct *p)
-{
-	struct cpu_ctx *cpuc;
-	struct task_ctx *taskc;
-	u64 now;
-
-	/*
-	 * For a non-latency-critical task, try to yield the current CPU if
-	 * there is a higher priority task in the run queue.
-	 */
-	if ((taskc = get_task_ctx(p)) && !is_lat_cri(taskc)) {
-		cpuc = get_cpu_ctx();
-		if (cpuc) {
-			now = scx_bpf_now();
-			try_yield_current_cpu(p, cpuc, taskc, now);
-		}
-	}
-}
-
 void BPF_STRUCT_OPS(lavd_runnable, struct task_struct *p, u64 enq_flags)
 {
 	struct task_struct *waker;
@@ -1736,7 +1717,6 @@ SCX_OPS_DEFINE(lavd_ops,
 	       .select_cpu		= (void *)lavd_select_cpu,
 	       .enqueue			= (void *)lavd_enqueue,
 	       .dispatch		= (void *)lavd_dispatch,
-	       .tick			= (void *)lavd_tick,
 	       .runnable		= (void *)lavd_runnable,
 	       .running			= (void *)lavd_running,
 	       .stopping		= (void *)lavd_stopping,

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -21,12 +21,12 @@ static int comp_preemption_info(struct preemption_info *prm_a,
 				struct preemption_info *prm_b)
 {
 	/*
-	 * Check if one's latency priority _or_ deadline is smaller or not.
+	 * Check one's latency criticality and deadline.
 	 */
-	if ((prm_a->lat_cri > prm_b->lat_cri) ||
+	if ((prm_a->lat_cri > prm_b->lat_cri) &&
 	    (prm_a->stopping_tm_est_ns < prm_b->stopping_tm_est_ns))
 		return -1;
-	if ((prm_a->lat_cri < prm_b->lat_cri) ||
+	if ((prm_a->lat_cri < prm_b->lat_cri) &&
 	    (prm_a->stopping_tm_est_ns > prm_b->stopping_tm_est_ns))
 		return 1;
 	return 0;
@@ -265,70 +265,6 @@ static bool try_find_and_kick_victim_cpu(struct task_struct *p,
 	 */
 	if (victim_cpuc)
 		ret = try_kick_cpu(p, victim_cpuc);
-
-	return ret;
-}
-
-static bool try_yield_current_cpu(struct task_struct *p_run,
-				  struct cpu_ctx *cpuc_run,
-				  struct task_ctx *taskc_run,
-				  u64 now)
-{
-	struct task_struct *p_wait;
-	struct task_ctx *taskc_wait;
-	struct preemption_info prm_run, prm_wait;
-	bool ret = false;
-
-	/*
-	 * If a task holds a lock, never yield.
-	 */
-	if (is_lock_holder(taskc_run))
-		return false;
-
-	/*
-	 * A slice-extended lock holder finally released the lock,
-	 * give up its extended time slice for fairness.
-	 */
-	if (taskc_run->lock_holder_xted) {
-		p_run->scx.slice = 0;
-		return true;
-	}
-
-	/*
-	 *  If a task already exhausted its time slice, there is nothing to do.
-	 */
-	if (READ_ONCE(p_run->scx.slice) == 0)
-		return false;
-
-	/*
-	 * If there is a higher priority task waiting on the global rq, the
-	 * current running task yield the CPU by shrinking its time slice to
-	 * zero.
-	 */
-	prm_run.stopping_tm_est_ns = taskc_run->last_running_clk +
-				     taskc_run->avg_runtime;
-	prm_run.lat_cri = taskc_run->lat_cri;
-
-	bpf_rcu_read_lock();
-	bpf_for_each(scx_dsq, p_wait, cpuc_run->cpdom_id, 0) {
-		taskc_wait = get_task_ctx(p_wait);
-		if (!taskc_wait)
-			break;
-
-		prm_wait.stopping_tm_est_ns = get_est_stopping_time(taskc_wait, now);
-		prm_wait.lat_cri = taskc_wait->lat_cri;
-
-		ret = can_task1_kick_task2(&prm_wait, &prm_run);
-
-		/*
-		 * Test only the first entry on the DSQ.
-		 */
-		break;
-	}
-	bpf_rcu_read_unlock();
-
-	if (ret)
-		p_run->scx.slice = 0;
 
 	return ret;
 }


### PR DESCRIPTION
The preemption at ops.tick() is cheap because it does not require expensive IPI. However, the quality of the preemption decision is suboptimal using only local information. It is insufficient to check that the current task is less latency-critical than the one in a DSQ. Even if it is true, there is no guarantee that the current task is the least latency-critical among currently running tasks. Moreover, the preemption at ops.tick() is rather redundant with the preemption at ops.qneueue(). The poor, redundant preemption decision pressures ops.enqueue() and ops.dispatch() operations. So, drop the preemption at ops.tick().

On the other hand, the preemption at the ops.enqueue() is more expensive. However, the quality of the decision is better because it tries to find the least latency-critical tasks among the running tasks using the Power of Two Random Choices technique. To avoid unnecessary preemption at ops.enqueue(), make the preemption decision more judiciously by tightening the preemption condition.