### PR TITLE
scx_lavd: simplify conditional return in can_direct_dispatch()

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -704,9 +704,7 @@ static bool can_direct_dispatch(u64 dsq_id, s32 cpu, bool is_idle)
 	 * If the chosen CPU is idle and there is nothing to do
 	 * in the domain, we can safely choose the fast track.
 	 */
-	if (is_idle && cpu >= 0 && !scx_bpf_dsq_nr_queued(dsq_id))
-		return true;
-	return false;
+	return is_idle && cpu >= 0 && !scx_bpf_dsq_nr_queued(dsq_id);
 }
 
 void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)


### PR DESCRIPTION
Replace verbose if-statement with a single-line conditional return to improve readability. 

The logic remains unchanged.