### PR TITLE
p2dq/chaos: expose bpf file contents from p2dq crate

### DIFF
--- a/scheds/rust/scx_chaos/Cargo.toml
+++ b/scheds/rust/scx_chaos/Cargo.toml
@@ -21,3 +21,4 @@ simplelog = "0.12"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.13" }
+scx_p2dq = { path = "../../../scheds/rust/scx_p2dq", version = "1.0.12" }

--- a/scheds/rust/scx_chaos/build.rs
+++ b/scheds/rust/scx_chaos/build.rs
@@ -2,11 +2,27 @@
 //
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
+use std::io::Write;
 
 fn main() {
-    // TODO: The BpfBuilder appears to assume only files in the crate are relevant to building,
-    // meaning chaos won't rebuild if p2dq sources change. This is fine for now as the CI should
-    // catch anything obvious with a clean build.
+    let include_path = std::env::var("OUT_DIR").unwrap() + "/include";
+
+    std::fs::create_dir_all(include_path.clone() + "/scx_p2dq").unwrap();
+    let mut file = std::fs::File::create(include_path.clone() + "/scx_p2dq/main.bpf.c").unwrap();
+    file.write_all(scx_p2dq::bpf_srcs::main_bpf_c()).unwrap();
+    let mut file = std::fs::File::create(include_path.clone() + "/scx_p2dq/intf.h").unwrap();
+    file.write_all(scx_p2dq::bpf_srcs::intf_h()).unwrap();
+
+    // TODO: this is a massive hack. BpfBuilder should be rewritten to have an explicit change of
+    // state between "builder" mode (where options are set) and "actualised" mode where they are
+    // turned into the useful arguments. As it is cflags is generated too early, and refactoring it
+    // is a pain and will require a change of interface.
+    let mut extra_flags = vec!["-I".to_string() + &include_path];
+    if let Ok(e) = std::env::var("BPF_EXTRA_CFLAGS_POST_INCL") {
+        extra_flags.push(e);
+    }
+    std::env::set_var("BPF_EXTRA_CFLAGS_POST_INCL", extra_flags.join(" "));
+
     scx_utils::BpfBuilder::new()
         .unwrap()
         .enable_intf("src/bpf/intf.h", "bpf_intf.rs")

--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -6,7 +6,7 @@
  */
 
 #define P2DQ_CREATE_STRUCT_OPS 0
-#include "../../../scx_p2dq/src/bpf/main.bpf.c"
+#include "scx_p2dq/main.bpf.c"
 
 #include "intf.h"
 

--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -224,3 +224,20 @@ macro_rules! init_skel {
         }
     };
 }
+
+pub mod bpf_srcs {
+
+    pub fn intf_h() -> &'static [u8] {
+        const INTF_H: &'static [u8] =
+            include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/intf.h"));
+
+        INTF_H
+    }
+
+    pub fn main_bpf_c() -> &'static [u8] {
+        const MAIN_BPF_C: &'static [u8] =
+            include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/main.bpf.c"));
+
+        MAIN_BPF_C
+    }
+}


### PR DESCRIPTION
scx_chaos can't be published to crates.io currently because it depends on being built in the monorepo. Expose the BPF sources as bytes in the p2dq crate, which also solves the issue of needing to rebuild when p2dq changes.

Adding the custom include dir is really hacky. The BpfBuilder defines the cflags really early, and it's not really possible to neatly change them after, for example with a `.add_include_path()` method. We would need to break this API pretty significantly to add this cleanly. For now, hack the environment variable in the build of chaos to add an extra flag "after" (with) the includes.

In the future we may need to do something more generic like the TAR_H feature in scx_utils, but for 2 files I think this is simpler to follow.

Test plan:
- `cargo build`
- CI