### PR TITLE
scx_tickless: Fix build warning

### DIFF
--- a/scheds/rust/scx_tickless/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_tickless/src/bpf/main.bpf.c
@@ -671,6 +671,8 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(tickless_init)
 		return ret;
 
 	init_timer(bpf_get_smp_processor_id());
+
+	return 0;
 }
 
 void BPF_STRUCT_OPS(tickless_exit, struct scx_exit_info *ei)


### PR DESCRIPTION
Fix the following build warning:
```
 warning: scx_tickless@1.0.3: src/bpf/main.bpf.c:674:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
 warning: scx_tickless@1.0.3:   674 | }
 warning: scx_tickless@1.0.3:       | ^
```
No functional change.