### PR TITLE
ci.py: run black and isort on self

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -3,10 +3,10 @@
 import argparse
 import json
 import os
+import random
 import subprocess
 import sys
 from typing import List, Optional
-import random
 
 
 def run_command(
@@ -57,7 +57,11 @@ def run_format():
     """Format all targets."""
     print("Running format...", flush=True)
 
+    run_command(["black", ".github/include/ci.py"])
+    run_command(["isort", ".github/include/ci.py"])
+
     run_command(["cargo", "fmt"])
+
     run_command(["git", "diff", "--exit-code"])
     print("✓ Format completed successfully", flush=True)
 

--- a/.github/include/flake.nix
+++ b/.github/include/flake.nix
@@ -76,6 +76,7 @@
                 propagatedBuildInputs = with pkgs; [
                   bash
                   binutils
+                  black
                   cargo
                   clang
                   clippy
@@ -85,6 +86,7 @@
                   gnugrep
                   gnumake
                   gnused
+                  isort
                   jq
                   llvmPackages.libclang
                   llvmPackages.libllvm


### PR DESCRIPTION
I like to keep this Python file linted. Enforce that in the CI so it doesn't break.

Test plan:
- `nix run ./.github/include#ci format`
- CI