### PR TITLE
scx_p2dq: Cache node CPU masks on llc_ctx

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -34,6 +34,7 @@ struct llc_ctx {
 	struct bpf_cpumask __kptr	*cpumask;
 	struct bpf_cpumask __kptr	*big_cpumask;
 	struct bpf_cpumask __kptr	*little_cpumask;
+	struct bpf_cpumask __kptr	*node_cpumask;
 };
 
 struct node_ctx {


### PR DESCRIPTION
In order to avoid an extra map lookup on select/enqueue cache the node CPU make on the llc_ctx. This yields a measurable improvement in wakeup latency and benchmark throughput.

`main` schbench results:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (127035 total samples)
          50.0th: 13         (29827 samples)
          90.0th: 19         (52666 samples)
        * 99.0th: 200        (8148 samples)
          99.9th: 1526       (1143 samples)
          min=1, max=6667
Request Latencies percentiles (usec) runtime 30 (s) (127364 total samples)
          50.0th: 3596       (39633 samples)
          90.0th: 7096       (48713 samples)
        * 99.0th: 8784       (11040 samples)
          99.9th: 17760      (1143 samples)
          min=3326, max=35616
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 4328       (10 samples)
        * 50.0th: 4360       (11 samples)
          90.0th: 4392       (8 samples)
          min=2074, max=4412
average rps: 4245.47
```

Cached `node_cpumask` results:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (131167 total samples)
          50.0th: 13         (32818 samples)
          90.0th: 18         (50127 samples)
        * 99.0th: 23         (10298 samples)
          99.9th: 43         (1107 samples)
          min=1, max=6713
Request Latencies percentiles (usec) runtime 30 (s) (131530 total samples)
          50.0th: 3572       (44394 samples)
          90.0th: 6984       (47623 samples)
        * 99.0th: 7352       (11833 samples)
          99.9th: 10576      (1154 samples)
          min=3155, max=19532
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 4376       (8 samples)
        * 50.0th: 4408       (13 samples)
          90.0th: 4440       (8 samples)
          min=3754, max=4462
average rps: 4384.33
```