### PR TITLE
scx_lavd: Make the load balancing core compaction- and capacity-aware.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -7,58 +7,141 @@
 /*
  * To be included to the main.bpf.c
  */
+
+u64 __attribute__ ((noinline)) calc_mig_delta(u64 avg_sc_load, int nz_qlen)
+{
+	/*
+	 * Note that added "noinline" to make the verifier happy.
+	 */
+	if (nz_qlen >= sys_stat.nr_active_cpdoms)
+		return avg_sc_load >> LAVD_CPDOM_MIG_SHIFT_OL;
+	if (nz_qlen == 0)
+		return avg_sc_load >> LAVD_CPDOM_MIG_SHIFT_UL;
+	return avg_sc_load >> LAVD_CPDOM_MIG_SHIFT;
+}
+
 static void plan_x_cpdom_migration(void)
 {
 	struct cpdom_ctx *cpdomc;
 	u64 dsq_id;
-	u32 avg_nr_q_tasks_per_cpu = 0, x_mig_delta;
 	u32 stealer_threshold, stealee_threshold, nr_stealee = 0;
+	u64 avg_sc_load = 0, min_sc_load = U64_MAX, max_sc_load = 0;
+	u64 x_mig_delta, util, qlen, sc_qlen;
+	bool overflow_running = false;
+	int nz_qlen = 0;
 
 	/*
-	 * Calcualte average queued tasks per CPU per compute domain.
+	 * The load balancing aims for two goals:
+	 *
+	 * 1) The *non-scaled* CPU utilizations of all active CPUs should be
+	 * the same or similar. This helps to maintain low latency
+	 * when the system is underloaded.
+	 *
+	 * 2) The *scaled* queue lengths of active compute domains should be
+	 * the same or similar. Using scaled queue length allows putting more
+	 * tasks to the powerful compute domains. This helps to maintain high
+	 * throughput when the system is overloaded.
+	 */
+
+	/*
+	 * Calculate scaled load for each active compute domain.
 	 */
 	bpf_for(dsq_id, 0, nr_cpdoms) {
 		if (dsq_id >= LAVD_CPDOM_MAX_NR)
 			break;
 
 		cpdomc = MEMBER_VPTR(cpdom_ctxs, [dsq_id]);
-		cpdomc->nr_q_tasks_per_cpu = (cpdomc->nr_queued_task << LAVD_SHIFT) / cpdomc->nr_cpus;
-		avg_nr_q_tasks_per_cpu += cpdomc->nr_q_tasks_per_cpu;
+		if (!cpdomc->nr_active_cpus) {
+			/*
+			 * If tasks are running on an overflow domain,
+			 * need load balancing.
+			 */
+			if (cpdomc->cur_util_sum > 0)
+				overflow_running = true;
+			continue;
+		}
+
+		util = (cpdomc->cur_util_sum << LAVD_SHIFT) / cpdomc->nr_active_cpus;
+		qlen = cpdomc->nr_queued_task;
+		sc_qlen = (qlen << (LAVD_SHIFT * 3)) / cpdomc->cap_sum_active_cpus;
+		cpdomc->sc_load = util + sc_qlen;
+		avg_sc_load += cpdomc->sc_load;
+
+		if (min_sc_load > cpdomc->sc_load)
+			min_sc_load = cpdomc->sc_load;
+		if (max_sc_load < cpdomc->sc_load)
+			max_sc_load = cpdomc->sc_load;
+		if (qlen)
+			nz_qlen++;
 	}
-	avg_nr_q_tasks_per_cpu /= nr_cpdoms;
+	if (sys_stat.nr_active_cpdoms)
+		avg_sc_load /= sys_stat.nr_active_cpdoms;
+
+	/*
+	 * Determine the criteria for stealer and stealee domains.
+	 * The more the system is loaded, the tighter criteria will be chosen.
+	 */
+	x_mig_delta = calc_mig_delta(avg_sc_load, nz_qlen);
+	stealer_threshold = avg_sc_load - x_mig_delta;
+	stealee_threshold = avg_sc_load + x_mig_delta;
+
+	if ((stealee_threshold > max_sc_load) && !overflow_running) {
+		/*
+		 * If there is no overloaded domain, do not try to steal.
+		 *  <~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~>
+		 * [stealer_threshold ... avg_sc_load ... max_sc_load ... stealee_threshold]
+		 *            -------------------------------------->
+		 */
+		return;
+	}
+	if ((stealee_threshold <= max_sc_load || overflow_running) &&
+	    (stealer_threshold < min_sc_load)) {
+		/*
+		 * If there is a overloaded domain, always try to steal.
+		 *  <~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~>
+		 * [stealer_threshold ... min_sc_load ... avg_sc_load ... stealee_threshold ... max_sc_load]
+		 *                        <--------------------------------------------------------------->
+		 */
+		stealer_threshold = min_sc_load;
+	}
 
 	/*
 	 * Determine stealer and stealee domains.
-	 *
-	 * A stealer domain, whose per-CPU queue length is shorter than
-	 * the average, will steal a task from any of stealee domain,
-	 * whose per-CPU queue length is longer than the average.
-	 * Compute domain around average will not do anything.
 	 */
-	x_mig_delta = avg_nr_q_tasks_per_cpu >> LAVD_CPDOM_MIGRATION_SHIFT;
-	stealer_threshold = avg_nr_q_tasks_per_cpu - x_mig_delta;
-	stealee_threshold = avg_nr_q_tasks_per_cpu + x_mig_delta;
-
 	bpf_for(dsq_id, 0, nr_cpdoms) {
 		if (dsq_id >= LAVD_CPDOM_MAX_NR)
 			break;
 
 		cpdomc = MEMBER_VPTR(cpdom_ctxs, [dsq_id]);
 
-		if (cpdomc->nr_q_tasks_per_cpu < stealer_threshold) {
+		/*
+		 * Under-loaded active domains become a stealer.
+		 */
+		if (cpdomc->nr_active_cpus &&
+		    cpdomc->sc_load <= stealer_threshold) {
 			WRITE_ONCE(cpdomc->is_stealer, true);
 			WRITE_ONCE(cpdomc->is_stealee, false);
+			continue;
 		}
-		else if (cpdomc->nr_q_tasks_per_cpu > stealee_threshold) {
+
+		/*
+		 * Over-loaded or non-active domains become a stealee.
+		 */
+		if (!cpdomc->nr_active_cpus ||
+		    cpdomc->sc_load >= stealee_threshold) {
 			WRITE_ONCE(cpdomc->is_stealer, false);
 			WRITE_ONCE(cpdomc->is_stealee, true);
 			nr_stealee++;
+			continue;
 		}
-		else {
-			WRITE_ONCE(cpdomc->is_stealer, false);
-			WRITE_ONCE(cpdomc->is_stealee, false);
-		}
+
+		/*
+		 * Otherwise, keep tasks as it is.
+		 */
+		WRITE_ONCE(cpdomc->is_stealer, false);
+		WRITE_ONCE(cpdomc->is_stealee, false);
 	}
+
 	sys_stat.nr_stealee = nr_stealee;
 }
 
@@ -77,11 +160,9 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 	s64 nuance;
 
 	/*
-	 * If all CPUs are not used -- i.e., the system is under-utilized,
-	 * there is no point of load balancing. It is better to make an
-	 * effort to increase the system utilization.
+	 * Only active domains steal the tasks from other domains.
 	 */
-	if (!use_full_cpus())
+	if (!cpdomc->nr_active_cpus)
 		return false;
 
 	/*
@@ -89,7 +170,7 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 	 * thundering herd problem. In other words, one out of nr_cpus
 	 * will try to steal a task at a moment.
 	 */
-	if (!prob_x_out_of_y(1, cpdomc->nr_cpus * LAVD_CPDOM_X_PROB_FT))
+	if (!prob_x_out_of_y(1, cpdomc->nr_active_cpus * LAVD_CPDOM_MIG_PROB_FT))
 		return false;
 
 	/*
@@ -118,7 +199,7 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 				return false;
 			}
 
-			if (!cpdomc_pick->is_stealee || !cpdomc_pick->is_valid)
+			if (!READ_ONCE(cpdomc_pick->is_stealee) || !cpdomc_pick->is_valid)
 				continue;
 
 			/*
@@ -148,7 +229,7 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 		 * increases, so, on the other hand, it increases the chance
 		 * of closer migration.
 		 */
-		if (!prob_x_out_of_y(1, LAVD_CPDOM_X_PROB_FT))
+		if (!prob_x_out_of_y(1, LAVD_CPDOM_MIG_PROB_FT))
 			break;
 	}
 

--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -209,7 +209,7 @@ s32 pick_idle_cpu_at_cpdom(struct pick_ctx *ctx, s64 cpdom, u64 scope,
 	 * Search an idle CPU in a compute domain
 	 * in the order of turbo, active, and overflow.
 	 */
-	if (!ctx->iat_empty && cpdc->is_active && cpdc->is_big) {
+	if (!ctx->iat_empty && cpdc->nr_active_cpus && cpdc->is_big) {
 		bpf_cpumask_and(ctx->temp_mask,
 				cast_mask(cpd_mask), cast_mask(ctx->iat_mask));
 		cpu = scx_bpf_pick_idle_cpu(cast_mask(ctx->temp_mask), scope);
@@ -218,7 +218,7 @@ s32 pick_idle_cpu_at_cpdom(struct pick_ctx *ctx, s64 cpdom, u64 scope,
 			return cpu;
 		}
 	}
-	if (!ctx->ia_empty && cpdc->is_active) {
+	if (!ctx->ia_empty && cpdc->nr_active_cpus) {
 		bpf_cpumask_and(ctx->temp_mask,
 				cast_mask(cpd_mask), cast_mask(ctx->ia_mask));
 		cpu = scx_bpf_pick_idle_cpu(cast_mask(ctx->temp_mask), scope);
@@ -329,7 +329,7 @@ bool can_run_on_domain(struct pick_ctx *ctx, s64 cpdom)
 		return false;
 
 	a_mask = ctx->a_mask;
-	if (a_mask && cpdc->is_active &&
+	if (a_mask && cpdc->nr_active_cpus &&
 	    bpf_cpumask_intersects(cast_mask(a_mask), cast_mask(cpd_mask)))
 		return true;
 

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -82,7 +82,8 @@ struct sys_stat {
 	u32	thr_perf_cri;	/* performance criticality threshold */
 
 	u32	nr_stealee;	/* number of compute domains to be migrated */
-	u32	nr_active;	/* number of active cores */
+	u32	nr_active;	/* number of active CPUs */
+	u32	nr_active_cpdoms; /* number of active compute domains */
 
 	u64	nr_sched;	/* total scheduling so far */
 	u64	nr_preempt;	/* total number of preemption operations triggered */

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -77,6 +77,8 @@ struct cpdom_ctx {
 	u8	is_stealee;			    /* stealer doamin should steal tasks from this domain */
 	u16	nr_cpus;			    /* the number of CPUs in this compute domain */
 	u32	nr_q_tasks_per_cpu;		    /* the number of queued tasks per CPU in this domain (x1000) */
+	u32	nr_queued_task;			    /* the number of queued tasks in this domain */
+	u32	cur_util_sum;			    /* the sum of  CPU utilization in the current interval */
 	u8	nr_neighbors[LAVD_CPDOM_MAX_DIST];  /* number of neighbors per distance */
 	u64	neighbor_bits[LAVD_CPDOM_MAX_DIST]; /* bitmask of neighbor bitmask per distance */
 	u64	__cpumask[LAVD_CPU_ID_MAX/64];	    /* cpumasks belongs to this compute domain */

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1632,10 +1632,11 @@ static s32 init_per_cpu_ctx(u64 now)
 					cpuc->cpdom_id = cpdomc->id;
 					cpuc->cpdom_alt_id = cpdomc->alt_id;
 
-					if (bpf_cpumask_test_cpu(cpu, online_cpumask))
+					if (bpf_cpumask_test_cpu(cpu, online_cpumask)) {
 						bpf_cpumask_set_cpu(cpu, cd_cpumask);
-					if (bpf_cpumask_test_cpu(cpu, cast_mask(active)))
-						WRITE_ONCE(cpdomc->is_active, true);
+						cpdomc->nr_active_cpus++;
+						cpdomc->cap_sum_active_cpus += cpuc->capacity;
+					}
 					cpdomc->nr_cpus++;
 				}
 			}

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -214,11 +214,11 @@ const volatile u64	slice_max_ns = LAVD_SLICE_MAX_NS_DFL;
 #include "util.bpf.c"
 #include "power.bpf.c"
 #include "introspec.bpf.c"
-#include "sys_stat.bpf.c"
 #include "preempt.bpf.c"
 #include "lock.bpf.c"
 #include "idle.bpf.c"
 #include "balance.bpf.c"
+#include "sys_stat.bpf.c"
 
 static u32 calc_greedy_ratio(struct task_ctx *taskc)
 {

--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -127,10 +127,10 @@ static void do_core_compaction(void)
 {
 	const volatile u16 *cpu_order = get_cpu_order();
 	struct cpu_ctx *cpuc;
-	struct bpf_cpumask *active, *ovrflw, *cd_cpumask;
+	struct bpf_cpumask *active, *ovrflw;
 	struct cpdom_ctx *cpdomc;
 	int nr_active, nr_active_old, cpu, i;
-	u32 sum_capacity = 0, big_capacity = 0;
+	u32 sum_capacity = 0, big_capacity = 0, nr_active_cpdoms = 0;
 	bool clear;
 	u64 cpdom_id;
 
@@ -173,9 +173,15 @@ static void do_core_compaction(void)
 			bpf_cpumask_set_cpu(cpu, active);
 			bpf_cpumask_clear_cpu(cpu, ovrflw);
 
-			cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpu]);
-			if (cpdomc)
-				WRITE_ONCE(cpdomc->is_active, true);
+			/*
+			 * Accumulate the capacity of active CPUs and
+			 * increase the number of active CPUs.
+			 */
+			cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpuc->cpdom_id]);
+			if (cpdomc) {
+				cpdomc->cap_sum_temp += cpuc->capacity;
+				cpdomc->nr_acpus_temp++;
+			}
 			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 
 			/*
@@ -213,20 +219,24 @@ static void do_core_compaction(void)
 	sys_stat.nr_active = nr_active;
 
 	/*
-	 * Maintain cpdomc->is_active reflecting the active set.
+	 * Update nr_active_cpus and cap_sum_active_cpus.
 	 */
 	bpf_for(cpdom_id, 0, nr_cpdoms) {
 		if (cpdom_id >= LAVD_CPDOM_MAX_NR)
 			break;
 
 		cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpdom_id]);
-		cd_cpumask = MEMBER_VPTR(cpdom_cpumask, [cpdom_id]);
-		if (!cpdomc || !cd_cpumask || !cpdomc->is_active)
+		if (!cpdomc)
 			continue;
+		WRITE_ONCE(cpdomc->nr_active_cpus, cpdomc->nr_acpus_temp);
+		WRITE_ONCE(cpdomc->nr_acpus_temp, 0);
+		WRITE_ONCE(cpdomc->cap_sum_active_cpus, cpdomc->cap_sum_temp);
+		WRITE_ONCE(cpdomc->cap_sum_temp, 0);
 
-		if (!bpf_cpumask_intersects(cast_mask(active), cast_mask(cd_cpumask)))
-			WRITE_ONCE(cpdomc->is_active, false);
+		if (cpdomc->nr_active_cpus)
+			nr_active_cpdoms++;
 	}
+	sys_stat.nr_active_cpdoms = nr_active_cpdoms;
 
 unlock_out:
 	bpf_rcu_read_unlock();
@@ -419,6 +429,7 @@ static int reinit_active_cpumask_for_performance(void)
 	const struct cpumask *online_cpumask;
 	struct cpdom_ctx *cpdomc;
 	u64 dsq_id;
+	u32 nr_active_cpdoms = 0;
 	int cpu, err = 0;
 
 	barrier();
@@ -446,21 +457,41 @@ static int reinit_active_cpumask_for_performance(void)
 	if (have_little_core) {
 		bpf_for(cpu, 0, nr_cpu_ids) {
 			cpuc = get_cpu_ctx_id(cpu);
-			if (!cpuc) {
-				err = -ESRCH;
-				goto unlock_out;
+			if (!cpuc)
+				continue;
+			if (!cpuc->is_online) {
+				bpf_cpumask_clear_cpu(cpu, active);
+				bpf_cpumask_clear_cpu(cpu, ovrflw);
+				continue;
 			}
 
 			if (cpuc->big_core) {
 				bpf_cpumask_set_cpu(cpu, active);
 				bpf_cpumask_clear_cpu(cpu, ovrflw);
-			}
-			else {
+			} else {
 				bpf_cpumask_set_cpu(cpu, ovrflw);
 				bpf_cpumask_clear_cpu(cpu, active);
 			}
+
+			cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpu]);
+			if (cpdomc) {
+				cpdomc->nr_acpus_temp++;
+				cpdomc->cap_sum_temp += cpuc->capacity;
+			}
 		}
 	} else {
+		bpf_for(cpu, 0, nr_cpu_ids) {
+			cpuc = get_cpu_ctx_id(cpu);
+			if (!cpuc || !cpuc->is_online)
+				continue;
+
+			cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpu]);
+			if (cpdomc) {
+				cpdomc->nr_acpus_temp++;
+				cpdomc->cap_sum_temp += cpuc->capacity;
+			}
+		}
+
 		online_cpumask = scx_bpf_get_online_cpumask();
 		nr_cpus_onln = bpf_cpumask_weight(online_cpumask);
 		bpf_cpumask_copy(active, online_cpumask);
@@ -470,16 +501,23 @@ static int reinit_active_cpumask_for_performance(void)
 	}
 
 	/*
-	 * Make all compute domains active.
+	 * Update nr_active_cpus and cap_sum_active_cpus.
 	 */
 	bpf_for(dsq_id, 0, nr_cpdoms) {
 		if (dsq_id >= LAVD_CPDOM_MAX_NR)
 			break;
 
 		cpdomc = MEMBER_VPTR(cpdom_ctxs, [dsq_id]);
-		cpdomc->is_active = true;
+		WRITE_ONCE(cpdomc->nr_active_cpus, cpdomc->nr_acpus_temp);
+		WRITE_ONCE(cpdomc->nr_acpus_temp, 0);
+		WRITE_ONCE(cpdomc->cap_sum_active_cpus, cpdomc->cap_sum_temp);
+		WRITE_ONCE(cpdomc->cap_sum_temp, 0);
+
+		if (cpdomc->nr_active_cpus)
+			nr_active_cpdoms++;
 	}
 	sys_stat.nr_active = nr_cpus_onln;
+	sys_stat.nr_active_cpdoms = nr_active_cpdoms;
 
 unlock_out:
 	bpf_rcu_read_unlock();

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -39,7 +39,6 @@ struct sys_stat_ctx {
 	u32		nr_perf_cri;
 	u32		nr_lat_cri;
 	u32		nr_x_migration;
-	u32		nr_stealee;
 	u32		nr_big;
 	u32		nr_pc_on_big;
 	u32		nr_lc_on_big;
@@ -62,67 +61,28 @@ static void init_sys_stat_ctx(struct sys_stat_ctx *c)
 	sys_stat.last_update_clk = c->now;
 }
 
-static void plan_x_cpdom_migration(struct sys_stat_ctx *c)
+static void collect_sys_stat(struct sys_stat_ctx *c)
 {
 	struct cpdom_ctx *cpdomc;
 	u64 dsq_id;
-	u32 avg_nr_q_tasks_per_cpu = 0, nr_q_tasks, x_mig_delta;
-	u32 stealer_threshold, stealee_threshold;
-
-	/*
-	 * Calcualte average queued tasks per CPU per compute domain.
-	 */
-	bpf_for(dsq_id, 0, nr_cpdoms) {
-		if (dsq_id >= LAVD_CPDOM_MAX_NR)
-			break;
-
-		nr_q_tasks = scx_bpf_dsq_nr_queued(dsq_id);
-		c->nr_queued_task += nr_q_tasks;
-
-		cpdomc = MEMBER_VPTR(cpdom_ctxs, [dsq_id]);
-		cpdomc->nr_q_tasks_per_cpu = (nr_q_tasks << LAVD_SHIFT) / cpdomc->nr_cpus;
-		avg_nr_q_tasks_per_cpu += cpdomc->nr_q_tasks_per_cpu;
-	}
-	avg_nr_q_tasks_per_cpu /= nr_cpdoms;
-
-	/*
-	 * Determine stealer and stealee domains.
-	 *
-	 * A stealer domain, whose per-CPU queue length is shorter than
-	 * the average, will steal a task from any of stealee domain,
-	 * whose per-CPU queue length is longer than the average.
-	 * Compute domain around average will not do anything.
-	 */
-	x_mig_delta = avg_nr_q_tasks_per_cpu >> LAVD_CPDOM_MIGRATION_SHIFT;
-	stealer_threshold = avg_nr_q_tasks_per_cpu - x_mig_delta;
-	stealee_threshold = avg_nr_q_tasks_per_cpu + x_mig_delta;
-
-	bpf_for(dsq_id, 0, nr_cpdoms) {
-		if (dsq_id >= LAVD_CPDOM_MAX_NR)
-			break;
-
-		cpdomc = MEMBER_VPTR(cpdom_ctxs, [dsq_id]);
-
-		if (cpdomc->nr_q_tasks_per_cpu < stealer_threshold) {
-			WRITE_ONCE(cpdomc->is_stealer, true);
-			WRITE_ONCE(cpdomc->is_stealee, false);
-		}
-		else if (cpdomc->nr_q_tasks_per_cpu > stealee_threshold) {
-			WRITE_ONCE(cpdomc->is_stealer, false);
-			WRITE_ONCE(cpdomc->is_stealee, true);
-			c->nr_stealee++;
-		}
-		else {
-			WRITE_ONCE(cpdomc->is_stealer, false);
-			WRITE_ONCE(cpdomc->is_stealee, false);
-		}
-	}
-}
-
-static void collect_sys_stat(struct sys_stat_ctx *c)
-{
 	int cpu;
 
+	/*
+	 * Collect statistics for each compute domain.
+	 */
+	bpf_for(dsq_id, 0, nr_cpdoms) {
+		if (dsq_id >= LAVD_CPDOM_MAX_NR)
+			break;
+
+		cpdomc = MEMBER_VPTR(cpdom_ctxs, [dsq_id]);
+		cpdomc->cur_util_sum = 0;
+		cpdomc->nr_queued_task = scx_bpf_dsq_nr_queued(dsq_id);
+		c->nr_queued_task += cpdomc->nr_queued_task;
+	}
+
+	/*
+	 * Collect statistics for each CPU.
+	 */
 	bpf_for(cpu, 0, nr_cpu_ids) {
 		struct cpu_ctx *cpuc = get_cpu_ctx_id(cpu);
 		if (!cpuc) {
@@ -221,7 +181,7 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 		}
 
 		/*
-		 * Calculcate per-CPU utilization
+		 * Calculcate per-CPU utilization.
 		 */
 		u64 compute = 0;
 		if (c->duration > cpuc->idle_total)
@@ -230,8 +190,12 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 		cpuc->cur_util = (compute << LAVD_SHIFT) / c->duration;
 		cpuc->avg_util = calc_asym_avg(cpuc->avg_util, cpuc->cur_util);
 
+		cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpuc->cpdom_id]);
+		if (cpdomc)
+			cpdomc->cur_util_sum += cpuc->cur_util;
+
 		/*
-		 * Accmulate system-wide idle time
+		 * Accmulate system-wide idle time.
 		 */
 		c->idle_total += cpuc->idle_total;
 		cpuc->idle_total = 0;
@@ -299,8 +263,6 @@ static void calc_sys_stat(struct sys_stat_ctx *c)
 			calc_avg32(sys_stat.max_perf_cri, c->max_perf_cri);
 	}
 
-	sys_stat.nr_stealee = c->nr_stealee;
-
 	if (c->nr_sched > 0)
 		avg_svc_time = c->tot_svc_time / c->nr_sched;
 	sys_stat.avg_svc_time = calc_avg(sys_stat.avg_svc_time, avg_svc_time);
@@ -359,7 +321,6 @@ static void do_update_sys_stat(void)
 	struct sys_stat_ctx c;
 
 	init_sys_stat_ctx(&c);
-	plan_x_cpdom_migration(&c);
 	collect_sys_stat(&c);
 	calc_sys_stat(&c);
 }
@@ -381,6 +342,8 @@ static void update_sys_stat(void)
 		reinit_cpumask_for_performance = false;
 		reinit_active_cpumask_for_performance();
 	}
+
+	plan_x_cpdom_migration();
 }
 
 static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)


### PR DESCRIPTION
Previously, load balancing assumed that all CPUs were in active sets and had
the same capacity. Also, it aims to equalize the DSQ length of each domain.
However, it does not work well if a system has heterogeneous processors
(big/LITTLE) or is under-loaded (i.e., DSQ lengths are all zero).

Thus, let's make the load-balancing core compaction and CPU capacity aware.
The load balancing now considers the active CPUs and each CPU's capacity.
The load balancing aims for two goals:

1) The *non-scaled* CPU utilizations of all active CPUs should be the same or
   similar. This helps to maintain low latency when the system is underloaded.

2) The *scaled* queue lengths of active compute domains should be the same or
   similar. Using scaled queue length allows putting more tasks to the powerful
   compute domains. This helps to maintain high throughput when the system is
   overloaded.
