### PR TITLE
scx_bpfland: Fix inverted logic for --no-wake-sync

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -479,7 +479,7 @@ static bool is_wake_sync(s32 prev_cpu, s32 this_cpu, u64 wake_flags)
 {
 	const struct task_struct *current = (void *)bpf_get_current_task_btf();
 
-	if (!no_wake_sync)
+	if (no_wake_sync)
 		return false;
 
 	if ((wake_flags & SCX_WAKE_SYNC) && !(current->flags & PF_EXITING))


### PR DESCRIPTION
The implementation of --no-wake-sync mistakenly inverted its intended behavior.

Flip the condition to match the correct semantics.

Fixes: 342233da ("scx_bpfland: Introduce --no-wake-sync")