### PR TITLE
scx_p2dq: Keep non-interactive tasks sticky

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -689,8 +689,11 @@ static s32 pick_idle_cpu(struct task_struct *p, task_ctx *taskc,
 	}
 
 	// Couldn't find anything idle just return something in the local LLC
-	if (llcx->cpumask)
+	if (interactive && llcx->cpumask)
 		cpu = bpf_cpumask_any_distribute(cast_mask(llcx->cpumask));
+	else
+		// non interactive tasks stay sticky
+		cpu = prev_cpu;
 
 found_cpu:
 	scx_bpf_put_cpumask(idle_cpumask);


### PR DESCRIPTION
Make non-interactive tasks sticky to their CPU when there are no idle CPUs and spray interactive tasks across CPUs. This is to give better cache locality for non interactive tasks.