### PR TITLE
scx_wd40: Fix incorrect null check

### DIFF
--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
@@ -80,7 +80,7 @@ dom_ptr lb_domain_alloc(u32 dom_id)
 	}
 
 	domc->direct_greedy_cpumask = scx_bitmap_alloc();
-	if (!domc->cpumask) {
+	if (!domc->direct_greedy_cpumask) {
 		scx_bitmap_free(domc->cpumask);
 		lb_domain_free(domc);
 		return NULL;


### PR DESCRIPTION
`lb_domain_alloc()` was checking `cpumask` twice instead of checking `direct_greedy_cpumask`.