### PR TITLE
scx_rustland_core: propagate errors from enable_sibling_cpu_fn

### DIFF
--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -88,6 +88,7 @@ pub mod bpf_intf;
 
 #[rustfmt::skip]
 mod bpf;
+use std::io::{self, ErrorKind};
 use std::mem::MaybeUninit;
 use std::time::SystemTime;
 

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
-use std::io::{self};
+use std::io::{self, ErrorKind};
 use std::mem::MaybeUninit;
 use std::time::Duration;
 use std::time::SystemTime;


### PR DESCRIPTION
Previously, errors during sibling CPU setup were silently ignored, making failures hard to debug. Now they are returned with context as `io::Error,` allowing the caller to handle them as needed.

Ref: #1866 