### PR TITLE
arena: compat fix

### DIFF
--- a/lib/cpumask.bpf.c
+++ b/lib/cpumask.bpf.c
@@ -5,7 +5,7 @@
 #include <lib/percpu.h>
 
 static struct scx_allocator scx_bitmap_allocator;
-size_t mask_size;
+extern size_t mask_size;
 
 __weak
 int scx_bitmap_init(__u64 total_mask_size)


### PR DESCRIPTION
This improves compatibility by avoiding conflicting definitions of mask_size (i.e. when pulled in via p2dq).