### PR TITLE
scx_rlfifo: Fix CPU assignment logic

### DIFF
--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -128,7 +128,7 @@ impl<'a> Scheduler<'a> {
             //
             // If we can't find any idle CPU, keep the task running on the same CPU.
             let cpu = self.bpf.select_cpu(task.pid, task.cpu, task.flags);
-            dispatched_task.cpu = if cpu < 0 { task.cpu } else { RL_CPU_ANY };
+            dispatched_task.cpu = if cpu >= 0 { cpu } else { task.cpu };
 
             // Determine the task's time slice: assign value inversely proportional to the number
             // of tasks waiting to be scheduled.


### PR DESCRIPTION
When an idle CPU is selected via `select_cpu()`, assign it directly instead of falling back to `RL_CPU_ANY`. If no idle CPU is available, keep the task running on its previous CPU.

This change makes the CPU assignment logic consistent with the comment description and ensures more deterministic scheduling behavior.