### PR TITLE
scx_rustland: Refactor dispatch_tasks to simplify control flow

### DIFF
--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -355,42 +355,33 @@ impl<'a> Scheduler<'a> {
 
     // Dispatch the first task from the task pool (sending them to the BPF dispatcher).
     fn dispatch_tasks(&mut self) {
-        match self.task_pool.pop() {
-            Some(task) => {
-                // Scale time slice based on the amount of tasks that are waiting in the
-                // scheduler's queue and the previously unused time slice budget, but make sure
-                // to assign at least slice_us_min.
-                let nr_waiting = self.nr_tasks_waiting() + 1;
-                let slice_ns = (self.slice_ns / nr_waiting).max(self.slice_ns_min);
+        if let Some(task) = self.task_pool.pop() {
+            // Scale time slice based on the amount of tasks that are waiting in the
+            // scheduler's queue and the previously unused time slice budget, but make sure
+            // to assign at least slice_us_min.
+            let nr_waiting = self.nr_tasks_waiting() + 1;
+            let slice_ns = (self.slice_ns / nr_waiting).max(self.slice_ns_min);
 
-                // Create a new task to dispatch.
-                let mut dispatched_task = DispatchedTask::new(&task.qtask);
+            // Create a new task to dispatch.
+            let mut dispatched_task = DispatchedTask::new(&task.qtask);
 
-                // Assign the time slice to the task and propagate the vruntime.
-                dispatched_task.slice_ns = slice_ns;
+            // Assign the time slice to the task and propagate the vruntime.
+            dispatched_task.slice_ns = slice_ns;
 
-                // Propagate the evaluated task's deadline to the scx_rustland_core backend.
-                dispatched_task.vtime = task.deadline;
+            // Propagate the evaluated task's deadline to the scx_rustland_core backend.
+            dispatched_task.vtime = task.deadline;
 
-                // Try to pick an idle CPU for the task.
-                let cpu = self
-                    .bpf
-                    .select_cpu(task.qtask.pid, task.qtask.cpu, task.qtask.flags);
-                dispatched_task.cpu = if cpu >= 0 { cpu } else { RL_CPU_ANY };
+            // Try to pick an idle CPU for the task.
+            let cpu = self
+                .bpf
+                .select_cpu(task.qtask.pid, task.qtask.cpu, task.qtask.flags);
+            dispatched_task.cpu = if cpu >= 0 { cpu } else { RL_CPU_ANY };
 
-                // Send task to the BPF dispatcher.
-                match self.bpf.dispatch_task(&dispatched_task) {
-                    Ok(_) => {}
-                    Err(_) => {
-                        /*
-                         * Re-add the task to the dispatched list in case of failure and stop
-                         * dispatching.
-                         */
-                        self.task_pool.push(task);
-                    }
-                }
+            // Send task to the BPF dispatcher.
+            if self.bpf.dispatch_task(&dispatched_task).is_err() {
+                // If dispatching fails, re-add the task to the pool and skip further dispatching.
+                self.task_pool.push(task);
             }
-            None => {}
         }
     }
 


### PR DESCRIPTION
1. Replaces a match statement with an if-let binding in dispatch_tasks, as the None arm was unused.

2. Also replaces a match on Result with an is_err() check, since only the Err case was handled and the Ok arm was empty.

No functional behavior is changed.