### PR TITLE
layered: use passed in p instead of bpf_task_from_pid

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2176,7 +2176,7 @@ err:
 	return -EINVAL;
 }
 
-static void maybe_refresh_layer(struct task_struct *p, struct task_ctx *taskc)
+static void maybe_refresh_layer(struct task_struct *p __arg_trusted, struct task_ctx *taskc)
 {
 	const char *cgrp_path;
 	bool matched = false;


### PR DESCRIPTION
layered: use passed in p instead of bpf_task_from_pid.

This fixes the situation where a task disappears (i.e. ends or it's pid is changed) wrt/ `bpf_task_from_pid` inside matcher code, causing layered to report unmatched tasks.

This looks like it was compat code around verifier issues previously (i.e. pid lookups are a nice, but somewhat problematic, way to make the verifier trust pointers).