### PR TITLE
scx_p2dq: Improve accuracy of runtime accounting

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -51,10 +51,9 @@ struct task_p2dq {
 	u32			cpu;
 	u32			llc_id;
 	u32			node_id;
-	bool			runnable;
-	u32			weight;
 	u64			used;
 	u64			last_dsq_id;
+	u64 			last_run_started;
 	u64 			last_run_at;
 	u64			llc_runs; /* how many runs on the current LLC */
 	int			last_dsq_index;


### PR DESCRIPTION
When tasks stop in p2dq only update the DSQ if the task is no longer runnable. This improves accounting of task utilization by not penalizing tasks that run for different intervals.

Suggested-by: Emil Tsalapatis <aimilios.tsalapatis@gmail.com>