### PR TITLE
nix: add bpf-clang derivation

### DIFF
--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Load dependencies
       if: ${{ runner.environment != 'github-hosted' }}
       run: |
-        nix run ./.github/include#nix-develop-gha -- ./.github/include#common
+        nix run ./.github/include#nix-develop-gha -- ./.github/include#gha-common
       shell: bash
 
     - uses: cachix/cachix-action@v14

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,7 +21,7 @@ jobs:
           cachix-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Load dependencies
-        run: nix run ./.github/include#nix-develop-gha -- ./.github/include#list-tests
+        run: nix run ./.github/include#nix-develop-gha -- ./.github/include#gha-list-tests
 
       - name: List tests
         id: output

--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -18,7 +18,7 @@ jobs:
           cachix-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Load dependencies
-        run: nix run ./.github/include#nix-develop-gha -- ./.github/include#update-kernels
+        run: nix run ./.github/include#nix-develop-gha -- ./.github/include#gha-update-kernels
 
       - name: List kernels
         id: output
@@ -45,7 +45,7 @@ jobs:
           cachix-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Load dependencies
-        run: nix run ./.github/include#nix-develop-gha -- ./.github/include#update-kernels
+        run: nix run ./.github/include#nix-develop-gha -- ./.github/include#gha-update-kernels
 
       - name: Update kernel
         run: |


### PR DESCRIPTION
Currently any builds completed with Nix dependencies use the default nix clang, which is "empty" and wrapped to make it functional. Although this appears to work completely fine, it spews a load of warnings about unused arguments and this specific wrapper being only meant for x86_64 (or other native system).

Write a custom wrapper for the unwrapped Nix clang that only provides the necessary arguments. This also exposes a dependency on kernel headers. For now, use the sched_ext/for-next headers, but leave this open to a matrix in the future.

This change:
- Adds bpf-clang to get rid of the warnings and explicitly depend on kernel headers.
- Creates a default development shell for users who want to grab a working set of dependencies with `nix develop ./.github/include` or something like `nix-direnv`.
- Cleans up the GitHub Actions specific devshells by adding the `gha-` prefix.

Test plan:
- CI
- `cargo clean && nix develop -i ./.github/include --command cargo build`

No Meson support as of yet.