### PR TITLE
scx_nest: Fix build error

### DIFF
--- a/scheds/c/scx_nest.bpf.c
+++ b/scheds/c/scx_nest.bpf.c
@@ -24,7 +24,6 @@
  * Copyright (c) 2023 Tejun Heo <tj@kernel.org>
  */
 #include <scx/common.bpf.h>
-#include <lib/sdt_task.h>
 
 #include "scx_nest.h"
 

--- a/scheds/include/scx/bpf_arena_common.h
+++ b/scheds/include/scx/bpf_arena_common.h
@@ -2,10 +2,6 @@
 /* Copyright (c) 2024 Meta Platforms, Inc. and affiliates. */
 #pragma once
 
-#ifndef NUMA_NO_NODE
-#define	NUMA_NO_NODE	(-1)
-#endif
-
 #ifndef arena_container_of
 #define arena_container_of(ptr, type, member)			\
 	({							\

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -33,6 +33,10 @@
 #define PF_EXITING			0x00000004
 #define CLOCK_MONOTONIC			1
 
+#ifndef NUMA_NO_NODE
+#define	NUMA_NO_NODE	(-1)
+#endif
+
 extern int LINUX_KERNEL_VERSION __kconfig;
 extern const char CONFIG_CC_VERSION_TEXT[64] __kconfig __weak;
 extern const char CONFIG_LOCALVERSION[64] __kconfig __weak;


### PR DESCRIPTION
Fix the following build error in scx_nest:
```
libbpf: elf: sec '.addr_space.1': to use global __arena variables the ARENA map should be explicitly declared in SEC(".maps")
Error: failed to open BPF object file: No such file or directory
```