### PR TITLE
scx_rustland_core: Forbid mmap() syscall

### DIFF
--- a/.github/include/flake.nix
+++ b/.github/include/flake.nix
@@ -95,6 +95,7 @@
                   gnused
                   isort
                   jq
+                  libseccomp.lib
                   llvmPackages.libclang
                   llvmPackages.libllvm
                   pkg-config
@@ -137,6 +138,7 @@
                       elfutils.out
                       zlib
                       zstd.out
+                      libseccomp.lib
                     ]))) + "'")
                   ]
                 ];

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,6 +2518,7 @@ dependencies = [
  "libc",
  "plain",
  "scx_utils",
+ "seccomp",
  "tar",
  "walkdir",
 ]
@@ -2673,6 +2674,25 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "xdg",
+]
+
+[[package]]
+name = "seccomp"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ca3dd4474d15e6fdaea3c411bfa688c55cd1ae0051391a2b46581fffaed315b"
+dependencies = [
+ "libc",
+ "seccomp-sys",
+]
+
+[[package]]
+name = "seccomp-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bcf74ba0708aeaf8d702e4f84f7458ae1de42d80e2c20963a395b6038e6be6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.65"
 plain = "0.2.3"
 libbpf-rs = "=0.25.0-beta.1"
 libc = "0.2.137"
+seccomp = "0.1"
 scx_utils = { path = "../scx_utils", version = "1.0.14" }
 
 [build-dependencies]

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -219,6 +219,8 @@ struct Scheduler<'a> {
 
 impl<'a> Scheduler<'a> {
     fn init(opts: &Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
+        let stats_server = StatsServer::new(stats::server_data()).launch()?;
+
         // Low-level BPF connector.
         let bpf = BpfScheduler::init(
             open_object,
@@ -227,7 +229,6 @@ impl<'a> Scheduler<'a> {
             opts.verbose,
             true, // Enable built-in idle CPU selection policy
         )?;
-        let stats_server = StatsServer::new(stats::server_data()).launch()?;
 
         info!("{} scheduler attached", SCHEDULER_NAME);
 


### PR DESCRIPTION
The user-space schedulers should never perform blocking memory allocations, otherwise the entire scheduling pipeline may get stuck.

To prevent this from happening, scx_rustland_core implements a GlobalAlloc with a custom memory allocator that operates on a pre-allocated locked memory arena and all the memory of the process is automatically locked.

However, external libraries/crates can still execute mmap() syscalls directly (i.e., libc), potentially stalling the scheduler, for example:

  R scx_rustland[159] -5016ms
      scx_state/flags=3/0x1 dsq_flags=0x0 ops_state/qseq=2/1
      sticky/holding_cpu=-1/-1 dsq_id=(n/a)
      dsq_vtime=0 slice=0 weight=100
      cpus=ff

    asm_sysvec_apic_timer_interrupt+0x1a/0x20
    mmap_region+0x65/0x140
    do_mmap+0x47d/0x620
    vm_mmap_pgoff+0xbc/0x1c0
    do_syscall_64+0xbb/0x1e0
    entry_SYSCALL_64_after_hwframe+0x77/0x7f

To catch these calls introduce a seccomp filter that returns EPERM when the mmap() syscall is invoked.

This doesn't solve the problem, but it allows to catch the code that invokes mmap() and we can exit early without having to wait for the watchdog timeout.