### PR TITLE
scxtop: Add default perf event configuration

### DIFF
--- a/rust/scx_utils/src/perf.rs
+++ b/rust/scx_utils/src/perf.rs
@@ -57,6 +57,6 @@ pub mod ioctls {
 
     #[allow(clippy::missing_safety_doc)]
     pub unsafe fn reset(fd: c_int, arg: c_uint) -> c_int {
-        unsafe { libc::ioctl(fd, perf::bindings::ENABLE.into(), arg) }
+        unsafe { libc::ioctl(fd, perf::bindings::RESET.into(), arg) }
     }
 }

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -31,7 +31,7 @@ use crate::{
     TraceStoppedAction,
 };
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use glob::glob;
 use libbpf_rs::Link;
 use libbpf_rs::ProgramInput;

--- a/tools/scxtop/src/cli.rs
+++ b/tools/scxtop/src/cli.rs
@@ -64,6 +64,9 @@ pub struct TuiArgs {
     /// Custom perf events colon delimited (ex: "<event_name>:<event and umask ex: 0x023>:<event_type ex: 4>")
     #[arg(long)]
     pub perf_events: Vec<String>,
+    /// Default perf event colon delimited (ex: "<event_name>:<event and umask ex: 0x023>:<event_type ex: 4>")
+    #[arg(long, default_value = "hw:cycles")]
+    pub default_perf_event: String,
 
     /// Automatically start a trace when a function takes too long to return.
     #[arg(

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -92,6 +92,8 @@ pub struct Config {
     trace_tick_warmup: Option<usize>,
     /// Duration to warmup a trace before collecting in ms.
     trace_warmup_ms: Option<u64>,
+    /// Default perf event
+    default_perf_event: Option<String>,
 }
 
 impl From<TuiArgs> for Config {
@@ -111,6 +113,7 @@ impl From<TuiArgs> for Config {
             trace_ticks: args.trace_ticks,
             trace_duration_ms: args.trace_duration_ms,
             worker_threads: args.worker_threads,
+            default_perf_event: Some(args.default_perf_event),
         }
     }
 }
@@ -152,6 +155,7 @@ impl Config {
             worker_threads: self.worker_threads.or(rhs.worker_threads),
             trace_tick_warmup: self.trace_tick_warmup.or(rhs.trace_tick_warmup),
             trace_warmup_ms: self.trace_warmup_ms.or(rhs.trace_warmup_ms),
+            default_perf_event: self.default_perf_event.or(rhs.default_perf_event),
         }
     }
 
@@ -217,6 +221,13 @@ impl Config {
         self.worker_threads.unwrap_or(4)
     }
 
+    /// Default perf event
+    pub fn default_perf_event(&self) -> String {
+        self.default_perf_event
+            .clone()
+            .unwrap_or("hw:cycles".to_string())
+    }
+
     /// Duration to warmup a trace before collecting in ns.
     pub fn trace_warmup_ns(&self) -> u64 {
         self.trace_warmup_ms
@@ -244,6 +255,7 @@ impl Config {
             worker_threads: None,
             trace_tick_warmup: None,
             trace_warmup_ms: None,
+            default_perf_event: None,
         }
     }
 
@@ -264,6 +276,7 @@ impl Config {
             worker_threads: None,
             trace_tick_warmup: None,
             trace_warmup_ms: None,
+            default_perf_event: None,
         };
         config.tick_rate_ms = Some(config.tick_rate_ms());
         config.debug = Some(config.debug());

--- a/tools/scxtop/src/perf_event.rs
+++ b/tools/scxtop/src/perf_event.rs
@@ -133,6 +133,8 @@ impl PerfEvent {
     /// Returns the set of default software events.
     pub fn default_sw_events() -> Vec<PerfEvent> {
         vec![
+            PerfEvent::new("sw".to_string(), "cpu-clock".to_string(), 0),
+            PerfEvent::new("sw".to_string(), "task-clock".to_string(), 0),
             PerfEvent::new("sw".to_string(), "context-switches".to_string(), 0),
             PerfEvent::new("sw".to_string(), "page-faults".to_string(), 0),
             PerfEvent::new("sw".to_string(), "minor-faults".to_string(), 0),
@@ -212,6 +214,12 @@ impl PerfEvent {
                 match self.event.to_lowercase().as_str() {
                     "cs" | "context-switches" => {
                         attrs.config = perf::bindings::PERF_COUNT_SW_CONTEXT_SWITCHES as u64;
+                    }
+                    "cpu-clock" => {
+                        attrs.config = perf::bindings::PERF_COUNT_SW_CPU_CLOCK as u64;
+                    }
+                    "task-clock" => {
+                        attrs.config = perf::bindings::PERF_COUNT_SW_TASK_CLOCK as u64;
                     }
                     "page-faults" | "faults" => {
                         attrs.config = perf::bindings::PERF_COUNT_SW_PAGE_FAULTS as u64;


### PR DESCRIPTION
Add configuration for setting the default perf event from either the CLI or config file.

```
$ ./target/release/scxtop --default-perf-event sw:task-clock
```
![2025-04-25-19:37:43](https://github.com/user-attachments/assets/f5116aa3-d6d9-4bba-bd50-bb9d9464e901)
