### PR TITLE
scx_rustland_core:  Expose nr_cpus_allowed to user-space

### DIFF
--- a/rust/scx_rustland_core/README.md
+++ b/rust/scx_rustland_core/README.md
@@ -78,6 +78,7 @@ Each task received from `.dequeue_task()` contains the following:
 struct QueuedTask {
     pub pid: i32,              // pid that uniquely identifies a task
     pub cpu: i32,              // CPU previously used by the task
+    pub nr_cpus_allowed: u64,  // Number of CPUs that the task can use
     pub flags: u64,            // task's enqueue flags
     pub start_ts: u64,         // Timestamp since last time the task ran on a CPU (in ns)
     pub stop_ts: u64,          // Timestamp since last time the task released a CPU (in ns)

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -76,6 +76,7 @@ pub const RL_CPU_ANY: i32 = bpf_intf::RL_CPU_ANY as i32;
 pub struct QueuedTask {
     pub pid: i32,              // pid that uniquely identifies a task
     pub cpu: i32,              // CPU where the task is running
+    pub nr_cpus_allowed: u64,  // Number of CPUs that the task can use
     pub flags: u64,            // task enqueue flags
     pub start_ts: u64,         // Timestamp since last time the task ran on a CPU
     pub stop_ts: u64,          // Timestamp since last time the task released a CPU
@@ -138,6 +139,7 @@ impl EnqueuedMessage {
         QueuedTask {
             pid: self.inner.pid,
             cpu: self.inner.cpu,
+            nr_cpus_allowed: self.inner.nr_cpus_allowed,
             flags: self.inner.flags,
             start_ts: self.inner.start_ts,
             stop_ts: self.inner.stop_ts,

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -82,7 +82,6 @@ pub struct QueuedTask {
     pub exec_runtime: u64,     // Total cpu time since last sleep
     pub weight: u64,           // Task static priority
     pub vtime: u64,            // Current vruntime
-    cpumask_cnt: u64,          // cpumask generation counter (private)
 }
 
 // Task queued for dispatching to the BPF component (see bpf_intf::dispatched_task_ctx).
@@ -93,7 +92,6 @@ pub struct DispatchedTask {
     pub flags: u64,    // special dispatch flags
     pub slice_ns: u64, // time slice assigned to the task (0 = default)
     pub vtime: u64,    // task deadline / vruntime
-    cpumask_cnt: u64,  // cpumask generation counter (private)
 }
 
 impl DispatchedTask {
@@ -108,7 +106,6 @@ impl DispatchedTask {
             flags: task.flags,
             slice_ns: 0, // use default time slice
             vtime: 0,
-            cpumask_cnt: task.cpumask_cnt,
         }
     }
 }
@@ -147,7 +144,6 @@ impl EnqueuedMessage {
             exec_runtime: self.inner.exec_runtime,
             weight: self.inner.weight,
             vtime: self.inner.vtime,
-            cpumask_cnt: self.inner.cpumask_cnt,
         }
     }
 }
@@ -548,7 +544,6 @@ impl<'cb> BpfScheduler<'cb> {
             flags,
             slice_ns,
             vtime,
-            cpumask_cnt,
             ..
         } = &mut dispatched_task.as_mut();
 
@@ -557,7 +552,6 @@ impl<'cb> BpfScheduler<'cb> {
         *flags = task.flags;
         *slice_ns = task.slice_ns;
         *vtime = task.vtime;
-        *cpumask_cnt = task.cpumask_cnt;
 
         // Store the task in the user ring buffer.
         //

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -82,7 +82,8 @@ struct domain_arg {
 struct queued_task_ctx {
 	s32 pid;
 	s32 cpu; /* CPU where the task is running */
-	u64 flags; /* task enqueue flags */
+	u64 nr_cpus_allowed; /* Number of CPUs that the task can use */
+	u64 flags; /* Task enqueue flags */
 	u64 start_ts; /* Timestamp since last time the task ran on a CPU */
 	u64 stop_ts; /* Timestamp since last time the task released a CPU */
 	u64 exec_runtime; /* Total cpu time since last sleep */

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -88,7 +88,6 @@ struct queued_task_ctx {
 	u64 exec_runtime; /* Total cpu time since last sleep */
 	u64 weight; /* Task static priority */
 	u64 vtime; /* Current task's vruntime */
-	u64 cpumask_cnt; /* cpumask generation counter */
 };
 
 /*
@@ -103,7 +102,6 @@ struct dispatched_task_ctx {
 	u64 flags; /* task enqueue flags */
 	u64 slice_ns; /* time slice assigned to the task (0=default) */
 	u64 vtime; /* task deadline / vruntime */
-	u64 cpumask_cnt; /* cpumask generation counter */
 };
 
 #endif /* __INTF_H */

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -720,6 +720,7 @@ static void get_task_info(struct queued_task_ctx *task,
 
 	task->pid = p->pid;
 	task->cpu = scx_bpf_task_cpu(p);
+	task->nr_cpus_allowed = p->nr_cpus_allowed;
 	task->flags = enq_flags;
 	task->start_ts = tctx ? tctx->start_ts : 0;
 	task->stop_ts = tctx ? tctx->stop_ts : 0;

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -222,12 +222,6 @@ struct task_ctx {
 	 * Execution time (in nanoseconds) since the last sleep event.
 	 */
 	u64 exec_runtime;
-
-	/*
-	 * cpumask generation counter: used to verify the validity of the
-	 * current task's cpumask.
-	 */
-	u64 cpumask_cnt;
 };
 
 /* Map that contains task-local storage. */
@@ -565,7 +559,6 @@ static void dispatch_task(const struct dispatched_task_ctx *task)
 {
 	struct task_struct *p;
 	struct task_ctx *tctx;
-	u64 curr_cpumask_cnt;
 
 	/* Ignore entry if the task doesn't exist anymore */
 	p = bpf_task_from_pid(task->pid);
@@ -610,36 +603,32 @@ static void dispatch_task(const struct dispatched_task_ctx *task)
 	if (!tctx)
 		goto out_release;
 
-	/* Read current cpumask generation counter */
-	curr_cpumask_cnt = tctx->cpumask_cnt;
-
 	/* Check if the CPU is valid, according to the cpumask */
 	if (!bpf_cpumask_test_cpu(task->cpu, p->cpus_ptr)) {
-		scx_bpf_dsq_insert_vtime(p, SHARED_DSQ, task->slice_ns, task->vtime, task->flags);
+		s32 cpu = scx_bpf_task_cpu(p);
+
+		scx_bpf_dsq_insert_vtime(p, cpu_to_dsq(cpu),
+					 task->slice_ns, task->vtime, task->flags);
 		__sync_fetch_and_add(&nr_bounce_dispatches, 1);
-		scx_bpf_kick_cpu(scx_bpf_task_cpu(p), SCX_KICK_IDLE);
+		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 		goto out_release;
 	}
 
 	/*
 	 * Dispatch a task to a specific per-CPU DSQ if the target CPU can be
-	 * used (according to the cpumask), otherwise redirect the task to the
-	 * shared DSQ.
+	 * used (according to the cpumask), otherwise cancel the dispatch.
 	 *
 	 * This can happen if the user-space scheduler dispatches the task to
-	 * an invalid CPU. In this case the redirection to the shared DSQ
-	 * allows to prevent potential stalls in the scheduler.
-	 *
-	 * If the cpumask is not valid anymore (determined by the cpumask_cnt
-	 * generation counter) we can simply cancel the dispatch event, since
-	 * the task will be re-enqueued by the core sched-ext code, potentially
-	 * selecting a different cpu and a different cpumask.
+	 * an invalid CPU. In this case cancelling the dispatch allows to
+	 * prevent potential stalls in the scheduler, since the task will
+	 * be re-enqueued by the core sched-ext code, potentially selecting
+	 * a different cpu and a different cpumask.
 	 */
 	scx_bpf_dsq_insert_vtime(p, cpu_to_dsq(task->cpu),
 				 task->slice_ns, task->vtime, task->flags);
 
 	/* If the cpumask is not valid anymore, ignore the dispatch event */
-	if (curr_cpumask_cnt != task->cpumask_cnt) {
+	if (!bpf_cpumask_test_cpu(task->cpu, p->cpus_ptr)) {
 		scx_bpf_dispatch_cancel();
 		__sync_fetch_and_add(&nr_cancel_dispatches, 1);
 		goto out_release;
@@ -737,7 +726,6 @@ static void get_task_info(struct queued_task_ctx *task,
 	task->exec_runtime = tctx ? tctx->exec_runtime : 0;
 	task->weight = p->scx.weight;
 	task->vtime = p->scx.dsq_vtime;
-	task->cpumask_cnt = tctx ? tctx->cpumask_cnt : 0;
 }
 
 /*
@@ -1001,20 +989,6 @@ void BPF_STRUCT_OPS(rustland_stopping, struct task_struct *p, bool runnable)
 	 * Update the partial execution time since last sleep.
 	 */
 	tctx->exec_runtime += now - tctx->start_ts;
-}
-
-/*
- * Task @p changes cpumask: update its local cpumask generation counter.
- */
-void BPF_STRUCT_OPS(rustland_set_cpumask, struct task_struct *p,
-		    const struct cpumask *cpumask)
-{
-	struct task_ctx *tctx;
-
-	tctx = try_lookup_task_ctx(p);
-	if (!tctx)
-		return;
-	tctx->cpumask_cnt++;
 }
 
 /*
@@ -1312,7 +1286,6 @@ SCX_OPS_DEFINE(rustland,
 	       .runnable		= (void *)rustland_runnable,
 	       .running			= (void *)rustland_running,
 	       .stopping		= (void *)rustland_stopping,
-	       .set_cpumask		= (void *)rustland_set_cpumask,
 	       .cpu_release		= (void *)rustland_cpu_release,
 	       .enable			= (void *)rustland_enable,
 	       .init_task		= (void *)rustland_init_task,

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -48,6 +48,7 @@
 //! struct QueuedTask {
 //!     pub pid: i32,              // pid that uniquely identifies a task
 //!     pub cpu: i32,              // CPU previously used by the task
+//!     pub nr_cpus_allowed: u64,  // Number of CPUs that the task can use
 //!     pub flags: u64,            // task's enqueue flags
 //!     pub start_ts: u64,         // Timestamp since last time the task ran on a CPU (in ns)
 //!     pub stop_ts: u64,          // Timestamp since last time the task released a CPU (in ns)


### PR DESCRIPTION
Drop the internal cpumask generation counter from the task context shared with user-space (it's just easier to check the validity of the target CPU using `p->cpus_ptr`) and expose `p->nr_cpus_allowed` to the user-space scheduler, which can use this information to implement better scheduling policies.

After these changes the size of `QueuedTask / queued_task_ctx` is still 64 bytes, that still fits in a cacheline (typically) and it corresponds to the minimal allocation size in the custom user-space memory allocator, and the size of `DispatchedTask / dispatched_task_ctx` is reduced from 40 bytes to 32 bytes.