### PR TITLE
scx_utils: cast ioctl opcodes to libc::Ioctl

### DIFF
--- a/rust/scx_utils/src/perf.rs
+++ b/rust/scx_utils/src/perf.rs
@@ -52,11 +52,11 @@ pub mod ioctls {
 
     #[allow(clippy::missing_safety_doc)]
     pub unsafe fn enable(fd: c_int, arg: c_uint) -> c_int {
-        unsafe { libc::ioctl(fd, perf::bindings::ENABLE.into(), arg) }
+        unsafe { libc::ioctl(fd, perf::bindings::ENABLE as libc::Ioctl, arg) }
     }
 
     #[allow(clippy::missing_safety_doc)]
     pub unsafe fn reset(fd: c_int, arg: c_uint) -> c_int {
-        unsafe { libc::ioctl(fd, perf::bindings::RESET.into(), arg) }
+        unsafe { libc::ioctl(fd, perf::bindings::RESET as libc::Ioctl, arg) }
     }
 }


### PR DESCRIPTION
On glibc, the ioctl() function takes an unsigned 32-bit integer. However, on other platforms such as musl, it instead takes a signed 32-bit integer. When perf_wrapper.h was being processed through bindgen, it was internally representing the enum variants as u32, which caused issues on musl where ioctl expects an i32. This commit does away with the perf_event_ioctls enum entirely, instead using constant uint16_t values to ensure they can be passed to ioctl on both glibc and musl systems.