### PR TITLE
scx_rustland_core: Support queued wakeups

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -249,7 +249,12 @@ impl<'cb> BpfScheduler<'cb> {
         let topo = Topology::new().unwrap();
         skel.maps.rodata_data.smt_enabled = topo.smt_enabled;
 
-        // Set scheduler options (defined in the BPF part).
+        // Set scheduler options.
+        skel.struct_ops.rustland_mut().flags = 0
+            | *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP
+            | *compat::SCX_OPS_ENQ_MIGRATION_DISABLED
+            | *compat::SCX_OPS_ENQ_LAST
+            | *compat::SCX_OPS_KEEP_BUILTIN_IDLE;
         if partial {
             skel.struct_ops.rustland_mut().flags |= *compat::SCX_OPS_SWITCH_PARTIAL;
         }


### PR DESCRIPTION
Queued wakeup (ttwu_queue) is a wakeup optimization that invokes ops.enqueue() via IPI to reduce cacheline transfers,

Enable this optimization and properly support queued wakeup tasks in ops.enqueue().

While at it also enable ops.enqueue() for migration-disabled tasks and move all the scheduler's flags in the Rust part of the code for consistency.