### PR TITLE
scx_utils: Remove unused assignment warning

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -603,7 +603,7 @@ fn cpu_capacity_source() -> Option<(String, usize, usize)> {
 
     // Find the most precise source for cpu_capacity estimation.
     let prefix = "/sys/devices/system/cpu/cpu0";
-    let mut raw_capacity = 0;
+    let mut raw_capacity;
     let mut suffix = sources[sources.len() - 1];
     'outer: for src in sources {
         let path_str = [prefix, src].join("/");


### PR DESCRIPTION
Initialize `raw_capacity` only when needed to avoid warning.

Ref: #1893

Log:
```shell
warning: value assigned to `raw_capacity` is never read
   --> rust/scx_utils/src/topology.rs:606:13
    |
606 |     let mut raw_capacity = 0;
    |             ^^^^^^^^^^^^
    |
    = help: maybe it is overwritten before being read?
    = note: `#[warn(unused_assignments)]` on by default

warning: `scx_utils` (lib) generated 1 warning
```