### PR TITLE
layered: add suffix matcher

### DIFF
--- a/scheds/rust/scx_layered/examples/prefix_suffix.json
+++ b/scheds/rust/scx_layered/examples/prefix_suffix.json
@@ -1,0 +1,59 @@
+[
+	{
+		"name": "match one container",
+		"matches": [
+			[
+				{ "CgroupPrefix": "system.slice/docker" },
+				{ "CgroupSuffix": "11df.scope/" }
+			]
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range_frac":  [0.25, 0.5],
+				"util_range": [0.4, 0.85],
+				"growth_algo": "RandomTopo",
+				"disallow_preempt_after_us": 0,
+				"protected": true
+			}
+		}
+	},
+	{
+		"name": "match other containers",
+		"matches": [
+			[{ "CgroupPrefix": "system.slice/docker" }]
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range_frac":  [0.5, 0.5],
+				"util_range": [0.4, 0.85],
+				"growth_algo": "RandomTopo",
+				"protected": true
+			}
+		}
+	},
+	{
+		"name": "third",
+		"matches": [
+			[{ "PcommPrefix": "stress-ng" }]
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range":  [5, 5],
+				"util_range": [0.4, 0.85],
+				"growth_algo": "RandomTopo",
+				"protected": true
+			}
+		}
+	},
+	{
+		"name": "fourth",
+		"matches": [
+			[]
+		],
+		"kind": {
+			"Open": {
+				"growth_algo": "RandomTopo"
+			}
+		}
+	}
+]

--- a/scheds/rust/scx_layered/examples/prefix_suffix.json
+++ b/scheds/rust/scx_layered/examples/prefix_suffix.json
@@ -4,7 +4,7 @@
 		"matches": [
 			[
 				{ "CgroupPrefix": "system.slice/docker" },
-				{ "CgroupSuffix": "21f.scope/" }
+				{ "CgroupSuffix": "f.scope/" }
 			]
 		],
 		"kind": {

--- a/scheds/rust/scx_layered/examples/prefix_suffix.json
+++ b/scheds/rust/scx_layered/examples/prefix_suffix.json
@@ -4,7 +4,7 @@
 		"matches": [
 			[
 				{ "CgroupPrefix": "system.slice/docker" },
-				{ "CgroupSuffix": "11df.scope/" }
+				{ "CgroupSuffix": "21f.scope/" }
 			]
 		],
 		"kind": {

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -249,6 +249,7 @@ enum layer_match_kind {
 	MATCH_IS_KTHREAD,
 	MATCH_USED_GPU_TID,
 	MATCH_USED_GPU_PID,
+	MATCH_CGROUP_SUFFIX,
 
 	NR_LAYER_MATCH_KINDS,
 };
@@ -256,6 +257,7 @@ enum layer_match_kind {
 struct layer_match {
 	int		kind;
 	char		cgroup_prefix[MAX_PATH];
+	char		cgroup_suffix[MAX_PATH];
 	char		comm_prefix[MAX_COMM];
 	char		pcomm_prefix[MAX_COMM];
 	int		nice;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1951,18 +1951,21 @@ static __noinline bool match_one(struct layer_match *match,
 
 	switch (match->kind) {
 	case MATCH_CGROUP_PREFIX: {
-		return match_prefix(match->cgroup_prefix, cgrp_path, MAX_PATH);
+		return match_prefix_suffix(match->cgroup_prefix, cgrp_path, false);
+	}
+	case MATCH_CGROUP_SUFFIX: {
+		return match_prefix_suffix(match->cgroup_suffix, cgrp_path, true);
 	}
 	case MATCH_COMM_PREFIX: {
 		char comm[MAX_COMM];
 		__builtin_memcpy(comm, p->comm, MAX_COMM);
-		return match_prefix(match->comm_prefix, comm, MAX_COMM);
+		return match_prefix_suffix(match->comm_prefix, comm, false);
 	}
 	case MATCH_PCOMM_PREFIX: {
 		char pcomm[MAX_COMM];
 
 		__builtin_memcpy(pcomm, p->group_leader->comm, MAX_COMM);
-		return match_prefix(match->pcomm_prefix, pcomm, MAX_COMM);
+		return match_prefix_suffix(match->pcomm_prefix, pcomm, false);
 	}
 	case MATCH_NICE_ABOVE:
 		return prio_to_nice((s32)p->static_prio) > match->nice;
@@ -2028,8 +2031,8 @@ static __noinline bool match_one(struct layer_match *match,
 		if (!taskc->join_layer[0])
 			return false;
 
-		return match_prefix(match->comm_prefix, taskc->join_layer,
-			SCXCMD_COMLEN);
+		return match_prefix_suffix(match->comm_prefix, taskc->join_layer,
+			false);
 	}
 	case MATCH_IS_GROUP_LEADER: {
 		// There is nuance to this around exec(2)s and group leader swaps.
@@ -3137,6 +3140,9 @@ static s32 init_layer(int layer_id)
 				break;
 			case MATCH_USED_GPU_PID:
 				dbg("%s GPU_PID %d", header, match->used_gpu_pid);
+				break;
+			case MATCH_CGROUP_SUFFIX:
+				dbg("%s CGROUP_SUFFIX \"%s\"", header, match->cgroup_suffix);
 				break;
 			default:
 				scx_bpf_error("%s Invalid kind", header);

--- a/scheds/rust/scx_layered/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/util.bpf.c
@@ -124,10 +124,12 @@ bool __noinline match_prefix_suffix(const char *prefix, const char *str, bool ma
 	if (match_suffix)
 		offset = str_len - match_str_len;
 	
-	bpf_for(c, offset, str_len) {
+	// use MAX_PATH instead of str_len for when 
+	// prefix/suffix == string.
+	bpf_for(c, offset, MAX_PATH) {
 		i = c - offset;
 
-		if ((c > str_len) || (i >= str_len) || (i < 0))
+		if ((c > MAX_PATH) || (i >= MAX_PATH) || (i < 0))
 			return false;
 
 		if (match_buf[i] == '\0')

--- a/scheds/rust/scx_layered/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/util.bpf.c
@@ -89,7 +89,7 @@ __hidden char *format_cgrp_path(struct cgroup *cgrp)
 bool __noinline match_prefix_suffix(const char *prefix, const char *str, bool match_suffix)
 {
 	u32 c, zero = 0;
-	int str_len, match_str_len, offset;
+	int str_len, match_str_len, offset, i;
 
 	if (!prefix || !str) {
 		scx_bpf_error("invalid args: %s %s",
@@ -123,19 +123,18 @@ bool __noinline match_prefix_suffix(const char *prefix, const char *str, bool ma
 
 	if (match_suffix)
 		offset = str_len - match_str_len;
-		
-	bpf_for(c, 0, MAX_PATH) {
-		c &= 0xfff;
-		
-		if ((offset + c) >= str_len)
+	
+	bpf_for(c, offset, str_len) {
+		i = c - offset;
+
+		if ((c > str_len) || (i >= str_len) || (i < 0))
 			return false;
 
-		if (match_buf[c] == '\0')
+		if (match_buf[i] == '\0')
 			return true;
 		
-		if (str_buf[offset + c] != match_buf[c])
+		if (str_buf[c] != match_buf[i])
 			return false;	
-
 	}
 	return false;
 }

--- a/scheds/rust/scx_layered/src/bpf/util.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/util.bpf.h
@@ -20,7 +20,7 @@ extern const volatile u32 debug;
 #define dbg(fmt, args...)	do { if (debug) bpf_printk(fmt, ##args); } while (0)
 #define trace(fmt, args...)	do { if (debug > 1) bpf_printk(fmt, ##args); } while (0)
 
-bool match_prefix(const char *prefix, const char *str, u32 max_len);
+bool match_prefix_suffix(const char *prefix, const char *str, bool match_suffix);
 char *format_cgrp_path(struct cgroup *cgrp);
 
 #endif /* __LAYERED_UTIL_H */

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -61,6 +61,7 @@ impl LayerSpec {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum LayerMatch {
     CgroupPrefix(String),
+    CgroupSuffix(String),
     CommPrefix(String),
     CommPrefixExclude(String),
     PcommPrefix(String),

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1217,6 +1217,10 @@ impl<'a> Scheduler<'a> {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_CGROUP_PREFIX as i32;
                             copy_into_cstr(&mut mt.cgroup_prefix, prefix.as_str());
                         }
+                        LayerMatch::CgroupSuffix(suffix) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_CGROUP_SUFFIX as i32;
+                            copy_into_cstr(&mut mt.cgroup_suffix, suffix.as_str());
+                        }
                         LayerMatch::CommPrefix(prefix) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_COMM_PREFIX as i32;
                             copy_into_cstr(&mut mt.comm_prefix, prefix.as_str());


### PR DESCRIPTION
add a cgroup matcher to match suffix of cgroup also.

I used suffix to partition layers docker containers tasks were ran on here:
![image](https://github.com/user-attachments/assets/35eaf693-e3e3-40de-935e-e2117c689327)
