### PR TITLE
scx_rustland_core: Minor optimizations

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -872,7 +872,7 @@ void BPF_STRUCT_OPS(rustland_dispatch, s32 cpu, struct task_struct *prev)
 	 * Consume all tasks from the @dispatched list and immediately dispatch
 	 * them on the target CPU decided by the user-space scheduler.
 	 */
-	bpf_user_ringbuf_drain(&dispatched, handle_dispatched_task, NULL, 0);
+	bpf_user_ringbuf_drain(&dispatched, handle_dispatched_task, NULL, BPF_RB_NO_WAKEUP);
 
        /*
 	* Always dispatch the user-space scheduler every time that a CPU

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -1011,6 +1011,15 @@ void BPF_STRUCT_OPS(rustland_cpu_release, s32 cpu,
 }
 
 /*
+ * A task joins the sched_ext scheduler.
+ */
+void BPF_STRUCT_OPS(rustland_enable, struct task_struct *p)
+{
+	p->scx.dsq_vtime = 0;
+	p->scx.slice = SCX_SLICE_DFL;
+}
+
+/*
  * A new task @p is being created.
  *
  * Allocate and initialize all the internal structures for the task (this
@@ -1274,6 +1283,7 @@ SCX_OPS_DEFINE(rustland,
 	       .stopping		= (void *)rustland_stopping,
 	       .set_cpumask		= (void *)rustland_set_cpumask,
 	       .cpu_release		= (void *)rustland_cpu_release,
+	       .enable			= (void *)rustland_enable,
 	       .init_task		= (void *)rustland_init_task,
 	       .init			= (void *)rustland_init,
 	       .exit			= (void *)rustland_exit,

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -783,8 +783,7 @@ void BPF_STRUCT_OPS(rustland_enqueue, struct task_struct *p, u64 enq_flags)
 	 * (i.e., ksoftirqd/N, rcuop/N, etc.).
 	 */
 	if (is_kswapd(p) || (is_kthread(p) && p->nr_cpus_allowed == 1)) {
-                scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL,
-				   enq_flags | SCX_ENQ_PREEMPT);
+                scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL, enq_flags);
 		__sync_fetch_and_add(&nr_kernel_dispatches, 1);
 		return;
 	}

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -683,7 +683,7 @@ s32 BPF_STRUCT_OPS(rustland_select_cpu, struct task_struct *p, s32 prev_cpu,
 	 */
 	cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags & !SCX_WAKE_SYNC, &is_idle);
 	if (is_idle && !scx_bpf_dsq_nr_queued(SHARED_DSQ)) {
-		scx_bpf_dsq_insert_vtime(p, cpu_to_dsq(cpu), SCX_SLICE_DFL, p->scx.dsq_vtime, 0);
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL, 0);
 		__sync_fetch_and_add(&nr_kernel_dispatches, 1);
 	}
 
@@ -792,14 +792,13 @@ void BPF_STRUCT_OPS(rustland_enqueue, struct task_struct *p, u64 enq_flags)
 	 * Give the task a chance to be directly dispatched if
 	 * ops.select_cpu() was skipped.
 	 */
-	if (builtin_idle && is_queued_wakeup(p, enq_flags)) {
+	if (builtin_idle && is_queued_wakeup(p, enq_flags) &&
+	    !scx_bpf_dsq_nr_queued(SHARED_DSQ)) {
 		s32 cpu = pick_idle_cpu(p, scx_bpf_task_cpu(p));
 
 		if (cpu >= 0) {
-			scx_bpf_dsq_insert_vtime(p, cpu_to_dsq(cpu),
-					   SCX_SLICE_DFL, p->scx.dsq_vtime, enq_flags);
+			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, SCX_SLICE_DFL, enq_flags);
 			__sync_fetch_and_add(&nr_kernel_dispatches, 1);
-			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 			return;
 		}
 	}


### PR DESCRIPTION
Some small optimizations, cleanups and refactoring aimed at making the code more understandable, especially the BPF -> user-space scheduler activation workflow.

In particular, the user-space scheduler is now dispatched using a separate DSQ (reducing the overhead a bit on the shared DSQ),  SCX_LOCAL_DSQ / SCX_LOCAL_DSQ_ON are used when possible to reduce the overhead on the per-CPU shared DSQs and per-CPU kthreads are not allowed to preempt other tasks (which is overkill and it only introduced unnecessary context switches).