### PR TITLE
arenas: update aarch64 compat ifdef

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -12,7 +12,7 @@
 struct {
 	__uint(type, BPF_MAP_TYPE_ARENA);
 	__uint(map_flags, BPF_F_MMAPABLE);
-#ifdef __TARGET_ARCH_arm64
+#if defined(__TARGET_ARCH_arm64) || defined(__aarch64__)
 	__uint(max_entries, 1 << 16); /* number of pages */
         __ulong(map_extra, (1ull << 32)); /* start of mmap() region */
 #else


### PR DESCRIPTION
Update aarch64 compat ifdef -- the current ifdef doesn't work on all aarch64 machines. This change makes it work on more.