### PR TITLE
lib/topology: add per-level traversal macros

### DIFF
--- a/lib/topology.bpf.c
+++ b/lib/topology.bpf.c
@@ -4,7 +4,7 @@
 #include <lib/cpumask.h>
 #include <lib/topology.h>
 
-topo_ptr topo_all;
+volatile topo_ptr topo_all;
 
 __weak
 int topo_contains(topo_ptr topo, u32 cpu)
@@ -214,22 +214,8 @@ u64 topo_mask_level_internal(topo_ptr topo, enum topo_level level)
 	return (u64)topo->mask;
 }
 
-struct topo_iter {
-	/* The current topology node. */
-	topo_ptr topo;
-	/*
-	 * The index for every node in the path of the tree for , -1 denotes levels > the current one.
-	 * E.g., [0, 1, 2, 1, 2] means:
-	 * - index on level 0 (we only have one top-level node]
-	 * - index 1 on level 1 (the top-level node's second child)
-	 * - index 2 on level 2 (the NUMA node topology node's third child)
-	 * and so on.
-	 */
-	int indices[TOPO_MAX_LEVEL];
-};
-
-static int
-topo_iter_init(topo_ptr topo, struct topo_iter *iter)
+static int __maybe_unused
+topo_iter_start_from(struct topo_iter *iter, topo_ptr topo)
 {
 	topo_ptr parent;
 	enum topo_level lvl;
@@ -338,6 +324,22 @@ topo_iter_next(struct topo_iter *iter)
 	return false;
 }
 
+__weak u64
+topo_iter_level_internal(struct topo_iter *iter, enum topo_level lvl)
+{
+	if (!iter)
+		return (u64)NULL;
+
+	do  {
+		if (!topo_iter_next(iter))
+			return (u64)NULL;
+	} while (iter->topo->level != lvl && can_loop);
+
+	return (u64)iter->topo;
+}
+
+volatile u64 a;
+
 __weak __maybe_unused
 int topo_print(void)
 {
@@ -351,7 +353,7 @@ int topo_print(void)
 		return 0;
 	}
 
-	ret = topo_iter_init(topo_all, &iter);
+	ret = topo_iter_start(&iter);
 	if (ret)
 		return ret;
 
@@ -375,6 +377,40 @@ int topo_print(void)
 
 		scx_bitmap_print(iter.topo->mask);
 	} while (topo_iter_next(&iter) && can_loop);
+
+	return 0;
+}
+
+
+__weak __maybe_unused
+int topo_print_by_level(void)
+{
+	struct topo_iter iter;
+	topo_ptr topo;
+
+	bpf_printk("TOP-LEVEL MASK");
+	scx_bitmap_print(topo_all->mask);
+	bpf_printk("\n");
+
+	bpf_printk("NODE MASKS");
+	TOPO_FOR_EACH_NODE(&iter, topo)
+		scx_bitmap_print(topo->mask);
+	bpf_printk("\n");
+
+	bpf_printk("LLC MASKS");
+	TOPO_FOR_EACH_LLC(&iter, topo)
+		scx_bitmap_print(topo->mask);
+	bpf_printk("\n");
+
+	bpf_printk("CORE MASKS");
+	TOPO_FOR_EACH_CORE(&iter, topo)
+		scx_bitmap_print(topo->mask);
+	bpf_printk("\n");
+
+	bpf_printk("CPU MASKS");
+	TOPO_FOR_EACH_CPU(&iter, topo)
+		scx_bitmap_print(topo->mask);
+	bpf_printk("\n");
 
 	return 0;
 }

--- a/scheds/include/lib/topology.h
+++ b/scheds/include/lib/topology.h
@@ -25,12 +25,53 @@ struct topology {
 	void *data;
 };
 
-topo_ptr topo_all __weak;
+extern volatile topo_ptr topo_all;
 
 int topo_init(scx_bitmap_t __arg_arena mask);
 int topo_contains(topo_ptr topo, u32 cpu);
 
 u64 topo_mask_level_internal(topo_ptr topo, enum topo_level level);
-#define topo_mask_level(topo, level) ((scx_bitmap_t) topo_mask_level_internal((topo), (level))
+#define topo_mask_level(topo, level) ((scx_bitmap_t) topo_mask_level_internal((topo), (level)))
 
 int topo_print(void);
+int topo_print_by_level(void);
+
+struct topo_iter {
+	/* The current topology node. */
+	topo_ptr topo;
+	/*
+	 * The index for every node in the path of the tree for , -1 denotes levels > the current one. 
+	 * E.g., [0, 1, 2, 1, 2] means:
+	 * - index on level 0 (we only have one top-level node]
+	 * - index 1 on level 1 (the top-level node's second child)
+	 * - index 2 on level 2 (the NUMA node topology node's third child)
+	 * and so on.
+	 */
+	int indices[TOPO_MAX_LEVEL];
+};
+
+/* Below is the machinery required for traversing the topology. It's better not to use it directly. */
+__weak u64 topo_iter_level_internal(struct topo_iter *iter, enum topo_level lvl);
+static inline int topo_iter_start(struct topo_iter *iter)
+{
+	int ind;
+
+	if (!topo_all)
+		return -EINVAL;
+
+	iter->topo = topo_all;
+	bpf_for(ind, 0, TOPO_MAX_LEVEL)
+		iter->indices[ind] = -1;
+
+	return 0;
+}
+
+#define TOPO_FOR_EACH_LEVEL(_iter, _topo, _lvl)		\
+	topo_iter_start((_iter));			\
+	while (((_topo) = ((topo_ptr)topo_iter_level_internal((_iter), _lvl))) && can_loop)
+
+/* User-friendly macros that are good for usage within schedulers. */
+#define TOPO_FOR_EACH_NODE(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_NODE)
+#define TOPO_FOR_EACH_LLC(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_LLC)
+#define TOPO_FOR_EACH_CORE(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_CORE)
+#define TOPO_FOR_EACH_CPU(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_CPU)

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -887,8 +887,10 @@ int wd40_setup(void)
 			return ret;
 	}
 
-	if (debug)
+	if (debug) {
 		topo_print();
+		topo_print_by_level();
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Add for loop-style macros for traversing the topology. This change removes the need for to hold all NUMA node/LLC/CPU state structs in an array and instead allows for embedding them in the topology.