### PR TITLE
scx_layered: Unify percpu kthread handling

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -655,6 +655,12 @@ struct Opts {
     #[clap(long, default_value = "false")]
     disable_percpu_kthread_preempt: bool,
 
+    /// Only highpri (nice < 0) per-cpu kthreads are preempting by default.
+    /// Make every per-cpu kthread preempting. Meaningful only if
+    /// --disable-percpu-kthread-preempt is not set.
+    #[clap(long, default_value = "false")]
+    percpu_kthread_preempt_all: bool,
+
     /// Show descriptions for statistics.
     #[clap(long)]
     help_stats: bool,
@@ -1928,6 +1934,8 @@ impl<'a> Scheduler<'a> {
         }
 
         skel.maps.rodata_data.percpu_kthread_preempt = !opts.disable_percpu_kthread_preempt;
+        skel.maps.rodata_data.percpu_kthread_preempt_all =
+            !opts.disable_percpu_kthread_preempt && opts.percpu_kthread_preempt_all;
         skel.maps.rodata_data.debug = opts.verbose as u32;
         skel.maps.rodata_data.slice_ns = opts.slice_us * 1000;
         skel.maps.rodata_data.max_exec_ns = if opts.max_exec_us > 0 {


### PR DESCRIPTION
There are two competing mechanisms that try to prioritize percpu kthreads. One goes off of is_preempt_kthread() test and allows preemption on all percpu kthreads; then, a recent commit added explicit logic to specify SCX_ENQ_PREEMPT in the kthread handling block in enqueue() and try_preempt_cpu(). Unify them so that:

- Don't let is_preempt_kthread() route percpu kthreads into the preemption path. The later kthread handling block does the same thing without all the preemption path hassles.

- Split is_preempt_kthread() test into is_percpu_kthread() and is_percpu_kthread_preempting(). The latter now only says yes if percpu_kthread_preempt is set and either percpu_kthread_preempt_all is set or the task is high priority.

- In the kthread handling block in enqueue(), SCX_ENQ_PREEMPT is added if is_percpu_kthread_preempting() is true. This allows the behavior to be controlled via --disable-percpu-kthread-preempt and --percpu-kthread-preempt-all.

- The explicit kthread skipping in try_preempt_cpu() is dropped as setting cpuc->current_prrempt in running() achieves the same thing. The condition in running() is updated to use is_perpcu_kthread() && is_percpu_kthread_preempting() to match the enqueue path.

Before, when percpu_kthread_preempt is set, all kthreads were preempting and traveled the preemption path, which can be costly and likely to be sub-optimal. After this patch, all percpu kthreads, which aren't explicitly in a preempting layer, will be queued on local DSQs. If percpu_kthread_preempt is set and percpu_kthread_preempt_all is not, which is the default, only high-priority (nice < 0) ones preempt. Note that this still doesn't travel the usual preemption path. It just sets SCX_ENQ_PREEMPT when inserting into the local DSQ.