### PR TITLE
rust: set lto to thin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = ["rust/scx_stats",
 resolver = "2"
 
 [profile.release]
-lto = true
+lto = "thin"
 
 [profile.release-fast]
 inherits = "release"


### PR DESCRIPTION
rust: set lto to thin.

This is what (afaik) most folks use for LTO AFAIK because it's mostly the same as LTO but scales better/is way faster.

This reduces local `--release` warm-cache build times for me for layered when editing main.bpf.c from 20 seconds to 4 seconds.

This also reduces local clean-build `--release` builds from 88 seconds to 50 seconds.