### PR TITLE
scx_lavd: get cpu context of scx_bpf_task_cpu in running

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1075,7 +1075,7 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 	/*
 	 * Update task statistics
 	 */
-	cpuc = get_cpu_ctx();
+	cpuc = get_cpu_ctx_id(scx_bpf_task_cpu(p));
 	taskc = get_task_ctx(p);
 	if (!cpuc || !taskc)
 		return;


### PR DESCRIPTION
Recent changes in the kernel added new restrictions to rq locks, aiming to prevent deadlocks. lavd triggers this new case in running when calling `scx_bpf_cpuperf_set`. This is because running has already locked an rq before entry and cpuperf_set attempted to operate on and lock a different rq, potentially causing a deadlock.

Get the `cpuc` in lavd_running identified by `scx_bpf_task_cpu` instead of the current CPU. I look forward to being told why this works, but the failure was completely reliable before and goes away with this change.

Relevant kernel commits:
- https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git/commit/?h=for-next&id=18853ba782bef65fc81ef2b3370382e5b479c5eb
- https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git/commit/?h=for-next&id=a11d6784d7316a6c77ca9f14fb1a698ebbb3c1fb

Test plan:
- This fix & CI with updated kernel: https://github.com/sched-ext/scx/actions/runs/14617926571/job/41011059539
- This fix & CI with previous kernel on this PR.
- No fix & failed CI with updated kernel: https://github.com/sched-ext/scx/actions/runs/14614177179/job/41003568052?pr=1727