### PR TITLE
ci: push kernel and headers to cachix explicitly

### DIFF
--- a/.github/actions/build-kernel/action.yml
+++ b/.github/actions/build-kernel/action.yml
@@ -17,3 +17,14 @@ runs:
     - name: Build kernel
       shell: bash
       run: nix build --no-link ./.github/include#kernels.'${{ inputs.repo-name }}'{,.headers}
+
+    - name: Explicitly push to cachix
+      shell: bash
+      run: |
+        # address an edge case where the dedicated runner has a local cache hit
+        # but that entry wasn't uploaded to cachix
+        if [ -f "$HOME/.config/cachix/cachix.dhall" ]; then
+          cachix push sched-ext $KERNEL_STORE_PATH $KERNEL_HEADERS_STORE_PATH
+        else
+          echo "no auth token; skipping cache push"
+        fi


### PR DESCRIPTION
Discussion in #1881 exposed a gap in the kernel caching process.

Current behaviour:
- Forked PR that changes the kernel fails to upload to the cache and future steps miss, wasting runner time. This is basically intended. Most kernel updates do not come from forked PRs - it does finish eventually.
- GitHub merge queue created branch has the perms, but GHA runners still miss the cache and one of those eventually uploads it after a build (they all build it).
- Entry is already cached by the time the PR is merged, meaning no one else has a cache miss.

This PR addresses the middle case. It was missing before because the self-hosted runner had already hit its local Nix store, and hence didn't upload the "new" result because the result isn't "new" (it was already built by the forked PR). Now we check whether we have the secret and force the upload of these important builds.

This saves a fair amount of runner time.

Test plan:
- Pushed to my fork. The new step failed cleanly with the "no auth" message.
- Pushed to the repo. The new step succeeds.