### PR TITLE
scxtop: aggregate GLOBAL and LOCAL DSQs

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -2331,7 +2331,10 @@ impl<'a> App<'a> {
             self.max_cpu_events,
         ));
 
-        if *next_dsq_id != scx_enums.SCX_DSQ_INVALID && *next_dsq_lat_us > 0 {
+        let next_dsq_id = Self::classify_dsq(*next_dsq_id);
+        let prev_dsq_id = Self::classify_dsq(*prev_dsq_id);
+
+        if next_dsq_id != scx_enums.SCX_DSQ_INVALID && *next_dsq_lat_us > 0 {
             if self.state == AppState::MangoApp {
                 if self.process_id > 0 && action.next_tgid == self.process_id as u32 {
                     cpu_data.add_event_data("dsq_lat_us", *next_dsq_lat_us);
@@ -2342,7 +2345,7 @@ impl<'a> App<'a> {
 
             let next_dsq_data = self
                 .dsq_data
-                .entry(*next_dsq_id)
+                .entry(next_dsq_id)
                 .or_insert(EventData::new(self.max_cpu_events));
 
             if self.state == AppState::MangoApp {
@@ -2369,10 +2372,10 @@ impl<'a> App<'a> {
             }
         }
 
-        if *prev_dsq_id != scx_enums.SCX_DSQ_INVALID && *prev_used_slice_ns > 0 {
+        if prev_dsq_id != scx_enums.SCX_DSQ_INVALID && *prev_used_slice_ns > 0 {
             let prev_dsq_data = self
                 .dsq_data
-                .entry(*prev_dsq_id)
+                .entry(prev_dsq_id)
                 .or_insert(EventData::new(self.max_cpu_events));
             if self.state == AppState::MangoApp {
                 if self.process_id > 0 && action.prev_tgid == self.process_id as u32 {
@@ -2381,6 +2384,17 @@ impl<'a> App<'a> {
             } else {
                 prev_dsq_data.add_event_data("dsq_slice_consumed", *prev_used_slice_ns);
             }
+        }
+    }
+
+    // Groups built-in dsq's (GLOBAL, LOCAL, and LOCAL-ON)
+    fn classify_dsq(dsq_id: u64) -> u64 {
+        if dsq_id & scx_enums.SCX_DSQ_FLAG_BUILTIN == 0 {
+            dsq_id
+        } else if (dsq_id & scx_enums.SCX_DSQ_LOCAL_ON) == scx_enums.SCX_DSQ_LOCAL_ON {
+            scx_enums.SCX_DSQ_LOCAL_ON
+        } else {
+            dsq_id & (scx_enums.SCX_DSQ_FLAG_BUILTIN | 3)
         }
     }
 

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -2394,6 +2394,7 @@ impl<'a> App<'a> {
         } else if (dsq_id & scx_enums.SCX_DSQ_LOCAL_ON) == scx_enums.SCX_DSQ_LOCAL_ON {
             scx_enums.SCX_DSQ_LOCAL_ON
         } else {
+            // Catches both GLOBAL and LOCAL bits (1 or 2)
             dsq_id & (scx_enums.SCX_DSQ_FLAG_BUILTIN | 3)
         }
     }


### PR DESCRIPTION
scxtop displays the data for each local DSQ, which can become unusable given the large amount of local DSQs. Ex.:

<img width="878" alt="Screenshot 2025-05-22 at 4 38 28 PM" src="https://github.com/user-attachments/assets/8b797b52-6030-437f-80c4-f485344ec2e2" />


In order, to make it more useful, we'll now group GLOBAL, LOCAL, and LOCAL_ON DSQs by using their respective [bitmasks](https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/sched/ext.h#n47). Ex.:

<img width="958" alt="Screenshot 2025-05-22 at 4 42 11 PM" src="https://github.com/user-attachments/assets/e43b656d-4b04-4e7c-90ba-b295e1d1afea" />