### PR TITLE
layered: add tgid tid count matcher

### DIFF
--- a/scheds/rust/scx_layered/examples/task_ge_le.json
+++ b/scheds/rust/scx_layered/examples/task_ge_le.json
@@ -1,0 +1,45 @@
+[
+	{
+		"name": "match le",
+		"matches": [
+			[
+				{ "CommPrefix": "sysbench" },
+				{ "ThreadCountLE": 2 }
+			]	
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range_frac":  [0.25, 0.5],
+				"util_range": [0.4, 0.85],
+				"growth_algo": "RandomTopo"
+			}
+		}
+	},
+	{
+		"name": "match ge",
+		"matches": [
+			[
+				{ "CommPrefix": "sysbench" },
+				{ "ThreadCountGE": 4 }
+			]
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range_frac":  [0.5, 0.5],
+				"util_range": [0.4, 0.85],
+				"growth_algo": "RandomTopo"
+			}
+		}
+	},
+	{
+		"name": "rest",
+		"matches": [
+			[]
+		],
+		"kind": {
+			"Open": {
+				"growth_algo": "RandomTopo"
+			}
+		}
+	}
+]

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -250,6 +250,8 @@ enum layer_match_kind {
 	MATCH_IS_KTHREAD,
 	MATCH_USED_GPU_TID,
 	MATCH_USED_GPU_PID,
+	MATCH_THREAD_COUNT_GE,
+	MATCH_THREAD_COUNT_LE,
 	MATCH_AVG_RUNTIME,
 	MATCH_CGROUP_SUFFIX,
 
@@ -274,6 +276,8 @@ struct layer_match {
 	bool		used_gpu_tid;
 	bool		used_gpu_pid;
 	bool		exclude;
+	u32		thread_count_ge;
+	u32		thread_count_le;
 	u64		min_avg_runtime_us;
 	u64		max_avg_runtime_us;
 };

--- a/scheds/rust/scx_layered/src/bpf/timer.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/timer.bpf.h
@@ -30,7 +30,6 @@ struct layered_timer {
 enum layer_timer_callbacks {
 	LAYERED_MONITOR,
 	ANTISTALL_TIMER,
-	TASK_COUNT_TIMER,
 	NOOP_TIMER,
 	MAX_TIMERS,
 };

--- a/scheds/rust/scx_layered/src/bpf/timer.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/timer.bpf.h
@@ -30,6 +30,7 @@ struct layered_timer {
 enum layer_timer_callbacks {
 	LAYERED_MONITOR,
 	ANTISTALL_TIMER,
+	TASK_COUNT_TIMER,
 	NOOP_TIMER,
 	MAX_TIMERS,
 };

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -89,6 +89,8 @@ pub enum LayerMatch {
     IsKthread(bool),
     UsedGpuTid(bool),
     UsedGpuPid(bool),
+    ThreadCountLE(u32),
+    ThreadCountGE(u32),
     AvgRuntime(u64, u64),
 }
 

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -589,6 +589,10 @@ struct Opts {
     #[clap(long, default_value = "false")]
     disable_antistall: bool,
 
+    /// Enable task count matcher
+    #[clap(long, default_value = "false")]
+    enable_task_count: bool,
+
     /// Maximum task runnable_at delay (in seconds) before antistall turns on
     #[clap(long, default_value = "3")]
     antistall_sec: u64,
@@ -1890,6 +1894,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.lo_fb_wait_ns = opts.lo_fb_wait_us * 1000;
         skel.maps.rodata_data.lo_fb_share_ppk = ((opts.lo_fb_share * 1024.0) as u32).clamp(1, 1024);
         skel.maps.rodata_data.enable_antistall = !opts.disable_antistall;
+        skel.maps.rodata_data.enable_task_count = opts.enable_task_count;
         skel.maps.rodata_data.enable_gpu_support = opts.enable_gpu_support;
 
         for (cpu, sib) in topo.sibling_cpus().iter().enumerate() {

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -595,10 +595,6 @@ struct Opts {
     #[clap(long, default_value = "false")]
     disable_antistall: bool,
 
-    /// Enable task count matcher
-    #[clap(long, default_value = "false")]
-    enable_task_count: bool,
-
     /// Maximum task runnable_at delay (in seconds) before antistall turns on
     #[clap(long, default_value = "3")]
     antistall_sec: u64,
@@ -1908,7 +1904,6 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.lo_fb_wait_ns = opts.lo_fb_wait_us * 1000;
         skel.maps.rodata_data.lo_fb_share_ppk = ((opts.lo_fb_share * 1024.0) as u32).clamp(1, 1024);
         skel.maps.rodata_data.enable_antistall = !opts.disable_antistall;
-        skel.maps.rodata_data.enable_task_count = opts.enable_task_count;
         skel.maps.rodata_data.enable_gpu_support = opts.enable_gpu_support;
 
         for (cpu, sib) in topo.sibling_cpus().iter().enumerate() {

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -320,6 +320,10 @@ lazy_static! {
 /// - UsedGpuPid: Bool. When true, matches if the tasks which have used gpu
 ///   by tgid/pid.
 ///
+/// - ThreadCountLE: u32. Matches PIDs with X or less threads.
+///
+/// - ThreadCountGE: u32. Matches PIDs with X or more threads.
+///
 /// - [EXPERIMENTAL] AvgRuntime: (u64, u64). Match tasks whose average runtime
 ///   is within the provided values [min, max).
 ///
@@ -1329,6 +1333,14 @@ impl<'a> Scheduler<'a> {
                         LayerMatch::UsedGpuPid(polarity) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_USED_GPU_PID as i32;
                             mt.used_gpu_pid.write(*polarity);
+                        }
+                        LayerMatch::ThreadCountLE(boundary) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_THREAD_COUNT_LE as i32;
+                            mt.thread_count_le = *boundary;
+                        }
+                        LayerMatch::ThreadCountGE(boundary) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_THREAD_COUNT_GE as i32;
+                            mt.thread_count_ge = *boundary;
                         }
                         LayerMatch::AvgRuntime(min, max) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_AVG_RUNTIME as i32;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -320,9 +320,11 @@ lazy_static! {
 /// - UsedGpuPid: Bool. When true, matches if the tasks which have used gpu
 ///   by tgid/pid.
 ///
-/// - ThreadCountLE: u32. Matches PIDs with X or less threads.
+/// - ThreadCountLE: u32. Matches PIDs with X or less threads. There is some
+///   approximation in how this works.
 ///
-/// - ThreadCountGE: u32. Matches PIDs with X or more threads.
+/// - ThreadCountGE: u32. Matches PIDs with X or more threads. There is some
+///   approximation in how this works.
 ///
 /// - [EXPERIMENTAL] AvgRuntime: (u64, u64). Match tasks whose average runtime
 ///   is within the provided values [min, max).


### PR DESCRIPTION
Add tgid tid matcher and supporting tgid/tid-count tracking.

This is to be used to enable writing policies that partition spammy PIDs with spammy threadpools (i.e. 10k threadpools) from those with not-spammy threadpools (i.e. threadpools w/ say, 10 threads).

This is imprecise in how it works (i.e. it tracks TIDs counted using a bloom filter), but this is for confining strongly misbehaving processes (i.e. 1k+ threadpools), so this might be fine (and preferable to more accurately tracking counts, tbh).

~I need to debug why counters aren't updating right, but the general idea is add a matcher that will run once per minute and count the number of task structs with the same TGID.~