### PR TITLE
scx_bpfland: Remove extra call to scx_bpf_now

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -1172,7 +1172,7 @@ void BPF_STRUCT_OPS(bpfland_stopping, struct task_struct *p, bool runnable)
 	/*
 	 * Evaluate the time slice used by the task.
 	 */
-	slice = scx_bpf_now() - tctx->last_run_at;
+	slice = now - tctx->last_run_at;
 
 	/*
 	 * Update task's execution time (exec_runtime), but never account


### PR DESCRIPTION
Remove extra call to `scx_bpf_now` as `now` is already initialized in stopping.