### PR TITLE
scx_utils, scx_lavd: Use per-CPU cache size for CPU preference order.

### DIFF
--- a/rust/scx_utils/src/misc.rs
+++ b/rust/scx_utils/src/misc.rs
@@ -117,6 +117,28 @@ pub fn read_file_usize_vec(path: &Path, separator: char) -> Result<Vec<usize>> {
         .collect::<Result<Vec<usize>>>()
 }
 
+pub fn read_file_byte(path: &Path) -> Result<usize> {
+    let val = std::fs::read_to_string(path)?;
+    let val = val.trim();
+
+    // E.g., 10K, 10M, 10G, 10
+    if val.ends_with("K") {
+        let byte = val[..val.len() - 1].parse::<usize>()?;
+        return Ok(byte * 1024);
+    }
+    if val.ends_with("M") {
+        let byte = val[..val.len() - 1].parse::<usize>()?;
+        return Ok(byte * 1024 * 1024);
+    }
+    if val.ends_with("G") {
+        let byte = val[..val.len() - 1].parse::<usize>()?;
+        return Ok(byte * 1024 * 1024 * 1024);
+    }
+
+    let byte = val.parse::<usize>()?;
+    Ok(byte)
+}
+
 /* Load is reported as weight * duty cycle
  *
  * In the Linux kernel, EEDVF uses default weight = 1 s.t.

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -785,22 +785,13 @@ fn create_numa_nodes(
             }
         }
 
-        let cpu_pattern = numa_path.join("cpu[0-9]*");
-        let cpu_paths = glob(cpu_pattern.to_string_lossy().as_ref())?;
         let big_little = has_big_little().unwrap_or(false);
         let capacity_src = cpu_capacity_source();
         let avg_cpu_freq = avg_cpu_freq();
-        for cpu_path in cpu_paths.filter_map(Result::ok) {
-            let cpu_str = cpu_path.to_str().unwrap().trim();
-            let cpu_id = match sscanf!(cpu_str, "/sys/devices/system/node/node{usize}/cpu{usize}") {
-                Ok((_, val)) => val,
-                Err(_) => {
-                    bail!("Failed to parse cpu ID {}", cpu_str);
-                }
-            };
-
+        let cpu_ids = read_cpu_ids()?;
+        for cpu_id in cpu_ids.iter() {
             create_insert_cpu(
-                cpu_id,
+                *cpu_id,
                 &mut node,
                 online_mask,
                 topo_ctx,


### PR DESCRIPTION
There are processors where CPUs with the same capacity have different cache sizes. To address such processors in determining CPU preference order, made the following three changes in topology:

- Add per-CPU cache size to Topology::Cpu (cache_size)
- Add the SMT level of a CPU to Topology::Cpu (smt_level)
- Assign core_id in a natural order

With these changes, scx_lavd was changed to take the per-CPU cache size into account -- always prefer a CPU with a bigger cache.
