### PR TITLE
scx_lavd: Don't print unnecessary CPU preference orders.

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -664,8 +664,12 @@ impl<'a> Scheduler<'a> {
         for (pos, cpu) in cpu_ps_order.iter().enumerate() {
             skel.maps.rodata_data.cpu_order_powersave[pos] = *cpu as u16;
         }
-        info!("CPU pref order in performance mode: {:?}", cpu_pf_order);
-        info!("CPU pref order in powersave mode: {:?}", cpu_ps_order);
+        if (!opts.powersave) {
+            info!("CPU pref order in performance mode: {:?}", cpu_pf_order);
+        }
+        if (!opts.performance) {
+            info!("CPU pref order in powersave mode: {:?}", cpu_ps_order);
+        }
 
         // Initialize compute domain contexts
         for (k, v) in topo.cpdom_map.iter() {


### PR DESCRIPTION
When starting the scheduler, CPU preference orders for performance and power-save modes were printed. Printing unnecessary information (e.g., the power-save order when the performance option is specified) would confuse the user. So let's print only relevant information.