### PR TITLE
docs: clarify QueuedTask time field comments

### DIFF
--- a/rust/scx_rustland_core/README.md
+++ b/rust/scx_rustland_core/README.md
@@ -79,8 +79,8 @@ struct QueuedTask {
     pub pid: i32,              // pid that uniquely identifies a task
     pub cpu: i32,              // CPU previously used by the task
     pub flags: u64,            // task's enqueue flags
-    pub exec_runtime: u64,     // Total cpu time in nanoseconds
-    pub sum_exec_runtime: u64, // Total cpu time in nanoseconds
+    pub exec_runtime: u64,     // Total cpu time since last sleep (in ns)
+    pub sum_exec_runtime: u64, // Total accumulated CPU time across all past executions of the task (in ns)
     pub weight: u64,           // Task priority in the range [1..10000] (default is 100)
     pub nvcsw: u64,            // Total amount of voluntary context switches
     pub slice: u64,            // Remaining time slice budget

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -48,8 +48,8 @@
 //!     pub pid: i32,              // pid that uniquely identifies a task
 //!     pub cpu: i32,              // CPU previously used by the task
 //!     pub flags: u64,            // task's enqueue flags
-//!     pub exec_runtime: u64,     // Total cpu time in nanoseconds
-//!     pub sum_exec_runtime: u64, // Total cpu time in nanoseconds
+//!     pub exec_runtime: u64,     // Total cpu time since last sleep (in ns)
+//!     pub sum_exec_runtime: u64, // Total accumulated CPU time across all past executions of the task (in ns)
 //!     pub weight: u64,           // Task priority in the range [1..10000] (default is 100)
 //!     pub nvcsw: u64,            // Total amount of voluntary context switches
 //!     pub slice: u64,            // Remaining time slice budget


### PR DESCRIPTION
This patch updates the comments for `exec_runtime` and `sum_exec_runtime` in the `QueuedTask` struct to better reflect their distinct meanings.

No functional behavior is changed.