### PR TITLE
rust: Handle return value from `Option::take`

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -573,7 +573,7 @@ impl<'cb> BpfScheduler<'cb> {
 
     // Called on exit to shutdown and report exit message from the BPF part.
     pub fn shutdown_and_report(&mut self) -> Result<UserExitInfo> {
-        self.struct_ops.take();
+        let _ = self.struct_ops.take();
         uei_report!(&self.skel, uei)
     }
 }

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -636,7 +636,7 @@ impl<'a> Scheduler<'a> {
             }
         }
 
-        self.struct_ops.take();
+        let _ = self.struct_ops.take();
         uei_report!(&self.skel, uei)
     }
 }

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -187,7 +187,7 @@ impl<'a> Scheduler<'a> {
             }
         }
 
-        self.struct_ops.take();
+        let _ = self.struct_ops.take();
         uei_report!(&self.skel, uei)
     }
 }

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -979,7 +979,7 @@ impl<'a> Scheduler<'a> {
         }
         self.rb_mgr.consume().unwrap();
 
-        self.struct_ops.take();
+        let _ = self.struct_ops.take();
         uei_report!(&self.skel, uei)
     }
 }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -2705,7 +2705,7 @@ impl<'a> Scheduler<'a> {
             }
         }
 
-        self.struct_ops.take();
+        let _ = self.struct_ops.take();
         uei_report!(&self.skel, uei)
     }
 }

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -377,7 +377,7 @@ impl<'a> Scheduler<'a> {
                 self.trigger_reconfiguration();
             }
         }
-        self.struct_ops.take();
+        let _ = self.struct_ops.take();
         uei_report!(&self.skel, uei)
     }
 

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -167,7 +167,7 @@ impl<'a> Scheduler<'a> {
             }
         }
 
-        self.struct_ops.take();
+        let _ = self.struct_ops.take();
         uei_report!(&self.skel, uei)
     }
 }

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -610,7 +610,7 @@ impl<'a> Scheduler<'a> {
             }
         }
 
-        self.struct_ops.take();
+        let _ = self.struct_ops.take();
         uei_report!(&self.skel, uei)
     }
 }

--- a/scheds/rust/scx_tickless/src/main.rs
+++ b/scheds/rust/scx_tickless/src/main.rs
@@ -251,7 +251,7 @@ impl<'a> Scheduler<'a> {
             }
         }
 
-        self.struct_ops.take();
+        let _ = self.struct_ops.take();
         uei_report!(&self.skel, uei)
     }
 }

--- a/scheds/rust/scx_wd40/src/main.rs
+++ b/scheds/rust/scx_wd40/src/main.rs
@@ -647,7 +647,7 @@ impl<'a> Scheduler<'a> {
             }
         }
 
-        self.struct_ops.take();
+        let _ = self.struct_ops.take();
         uei_report!(&self.skel, uei)
     }
 }


### PR DESCRIPTION
Use `let _ = self.struct_ops.take();` to explicitly discard the return value and suppress potential warnings. This makes the intent clearer, indicating that the call is made purely for its side effect.

No functional behavior is changed.

Ref : https://doc.rust-lang.org/core/option/enum.Option.html#method.take