### PR TITLE
scx_rustland_core: Move mandatory scheduler options to BPF

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -249,12 +249,9 @@ impl<'cb> BpfScheduler<'cb> {
         let topo = Topology::new().unwrap();
         skel.maps.rodata_data.smt_enabled = topo.smt_enabled;
 
-        // Set scheduler options.
-        skel.struct_ops.rustland_mut().flags = 0
-            | *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP
-            | *compat::SCX_OPS_ENQ_MIGRATION_DISABLED
-            | *compat::SCX_OPS_ENQ_LAST
-            | *compat::SCX_OPS_KEEP_BUILTIN_IDLE;
+        // Enable optional scheduler settings.
+        skel.struct_ops.rustland_mut().flags |=
+            *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP | *compat::SCX_OPS_ENQ_MIGRATION_DISABLED;
         if partial {
             skel.struct_ops.rustland_mut().flags |= *compat::SCX_OPS_SWITCH_PARTIAL;
         }

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -1297,6 +1297,7 @@ SCX_OPS_DEFINE(rustland,
 	       .init_task		= (void *)rustland_init_task,
 	       .init			= (void *)rustland_init,
 	       .exit			= (void *)rustland_exit,
+	       .flags			= SCX_OPS_KEEP_BUILTIN_IDLE | SCX_OPS_ENQ_LAST,
 	       .timeout_ms		= 5000,
 	       .dispatch_max_batch	= MAX_DISPATCH_SLOT,
 	       .name			= "rustland");


### PR DESCRIPTION
SCX_OPS_KEEP_BUILTIN_IDLE and SCX_OPS_ENQ_LAST are strictly required for scx_rustland_core to function correctly. Without them, the framework may behave incorrectly, potentially leading to runtime errors or stalls.

To ensure these options are always defined, move them to BPF, instead of relying on the compat APIs. In this way, any missing definitions will result in a build-time error rather than runtime failures.