### PR TITLE
layered: add match debug capability

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -614,6 +614,13 @@ struct Opts {
     #[clap(long, default_value = "false")]
     disable_antistall: bool,
 
+    /// Enable match debug
+    /// This stores a mapping of task tid
+    /// to layer id such that bpftool map dump
+    /// can be used to debug layer matches.
+    #[clap(long, default_value = "false")]
+    enable_match_debug: bool,
+
     /// Maximum task runnable_at delay (in seconds) before antistall turns on
     #[clap(long, default_value = "3")]
     antistall_sec: u64,
@@ -1915,6 +1922,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.lo_fb_wait_ns = opts.lo_fb_wait_us * 1000;
         skel.maps.rodata_data.lo_fb_share_ppk = ((opts.lo_fb_share * 1024.0) as u32).clamp(1, 1024);
         skel.maps.rodata_data.enable_antistall = !opts.disable_antistall;
+        skel.maps.rodata_data.enable_match_debug = opts.enable_match_debug;
         skel.maps.rodata_data.enable_gpu_support = opts.enable_gpu_support;
 
         for (cpu, sib) in topo.sibling_cpus().iter().enumerate() {


### PR DESCRIPTION
Add a matcher to layered to enable using the command `bpftool map dump layer_match_dbg` to determine which layers tids have been matched to.,

This shows a pid being there while it was alive and gone after it was killed:
```
scx on  layered-debug-map [!] is 📦 v1.0.12 via 🐍 v3.13.3 via 🦀 v1.87.0 
❯ sudo bpftool map dump name layer_match_dbg | jq '.[] | select (.key == '945031')'
{
  "key": 945031,
  "value": 3
}

scx on  layered-debug-map [!] is 📦 v1.0.12 via 🐍 v3.13.3 via 🦀 v1.87.0 
❯ sudo bpftool map dump name layer_match_dbg | jq '.[] | select (.key == '945031')'
```