### PR TITLE
scx_utils, scx_lavd: Group CPUs in the same performance domain.

### DIFF
--- a/rust/scx_utils/src/energy_model.rs
+++ b/rust/scx_utils/src/energy_model.rs
@@ -65,6 +65,15 @@ impl EnergyModel {
 
         Ok(EnergyModel { perf_doms })
     }
+
+    pub fn get_pd(&self, cpu_id: usize) -> Option<&PerfDomain> {
+        for (_, pd) in self.perf_doms.iter() {
+            if pd.span.test_cpu(cpu_id) {
+                return Some(&pd);
+            }
+        }
+        None
+    }
 }
 
 impl PerfDomain {


### PR DESCRIPTION
When deciding the CPU preference order, group the CPUs in the same performance domain (i.e., CPU frequency domain) to minimize the number of active performance domains.