### PR TITLE
scx_utils: Add mangolog module

### DIFF
--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -50,6 +50,10 @@ default = []
 gpu-topology = ["dep:nvml-wrapper"]
 autopower = ["dep:zbus"]
 
+[[example]]
+name = "mangolog"
+crate-type = ["bin"]
+
 [lints.clippy]
 not_unsafe_ptr_arg_deref = "allow"
 

--- a/rust/scx_utils/examples/mangolog.rs
+++ b/rust/scx_utils/examples/mangolog.rs
@@ -1,0 +1,91 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+use scx_utils::mangoapp::mangoapp_msg_v1;
+
+use anyhow::bail;
+use anyhow::Result;
+use libc::{msgget, msgrcv, IPC_NOWAIT};
+
+use std::mem;
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+use std::{ffi::CString, io};
+
+fn main() -> Result<()> {
+    // NOTE: the mangoapp file has to be present when gamescope launches in order to read from the
+    // message queue. For example when launching Counter Strike 2 the mangoapp file needs to be in
+    // $HOME/.local/share/Steam/steamapps/common/Counter-String Global Offensive/mangoapp and the
+    // program needs to run in the same directory as well.
+    let file_path = Path::new("mangoapp");
+    if !file_path.exists() {
+        bail!("mangoapp file does not exists");
+    }
+
+    // Create the key for msgget reads using the mangoapp file
+    let path = CString::new("mangoapp").unwrap();
+    let key = unsafe { libc::ftok(path.as_ptr(), 65) };
+    if key == -1 {
+        bail!("failed to ftok: {}", io::Error::last_os_error());
+    }
+
+    // Get the key from the queue
+    let msgid = unsafe { msgget(key.try_into().unwrap(), 0) };
+    if msgid == -1 {
+        bail!("msgget failed: {}", std::io::Error::last_os_error());
+    }
+
+    let mut raw_msg: mangoapp_msg_v1 = unsafe { mem::zeroed() };
+
+    loop {
+        let msg_size = unsafe {
+            msgrcv(
+                msgid,
+                &mut raw_msg as *mut _ as *mut libc::c_void,
+                mem::size_of::<mangoapp_msg_v1>() - mem::size_of::<i64>(),
+                0,
+                IPC_NOWAIT, // XXX: this should probably use MSG_COPY as it pulls messages off the
+                            // queue and may mess with mangohud or other mangoapp uses.
+            )
+        };
+
+        if msg_size as isize != -1 {
+            let frametime = raw_msg.visible_frametime_ns;
+            let upscale = raw_msg.fsr_upscale;
+            let sharpness = raw_msg.fsr_sharpness;
+            let app_frametime_ns = raw_msg.app_frametime_ns;
+            let pid = raw_msg.pid;
+            let latency_ns = raw_msg.latency_ns;
+            let output_width = raw_msg.output_width;
+            let output_height = raw_msg.output_height;
+            let wants_hdr = raw_msg.wants_hdr();
+            let steam_focused = raw_msg.steam_focused();
+
+            println!("Received MangoApp data:");
+            println!("  Visible Frametime: {}", frametime);
+            println!("  FSR Upscale: {}", upscale);
+            println!("  FSR Sharpness: {}", sharpness);
+            println!("  App Frametime: {}", app_frametime_ns);
+            println!("  Latency: {}", latency_ns);
+            println!("  PID: {}", pid);
+            println!("  Output Width: {}", output_width);
+            println!("  Output Height: {}", output_height);
+            println!("  App Wants HDR: {}", wants_hdr);
+            println!("  Steam Focused: {}", steam_focused);
+            println!(
+                "  Engine Name: {}",
+                String::from_utf8_lossy(unsafe {
+                    &*(raw_msg.engine_name.as_ptr() as *const [u8; 40])
+                })
+            );
+        } else {
+            bail!(
+                "mangoapp: msgrcv returned -1 with error {}",
+                io::Error::last_os_error()
+            );
+        }
+        thread::sleep(Duration::from_secs(1));
+    }
+}

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -86,6 +86,8 @@ mod infeasible;
 pub use infeasible::LoadAggregator;
 pub use infeasible::LoadLedger;
 
+pub mod mangoapp;
+
 pub mod misc;
 pub use misc::monitor_stats;
 pub use misc::normalize_load_metric;

--- a/rust/scx_utils/src/mangoapp.rs
+++ b/rust/scx_utils/src/mangoapp.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C, packed)]
+pub struct mangoapp_msg_header {
+    pub msg_type: libc::c_long,
+    pub version: u32,
+}
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C, packed)]
+pub struct mangoapp_msg_v1 {
+    pub header: mangoapp_msg_header,
+    pub pid: u32,
+    pub app_frametime_ns: u64,
+    pub fsr_upscale: u8,
+    pub fsr_sharpness: u8,
+    pub visible_frametime_ns: u64,
+    pub latency_ns: u64,
+    pub output_width: u32,
+    pub output_height: u32,
+    pub display_refresh: u16,
+    b_app_wants_hdr_steam_focused: u8, // Packs bAppWantsHDR and bSteamFocused
+    pub engine_name: [libc::c_char; 40],
+}
+
+impl mangoapp_msg_v1 {
+    const B_APP_WANTS_HDR_MASK: u8 = 0b0000_0001;
+    const B_STEAM_FOCUSED_MASK: u8 = 0b0000_0010;
+    #[inline]
+
+    pub fn wants_hdr(&self) -> bool {
+        (self.b_app_wants_hdr_steam_focused & Self::B_APP_WANTS_HDR_MASK) != 0
+    }
+
+    #[inline]
+    pub fn set_wants_hdr(&mut self, value: bool) {
+        if value {
+            self.b_app_wants_hdr_steam_focused |= Self::B_APP_WANTS_HDR_MASK;
+        } else {
+            self.b_app_wants_hdr_steam_focused &= !Self::B_APP_WANTS_HDR_MASK;
+        }
+    }
+
+    #[inline]
+    pub fn steam_focused(&self) -> bool {
+        (self.b_app_wants_hdr_steam_focused & Self::B_STEAM_FOCUSED_MASK) != 0
+    }
+
+    #[inline]
+    pub fn set_steam_focused(&mut self, value: bool) {
+        if value {
+            self.b_app_wants_hdr_steam_focused |= Self::B_STEAM_FOCUSED_MASK;
+        } else {
+            self.b_app_wants_hdr_steam_focused &= !Self::B_STEAM_FOCUSED_MASK;
+        }
+    }
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct mangoapp_ctrl_header {
+    pub msg_type: libc::c_long,
+    pub ctrl_msg_type: u32,
+    pub version: u32,
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct mangoapp_ctrl_msgid1_v1 {
+    pub hdr: mangoapp_ctrl_header,
+    pub no_display: u8,
+    pub log_session: u8,
+    pub log_session_name: [libc::c_char; 64],
+    pub reload_config: u8,
+}


### PR DESCRIPTION
Add module for reading from mangoapp via gamescope. This module can be used to gather real time data for gaming.

Output from running the example:
```
~/.local/share/Steam/steamapps/common/Counter-Strike Global Offensive $  ~/git/scx/target/release/examples/mangolog
Received MangoApp data:
  Visible Frametime: 4753886
  FSR Upscale: 0
  FSR Sharpness: 2
  App Frametime: 4753886
  Latency: 18446744073709551615
  PID: 27004
  Output Width: 1920
  Output Height: 1177
  App Wants HDR: false
  Steam Focused: false
  Engine Name:
Received MangoApp data:
  Visible Frametime: 5128282
  FSR Upscale: 0
  FSR Sharpness: 2
  App Frametime: 5128282
  Latency: 18446744073709551615
  PID: 27004
  Output Width: 1920
  Output Height: 1177
  App Wants HDR: false
  Steam Focused: false
  Engine Name:
  ```
  I may integrate this library into `scxtop` for collecting gaming/scheduling stats.