### PR TITLE
scx_wd40: integrate with topology add level calculation topology call

### DIFF
--- a/lib/cpumask.bpf.c
+++ b/lib/cpumask.bpf.c
@@ -6,8 +6,7 @@
 
 extern const volatile u32 nr_cpu_ids;
 
-static struct scx_allocator scx_bitmap_allocator;
-size_t mask_size;
+extern size_t mask_size;
 
 __weak int
 scx_bitmap_to_bpf(struct bpf_cpumask __kptr *bpfmask __arg_trusted,

--- a/lib/topology.bpf.c
+++ b/lib/topology.bpf.c
@@ -238,11 +238,11 @@ int topo_print(void)
 		stack[lvl] = 0;
 
 		bpf_printk("[%d, %d, %d ,%d, %d]",
-			   stack[0],
-			   stack[1],
-			   stack[2],
-			   stack[3],
-			   stack[4]);
+			   stack[TOPO_TOP],
+			   stack[TOPO_NODE],
+			   stack[TOPO_LLC],
+			   stack[TOPO_CORE],
+			   stack[TOPO_CPU]);
 
 		scx_bitmap_print(topo->mask);
 	}

--- a/lib/topology.bpf.c
+++ b/lib/topology.bpf.c
@@ -187,6 +187,25 @@ topo_ptr topo_find_sibling(topo_ptr topo, u32 cpu)
 
 }
 
+__weak
+u64 topo_mask_level_internal(topo_ptr topo, enum topo_level level)
+{
+	if (unlikely(level < 0 || level >= TOPO_MAX_LEVEL)) {
+		scx_bpf_error("invalid topology level %d", level);
+		return (u64)NULL;
+	}
+
+	if (unlikely(topo->level < level)) {
+		scx_bpf_error("requesting cpumask from lower level %d, starting from %d", level, topo->level);
+		return (u64)NULL;
+	}
+
+	while (topo->level > level && can_loop)
+		topo = topo->parent;
+
+	return (u64)topo->mask;
+}
+
 __weak __maybe_unused
 int topo_print(void)
 {

--- a/scheds/include/lib/topology.h
+++ b/scheds/include/lib/topology.h
@@ -45,4 +45,9 @@ struct topo_iter {
 	for ((_child) = NULL; (_child = TOPO_ITER_NEXT(_iter)) && can_loop;)
 
 int topo_init(scx_bitmap_t __arg_arena mask);
+int topo_contains(topo_ptr topo, u32 cpu);
+
+u64 topo_mask_level_internal(topo_ptr topo, enum topo_level level);
+#define topo_mask_level(topo, level) ((scx_bitmap_t) topo_mask_level_internal((topo), (level))
+
 int topo_print(void);

--- a/scheds/include/lib/topology.h
+++ b/scheds/include/lib/topology.h
@@ -4,15 +4,22 @@ struct topology;
 typedef struct topology __arena * topo_ptr;
 
 #define TOPO_MAX_CHILDREN (16)
-/* Levels are : Top, NUMA node, LLC, Core, Hyperthread */
-#define TOPO_MAX_LEVEL (5)
+
+enum topo_level {
+	TOPO_TOP	= 0,
+	TOPO_NODE	= 1,
+	TOPO_LLC	= 2,
+	TOPO_CORE	= 3,
+	TOPO_CPU	= 4,
+	TOPO_MAX_LEVEL	= 5,
+};
 
 struct topology {
 	topo_ptr parent;
 	topo_ptr children[TOPO_MAX_CHILDREN];
 	size_t nr_children;
 	scx_bitmap_t mask;
-	size_t level;
+	enum topo_level level;
 
 	/* Generic pointer, can be used for anything. */
 	void *data;

--- a/scheds/rust/scx_wd40/build.rs
+++ b/scheds/rust/scx_wd40/build.rs
@@ -13,6 +13,7 @@ fn main() {
         .add_source("src/bpf/deadline.bpf.c")
         .add_source("src/bpf/placement.bpf.c")
         .add_source("src/bpf/deadline.bpf.c")
+        .add_source("../../../lib/bitmap.bpf.c")
         .add_source("../../../lib/cpumask.bpf.c")
         .add_source("../../../lib/sdt_task.bpf.c")
         .add_source("../../../lib/sdt_alloc.bpf.c")

--- a/scheds/rust/scx_wd40/build.rs
+++ b/scheds/rust/scx_wd40/build.rs
@@ -13,10 +13,12 @@ fn main() {
         .add_source("src/bpf/deadline.bpf.c")
         .add_source("src/bpf/placement.bpf.c")
         .add_source("src/bpf/deadline.bpf.c")
+        .add_source("../../../lib/arena.bpf.c")
         .add_source("../../../lib/bitmap.bpf.c")
         .add_source("../../../lib/cpumask.bpf.c")
         .add_source("../../../lib/sdt_task.bpf.c")
         .add_source("../../../lib/sdt_alloc.bpf.c")
+        .add_source("../../../lib/topology.bpf.c")
         .compile_link_gen()
         .unwrap();
 }

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -52,6 +52,7 @@
 #include <scx/bpf_arena_common.h>
 #include <scx/bpf_arena_spin_lock.h>
 
+#include <lib/arena.h>
 #include <lib/cpumask.h>
 #include <lib/percpu.h>
 
@@ -852,22 +853,9 @@ static s32 initialize_cpu(s32 cpu)
 }
 
 SEC("syscall")
-int wd40_arena_setup(void)
+int wd40_setup(void)
 {
 	int ret, i;
-
-	ret = scx_static_init(STATIC_ALLOC_PAGES_GRANULARITY);
-	if (ret)
-		return ret;
-
-	/* How many types to store all CPU IDs? */
-	ret = scx_bitmap_init(div_round_up(nr_cpu_ids, 8));
-	if (ret)
-		return ret;
-
-	ret = scx_percpu_storage_init();
-	if (ret)
-		return ret;
 
 	ret = create_save_scx_bitmap(&all_cpumask);
 	if (ret)
@@ -882,10 +870,6 @@ int wd40_arena_setup(void)
 		return ret;
 
 	ret = lb_domain_init();
-	if (ret)
-		return ret;
-
-	ret = scx_task_init(sizeof(struct task_ctx));
 	if (ret)
 		return ret;
 

--- a/scheds/rust/scx_wd40/src/main.rs
+++ b/scheds/rust/scx_wd40/src/main.rs
@@ -29,6 +29,8 @@ use std::time::UNIX_EPOCH;
 use stats::ClusterStats;
 use stats::NodeStats;
 
+use std::ffi::c_ulong;
+
 #[macro_use]
 extern crate static_assertions;
 
@@ -53,7 +55,9 @@ use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
 use scx_utils::uei_exited;
 use scx_utils::uei_report;
+use scx_utils::Core;
 use scx_utils::Cpumask;
+use scx_utils::Llc;
 use scx_utils::Topology;
 use scx_utils::UserExitInfo;
 use scx_utils::NR_CPU_IDS;
@@ -365,6 +369,133 @@ struct Scheduler<'a> {
 }
 
 impl<'a> Scheduler<'a> {
+    fn setup_allocators(skel: &mut BpfSkel<'a>) -> Result<()> {
+        // Allocate the arena memory from the BPF side so userspace initializes it before starting
+        // the scheduler. Despite the function call's name this is neither a test nor a test run,
+        // it's the recommended way of executing SEC("syscall") probes.
+        let mut args = types::arena_init_args {
+            static_pages: bpf_intf::consts_STATIC_ALLOC_PAGES_GRANULARITY as c_ulong,
+            task_ctx_size: std::mem::size_of::<types::task_ctx>() as c_ulong,
+        };
+
+        let input = ProgramInput {
+            context_in: Some(unsafe {
+                std::slice::from_raw_parts_mut(
+                    &mut args as *mut _ as *mut u8,
+                    std::mem::size_of_val(&args),
+                )
+            }),
+            ..Default::default()
+        };
+
+        let output = skel.progs.arena_init.test_run(input)?;
+        if output.return_value != 0 {
+            bail!(
+                "Could not initialize arenas, p2dq_setup returned {}",
+                output.return_value as i32
+            );
+        }
+
+        Ok(())
+    }
+
+    fn setup_topology_node(skel: &mut BpfSkel<'a>, mask: &[u64]) -> Result<()> {
+        // Copy the address of ptr to the kernel to populate it from BPF with the arena pointer.
+        let input = ProgramInput {
+            ..Default::default()
+        };
+
+        let output = skel.progs.arena_alloc_mask.test_run(input)?;
+        if output.return_value != 0 {
+            bail!(
+                "Could not initialize arenas, setup_topology_node returned {}",
+                output.return_value as i32
+            );
+        }
+
+        let ptr = unsafe {
+            std::mem::transmute::<u64, &mut [u64; 10]>(skel.maps.bss_data.arena_topo_setup_ptr)
+        };
+
+        let (valid_mask, _) = ptr.split_at_mut(mask.len());
+        valid_mask.clone_from_slice(mask);
+
+        let input = ProgramInput {
+            ..Default::default()
+        };
+        let output = skel.progs.arena_topology_node_init.test_run(input)?;
+        if output.return_value != 0 {
+            bail!(
+                "p2dq_topology_node_init returned {}",
+                output.return_value as i32
+            );
+        }
+
+        Ok(())
+    }
+
+    fn setup_topology(skel: &mut BpfSkel<'a>) -> Result<()> {
+        let topo = Topology::new().expect("Failed to build host topology");
+
+        Self::setup_topology_node(skel, topo.span.as_raw_slice())?;
+
+        for (_, node) in topo.nodes {
+            Self::setup_topology_node(skel, node.span.as_raw_slice())?;
+        }
+
+        for (_, llc) in topo.all_llcs {
+            Self::setup_topology_node(
+                skel,
+                Arc::<Llc>::into_inner(llc)
+                    .expect("missing llc")
+                    .span
+                    .as_raw_slice(),
+            )?;
+        }
+        for (_, core) in topo.all_cores {
+            Self::setup_topology_node(
+                skel,
+                Arc::<Core>::into_inner(core)
+                    .expect("missing core")
+                    .span
+                    .as_raw_slice(),
+            )?;
+        }
+        for (_, cpu) in topo.all_cpus {
+            let mut mask = [0; 9];
+            mask[cpu.id.checked_shr(64).unwrap_or(0)] |= 1 << (cpu.id % 64);
+            Self::setup_topology_node(skel, &mask)?;
+        }
+
+        Ok(())
+    }
+
+    fn setup_wd40(skel: &mut BpfSkel<'a>) -> Result<()> {
+        // Allocate the arena memory from the BPF side so userspace initializes it before starting
+        // the scheduler. Despite the function call's name this is neither a test nor a test run,
+        // it's the recommended way of executing SEC("syscall") probes.
+        let input = ProgramInput {
+            ..Default::default()
+        };
+        let output = skel.progs.wd40_setup.test_run(input)?;
+        if output.return_value != 0 {
+            bail!(
+                "Could not initialize WD40 arenas, wd40_arena_setup returned {}",
+                output.return_value as i32
+            );
+        }
+
+        Ok(())
+    }
+
+    fn setup_arenas(skel: &mut BpfSkel<'a>) -> Result<()> {
+        Self::setup_allocators(skel)?;
+        Self::setup_topology(skel)?;
+        Self::setup_wd40(skel)?;
+
+        Ok(())
+    }
+
     fn init(opts: &Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
         // Open the BPF prog first for verification.
         let mut skel_builder = BpfSkelBuilder::default();
@@ -434,19 +565,7 @@ impl<'a> Scheduler<'a> {
 
         let mut skel = scx_ops_load!(skel, wd40, uei)?;
 
-        // Allocate the arena memory from the BPF side so userspace initializes it before starting
-        // the scheduler. Despite the function call's name this is neither a test nor a test run,
-        // it's the recommended way of executing SEC("syscall") probes.
-        let input = ProgramInput {
-            ..Default::default()
-        };
-        let output = skel.progs.wd40_arena_setup.test_run(input)?;
-        if output.return_value != 0 {
-            bail!(
-                "Could not initialize WD40 arenas, wd40_arena_setup returned {}",
-                output.return_value as i32
-            );
-        }
+        Self::setup_arenas(&mut skel)?;
 
         println!(
             "Mask length {} NR_CPU_IDS {}",

--- a/scheds/rust/scx_wd40/src/main.rs
+++ b/scheds/rust/scx_wd40/src/main.rs
@@ -128,14 +128,6 @@ struct Opts {
     #[clap(short = 'c', long, default_value = "3")]
     cache_level: u32,
 
-    /// Instead of using cache locality, set the cpumask for each domain
-    /// manually. Provide multiple --cpumasks, one for each domain. E.g.
-    /// --cpumasks 0xff_00ff --cpumasks 0xff00 will create two domains, with
-    /// the corresponding CPUs belonging to each domain. Each CPU must
-    /// belong to precisely one domain.
-    #[clap(short = 'C', long, num_args = 1.., conflicts_with = "cache_level")]
-    cpumasks: Vec<String>,
-
     /// When non-zero, enable greedy task stealing. When a domain is idle, a cpu
     /// will attempt to steal tasks from another domain as follows:
     ///
@@ -508,7 +500,7 @@ impl<'a> Scheduler<'a> {
         let mut skel = scx_ops_open!(skel_builder, open_object, wd40).unwrap();
 
         // Initialize skel according to @opts.
-        let domains = Arc::new(DomainGroup::new(&Topology::new()?, &opts.cpumasks)?);
+        let domains = Arc::new(DomainGroup::new(&Topology::new()?)?);
 
         if *NR_CPU_IDS > MAX_CPUS {
             bail!(


### PR DESCRIPTION
Bring scx_wd40 up to speed with the other schedulers:
1) Use the most recent arena syscall API to set up allocator state
2) Initialize the arena BPF topology tree for the scheduler
3) Introduce a new topology call in lib/topology that will be used in subsequent diffs to simplify the code