### PR TITLE
load_balance: Refactor `find_first_candidate`

### DIFF
--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -690,10 +690,7 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
     where
         I: IntoIterator<Item = &'d TaskInfo>,
     {
-        match tasks_by_load.into_iter().next() {
-            Some(task) => Some(task),
-            None => None,
-        }
+        tasks_by_load.into_iter().next()
     }
 
     /// Try to find a task in @push_dom to be moved into @pull_dom. If a task is

--- a/scheds/rust/scx_wd40/src/load_balance.rs
+++ b/scheds/rust/scx_wd40/src/load_balance.rs
@@ -686,10 +686,7 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
     where
         I: IntoIterator<Item = &'d TaskInfo>,
     {
-        match tasks_by_load.into_iter().next() {
-            Some(task) => Some(task),
-            None => None,
-        }
+        tasks_by_load.into_iter().next()
     }
 
     /// Try to find a task in @push_dom to be moved into @pull_dom. If a task is


### PR DESCRIPTION
Replace redundant `match` expression with a direct call to `next()`, which already returns an `Option`.

No functional behavior is changed.

Edit: Change title prefix to `load_balance`