### PR TITLE
lib/sdt_alloc: Return -ENOMEM instead of NULL on alloc failure

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -667,7 +667,7 @@ void __arena *scx_static_alloc(size_t bytes, size_t alignment)
 					       scx_static.max_alloc_bytes / PAGE_SIZE,
 					       NUMA_NO_NODE, 0);
 		if (!memory)
-			return NULL;
+			return -ENOMEM;
 
 		bpf_spin_lock(&alloc_lock);
 


### PR DESCRIPTION
Replace the NULL return value with -ENOMEM to indicate allocation failure explicity.

Ref: #1987 