### PR TITLE
nix: build veristat from source

### DIFF
--- a/.github/include/flake.lock
+++ b/.github/include/flake.lock
@@ -58,7 +58,8 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nix-develop-gha": "nix-develop-gha",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "veristat-src": "veristat-src"
       }
     },
     "systems": {
@@ -73,6 +74,22 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "veristat-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1736364478,
+        "narHash": "sha256-07awVCMrFFG69cGtucLYGT+mqcRZ9F9ZHvxARLLYpM0=",
+        "owner": "libbpf",
+        "repo": "veristat",
+        "rev": "3bf5cdf98b05faf53dca21492e69ffb4605c6d42",
+        "type": "github"
+      },
+      "original": {
+        "owner": "libbpf",
+        "repo": "veristat",
         "type": "github"
       }
     }

--- a/.github/include/flake.nix
+++ b/.github/include/flake.nix
@@ -12,9 +12,14 @@
 
     nix-develop-gha.url = "github:nicknovitski/nix-develop";
     nix-develop-gha.inputs.nixpkgs.follows = "nixpkgs";
+
+    veristat-src = {
+      url = "github:libbpf/veristat";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, nix-develop-gha, ... }:
+  outputs = { self, nixpkgs, flake-utils, nix-develop-gha, veristat-src, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ]
       (system:
         let
@@ -53,6 +58,11 @@
 
           packages = {
             nix-develop-gha = nix-develop-gha.packages."${system}".default;
+
+            veristat = pkgs.callPackage ./veristat.nix {
+              version = "git";
+              src = veristat-src;
+            };
 
             kernels = builtins.mapAttrs
               (name: details: (pkgs.callPackage ./build-kernel.nix {

--- a/.github/include/veristat.nix
+++ b/.github/include/veristat.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, llvmPackages
+, clang
+, libbpf
+, elfutils
+, zlib
+, pkg-config
+, version
+, src
+}:
+
+stdenv.mkDerivation {
+  pname = "veristat";
+  inherit version src;
+
+  buildInputs = [
+    elfutils
+    zlib
+  ];
+
+  buildPhase = ''
+    # The Makefile expects to build libbpf from source. We already have a built
+    # version, and this is a single C file with minimal dependencies, so compile
+    # and link it by hand.
+
+    cd src
+    $CC $CFLAGS -I${libbpf}/include -DVERISTAT_VERSION='"${version}"' \
+        -c veristat.c -o veristat.o
+    $CC veristat.o ${libbpf}/lib/libbpf.a -lelf -lz -o veristat
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m755 veristat $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "Tool to provide statistics from the BPF verifier for BPF programs";
+    homepage = "https://github.com/libbpf/veristat";
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+  };
+}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -76,6 +76,9 @@ jobs:
         with:
           repo-name: ${{ inputs.repo-name }}
 
+      - name: Install Veristat
+        run: nix-env -i $(nix build --no-link --print-out-paths ./.github/include#veristat)
+
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
       - uses: Swatinem/rust-cache@v2
@@ -94,11 +97,6 @@ jobs:
           key: virtiofsd-binary
       - if: ${{ steps.cache-virtiofsd.outputs.cache-hit != 'true' }}
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
-
-      # veristat
-      - run: wget https://github.com/libbpf/veristat/releases/download/v0.3.2/veristat-v0.3.2-amd64.tar.gz
-      - run: tar -xvf veristat-v0.3.2-amd64.tar.gz && sudo cp veristat /usr/bin/
-      - run: sudo chmod +x /usr/bin/veristat && sudo chmod 755 /usr/bin/veristat
 
       # The actual build:
       - run: meson setup build -Dkernel=$KERNEL_STORE_PATH/bzImage -Dkernel_headers=$KERNEL_HEADERS_STORE_PATH -Denable_stress=true -Dvng_rw_mount=true -Dextra_sched_args=" ${{ matrix.scheduler['flags'] }}"

--- a/meson-scripts/veristat
+++ b/meson-scripts/veristat
@@ -27,7 +27,7 @@ if [ -n "${SCHED}" ]; then
   if [ -n "${KERNEL}" ]; then
     timeout --preserve-status ${GUEST_TIMEOUT} \
       vng --user root -m 10G --cpu 8 -v --user root -r ${KERNEL} -- \
-        sudo veristat ${BPF_PATH} 2>&1 | tee veristat.ci.log
+        sudo $(which veristat) ${BPF_PATH} 2>&1 | tee veristat.ci.log
     exit $?
   else
     sudo veristat ${BPF_PATH} 2>&1 | tee veristat.ci.log
@@ -39,7 +39,7 @@ for BPF_PATH in $(find ${BUILD_DIR} -type f -name bpf.bpf.o); do
   if [ -n "${KERNEL}" ]; then
     timeout --preserve-status ${GUEST_TIMEOUT} \
       vng --user root -m 10G --cpu 8 $VNG_RW -v --user root -r ${KERNEL} -- \
-        sudo veristat ${BPF_PATH} 2>&1 | tee "$(basename "${BPF_PATH}")-veristat.ci.log"
+        sudo $(which veristat) ${BPF_PATH} 2>&1 | tee "$(basename "${BPF_PATH}")-veristat.ci.log"
   else
     echo "$BPF_PATH"
     sudo veristat ${BPF_PATH} 2>&1 | tee "$(basename "${BPF_PATH}")-veristat.ci.log"


### PR DESCRIPTION
We currently grab a pre-built binary for veristat. This is reproducible, but not ideal. Build it from source with Nix.

Test plan:
- CI
- Verified the veristat output is there in the uploaded pack. It is.