### PR TITLE
bitmap: Use 0ULL in scx_bitmap_clear()

### DIFF
--- a/lib/bitmap.bpf.c
+++ b/lib/bitmap.bpf.c
@@ -95,7 +95,7 @@ int scx_bitmap_clear(scx_bitmap_t __arg_arena mask)
 	int i;
 
 	bpf_for(i, 0, mask_size) {
-		mask->bits[i] = 0;
+		mask->bits[i] = 0ULL;
 	}
 
 	return 0;


### PR DESCRIPTION
Assign 0ULL instead of 0 to match the u64 type of mask->bits[].