### PR TITLE
scx_rustland_core: fix nr_queued not decremented after dequeue

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -510,7 +510,7 @@ impl<'cb> BpfScheduler<'cb> {
             LIBBPF_STOP => {
                 // A valid task is received, convert data to a proper task struct.
                 let task = unsafe { EnqueuedMessage::from_bytes(&BUF.0).to_queued_task() };
-                let _ = self.skel.maps.bss_data.nr_queued.saturating_sub(1);
+                self.skel.maps.bss_data.nr_queued = self.skel.maps.bss_data.nr_queued.saturating_sub(1);
 
                 Ok(Some(task))
             }


### PR DESCRIPTION
The `dequeue_task()` function called `saturating_sub(1)` on `nr_queued` but did not assign the result back to the field, leaving the counter unchanged. Assign the decremented value back to ensure `nr_queued` is updated correctly.