### PR TITLE
scx_p2dq: Refactor pick_idle_cpu for affinitized tasks

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -48,7 +48,6 @@ struct task_p2dq {
 	u64			dsq_id;
 	u64			slice_ns;
 	int			dsq_index;
-	u32			cpu;
 	u32			llc_id;
 	u32			node_id;
 	u64			used;


### PR DESCRIPTION
Refactor pick_idle_cpu to split out affinitized task handling to pick_idle_affinitized_cpu. This makes the code for handling affinitized tasks easier to follow. Remove the `cpu` field from the `taskc_ctx` as this can easily be queried with `scx_bpf_task_cpu`.