### PR TITLE
scx_chaos: Refactor thread join error handling

### DIFF
--- a/scheds/rust/scx_chaos/src/main.rs
+++ b/scheds/rust/scx_chaos/src/main.rs
@@ -249,10 +249,9 @@ fn main() -> Result<()> {
         cvar.notify_all();
     }
 
-    match scheduler_thread.join() {
-        Ok(_) => {}
-        Err(e) => panic::resume_unwind(e),
-    };
+    if let Err(e) = scheduler_thread.join() {
+        panic::resume_unwind(e);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Replace match statement with an if-let binding, as the Ok arm is empty.

No functional behavior is changed.