### PR TITLE
scx_mitosis: Strip down for static cpu pinning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -318,6 +319,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "below-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2130c90f5c21a67bf91a2316c95f0878a9bede81f140d3660b612ba7cc862f7"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "cursive",
+ "humantime",
+ "once_cell",
+ "regex",
+ "slog",
+ "slog-term",
+ "walkdir",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,14 +544,15 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgroupfs"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66348822148cc35473745aaec1dfef694010fc8b437541ef6e64db5c223a0846"
+checksum = "fec72c8f99a7f541817bd12ef19a4a58931b00f475e4fb7143a8831541083d35"
 dependencies = [
- "nix 0.25.1",
+ "below-common",
+ "nix 0.29.0",
  "openat",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.10",
 ]
 
 [[package]]
@@ -546,6 +565,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -803,6 +823,22 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
@@ -810,7 +846,7 @@ dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
  "futures-core",
- "mio",
+ "mio 1.0.3",
  "parking_lot",
  "rustix 0.38.43",
  "serde",
@@ -852,6 +888,45 @@ checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
 dependencies = [
  "nix 0.29.0",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cursive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5438eb16bdd8af51b31e74764fef5d0a9260227a5ec82ba75c9d11ce46595839"
+dependencies = [
+ "ahash",
+ "cfg-if",
+ "crossbeam-channel",
+ "crossterm 0.25.0",
+ "cursive_core",
+ "lazy_static",
+ "libc",
+ "log",
+ "signal-hook",
+ "unicode-segmentation",
+ "unicode-width 0.1.12",
+]
+
+[[package]]
+name = "cursive_core"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db3b58161228d0dcb45c7968c5e74c3f03ad39e8983e58ad7d57061aa2cd94d"
+dependencies = [
+ "ahash",
+ "crossbeam-channel",
+ "enum-map",
+ "enumset",
+ "lazy_static",
+ "log",
+ "num",
+ "owning_ref",
+ "time",
+ "unicode-segmentation",
+ "unicode-width 0.1.12",
+ "xi-unicode",
 ]
 
 [[package]]
@@ -929,6 +1004,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +1023,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -971,6 +1067,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 
 [[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,10 +1108,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumset"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a4b049558765cef5f0c1a273c3fc57084d768b44d2f98127aef4cceb17293"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c3b24c345d8c314966bdc1832f6c2635bfcce8e7cf363bd115987bba2ee242"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "errno"
@@ -1305,6 +1451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1512,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.95",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+dependencies = [
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1596,6 +1759,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
@@ -1669,6 +1844,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1896,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1e07f67225c1eb911d16c2f72492669c1fb08212dbfaa1f6cfbeb119152cfa"
 dependencies = [
  "bindgen 0.63.0",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1816,6 +2043,15 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owning_ref"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "parking"
@@ -2124,7 +2360,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
- "crossterm",
+ "crossterm 0.28.1",
  "indoc",
  "instability",
  "itertools",
@@ -2656,7 +2892,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "config",
- "crossterm",
+ "crossterm 0.28.1",
  "derive_deref",
  "directories",
  "futures",
@@ -2816,7 +3052,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
+ "mio 1.0.3",
  "signal-hook",
 ]
 
@@ -2859,6 +3096,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+dependencies = [
+ "erased-serde",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6e022d0b998abfe5c3782c1f03551a596269450ccd677ea51c56f8b214610e8"
+dependencies = [
+ "is-terminal",
+ "slog",
+ "term",
+ "thread_local",
+ "time",
 ]
 
 [[package]]
@@ -2921,6 +3180,12 @@ dependencies = [
  "syn 2.0.95",
  "unicode-width 0.1.12",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -3035,6 +3300,17 @@ dependencies = [
  "once_cell",
  "rustix 1.0.5",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -3166,7 +3442,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 1.0.3",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3864,6 +4140,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "xi-unicode"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "yaml-rust2"

--- a/scheds/rust/scx_mitosis/Cargo.toml
+++ b/scheds/rust/scx_mitosis/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-2.0-only"
 [dependencies]
 anyhow = "1.0.65"
 bitvec = "1.0"
-cgroupfs = "0.7"
+cgroupfs = "0.9.0"
 clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7"

--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -19,6 +19,7 @@ typedef _Bool bool;
 #endif
 
 enum consts {
+	CACHELINE_SIZE = 64,
 	MAX_CPUS_SHIFT = 9,
 	MAX_CPUS = 1 << MAX_CPUS_SHIFT,
 	MAX_CPUS_U8 = MAX_CPUS / 8,
@@ -45,11 +46,8 @@ struct cpu_ctx {
 };
 
 struct cgrp_ctx {
-	struct ravg_data load_rd;
-	u64 load;
-	struct ravg_data pinned_load_rd;
-	u64 pinned_load;
 	u32 cell;
+	bool cell_owner;
 };
 
 #endif /* __INTF_H */

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -6,51 +6,32 @@ mod bpf_skel;
 pub use bpf_skel::*;
 pub mod bpf_intf;
 
-use std::collections::BTreeMap;
-use std::collections::HashMap;
-use std::collections::VecDeque;
-use std::fs::File;
 use std::mem::MaybeUninit;
-use std::os::fd::AsRawFd;
-use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use anyhow::anyhow;
-use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
-use bitvec::prelude::*;
-use cgroupfs::CgroupReader;
 use clap::Parser;
-use itertools::Itertools;
 use libbpf_rs::MapCore as _;
 use libbpf_rs::OpenObject;
 use log::debug;
 use log::info;
 use log::trace;
-use maplit::btreemap;
-use maplit::hashmap;
-use scx_utils::compat;
 use scx_utils::init_libbpf_logging;
-use scx_utils::ravg::ravg_read;
 use scx_utils::scx_enums;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
 use scx_utils::uei_exited;
 use scx_utils::uei_report;
+use scx_utils::Topology;
 use scx_utils::UserExitInfo;
+use scx_utils::NR_CPUS_POSSIBLE;
+use scx_utils::NR_CPU_IDS;
 
-const RAVG_FRAC_BITS: u32 = bpf_intf::ravg_consts_RAVG_FRAC_BITS;
-const MAX_CPUS: usize = bpf_intf::consts_MAX_CPUS as usize;
 const MAX_CELLS: usize = bpf_intf::consts_MAX_CELLS as usize;
-const USAGE_HALF_LIFE: u32 = bpf_intf::consts_USAGE_HALF_LIFE;
-
-lazy_static::lazy_static! {
-    static ref NR_POSSIBLE_CPUS: usize = libbpf_rs::num_possible_cpus().unwrap();
-}
 
 /// scx_mitosis: A dynamic affinity scheduler
 ///
@@ -89,447 +70,52 @@ unsafe fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
     }
 }
 
-fn now_monotonic() -> u64 {
-    let mut time = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    let ret = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut time) };
-    assert!(ret == 0);
-    time.tv_sec as u64 * 1_000_000_000 + time.tv_nsec as u64
-}
-
-#[derive(Debug)]
-struct CpuPool {
-    nr_cpus: usize,
-    all_cpus: BitVec,
-    available_cpus: BitVec,
-}
-
-// TODO: The way we alloc/free CPUs to/from cells is totally topology agnostic,
-// needs to be much smarter.
-impl CpuPool {
-    fn new() -> Result<Self> {
-        if *NR_POSSIBLE_CPUS > MAX_CPUS {
-            bail!(
-                "NR_POSSIBLE_CPUS {} > MAX_CPUS {}",
-                *NR_POSSIBLE_CPUS,
-                MAX_CPUS
-            );
-        }
-
-        let mut nr_offline = 0;
-        let mut all_cpus = bitvec![1; *NR_POSSIBLE_CPUS];
-
-        for cpu in 0..*NR_POSSIBLE_CPUS {
-            let path = format!("/sys/devices/system/cpu/cpu{}", cpu,);
-            if !std::path::Path::new(&path).exists() {
-                nr_offline += 1;
-                all_cpus.set(cpu, false);
-            }
-        }
-
-        let nr_cpus = *NR_POSSIBLE_CPUS - nr_offline;
-
-        info!("CPUs: online/possible={}/{}", nr_cpus, *NR_POSSIBLE_CPUS);
-
-        Ok(Self {
-            nr_cpus,
-            all_cpus: all_cpus.clone(),
-            available_cpus: all_cpus,
-        })
-    }
-
-    fn alloc(&mut self) -> Option<usize> {
-        let cpu = self.available_cpus.first_one()?;
-        self.available_cpus.set(cpu, false);
-        Some(cpu)
-    }
-
-    fn free(&mut self, cands: &mut BitVec) -> Option<usize> {
-        let cpu = cands.last_one()?;
-        self.available_cpus.set(cpu, true);
-        cands.set(cpu, false);
-        Some(cpu)
-    }
-}
-
-#[derive(Clone, Debug)]
-struct Cgroup {
-    name: String,
-    load: f64,
-    pinned_load: f64,
-}
-
-impl Ord for Cgroup {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.name.cmp(&other.name)
-    }
-}
-
-impl PartialOrd for Cgroup {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl PartialEq for Cgroup {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
-    }
-}
-
-impl Eq for Cgroup {}
-
-#[derive(Debug)]
-struct Cell {
-    cgroups: BTreeMap<String, Cgroup>,
-    cpu_assignment: BitVec,
-    load: f64,
-    pinned_load: f64,
-}
-
-#[derive(Debug)]
-enum SplitOrMerge {
-    Split(Split),
-    Merge(Merge),
-}
-
-#[derive(Debug)]
-struct Split {
-    cell: u32,
-    g1: Vec<Cgroup>,
-    g2: Vec<Cgroup>,
-    score: f64,
-}
-
-impl std::fmt::Display for Split {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        writeln!(f, "Split Cell({}), Score({})", self.cell, self.score)?;
-        writeln!(f, "g1:")?;
-        for cg in self.g1.iter() {
-            if cg.load == 0.0 && cg.pinned_load == 0.0 {
-                continue;
-            }
-            writeln!(
-                f,
-                "/{}: load={} pinned_load={}",
-                cg.name, cg.load, cg.pinned_load
-            )?;
-        }
-        writeln!(f, "g2:")?;
-        for cg in self.g2.iter() {
-            if cg.load == 0.0 && cg.pinned_load == 0.0 {
-                continue;
-            }
-            writeln!(
-                f,
-                "/{}: load={} pinned_load={}",
-                cg.name, cg.load, cg.pinned_load
-            )?;
-        }
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-struct Merge {
-    cell1: u32,
-    cell2: u32,
-    score: f64,
-}
-
-impl std::fmt::Display for Merge {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "Merge Cells {} and {}, Score({})",
-            self.cell1, self.cell2, self.score
-        )?;
-        Ok(())
-    }
-}
-
 struct Scheduler<'a> {
     skel: BpfSkel<'a>,
-    struct_ops: Option<libbpf_rs::Link>,
-    cpu_pool: CpuPool,
-    cells: BTreeMap<u32, Cell>,
-    cgroup_to_cell: HashMap<String, u32>,
     prev_percpu_cell_cycles: Vec<[u64; MAX_CELLS]>,
-    last_reconfiguration: std::time::Instant,
-    last_cpu_rebalancing: std::time::Instant,
-    reconfiguration_interval: std::time::Duration,
-    cpu_rebalancing_interval: std::time::Duration,
     monitor_interval: std::time::Duration,
 }
 
 impl<'a> Scheduler<'a> {
     fn init(opts: &Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
-        let mut cpu_pool = CpuPool::new()?;
+        let topology = Topology::new()?;
 
         let mut skel_builder = BpfSkelBuilder::default();
         skel_builder.obj_builder.debug(opts.verbose > 1);
         init_libbpf_logging(None);
         let mut skel = scx_ops_open!(skel_builder, open_object, mitosis)?;
 
-        // scheduler_tick() got renamed to sched_tick() during v6.10-rc.
-        let sched_tick_name = match compat::ksym_exists("sched_tick")? {
-            true => "sched_tick",
-            false => "scheduler_tick",
-        };
-
-        skel.progs
-            .sched_tick_fentry
-            .set_attach_target(0, Some(sched_tick_name.into()))
-            .context("Failed to set attach target for sched_tick_fentry()")?;
-
         skel.struct_ops.mitosis_mut().exit_dump_len = opts.exit_dump_len;
 
         skel.maps.rodata_data.slice_ns = scx_enums.SCX_SLICE_DFL;
 
-        if opts.verbose >= 1 {
-            skel.maps.rodata_data.debug = true;
-        }
-        skel.maps.rodata_data.nr_possible_cpus = *NR_POSSIBLE_CPUS as u32;
-        for cpu in cpu_pool.all_cpus.iter_ones() {
+        skel.maps.rodata_data.nr_possible_cpus = *NR_CPUS_POSSIBLE as u32;
+        for cpu in topology.all_cores.keys() {
             skel.maps.rodata_data.all_cpus[cpu / 8] |= 1 << (cpu % 8);
-            skel.maps.bss_data.cells[0].cpus[cpu / 8] |= 1 << (cpu % 8);
-        }
-        for _ in 0..cpu_pool.all_cpus.count_ones() {
-            cpu_pool.alloc();
         }
 
-        let mut skel = scx_ops_load!(skel, mitosis, uei)?;
+        let skel = scx_ops_load!(skel, mitosis, uei)?;
 
-        let struct_ops = Some(scx_ops_attach!(skel, mitosis)?);
-        info!("Mitosis Scheduler Attached");
-
-        // Initial configuration: Cell 0 with the rootcg assigned to it
-        let cells = btreemap! {
-            0 => Cell {
-                cgroups: btreemap!{
-                    "".to_string() => Cgroup {
-                        name: "".to_string(),
-                        load: 0.0,
-                        pinned_load: 0.0,
-                    }
-                },
-                cpu_assignment: cpu_pool.all_cpus.clone(),
-                load: 0.0,
-                pinned_load: 0.0,
-            }
-        };
-        let cgroup_to_cell = hashmap! {
-            "".to_string() => 0
-        };
-        let now = std::time::Instant::now();
-        let nr_cpus = cpu_pool.nr_cpus;
         Ok(Self {
             skel,
-            struct_ops,
-            cpu_pool,
-            cells,
-            cgroup_to_cell,
-            prev_percpu_cell_cycles: vec![[0; MAX_CELLS]; nr_cpus],
-            last_reconfiguration: now,
-            last_cpu_rebalancing: now,
-            reconfiguration_interval: std::time::Duration::from_secs(
-                opts.reconfiguration_interval_s,
-            ),
-            cpu_rebalancing_interval: std::time::Duration::from_secs(
-                opts.rebalance_cpus_interval_s,
-            ),
+            prev_percpu_cell_cycles: vec![[0; MAX_CELLS]; *NR_CPU_IDS],
             monitor_interval: std::time::Duration::from_secs(opts.monitor_interval_s),
         })
     }
 
     fn run(&mut self, shutdown: Arc<AtomicBool>) -> Result<UserExitInfo> {
+        let struct_ops = scx_ops_attach!(self.skel, mitosis)?;
+        info!("Mitosis Scheduler Attached");
         while !shutdown.load(Ordering::Relaxed) && !uei_exited!(&self.skel, uei) {
             std::thread::sleep(self.monitor_interval);
-            let total_load = self.collect_cgroup_load()?;
             self.debug()?;
-            let mut reconfigured = false;
-            if self.skel.maps.bss_data.user_global_seq != self.skel.maps.bss_data.global_seq {
-                trace!("BPF reconfiguration still in progress, skipping further changes");
-                continue;
-            } else if self.last_reconfiguration.elapsed() >= self.reconfiguration_interval {
-                trace!("Reconfiguring");
-                reconfigured = true;
-                match self.reconfigure()? {
-                    Some(SplitOrMerge::Split(s)) => self.split(s)?,
-                    Some(SplitOrMerge::Merge(m)) => self.merge(m)?,
-                    _ => {
-                        trace!("No beneficial reconfiguration found");
-                        reconfigured = false;
-                    }
-                }
-                self.last_reconfiguration = std::time::Instant::now();
-            }
-            if reconfigured || self.last_cpu_rebalancing.elapsed() >= self.cpu_rebalancing_interval
-            {
-                trace!("CPU rebalancing");
-                self.assign_cpus(total_load)?;
-                self.last_cpu_rebalancing = std::time::Instant::now();
-                if reconfigured {
-                    self.update_cgroup_to_cell_assignment()?;
-                }
-                self.trigger_reconfiguration();
-            }
         }
-        let _ = self.struct_ops.take();
+        drop(struct_ops);
         uei_report!(&self.skel, uei)
-    }
-
-    fn update_cgroup_to_cell_assignment(&mut self) -> Result<()> {
-        for (cgroup, cell_idx) in self.cgroup_to_cell.iter() {
-            let mut cg_path = String::from("/sys/fs/cgroup/");
-            cg_path.push_str(cgroup);
-            let cg_file = File::open(&cg_path)
-                .with_context(|| format!("Failed to open path: {}", cg_path))?;
-            let cg_fd = cg_file.as_raw_fd();
-            let cg_fd_slice = unsafe { any_as_u8_slice(&cg_fd) };
-            let cell_idx_u32 = *cell_idx as libc::__u32;
-            let cell_idx_slice = unsafe { any_as_u8_slice(&cell_idx_u32) };
-            /* XXX: NO_EXIST should be correct here, but it fails */
-            self.skel
-                .maps
-                .cgrp_cell_assignment
-                .update(cg_fd_slice, cell_idx_slice, libbpf_rs::MapFlags::ANY)
-                .with_context(|| {
-                    format!("Failed to update cgroup cell assignment for: {}", cg_path)
-                })?;
-            trace!("Assigned {} to {}", cgroup, cell_idx);
-        }
-        self.skel.maps.bss_data.update_cell_assignment = true;
-        Ok(())
-    }
-
-    fn trigger_reconfiguration(&mut self) {
-        trace!("Triggering Reconfiguration");
-        self.skel.maps.bss_data.user_global_seq += 1;
-    }
-
-    /// Iterate through each cg in the cgroupfs, read its load from BPF and
-    /// update the cells map
-    fn collect_cgroup_load(&mut self) -> Result<f64> {
-        let mut cgroup_to_cell = HashMap::new();
-
-        for (_, cell) in self.cells.iter_mut() {
-            cell.cgroups = BTreeMap::new();
-            cell.load = 0.0;
-            cell.pinned_load = 0.0;
-        }
-        let now_mono = now_monotonic();
-        let mut stack = VecDeque::new();
-        let root = CgroupReader::root()?;
-        stack.push_back(root);
-        let mut total_load = 0.0;
-        while let Some(reader) = stack.pop_back() {
-            for child in reader.child_cgroup_iter()? {
-                stack.push_back(child);
-            }
-            let mut path = PathBuf::new();
-            path.push(cgroupfs::DEFAULT_CG_ROOT);
-            path.push(reader.name());
-            let cg = File::open(path).with_context(|| {
-                format!("Failed to open cgroup dir {}", reader.name().display())
-            })?;
-            let cg_fd = cg.as_raw_fd();
-            let cg_fd_slice = unsafe { any_as_u8_slice(&cg_fd) };
-            if let Some(v) = self
-                .skel
-                .maps
-                .cgrp_ctx
-                .lookup(cg_fd_slice, libbpf_rs::MapFlags::ANY)
-                .with_context(|| {
-                    format!(
-                        "Failed to lookup cgroup {} in cgrp_ctx map",
-                        reader.name().display()
-                    )
-                })?
-            {
-                let cgrp_ctx = unsafe {
-                    let ptr = v.as_slice().as_ptr() as *const bpf_intf::cgrp_ctx;
-                    *ptr
-                };
-                let rd = &cgrp_ctx.load_rd;
-                let load = ravg_read(
-                    rd.val,
-                    rd.val_at,
-                    rd.old,
-                    rd.cur,
-                    now_mono,
-                    USAGE_HALF_LIFE,
-                    RAVG_FRAC_BITS,
-                );
-                total_load += load;
-                let pinned_rd = &cgrp_ctx.pinned_load_rd;
-                let pinned_load = ravg_read(
-                    pinned_rd.val,
-                    pinned_rd.val_at,
-                    pinned_rd.old,
-                    pinned_rd.cur,
-                    now_mono,
-                    USAGE_HALF_LIFE,
-                    RAVG_FRAC_BITS,
-                );
-                let name = reader.name().to_string_lossy().to_string();
-
-                // We don't trust BPF knows the cgroup's cell (e.g. if a
-                // reconfiguration is in flight) so rely on userspace as the
-                // source of truth. If we don't know the cell, then walk up the
-                // hierarchy.
-                let cell_idx = self
-                    .cgroup_to_cell
-                    .get(&name)
-                    .or_else(|| {
-                        let mut s = name.as_str();
-                        while let Some((parent, _)) = s.rsplit_once('/') {
-                            if let Some(cell) = cgroup_to_cell.get(parent) {
-                                return Some(cell);
-                            }
-                            s = parent;
-                        }
-                        cgroup_to_cell.get("")
-                    })
-                    .copied()
-                    .ok_or_else(|| anyhow!("Failed to identify cell for cgroup {}", name))?;
-
-                cgroup_to_cell.insert(name.clone(), cell_idx);
-                let cell = self.cells.get_mut(&cell_idx).ok_or_else(|| {
-                    anyhow!(
-                        "Cgroup {} maps to cell {} which doesn't exist",
-                        name,
-                        cell_idx
-                    )
-                })?;
-                cell.cgroups.insert(
-                    name.clone(),
-                    Cgroup {
-                        name,
-                        load,
-                        pinned_load,
-                    },
-                );
-                cell.load += load;
-                cell.pinned_load += pinned_load;
-            }
-        }
-        self.cgroup_to_cell = cgroup_to_cell;
-        Ok(total_load)
     }
 
     /// Output various debugging data like per cell stats, per-cpu stats, etc.
     fn debug(&mut self) -> Result<()> {
-        for (cell_idx, cell) in self.cells.iter() {
-            trace!(
-                "Cell {}, Load: {}, Pinned Load: {}",
-                cell_idx,
-                cell.load,
-                cell.pinned_load
-            );
-        }
         let zero = 0 as libc::__u32;
         let zero_slice = unsafe { any_as_u8_slice(&zero) };
         if let Some(v) = self
@@ -554,253 +140,6 @@ impl<'a> Scheduler<'a> {
             }
         }
         Ok(())
-    }
-
-    /// This determines what action to take (split a cell or merge two)
-    fn reconfigure(&mut self) -> Result<Option<SplitOrMerge>> {
-        let mut ret = None;
-        // This is just a place-holder to validate the mechanisms. Right now it
-        // just flip-flops between splitting Cell 0 and merging Cells 0 and 1
-        if self.cells.len() < 2 {
-            // Find the best scoring split out of all the Cells.
-            for (cell_idx, cell) in self.cells.iter() {
-                let split = self.find_best_split(cell, *cell_idx)?;
-                if let Some(ref sp) = split {
-                    match ret {
-                        Some(SplitOrMerge::Split(ref bsp)) if bsp.score > sp.score => {}
-                        _ => {
-                            ret = split.map(|s| SplitOrMerge::Split(s));
-                        }
-                    };
-                }
-            }
-        } else {
-            // For each cell pair, find the best merge
-            let mut best_score = 0.0;
-            for ((cell_idx1, cell1), (cell_idx2, cell2)) in self.cells.iter().tuple_combinations() {
-                let mut score = 0.0;
-                for (_, c1) in cell1.cgroups.iter() {
-                    for (_, c2) in cell2.cgroups.iter() {
-                        score += self.score_cgroup_pair(c1, c2);
-                    }
-                }
-                if score > best_score {
-                    best_score = score;
-                    ret = Some(SplitOrMerge::Merge(Merge {
-                        cell1: *cell_idx1,
-                        cell2: *cell_idx2,
-                        score: best_score,
-                    }));
-                }
-            }
-        }
-        Ok(ret)
-    }
-
-    fn allocate_cell(&mut self) -> Result<u32> {
-        for i in 0u32..MAX_CELLS as u32 {
-            if !self.cells.contains_key(&i) {
-                return Ok(i);
-            }
-        }
-        bail!("No free cell available");
-    }
-
-    /// Assign CPUs based on per-cell load
-    fn assign_cpus(&mut self, total_load: f64) -> Result<()> {
-        let max_cpus = self.cpu_pool.nr_cpus - self.cells.len() + 1;
-        // Figure out how many cpus each cell should have
-        let cells_cpus = self
-            .cells
-            .iter()
-            .map(|(cell_idx, cell)| {
-                let cell_load_frac = cell.load / total_load;
-                let cell_cpus = cell_load_frac * self.cpu_pool.nr_cpus as f64;
-                let cell_cpus_usz = if cell_cpus <= 1.0 {
-                    1
-                } else if cell_cpus >= max_cpus as f64 {
-                    max_cpus
-                } else {
-                    cell_cpus.round() as usize
-                };
-                trace!("Allocating {} cpus to Cell {}", cell_cpus_usz, cell_idx);
-                (*cell_idx, cell_cpus_usz)
-            })
-            .collect::<BTreeMap<u32, usize>>();
-        // Free first
-        for (cell_idx, cpus) in cells_cpus.iter() {
-            let cell = self
-                .cells
-                .get_mut(cell_idx)
-                .ok_or(anyhow!("non-existent cell"))?;
-            trace!(
-                "Cell {} has {} cpus assigned",
-                cell_idx,
-                cell.cpu_assignment.count_ones()
-            );
-            while cell.cpu_assignment.count_ones() > *cpus {
-                let freed_cpu = self
-                    .cpu_pool
-                    .free(&mut cell.cpu_assignment)
-                    .ok_or(anyhow!("No cpus to free"))?;
-                trace!("Freeing {} from Cell {}", freed_cpu, cell_idx);
-                self.skel.maps.bss_data.cells[*cell_idx as usize].cpus[freed_cpu / 8] &=
-                    !(1 << freed_cpu % 8);
-            }
-        }
-        // Allocate after
-        for (cell_idx, cpus) in cells_cpus.iter() {
-            let cell = self
-                .cells
-                .get_mut(cell_idx)
-                .ok_or(anyhow!("non-existent cell"))?;
-            while cell.cpu_assignment.count_ones() < *cpus {
-                let new_cpu = self
-                    .cpu_pool
-                    .alloc()
-                    .ok_or(anyhow!("No cpus to allocate"))?;
-                trace!("Allocating {} to Cell {}", new_cpu, cell_idx);
-                cell.cpu_assignment.set(new_cpu, true);
-                self.skel.maps.bss_data.cells[*cell_idx as usize].cpus[new_cpu / 8] |=
-                    1 << new_cpu % 8;
-            }
-        }
-        for (cell_idx, cell) in self.skel.maps.bss_data.cells.iter().enumerate() {
-            trace!("Cell {} Cpumask {:X?}", cell_idx, cell.cpus);
-        }
-        Ok(())
-    }
-
-    /// Execute a split, allocating a new cell, assigning cgroups
-    fn split(&mut self, split: Split) -> Result<()> {
-        trace!("Performing split: {}", split);
-        let new_cell_idx = self.allocate_cell()?;
-        let mut new_cell_load = 0.0;
-        let mut new_cell_pinned_load = 0.0;
-        for cg in split.g2.iter() {
-            new_cell_load += cg.load;
-            new_cell_pinned_load += cg.pinned_load;
-            let cg_cell = self
-                .cgroup_to_cell
-                .get_mut(&cg.name)
-                .ok_or(anyhow!("Could not change cell of cgroup to be split"))?;
-            *cg_cell = new_cell_idx;
-        }
-        self.cells.insert(
-            new_cell_idx,
-            Cell {
-                cgroups: split
-                    .g2
-                    .into_iter()
-                    .map(|cg| (cg.name.clone(), cg))
-                    .collect(),
-                cpu_assignment: bitvec!(0; *NR_POSSIBLE_CPUS),
-                load: new_cell_load,
-                pinned_load: new_cell_pinned_load,
-            },
-        );
-        let old_cell = self
-            .cells
-            .get_mut(&split.cell)
-            .expect("Cell to split should exist");
-        old_cell.cgroups = split
-            .g1
-            .into_iter()
-            .map(|cg| (cg.name.clone(), cg))
-            .collect();
-        old_cell.load -= new_cell_load;
-        old_cell.pinned_load -= new_cell_pinned_load;
-        info!(
-            "Split from Cell {}, Load: {}, Pinned Load: {}",
-            split.cell, old_cell.load, old_cell.pinned_load
-        );
-        info!(
-            "Created new Cell {}, Load: {}, Pinned Load: {}",
-            new_cell_idx, new_cell_load, new_cell_pinned_load
-        );
-        Ok(())
-    }
-
-    /// Execute a merge, combining two cells into one
-    fn merge(&mut self, merge: Merge) -> Result<()> {
-        trace!("Performing Merge: {}", merge);
-        let mut cell2 = self
-            .cells
-            .remove(&merge.cell2)
-            .ok_or_else(|| anyhow!("Could not find merge cell {}", merge.cell2))?;
-        for (cg, _) in cell2.cgroups.iter() {
-            let cg_cell = self
-                .cgroup_to_cell
-                .get_mut(cg)
-                .ok_or_else(|| anyhow!("Could not find cgroup {}", cg))?;
-            *cg_cell = merge.cell1;
-        }
-
-        let cell1 = self
-            .cells
-            .get_mut(&merge.cell1)
-            .ok_or_else(|| anyhow!("could not find merge cell {}", merge.cell1))?;
-
-        cell1.cgroups.append(&mut cell2.cgroups);
-        // XXX: I don't love manipulating the CPU mask here and not in assign_cpus
-        for cpu in cell2.cpu_assignment.iter_ones() {
-            self.skel.maps.bss_data.cells[merge.cell1 as usize].cpus[cpu / 8] |= 1 << cpu % 8;
-            self.skel.maps.bss_data.cells[merge.cell2 as usize].cpus[cpu / 8] &= !(1 << cpu % 8);
-        }
-        cell1.cpu_assignment |= cell2.cpu_assignment;
-        cell1.load += cell2.load;
-        cell1.pinned_load += cell2.pinned_load;
-
-        Ok(())
-    }
-
-    /// This is largely a placeholder, it views the Cell as a fully-connected
-    /// graph of cgroups where edges are the score of the pair (see
-    /// score_cgroup_pair) and then identifies the max-cut of that graph.
-    fn find_best_split(&self, cell: &Cell, cell_idx: u32) -> Result<Option<Split>> {
-        let num_cgroups = cell.cgroups.len();
-        let mut best_score = 0.0;
-        let mut best_split = None;
-        for combo_vec in cell.cgroups.iter().combinations(num_cgroups) {
-            for i in 1..(num_cgroups - 2) {
-                let mut score = 0.0;
-                let (g1, g2) = combo_vec.split_at(i);
-                for (_, c1) in g1.iter() {
-                    for (_, c2) in g2.iter() {
-                        score += self.score_cgroup_pair(c1, c2);
-                    }
-                }
-                if score > best_score {
-                    best_score = score;
-                    let mut g1: Vec<Cgroup> = g1.iter().map(|(_, c)| (*c).clone()).collect();
-                    g1.sort_by(|a, b| b.load.partial_cmp(&a.load).expect("Can't compare loads"));
-                    let mut g2: Vec<Cgroup> = g2.iter().map(|(_, c)| (*c).clone()).collect();
-                    g2.sort_by(|a, b| b.load.partial_cmp(&a.load).expect("Can't compare loads"));
-                    best_split = Some(Split {
-                        cell: cell_idx,
-                        g1,
-                        g2,
-                        score,
-                    });
-                }
-            }
-        }
-        Ok(best_split)
-    }
-
-    /// This is a straight-up placeholder - can take into account cgroup tree
-    /// distance, weights, etc. The idea is that higher scoring pairs should be
-    /// in separate cells.
-    fn score_cgroup_pair(&self, c1: &Cgroup, c2: &Cgroup) -> f64 {
-        c1.load * c2.load
-    }
-}
-
-impl Drop for Scheduler<'_> {
-    fn drop(&mut self) {
-        if let Some(struct_ops) = self.struct_ops.take() {
-            drop(struct_ops);
-        }
     }
 }
 


### PR DESCRIPTION
This more or less completely reworks mitosis to allocate cells based on static CPU pinning. If it sees a cgroup with a cpuset configured, it will dynamically allocate a new cell and otherwise schedule as before. Eventually I expect to add back in the dynamic cell creation from userspace, but for now it's not needed.