### PR TITLE
scx_layered: Remove redundant !idle test in layered_update_idle()

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2821,9 +2821,6 @@ void BPF_STRUCT_OPS(layered_update_idle, s32 cpu, bool idle)
 	cpuc->protect_owned = false;
 	cpuc->usage_at_idle = cpuc->usage;
 
-	if (!idle)
-		return;
-
 	/*
 	 * Interlocked with kick_idle_cpu() in layered_enqueue(). Either they
 	 * see idle set or we see the task in one of the DSQs.


### PR DESCRIPTION
It's already tested on function entry. No need to test again. Spotted by Daniel Hodges.