### PR TITLE
scxtop: add default instruction to help page

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -1825,6 +1825,15 @@ impl<'a> App<'a> {
             )),
             Line::from(Span::styled(
                 format!(
+                    "{}: display default view",
+                    self.config
+                        .active_keymap
+                        .action_keys_string(Action::SetState(AppState::Default))
+                ),
+                Style::default(),
+            )),
+            Line::from(Span::styled(
+                format!(
                     "{}: display LLC view",
                     self.config
                         .active_keymap


### PR DESCRIPTION
Adds the default instruction "d" to the help menu.