### PR TITLE
ci: update ubuntu installations to clang 19

### DIFF
--- a/.github/actions/install-deps-action/action.yml
+++ b/.github/actions/install-deps-action/action.yml
@@ -23,8 +23,10 @@ runs:
         linux-headers-generic linux-tools-common linux-tools-generic make \
         ninja-build pahole pkg-config python3-dev python3-pip python3-requests \
         qemu-kvm rsync stress-ng udev zstd libseccomp-dev libcap-ng-dev \
-        llvm clang python3-full curl meson bpftrace dwarves rustup \
+        llvm-19 clang-19 python3-full curl meson bpftrace dwarves rustup \
         protobuf-compiler
+
+        echo /usr/lib/llvm-19/bin >> $GITHUB_PATH
       shell: bash
 
     # ensure some toolchain is installed


### PR DESCRIPTION
Update llvm to 19 in the Ubuntu runners. This is needed for proper arena support and was leading to verifier errors.

Test plan:
- CI