### PR TITLE
lib/sdt_alloc: Switch to new memory block on alloc overflow

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -679,6 +679,13 @@ void __arena *scx_static_alloc(size_t bytes, size_t alignment)
 			scx_bpf_error("concurrent static memory allocations unsupported");
 			return NULL;
 		}
+
+		/* Switch to new memory block, reset offset,
+		 * and recalculate base address.
+		 */
+		scx_static.memory = memory;
+		scx_static.off = 0;
+		addr = (__u64) scx_static.memory + scx_static.off;
 	}
 
 	ptr = (void __arena *)(addr + padding);


### PR DESCRIPTION
When the static allocator runs out of space it now allocates a fresh arena block, resets the offset to zero, and recalculates the base address before resuming. 
This prevents overlapping allocations and possible memory corruption that occurred when continuing to use the exhausted block. The existing spin-lock check still guards against concurrent replacements, so thread-safety semantics are preserved.