### PR TITLE
scx_p2dq: Refactor slice handling

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -45,6 +45,7 @@ struct node_ctx {
 
 struct task_p2dq {
 	u64			dsq_id;
+	u64			slice_ns;
 	int			dsq_index;
 	u32			cpu;
 	u32			llc_id;


### PR DESCRIPTION
Add slice_ns to the task_ctx field so that slice times can be dynamically adjusted per task. Refactor various lookups to use the new slice_ns field on the task_ctx.