### PR TITLE
scx_rustland_core: Reduce overhead and maximize CPU utilization

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -861,10 +861,8 @@ void BPF_STRUCT_OPS(rustland_dispatch, s32 cpu, struct task_struct *prev)
 	 * No more tasks to process, check if we need to keep the CPU alive to
 	 * process pending tasks from the user-space scheduler.
 	 */
-	if (dispatch_user_scheduler()) {
+	if (dispatch_user_scheduler())
 		scx_bpf_dsq_move_to_local(SHARED_DSQ);
-		scx_bpf_kick_cpu(cpu, 0);
-	}
 }
 
 void BPF_STRUCT_OPS(rustland_runnable, struct task_struct *p, u64 enq_flags)
@@ -948,15 +946,6 @@ void BPF_STRUCT_OPS(rustland_update_idle, s32 cpu, bool idle)
 		 * Wake up the idle CPU and trigger a resched, so that it can
 		 * immediately accept dispatched tasks.
 		 */
-		scx_bpf_kick_cpu(cpu, 0);
-		return;
-	}
-
-	/*
-	 * Kick the CPU if there are still tasks dispatched to the
-	 * corresponding per-CPU DSQ.
-	 */
-	if (scx_bpf_dsq_nr_queued(cpu_to_dsq(cpu)) > 0) {
 		scx_bpf_kick_cpu(cpu, 0);
 		return;
 	}

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -785,6 +785,18 @@ static bool dispatch_user_scheduler(void)
 {
 	struct task_struct *p;
 
+	/*
+	 * If there are pending tasks, mark that user-space scheduling is
+	 * needed.
+	 */
+	if (usersched_has_pending_tasks())
+		set_usersched_needed();
+
+	/*
+	 * Prevent a burst of duplicate dispatches across all the CPUs,
+	 * allowing only the first one to dispatch the user-space
+	 * scheduler.
+	 */
 	if (!test_and_clear_usersched_needed())
 		return false;
 


### PR DESCRIPTION
A set of improvements to reduce unnecessary overhead in scx_rustland_core and maximize CPU utilization.

With these changes, scx_rustland achieves nearly the same performance as scx_bpfland (except under extreme system overload) and it seems to remain stable and stall-free across all the stress test scenarios I conducted.