### PR TITLE
scxtop: Switch from char to u8

### DIFF
--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -54,7 +54,7 @@ enum event_type {
 struct sched_switch_event {
 	u32		cpu;
 	bool		preempt;
-	char		next_comm[MAX_COMM];
+	u8		next_comm[MAX_COMM];
 	u64		next_dsq_id;
 	u64		next_dsq_lat_us;
 	u32		next_dsq_nr;
@@ -63,7 +63,7 @@ struct sched_switch_event {
 	u32		next_pid;
 	u32		next_tgid;
 	int		next_prio;
-	char		prev_comm[MAX_COMM];
+	u8		prev_comm[MAX_COMM];
 	u64		prev_dsq_id;
 	u64		prev_used_slice_ns;
 	u64		prev_slice_ns;
@@ -77,7 +77,7 @@ struct wakeup_event {
 	u32		pid;
 	u32		tgid;
 	int		prio;
-	char		comm[MAX_COMM];
+	u8		comm[MAX_COMM];
 };
 
 struct set_perf_event {
@@ -95,14 +95,14 @@ struct exit_event {
 	u32		pid;
 	u32		prio;
 	u32		tgid;
-	char		comm[MAX_COMM];
+	u8		comm[MAX_COMM];
 };
 
 struct fork_event {
 	u32		parent_pid;
 	u32		child_pid;
-	char		parent_comm[MAX_COMM];
-	char		child_comm[MAX_COMM];
+	u8		parent_comm[MAX_COMM];
+	u8		child_comm[MAX_COMM];
 };
 
 struct exec_event {

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -405,7 +405,7 @@ int BPF_KPROBE(scx_dispatch_from_dsq_set_vtime, struct bpf_iter_scx_dsq *it__ite
 	return on_move_set_vtime(NULL, vtime);
 }
 
-static void record_real_comm(char *comm, struct task_struct *task)
+static void record_real_comm(u8 *comm, struct task_struct *task)
 {
 	if (task->flags & PF_WQ_WORKER) {
 		/*

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -51,7 +51,6 @@ pub use plain::Plain;
 unsafe impl Plain for crate::bpf_skel::types::bpf_event {}
 
 use smartstring::alias::String as SsoString;
-use std::ffi::CStr;
 
 pub const APP: &str = "scxtop";
 pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
@@ -390,9 +389,8 @@ impl TryFrom<&bpf_event> for Action {
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_SCHED_WAKEUP => {
                 let wakeup = unsafe { event.event.wakeup };
-                let comm = unsafe { CStr::from_ptr(event.event.wakeup.comm.as_ptr()) }
-                    .to_string_lossy()
-                    .to_string();
+
+                let comm = String::from_utf8_lossy(&wakeup.comm);
 
                 Ok(Action::SchedWakeup(SchedWakeupAction {
                     ts: event.ts,
@@ -406,9 +404,8 @@ impl TryFrom<&bpf_event> for Action {
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_SCHED_WAKING => {
                 let waking = unsafe { &event.event.waking };
-                let comm = unsafe { CStr::from_ptr(waking.comm.as_ptr()) }
-                    .to_string_lossy()
-                    .to_string();
+
+                let comm = String::from_utf8_lossy(&waking.comm);
 
                 Ok(Action::SchedWaking(SchedWakingAction {
                     ts: event.ts,
@@ -427,9 +424,7 @@ impl TryFrom<&bpf_event> for Action {
             })),
             bpf_intf::event_type_EXIT => {
                 let exit = unsafe { &event.event.exit };
-                let comm = unsafe { CStr::from_ptr(exit.comm.as_ptr()) }
-                    .to_string_lossy()
-                    .to_string();
+                let comm = String::from_utf8_lossy(&exit.comm);
 
                 Ok(Action::Exit(ExitAction {
                     ts: event.ts,
@@ -443,12 +438,8 @@ impl TryFrom<&bpf_event> for Action {
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_FORK => {
                 let fork = unsafe { &event.event.fork };
-                let parent_comm = unsafe { CStr::from_ptr(fork.parent_comm.as_ptr()) }
-                    .to_string_lossy()
-                    .to_string();
-                let child_comm = unsafe { CStr::from_ptr(fork.child_comm.as_ptr()) }
-                    .to_string_lossy()
-                    .to_string();
+                let parent_comm = String::from_utf8_lossy(&fork.parent_comm);
+                let child_comm = String::from_utf8_lossy(&fork.child_comm);
 
                 Ok(Action::Fork(ForkAction {
                     ts: event.ts,
@@ -467,12 +458,8 @@ impl TryFrom<&bpf_event> for Action {
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_SCHED_SWITCH => {
                 let sched_switch = unsafe { &event.event.sched_switch };
-                let prev_comm = unsafe { CStr::from_ptr(sched_switch.prev_comm.as_ptr()) }
-                    .to_string_lossy()
-                    .to_string();
-                let next_comm = unsafe { CStr::from_ptr(sched_switch.next_comm.as_ptr()) }
-                    .to_string_lossy()
-                    .to_string();
+                let prev_comm = String::from_utf8_lossy(&sched_switch.prev_comm);
+                let next_comm = String::from_utf8_lossy(&sched_switch.next_comm);
 
                 Ok(Action::SchedSwitch(SchedSwitchAction {
                     ts: event.ts,


### PR DESCRIPTION
char is signed by default on x86 but not on aarch64/riscv64, this produces a build-error when trying to use CStr to load a pointer to the generated skel.

Switching to u8 instead of char and modifying the rust code to use String::from_utf8_lossy compiles and runs on the specified platforms.

Fixes: #1803