### PR TITLE
scx_rustland: Refactor TaskTree pop to remove redundant else

### DIFF
--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -196,12 +196,10 @@ impl TaskTree {
 
     // Pop the first item from the BTreeSet (item with the shortest deadline).
     fn pop(&mut self) -> Option<Task> {
-        if let Some(task) = self.tasks.pop_first() {
+        self.tasks.pop_first().map(|task| {
             self.task_map.remove(&task.qtask.pid);
-            Some(task)
-        } else {
-            None
-        }
+            task
+        })
     }
 }
 


### PR DESCRIPTION
The else branch in `TaskTree::pop` was returning `None` explicitly, even though that is already the default behavior when using `Option::map`. This refactor simplifies the logic and improves readability by adopting a more idiomatic Rust approach.

No change in functionality; this is a cleanup for clarity.