### PR TITLE
scx_lavd: Get the right CPU context from ops.stopping()

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1115,7 +1115,7 @@ void BPF_STRUCT_OPS(lavd_stopping, struct task_struct *p, bool runnable)
 	/*
 	 * Update task statistics
 	 */
-	cpuc = get_cpu_ctx();
+	cpuc = get_cpu_ctx_id(scx_bpf_task_cpu(p));
 	taskc = get_task_ctx(p);
 	if (!cpuc || !taskc)
 		return;


### PR DESCRIPTION
Similarly to commit e81fa0d3 ("lavd: get cpu context of scx_bpf_task_cpu in running") apply the same change to ops.stopping() as well.

Both ops.running() and ops.stopping() can be called from a CPU other than the one the task is assigned to (i.e., a task changing a property of another task), therefore always rely on scx_bpf_task_cpu() to get the right CPU context.