### PR TITLE
scx_lavd: Add --preempt-shift option.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-num"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822c4000301ac390e65995c62207501e3ef800a1fc441df913a5e8e4dc374816"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +2381,7 @@ dependencies = [
  "anyhow",
  "bitvec",
  "clap",
+ "clap-num",
  "crossbeam",
  "ctrlc",
  "fb_procfs",

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-2.0-only"
 anyhow = "1.0.65"
 bitvec = { version = "1.0", features = ["serde"] }
 clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+clap-num = { version = "1.2.0" }
 crossbeam = "0.8.4"
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7"

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -41,7 +41,6 @@ enum consts_internal  {
 	LAVD_LC_RUNTIME_MAX		= LAVD_TIME_ONE_SEC,
 	LAVD_LC_WEIGHT_BOOST		= 128, /* 2^7 */
 	LAVD_LC_GREEDY_PENALTY		= p2s(20),  /* 20% */
-	LAVD_LC_PREEMPT_SHIFT		= 6, /* roughly top 1.56% for preemption. */
 
 	LAVD_CPU_UTIL_MAX_FOR_CPUPERF	= p2s(85), /* 85.0% */
 

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -218,10 +218,12 @@ static void ask_cpu_yield(struct cpu_ctx *victim_cpuc)
 		 * (SCX_SLICE_DFL, 20 msec).
 		 */
 		u64 old = victim_cpuc->stopping_tm_est_ns;
-		bool ret = __sync_bool_compare_and_swap(
+		if (old) {
+			bool ret = __sync_bool_compare_and_swap(
 				&victim_cpuc->stopping_tm_est_ns, old, 0);
-		if (ret)
-			WRITE_ONCE(victim_p->scx.slice, 1);
+			if (ret)
+				WRITE_ONCE(victim_p->scx.slice, 1);
+		}
 	}
 }
 

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -252,7 +252,7 @@ static void calc_sys_stat(struct sys_stat_ctx *c)
 	sys_stat.max_lat_cri = calc_avg32(sys_stat.max_lat_cri, c->max_lat_cri);
 	sys_stat.avg_lat_cri = calc_avg32(sys_stat.avg_lat_cri, c->avg_lat_cri);
 	sys_stat.thr_lat_cri = sys_stat.max_lat_cri - ((sys_stat.max_lat_cri -
-				sys_stat.avg_lat_cri) >> LAVD_LC_PREEMPT_SHIFT);
+				sys_stat.avg_lat_cri) >> preempt_shift);
 
 	if (have_little_core) {
 		sys_stat.min_perf_cri =

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -35,6 +35,7 @@ volatile bool		reinit_cpumask_for_performance;
 const volatile bool	is_autopilot_on;
 const volatile bool	is_smt_active;
 const volatile u8	verbose;
+const volatile u8	preempt_shift;
 
 /*
  * Exit information


### PR DESCRIPTION
Limit the ratio of preemption to the roughly top P% of latency-critical tasks. When N is given as an argument, P is 0.5^N * 100. The default value is 6, which limits the preemption for the top 1.56% of latency-critical tasks.