### PR TITLE
scxtop: adding guiding instructions

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -1882,6 +1882,15 @@ impl<'a> App<'a> {
                 ),
                 Style::default(),
             )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "For bug reporting and project updates, visit:",
+                Style::default(),
+            )),
+            Line::from(Span::styled(
+                "https://github.com/sched-ext/scx",
+                Style::default(),
+            )),
         ];
         frame.render_widget(
             Paragraph::new(text)
@@ -1942,7 +1951,7 @@ impl<'a> App<'a> {
             .title_alignment(Alignment::Center)
             .title(
                 format!(
-                    "Type to filter list, use ▲ ▼  ({}/{}) to scroll, {} to select",
+                    "Type to filter list, use ▲ ▼  ({}/{}) to scroll, {} to select, Esc to exit",
                     self.config.active_keymap.action_keys_string(Action::PageUp),
                     self.config
                         .active_keymap


### PR DESCRIPTION
Adding some helpful instructions in the event and help page:
Event page - explaining how to exit
<img width="1920" alt="Screenshot 2025-05-30 at 3 14 38 PM" src="https://github.com/user-attachments/assets/38d701a8-c908-4cb9-9414-cda5bfc446f9" />

Help page - adding a link to this github for issues or to get involved
<img width="1915" alt="Screenshot 2025-05-30 at 3 14 52 PM" src="https://github.com/user-attachments/assets/0770de65-73ba-4dbb-80b1-6c318070801d" />
