### PR TITLE
scx_rustland_core / scx_rustland: Multiple improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "scx_rustland_core"
-version = "2.2.11"
+version = "2.3.1"
 dependencies = [
  "anyhow",
  "libbpf-rs",

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland_core"
-version = "2.2.11"
+version = "2.3.1"
 edition = "2021"
 authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"

--- a/rust/scx_rustland_core/README.md
+++ b/rust/scx_rustland_core/README.md
@@ -79,11 +79,10 @@ struct QueuedTask {
     pub pid: i32,              // pid that uniquely identifies a task
     pub cpu: i32,              // CPU previously used by the task
     pub flags: u64,            // task's enqueue flags
+    pub start_ts: u64,         // Timestamp since last time the task ran on a CPU (in ns)
+    pub stop_ts: u64,          // Timestamp since last time the task released a CPU (in ns)
     pub exec_runtime: u64,     // Total cpu time since last sleep (in ns)
-    pub sum_exec_runtime: u64, // Total accumulated CPU time across all past executions of the task (in ns)
     pub weight: u64,           // Task priority in the range [1..10000] (default is 100)
-    pub nvcsw: u64,            // Total amount of voluntary context switches
-    pub slice: u64,            // Remaining time slice budget
     pub vtime: u64,            // Current task vruntime / deadline (set by the scheduler)
 }
 ```

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -77,6 +77,8 @@ pub struct QueuedTask {
     pub pid: i32,              // pid that uniquely identifies a task
     pub cpu: i32,              // CPU where the task is running
     pub flags: u64,            // task enqueue flags
+    pub start_ts: u64,         // Timestamp since last time the task ran on a CPU
+    pub stop_ts: u64,          // Timestamp since last time the task released a CPU
     pub exec_runtime: u64,     // Total cpu time since last sleep
     pub sum_exec_runtime: u64, // Total cpu time
     pub nvcsw: u64,            // Total amount of voluntary context switches
@@ -143,6 +145,8 @@ impl EnqueuedMessage {
             pid: self.inner.pid,
             cpu: self.inner.cpu,
             flags: self.inner.flags,
+            start_ts: self.inner.start_ts,
+            stop_ts: self.inner.stop_ts,
             exec_runtime: self.inner.exec_runtime,
             sum_exec_runtime: self.inner.sum_exec_runtime,
             nvcsw: self.inner.nvcsw,

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -80,10 +80,7 @@ pub struct QueuedTask {
     pub start_ts: u64,         // Timestamp since last time the task ran on a CPU
     pub stop_ts: u64,          // Timestamp since last time the task released a CPU
     pub exec_runtime: u64,     // Total cpu time since last sleep
-    pub sum_exec_runtime: u64, // Total cpu time
-    pub nvcsw: u64,            // Total amount of voluntary context switches
     pub weight: u64,           // Task static priority
-    pub slice: u64,            // Time slice budget
     pub vtime: u64,            // Current vruntime
     cpumask_cnt: u64,          // cpumask generation counter (private)
 }
@@ -148,10 +145,7 @@ impl EnqueuedMessage {
             start_ts: self.inner.start_ts,
             stop_ts: self.inner.stop_ts,
             exec_runtime: self.inner.exec_runtime,
-            sum_exec_runtime: self.inner.sum_exec_runtime,
-            nvcsw: self.inner.nvcsw,
             weight: self.inner.weight,
-            slice: self.inner.slice,
             vtime: self.inner.vtime,
             cpumask_cnt: self.inner.cpumask_cnt,
         }

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -83,6 +83,8 @@ struct queued_task_ctx {
 	s32 pid;
 	s32 cpu; /* CPU where the task is running */
 	u64 flags; /* task enqueue flags */
+	u64 start_ts; /* Timestamp since last time the task ran on a CPU */
+	u64 stop_ts; /* Timestamp since last time the task released a CPU */
 	u64 exec_runtime; /* Total cpu time since last sleep */
 	u64 sum_exec_runtime; /* Total cpu time */
 	u64 nvcsw; /* Total amount of voluntary context switches */

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -86,10 +86,7 @@ struct queued_task_ctx {
 	u64 start_ts; /* Timestamp since last time the task ran on a CPU */
 	u64 stop_ts; /* Timestamp since last time the task released a CPU */
 	u64 exec_runtime; /* Total cpu time since last sleep */
-	u64 sum_exec_runtime; /* Total cpu time */
-	u64 nvcsw; /* Total amount of voluntary context switches */
 	u64 weight; /* Task static priority */
-	u64 slice; /* Time slice budget */
 	u64 vtime; /* Current task's vruntime */
 	u64 cpumask_cnt; /* cpumask generation counter */
 };

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -708,10 +708,7 @@ static void get_task_info(struct queued_task_ctx *task,
 	task->start_ts = tctx ? tctx->start_ts : 0;
 	task->stop_ts = tctx ? tctx->stop_ts : 0;
 	task->exec_runtime = tctx ? tctx->exec_runtime : 0;
-	task->sum_exec_runtime = p->se.sum_exec_runtime;
-	task->nvcsw = p->nvcsw;
 	task->weight = p->scx.weight;
-	task->slice = p->scx.slice;
 	task->vtime = p->scx.dsq_vtime;
 	task->cpumask_cnt = tctx ? tctx->cpumask_cnt : 0;
 }

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -29,6 +29,7 @@
 
 #define PF_IO_WORKER			0x00000010	/* Task is an IO worker */
 #define PF_WQ_WORKER			0x00000020	/* I'm a workqueue worker */
+#define PF_KSWAPD			0x00020000      /* I am kswapd */
 #define PF_KTHREAD			0x00200000	/* I am a kernel thread */
 #define PF_EXITING			0x00000004
 #define CLOCK_MONOTONIC			1

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -13,11 +13,11 @@ ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "=0.25.0-beta.1"
 libc = "0.2.137"
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.15" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.11" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.1" }
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.15" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.11" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.1" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -44,15 +44,15 @@
 //!
 //! Each task received from dequeue_task() contains the following:
 //!
+//!
 //! struct QueuedTask {
 //!     pub pid: i32,              // pid that uniquely identifies a task
 //!     pub cpu: i32,              // CPU previously used by the task
 //!     pub flags: u64,            // task's enqueue flags
+//!     pub start_ts: u64,         // Timestamp since last time the task ran on a CPU (in ns)
+//!     pub stop_ts: u64,          // Timestamp since last time the task released a CPU (in ns)
 //!     pub exec_runtime: u64,     // Total cpu time since last sleep (in ns)
-//!     pub sum_exec_runtime: u64, // Total accumulated CPU time across all past executions of the task (in ns)
 //!     pub weight: u64,           // Task priority in the range [1..10000] (default is 100)
-//!     pub nvcsw: u64,            // Total amount of voluntary context switches
-//!     pub slice: u64,            // Remaining time slice budget
 //!     pub vtime: u64,            // Current task vruntime / deadline (set by the scheduler)
 //! }
 //!

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -20,12 +20,12 @@ serde = { version = "1.0.215", features = ["derive"] }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.12" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.12" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.15" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.11" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.1" }
 simplelog = "0.12"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.15" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.2.11" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.1" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION
This PR provides multiple improvements for scx_rustland_core and scx_rustland both in terms of performance and robustness.

Summary of the changes:
- scx_rustland_core:
  - The `struct QueuedTask` now provides `ops.running()` and `ops.stopping()` timestamps for a more accurate time slice evaluation. The struct has been also made more compact, dropping some attributes that can be inferred, reducing its size to 64 bytes (small enough to typically fit in a single cacheline).
  - Reduced some unnecessary overhead in the idle CPU selection policy (the checks for online CPUs have been removed, since on hotplug events the scheduler is restarted anyway).
  - kswapd is now always directly dispatched from BPF to prevent potential stall conditions 

- scx_rustland:
  - Improved accuracy of the time slice (using the new `start_ts` and `stop_ts` timestamps provided by scx_rustland_core)
  - Reduced unnecessary scheduler's overhead (dropped `TaskInfoMap`, dropped congestion control threshold)
  - Add a small penalty to newly created tasks to smooth the responsiveness disruption caused by potential bursts of new tasks

Tests:
 - Usual "gaming while building the kernel" scenario, using the [WebGL Acquarium demo](https://webglsamples.org/aquarium/aquarium.html) (15000 fishes) on an system with 8 CPUs Intel i7-1195G7 @ 2.90GHz, running `make -j 32`:
```
+---------------+-----------+
| rustland-next | 45-47 fps |
| rustland      | 28-35 fps |
+---------------+-----------+
```

 - Typical stress tests using `stress-ng` and `perf bench` also show consistent improvements and better stability overall (it's way more difficult to trigger stalls).