### PR TITLE
ci: fix CACHIX_AUTH_TOKEN access in integration-tests

### DIFF
--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -14,14 +14,14 @@ runs:
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: Load dependencies
-      if: ${{ runner.environment != 'github-hosted' }}
+      if: ${{ runner.environment == 'self-hosted' }}
       run: |
         nix run ./.github/include#nix-develop-gha -- ./.github/include#common
       shell: bash
 
     - uses: cachix/cachix-action@v14
       name: Configure Cachix (self-hosted)
-      if: ${{ runner.environment != 'github-hosted' }}
+      if: ${{ runner.environment == 'self-hosted' }}
       with:
         name: sched-ext
         authToken: '${{ inputs.cachix-auth-token }}'
@@ -30,7 +30,7 @@ runs:
 
     - uses: cachix/cachix-action@v14
       name: Configure Cachix (github-hosted)
-      if: ${{ runner.environment == 'github-hosted' }}
+      if: ${{ runner.environment != 'self-hosted' }}
       with:
         name: sched-ext
         authToken: '${{ inputs.cachix-auth-token }}'

--- a/.github/workflows/6_12.yml
+++ b/.github/workflows/6_12.yml
@@ -23,6 +23,7 @@ jobs:
   integration-test:
     uses: ./.github/workflows/integration-tests.yml
     needs: build-kernel
+    secrets: inherit
     with:
       repo-name: stable/6_12
 

--- a/.github/workflows/bpf-next-test.yml
+++ b/.github/workflows/bpf-next-test.yml
@@ -23,6 +23,7 @@ jobs:
   integration-test:
     uses: ./.github/workflows/integration-tests.yml
     needs: build-kernel
+    secrets: inherit
     with:
       repo-name: bpf/bpf-next
 

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -50,6 +50,7 @@ jobs:
   integration-test:
     uses: ./.github/workflows/integration-tests.yml
     needs: build-kernel
+    secrets: inherit
     with:
       repo-name: sched_ext/for-next
 

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -23,6 +23,7 @@ jobs:
   integration-test:
     uses: ./.github/workflows/integration-tests.yml
     needs: build-kernel
+    secrets: inherit
     with:
       repo-name: stable/linux-rolling-stable
 


### PR DESCRIPTION
Reusable workflows can't read secrets by default. This meant that jobs under `integration-test.yml` couldn't upload artifacts to the Nix cache, causing some cache misses. As we own and trust this workflow, inherit all secrets.

Do a little cleanup in `install-nix` to make the use of "self-hosted" uniform.

Test plan:
- CI
- Previously "Post Install Nix" reported that it couldn't upload artifacts due to a missing key. Now it works and veristat isn't always a cache miss.