### PR TITLE
scx_lavd: Clean up command line options.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -149,8 +149,7 @@ bool init_idle_ato_masks(struct pick_ctx *ctx, const struct cpumask *idle_mask)
 	else
 		ctx->io_empty = true;
 
-	if (ctx->ia_empty || !have_turbo_core ||
-	    no_prefer_turbo_core || !turbo_cpumask)
+	if (ctx->ia_empty || !have_turbo_core || !turbo_cpumask)
 		ctx->iat_empty = true;
 	else if (turbo_cpumask) {
 		bpf_cpumask_and(ctx->iat_mask, cast_mask(ctx->ia_mask),

--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -277,8 +277,6 @@ static int do_set_power_profile(s32 pm, int util)
 	switch (pm) {
 	case LAVD_PM_PERFORMANCE:
 		no_core_compaction = true;
-		no_freq_scaling = false;
-		no_prefer_turbo_core = false;
 		is_powersave_mode = false;
 
 		/*
@@ -295,16 +293,12 @@ static int do_set_power_profile(s32 pm, int util)
 		break;
 	case LAVD_PM_BALANCED:
 		no_core_compaction = false;
-		no_freq_scaling = false;
-		no_prefer_turbo_core = false;
 		is_powersave_mode = false;
 		reinit_cpumask_for_performance = false;
 		debugln("Set the scheduler's power profile to balanced mode: %d", util);
 		break;
 	case LAVD_PM_POWERSAVE:
 		no_core_compaction = false;
-		no_freq_scaling = false;
-		no_prefer_turbo_core = true;
 		is_powersave_mode = true;
 		reinit_cpumask_for_performance = false;
 		debugln("Set the scheduler's power profile to power-save mode: %d", util);

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -30,7 +30,6 @@ volatile bool		no_preemption;
 volatile bool		no_wake_sync;
 volatile bool		no_core_compaction;
 volatile bool		no_freq_scaling;
-volatile bool		no_prefer_turbo_core;
 volatile bool		is_powersave_mode;
 volatile bool		reinit_cpumask_for_performance;
 const volatile bool	is_autopilot_on;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -71,24 +71,41 @@ use stats::SysStats;
 /// See the more detailed overview of the LAVD design at main.bpf.c.
 #[derive(Debug, Parser)]
 struct Opts {
-    /// Automatically decide the scheduler's power mode based on system load.
-    /// This is a default mode if you don't specify the following options:
+    /// Automatically decide the scheduler's power mode (performance vs.
+    /// powersave vs. balanced), CPU preference order, etc, based on system
+    /// load. The options affecting the power mode and the use of core compaction
+    /// (--autopower, --performance, --powersave, --balanced,
+    /// --no-core-compaction) cannot be used with this option. When no option
+    /// is specified, this is a default mode.
     #[clap(long = "autopilot", action = clap::ArgAction::SetTrue)]
     autopilot: bool,
 
-    /// Automatically decide the scheduler's power mode based on the system's active power profile.
+    /// Automatically decide the scheduler's power mode (performance vs.
+    /// powersave vs. balanced) based on the system's active power profile.
+    /// The scheduler's power mode decides the CPU preference order and the use
+    /// of core compaction, so the options affecting these (--autopilot,
+    /// --no-core-compaction) cannot be used with this option.
     #[clap(long = "autopower", action = clap::ArgAction::SetTrue)]
     autopower: bool,
 
-    /// Run in performance mode to get maximum performance.
+    /// Run the scheduler in performance mode to get maximum performance.
+    /// This option cannot be used with other conflicting options (--autopilot,
+    /// --autopower, --balanced, --powersave, --no-core-compaction)
+    /// affecting the use of core compaction.
     #[clap(long = "performance", action = clap::ArgAction::SetTrue)]
     performance: bool,
 
-    /// Run in powersave mode to minimize power consumption.
+    /// Run the scheduler in powersave mode to minimize powr consumption.
+    /// This option cannot be used with other conflicting options (--autopilot,
+    /// --autopower, --performance, --balanced, --no-core-compaction)
+    /// affecting the use of core compaction.
     #[clap(long = "powersave", action = clap::ArgAction::SetTrue)]
     powersave: bool,
 
-    /// Run in balanced mode aiming for sweetspot between power and performance (default).
+    /// Run the scheduler in balanced mode aiming for sweetspot between power
+    /// and performance. This option cannot be used with other conflicting
+    /// options (--autopilot, --autopower, --performance, --powersave,
+    /// --no-core-compaction) affecting the use of core compaction.
     #[clap(long = "balanced", action = clap::ArgAction::SetTrue)]
     balanced: bool,
 
@@ -100,7 +117,10 @@ struct Opts {
     #[clap(long = "slice-min-us", default_value = "300")]
     slice_min_us: u64,
 
-    /// List of CPUs in preferred order (e.g., "0-3,7,6,5,4").
+    /// List of CPUs in preferred order (e.g., "0-3,7,6,5,4"). The scheduler
+    /// uses the CPU preference mode only when the core compaction is enabled
+    /// (i.e., balanced or powersave mode is specified as an option or chosen
+    /// in the autopilot or autopower mode).
     #[clap(long = "cpu-pref-order", default_value = "")]
     cpu_pref_order: String,
 
@@ -116,32 +136,18 @@ struct Opts {
     #[clap(long = "no-wake-sync", action = clap::ArgAction::SetTrue)]
     no_wake_sync: bool,
 
-    /// Disable core compaction and schedule tasks across all online CPUs. Core compaction attempts
-    /// to keep idle CPUs idle in favor of scheduling tasks on CPUs that are already
-    /// awake. See main.bpf.c for more info. Normally set by the power mode, but can be set independently if
-    /// desired.
+    /// Disable core compaction so the scheduler uses all the online CPUs.
+    /// The core compaction attempts to minimize the number of actively used
+    /// CPUs for unaffinitized tasks, respecting the CPU preference order.
+    /// Normally, the core compaction is enabled by the power mode (i.e.,
+    /// balanced or powersave mode is specified as an option or chosen in
+    /// the autopilot or autopower mode). This option cannot be used with the
+    /// other options that control the core compaction (--autopilot,
+    /// --autopower, --performance, --balanced, --powersave).
     #[clap(long = "no-core-compaction", action = clap::ArgAction::SetTrue)]
     no_core_compaction: bool,
 
-    /// Schedule tasks on SMT siblings before using other physcial cores when core compaction is
-    /// enabled. Normally set by the power mode, but can be set independently if desired.
-    #[clap(long = "prefer-smt-core", action = clap::ArgAction::SetTrue)]
-    prefer_smt_core: bool,
-
-    /// Schedule tasks on little (efficiency) cores before big (performance) cores when core compaction is
-    /// enabled. Normally set by the power mode, but can be set independently if desired.
-    #[clap(long = "prefer-little-core", action = clap::ArgAction::SetTrue)]
-    prefer_little_core: bool,
-
-    /// Do not specifically prefer to schedule on turbo cores. Normally set by the power mode, but
-    /// can be set independently if desired.
-    #[clap(long = "no-prefer-turbo-core", action = clap::ArgAction::SetTrue)]
-    no_prefer_turbo_core: bool,
-
-    /// Disable controlling the CPU frequency. In order to improve latency and responsiveness of
-    /// performance-critical tasks, scx_lavd increases the CPU frequency even if CPU usage is low.
-    /// See main.bpf.c for more info. Normally set by the power mode, but can be set independently
-    /// if desired.
+    /// Disable controlling the CPU frequency.
     #[clap(long = "no-freq-scaling", action = clap::ArgAction::SetTrue)]
     no_freq_scaling: bool,
 
@@ -179,14 +185,7 @@ impl Opts {
             && self.performance == false
             && self.powersave == false
             && self.balanced == false
-            && self.cpu_pref_order == ""
             && self.no_core_compaction == false
-            && self.prefer_smt_core == false
-            && self.prefer_little_core == false
-            && self.no_prefer_turbo_core == false
-            && self.no_freq_scaling == false
-            && self.monitor == None
-            && self.monitor_sched_samples == None
     }
 
     fn proc(&mut self) -> Option<&mut Self> {
@@ -198,22 +197,10 @@ impl Opts {
 
         if self.performance {
             self.no_core_compaction = true;
-            self.prefer_smt_core = false;
-            self.prefer_little_core = false;
-            self.no_prefer_turbo_core = false;
-            self.no_freq_scaling = true;
         } else if self.powersave {
             self.no_core_compaction = false;
-            self.prefer_smt_core = true;
-            self.prefer_little_core = true;
-            self.no_prefer_turbo_core = true;
-            self.no_freq_scaling = false;
         } else if self.balanced {
             self.no_core_compaction = false;
-            self.prefer_smt_core = false;
-            self.prefer_little_core = false;
-            self.no_prefer_turbo_core = false;
-            self.no_freq_scaling = false;
         }
 
         Some(self)
@@ -642,17 +629,12 @@ impl<'a> Scheduler<'a> {
         }
     }
 
-    fn is_powersave_mode(opts: &Opts) -> bool {
-        opts.prefer_smt_core && opts.prefer_little_core
-    }
-
     fn init_globals(skel: &mut OpenBpfSkel, opts: &Opts, topo: &FlatTopology) {
         skel.maps.bss_data.no_preemption = opts.no_preemption;
         skel.maps.bss_data.no_wake_sync = opts.no_wake_sync;
         skel.maps.bss_data.no_core_compaction = opts.no_core_compaction;
         skel.maps.bss_data.no_freq_scaling = opts.no_freq_scaling;
-        skel.maps.bss_data.no_prefer_turbo_core = opts.no_prefer_turbo_core;
-        skel.maps.bss_data.is_powersave_mode = Self::is_powersave_mode(&opts);
+        skel.maps.bss_data.is_powersave_mode = opts.powersave;
         skel.maps.rodata_data.nr_cpu_ids = *NR_CPU_IDS as u64;
         skel.maps.rodata_data.is_smt_active = topo.smt_enabled;
         skel.maps.rodata_data.is_autopilot_on = opts.autopilot;


### PR DESCRIPTION
As the number of options grows in LAVD, it becomes harder to provide the right set of options because some options are conflicting (e.g., --autopilot vs. --no-core-compaction), so they cannot be used together.

To address this problem, this PR updates comments on each option and adds sanity checks if conflicting options are used or not. 

