### PR TITLE
Revert "scx_rustland_core: Maximize CPU utilization"

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -785,18 +785,6 @@ static bool dispatch_user_scheduler(void)
 {
 	struct task_struct *p;
 
-	/*
-	 * If there are pending tasks, mark that user-space scheduling is
-	 * needed.
-	 */
-	if (usersched_has_pending_tasks())
-		set_usersched_needed();
-
-	/*
-	 * Prevent a burst of duplicate dispatches across all the CPUs,
-	 * allowing only the first one to dispatch the user-space
-	 * scheduler.
-	 */
 	if (!test_and_clear_usersched_needed())
 		return false;
 


### PR DESCRIPTION
Commit c688b10b ("scx_rustland_core: Maximize CPU utilization") can increase CPU utilization with some topologies, but in systems with many CPUs it can significantly degrade performance.

Revert this commit for now to prevent big performance regressions on large systems.