### PR TITLE
scx_central: Suppress potential unused param warning

### DIFF
--- a/scheds/c/scx_central.c
+++ b/scheds/c/scx_central.c
@@ -40,6 +40,7 @@ static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va
 
 static void sigint_handler(int dummy)
 {
+	(void)dummy;
 	exit_req = 1;
 }
 


### PR DESCRIPTION
Cast the unused parameter to void to prevent potential -Wunused-parameter warnings under stricter compiler flags. No functional changes.