### PR TITLE
scx_p2dq: Fix LLC id handling and refactor load balancing

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -28,6 +28,7 @@ struct llc_ctx {
 	u32				lb_llc_id;
 	u64				last_period_ns;
 	u64				load;
+	u32				index;
 	bool				all_big;
 	u64				dsqs[MAX_DSQS_PER_LLC];
 	u64				dsq_max_vtime[MAX_DSQS_PER_LLC];

--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -243,6 +243,9 @@ macro_rules! init_skel {
             $skel.maps.bss_data.cpu_llc_ids[cpu.id] = cpu.llc_id as u64;
             $skel.maps.bss_data.cpu_node_ids[cpu.id] = cpu.node_id as u64;
         }
+        for llc in $crate::TOPO.all_llcs.values() {
+            $skel.maps.bss_data.llc_ids[llc.id] = llc.id as u64;
+        }
     };
 }
 


### PR DESCRIPTION
Fix LLC id handling by distinguishing the LLC id from the system perspective from the LLC index for iteration order. This fixes potential issues where LLCs may have LLC ids that are non incremental.

Cleanup dispatch_pick_two and remove the pick_two_llc_ctx helper method. Add new helper methods for consuming from LLCs consume_llc and consume_llc_compat. Update the load balancing so that when pick two load balancing is done both LLCs can be attempted if one LLC has no tasks. This provides better work conservation.

I had a few of these ideas after a long debugging session with @yaakov-stein.

Perf tests on partially loaded on large LLC system (AMD Bergamo):
`main`:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (405962 total samples)
          50.0th: 10         (151118 samples)
          90.0th: 13         (108176 samples)
        * 99.0th: 19         (31164 samples)
          99.9th: 127        (2708 samples)
          min=1, max=7387
Request Latencies percentiles (usec) runtime 30 (s) (406712 total samples)
          50.0th: 6648       (126544 samples)
          90.0th: 10864      (156996 samples)
        * 99.0th: 12528      (35418 samples)
          99.9th: 16608      (3432 samples)
          min=5828, max=85730
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13360      (7 samples)
        * 50.0th: 13648      (9 samples)
          90.0th: 13776      (15 samples)
          min=12247, max=13789
average rps: 13557.07
```
This PR:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (409928 total samples)
          50.0th: 7          (120108 samples)
          90.0th: 11         (138768 samples)
        * 99.0th: 15         (21576 samples)
          99.9th: 25         (2404 samples)
          min=1, max=991
Request Latencies percentiles (usec) runtime 30 (s) (410802 total samples)
          50.0th: 6600       (116020 samples)
          90.0th: 10416      (163385 samples)
        * 99.0th: 12208      (36881 samples)
          99.9th: 12816      (3489 samples)
          min=5809, max=21802
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13616      (7 samples)
        * 50.0th: 13712      (11 samples)
          90.0th: 13776      (11 samples)
          min=13446, max=13807
average rps: 13693.40
```
`eevdf`:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (404180 total samples)
          50.0th: 5          (0 samples)
          90.0th: 7          (138238 samples)
        * 99.0th: 11         (29976 samples)
          99.9th: 22         (2723 samples)
          min=1, max=2186
Request Latencies percentiles (usec) runtime 30 (s) (404985 total samples)
          50.0th: 6568       (121997 samples)
          90.0th: 11760      (155869 samples)
        * 99.0th: 12592      (35900 samples)
          99.9th: 13136      (3449 samples)
          min=5833, max=26987
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13360      (7 samples)
        * 50.0th: 13584      (10 samples)
          90.0th: 13712      (12 samples)
          min=12095, max=13790
average rps: 13499.50
```


At full saturation there are slight improvements as well.
`main`:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (403585 total samples)
          50.0th: 13         (103735 samples)
          90.0th: 196        (158695 samples)
        * 99.0th: 1042       (36305 samples)
          99.9th: 2244       (3608 samples)
          min=1, max=18391
Request Latencies percentiles (usec) runtime 30 (s) (404282 total samples)
          50.0th: 12176      (121832 samples)
          90.0th: 14192      (161193 samples)
        * 99.0th: 26848      (36051 samples)
          99.9th: 43968      (3622 samples)
          min=5863, max=131722
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13360      (9 samples)
        * 50.0th: 13520      (10 samples)
          90.0th: 13648      (9 samples)
          min=12525, max=13754
average rps: 13476.07
```
PR:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (406077 total samples)
          50.0th: 23         (115118 samples)
          90.0th: 202        (160296 samples)
        * 99.0th: 1326       (36465 samples)
          99.9th: 2804       (3653 samples)
          min=1, max=8243
Request Latencies percentiles (usec) runtime 30 (s) (406506 total samples)
          50.0th: 12240      (122658 samples)
          90.0th: 14960      (160450 samples)
        * 99.0th: 24416      (36526 samples)
          99.9th: 35520      (3633 samples)
          min=6231, max=61153
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13424      (8 samples)
        * 50.0th: 13520      (8 samples)
          90.0th: 13648      (13 samples)
          min=13288, max=13673
average rps: 13550.20
```