### PR TITLE
scx_rustland: replace `or_insert_with_key` with `or_insert`

### DIFF
--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -285,13 +285,9 @@ impl<'a> Scheduler<'a> {
     fn update_enqueued(&mut self, task: &QueuedTask) -> u64 {
         // Get task information if the task is already stored in the task map,
         // otherwise create a new entry for it.
-        let task_info = self
-            .task_map
-            .tasks
-            .entry(task.pid)
-            .or_insert_with_key(|&_pid| TaskInfo {
-                vruntime: self.min_vruntime,
-            });
+        let task_info = self.task_map.tasks.entry(task.pid).or_insert(TaskInfo {
+            vruntime: self.min_vruntime,
+        });
 
         // Update global minimum vruntime based on the previous task's vruntime.
         if self.min_vruntime < task.vtime {


### PR DESCRIPTION
The use of `or_insert_with_key()` is unnecessary here since the inserted value does not depend on the key. 
`or_insert()` provides the same behavior more simply.

This minor change improves clarity and readability, and I believe it's a reasonable cleanup rather than churn.
