### PR TITLE
scx_rustland_core: drop unused variable

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -545,7 +545,6 @@ static void dispatch_task(const struct dispatched_task_ctx *task)
 	struct task_struct *p;
 	struct task_ctx *tctx;
 	u64 dsq_id, curr_cpumask_cnt;
-	s32 cpu;
 
 	/* Ignore entry if the task doesn't exist anymore */
 	p = bpf_task_from_pid(task->pid);


### PR DESCRIPTION
Remove the unused variable `cpu` from dispatch_task() in main.bpf.c. The variable was never read or assigned, and its presence triggered a -Wunused-variable warning during BPF compilation.

Log:
```
warning: scx_rlfifo@1.0.12: main.bpf.c:548:6: warning: unused variable 'cpu' [-Wunused-variable]
warning: scx_rlfifo@1.0.12:   548 |         s32 cpu;
warning: scx_rlfifo@1.0.12:       |             ^~~
warning: scx_rlfifo@1.0.12: 1 warning generated.
warning: scx_rustland@1.0.12: main.bpf.c:548:6: warning: unused variable 'cpu' [-Wunused-variable]
warning: scx_rustland@1.0.12:   548 |         s32 cpu;
warning: scx_rustland@1.0.12:       |             ^~~
warning: scx_rustland@1.0.12: 1 warning generated.
```