### PR TITLE
scx_bpfland: Correct "devices" spelling in --throttle-us description

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -137,7 +137,7 @@ struct Opts {
 
     /// Throttle the running CPUs by periodically injecting idle cycles.
     ///
-    /// This option can help extend battery life on portable devieces, reduce heating, fan noise
+    /// This option can help extend battery life on portable devices, reduce heating, fan noise
     /// and overall energy consumption (0 = disable).
     #[clap(short = 't', long, default_value = "0")]
     throttle_us: u64,


### PR DESCRIPTION
Commit 8c3e9029f1c51f053a22f050d313d129d5f855f5 added --throttle-us to bpfland, but the description when shown in `scx_bpfland --help` has a typo for "devices" (admittedly, the typo also exists in the commit description). Fix this by removing the extra 'e'

Fixes: 8c3e9029f1c5 ("scx_bpfland: Introduce --throttle-us")