### PR TITLE
scx_rustland_core: Ensure migration-disabled tasks are always enqueued

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -1314,7 +1314,7 @@ SCX_OPS_DEFINE(rustland,
 	       .init_task		= (void *)rustland_init_task,
 	       .init			= (void *)rustland_init,
 	       .exit			= (void *)rustland_exit,
-	       .flags			= SCX_OPS_KEEP_BUILTIN_IDLE | SCX_OPS_ENQ_LAST,
+	       .flags			= SCX_OPS_KEEP_BUILTIN_IDLE | SCX_OPS_ENQ_LAST | SCX_OPS_ENQ_MIGRATION_DISABLED,
 	       .timeout_ms		= 5000,
 	       .dispatch_max_batch	= MAX_DISPATCH_SLOT,
 	       .name			= "rustland");


### PR DESCRIPTION
Letting the kernel directly dispatch migration-disabled tasks can lead to inefficiencies and unfairness, as these tasks bypass the user-space scheduler and override others. They also receive the default time slice, which can further amplify the imbalance.

To address this, enable SCX_OPS_ENQ_MIGRATION_DISABLED so that migration-disabled tasks are enqueued and managed by the user-space scheduler like all other tasks.