### PR TITLE
scxtop: fix minor rendering bug

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -1303,8 +1303,6 @@ impl<'a> App<'a> {
             frame.render_widget(block, area);
             return Ok(());
         }
-        let dsq_constraints = vec![Constraint::Percentage(1), Constraint::Percentage(99)];
-        let dsqs_verticle = Layout::vertical(dsq_constraints).split(area);
         let sample_rate = self.skel.maps.data_data.sample_rate;
 
         let dsq_global_iter = self
@@ -1356,7 +1354,7 @@ impl<'a> App<'a> {
             .bar_gap(0)
             .bar_width(1);
 
-        frame.render_widget(barchart, dsqs_verticle[1]);
+        frame.render_widget(barchart, area);
         Ok(())
     }
 


### PR DESCRIPTION
There is a minor rendering bug when the screen is large. At the top left of the screen, the panes are a bit misaligned. Ex.:

<img width="1920" alt="Screenshot 2025-05-29 at 6 23 08 PM" src="https://github.com/user-attachments/assets/b8629008-c043-4265-a20f-ba1e8f0d2d7a" />

With the fix, the panes stay aligned even at larger sizes:

<img width="1920" alt="Screenshot 2025-05-29 at 6 24 50 PM" src="https://github.com/user-attachments/assets/52164847-36ad-4bf0-a1dd-b75952f8f624" />


