### PR TITLE
scxtop: attach dsq bpf programs on kernels < 6.13

### DIFF
--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -76,7 +76,7 @@ fn attach_progs(skel: &mut BpfSkel) -> Result<Vec<Link>> {
     ];
 
     // 6.13 compatibility
-    if compat::ksym_exists("scx_insert_vtime").is_ok() {
+    if compat::ksym_exists("scx_insert_vtime")? {
         if let Ok(link) = skel.progs.scx_insert_vtime.attach() {
             links.push(link);
         }


### PR DESCRIPTION
On kernsl < 6.13, scxtop isn't attaching bpf programs that capture dsq information and therefore isn't capturing any dsq related information. `ksym_attach` returns a Result which is always Ok() and therefore the `is_ok()` used in the current implementation meant that we always went down the 6.13 path, regardless of version.

On a 6.9 based system we previously capture no dsq information and this is demonstrated by the lack of counter tracks created. We should create a number of tracks including one for each dsq to store latency information but we only see one (for the invalid dsq - 0 ):

```
$ ./trace_processor ./scxtop.out.nodsq
> select count(*) from counter_track where name like '%latency ns%';
count(*)
--------------------
                   1
```

With the fix we se a lot of tracks created:

```
$ ./trace_processor ./scxtop.out
> select count(*) from counter_track where name like '%latency ns%';
count(*)
--------------------
                  46
```
