### PR TITLE
ci: add timeout to integration-tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   integration-test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     strategy:
           matrix:
             scheduler: [ scx_bpfland, scx_chaos, scx_lavd, scx_layered, scx_rlfifo, scx_rustland, scx_rusty, scx_p2dq, scx_tickless ]
@@ -83,6 +84,7 @@ jobs:
 
   layered-matrix:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     strategy:
           matrix:
             scheduler: [ scx_layered ]


### PR DESCRIPTION
If there's a kernel panic sometimes vng gets stuck and runs forever, which isn't caught by our `timeout` because it's inside the VM. These take 6 hours[0] before they time out on the GitHub Runners.

These jobs take around 5 minutes. Set the timeout to 15 which is comfortable and will free up our stuck runners more quickly.

Test plan:
- CI

[0] https://github.com/sched-ext/scx/actions/runs/14750194704/job/41405669080