### PR TITLE
scx_rustland: simplify monitor request handling in run()

### DIFF
--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -426,9 +426,8 @@ impl<'a> Scheduler<'a> {
             self.schedule();
 
             // Handle monitor requests asynchronously.
-            match req_ch.try_recv() {
-                Ok(()) => res_ch.send(self.get_metrics())?,
-                Err(_) => {}
+            if req_ch.try_recv().is_ok() {
+                res_ch.send(self.get_metrics())?;
             }
         }
 


### PR DESCRIPTION
Replaces a match on Result with an is_ok() check, since only the Ok case was meaningful.

No functional behavior is changed.