### PR TITLE
sdt_task: Avoid use-after-free after deleting task_storage

### DIFF
--- a/lib/sdt_task.bpf.c
+++ b/lib/sdt_task.bpf.c
@@ -84,6 +84,5 @@ void scx_task_free(struct task_struct *p)
 		return;
 
 	scx_alloc_free_idx(&scx_task_allocator, mval->tid.idx);
-	mval->data = NULL;
-	mval->tptr = 0;
+	bpf_task_storage_delete(&scx_task_map, p);
 }

--- a/scheds/rust/scx_rusty/src/bpf/sdt_task.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/sdt_task.bpf.c
@@ -87,6 +87,5 @@ void sdt_task_free(struct task_struct *p)
 		return;
 
 	sdt_free_idx(&sdt_task_allocator, mval->tid.idx);
-	mval->data = NULL;
-	mval->tptr = 0;
+	bpf_task_storage_delete(&sdt_task_map, p);
 }


### PR DESCRIPTION
~In scx_task_free(), after releasing the allocator index, invoke bpf_task_storage_delete() to remove the task's entry from the BPF map.~

~Also zero-initialize `mval->tid` so that no stale identifier remains in local storage.~

Edit: Remove redundant mval field updates after deletion.