### PR TITLE
layered: add cgrp contains matcher

### DIFF
--- a/scheds/rust/scx_layered/examples/cgrp_contains.json
+++ b/scheds/rust/scx_layered/examples/cgrp_contains.json
@@ -1,0 +1,58 @@
+[
+	{
+		"name": "match one container",
+		"matches": [
+			[
+				{ "CgroupContains": "nope" }
+			]
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range_frac":  [0.25, 0.5],
+				"util_range": [0.4, 0.85],
+				"growth_algo": "RandomTopo",
+				"disallow_preempt_after_us": 0,
+				"protected": true
+			}
+		}
+	},
+	{
+		"name": "match other containers",
+		"matches": [
+			[{ "CgroupContains": "docker" }]
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range_frac":  [0.5, 0.5],
+				"util_range": [0.4, 0.85],
+				"growth_algo": "RandomTopo",
+				"protected": true
+			}
+		}
+	},
+	{
+		"name": "third",
+		"matches": [
+			[{ "PcommPrefix": "stress-ng" }]
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range":  [5, 5],
+				"util_range": [0.4, 0.85],
+				"growth_algo": "RandomTopo",
+				"protected": true
+			}
+		}
+	},
+	{
+		"name": "fourth",
+		"matches": [
+			[]
+		],
+		"kind": {
+			"Open": {
+				"growth_algo": "RandomTopo"
+			}
+		}
+	}
+]

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -253,6 +253,7 @@ enum layer_match_kind {
 	MATCH_USED_GPU_PID,
 	MATCH_AVG_RUNTIME,
 	MATCH_CGROUP_SUFFIX,
+	MATCH_CGROUP_CONTAINS,
 
 	NR_LAYER_MATCH_KINDS,
 };
@@ -261,6 +262,7 @@ struct layer_match {
 	int		kind;
 	char		cgroup_prefix[MAX_PATH];
 	char		cgroup_suffix[MAX_PATH];
+	char		cgroup_substr[MAX_PATH];
 	char		comm_prefix[MAX_COMM];
 	char		pcomm_prefix[MAX_COMM];
 	int		nice;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2148,21 +2148,24 @@ static __noinline bool match_one(struct layer_match *match,
 
 	switch (match->kind) {
 	case MATCH_CGROUP_PREFIX: {
-		return match_prefix_suffix(match->cgroup_prefix, cgrp_path, false);
+		return match_str(match->cgroup_prefix, cgrp_path, STR_PREFIX);
 	}
 	case MATCH_CGROUP_SUFFIX: {
-		return match_prefix_suffix(match->cgroup_suffix, cgrp_path, true);
+		return match_str(match->cgroup_suffix, cgrp_path, STR_SUFFIX);
+	}
+	case MATCH_CGROUP_CONTAINS: {
+		return match_str(match->cgroup_substr, cgrp_path, STR_SUBSTR);
 	}
 	case MATCH_COMM_PREFIX: {
 		char comm[MAX_COMM];
 		__builtin_memcpy(comm, p->comm, MAX_COMM);
-		return match_prefix_suffix(match->comm_prefix, comm, false);
+		return match_str(match->comm_prefix, comm, STR_PREFIX);
 	}
 	case MATCH_PCOMM_PREFIX: {
 		char pcomm[MAX_COMM];
 
 		__builtin_memcpy(pcomm, p->group_leader->comm, MAX_COMM);
-		return match_prefix_suffix(match->pcomm_prefix, pcomm, false);
+		return match_str(match->pcomm_prefix, pcomm, STR_PREFIX);
 	}
 	case MATCH_NICE_ABOVE:
 		return prio_to_nice((s32)p->static_prio) > match->nice;
@@ -2228,8 +2231,8 @@ static __noinline bool match_one(struct layer_match *match,
 		if (!taskc->join_layer[0])
 			return false;
 
-		return match_prefix_suffix(match->comm_prefix, taskc->join_layer,
-			false);
+		return match_str(match->comm_prefix, taskc->join_layer,
+			STR_PREFIX);
 	}
 	case MATCH_IS_GROUP_LEADER: {
 		// There is nuance to this around exec(2)s and group leader swaps.
@@ -3435,6 +3438,9 @@ static s32 init_layer(int layer_id)
 					match->max_avg_runtime_us);
 			case MATCH_CGROUP_SUFFIX:
 				dbg("%s CGROUP_SUFFIX \"%s\"", header, match->cgroup_suffix);
+				break;
+			case MATCH_CGROUP_CONTAINS:
+				dbg("%s CGROUP_CONTAINS \"%s\"", header, match->cgroup_substr);
 				break;
 			default:
 				scx_bpf_error("%s Invalid kind", header);

--- a/scheds/rust/scx_layered/src/bpf/util.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/util.bpf.h
@@ -20,7 +20,13 @@ extern const volatile u32 debug;
 #define dbg(fmt, args...)	do { if (debug) bpf_printk(fmt, ##args); } while (0)
 #define trace(fmt, args...)	do { if (debug > 1) bpf_printk(fmt, ##args); } while (0)
 
-bool match_prefix_suffix(const char *prefix, const char *str, bool match_suffix);
+enum MatchType {
+    STR_PREFIX = 0,
+    STR_SUFFIX = 1,
+    STR_SUBSTR = 2
+};
+
+bool match_str(const char *prefix, const char *str, enum MatchType match_type);
 char *format_cgrp_path(struct cgroup *cgrp);
 
 #endif /* __LAYERED_UTIL_H */

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -75,6 +75,7 @@ pub enum LayerPlacement {
 pub enum LayerMatch {
     CgroupPrefix(String),
     CgroupSuffix(String),
+    CgroupContains(String),
     CommPrefix(String),
     CommPrefixExclude(String),
     PcommPrefix(String),

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1283,6 +1283,10 @@ impl<'a> Scheduler<'a> {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_CGROUP_SUFFIX as i32;
                             copy_into_cstr(&mut mt.cgroup_suffix, suffix.as_str());
                         }
+                        LayerMatch::CgroupContains(substr) => {
+                            mt.kind = bpf_intf::layer_match_kind_MATCH_CGROUP_CONTAINS as i32;
+                            copy_into_cstr(&mut mt.cgroup_substr, substr.as_str());
+                        }
                         LayerMatch::CommPrefix(prefix) => {
                             mt.kind = bpf_intf::layer_match_kind_MATCH_COMM_PREFIX as i32;
                             copy_into_cstr(&mut mt.comm_prefix, prefix.as_str());
@@ -2820,6 +2824,16 @@ fn verify_layer_specs(specs: &[LayerSpec]) -> Result<()> {
                     LayerMatch::CgroupPrefix(prefix) => {
                         if prefix.len() > MAX_PATH {
                             bail!("Spec {:?} has too long a cgroup prefix", spec.name);
+                        }
+                    }
+                    LayerMatch::CgroupSuffix(suffix) => {
+                        if suffix.len() > MAX_PATH {
+                            bail!("Spec {:?} has too long a cgroup suffix", spec.name);
+                        }
+                    }
+                    LayerMatch::CgroupContains(substr) => {
+                        if substr.len() > MAX_PATH {
+                            bail!("Spec {:?} has too long a cgroup substr", spec.name);
                         }
                     }
                     LayerMatch::CommPrefix(prefix) => {


### PR DESCRIPTION
Add a matcher to layered to match cgroups which contain a specified substring.


seems to work w/ test json:
![image](https://github.com/user-attachments/assets/7c8531b5-9134-4f23-b089-e9d2a010a769)
