### PR TITLE
scx_layered: Make exclusive work better

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -161,7 +161,6 @@ struct cpu_ctx {
 	bool			current_preempt;
 	bool			current_exclusive;
 	bool			prev_exclusive;
-	bool			maybe_idle;
 	bool			yielding;
 	bool			try_preempt_first;
 	bool			is_big;

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -159,9 +159,9 @@ struct cpu_prox_map {
 struct cpu_ctx {
 	s32			cpu;
 	bool			current_preempt;
-	bool			current_exclusive;
-	bool			prev_exclusive;
-	bool			next_exclusive;
+	bool			current_excl;
+	bool			prev_excl;
+	bool			next_excl;
 	bool			yielding;
 	bool			try_preempt_first;
 	bool			is_big;
@@ -325,7 +325,7 @@ struct layer {
 	int			kind;
 	bool			preempt;
 	bool			preempt_first;
-	bool			exclusive;
+	bool			excl;
 	bool			allow_node_aligned;
 	bool			skip_remote_node;
 	bool			prev_over_idle_core;

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -161,6 +161,7 @@ struct cpu_ctx {
 	bool			current_preempt;
 	bool			current_exclusive;
 	bool			prev_exclusive;
+	bool			next_exclusive;
 	bool			yielding;
 	bool			try_preempt_first;
 	bool			is_big;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1887,10 +1887,8 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 		struct cpu_ctx *sib_cpuc;
 		s32 sib;
 
-		if ((sib = sibling_cpu(cpu)) < 0 || !(sib_cpuc = lookup_cpu_ctx(sib)))
-			return;
-
-		if (sib_cpuc->current_excl || sib_cpuc->next_excl) {
+		if ((sib = sibling_cpu(cpu)) >= 0 && (sib_cpuc = lookup_cpu_ctx(sib)) &&
+		    (sib_cpuc->current_excl || sib_cpuc->next_excl)) {
 			gstat_inc(GSTAT_EXCL_IDLE, cpuc);
 			return;
 		}

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -809,7 +809,11 @@ static s32 pick_idle_cpu_from(const struct cpumask *cand_cpumask, s32 prev_cpu,
 			return -EBUSY;
 	}
 
-	bpf_for(i, 0, MAX_CPUS) {
+	/*
+	 * FIXME - The following should ideally be bpf_for(i, 0, nr_cpu_ids) but
+	 * that causes a mysterious verification failure. Try 32 times instead.
+	 */
+	for (i = 0; i < 32; i++) {
 		struct cpu_ctx *sib_cpuc;
 		s32 sib;
 

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1913,6 +1913,10 @@ impl<'a> Scheduler<'a> {
                 _ => false,
             })
             .count() as u32;
+        skel.maps.rodata_data.nr_exclusive_layers = layer_specs
+            .iter()
+            .filter(|spec| spec.kind.common().exclusive)
+            .count() as u32;
 
         let mut min_open = u64::MAX;
         let mut min_preempt = u64::MAX;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1376,7 +1376,7 @@ impl<'a> Scheduler<'a> {
                 copy_into_cstr(&mut layer.name, layer_name.as_str());
                 layer.preempt.write(*preempt);
                 layer.preempt_first.write(*preempt_first);
-                layer.exclusive.write(*exclusive);
+                layer.excl.write(*exclusive);
                 layer.allow_node_aligned.write(*allow_node_aligned);
                 layer.skip_remote_node.write(*skip_remote_node);
                 layer.prev_over_idle_core.write(*prev_over_idle_core);
@@ -1913,7 +1913,7 @@ impl<'a> Scheduler<'a> {
                 _ => false,
             })
             .count() as u32;
-        skel.maps.rodata_data.nr_exclusive_layers = layer_specs
+        skel.maps.rodata_data.nr_excl_layers = layer_specs
             .iter()
             .filter(|spec| spec.kind.common().exclusive)
             .count() as u32;


### PR DESCRIPTION
Exclusive flag was really leaky - e.g. it wasn't excluding idle CPU picking so it was really easy for other tasks to occupy the preempted sibling. This PR improves exclusive handling so that it's a lot less leaky (the sibling is a lot more likely to stay idle) and exclusive tasks can share siblings when there are no CPUs left.