### PR TITLE
scx_p2dq: Add --select-idle-in-enqueue flag

### DIFF
--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -74,6 +74,10 @@ pub struct SchedulerOpts {
     #[clap(long, action = clap::ArgAction::SetTrue)]
     pub wakeup_llc_migrations: bool,
 
+    /// Allow selecting idle in enqueue path.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub select_idle_in_enqueue: bool,
+
     /// Set idle QoS resume latency based in microseconds.
     #[clap(long)]
     pub idle_resume_us: Option<u32>,
@@ -200,7 +204,7 @@ macro_rules! init_open_skel {
             $skel.maps.rodata_data.keep_running_enabled = opts.keep_running;
             $skel.maps.rodata_data.max_dsq_pick2 = opts.max_dsq_pick2;
             $skel.maps.rodata_data.smt_enabled = $crate::TOPO.smt_enabled;
-            $skel.maps.rodata_data.select_idle_in_enqueue = true;
+            $skel.maps.rodata_data.select_idle_in_enqueue = opts.select_idle_in_enqueue;
             $skel.maps.rodata_data.wakeup_lb_busy = opts.wakeup_lb_busy;
             $skel.maps.rodata_data.wakeup_llc_migrations = opts.wakeup_llc_migrations;
             $skel.maps.rodata_data.max_exec_ns =


### PR DESCRIPTION
Add select_idle_in_enqueue flag to optionally enable select idle CPU in the enqueue path. Enabling this option may lead to better CPU selection at the cost of wakeup latency.

(new) default disabled:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (411907 total samples)
          50.0th: 6          (131894 samples)
          90.0th: 9          (122217 samples)
        * 99.0th: 13         (28193 samples)
          99.9th: 106        (3104 samples)
          min=1, max=17011
Request Latencies percentiles (usec) runtime 30 (s) (412632 total samples)
          50.0th: 6568       (122113 samples)
          90.0th: 10736      (162216 samples)
        * 99.0th: 12368      (37024 samples)
          99.9th: 16144      (3570 samples)
          min=5831, max=105697
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13744      (7 samples)
        * 50.0th: 13808      (10 samples)
          90.0th: 13872      (14 samples)
          min=12007, max=13881
average rps: 13754.40
```
with `--select-idle-in-enqueue` enabled:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (409611 total samples)
          50.0th: 7          (107342 samples)
          90.0th: 10         (80733 samples)
        * 99.0th: 14         (25656 samples)
          99.9th: 88         (3247 samples)
          min=1, max=15750
Request Latencies percentiles (usec) runtime 30 (s) (410393 total samples)
          50.0th: 6600       (130292 samples)
          90.0th: 10736      (157441 samples)
        * 99.0th: 12432      (36253 samples)
          99.9th: 16928      (3401 samples)
          min=5812, max=114258
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13680      (9 samples)
        * 50.0th: 13744      (7 samples)
          90.0th: 13808      (14 samples)
          min=12016, max=13838
average rps: 13679.77
```