### PR TITLE
scx_layered: Consume task_hint::hint for controlling vruntime advancement

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2505,6 +2505,7 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 	struct cpu_ctx *cpuc;
 	struct task_ctx *taskc;
 	struct layer *task_layer;
+	struct task_hint *task_hint;
 	u64 now = scx_bpf_now();
 	u64 usage_since_idle;
 	s32 task_lid;
@@ -2575,7 +2576,17 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 
 	if (cpuc->yielding && runtime < task_layer->slice_ns)
 		runtime = task_layer->slice_ns;
-	p->scx.dsq_vtime += runtime * 100 / p->scx.weight;
+
+	runtime = runtime * 100 / p->scx.weight;
+
+	task_hint = bpf_task_storage_get(&scx_layered_task_hint_map, p, NULL, 0);
+	if (task_hint) {
+		u64 hint = task_hint->hint ?: 1;
+		hint = hint < 1024 ? hint : 1024;
+		runtime = (runtime * hint) / 1024;
+	}
+
+	p->scx.dsq_vtime += runtime;
 	cpuc->maybe_idle = true;
 }
 


### PR DESCRIPTION
Use the passed in task_hint to control how vruntime advancement is scaled for threads. Currently, a linear scaling mode is used, but we can do other approaches (logarithmic/exponential) etc.

TODO: A little more testing, with a different scaling function.