### PR TITLE
scx_stats: simplify channel send error handling with is_err()

### DIFF
--- a/rust/scx_stats/src/server.rs
+++ b/rust/scx_stats/src/server.rs
@@ -522,9 +522,8 @@ where
                             }
                         };
 
-                        match inner_ch.req.send(req) {
-                            Ok(()) => {}
-                            Err(SendError(..)) => break 'outer,
+                        if inner_ch.req.send(req).is_err() {
+                            break 'outer;
                         }
 
                         let resp = match inner_ch.res.recv() {
@@ -532,12 +531,9 @@ where
                             Err(RecvError) => break 'outer,
                         };
 
-                        match pair.req.send(resp) {
-                            Ok(()) => {}
-                            Err(SendError(..)) => {
-                                idx_to_drop = Some(*idx);
-                                break 'select;
-                            }
+                        if pair.req.send(resp).is_err() {
+                            idx_to_drop = Some(*idx);
+                            break 'select;
                         }
                     }
                 }


### PR DESCRIPTION
Replaces a match on Result with an is_err() check in the proxy loop, since only the Err case was meaningful and the Ok arm was empty.

No functional behavior is changed.