### PR TITLE
scx_p2dq: Call print_topology after attaching scheduler

### DIFF
--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -88,6 +88,7 @@ struct CliOpts {
 struct Scheduler<'a> {
     skel: BpfSkel<'a>,
     struct_ops: Option<libbpf_rs::Link>,
+    verbose: u8,
 
     stats_server: StatsServer<(), Metrics>,
 }
@@ -124,6 +125,7 @@ impl<'a> Scheduler<'a> {
         Ok(Self {
             skel,
             struct_ops: None,
+            verbose,
             stats_server,
         })
     }
@@ -284,6 +286,10 @@ impl<'a> Scheduler<'a> {
         self.setup_topology()?;
 
         self.struct_ops = Some(scx_ops_attach!(self.skel, p2dq)?);
+
+        if self.verbose > 1 {
+            self.print_topology()?;
+        }
 
         info!("P2DQ scheduler started! Run `scx_p2dq --monitor` for metrics.");
 


### PR DESCRIPTION
Call the topology print test after attaching to verify arena setup and suppress dead_code warning.

<details>
<summary> Edit : Warning log</summary>

```shell
warning: method `print_topology` is never used
   --> scheds/rust/scx_p2dq/src/main.rs:266:8
    |
95  | impl<'a> Scheduler<'a> {
    | ---------------------- method in this implementation
...
266 |     fn print_topology(&mut self) -> Result<()> {
    |        ^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: `scx_p2dq` (bin "scx_p2dq") generated 1 warning
```