### PR TITLE
lib/sdt_task: Handle allocation failure

### DIFF
--- a/lib/sdt_task.bpf.c
+++ b/lib/sdt_task.bpf.c
@@ -39,6 +39,8 @@ void __arena *scx_task_alloc(struct task_struct *p)
 		return NULL;
 
 	data = scx_alloc(&scx_task_allocator);
+	if (unlikely(!data))
+		return NULL;
 
 	mval->tid = data->tid;
 	mval->tptr = (__u64) p;


### PR DESCRIPTION
Add a check for failed allocation when calling scx_alloc().