### PR TITLE
ci.py: add --locked to cargo to detect bad locks

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -66,7 +66,7 @@ def run_build():
     """Build all targets."""
     print("Running build...", flush=True)
 
-    run_command(["cargo", "build", "--all-targets"])
+    run_command(["cargo", "build", "--all-targets", "--locked"])
     print("✓ Build completed successfully", flush=True)
 
 


### PR DESCRIPTION
Occasionally we push changes that forget to lock the Cargo.lock file correctly after updating dependencies or changing versions for a release. Add `--locked` to the build step in CI to validate this.

Test plan:
- Reverted f932754 and validated that this failed.