### PR TITLE
layered: cleanup skip-preempt

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1135,7 +1135,7 @@ static bool try_preempt_cpu(s32 cand, struct task_struct *p, struct task_ctx *ta
 	struct cpu_ctx *cpuc, *cand_cpuc, *sib_cpuc = NULL;
 	struct rq *rq = NULL;
 	s32 sib;
-	struct sched_class *ext_sched_class = NULL, *idle_sched_class = NULL;
+	struct sched_class *ext_sched_class, *idle_sched_class;
 
 	if (cand >= nr_possible_cpus || !bpf_cpumask_test_cpu(cand, p->cpus_ptr))
 		return false;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -60,6 +60,7 @@ const volatile bool enable_gpu_support = false;
 /* Delay permitted, in seconds, before antistall activates */
 const volatile u64 antistall_sec = 3;
 const u32 zero_u32 = 0;
+const volatile bool enable_skip_preempt = false;
 
 /*
  * XXX sched classes should be exported kernel
@@ -1148,15 +1149,17 @@ static bool try_preempt_cpu(s32 cand, struct task_struct *p, struct task_ctx *ta
 
 	rq = scx_bpf_cpu_rq(cand);
 	
-	ext_sched_class = (struct sched_class *)(unsigned long long)ext_sched_class_addr;
-	idle_sched_class = (struct sched_class *)(unsigned long long)idle_sched_class_addr;
+	if (enable_skip_preempt) {
+		ext_sched_class = (struct sched_class *)(unsigned long long)ext_sched_class_addr;
+		idle_sched_class = (struct sched_class *)(unsigned long long)idle_sched_class_addr;
 
-	if (rq && (rq->curr->sched_class != ext_sched_class) &&
-		(rq->curr->sched_class != idle_sched_class)) {
-		if (!(cpuc = lookup_cpu_ctx(-1)))
+		if (rq && (rq->curr->sched_class != ext_sched_class) &&
+			(rq->curr->sched_class != idle_sched_class)) {
+			if (!(cpuc = lookup_cpu_ctx(-1)))
+				return false;
+			gstat_inc(GSTAT_SKIP_PREEMPT, cpuc);
 			return false;
-		gstat_inc(GSTAT_SKIP_PREEMPT, cpuc);
-		return false;
+		}
 	}
 
 	/*

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1840,7 +1840,9 @@ impl<'a> Scheduler<'a> {
             skel.maps.rodata_data.ext_sched_class_addr = ext_sched_class_addr.unwrap();
             skel.maps.rodata_data.idle_sched_class_addr = idle_sched_class_addr.unwrap();
         } else {
-            warn!("skip_preempt is not supported, ignoring");
+            warn!(
+                "Unable to get sched_class addresses from /proc/kallsyms, disabling skip_preempt."
+            );
         }
 
         skel.maps.rodata_data.slice_ns = scx_enums.SCX_SLICE_DFL;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1840,6 +1840,8 @@ impl<'a> Scheduler<'a> {
             skel.maps.rodata_data.ext_sched_class_addr = ext_sched_class_addr.unwrap();
             skel.maps.rodata_data.idle_sched_class_addr = idle_sched_class_addr.unwrap();
             skel.maps.rodata_data.enable_skip_preempt = true;
+        } else {
+            warn!("skip_preempt is not supported, ignoring");
         }
 
         skel.maps.rodata_data.slice_ns = scx_enums.SCX_SLICE_DFL;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1833,8 +1833,14 @@ impl<'a> Scheduler<'a> {
             }
         }
 
-        skel.maps.rodata_data.ext_sched_class_addr = get_kallsyms_addr("ext_sched_class")?;
-        skel.maps.rodata_data.idle_sched_class_addr = get_kallsyms_addr("idle_sched_class")?;
+        let ext_sched_class_addr = get_kallsyms_addr("ext_sched_class");
+        let idle_sched_class_addr = get_kallsyms_addr("idle_sched_class");
+
+        if ext_sched_class_addr.is_ok() && idle_sched_class_addr.is_ok() {
+            skel.maps.rodata_data.ext_sched_class_addr = ext_sched_class_addr.unwrap();
+            skel.maps.rodata_data.idle_sched_class_addr = idle_sched_class_addr.unwrap();
+            skel.maps.rodata_data.enable_skip_preempt = true;
+        }
 
         skel.maps.rodata_data.slice_ns = scx_enums.SCX_SLICE_DFL;
         skel.maps.rodata_data.max_exec_ns = 20 * scx_enums.SCX_SLICE_DFL;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1839,7 +1839,6 @@ impl<'a> Scheduler<'a> {
         if ext_sched_class_addr.is_ok() && idle_sched_class_addr.is_ok() {
             skel.maps.rodata_data.ext_sched_class_addr = ext_sched_class_addr.unwrap();
             skel.maps.rodata_data.idle_sched_class_addr = idle_sched_class_addr.unwrap();
-            skel.maps.rodata_data.enable_skip_preempt = true;
         } else {
             warn!("skip_preempt is not supported, ignoring");
         }


### PR DESCRIPTION
Have layered only attempt to skip preemption's that it could not accomplish (i.e. due to tasks with RT sched class) when kallsyms addresses for idle sched class and ext sched class are present.

At the present, layered would exit if those addresses were unobtainable.

still works when kallsyms present for both the skip and not-skip cases:
![Screenshot From 2025-05-09 13-37-40](https://github.com/user-attachments/assets/d0b5fae2-58d9-4989-a37f-6f7109ad7229)
![Screenshot From 2025-05-09 13-37-30](https://github.com/user-attachments/assets/4dbdf28f-5468-400b-9251-7fa4efe615d7)