### PR TITLE
scx_rustland_core/builder: Refactor file write guard

### DIFF
--- a/rust/scx_rustland_core/src/rustland_builder.rs
+++ b/rust/scx_rustland_core/src/rustland_builder.rs
@@ -26,10 +26,8 @@ impl RustLandBuilder {
         let path = Path::new(file_name);
 
         // Limit file writing to when file contents differ (for caching)
-        if let Ok(bytes_there) = fs::read(path) {
-            if bytes_there == content {
-                return;
-            }
+        if fs::read(path).map_or(false, |b| b == content) {
+            return;
         }
 
         let mut file = File::create(path).expect("Unable to create file");


### PR DESCRIPTION
Use `map_or()` to simplify the logic.

No functional change.