### PR TITLE
scx_layered: add template suffix as and term to each or block

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -3036,8 +3036,11 @@ fn main() -> Result<()> {
 
                         genspec.cpuset = Some(mask);
 
-                        // Push the new "and" rule.
-                        genspec.matches.push(vec![mt.clone()]);
+                        // Push the new "and" rule into each "or" term.
+                        for orterm in &mut genspec.matches {
+                            orterm.push(mt.clone());
+                        }
+
                         match &mt {
                             LayerMatch::CgroupSuffix(cgroup) => genspec.name.push_str(cgroup),
                             _ => bail!("Template match has unexpected type"),


### PR DESCRIPTION
Templates are supposed to specialize layers to a cgroup by adding a new term to the per-layer matcher. However, this new term is currently being added as an or-term to the matcher, while we should instead be adding it as an and-term for each or-term. Fix this by adding the new condition to each or-term in the layer.