### PR TITLE
scx_lavd: Donate tasks at ops.select_cpu() and ops.enqueue().

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -56,8 +56,12 @@ static void plan_x_cpdom_migration(void)
 			 * If tasks are running on an overflow domain,
 			 * need load balancing.
 			 */
-			if (cpdomc->cur_util_sum > 0)
+			if (cpdomc->cur_util_sum > 0) {
 				overflow_running = true;
+				cpdomc->sc_load = U32_MAX;
+			}
+			else
+				cpdomc->sc_load = 0;
 			continue;
 		}
 

--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -51,7 +51,7 @@ enum {
 	LAVD_CPU_ID_MAX			= 512,
 
 	LAVD_CPDOM_MAX_NR		= 16, /* maximum number of compute domain */
-	LAVD_CPDOM_MAX_DIST		= 4,  /* maximum distance from one compute domain to another */
+	LAVD_CPDOM_MAX_DIST		= 3,  /* maximum distance from one compute domain to another */
 
 	LAVD_STATUS_STR_LEN		= 4, /* {LR: Latency-critical, Regular}
 						{HI: performance-Hungry, performance-Insensitive}

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -327,22 +327,38 @@ static void do_update_sys_stat(void)
 
 static void update_sys_stat(void)
 {
+	/*
+	 * Update system statistics.
+	 */
 	do_update_sys_stat();
 
+	/*
+	 * Change the power profile based on the statistics.
+	 */
 	if (is_autopilot_on)
 		do_autopilot();
 
+	/*
+	 * Perform core compaction for powersave and balance mode.
+	 * Or turn on all CPUs for performance mode.
+	 */
 	if (!no_core_compaction)
 		do_core_compaction();
-
-	calc_sys_time_slice();
-	update_thr_perf_cri();
 
 	if (reinit_cpumask_for_performance) {
 		reinit_cpumask_for_performance = false;
 		reinit_active_cpumask_for_performance();
 	}
 
+	/*
+	 * Update time slice and performance criticality threshold.
+	 */
+	calc_sys_time_slice();
+	update_thr_perf_cri();
+
+	/*
+	 * Plan cross-domain task migration.
+	 */
 	if (nr_cpdoms > 1)
 		plan_x_cpdom_migration();
 }


### PR DESCRIPTION
When the system is underloaded, task stealing does not work well since there is almost always no task in DSQ.

To address this problem, when the system is underloaded, perform task donation at ops.select_cpu() and ops.enqueue() paths.

More specifically, try task donation when the sticky domain is a stealee domain (i.e., relatively overloaded) and there is no fully idle CPU on the sticky domain while picking an idle CPU at ops.select_cpu() and ops.enqueue(). In this case, traverse neighbor domains in distance order, find a fully idle CPU, and migrate the domain having the fully idle CPU.