### PR TITLE
scx_rlfifo: Clarify Round-Robin scheduling

### DIFF
--- a/scheds/rust/scx_rlfifo/README.md
+++ b/scheds/rust/scx_rlfifo/README.md
@@ -4,8 +4,10 @@ This is a single user-defined scheduler used within [sched_ext](https://github.c
 
 ## Overview
 
-scx_rlfifo is a simple FIFO scheduler runs in user-space, based on the
+scx_rlfifo is a simple Round-Robin scheduler runs in user-space, based on the
 scx_rustland_core framework.
+It dequeues tasks in FIFO order and assigns dynamic time slices, preempting and
+re-enqueuing tasks to achieve basic Round-Robin behavior.
 
 ## Typical Use Case
 

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -3,12 +3,15 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
-//! # FIFO Linux kernel scheduler that runs in user-space
+//! # Round-Robin Linux kernel scheduler that runs in user-space
 //!
 //! ## Overview
 //!
-//! This is a fully functional FIFO scheduler for the Linux kernel that operates in user-space and
-//! it is 100% implemented in Rust.
+//! This is a fully functional Round-Robin scheduler for the Linux kernel that operates
+//! in user-space and it is 100% implemented in Rust.
+//!
+//! It dequeues tasks in FIFO order and assigns dynamic time slices, preempting and
+//! re-enqueuing tasks to achieve basic Round-Robin behavior.
 //!
 //! The scheduler is designed to serve as a simple template for developers looking to implement
 //! more advanced scheduling policies.


### PR DESCRIPTION
Update both README and source file to clarify that scx_rlfifo implements a simple Round-Robin scheduler rather than pure FIFO.

Tasks are dequeued in FIFO order but assigned dynamic time slices, enabling preemption and re-enqueueing to achieve Round-Robin execution.