### PR TITLE
scx_lavd: Reduce the preemption overhead and more.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -655,7 +655,7 @@ s32 pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle)
 	 * since it is busy running this code. Also, just in case the waker CPU
 	 * is in a different domain with the sticky CPU, reset sticky_cpdom.
 	 */
-	if (is_sync_waker_idle(ctx, sticky_cpu)) {
+	if (!no_wake_sync && is_sync_waker_idle(ctx, sticky_cpu)) {
 		cpu = ctx->sync_waker_cpu;
 		sticky_cpdom = -ENOENT;
 		goto unlock_out;

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -85,6 +85,7 @@ struct sys_stat {
 	u32	nr_active;	/* number of active cores */
 
 	u64	nr_sched;	/* total scheduling so far */
+	u64	nr_preempt;	/* total number of preemption operations triggered */
 	u64	nr_perf_cri;	/* number of performance-critical tasks scheduled */
 	u64	nr_lat_cri;	/* number of latency-critical tasks scheduled */
 	u64	nr_x_migration; /* number of cross domain migration */

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -149,6 +149,7 @@ struct cpu_ctx {
 	/*
 	 * Information for statistics.
 	 */
+	volatile u32	nr_preempt;
 	volatile u32	nr_x_migration;
 	volatile u32	nr_perf_cri;
 	volatile u32	nr_lat_cri;

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -39,6 +39,7 @@ enum consts_internal  {
 	LAVD_LC_RUNTIME_MAX		= LAVD_TIME_ONE_SEC,
 	LAVD_LC_WEIGHT_BOOST		= 128, /* 2^7 */
 	LAVD_LC_GREEDY_PENALTY		= p2s(20),  /* 20% */
+	LAVD_LC_PREEMPT_SHIFT		= 6, /* roughly top 1.56% for preemption. */
 
 	LAVD_NEW_PROC_PENALITY		= 5,
 	LAVD_GREEDY_RATIO_NEW		= (LAVD_SCALE * LAVD_NEW_PROC_PENALITY),

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -773,7 +773,8 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 	 * Try to find and kick a victim CPU, which runs a less urgent task,
 	 * from dsq_id. The kick will be done asynchronously.
 	 */
-	try_find_and_kick_victim_cpu(p, taskc, dsq_id);
+	if (!no_preemption)
+		try_find_and_kick_victim_cpu(p, taskc, dsq_id);
 }
 
 void BPF_STRUCT_OPS(lavd_dispatch, s32 cpu, struct task_struct *prev)

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -250,8 +250,10 @@ static void try_find_and_kick_victim_cpu(struct task_struct *p,
 	/*
 	 * If a victim CPU is chosen, preempt the victim by kicking it.
 	 */
-	if (victim_cpuc)
+	if (victim_cpuc) {
 		ask_cpu_yield(victim_cpuc);
+		cpuc_cur->nr_preempt++;
+	}
 }
 
 static void reset_cpu_preemption_info(struct cpu_ctx *cpuc, bool released)

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -284,7 +284,7 @@ static void calc_sys_stat(struct sys_stat_ctx *c)
 	sys_stat.max_lat_cri = calc_avg32(sys_stat.max_lat_cri, c->max_lat_cri);
 	sys_stat.avg_lat_cri = calc_avg32(sys_stat.avg_lat_cri, c->avg_lat_cri);
 	sys_stat.thr_lat_cri = sys_stat.max_lat_cri - ((sys_stat.max_lat_cri -
-				sys_stat.avg_lat_cri) >> 1);
+				sys_stat.avg_lat_cri) >> LAVD_LC_PREEMPT_SHIFT);
 
 	if (have_little_core) {
 		sys_stat.min_perf_cri =

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -35,6 +35,7 @@ struct sys_stat_ctx {
 	s32		avg_lat_cri;
 	u64		sum_lat_cri;
 	u32		nr_sched;
+	u32		nr_preempt;
 	u32		nr_perf_cri;
 	u32		nr_lat_cri;
 	u32		nr_x_migration;
@@ -179,6 +180,9 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 		c->nr_sched += cpuc->nr_sched;
 		cpuc->nr_sched = 0;
 
+		c->nr_preempt += cpuc->nr_preempt;
+		cpuc->nr_preempt = 0;
+
 		if (cpuc->max_lat_cri > c->max_lat_cri)
 			c->max_lat_cri = cpuc->max_lat_cri;
 		cpuc->max_lat_cri = 0;
@@ -309,6 +313,7 @@ static void calc_sys_stat(struct sys_stat_ctx *c)
 	if (cnt++ == LAVD_SYS_STAT_DECAY_TIMES) {
 		cnt = 0;
 		sys_stat.nr_sched >>= 1;
+		sys_stat.nr_preempt >>= 1;
 		sys_stat.nr_perf_cri >>= 1;
 		sys_stat.nr_lat_cri >>= 1;
 		sys_stat.nr_x_migration >>= 1;
@@ -322,6 +327,7 @@ static void calc_sys_stat(struct sys_stat_ctx *c)
 	}
 
 	sys_stat.nr_sched += c->nr_sched;
+	sys_stat.nr_preempt += c->nr_preempt;
 	sys_stat.nr_perf_cri += c->nr_perf_cri;
 	sys_stat.nr_lat_cri += c->nr_lat_cri;
 	sys_stat.nr_x_migration += c->nr_x_migration;

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -26,6 +26,7 @@ struct sys_stat	sys_stat;
 /*
  * Options
  */
+volatile bool		no_preemption;
 volatile bool		no_core_compaction;
 volatile bool		no_freq_scaling;
 volatile bool		no_prefer_turbo_core;

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -27,6 +27,7 @@ struct sys_stat	sys_stat;
  * Options
  */
 volatile bool		no_preemption;
+volatile bool		no_wake_sync;
 volatile bool		no_core_compaction;
 volatile bool		no_freq_scaling;
 volatile bool		no_prefer_turbo_core;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -112,6 +112,10 @@ struct Opts {
     #[clap(long = "no-preemption", action = clap::ArgAction::SetTrue)]
     no_preemption: bool,
 
+    /// Disable an optimization for synchronous wake-up.
+    #[clap(long = "no-wake-sync", action = clap::ArgAction::SetTrue)]
+    no_wake_sync: bool,
+
     /// Disable core compaction and schedule tasks across all online CPUs. Core compaction attempts
     /// to keep idle CPUs idle in favor of scheduling tasks on CPUs that are already
     /// awake. See main.bpf.c for more info. Normally set by the power mode, but can be set independently if
@@ -644,6 +648,7 @@ impl<'a> Scheduler<'a> {
 
     fn init_globals(skel: &mut OpenBpfSkel, opts: &Opts, topo: &FlatTopology) {
         skel.maps.bss_data.no_preemption = opts.no_preemption;
+        skel.maps.bss_data.no_wake_sync = opts.no_wake_sync;
         skel.maps.bss_data.no_core_compaction = opts.no_core_compaction;
         skel.maps.bss_data.no_freq_scaling = opts.no_freq_scaling;
         skel.maps.bss_data.no_prefer_turbo_core = opts.no_prefer_turbo_core;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -108,6 +108,10 @@ struct Opts {
     #[clap(long = "no-futex-boost", action = clap::ArgAction::SetTrue)]
     no_futex_boost: bool,
 
+    /// Disable preemption.
+    #[clap(long = "no-preemption", action = clap::ArgAction::SetTrue)]
+    no_preemption: bool,
+
     /// Disable core compaction and schedule tasks across all online CPUs. Core compaction attempts
     /// to keep idle CPUs idle in favor of scheduling tasks on CPUs that are already
     /// awake. See main.bpf.c for more info. Normally set by the power mode, but can be set independently if
@@ -639,6 +643,7 @@ impl<'a> Scheduler<'a> {
     }
 
     fn init_globals(skel: &mut OpenBpfSkel, opts: &Opts, topo: &FlatTopology) {
+        skel.maps.bss_data.no_preemption = opts.no_preemption;
         skel.maps.bss_data.no_core_compaction = opts.no_core_compaction;
         skel.maps.bss_data.no_freq_scaling = opts.no_freq_scaling;
         skel.maps.bss_data.no_prefer_turbo_core = opts.no_prefer_turbo_core;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -763,6 +763,7 @@ impl<'a> Scheduler<'a> {
                 let nr_queued_task = st.nr_queued_task;
                 let nr_active = st.nr_active;
                 let nr_sched = st.nr_sched;
+                let nr_preempt = st.nr_preempt;
                 let pc_pc = Self::get_pc(st.nr_perf_cri, nr_sched);
                 let pc_lc = Self::get_pc(st.nr_lat_cri, nr_sched);
                 let pc_x_migration = Self::get_pc(st.nr_x_migration, nr_sched);
@@ -784,6 +785,7 @@ impl<'a> Scheduler<'a> {
                     nr_queued_task,
                     nr_active,
                     nr_sched,
+                    nr_preempt,
                     pc_pc,
                     pc_lc,
                     pc_x_migration,

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -31,6 +31,9 @@ pub struct SysStats {
     #[stat(desc = "Number of context switches")]
     pub nr_sched: u64,
 
+    #[stat(desc = "Number of task preemption triggered")]
+    pub nr_preempt: u64,
+
     #[stat(desc = "% of performance-critical tasks")]
     pub pc_pc: f64,
 
@@ -69,11 +72,12 @@ impl SysStats {
     pub fn format_header<W: Write>(w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "\x1b[93m| {:8} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:11} | {:12} | {:12} | {:12} |\x1b[0m",
+            "\x1b[93m| {:8} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:11} | {:12} | {:12} | {:12} |\x1b[0m",
             "MSEQ",
             "# Q TASK",
             "# ACT CPU",
             "# SCHED",
+            "# PREEMPT",
             "PERF-CR%",
             "LAT-CR%",
             "X-MIG%",
@@ -96,11 +100,12 @@ impl SysStats {
 
         writeln!(
             w,
-            "| {:8} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:11} | {:12} | {:12} | {:12} |",
+            "| {:8} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:8} | {:11} | {:12} | {:12} | {:12} |",
             self.mseq,
             self.nr_queued_task,
             self.nr_active,
             self.nr_sched,
+            self.nr_preempt,
             GPoint(self.pc_pc),
             GPoint(self.pc_lc),
             GPoint(self.pc_x_migration),


### PR DESCRIPTION
Preemption is good, but it is not free. It costs to find a victim CPU and send a preemption signal (IPI) to the remote victim CPU.

This PR optimizes the preemption operations in various ways:

1) Set the bar higher to trigger preemption operations. Now, the top 1.5-3% latency-critical tasks will be considered for preemption.

2) Replace the IPI-based remote CPU kick, scx_bpf_kick_cpu(), to resetting a victim task's slice to zero. While this does not trigger preemption immediately, it can avoid expensive IPI, which is even more costly in some (old) architectures.

In addition to these main changes, the following related, minor changes were included:

1) Add two options: --no-preemption and --no-wake-sync.
2) Print the preemption statistics for tunning and debugging.

