### PR TITLE
scxtop: Add mangoapp TUI view

### DIFF
--- a/rust/scx_utils/examples/mangolog.rs
+++ b/rust/scx_utils/examples/mangolog.rs
@@ -2,7 +2,7 @@
 
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
-use scx_utils::mangoapp::mangoapp_msg_v1;
+use scx_utils::mangoapp::{mangoapp_msg_v1, MANGOAPP_PROJ_ID};
 
 use anyhow::bail;
 use anyhow::Result;
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
 
     // Create the key for msgget reads using the mangoapp file
     let path = CString::new("mangoapp").unwrap();
-    let key = unsafe { libc::ftok(path.as_ptr(), 65) };
+    let key = unsafe { libc::ftok(path.as_ptr(), MANGOAPP_PROJ_ID) };
     if key == -1 {
         bail!("failed to ftok: {}", io::Error::last_os_error());
     }

--- a/rust/scx_utils/src/mangoapp.rs
+++ b/rust/scx_utils/src/mangoapp.rs
@@ -3,6 +3,8 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
+pub const MANGOAPP_PROJ_ID: i32 = 65;
+
 #[derive(Debug, Copy, Clone)]
 #[repr(C, packed)]
 pub struct mangoapp_msg_header {
@@ -30,8 +32,8 @@ pub struct mangoapp_msg_v1 {
 impl mangoapp_msg_v1 {
     const B_APP_WANTS_HDR_MASK: u8 = 0b0000_0001;
     const B_STEAM_FOCUSED_MASK: u8 = 0b0000_0010;
-    #[inline]
 
+    #[inline]
     pub fn wants_hdr(&self) -> bool {
         (self.b_app_wants_hdr_steam_focused & Self::B_APP_WANTS_HDR_MASK) != 0
     }

--- a/tools/scxtop/src/cli.rs
+++ b/tools/scxtop/src/cli.rs
@@ -82,6 +82,16 @@ pub struct TuiArgs {
     /// Minimum latency to trigger a trace.
     #[arg(long, default_value_t = 100000000)]
     pub experimental_long_tail_tracing_min_latency_ns: u64,
+
+    /// Trace mangoapp applications
+    #[arg(long, default_value_t = false)]
+    pub mangoapp_tracing: bool,
+    /// Mangoapp poll interval in ms
+    #[arg(long, default_value_t = 1000)]
+    pub mangoapp_poll_intvl_ms: u64,
+    /// Mangoapp path for System V IPC key
+    #[arg(long, default_value = "mangoapp")]
+    pub mangoapp_path: String,
 }
 
 #[derive(Clone, Parser, Debug)]
@@ -102,6 +112,7 @@ pub struct TraceArgs {
     pub verbose: u8,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 pub enum Commands {
     /// Runs the scxtop TUI.

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -44,6 +44,7 @@ impl Default for KeyMap {
         bindings.insert(Key::Char('L'), Action::ToggleLocalization);
         bindings.insert(Key::Char('P'), Action::ToggleHwPressure);
         bindings.insert(Key::Char('h'), Action::SetState(AppState::Help));
+        bindings.insert(Key::Char('m'), Action::SetState(AppState::MangoApp));
         bindings.insert(Key::Char('?'), Action::SetState(AppState::Help));
         bindings.insert(Key::Char('l'), Action::SetState(AppState::Llc));
         bindings.insert(Key::Char('n'), Action::SetState(AppState::Node));
@@ -346,6 +347,7 @@ pub fn parse_action(action_str: &str) -> Result<Action> {
         "ToggleHwPressure" => Ok(Action::ToggleHwPressure),
         "AppStateHelp" => Ok(Action::SetState(AppState::Help)),
         "AppStateLlc" => Ok(Action::SetState(AppState::Llc)),
+        "AppStateMangoApp" => Ok(Action::SetState(AppState::MangoApp)),
         "AppStateNode" => Ok(Action::SetState(AppState::Node)),
         "AppStateScheduler" => Ok(Action::SetState(AppState::Scheduler)),
         "SaveConfig" => Ok(Action::SaveConfig),

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -14,6 +14,7 @@ pub mod edm;
 mod event_data;
 mod keymap;
 mod llc_data;
+pub mod mangoapp;
 mod node_data;
 mod perf_event;
 mod perfetto_trace;
@@ -77,6 +78,8 @@ pub enum AppState {
     Scheduler,
     /// Application is in the tracing  state.
     Tracing,
+    /// Application is in the mangoapp state.
+    MangoApp,
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -246,6 +249,19 @@ pub struct PstateSampleAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct MangoAppAction {
+    pub pid: u32,
+    pub vis_frametime: u64,
+    pub app_frametime: u64,
+    pub fsr_upscale: u8,
+    pub fsr_sharpness: u8,
+    pub latency_ns: u64,
+    pub output_width: u32,
+    pub output_height: u32,
+    pub display_refresh: u16,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Action {
     ChangeTheme,
     ClearEvent,
@@ -265,6 +281,7 @@ pub enum Action {
     IncBpfSampleRate,
     IncTickRate,
     IPI(IPIAction),
+    MangoApp(MangoAppAction),
     NextEvent,
     NextViewState,
     PageDown,

--- a/tools/scxtop/src/mangoapp.rs
+++ b/tools/scxtop/src/mangoapp.rs
@@ -1,0 +1,91 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use anyhow::anyhow;
+use anyhow::Result;
+use libc::{ftok, msgget, msgrcv, IPC_NOWAIT};
+use log::info;
+use scx_utils::mangoapp::{mangoapp_msg_v1, MANGOAPP_PROJ_ID};
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::time::Duration;
+
+use crate::Action;
+use crate::MangoAppAction;
+
+use std::mem;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::{ffi::CString, io};
+
+pub async fn poll_mangoapp(
+    mangoapp_path: CString,
+    poll_intvl_ms: u64,
+    action_tx: UnboundedSender<Action>,
+    shutdown: Arc<AtomicBool>,
+) -> Result<()> {
+    let key = unsafe { ftok(mangoapp_path.as_ptr(), MANGOAPP_PROJ_ID) };
+    if key == -1 {
+        return Err(anyhow!("failed to ftok: {}", io::Error::last_os_error()));
+    }
+
+    // Get the key from the queue
+    let msgid = unsafe { msgget(key, 0) };
+    if msgid == -1 {
+        return Err(anyhow!(
+            "msgget failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    loop {
+        let mut raw_msg: mangoapp_msg_v1 = unsafe { mem::zeroed() };
+        let msg_size = unsafe {
+            msgrcv(
+                msgid,
+                &mut raw_msg as *mut _ as *mut libc::c_void,
+                mem::size_of::<mangoapp_msg_v1>() - mem::size_of::<i64>(),
+                0,
+                IPC_NOWAIT, // XXX: this should probably use MSG_COPY as it pulls messages off the
+                            // queue and may mess with mangohud or other mangoapp uses.
+            )
+        };
+        if msg_size as isize == -1 {
+            info!(
+                "mangoapp: msgrcv returned -1 with error {}",
+                io::Error::last_os_error()
+            );
+            tokio::time::sleep(Duration::from_millis(poll_intvl_ms)).await;
+            continue;
+        }
+
+        let vis_frametime = raw_msg.visible_frametime_ns;
+        let fsr_upscale = raw_msg.fsr_upscale;
+        let fsr_sharpness = raw_msg.fsr_sharpness;
+        let app_frametime = raw_msg.app_frametime_ns;
+        let pid = raw_msg.pid;
+        let latency_ns = raw_msg.latency_ns;
+        let output_width = raw_msg.output_width;
+        let output_height = raw_msg.output_height;
+        let display_refresh = raw_msg.display_refresh;
+        let action = MangoAppAction {
+            pid,
+            vis_frametime,
+            app_frametime,
+            fsr_upscale,
+            fsr_sharpness,
+            latency_ns,
+            output_width,
+            output_height,
+            display_refresh,
+        };
+
+        action_tx.send(Action::MangoApp(action))?;
+        if shutdown.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(poll_intvl_ms)).await;
+    }
+}


### PR DESCRIPTION
Add a view to the TUI to render data from mangoapp. Show scheduler metrics and perf events for the application running with mangoapp enabled.
    
This is a continuation of #1708. An example showing filtered perf events and scheduler stats for CS2:
![2025-04-20-22:41:12](https://github.com/user-attachments/assets/3e057f00-f588-42ae-b33d-ffd7e18e5de0)
