### PR TITLE
scheds/c: Validate CPU count from libbpf

### DIFF
--- a/scheds/c/scx_central.c
+++ b/scheds/c/scx_central.c
@@ -61,6 +61,7 @@ restart:
 	skel->rodata->nr_cpu_ids = libbpf_num_possible_cpus();
 	skel->rodata->slice_ns = __COMPAT_ENUM_OR_ZERO("scx_public_consts", "SCX_SLICE_DFL");
 
+	assert(skel->rodata->nr_cpu_ids > 0);
 	assert(skel->rodata->nr_cpu_ids <= INT32_MAX);
 
 	while ((opt = getopt(argc, argv, "s:c:pvh")) != -1) {

--- a/scheds/c/scx_flatcg.c
+++ b/scheds/c/scx_flatcg.c
@@ -6,6 +6,7 @@
  */
 #include <stdio.h>
 #include <signal.h>
+#include <assert.h>
 #include <unistd.h>
 #include <libgen.h>
 #include <limits.h>
@@ -137,6 +138,7 @@ restart:
 	skel = SCX_OPS_OPEN(flatcg_ops, scx_flatcg);
 
 	skel->rodata->nr_cpus = libbpf_num_possible_cpus();
+	assert(skel->rodata->nr_cpus > 0);
 	skel->rodata->cgrp_slice_ns = __COMPAT_ENUM_OR_ZERO("scx_public_consts", "SCX_SLICE_DFL");
 
 	while ((opt = getopt(argc, argv, "s:i:dfvh")) != -1) {

--- a/scheds/c/scx_nest.c
+++ b/scheds/c/scx_nest.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <inttypes.h>
 #include <signal.h>
+#include <assert.h>
 #include <libgen.h>
 #include <bpf/bpf.h>
 #include <scx/common.h>
@@ -66,6 +67,7 @@ static struct nest_stat nest_stats[NEST_STAT(NR)] = {
 static void read_stats(struct scx_nest *skel, u64 *stats)
 {
 	int nr_cpus = libbpf_num_possible_cpus();
+	assert(nr_cpus > 0);
 	u64 cnts[NEST_STAT(NR)][nr_cpus];
 	u32 idx;
 
@@ -170,6 +172,7 @@ restart:
 	skel = SCX_OPS_OPEN(nest_ops, scx_nest);
 
 	skel->rodata->nr_cpus = libbpf_num_possible_cpus();
+	assert(skel->rodata->nr_cpus > 0);
 	skel->rodata->sampling_cadence_ns = SAMPLING_CADENCE_S * 1000 * 1000 * 1000;
 	skel->rodata->slice_ns = __COMPAT_ENUM_OR_ZERO("scx_public_consts", "SCX_SLICE_DFL");
 

--- a/scheds/c/scx_pair.c
+++ b/scheds/c/scx_pair.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <inttypes.h>
 #include <signal.h>
+#include <assert.h>
 #include <libgen.h>
 #include <bpf/bpf.h>
 #include <scx/common.h>
@@ -55,6 +56,7 @@ restart:
 	skel = SCX_OPS_OPEN(pair_ops, scx_pair);
 
 	skel->rodata->nr_cpu_ids = libbpf_num_possible_cpus();
+	assert(skel->rodata->nr_cpu_ids > 0);
 	skel->rodata->pair_batch_dur_ns = __COMPAT_ENUM_OR_ZERO("scx_public_consts", "SCX_SLICE_DFL");
 
 	/* pair up the earlier half to the latter by default, override with -s */

--- a/scheds/c/scx_prev.c
+++ b/scheds/c/scx_prev.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <signal.h>
+#include <assert.h>
 #include <libgen.h>
 #include <bpf/bpf.h>
 #include <scx/common.h>
@@ -43,6 +44,7 @@ static void sigint_handler(int unused)
 static void read_stats(struct scx_prev *skel, __u64 *stats)
 {
 	int nr_cpus = libbpf_num_possible_cpus();
+	assert(nr_cpus > 0);
 	__u64 cnts[4][nr_cpus];
 	__u32 idx;
 

--- a/scheds/c/scx_simple.c
+++ b/scheds/c/scx_simple.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <signal.h>
+#include <assert.h>
 #include <libgen.h>
 #include <bpf/bpf.h>
 #include <scx/common.h>
@@ -41,6 +42,7 @@ static void sigint_handler(int simple)
 static void read_stats(struct scx_simple *skel, __u64 *stats)
 {
 	int nr_cpus = libbpf_num_possible_cpus();
+	assert(nr_cpus > 0);
 	__u64 cnts[2][nr_cpus];
 	__u32 idx;
 


### PR DESCRIPTION
Ensure the return value of `libbpf_num_possible_cpus()` is positive before use. This avoids undefined behavior when the function fails and returns zero or a negative error code.

Ref : https://docs.ebpf.io/ebpf-library/libbpf/userspace/libbpf_num_possible_cpus/

I believe the Rust-based schedulers might also be affected by the same issue. If this patch is helpful, I’d be happy to send a follow-up patch to add a similar check in the Rust version as well.