### PR TITLE
rust: Remove redundant references in log statements

### DIFF
--- a/rust/scx_stats/README.md
+++ b/rust/scx_stats/README.md
@@ -123,7 +123,7 @@ The above creates a client instance. Let's query the statistics:
 
 ```rust
     let resp = client.request::<ClusterStats>("stat", vec![]);
-    println!("{:#?}", &resp);
+    println!("{:#?}", resp);
 ```
 
 The above is equivalent to querying the `top` target:
@@ -131,7 +131,7 @@ The above is equivalent to querying the `top` target:
 ```rust
     println!("\n===== Requesting \"stat\" with \"target\"=\"top\":");
     let resp = client.request::<ClusterStats>("stat", vec![("target".into(), "top".into())]);
-    println!("{:#?}", &resp);
+    println!("{:#?}", resp);
 ```
 
 If `("args", BTreeMap<String, String>)` is passed in as a part of the

--- a/rust/scx_stats/examples/client.rs
+++ b/rust/scx_stats/examples/client.rs
@@ -21,24 +21,24 @@ fn main() {
 
     println!("===== Requesting \"stats_meta\":");
     let resp = client.request::<BTreeMap<String, StatsMeta>>("stats_meta", vec![]);
-    println!("{:#?}", &resp);
+    println!("{:#?}", resp);
 
     println!("\n===== Requesting \"stats\" without arguments:");
     let resp = client.request::<ClusterStats>("stats", vec![]);
-    println!("{:#?}", &resp);
+    println!("{:#?}", resp);
 
     println!("\n===== Requesting \"stats\" with \"target\"=\"non-existent\":");
     let resp =
         client.request::<ClusterStats>("stats", vec![("target".into(), "non-existent".into())]);
-    println!("{:#?}", &resp);
+    println!("{:#?}", resp);
 
     println!("\n===== Requesting \"stats\" with \"target\"=\"all\":");
     let resp = client.request::<ClusterStats>("stats", vec![("target".into(), "top".into())]);
-    println!("{:#?}", &resp);
+    println!("{:#?}", resp);
 
     println!("\n===== Requesting \"stats\" but receiving with serde_json::Value:");
     let resp = client.request::<serde_json::Value>("stats", vec![("target".into(), "top".into())]);
-    println!("{:#?}", &resp);
+    println!("{:#?}", resp);
 
     println!("\n===== Requesting \"stats_meta\" but receiving with serde_json::Value:");
     let resp = client

--- a/rust/scx_stats/examples/server.rs
+++ b/rust/scx_stats/examples/server.rs
@@ -55,7 +55,7 @@ fn main() {
             Box::new(move |_args, (tx, rx)| {
                 let id = current().id();
                 let res = tx.send(id);
-                debug!("Sendt {:?} {:?}", id, &res);
+                debug!("Sendt {:?} {:?}", id, res);
                 let res = rx.recv();
                 debug!("Recevied {:?}", res);
                 stats.to_json()
@@ -75,7 +75,7 @@ fn main() {
     spawn(move || {
         while let Ok(id) = rx.recv() {
             if let Err(e) = tx.send(format!("hello {:?}", &id)) {
-                warn!("Server channel errored ({:?})", &e);
+                warn!("Server channel errored ({:?})", e);
                 break;
             }
         }

--- a/rust/scx_stats/src/server.rs
+++ b/rust/scx_stats/src/server.rs
@@ -560,16 +560,16 @@ where
                     let (req_pair, res_pair) = ChannelPair::<Req, Res>::bidi();
                     match add_req.send(res_pair) {
                         Ok(()) => debug!("sent new channel to proxy"),
-                        Err(e) => warn!("StatsServer::proxy() failed ({})", &e),
+                        Err(e) => warn!("StatsServer::proxy() failed ({})", e),
                     }
 
                     spawn(move || {
                         if let Err(e) = Self::serve(stream, data, req_pair, exit) {
-                            warn!("stat communication errored ({})", &e);
+                            warn!("stat communication errored ({})", e);
                         }
                     });
                 }
-                Err(e) => warn!("failed to accept stat connection ({})", &e),
+                Err(e) => warn!("failed to accept stat connection ({})", e),
             }
         }
     }

--- a/rust/scx_stats/src/stats.rs
+++ b/rust/scx_stats/src/stats.rs
@@ -256,7 +256,7 @@ impl StatsFieldAttrs {
                         }
                         v => Err(Error::new(
                             attr.span(),
-                            format!("Not a field attribute: {:?}", &v),
+                            format!("Not a field attribute: {:?}", v),
                         ))?,
                     }
                 }

--- a/rust/scx_utils/src/bpf_builder.rs
+++ b/rust/scx_utils/src/bpf_builder.rs
@@ -473,7 +473,7 @@ mod tests {
         unsafe { std::env::set_var("OUT_DIR", td.path()) };
 
         let res = super::BpfBuilder::new();
-        assert!(res.is_ok(), "Failed to create BpfBuilder ({:?})", &res);
+        assert!(res.is_ok(), "Failed to create BpfBuilder ({:?})", res);
     }
 
     #[test]

--- a/rust/scx_utils/src/misc.rs
+++ b/rust/scx_utils/src/misc.rs
@@ -46,12 +46,12 @@ where
                 Ok(v) => v,
                 Err(e) => match e.downcast_ref::<std::io::Error>() {
                     Some(ioe) => {
-                        info!("Connection to stats_server failed ({})", &ioe);
+                        info!("Connection to stats_server failed ({})", ioe);
                         sleep(Duration::from_secs(1));
                         break;
                     }
                     None => {
-                        warn!("error on handling stats_server result {}", &e);
+                        warn!("error on handling stats_server result {}", e);
                         sleep(Duration::from_secs(1));
                         break;
                     }

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -806,7 +806,7 @@ impl<'a> Scheduler<'a> {
             nr_active: tx.nr_active,
         }) {
             Ok(()) | Err(TrySendError::Full(_)) => 0,
-            Err(e) => panic!("failed to send on intrspc_tx ({})", &e),
+            Err(e) => panic!("failed to send on intrspc_tx ({})", e),
         }
     }
 

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -297,7 +297,7 @@ pub fn server_data(nr_cpus_onln: u64) -> StatsServerData<StatsReq, StatsRes> {
         req_ch.send(StatsReq::NewSampler(tid))?;
         match res_ch.recv()? {
             StatsRes::Ack => {}
-            res => bail!("invalid response: {:?}", &res),
+            res => bail!("invalid response: {:?}", res),
         }
 
         let read: Box<dyn StatsReader<StatsReq, StatsRes>> =
@@ -308,7 +308,7 @@ pub fn server_data(nr_cpus_onln: u64) -> StatsServerData<StatsReq, StatsRes> {
                 let stats = match res_ch.recv()? {
                     StatsRes::SysStats(v) => v,
                     StatsRes::Bye => bail!("preempted by another sampler"),
-                    res => bail!("invalid response: {:?}", &res),
+                    res => bail!("invalid response: {:?}", res),
                 };
 
                 stats.to_json()
@@ -322,7 +322,7 @@ pub fn server_data(nr_cpus_onln: u64) -> StatsServerData<StatsReq, StatsRes> {
             req_ch.send(StatsReq::NewSampler(tid))?;
             match res_ch.recv()? {
                 StatsRes::Ack => {}
-                res => bail!("invalid response: {:?}", &res),
+                res => bail!("invalid response: {:?}", res),
             }
 
             let read: Box<dyn StatsReader<StatsReq, StatsRes>> =
@@ -333,7 +333,7 @@ pub fn server_data(nr_cpus_onln: u64) -> StatsServerData<StatsReq, StatsRes> {
                     let samples = match res_ch.recv()? {
                         StatsRes::SchedSamples(v) => v,
                         StatsRes::Bye => bail!("preempted by another sampler"),
-                        res => bail!("invalid response: {:?}", &res),
+                        res => bail!("invalid response: {:?}", res),
                     };
 
                     samples.to_json()

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -648,7 +648,7 @@ pub fn server_data() -> StatsServerData<StatsReq, StatsRes> {
         req_ch.send(StatsReq::Hello(tid))?;
         let mut stats = Some(match res_ch.recv()? {
             StatsRes::Hello(v) => v,
-            res => bail!("invalid response to Hello: {:?}", &res),
+            res => bail!("invalid response to Hello: {:?}", res),
         });
 
         let read: Box<dyn StatsReader<StatsReq, StatsRes>> =
@@ -656,7 +656,7 @@ pub fn server_data() -> StatsServerData<StatsReq, StatsRes> {
                 req_ch.send(StatsReq::Refresh(tid, stats.take().unwrap()))?;
                 let (new_stats, sys_stats) = match res_ch.recv()? {
                     StatsRes::Refreshed(v) => v,
-                    res => bail!("invalid response to Refresh: {:?}", &res),
+                    res => bail!("invalid response to Refresh: {:?}", res),
                 };
                 stats = Some(new_stats);
                 sys_stats.to_json()
@@ -669,7 +669,7 @@ pub fn server_data() -> StatsServerData<StatsReq, StatsRes> {
         req_ch.send(StatsReq::Bye(current().id())).unwrap();
         match res_ch.recv().unwrap() {
             StatsRes::Bye => {}
-            res => panic!("invalid response to Bye: {:?}", &res),
+            res => panic!("invalid response to Bye: {:?}", res),
         }
     });
 


### PR DESCRIPTION
Avoid unnecessary use of `&` in formatting macros like `info!` and `warn!` for cleaner ~and more idiomatic~ Rust code.

Edit: Since what is considered idiomatic can be subjective.