### PR TITLE
scx_layered: Support task hint map

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -75,6 +75,18 @@ u32 nr_empty_layer_ids;
 
 UEI_DEFINE(uei);
 
+struct task_hint {
+	u64 hint;
+	u64 __reserved[3];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_TASK_STORAGE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__type(key, int);
+	__type(value, struct task_hint);
+} scx_layered_task_hint_map SEC(".maps");
+
 static inline s32 prio_to_nice(s32 static_prio)
 {
 	/* See DEFAULT_PRIO and PRIO_TO_NICE in include/linux/sched/prio.h */


### PR DESCRIPTION
Add support for creating and pinning a 'scx_layered_task_hint_map' in bpffs so that tasks on the system can open it and update their values to add task hints. Mark the map as 666 so that all tasks are allowed to open it and write to it by default.

As a follow up, we would want to enforce access control such that a bpf_map_update_elem on this map can only happen from a task when the pidfd for the key is the same as its thread ID. This needs to be done using BPF LSM or something similar. Currently anyone who can obtain a pidfd for a task can write its hint. However, this is not something we can fix now as LSM or equivalent support in kernel is missing.

TODO: 

- [ ] Access control so tasks cannot overwrite each others value (low priority)?
- [ ] Consume the hint in `struct task_hint` to perform weighted vruntime progression.