### PR TITLE
scx_utils: Choose a CPU capacity source more judiciously.

### DIFF
--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -333,6 +333,7 @@ impl Cpumask {
 }
 
 pub fn read_cpulist(cpulist: &str) -> Result<Vec<usize>> {
+    let cpulist = cpulist.trim_end_matches('\0');
     let cpu_groups: Vec<&str> = cpulist.split(',').collect();
     let mut cpu_ids = vec![];
     for group in cpu_groups.iter() {

--- a/rust/scx_utils/src/misc.rs
+++ b/rust/scx_utils/src/misc.rs
@@ -81,7 +81,7 @@ pub fn set_rlimit_infinity() {
 
 /// Read a file and parse its content into the specified type.
 ///
-/// Trims whitespace before parsing.
+/// Trims null and whitespace before parsing.
 ///
 /// # Errors
 /// Returns an error if reading or parsing fails.
@@ -96,6 +96,7 @@ where
             bail!("Failed to open or read file {:?}", path);
         }
     };
+    let val = val.trim_end_matches('\0');
 
     match val.trim().parse::<T>() {
         Ok(parsed) => Ok(parsed),
@@ -107,6 +108,7 @@ where
 
 pub fn read_file_usize_vec(path: &Path, separator: char) -> Result<Vec<usize>> {
     let val = std::fs::read_to_string(path)?;
+    let val = val.trim_end_matches('\0');
 
     val.split(separator)
         .map(|s| {
@@ -119,6 +121,7 @@ pub fn read_file_usize_vec(path: &Path, separator: char) -> Result<Vec<usize>> {
 
 pub fn read_file_byte(path: &Path) -> Result<usize> {
     let val = std::fs::read_to_string(path)?;
+    let val = val.trim_end_matches('\0');
     let val = val.trim();
 
     // E.g., 10K, 10M, 10G, 10


### PR DESCRIPTION
A case was reported that /sys/devices/system/cpu/cpuX/acpi_cppc/highest_perf
have the same value for all CPUs on an Intel hybrid processor (i7-13650hx).
This should be a bug on the driver's side.

To circumvent such a problem, make more efforts to find a source that can tell
the capacity differences among the cores. If there is no such source, resort
to the max frequency of CPUs to estimate CPU capacity.

This should solve the following issue:
  https://github.com/sched-ext/scx/issues/1893

