### PR TITLE
ci: re-enable rustland on stable kernels

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,15 +37,12 @@ jobs:
             "scx_bpfland",
             "scx_chaos",
             "scx_lavd",
-            "scx_rlfifo",
-            "scx_rusty",
             "scx_p2dq",
+            "scx_rlfifo",
+            "scx_rustland",
+            "scx_rusty",
             "scx_tickless",
           ]]
-
-          # disable rustland on stable/ kernels, see https://github.com/sched-ext/scx/issues/1794 for more info
-          if not kernel.startswith("stable/"):
-            matrix.append({ "name": "scx_rustland", "flags": "" })
 
           for flags in itertools.product(
               ["--disable-topology=false", "--disable-topology=true"],


### PR DESCRIPTION
Rustland got disabled on these stable kernels a while ago because it kept failing. This has hopefully been addressed now, so enable these tests again.

Tracking in #1794. If this is stable for a while we can close that issue.

Test plan:
- Added push to 6.12/rolling-stable. They passed. Will track over time after it lands.