### PR TITLE
bitmap: Fix scx_bitmap_empty() to return correct result

### DIFF
--- a/lib/bitmap.bpf.c
+++ b/lib/bitmap.bpf.c
@@ -132,7 +132,7 @@ bool scx_bitmap_empty(scx_bitmap_t __arg_arena mask)
 
 	bpf_for(i, 0, mask_size) {
 		if (mask->bits[i])
-			return true;
+			return false;
 	}
 
 	return true;


### PR DESCRIPTION
scx_bitmap_empty() was incorrectly returning true when any bit was set.