### PR TITLE
scx_userspace_arena: set edition to 2021

### DIFF
--- a/rust/scx_userspace_arena/Cargo.toml
+++ b/rust/scx_userspace_arena/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scx_userspace_arena"
 version = "1.0.11"
-edition = "2024"
+edition = "2021"
 authors = ["Jake Hillion <jake@hillion.co.uk>"]
 license = "GPL-2.0-only"
 repository = "https://github.com/sched-ext/scx"


### PR DESCRIPTION
Edition of scx_userspace_arena was accidentally committed as 2024. Reset to 2021 for the previously mentioned compatibility issues.

Test plan:
- CI