### PR TITLE
ci.py: switch to cargo-nextest

### DIFF
--- a/.github/include/flake.nix
+++ b/.github/include/flake.nix
@@ -78,6 +78,7 @@
                   binutils
                   black
                   cargo
+                  cargo-nextest
                   clang
                   clippy
                   coreutils


### PR DESCRIPTION
The CI currently builds the tests then parses the Cargo output to find the test binaries. This does work but it's pretty grim. Switch to `cargo-nextest` with its explicit support for running tests from an archive. This runs the tests in parallel for a whole workspace, rather than the behaviour before (and with `cargo test`) of running a single test crate at a time, and overall provides a much nicer interface for CI output.

The archive extraction takes a dominant amount of time given how few tests we have at the minute. With 8 CPUs this goes from 25s to 35s for this step in the CI, which is a big percentage but a small amount of absolute time. Bump the cores in the VM to mitigate this, which is worth it anyway because tests will run in parallel now.

Test plan:
- `nix run ./.github/include#ci all`
- CI