### PR TITLE
Revamp scx_rustland

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -195,6 +195,7 @@ impl<'cb> BpfScheduler<'cb> {
         exit_dump_len: u32,
         partial: bool,
         debug: bool,
+        builtin_idle: bool,
     ) -> Result<Self> {
         let shutdown = Arc::new(AtomicBool::new(false));
         set_ctrlc_handler(shutdown.clone()).context("Error setting Ctrl-C handler")?;
@@ -255,6 +256,7 @@ impl<'cb> BpfScheduler<'cb> {
         skel.struct_ops.rustland_mut().exit_dump_len = exit_dump_len;
 
         skel.maps.bss_data.usersched_pid = std::process::id();
+        skel.maps.rodata_data.builtin_idle = builtin_idle;
         skel.maps.rodata_data.debug = debug;
 
         // Attach BPF scheduler.

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -77,6 +77,7 @@ pub struct QueuedTask {
     pub pid: i32,              // pid that uniquely identifies a task
     pub cpu: i32,              // CPU where the task is running
     pub flags: u64,            // task enqueue flags
+    pub exec_runtime: u64,     // Total cpu time since last sleep
     pub sum_exec_runtime: u64, // Total cpu time
     pub nvcsw: u64,            // Total amount of voluntary context switches
     pub weight: u64,           // Task static priority
@@ -142,6 +143,7 @@ impl EnqueuedMessage {
             pid: self.inner.pid,
             cpu: self.inner.cpu,
             flags: self.inner.flags,
+            exec_runtime: self.inner.exec_runtime,
             sum_exec_runtime: self.inner.sum_exec_runtime,
             nvcsw: self.inner.nvcsw,
             weight: self.inner.weight,

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -83,6 +83,7 @@ struct queued_task_ctx {
 	s32 pid;
 	s32 cpu; /* CPU where the task is running */
 	u64 flags; /* task enqueue flags */
+	u64 exec_runtime; /* Total cpu time since last sleep */
 	u64 sum_exec_runtime; /* Total cpu time */
 	u64 nvcsw; /* Total amount of voluntary context switches */
 	u64 weight; /* Task static priority */

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -229,46 +229,6 @@ struct task_ctx *try_lookup_task_ctx(const struct task_struct *p)
 }
 
 /*
- * Intercept when a task is executing __handle_mm_fault().
- */
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, __u32);
-	__type(value, __u64);
-	__uint(max_entries, MAX_ENQUEUED_TASKS);
-} pid_mm_fault_map SEC(".maps");
-
-SEC("fentry/handle_mm_fault")
-int BPF_PROG(kprobe_handle_mm_fault, void *vma,
-	     unsigned long address, unsigned int flags)
-{
-	pid_t pid = bpf_get_current_pid_tgid() >> 32;
-	u64 value = true;
-
-	bpf_map_update_elem(&pid_mm_fault_map, &pid, &value, BPF_ANY);
-
-	return 0;
-}
-
-SEC("fexit/handle_mm_fault")
-int BPF_PROG(kretprobe_handle_mm_fault)
-{
-	pid_t pid = bpf_get_current_pid_tgid() >> 32;
-	bpf_map_delete_elem(&pid_mm_fault_map, &pid);
-
-	return 0;
-}
-
-/*
- * Return true if a task is handling a page fault, false otherwise.
- */
-static bool in_mm_fault(pid_t pid)
-{
-	u64 *value = bpf_map_lookup_elem(&pid_mm_fault_map, &pid);
-	return value != NULL;
-}
-
-/*
  * Heartbeat timer used to periodically trigger the check to run the user-space
  * scheduler.
  *
@@ -775,18 +735,6 @@ void BPF_STRUCT_OPS(rustland_enqueue, struct task_struct *p, u64 enq_flags)
                 scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL,
 				   enq_flags | SCX_ENQ_PREEMPT);
 		__sync_fetch_and_add(&nr_kernel_dispatches, 1);
-		return;
-	}
-
-	/*
-	 * Bypass user-space scheduling for faulting tasks to prevent potential
-	 * deadlock conditions. They can just be dispatched to the shared DSQ
-	 * using ith the highest priority.
-	 */
-	if (in_mm_fault(p->pid)) {
-		scx_bpf_dsq_insert_vtime(p, SHARED_DSQ, SCX_SLICE_DFL, 0, enq_flags);
-		__sync_fetch_and_add(&nr_kernel_dispatches, 1);
-		kick_task_cpu(p);
 		return;
 	}
 

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -106,6 +106,7 @@ impl<'a> Scheduler<'a> {
             0,     // exit_dump_len (buffer size of exit info, 0 = default)
             false, // partial (false = include all tasks)
             false, // debug (false = debug mode off)
+            false, // builtin_idle (false = idle selection policy in user-space)
         )?;
         Ok(Self { bpf })
     }

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -33,9 +33,6 @@ const SCHEDULER_NAME: &'static str = "RustLand";
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
-/// Task is being enqueued as a result of a wakeup event.
-const SCX_ENQ_WAKEUP: u64 = 1;
-
 /// scx_rustland: user-space scheduler written in Rust
 ///
 /// scx_rustland is designed to prioritize interactive workloads over background CPU-intensive
@@ -118,17 +115,10 @@ struct Opts {
 
 // Time constants.
 const NSEC_PER_USEC: u64 = 1_000;
-const NSEC_PER_SEC: u64 = 1_000_000_000;
-
-// Maximum multiplier for the dynamic task priority.
-const MAX_LATENCY_WEIGHT: u64 = 1_000;
 
 // Basic item stored in the task information map.
 #[derive(Debug)]
 struct TaskInfo {
-    nvcsw: u64,
-    nvcsw_ts: u64,
-    avg_nvcsw: u64,
     sum_exec_runtime: u64, // total cpu time used by the task
     vruntime: u64,         // total vruntime of the task
 }
@@ -287,17 +277,11 @@ impl<'a> Scheduler<'a> {
         ts.as_nanos() as u64
     }
 
-    fn calc_avg(old_val: u64, new_val: u64) -> u64 {
-        (old_val - (old_val >> 2)) + (new_val >> 2)
-    }
-
     // Update task's vruntime based on the information collected from the kernel and return to the
     // caller the evaluated task's deadline.
     //
     // This method implements the main task ordering logic of the scheduler.
     fn update_enqueued(&mut self, task: &QueuedTask) -> u64 {
-        let now = Self::now();
-
         // Get task information if the task is already stored in the task map,
         // otherwise create a new entry for it.
         let task_info = self
@@ -305,22 +289,13 @@ impl<'a> Scheduler<'a> {
             .tasks
             .entry(task.pid)
             .or_insert_with_key(|&_pid| TaskInfo {
-                nvcsw: task.nvcsw,
-                nvcsw_ts: now,
-                avg_nvcsw: 0,
                 sum_exec_runtime: task.sum_exec_runtime,
                 vruntime: self.min_vruntime,
             });
 
-        // Refresh voluntary context switches metrics.
-        let delta_t = now - task_info.nvcsw_ts;
-        if delta_t >= NSEC_PER_SEC {
-            let delta_nvcsw = task.nvcsw - task_info.nvcsw;
-            let avg_nvcsw = (delta_nvcsw * NSEC_PER_SEC / delta_t).min(1000);
-
-            task_info.nvcsw = task.nvcsw;
-            task_info.nvcsw_ts = now;
-            task_info.avg_nvcsw = Self::calc_avg(task_info.avg_nvcsw, avg_nvcsw);
+        // Update global minimum vruntime based on the previous task's vruntime.
+        if self.min_vruntime < task.vtime {
+            self.min_vruntime = task.vtime;
         }
 
         // Evaluate used task time slice.
@@ -332,35 +307,17 @@ impl<'a> Scheduler<'a> {
         // Update total task cputime.
         task_info.sum_exec_runtime = task.sum_exec_runtime;
 
-        // Update task's vruntime re-aligning it to min_vruntime.
-        //
-        // The amount of vruntime budget an idle task can accumulate is adjusted in function of its
-        // latency weight, which is derived from the average number of voluntary context switches.
-        // This ensures that latency-sensitive tasks receive a priority boost.
-        let latency_weight = {
-            let base_weight = task_info.avg_nvcsw.min(MAX_LATENCY_WEIGHT);
-            // Boost tasks being enqueued as a result of a wakeup event by an additional 2x factor.
-            let weight_multiplier = if task.flags & SCX_ENQ_WAKEUP != 0 {
-                2
-            } else {
-                1
-            };
-            (base_weight * weight_multiplier) + 1
-        };
-        let min_vruntime = self
-            .min_vruntime
-            .saturating_sub(self.slice_ns * latency_weight);
+        // Update task's vruntime re-aligning it to min_vruntime (never allow a task to accumulate
+        // a budget of more than a time slice to prevent starvation).
+        let min_vruntime = self.min_vruntime.saturating_sub(self.slice_ns);
         if task_info.vruntime < min_vruntime {
             task_info.vruntime = min_vruntime;
         }
         let vslice = slice * 100 / task.weight;
         task_info.vruntime += vslice;
 
-        // Update global minimum vruntime.
-        self.min_vruntime += vslice;
-
         // Return the task's deadline.
-        task_info.vruntime
+        task_info.vruntime + task.exec_runtime.min(self.slice_ns * 100)
     }
 
     // Drain all the tasks from the queued list, update their vruntime (Self::update_enqueued()),

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -230,7 +230,13 @@ struct Scheduler<'a> {
 impl<'a> Scheduler<'a> {
     fn init(opts: &Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
         // Low-level BPF connector.
-        let bpf = BpfScheduler::init(open_object, opts.exit_dump_len, opts.partial, opts.verbose)?;
+        let bpf = BpfScheduler::init(
+            open_object,
+            opts.exit_dump_len,
+            opts.partial,
+            opts.verbose,
+            true, // Enable built-in idle CPU selection policy
+        )?;
         let stats_server = StatsServer::new(stats::server_data()).launch()?;
 
         info!("{} scheduler attached", SCHEDULER_NAME);


### PR DESCRIPTION
A set of fixes/improvements for scx_rustland_core:
 - avoid refilling task's time slice in ops.running() that may cause starvation
 - expose task's CPU time since last sleep to user-space
 - allow to toggle bulilt-in idle CPU policy

And a redesign of scx_rustland:
 - use scheduling policy similar to bpfland and flash
 - enable the built-in idle CPU selection policy to get optimal performance when the system is not fully saturated

This should fix #1731.