### PR TITLE
scx_p2dq: Update slice accounting

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -856,7 +856,6 @@ void BPF_STRUCT_OPS(p2dq_running, struct task_struct *p)
 		stat_inc(P2DQ_STAT_NODE_MIGRATION);
 	}
 
-	taskc->last_run_at = scx_bpf_now();
 	taskc->llc_id = llcx->id;
 	taskc->node_id = llcx->node_id;
 	cpuc->dsq_index = taskc->dsq_index;
@@ -873,6 +872,7 @@ void BPF_STRUCT_OPS(p2dq_running, struct task_struct *p)
 	if (taskc->dsq_index == nr_dsqs_per_llc-1) {
 		scx_bpf_cpuperf_set(task_cpu, SCX_CPUPERF_ONE);
 	}
+	taskc->last_run_at = bpf_ktime_get_ns();
 }
 
 
@@ -881,7 +881,7 @@ void BPF_STRUCT_OPS(p2dq_stopping, struct task_struct *p, bool runnable)
 	task_ctx *taskc;
 	struct llc_ctx *llcx;
 	u64 used, scaled_used, last_dsq_slice_ns;
-	u64 now = scx_bpf_now();
+	u64 now = bpf_ktime_get_ns();
 
 	if (!(taskc = lookup_task_ctx(p)))
 		return;


### PR DESCRIPTION
Update slice accounting to use bpf_ktime_get_ns for more accuracy. Using scx_bpf_now would sometimes result in accounted slices being longer than the possible time slice.


Existing code:
```
           grep-283681  [057] d...1 614524.030640: bpf_trace_printk: grep used 92011 scaled_used 92011  slice 100000
  kworker/u712:0-4018953 [057] d...1 614524.030644: bpf_trace_printk: kworker/u712:0 used 1793 scaled_used 1793  slice 100000
 GlobalCPUThread-277560  [021] d...1 614524.031123: bpf_trace_printk: GlobalCPUThread used 42745 scaled_used 42745  slice 100000
         bpftool-283683  [059] dN..1 614524.031168: bpf_trace_printk: bpftool used 526956 scaled_used 526956  slice 3200000
            grep-283681  [057] d...1 614524.031201: bpf_trace_printk: grep used 45760 scaled_used 45760  slice 3200000
 sched_ext_ops_h-1385654 [040] d...1 614524.031445: bpf_trace_printk: bpftool used 273538 scaled_used 273538  slice 100000
 ```