### PR TITLE
chaos: return prev_cpu instaed of -EINVAL in select_cpu

### DIFF
--- a/meson-scripts/stress_tests.ini
+++ b/meson-scripts/stress_tests.ini
@@ -43,7 +43,7 @@ timeout_sec: 45
 
 [scx_chaos]
 sched: scx_chaos
-sched_args:
+sched_args: --random-delay-frequency 0.5 --random-delay-min-us 1000 --random-delay-max-us 2000
 stress_cmd: stress-ng -t 31 --aggressive -M -c `nproc` -f `nproc` --affinity 1 --affinity-delay 1 --affinity-pin
 timeout_sec: 45
 

--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -88,7 +88,7 @@ static __always_inline enum chaos_trait_kind choose_chaos(struct chaos_task_ctx 
 	return CHAOS_TRAIT_NONE;
 }
 
-static __always_inline bool chaos_trait_skips_enqueue(struct chaos_task_ctx *taskc)
+static __always_inline bool chaos_trait_skips_select_cpu(struct chaos_task_ctx *taskc)
 {
 	if (taskc->next_trait == CHAOS_TRAIT_RANDOM_DELAYS)
 		return true;
@@ -500,8 +500,8 @@ s32 BPF_STRUCT_OPS(chaos_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wa
 		goto p2dq;
 
 	// don't allow p2dq to select_cpu if we plan chaos to ensure we hit enqueue
-	if (chaos_trait_skips_enqueue(wakee_ctx))
-		return -EINVAL;
+	if (chaos_trait_skips_select_cpu(wakee_ctx))
+		return prev_cpu;
 
 p2dq:
 	return p2dq_select_cpu_impl(p, prev_cpu, wake_flags);


### PR DESCRIPTION
select_cpu currently returns -EINVAL if the chaos mode should skip p2dq's select_cpu. This isn't valid and leads to an error in the kernel. Update this to return `prev_cpu` instead. Also rename the helper as the current name seems incorrect.

Symptom:

```
DEBUG DUMP
================================================================================

swapper/28[0] triggered exit kind 1024:
  runtime error (invalid CPU -22 from ops.select_cpu())

Backtrace:
  ops_cpu_valid+0x58/0x80
  select_task_rq_scx+0xe9/0x1b0
  try_to_wake_up+0x165/0x790
  call_timer_fn+0x2a/0x130
  __run_timers+0x206/0x2a0
  timer_expire_remote+0x4a/0x70
  tmigr_handle_remote_up+0x2e5/0x350
  __walk_groups.isra.0+0x22/0x80
  tmigr_handle_remote+0xa0/0xf0
  handle_softirqs+0xe4/0x2f0
  __irq_exit_rcu+0xd6/0x100
  sysvec_apic_timer_interrupt+0x73/0x80
  asm_sysvec_apic_timer_interrupt+0x1a/0x20
  cpuidle_enter_state+0xcd/0x440
  cpuidle_enter+0x2d/0x50
  do_idle+0x1b1/0x210
  cpu_startup_entry+0x29/0x30
  start_secondary+0x11e/0x140
  common_startup_64+0x13e/0x141

CPU states
----------

CPU 56  : nr_run=1 flags=0x9 cpu_rel=0 ops_qseq=7049 pnt_seq=78215
          curr=systemd-udevd[3155] class=ext_sched_class

 *R systemd-udevd[3155] -3ms
      scx_state/flags=3/0x5 dsq_flags=0x0 ops_state/qseq=0/0
      sticky/holding_cpu=-1/-1 dsq_id=(n/a)
      dsq_vtime=0 slice=18008449 weight=100
      cpus=ffffffff,ffffffff,ffffffff

CPU 72  : nr_run=1 flags=0x1 cpu_rel=0 ops_qseq=372 pnt_seq=6902
          curr=swapper/72[0] class=idle_sched_class

  R rcu_preempt[19] +0ms
      scx_state/flags=3/0x9 dsq_flags=0x1 ops_state/qseq=0/0
      sticky/holding_cpu=-1/-1 dsq_id=0x1001c
      dsq_vtime=16602939019938 slice=19969220 weight=100
      cpus=ffffffff,ffffffff,ffffffff

    rcu_gp_kthread+0x1ac/0x280
    kthread+0xee/0x250
    ret_from_fork+0x34/0x50
    ret_from_fork_asm+0x1a/0x30

================================================================================
```

Test plan:
- Failed before, succeeds after.
- Added some flags in the CI to test this case.