### PR TITLE
scx_utils, scxtop: Bindgen perf event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,16 +1859,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
-name = "perf-event-open-sys2"
-version = "5.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c25955321465255e437600b54296983fab1feac2cd0c38958adeb26dbae49e"
-dependencies = [
- "libc",
- "memoffset 0.9.1",
-]
-
-[[package]]
 name = "pest"
 version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2661,7 +2651,6 @@ dependencies = [
  "log-panics",
  "nix 0.29.0",
  "num-format",
- "perf-event-open-sys2",
  "plain",
  "prost",
  "prost-build",

--- a/rust/scx_utils/build.rs
+++ b/rust/scx_utils/build.rs
@@ -14,4 +14,17 @@ fn main() {
         .cargo_target_triple()
         .emit()
         .unwrap();
+
+    let bindings = bindgen::Builder::default()
+        .header("perf_wrapper.h")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .prepend_enum_name(false)
+        .derive_default(true)
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("perf_bindings.rs"))
+        .expect("Couldn't write bindings!");
 }

--- a/rust/scx_utils/perf_wrapper.h
+++ b/rust/scx_utils/perf_wrapper.h
@@ -1,0 +1,23 @@
+// This file is consumed by bindgen, called from our build.rs file.
+
+#include <linux/perf_event.h>
+
+// for __NR_perf_event_open
+#include <asm/unistd.h>
+#include <asm/perf_regs.h>
+
+// bindgen won't capture preprocessor macro definitions, so we have to do this.
+enum perf_event_ioctls {
+    ENABLE = PERF_EVENT_IOC_ENABLE,
+    DISABLE = PERF_EVENT_IOC_DISABLE,
+    REFRESH = PERF_EVENT_IOC_REFRESH,
+    RESET = PERF_EVENT_IOC_RESET,
+    PERIOD = PERF_EVENT_IOC_PERIOD,
+    SET_OUTPUT = PERF_EVENT_IOC_SET_OUTPUT,
+    SET_FILTER = PERF_EVENT_IOC_SET_FILTER,
+    ID = PERF_EVENT_IOC_ID,
+    SET_BPF = PERF_EVENT_IOC_SET_BPF,
+    PAUSE_OUTPUT = PERF_EVENT_IOC_PAUSE_OUTPUT,
+    QUERY_BPF = PERF_EVENT_IOC_QUERY_BPF,
+    MODIFY_ATTRIBUTES = PERF_EVENT_IOC_MODIFY_ATTRIBUTES,
+};

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -104,3 +104,5 @@ pub use enums::scx_enums;
 
 #[cfg(feature = "autopower")]
 pub mod autopower;
+
+pub mod perf;

--- a/rust/scx_utils/src/perf.rs
+++ b/rust/scx_utils/src/perf.rs
@@ -1,0 +1,60 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+use libc::pid_t;
+use std::os::raw::{c_int, c_ulong};
+
+/// The `perf_event_open` system call.
+///
+/// See the [`perf_event_open(2) man page`][man] for details.
+///
+/// On error, this returns -1, and the C `errno` value (accessible via
+/// `std::io::Error::last_os_error`) is set to indicate the error.
+///
+/// Note: The `attrs` argument needs to be a `*mut` because if the `size` field
+/// is too small or too large, the kernel writes the size it was expecing back
+/// into that field. It might do other things as well.
+///
+/// # Safety
+///
+/// The `attrs` argument must point to a properly initialized
+/// `perf_event_attr` struct. The measurements and other behaviors its
+/// contents request must be safe.
+///
+/// [man]: https://www.mankier.com/2/perf_event_open
+pub unsafe fn perf_event_open(
+    attrs: *mut bindings::perf_event_attr,
+    pid: pid_t,
+    cpu: c_int,
+    group_fd: c_int,
+    flags: c_ulong,
+) -> c_int {
+    libc::syscall(
+        bindings::__NR_perf_event_open as libc::c_long,
+        attrs as *const bindings::perf_event_attr,
+        pid,
+        cpu,
+        group_fd,
+        flags,
+    ) as c_int
+}
+
+pub mod bindings {
+    include!(concat!(env!("OUT_DIR"), "/perf_bindings.rs"));
+}
+
+pub mod ioctls {
+    use crate::perf;
+    use std::os::raw::{c_int, c_uint};
+
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn enable(fd: c_int, arg: c_uint) -> c_int {
+        libc::ioctl(fd, perf::bindings::ENABLE.into(), arg)
+    }
+
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn reset(fd: c_int, arg: c_uint) -> c_int {
+        libc::ioctl(fd, perf::bindings::ENABLE.into(), arg)
+    }
+}

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -33,7 +33,6 @@ libbpf-rs = "=0.25.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 num-format = { version = "0.4.3", features = ["with-serde", "with-system-locale"] }
-perf-event-open-sys2 = "5.0.6"
 plain = "0.2.3"
 prost = "0.13.5"
 rand = "0.8.5"


### PR DESCRIPTION
This PR adds a perf module to scx_utils that uses the bindgen crate to generate the bindings for perf_event_open syscall.

This replaces the use of perf-event-open-sys2 crate in scxtop in order to be more portable.