### PR TITLE
add cargo fmt git hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "Running cargo fmt..."
+cargo fmt --all
+
+# Stage any files modified by cargo fmt
+git add $(git diff --name-only)
+
+exit 0
+


### PR DESCRIPTION
Add a git hook to format files like how ci does before committing (i.e. to remove fmt from the list of things everyone needs to care about etc.).

This is enable-able for folks's clones/forks via the following command:
```
git config core.hooksPath .githooks
```
