### PR TITLE
layered: improve compat of excl fixes on older kernels

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1906,7 +1906,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 	if (antistall_consume(cpuc))
 		return;
 	
-	if (sib_keep_idle(cpu, prev))
+	if (prev && sib_keep_idle(cpu, prev))
 		return;
 
 	/*


### PR DESCRIPTION
improve compat of excl fixes on older kernels

older verifiers need the extra check on prev_layer and pulling out sib_keep_idle to reduce complexity (instruction count).