### PR TITLE
scxtop: add search module with fuzzy matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,7 +372,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -504,6 +510,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +580,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -772,6 +811,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "criterion"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1343,6 +1415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1475,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c00f1d62d57408109a871dd9e12b76645ec4284406d5ec838d277777ef1ef6c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -1539,6 +1630,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2004,6 +2104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openat"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2200,6 +2306,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polling"
 version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,7 +2408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -2294,7 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
@@ -2372,7 +2506,7 @@ dependencies = [
  "crossterm 0.28.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "serde",
@@ -2623,7 +2757,7 @@ dependencies = [
  "fb_procfs",
  "gpoint",
  "hex",
- "itertools",
+ "itertools 0.13.0",
  "libbpf-rs",
  "libc",
  "log",
@@ -2692,7 +2826,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "fb_procfs",
- "itertools",
+ "itertools 0.13.0",
  "lazy_static",
  "libbpf-rs",
  "libc",
@@ -2902,10 +3036,12 @@ dependencies = [
  "clap",
  "clap_complete",
  "config",
+ "criterion",
  "crossterm 0.28.1",
  "derive_deref",
  "directories",
  "futures",
+ "fuzzy-matcher",
  "glob",
  "hashbrown 0.15.2",
  "json5",
@@ -3444,6 +3580,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3639,7 +3785,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.12",
 ]
@@ -3816,6 +3962,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+
+[[package]]
+name = "web-sys"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "which"

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -56,6 +56,12 @@ log-panics = { version = "2", features = ["with-backtrace"]}
 hashbrown = "0.15.2"
 smartstring = { version = "1.0.1", features = ["serde"] }
 nix = { version = "0.29", features = ["time"] }
+fuzzy-matcher = "0.3.7"
+criterion = "0.6.0"
+
+[[bench]]
+name = "my_benchmark"
+harness = false
 
 [build-dependencies]
 prost-build = "0.13.5"

--- a/tools/scxtop/benches/my_benchmark.rs
+++ b/tools/scxtop/benches/my_benchmark.rs
@@ -1,0 +1,69 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use scxtop::available_perf_events;
+use scxtop::Search;
+
+fn get_search() -> Search {
+    let available_perf_events_list: Vec<String> = available_perf_events()
+        .unwrap()
+        .iter()
+        .flat_map(|(subsystem, events)| {
+            events
+                .iter()
+                .map(|event| format!("{}:{}", subsystem.clone(), event.clone()))
+        })
+        .collect();
+    Search::new(available_perf_events_list)
+}
+
+fn bench_empty(c: &mut Criterion) {
+    let search = get_search();
+    let i = "";
+
+    let mut group = c.benchmark_group("Empty String Search");
+
+    group.bench_with_input(BenchmarkId::new("Fuzzy Empty", i), i, |b, i| {
+        b.iter(|| search.fuzzy_search(i))
+    });
+    group.bench_with_input(BenchmarkId::new("Substring Empty", i), i, |b, i| {
+        b.iter(|| search.substring_search(i))
+    });
+    group.finish();
+}
+
+fn bench_easy_string(c: &mut Criterion) {
+    let search = get_search();
+    let i = "alarm";
+
+    let mut group = c.benchmark_group("Easy String Search");
+
+    group.bench_with_input(BenchmarkId::new("Fuzzy Easy String", i), i, |b, i| {
+        b.iter(|| search.fuzzy_search(i))
+    });
+    group.bench_with_input(BenchmarkId::new("Substring Easy String", i), i, |b, i| {
+        b.iter(|| search.substring_search(i))
+    });
+    group.finish();
+}
+
+fn bench_complex_string(c: &mut Criterion) {
+    let search = get_search();
+    let i = "alrMcacEL";
+
+    let mut group = c.benchmark_group("Complex String Search");
+
+    group.bench_with_input(BenchmarkId::new("Fuzzy Complex String", i), i, |b, i| {
+        b.iter(|| search.fuzzy_search(i))
+    });
+    group.bench_with_input(BenchmarkId::new("Substring Complex", i), i, |b, i| {
+        b.iter(|| search.substring_search(i))
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_empty,
+    bench_easy_string,
+    bench_complex_string
+);
+criterion_main!(benches);

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -19,6 +19,7 @@ mod node_data;
 mod perf_event;
 mod perfetto_trace;
 pub mod protos;
+mod search;
 mod stats;
 mod theme;
 pub mod tracer;
@@ -38,6 +39,7 @@ pub use perf_event::available_perf_events;
 pub use perf_event::PerfEvent;
 pub use perfetto_trace::PerfettoTraceManager;
 pub use protos::*;
+pub use search::Search;
 pub use stats::StatAggregation;
 pub use stats::VecStats;
 pub use theme::AppTheme;
@@ -57,7 +59,7 @@ pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
-This software may be used and distributed according to the terms of the 
+This software may be used and distributed according to the terms of the
 GNU General Public License version 2.";
 pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 

--- a/tools/scxtop/src/search.rs
+++ b/tools/scxtop/src/search.rs
@@ -1,0 +1,191 @@
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+
+#[derive(Debug, Clone)]
+pub struct Search {
+    entries: Vec<String>,
+}
+
+impl Search {
+    pub fn new(entries: Vec<String>) -> Self {
+        Self { entries }
+    }
+
+    pub fn substring_search(&self, input: &str) -> Vec<String> {
+        let input = &input.to_lowercase();
+
+        self.entries
+            .iter()
+            .filter(|entry| entry.to_lowercase().contains(input))
+            .cloned()
+            .collect()
+    }
+
+    pub fn fuzzy_search(&self, input: &str) -> Vec<String> {
+        let matcher = SkimMatcherV2::default().ignore_case();
+
+        let mut fuzzy_results: Vec<(&String, i64)> = self
+            .entries
+            .iter()
+            .filter_map(|entry| {
+                matcher
+                    .fuzzy_match(entry, input)
+                    .map(|score| (entry, score))
+            })
+            .collect();
+
+        fuzzy_results.sort_by(|a, b| b.1.cmp(&a.1));
+
+        fuzzy_results
+            .into_iter()
+            .map(|(entry, _)| entry.clone())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_events() -> Vec<String> {
+        vec![
+            "alarmtimer:alarmtimer_suspend",
+            "alarmtimer:alarmtimer_fired",
+            "amd_cpu:amd_pstate_perf",
+            "avc:selinux_audited",
+            "btrfs:btrfs_reserve_extent",
+            "btrfs:qgroup_num_dirty_extents",
+            "btrfs:run_delayed_ref_head",
+            "ext4:ext4_fsmap_low_key",
+            "ext4:ext4_fc_stats",
+            "ext4:ext4_mb_new_inode_pa",
+            "syscalls:sys_enter_timerfd_settime",
+            "syscalls:sys_enter_settimeofday",
+            "syscalls:sys_exit_gettid",
+            "syscalls:sys_exit_kcmp",
+            "syscalls:sys_exit_pselect6",
+            "xfs:xfs_swap_extent_before",
+            "xfs:xfs_bmap_free_defer",
+            "xhci-hcd:xhci_address_ctrl_ctx",
+            "alarmtimer:alarmtimer_cancel",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect()
+    }
+
+    #[test]
+    fn test_fuzzy_search_empty() {
+        let events = test_events();
+        let search = Search::new(events);
+        let results = search.fuzzy_search("");
+
+        assert_eq!(
+            results.len(),
+            19,
+            "Expected all results, got {}",
+            results.len()
+        );
+    }
+
+    #[test]
+    fn test_fuzzy_search_basic() {
+        let events = test_events();
+        let search = Search::new(events);
+
+        let results = search.fuzzy_search("gettid");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], "syscalls:sys_exit_gettid".to_string());
+    }
+
+    #[test]
+    fn test_fuzzy_search_exact_input() {
+        let events = test_events();
+        let search = Search::new(events);
+        let results = search.fuzzy_search("alarmtimer_cancel");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], "alarmtimer:alarmtimer_cancel".to_string());
+    }
+
+    #[test]
+    fn test_fuzzy_search_exact_input_multiple_results() {
+        let events = test_events();
+        let search = Search::new(events);
+        let results = search.fuzzy_search("alarm");
+
+        let expected_matches = vec![
+            "alarmtimer:alarmtimer_suspend",
+            "alarmtimer:alarmtimer_fired",
+            "alarmtimer:alarmtimer_cancel",
+        ];
+
+        for expected in expected_matches.iter() {
+            assert!(
+                results.contains(&expected.to_string()),
+                "Missing expected match: {}",
+                expected
+            );
+        }
+
+        assert!(results.len() >= expected_matches.len());
+    }
+
+    #[test]
+    fn test_fuzzy_search_complex_input() {
+        let events = test_events();
+        let search = Search::new(events);
+        let results = search.fuzzy_search("alrMcacEL");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], "alarmtimer:alarmtimer_cancel".to_string());
+    }
+
+    #[test]
+    fn test_fuzzy_search_reuse_search() {
+        let events = test_events();
+        let search = Search::new(events);
+
+        let results = search.fuzzy_search("");
+        assert_eq!(
+            results.len(),
+            19,
+            "Expected all results, got {}",
+            results.len()
+        );
+
+        let results = search.fuzzy_search("gettid");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], "syscalls:sys_exit_gettid".to_string());
+
+        let results = search.fuzzy_search("alarmtimer_cancel");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], "alarmtimer:alarmtimer_cancel".to_string());
+
+        let results = search.fuzzy_search("alarm");
+        let expected_matches = vec![
+            "alarmtimer:alarmtimer_suspend",
+            "alarmtimer:alarmtimer_fired",
+            "alarmtimer:alarmtimer_cancel",
+        ];
+
+        for expected in expected_matches.iter() {
+            assert!(
+                results.contains(&expected.to_string()),
+                "Missing expected match: {}",
+                expected
+            );
+        }
+
+        assert!(
+            results.len() >= expected_matches.len(),
+            "Expected all results, got {}",
+            results.len()
+        );
+
+        let results = search.fuzzy_search("alrMcacEL");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], "alarmtimer:alarmtimer_cancel".to_string());
+    }
+}


### PR DESCRIPTION
In order to enable filtering perf events in scxtop, we'll need fuzzy matching functionality. This module will provide the initial fuzzy search. At the moment, it's relatively naive but it will fuzzy match on missed characters and substrings (I'll probably add some manual levenshtein calculations as well to enable it to catch typos and out of order characters). Here are some current examples of what it will match on and what it won't:

Substring - "gettid" == "syscalls:sys_exit_gettid"
Missing - "ssall" == "syscalls:sys_exit_gettid"
Capitalization + substring + missing - "alrMcacEL" == "alarmtimer:alarmtimer_cancel"
Typo - "albrm" != "alarmtimer:alarmtimer_cancel"

The fuzzy matching is largely done using the [fuzzy-matching](https://docs.rs/fuzzy-matcher/latest/fuzzy_matcher/index.html) crate, which is based on [skim](https://github.com/skim-rs/skim).


Here are some performance benchmarks, comparing fuzzy_search to a substring_search:

<img width="493" alt="Screenshot 2025-05-23 at 5 53 13 PM" src="https://github.com/user-attachments/assets/08f2b9e0-2034-4819-b084-de344a4049c2" />

Given that the median is consistently less than 350 microseconds, we should be fine performance-wise. Benchmarking was done using [Criterion](https://docs.rs/criterion/latest/criterion/).