### PR TITLE
scx_lavd: Change the min slice to 500us.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -33,7 +33,7 @@ enum consts_internal  {
 	LAVD_MAX_RETRY			= 3,
 
 	LAVD_TARGETED_LATENCY_NS	= (20ULL * NSEC_PER_MSEC),
-	LAVD_SLICE_MIN_NS_DFL		= (300ULL * NSEC_PER_USEC), /* min time slice */
+	LAVD_SLICE_MIN_NS_DFL		= (500ULL * NSEC_PER_USEC), /* min time slice */
 	LAVD_SLICE_MAX_NS_DFL		= (5ULL * NSEC_PER_MSEC), /* max time slice */
 	LAVD_ACC_RUNTIME_MAX		= (LAVD_TARGETED_LATENCY_NS * 10),
 

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -115,7 +115,7 @@ struct Opts {
     slice_max_us: u64,
 
     /// Minimum scheduling slice duration in microseconds.
-    #[clap(long = "slice-min-us", default_value = "300")]
+    #[clap(long = "slice-min-us", default_value = "500")]
     slice_min_us: u64,
 
     /// List of CPUs in preferred order (e.g., "0-3,7,6,5,4"). The scheduler


### PR DESCRIPTION
Increase the minimum time slice from 300 usec to 500 usec since 500 usec seems generally works better.