### PR TITLE
p2dq/chaos: add trait for skeletons that can have their arenas setup

### DIFF
--- a/scheds/rust/scx_chaos/src/lib.rs
+++ b/scheds/rust/scx_chaos/src/lib.rs
@@ -7,6 +7,7 @@ mod bpf_skel;
 
 use bpf_skel::BpfSkel;
 
+use scx_p2dq::P2dqArenaProgs;
 use scx_p2dq::SchedulerOpts as P2dqOpts;
 use scx_userspace_arena::alloc::Allocator;
 use scx_userspace_arena::alloc::HeapAllocator;
@@ -20,6 +21,8 @@ use scx_utils::uei_report;
 use anyhow::bail;
 use anyhow::Result;
 use libbpf_rs::OpenObject;
+use libbpf_rs::ProgramInput;
+use libbpf_rs::ProgramOutput;
 use log::debug;
 use nix::unistd::Pid;
 
@@ -61,6 +64,24 @@ unsafe impl Allocator for ArenaAllocator {
                 layout,
             )
         }
+    }
+}
+
+impl P2dqArenaProgs for BpfSkel<'_> {
+    fn run_arena_init<'b>(&self, input: ProgramInput<'b>) -> Result<ProgramOutput<'b>> {
+        Ok(self.progs.p2dq_arena_init.test_run(input)?)
+    }
+
+    fn run_alloc_mask<'b>(&self, input: ProgramInput<'b>) -> Result<ProgramOutput<'b>> {
+        Ok(self.progs.p2dq_alloc_mask.test_run(input)?)
+    }
+
+    fn run_topology_node_init<'b>(&self, input: ProgramInput<'b>) -> Result<ProgramOutput<'b>> {
+        Ok(self.progs.p2dq_topology_node_init.test_run(input)?)
+    }
+
+    fn setup_ptr(&self) -> u64 {
+        self.maps.bss_data.setup_ptr
     }
 }
 

--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -5,8 +5,14 @@
 pub use scx_utils::CoreType;
 use scx_utils::Topology;
 pub use scx_utils::NR_CPU_IDS;
+use scx_utils::{Core, Llc};
 
+use anyhow::{bail, Result};
 use clap::Parser;
+use libbpf_rs::ProgramInput;
+use libbpf_rs::ProgramOutput;
+
+use std::sync::Arc;
 
 lazy_static::lazy_static! {
         pub static ref TOPO: Topology = Topology::new().unwrap();
@@ -139,6 +145,110 @@ pub fn dsq_slice_ns(dsq_index: u64, min_slice_us: u64, dsq_shift: u64) -> u64 {
     result
 }
 
+/// Trait for interfacing with BPF arena programs
+pub trait P2dqArenaProgs {
+    /// Run the arena initialization program and return the result
+    fn run_arena_init<'a>(&self, input: ProgramInput<'a>) -> Result<ProgramOutput<'a>>;
+
+    /// Run the allocation mask program and return the result
+    fn run_alloc_mask<'a>(&self, input: ProgramInput<'a>) -> Result<ProgramOutput<'a>>;
+
+    /// Run the topology node initialization program and return the result
+    fn run_topology_node_init<'a>(&self, input: ProgramInput<'a>) -> Result<ProgramOutput<'a>>;
+
+    /// Access to the setup pointer in BSS data
+    fn setup_ptr(&self) -> u64;
+}
+
+pub fn setup_arenas<T: P2dqArenaProgs>(skel: &T) -> Result<()> {
+    // Allocate the arena memory from the BPF side so userspace initializes it before starting
+    // the scheduler. Despite the function call's name this is neither a test nor a test run,
+    // it's the recommended way of executing SEC("syscall") probes.
+    let input = ProgramInput {
+        ..Default::default()
+    };
+
+    let output = skel.run_arena_init(input)?;
+    if output.return_value != 0 {
+        bail!(
+            "Could not initialize arenas, p2dq_setup returned {}",
+            output.return_value as i32
+        );
+    }
+
+    Ok(())
+}
+
+fn setup_topology_node<T: P2dqArenaProgs>(skel: &T, mask: &[u64]) -> Result<()> {
+    // Copy the address of ptr to the kernel to populate it from BPF with the arena pointer.
+    let input = ProgramInput {
+        ..Default::default()
+    };
+
+    let output = skel.run_alloc_mask(input)?;
+    if output.return_value != 0 {
+        bail!(
+            "Could not initialize arenas, setup_topology_node returned {}",
+            output.return_value as i32
+        );
+    }
+
+    let ptr = unsafe { std::mem::transmute::<u64, &mut [u64; 10]>(skel.setup_ptr()) };
+
+    let (valid_mask, _) = ptr.split_at_mut(mask.len());
+    valid_mask.clone_from_slice(mask);
+
+    let input = ProgramInput {
+        ..Default::default()
+    };
+    let output = skel.run_topology_node_init(input)?;
+    if output.return_value != 0 {
+        bail!(
+            "p2dq_topology_node_init returned {}",
+            output.return_value as i32
+        );
+    }
+
+    Ok(())
+}
+
+pub fn setup_topology<T: P2dqArenaProgs>(skel: &T) -> Result<()> {
+    let topo = Topology::new().expect("Failed to build host topology");
+
+    setup_topology_node(skel, topo.span.as_raw_slice())?;
+
+    for (_, node) in topo.nodes {
+        setup_topology_node(skel, node.span.as_raw_slice())?;
+    }
+
+    for (_, llc) in topo.all_llcs {
+        setup_topology_node(
+            skel,
+            Arc::<Llc>::into_inner(llc)
+                .expect("missing llc")
+                .span
+                .as_raw_slice(),
+        )?;
+    }
+
+    for (_, core) in topo.all_cores {
+        setup_topology_node(
+            skel,
+            Arc::<Core>::into_inner(core)
+                .expect("missing core")
+                .span
+                .as_raw_slice(),
+        )?;
+    }
+    for (_, cpu) in topo.all_cpus {
+        let mut mask = [0; 9];
+        mask[cpu.id.checked_shr(64).unwrap_or(0)] |= 1 << (cpu.id % 64);
+        setup_topology_node(skel, &mask)?;
+    }
+
+    Ok(())
+}
+
 #[macro_export]
 macro_rules! init_open_skel {
     ($skel: expr, $opts: expr, $verbose: expr) => {
@@ -238,6 +348,9 @@ macro_rules! init_skel {
             $skel.maps.bss_data.cpu_llc_ids[cpu.id] = cpu.llc_id as u64;
             $skel.maps.bss_data.cpu_node_ids[cpu.id] = cpu.node_id as u64;
         }
+
+        $crate::setup_arenas($skel)?;
+        $crate::setup_topology($skel)?;
     };
 }
 

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -9,9 +9,6 @@ pub mod bpf_intf;
 pub mod stats;
 use stats::Metrics;
 
-use scx_p2dq::SchedulerOpts;
-use scx_p2dq::TOPO;
-
 use std::mem::MaybeUninit;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -37,24 +34,46 @@ use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
 use scx_utils::uei_exited;
 use scx_utils::uei_report;
-use scx_utils::Topology;
 use scx_utils::UserExitInfo;
 use scx_utils::NR_CPU_IDS;
-use scx_utils::{Core, Llc};
 
-use crate::bpf_intf::stat_idx_P2DQ_NR_STATS;
-use crate::bpf_intf::stat_idx_P2DQ_STAT_DIRECT;
-use crate::bpf_intf::stat_idx_P2DQ_STAT_DISPATCH_PICK2;
-use crate::bpf_intf::stat_idx_P2DQ_STAT_DSQ_CHANGE;
-use crate::bpf_intf::stat_idx_P2DQ_STAT_DSQ_SAME;
-use crate::bpf_intf::stat_idx_P2DQ_STAT_IDLE;
-use crate::bpf_intf::stat_idx_P2DQ_STAT_KEEP;
-use crate::bpf_intf::stat_idx_P2DQ_STAT_LLC_MIGRATION;
-use crate::bpf_intf::stat_idx_P2DQ_STAT_NODE_MIGRATION;
-use crate::bpf_intf::stat_idx_P2DQ_STAT_SELECT_PICK2;
-use crate::bpf_intf::stat_idx_P2DQ_STAT_WAKE_LLC;
-use crate::bpf_intf::stat_idx_P2DQ_STAT_WAKE_MIG;
-use crate::bpf_intf::stat_idx_P2DQ_STAT_WAKE_PREV;
+use bpf_intf::stat_idx_P2DQ_NR_STATS;
+use bpf_intf::stat_idx_P2DQ_STAT_DIRECT;
+use bpf_intf::stat_idx_P2DQ_STAT_DISPATCH_PICK2;
+use bpf_intf::stat_idx_P2DQ_STAT_DSQ_CHANGE;
+use bpf_intf::stat_idx_P2DQ_STAT_DSQ_SAME;
+use bpf_intf::stat_idx_P2DQ_STAT_IDLE;
+use bpf_intf::stat_idx_P2DQ_STAT_KEEP;
+use bpf_intf::stat_idx_P2DQ_STAT_LLC_MIGRATION;
+use bpf_intf::stat_idx_P2DQ_STAT_NODE_MIGRATION;
+use bpf_intf::stat_idx_P2DQ_STAT_SELECT_PICK2;
+use bpf_intf::stat_idx_P2DQ_STAT_WAKE_LLC;
+use bpf_intf::stat_idx_P2DQ_STAT_WAKE_MIG;
+use bpf_intf::stat_idx_P2DQ_STAT_WAKE_PREV;
+use scx_p2dq::P2dqArenaProgs;
+use scx_p2dq::SchedulerOpts;
+use scx_p2dq::TOPO;
+
+impl P2dqArenaProgs for BpfSkel<'_> {
+    fn run_arena_init<'b>(&self, input: ProgramInput<'b>) -> Result<libbpf_rs::ProgramOutput<'b>> {
+        Ok(self.progs.p2dq_arena_init.test_run(input)?)
+    }
+
+    fn run_alloc_mask<'b>(&self, input: ProgramInput<'b>) -> Result<libbpf_rs::ProgramOutput<'b>> {
+        Ok(self.progs.p2dq_alloc_mask.test_run(input)?)
+    }
+
+    fn run_topology_node_init<'b>(
+        &self,
+        input: ProgramInput<'b>,
+    ) -> Result<libbpf_rs::ProgramOutput<'b>> {
+        Ok(self.progs.p2dq_topology_node_init.test_run(input)?)
+    }
+
+    fn setup_ptr(&self) -> u64 {
+        self.maps.bss_data.setup_ptr
+    }
+}
 
 /// scx_p2dq: A pick 2 dumb queuing load balancing scheduler.
 ///
@@ -176,95 +195,6 @@ impl<'a> Scheduler<'a> {
         uei_report!(&self.skel, uei)
     }
 
-    fn setup_arenas(&mut self) -> Result<()> {
-        // Allocate the arena memory from the BPF side so userspace initializes it before starting
-        // the scheduler. Despite the function call's name this is neither a test nor a test run,
-        // it's the recommended way of executing SEC("syscall") probes.
-        let input = ProgramInput {
-            ..Default::default()
-        };
-
-        let output = self.skel.progs.p2dq_arena_init.test_run(input)?;
-        if output.return_value != 0 {
-            bail!(
-                "Could not initialize arenas, p2dq_setup returned {}",
-                output.return_value as i32
-            );
-        }
-
-        Ok(())
-    }
-
-    fn setup_topology_node(&mut self, mask: &[u64]) -> Result<()> {
-        // Copy the address of ptr to the kernel to populate it from BPF with the arena pointer.
-        let input = ProgramInput {
-            ..Default::default()
-        };
-
-        let output = self.skel.progs.p2dq_alloc_mask.test_run(input)?;
-        if output.return_value != 0 {
-            bail!(
-                "Could not initialize arenas, setup_topology_node returned {}",
-                output.return_value as i32
-            );
-        }
-
-        let ptr = unsafe {
-            std::mem::transmute::<u64, &mut [u64; 10]>(self.skel.maps.bss_data.setup_ptr)
-        };
-
-        let (valid_mask, _) = ptr.split_at_mut(mask.len());
-        valid_mask.clone_from_slice(mask);
-
-        let input = ProgramInput {
-            ..Default::default()
-        };
-        let output = self.skel.progs.p2dq_topology_node_init.test_run(input)?;
-        if output.return_value != 0 {
-            bail!(
-                "p2dq_topology_node_init returned {}",
-                output.return_value as i32
-            );
-        }
-
-        Ok(())
-    }
-
-    fn setup_topology(&mut self) -> Result<()> {
-        let topo = Topology::new().expect("Failed to build host topology");
-
-        self.setup_topology_node(topo.span.as_raw_slice())?;
-
-        for (_, node) in topo.nodes {
-            self.setup_topology_node(node.span.as_raw_slice())?;
-        }
-
-        for (_, llc) in topo.all_llcs {
-            self.setup_topology_node(
-                Arc::<Llc>::into_inner(llc)
-                    .expect("missing llc")
-                    .span
-                    .as_raw_slice(),
-            )?;
-        }
-
-        for (_, core) in topo.all_cores {
-            self.setup_topology_node(
-                Arc::<Core>::into_inner(core)
-                    .expect("missing core")
-                    .span
-                    .as_raw_slice(),
-            )?;
-        }
-        for (_, cpu) in topo.all_cpus {
-            let mut mask = [0; 9];
-            mask[cpu.id.checked_shr(64).unwrap_or(0)] |= 1 << (cpu.id % 64);
-            self.setup_topology_node(&mask)?;
-        }
-
-        Ok(())
-    }
-
     fn print_topology(&mut self) -> Result<()> {
         let input = ProgramInput {
             ..Default::default()
@@ -282,9 +212,6 @@ impl<'a> Scheduler<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.setup_arenas()?;
-        self.setup_topology()?;
-
         self.struct_ops = Some(scx_ops_attach!(self.skel, p2dq)?);
 
         if self.verbose > 1 {


### PR DESCRIPTION
c5cb9b4 recently started using the arena to store data for the topology in scx_p2dq. This wasn't fully implemented for chaos so chaos lost visibility of the topology abstraction, causing certain failures. Implement a trait on the p2dq/chaos skeletons to expose this functionality, and call it in the shared `init_skel` macro rather than in each scheduler. The trait approach was chosen as a compromise between code duplication and being stuck in macros for this sort of work.

Test plan:
- CI