### PR TITLE
scx_loader: Add rustland scheduler

### DIFF
--- a/rust/scx_loader/configuration.md
+++ b/rust/scx_loader/configuration.md
@@ -54,12 +54,18 @@ auto_mode = []
 gaming_mode = ["-f 5000 -s 5000"]
 lowlatency_mode = ["-f 5000 -s 1000"]
 powersave_mode = ["-f 50 -p"]
+
+[scheds.scx_rustland]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
 ```
 
 **`default_sched`:**
 
 * This field specifies the scheduler that will be started automatically when `scx_loader` starts (e.g., on boot).
-* It should be set to the name of a supported scheduler (e.g., `"scx_bpfland"`, `"scx_rusty"`, `"scx_lavd"`, `"scx_flash", `"scx_p2dq"``).
+* It should be set to the name of a supported scheduler (e.g., `"scx_bpfland"`, `"scx_rusty"`, `"scx_lavd"`, `"scx_flash"`, `"scx_p2dq"`, `"scx_rustland"`).
 * If this field is not present or is set to an empty string, no scheduler will be started automatically.
 
 **`default_mode`:**
@@ -70,7 +76,7 @@ powersave_mode = ["-f 50 -p"]
 
 **`[scheds.scx_name]`:**
 
-* This section defines the custom flags for a specific scheduler. Replace `scx_name` with the actual name of the scheduler (e.g., `scx_bpfland`, `scx_rusty`, `scx_lavd`, `scx_flash`, `scx_p2dq`).
+* This section defines the custom flags for a specific scheduler. Replace `scx_name` with the actual name of the scheduler (e.g., `scx_bpfland`, `scx_rusty`, `scx_lavd`, `scx_flash`, `scx_p2dq`, `scx_rustland`).
 
 **`auto_mode`, `gaming_mode`, `lowlatency_mode`, `powersave_mode`, `server_mode`:**
 
@@ -97,6 +103,8 @@ The example configuration above shows how to set custom flags for different sche
 * For `scx_p2dq`:
     * Low Latency mode: `-y`
     * Server mode: `--keep-running`
+* For `scx_rustland`:
+    * No custom flags are defined, so the default flags for each mode will be used.
 
 ## Fallback Behavior
 

--- a/rust/scx_loader/src/config.rs
+++ b/rust/scx_loader/src/config.rs
@@ -101,6 +101,10 @@ pub fn get_default_config() -> Config {
                 "scx_tickless".to_string(),
                 get_default_sched_for_config(&SupportedSched::Tickless),
             ),
+            (
+                "scx_rustland".to_string(),
+                get_default_sched_for_config(&SupportedSched::Rustland),
+            ),
         ]),
     }
 }
@@ -216,6 +220,8 @@ fn get_default_scx_flags_for_mode(scx_sched: &SupportedSched, sched_mode: SchedM
             SchedMode::Server => vec!["-f", "100"],
             SchedMode::Auto => vec![],
         },
+        // scx_rustland doesn't support any of these modes
+        SupportedSched::Rustland => vec![],
     }
 }
 
@@ -269,6 +275,13 @@ gaming_mode = ["-f", "5000", "-s", "5000"]
 lowlatency_mode = ["-f", "5000", "-s", "1000"]
 powersave_mode = ["-f", "50", "-p"]
 server_mode = ["-f", "100"]
+
+[scheds.scx_rustland]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
 "#;
 
         let parsed_config = parse_config_content(config_str).expect("Failed to parse config");

--- a/rust/scx_loader/src/lib.rs
+++ b/rust/scx_loader/src/lib.rs
@@ -32,6 +32,8 @@ pub enum SupportedSched {
     P2DQ,
     #[serde(rename = "scx_tickless")]
     Tickless,
+    #[serde(rename = "scx_rustland")]
+    Rustland,
 }
 
 impl FromStr for SupportedSched {
@@ -44,6 +46,7 @@ impl FromStr for SupportedSched {
             "scx_lavd" => Ok(SupportedSched::Lavd),
             "scx_p2dq" => Ok(SupportedSched::P2DQ),
             "scx_tickless" => Ok(SupportedSched::Tickless),
+            "scx_rustland" => Ok(SupportedSched::Rustland),
             "scx_rusty" => Ok(SupportedSched::Rusty),
             _ => Err(anyhow::anyhow!("{scx_name} is not supported")),
         }
@@ -65,6 +68,7 @@ impl From<SupportedSched> for &str {
             SupportedSched::Lavd => "scx_lavd",
             SupportedSched::P2DQ => "scx_p2dq",
             SupportedSched::Tickless => "scx_tickless",
+            SupportedSched::Rustland => "scx_rustland",
             SupportedSched::Rusty => "scx_rusty",
         }
     }

--- a/rust/scx_loader/src/main.rs
+++ b/rust/scx_loader/src/main.rs
@@ -94,6 +94,7 @@ impl ScxLoader {
             "scx_lavd",
             "scx_p2dq",
             "scx_tickless",
+            "scx_rustland",
             "scx_rusty",
         ]
     }


### PR DESCRIPTION
With the recent changes, scx_rustland has become quite a stable scheduler. Although there are more stable and sensible choices for the user, rustland also performs well.
Moreover, integrating scx_rustland into scx_loader will make it much easier to test new changes and pull requests.

```
lucjan at cachyos ~ 11:23:28    
❯ scxctl list          
supported schedulers: ["bpfland", "flash", "lavd", "p2dq", "tickless", "rustland", "rusty"]
lucjan at cachyos ~ 11:23:37    
❯ scxctl start -s rustland
started Rustland in Auto mode
lucjan at cachyos ~ 11:23:46    
❯ systemctl status scx_loader.service
● scx_loader.service - DBUS on-demand loader of sched-ext schedulers
     Loaded: loaded (/usr/lib/systemd/system/scx_loader.service; disabled; preset: disabled)
     Active: active (running) since Fri 2025-05-16 11:23:37 CEST; 14s ago
 Invocation: f7359caeab4247fcba159318c3fca94c
   Main PID: 87900 (scx_loader)
      Tasks: 22 (limit: 37394)
     Memory: 81.7M (peak: 82.2M)
        CPU: 114ms
     CGroup: /system.slice/scx_loader.service
             ├─87900 /usr/bin/scx_loader
             └─87964 scx_rustland

maj 16 11:23:37 cachyos systemd[1]: Starting DBUS on-demand loader of sched-ext schedulers...
maj 16 11:23:37 cachyos scx_loader[87900]: [INFO]: Starting as dbus interface
maj 16 11:23:37 cachyos systemd[1]: Started DBUS on-demand loader of sched-ext schedulers.
maj 16 11:23:46 cachyos scx_loader[87900]: [INFO]: starting Rustland with mode Auto..
maj 16 11:23:46 cachyos scx_loader[87900]: [INFO]: Got event to start scheduler!
maj 16 11:23:46 cachyos scx_loader[87900]: [INFO]: starting scx_rustland command
maj 16 11:23:46 cachyos scx_loader[87964]: 09:23:46 [INFO] RustLand scheduler attached
```