### PR TITLE
layered: cpumask match constraints

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2367,7 +2367,7 @@ static bool get_aligned_layer(struct task_struct *p __arg_trusted, u64 layer_id,
 		}
 	}
 
-	if (is_cpumask) {
+	if (!is_cpumask) {
 		if (is_subset) {
 			if ((cpumask = cast_mask(lookup_layer_cpuset(layer_id))) &&
 				!bpf_cpumask_subset(p->cpus_ptr, cpumask))

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2402,10 +2402,10 @@ static void maybe_refresh_layer(struct task_struct *p __arg_trusted, struct task
 		__sync_fetch_and_add(&layers[taskc->layer_id].nr_tasks, -1);
 
 	// Match tasks in a tiered manner.
-	// Layer has CPUs which can all run task.
-	// Layer can have CPUs which can all run task.
-	// Layer has CPUs some of which can run task.
-	// Layer can have CPUs, some of which can run task.
+	// Layer has all CPUs which can run task.
+	// Layer can have all CPUs which can run task.
+	// Layer has some CPUs which can run task.
+	// Layer can have some CPUs which can run task.
 	// Layer can't have CPUs which can run task (i.e. lo fb).
 	bpf_for(i, 0, 5) {
 		if (matched)


### PR DESCRIPTION
Add cpumask based matcher constraints to layer matching to nudge tasks onto the best suited layer.

This solves the problem of lo fb being overutilized due to tasks matching into their first eligible layer.

It is unclear if matching in this manner is excessive, but test results indicate this is better than what we were previously doing.