### PR TITLE
scx_rustland_core: Always dispatch khugepaged directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,7 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "plain",
+ "procfs",
  "scx_rustland_core",
  "scx_utils",
 ]

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-2.0-only"
 [dependencies]
 anyhow = "1.0.65"
 plain = "0.2.3"
+procfs = "0.17"
 ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "=0.25.0-beta.1"
 libc = "0.2.137"


### PR DESCRIPTION
khugepaged can arbitrarily unmap and remap memory pages in any user-space task at any time.

If this happens for the user-space scheduler task, we may trigger the following stall scenario:
 - kugepaged umaps a page in the user-space scheduler's address space
 - khugepaged is de-scheduled and re-enqueued
 - user-space scheduler is blocked waiting for its page to be remapped
 - khugepaged can't be scheduled again
 - stall

Prevent this by always dispatching khugepaged directly, allowing it to bypass the user-space scheduler.

With that in place, we can even hint khugepaged to use huge pages for the preallocated memory arena used by the scx_rustland_core allocator and avoid disabling huge pages entirely.