### PR TITLE
scx_rustland: Update doc and default settings

### DIFF
--- a/scheds/rust/scx_rustland/README.md
+++ b/scheds/rust/scx_rustland/README.md
@@ -4,9 +4,9 @@ This is a single user-defined scheduler used within [sched_ext](https://github.c
 
 ## Overview
 
-scx_rustland is made of a BPF component (scx_rustland_core) that implements the
-low level sched-ext functionalities and a user-space counterpart (scheduler),
-written in Rust, that implements the actual scheduling policy.
+scx_rustland is based on scx_rustland_core, a BPF component that abstracts
+the low-level sched_ext functionalities. The actual scheduling policy is
+entirely implemented in user space and it is written in Rust.
 
 ## How To Install
 
@@ -25,9 +25,9 @@ implemented in Rust.
 
 ## Production Ready?
 
-Not quite. For production scenarios, other schedulers are likely to exhibit
-better performance, as offloading all scheduling decisions to user-space comes
-with a certain cost.
+For performance-critical production scenarios, other schedulers are likely
+to exhibit better performance, as offloading all scheduling decisions to
+user-space comes with a certain cost (even if it's minimal).
 
 However, a scheduler entirely implemented in user-space holds the potential for
 seamless integration with sophisticated libraries, tracing tools, external

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -74,11 +74,11 @@ const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 #[derive(Debug, Parser)]
 struct Opts {
     /// Scheduling slice duration in microseconds.
-    #[clap(short = 's', long, default_value = "5000")]
+    #[clap(short = 's', long, default_value = "20000")]
     slice_us: u64,
 
     /// Scheduling minimum slice duration in microseconds.
-    #[clap(short = 'S', long, default_value = "500")]
+    #[clap(short = 'S', long, default_value = "1000")]
     slice_us_min: u64,
 
     /// If specified, only tasks which have their scheduling policy set to SCHED_EXT using

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -42,24 +42,26 @@ const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 /// scx_rustland is also designed to be an "easy to read" template that can be used by any
 /// developer to quickly experiment more complex scheduling policies fully implemented in Rust.
 ///
-/// The scheduler is made of a BPF component (scx_rustland_core) that implements the low level
-/// sched-ext functionalities and a user-space counterpart (scheduler), written in Rust, that
-/// implements the actual scheduling policy.
+/// The scheduler is based on scx_rustland_core, which implements the low level sched-ext
+/// functionalities.
 ///
-/// The default scheduling policy implemented in the user-space scheduler is a based on virtual
-/// runtime (vruntime):
+/// The scheduling policy implemented in user-space is a based on a deadline, evaluated as
+/// following:
 ///
-/// - each task receives the same time slice of execution (slice_ns)
+///       deadline = vruntime + exec_runtime
 ///
-/// - the actual execution time, adjusted based on the task's static priority (weight), determines
-///   the vruntime
+/// Where, vruntime reflects the task's total runtime scaled by weight (ensuring fairness), while
+/// exec_runtime accounts the CPU time used since the last sleep (capturing responsiveness). Tasks
+/// are then dispatched from the lowest to the highest deadline.
 ///
-/// - tasks are then dispatched from the lowest to the highest vruntime
+/// This approach favors latency-sensitive tasks: those that frequently sleep will accumulate less
+/// exec_runtime, resulting in earlier deadlines. In contrast, CPU-intensive tasks that don’t sleep
+/// accumulate a larger exec_runtime and thus get scheduled later.
 ///
-/// All the tasks are stored in a BTreeSet (TaskTree), using vruntime as the ordering key.
-/// Once the order of execution is determined all tasks are sent back to the BPF counterpart to be
-/// dispatched. To keep track of the accumulated cputime and vruntime the scheduler maintain a
-/// HashMap (TaskInfoMap) indexed by pid.
+/// All the tasks are stored in a BTreeSet (TaskTree), using the deadline as the ordering key.
+/// Once the order of execution is determined all tasks are sent back to the BPF counterpart
+/// (scx_rustland_core) to be dispatched. To keep track of the accumulated execution time and
+/// vruntime, the scheduler maintains a HashMap (TaskInfoMap), indexed by pid.
 ///
 /// The BPF dispatcher is completely agnostic of the particular scheduling policy implemented in
 /// user-space. For this reason developers that are willing to use this scheduler to experiment
@@ -68,8 +70,7 @@ const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 ///
 /// === Troubleshooting ===
 ///
-/// - Reduce the time slice (option `-s`) if you experience audio issues (i.e., cracking audio or
-///   audio packet loss).
+/// - Reduce the time slice (option `-s`) if you experience lag or cracking audio.
 ///
 #[derive(Debug, Parser)]
 struct Opts {


### PR DESCRIPTION
With rustland now aligned to a scheduling policy similar to bpfland, update the default time slice settings and the scheduler's documentation to reflect the new design.