### PR TITLE
scx_rustland_core: Remove unnecessary CPU wakeup from rs_select_cpu()

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -663,15 +663,6 @@ int rs_select_cpu(struct task_cpu_arg *input)
 
 	bpf_task_release(p);
 
-	/*
-	 * Wake-up the CPU if idle. Use SCX_KICK_IDLE to prevent unecessary
-	 * rescheduling events in case the CPU is already awake (since we don't
-	 * know exactly what the user-space scheduler is doing we can't
-	 * implicitly assume that the target CPU is idle here).
-	 */
-	if (cpu >= 0)
-		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
-
 	return cpu;
 }
 


### PR DESCRIPTION
When a user-space scheduler selects an idle CPU via rs_select_cpu(), there's no need to immediately wake it up. At this point, the task still needs to be dispatched through the BPF code, and its exact dispatch time is unknown.

The BPF side already handles CPU wakeups proactively when a task is enqueued in a DSQ, which is more accurate and efficient than waking the CPU prematurely during selection, therefore drop the proactive wakeup from rs_select_cpu().