### PR TITLE
ci.py: remove nix dependency from path and add experimental features flag

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -53,7 +53,10 @@ def run_format():
 
     run_command(["cargo", "fmt"])
 
-    run_command(["nix", "fmt"], cwd=".github/include")
+    run_command(
+        ["nix", "--extra-experimental-features", "nix-command flakes", "fmt"],
+        cwd=".github/include",
+    )
 
     run_command(["git", "diff", "--exit-code"])
     print("✓ Format completed successfully", flush=True)

--- a/.github/include/flake.nix
+++ b/.github/include/flake.nix
@@ -91,7 +91,6 @@
                   jq
                   llvmPackages.libclang
                   llvmPackages.libllvm
-                  nix
                   pkg-config
                   protobuf
                   rustc


### PR DESCRIPTION
ci.py has its dependencies managed with Nix. Turns out managing Nix with Nix was a bad idea (who would have thought). If this version differs from your system version it causes a hang on the `nix fmt` step. It's fine in the CI but has issues locally.

Drop the `nix` dependency from the Nix wrapper. This didn't help anyway: you either ran the script with Nix and thus already have Nix, or you didn't and this doesn't help. Also add the
`"--extra-experimental-features 'nix-command flakes'` nonsense so this works on more systems.

Test plan:
- Locally. Works now on my machine.
- CI. Still works.