### PR TITLE
lib/topo: rework topology traversal

### DIFF
--- a/lib/topology.bpf.c
+++ b/lib/topology.bpf.c
@@ -214,65 +214,167 @@ u64 topo_mask_level_internal(topo_ptr topo, enum topo_level level)
 	return (u64)topo->mask;
 }
 
+struct topo_iter {
+	/* The current topology node. */
+	topo_ptr topo;
+	/*
+	 * The index for every node in the path of the tree for , -1 denotes levels > the current one.
+	 * E.g., [0, 1, 2, 1, 2] means:
+	 * - index on level 0 (we only have one top-level node]
+	 * - index 1 on level 1 (the top-level node's second child)
+	 * - index 2 on level 2 (the NUMA node topology node's third child)
+	 * and so on.
+	 */
+	int indices[TOPO_MAX_LEVEL];
+};
+
+static int
+topo_iter_init(topo_ptr topo, struct topo_iter *iter)
+{
+	topo_ptr parent;
+	enum topo_level lvl;
+	int ind;
+
+	if (!topo_all)
+		return -EINVAL;
+
+	iter->topo = topo;
+	bpf_for(ind, 0, TOPO_MAX_LEVEL)
+		iter->indices[ind] = -1;
+
+	parent = topo->parent;
+	for (lvl = topo->level; lvl > 0 && can_loop; lvl--) {
+		for (ind = 0; ind < parent->nr_children && can_loop; ind++) {
+			if (parent->children[ind] == topo)
+				break;
+		}
+
+		if (ind == parent->nr_children) {
+			scx_bpf_error("could not find topology node in parent");
+			return -EINVAL;
+		}
+
+
+		if (unlikely(lvl >= TOPO_MAX_LEVEL)) {
+			scx_bpf_error("invalid level %d", lvl);
+			return -EINVAL;
+		}
+
+		iter->indices[lvl] = ind;
+
+		/* Go one level up. */
+		parent = parent->parent;
+		topo = topo->parent;
+	}
+
+	/* We know we only have one root topology node. */
+	iter->indices[0] = 0;
+
+	return 0;
+}
+
+/* We choose in-order traversal. */
+__weak bool
+topo_iter_next(struct topo_iter *iter)
+{
+	topo_ptr parent;
+	enum topo_level lvl;
+
+	if (unlikely(!iter)) {
+		scx_bpf_error("passing NULL iterator");
+		return false;
+	}
+
+	/* Case 1: We have children. Go one step down and get the left most one. */
+	if (iter->topo->nr_children > 0) {
+		iter->topo = iter->topo->children[0];
+
+		lvl = iter->topo->level;
+		if (unlikely(lvl < 0 || lvl >= TOPO_MAX_LEVEL)) {
+			/*
+			 * XXXETSAL: We have both bpf_printk and scx_bpf_error
+			 * out of an abundance of caution: In some cases scx_bpf_error
+			 * does not fire at all, making debugging more difficult.
+			 */
+			bpf_printk("invalid child level %d", lvl);
+			scx_bpf_error("invalid child level %d", lvl);
+			return false;
+		}
+
+		iter->indices[lvl] = 0;
+
+		return true;
+	}
+
+
+	/*
+	 * Case 2: We have no children. Go up until we find a rightmost sibling,
+	 * then choose that sibling.
+	 */
+	while (iter->topo->level > 0 && can_loop) {
+		lvl = iter->topo->level;
+		if (unlikely(lvl < 0 || lvl >= TOPO_MAX_LEVEL)) {
+			bpf_printk("invalid level %d", lvl);
+			scx_bpf_error("invalid level %d", lvl);
+			return false;
+		}
+
+		iter->indices[lvl] += 1;
+
+		parent = iter->topo->parent;
+		if (iter->indices[lvl] == parent->nr_children) {
+			/* Done with parent, go up a level. */
+			iter->indices[lvl] = -1;
+			iter->topo = parent;
+			continue;
+		}
+
+		iter->topo = parent->children[iter->indices[lvl]];
+		return true;
+	}
+
+	/* Could not find a right sibling for any ancestor. */
+
+	return false;
+}
+
 __weak __maybe_unused
 int topo_print(void)
 {
-	int stack[TOPO_MAX_LEVEL];
-	topo_ptr topo;
-	int ind, lvl;
+	struct topo_iter iter;
+	char indent[TOPO_MAX_LEVEL];
+	int ret;
+	int i;
 
-	for (ind = 0; ind < TOPO_MAX_LEVEL && can_loop; ind++) {
-		stack[ind] = 0;
-	}
-
-	topo = topo_all;
-	if (!topo) {
+	if (!topo_all) {
 		bpf_printk("[NO TOPOLOGY]");
 		return 0;
 	}
 
-	lvl = ind = 0;
-	while (lvl >= 0 && can_loop) {
-		if (unlikely(lvl >= TOPO_MAX_LEVEL)) {
-			bpf_printk("Out of bounds");
-			break;
+	ret = topo_iter_init(topo_all, &iter);
+	if (ret)
+		return ret;
+
+	do {
+		bpf_for(i, 0, TOPO_MAX_LEVEL) {
+			if (i == iter.topo->level) {
+				indent[i] = '\0';
+				break;
+			}
+
+			indent[i] = '\t';
 		}
+		bpf_printk("%s (LEVEL %d) [%d, %d, %d ,%d, %d]",
+			indent,
+			iter.topo->level,
+			iter.indices[TOPO_TOP],
+			iter.indices[TOPO_NODE],
+			iter.indices[TOPO_LLC],
+			iter.indices[TOPO_CORE],
+			iter.indices[TOPO_CPU]);
 
-		ind = stack[lvl];
-
-		/* If past the index, go up. */
-		if (ind == topo->nr_children) {
-			topo = topo->parent;
-			stack[lvl] = -1;
-			lvl -= 1;
-
-			continue;
-		}
-
-		topo = topo->children[ind];
-		if (!topo) {
-			bpf_printk("[ERROR] No child found");
-			return 0;
-		}
-
-		stack[lvl] += 1;
-		lvl += 1;
-
-		if (unlikely(lvl >= TOPO_MAX_LEVEL)) {
-			bpf_printk("Out of bounds");
-			break;
-		}
-		stack[lvl] = 0;
-
-		bpf_printk("[%d, %d, %d ,%d, %d]",
-			   stack[TOPO_TOP],
-			   stack[TOPO_NODE],
-			   stack[TOPO_LLC],
-			   stack[TOPO_CORE],
-			   stack[TOPO_CPU]);
-
-		scx_bitmap_print(topo->mask);
-	}
+		scx_bitmap_print(iter.topo->mask);
+	} while (topo_iter_next(&iter) && can_loop);
 
 	return 0;
 }

--- a/scheds/include/lib/topology.h
+++ b/scheds/include/lib/topology.h
@@ -27,23 +27,6 @@ struct topology {
 
 topo_ptr topo_all __weak;
 
-struct topo_iter {
-	topo_ptr topo;
-	size_t i;
-};
-
-#define TOPO_ITER_INIT(_iter, _topo)	\
-	do { (_iter).topo = (_topo); (_iter).i = 0; } while (0)
-
-#define TOPO_ITER_DONE(_iter) ((_iter).i == (_iter).topo->nr_children)
-
-#define TOPO_ITER_NEXT(_iter) \
-	(TOPO_ITER_DONE(_iter) ? NULL : (_iter).topo->children[(_iter).i++])
-
-#define TOPO_FOR_EACH_CHILD(_iter, _topo, _child)		\
-	TOPO_ITER_INIT(_iter, _topo);				\
-	for ((_child) = NULL; (_child = TOPO_ITER_NEXT(_iter)) && can_loop;)
-
 int topo_init(scx_bitmap_t __arg_arena mask);
 int topo_contains(topo_ptr topo, u32 cpu);
 

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -39,22 +39,17 @@
  * load balance based on userspace's setting of the target_dom field.
  */
 
-#ifdef LSP
-#define __bpf__
-#include "../../../../include/scx/common.bpf.h"
-#include "../../../../include/scx/ravg_impl.bpf.h"
-#else
 #include <scx/common.bpf.h>
-#include <scx/ravg_impl.bpf.h>
-#include <lib/sdt_task.h>
-#endif
 
 #include <scx/bpf_arena_common.h>
 #include <scx/bpf_arena_spin_lock.h>
+#include <scx/ravg_impl.bpf.h>
 
 #include <lib/arena.h>
 #include <lib/cpumask.h>
 #include <lib/percpu.h>
+#include <lib/topology.h>
+#include <lib/sdt_task.h>
 
 #include "intf.h"
 #include "types.h"
@@ -891,6 +886,9 @@ int wd40_setup(void)
 		if (ret)
 			return ret;
 	}
+
+	if (debug)
+		topo_print();
 
 	return 0;
 }


### PR DESCRIPTION
Many schedulers like scx_rusty often keep arrays of IDs for all LLCs and NUMA nodes in the systems that they use travesre linearly during operations like load balancing. We can offer a unified interface for such traversals through iterators on the base topology struct. Introduce an in-order iteration algorithm for topology nodes with the aim of replacing per-scheduler bookkeeping in the future.