### PR TITLE
scx_bpfland: simplify error handling for sibling CPU setup

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -577,14 +577,11 @@ impl<'a> Scheduler<'a> {
             );
             for cpu in &cpus {
                 for sibling_cpu in &cpus {
-                    match enable_sibling_cpu_fn(skel, cache_lvl, *cpu, *sibling_cpu) {
-                        Ok(()) => {}
-                        Err(_) => {
-                            warn!(
-                                "L{} cache ID {}: failed to set CPU {} sibling {}",
-                                cache_lvl, cache_id, *cpu, *sibling_cpu
-                            );
-                        }
+                    if enable_sibling_cpu_fn(skel, cache_lvl, *cpu, *sibling_cpu).is_err() {
+                        warn!(
+                            "L{} cache ID {}: failed to set CPU {} sibling {}",
+                            cache_lvl, cache_id, *cpu, *sibling_cpu
+                        );
                     }
                 }
             }


### PR DESCRIPTION
Replaces a match on Result with an is_err() check, since only the Err case was meaningful and the Ok arm was empty.

No functional behavior is changed.