### PR TITLE
scx_layered: Replace division with bitwise shift

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2739,7 +2739,7 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 	if (task_hint) {
 		u64 hint = task_hint->hint ?: 1;
 		hint = hint < 1024 ? hint : 1024;
-		runtime = (runtime * hint) / 1024;
+		runtime = (runtime * hint) >> 10;
 	}
 
 	p->scx.dsq_vtime += runtime;


### PR DESCRIPTION
Replaces division by 1024 with a right shift by 10 when scaling runtime with task_hint.
No functional change.