### PR TITLE
scx_layered: Flip the return polarity of sib_keep_idle()

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1875,11 +1875,11 @@ bool sib_keep_idle(s32 cpu, struct task_struct *prev __arg_trusted, struct cpu_c
 		if ((sib = sibling_cpu(cpu)) >= 0 && (sib_cpuc = lookup_cpu_ctx(sib)) &&
 		    (sib_cpuc->current_excl || sib_cpuc->next_excl)) {
 			gstat_inc(GSTAT_EXCL_IDLE, cpuc);
-			return false;
+			return true;
 		}
 	}
-	
-	return true;
+
+	return false;
 }
 
 void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
@@ -1898,7 +1898,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 	if (antistall_consume(cpuc))
 		return;
 	
-	if (prev && !sib_keep_idle(cpu, prev, cpuc))
+	if (prev && sib_keep_idle(cpu, prev, cpuc))
 		return;
 
 	/*


### PR DESCRIPTION
It was returning false when the CPU should go idle. Flip it.