### PR TITLE
scx_rustland: fallback to original CPU if no idle CPU is available

### DIFF
--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -383,7 +383,7 @@ impl<'a> Scheduler<'a> {
                 let cpu = self
                     .bpf
                     .select_cpu(task.qtask.pid, task.qtask.cpu, task.qtask.flags);
-                dispatched_task.cpu = if cpu >= 0 { cpu } else { RL_CPU_ANY };
+                dispatched_task.cpu = if cpu >= 0 { cpu } else { task.qtask.cpu };
 
                 // Send task to the BPF dispatcher.
                 match self.bpf.dispatch_task(&dispatched_task) {


### PR DESCRIPTION
If no idle CPU is found, fall back to the task's original CPU instead of `RL_CPU_ANY` to avoid unnecessary migrations.

Ref: #1765