### PR TITLE
scx_p2dq: Optimize default hot paths

### DIFF
--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -459,15 +459,13 @@ void BPF_STRUCT_OPS(chaos_runnable, struct task_struct *p, u64 enq_flags)
 {
 	struct chaos_task_ctx *wakee_ctx;
 	if (!(wakee_ctx = lookup_create_chaos_task_ctx(p)))
-		goto p2dq;
+		return;
 
 	enum chaos_trait_kind t = choose_chaos(wakee_ctx);
 	if (t == CHAOS_TRAIT_NONE)
-		goto p2dq;
+		return;
 
 	wakee_ctx->next_trait = t;
-p2dq:
-	return p2dq_runnable_impl(p, enq_flags);
 }
 
 void BPF_STRUCT_OPS(chaos_running, struct task_struct *p)

--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -62,7 +62,7 @@ const volatile bool interactive_fifo = false;
 const volatile bool keep_running_enabled = true;
 const volatile bool kthreads_local = true;
 const volatile bool max_dsq_pick2 = false;
-const volatile bool freq_control = true;
+const volatile bool freq_control = false;
 const volatile bool select_idle_in_enqueue = true;
 const volatile u64 max_exec_ns = 20 * NSEC_PER_MSEC;
 
@@ -849,16 +849,6 @@ out:
 	pro->kind = P2DQ_ENQUEUE_PROMISE_COMPLETE;
 }
 
-static __always_inline void p2dq_runnable_impl(struct task_struct *p, u64 enq_flags)
-{
-	task_ctx *wakee_ctx;
-
-	if (!(wakee_ctx = lookup_task_ctx(p)))
-		return;
-
-	wakee_ctx->is_kworker = p->flags & (PF_KTHREAD | PF_WQ_WORKER | PF_IO_WORKER);
-}
-
 static __always_inline int p2dq_running_impl(struct task_struct *p)
 {
 	task_ctx *taskc;
@@ -1613,11 +1603,6 @@ void BPF_STRUCT_OPS(p2dq_exit, struct scx_exit_info *ei)
 }
 
 #if P2DQ_CREATE_STRUCT_OPS
-void BPF_STRUCT_OPS(p2dq_runnable, struct task_struct *p, u64 enq_flags)
-{
-	return p2dq_runnable_impl(p, enq_flags);
-}
-
 s32 BPF_STRUCT_OPS_SLEEPABLE(p2dq_init)
 {
 	return p2dq_init_impl();
@@ -1655,7 +1640,6 @@ SCX_OPS_DEFINE(p2dq,
 	       .select_cpu		= (void *)p2dq_select_cpu,
 	       .enqueue			= (void *)p2dq_enqueue,
 	       .dispatch		= (void *)p2dq_dispatch,
-	       .runnable		= (void *)p2dq_runnable,
 	       .running			= (void *)p2dq_running,
 	       .stopping		= (void *)p2dq_stopping,
 	       .set_cpumask		= (void *)p2dq_set_cpumask,

--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -40,6 +40,10 @@ pub struct SchedulerOpts {
     #[clap(short = 'e', long, action = clap::ArgAction::SetTrue)]
     pub eager_load_balance: bool,
 
+    /// Enables CPU frequency control.
+    #[clap(short = 'f', long, action = clap::ArgAction::SetTrue)]
+    pub freq_control: bool,
+
     /// ***DEPRECATED*** Disables greedy idle CPU selection, may cause better load balancing on
     /// multi-LLC systems.
     #[clap(short = 'g', long, default_value_t = get_default_greedy_disable(), action = clap::ArgAction::Set)]
@@ -203,6 +207,7 @@ macro_rules! init_open_skel {
             $skel.maps.rodata_data.dispatch_lb_busy = opts.dispatch_lb_busy;
             $skel.maps.rodata_data.dispatch_lb_interactive = opts.dispatch_lb_interactive;
             $skel.maps.rodata_data.eager_load_balance = !opts.eager_load_balance;
+            $skel.maps.rodata_data.freq_control = opts.freq_control;
             $skel.maps.rodata_data.has_little_cores = $crate::TOPO.has_little_cores();
             $skel.maps.rodata_data.interactive_sticky = opts.interactive_sticky;
             $skel.maps.rodata_data.interactive_fifo = opts.interactive_fifo;


### PR DESCRIPTION
Saw a few hotpaths in profiling that don't need to be enabled by default. The first is that the runnable callback doesn't really do anything critical and causes redundant map lookups.

CPU frequency control can be disabled by default and enabled if a relevant CPU frequency governor is used. This saves some extra lookups in the running path, which is rather hot.

Running `schbench` to partially saturate a machine with `p2dq`:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (409578 total samples)
          50.0th: 6          (126999 samples)
          90.0th: 9          (133771 samples)
        * 99.0th: 13         (29130 samples)
          99.9th: 95         (3589 samples)
          min=1, max=7852
Request Latencies percentiles (usec) runtime 30 (s) (410428 total samples)
          50.0th: 6616       (127589 samples)
          90.0th: 10768      (157072 samples)
        * 99.0th: 12496      (37138 samples)
          99.9th: 16336      (3487 samples)
          min=5825, max=90618
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13616      (7 samples)
        * 50.0th: 13744      (16 samples)
          90.0th: 13776      (7 samples)
          min=12561, max=13804
average rps: 13680.93
```
`eevdf`:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (399703 total samples)
          50.0th: 5          (159237 samples)
          90.0th: 7          (127713 samples)
        * 99.0th: 10         (19680 samples)
          99.9th: 22         (2660 samples)
          min=1, max=2865
Request Latencies percentiles (usec) runtime 30 (s) (400480 total samples)
          50.0th: 6600       (115565 samples)
          90.0th: 11888      (157483 samples)
        * 99.0th: 12624      (35222 samples)
          99.9th: 13328      (3461 samples)
          min=5835, max=44126
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13136      (7 samples)
        * 50.0th: 13456      (10 samples)
          90.0th: 13744      (12 samples)
          min=11299, max=13868
average rps: 13349.33
```
