### PR TITLE
scx_rustland_core: Disable THP for user-space scheduler

### DIFF
--- a/rust/scx_rustland_core/src/alloc.rs
+++ b/rust/scx_rustland_core/src/alloc.rs
@@ -497,7 +497,13 @@ impl UserAllocator {
             if res != 0 {
                 panic!("mlockall failed with error code: {}", res);
             }
-        };
+
+            // Prevent khugpaged from unmapping pages underneath.
+            let res = libc::prctl(libc::PR_SET_THP_DISABLE, 1, 0, 0, 0);
+            if res != 0 {
+                panic!("Failed to disable THP: {}", res);
+            }
+        }
     }
 
     #[allow(static_mut_refs)]


### PR DESCRIPTION
Unmapping/remapping pages in the user-space scheduler's address space can lead to stall conditions: completing the operation may requires a kthread to run, but the kthread cannot run because the user-space scheduler is blocked => deadlock.

To prevent this stall condition, disable transparent huge pages for the user-space scheduler task. This ensures that khugepaged won't touch those pages, thereby avoiding the stall.