### PR TITLE
layered: add flag to check hi dsq before dispatch

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -53,6 +53,8 @@ const volatile u64 lo_fb_wait_ns = 5000000;	/* !0 for veristat */
 const volatile u32 lo_fb_share_ppk = 128;	/* !0 for veristat */
 const volatile bool percpu_kthread_preempt = true;
 
+const volatile bool check_hi_before_dispatch = false;
+
 /* Flag to enable or disable antistall feature */
 const volatile bool enable_antistall = true;
 const volatile bool enable_gpu_support = false;
@@ -1802,7 +1804,8 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 		return;
 
 	/* always consume hi_fb_dsq_id first for kthreads */
-	if (scx_bpf_dsq_move_to_local(cpuc->hi_fb_dsq_id))
+	if ((!check_hi_before_dispatch || (scx_bpf_dsq_nr_queued(cpuc->hi_fb_dsq_id) != 0)) &&
+		scx_bpf_dsq_move_to_local(cpuc->hi_fb_dsq_id))
 		return;
 
 	/*

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -582,6 +582,11 @@ struct Opts {
     #[clap(long, default_value = "false")]
     disable_antistall: bool,
 
+    /// check hi dsq has queued tasks before attempting to
+    /// dispatch it.
+    #[clap(long, default_value = "false")]
+    check_hi_before_dispatch: bool,
+    
     /// Maximum task runnable_at delay (in seconds) before antistall turns on
     #[clap(long, default_value = "3")]
     antistall_sec: u64,
@@ -1829,6 +1834,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.lo_fb_wait_ns = opts.lo_fb_wait_us * 1000;
         skel.maps.rodata_data.lo_fb_share_ppk = ((opts.lo_fb_share * 1024.0) as u32).clamp(1, 1024);
         skel.maps.rodata_data.enable_antistall = !opts.disable_antistall;
+        skel.maps.rodata_data.check_hi_before_dispatch = opts.check_hi_before_dispatch;
         skel.maps.rodata_data.enable_gpu_support = opts.enable_gpu_support;
 
         for (cpu, sib) in topo.sibling_cpus().iter().enumerate() {


### PR DESCRIPTION
add flag `--check-hi-before-dispatch` to check that the high fallback dsq does not have 0 tasks in it before dispatching it, default to current behavior.