### PR TITLE
scx_central: Remove unused -p option from getopt()

### DIFF
--- a/scheds/c/scx_central.c
+++ b/scheds/c/scx_central.c
@@ -64,7 +64,7 @@ restart:
 	assert(skel->rodata->nr_cpu_ids > 0);
 	assert(skel->rodata->nr_cpu_ids <= INT32_MAX);
 
-	while ((opt = getopt(argc, argv, "s:c:pvh")) != -1) {
+	while ((opt = getopt(argc, argv, "s:c:vh")) != -1) {
 		switch (opt) {
 		case 's':
 			skel->rodata->slice_ns = strtoull(optarg, NULL, 0) * 1000;


### PR DESCRIPTION
Drop the -p option from the getopt option string since it was not handled in the switch statement.