### PR TITLE
ci: track 6.12 lts kernel and test it 6-hourly

### DIFF
--- a/.github/workflows/6_12.yml
+++ b/.github/workflows/6_12.yml
@@ -1,0 +1,36 @@
+name: 6_12-test
+
+on:
+  # only runs on main, every 6 hours. specify hours explicitly so scheduled runs can be offset and use a random minute.
+  schedule:
+    - cron: "46 1,7,13,19 * * *"
+
+jobs:
+  build-kernel:
+    uses: ./.github/workflows/build-kernel.yml
+    with:
+      repo-name: stable/6_12
+
+  integration-test:
+    uses: ./.github/workflows/integration-tests.yml
+    needs: build-kernel
+    with:
+      repo-name: stable/6_12
+
+  notify-job:
+    runs-on: ubuntu-latest
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    needs:
+      - integration-test
+    steps:
+    - uses: actions/checkout@v2
+    - name: Slack Notification
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_USERNAME: ci
+        SLACK_ICON: https://www.dictionary.com/e/wp-content/uploads/2018/03/thisisfine-1.jpg
+        SLACK_TITLE: Workflow failed
+        SLACK_MESSAGE: 6.12 ci job failed.
+        SLACK_COLOR: failure
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+

--- a/kernel-versions.json
+++ b/kernel-versions.json
@@ -15,6 +15,14 @@
     "narHash": "sha256-wBhng0fVnekeChWGFkOU73Q6cEWRFjGYpMkKzpge71A=",
     "kernelVersion": "6.15.0-rc3"
   },
+  "stable/6_12": {
+    "repo": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-6.12.y",
+    "commitHash": "ef4999852d307d38cfdecd91ed6892cc03beb9b8",
+    "lastModified": 1745573568,
+    "narHash": "sha256-rpjKq+QXwe9vJ5P0VZ/DR8wj2G+uiuwQzr6GbwVOROo=",
+    "kernelVersion": "6.12.25"
+  },
   "stable/linux-rolling-stable": {
     "repo": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
     "branch": "linux-rolling-stable",


### PR DESCRIPTION
6.12 is LTS and has several incompatibilities with 6.13+. Add it to the CI tests, 6-hourly for now.

Test plan:
- CI
- Ran separately with `push:` enabled, it worked.