### PR TITLE
lib/arena: expand argument passing from userspace

### DIFF
--- a/lib/arena.bpf.c
+++ b/lib/arena.bpf.c
@@ -61,7 +61,7 @@ int arena_topology_node_init(struct arena_topology_node_init_args *args)
 	scx_bitmap_t bitmap = (scx_bitmap_t)container_of(args->bitmap, struct scx_bitmap, bits);
 	int ret;
 
-	ret = topo_init(bitmap);
+	ret = topo_init(bitmap, args->data_size);
 	if (ret)
 		return ret;
 

--- a/lib/arena.bpf.c
+++ b/lib/arena.bpf.c
@@ -15,7 +15,6 @@
  */
 
 struct task_ctx;
-u64 arena_topo_setup_ptr;
 
 SEC("syscall")
 int arena_init(struct arena_init_args *args)
@@ -43,7 +42,7 @@ int arena_init(struct arena_init_args *args)
 }
 
 SEC("syscall")
-int arena_alloc_mask(void)
+int arena_alloc_mask(struct arena_alloc_mask_args *args)
 {
 	scx_bitmap_t bitmap;
 
@@ -51,22 +50,20 @@ int arena_alloc_mask(void)
 	if (!bitmap)
 		return -ENOMEM;
 
-	arena_topo_setup_ptr = (u64)&bitmap->bits;
+	args->bitmap = (u64)&bitmap->bits;
 
 	return 0;
 }
 
 SEC("syscall")
-int arena_topology_node_init(void)
+int arena_topology_node_init(struct arena_topology_node_init_args *args)
 {
-	scx_bitmap_t bitmap = (scx_bitmap_t)container_of(arena_topo_setup_ptr, struct scx_bitmap, bits);
+	scx_bitmap_t bitmap = (scx_bitmap_t)container_of(args->bitmap, struct scx_bitmap, bits);
 	int ret;
 
 	ret = topo_init(bitmap);
 	if (ret)
 		return ret;
-
-	arena_topo_setup_ptr = 0;
 
 	return 0;
 }

--- a/lib/topology.bpf.c
+++ b/lib/topology.bpf.c
@@ -72,7 +72,7 @@ int topo_add(topo_ptr parent, scx_bitmap_t mask)
 }
 
 __weak
-int topo_init(scx_bitmap_t __arg_arena mask)
+int topo_init(scx_bitmap_t __arg_arena mask, u64 data_size)
 {
 	/* Initializing the child to appease the verifier. */
 	topo_ptr topo, child = NULL;
@@ -122,6 +122,13 @@ int topo_init(scx_bitmap_t __arg_arena mask)
 		}
 
 		topo = child;
+	}
+
+	topo->data = NULL;
+	if (data_size) {
+		topo->data = scx_static_alloc(data_size, 1);
+		if (!topo->data)
+			return -ENOMEM;
 	}
 
 	scx_bpf_error("topology is too deep");

--- a/scheds/include/lib/arena.h
+++ b/scheds/include/lib/arena.h
@@ -15,6 +15,7 @@ int arena_alloc_mask(struct arena_alloc_mask_args *args);
 
 struct arena_topology_node_init_args {
 	u64 bitmap;
+	u64 data_size;
 };
 
 int arena_topology_node_init(struct arena_topology_node_init_args *args);

--- a/scheds/include/lib/arena.h
+++ b/scheds/include/lib/arena.h
@@ -6,11 +6,17 @@ struct arena_init_args {
 };
 
 int arena_init(struct arena_init_args *args);
-int arena_alloc_mask(void);
 
-struct arena_topology_node_init_args {
-	u64 setup_ptr;
+struct arena_alloc_mask_args {
+	u64 bitmap;
 };
 
-int arena_topology_node_init();
+int arena_alloc_mask(struct arena_alloc_mask_args *args);
+
+struct arena_topology_node_init_args {
+	u64 bitmap;
+};
+
+int arena_topology_node_init(struct arena_topology_node_init_args *args);
+
 int arena_topology_print(void);

--- a/scheds/include/lib/topology.h
+++ b/scheds/include/lib/topology.h
@@ -27,7 +27,7 @@ struct topology {
 
 extern volatile topo_ptr topo_all;
 
-int topo_init(scx_bitmap_t __arg_arena mask);
+int topo_init(scx_bitmap_t __arg_arena mask, u64 data_size);
 int topo_contains(topo_ptr topo, u32 cpu);
 
 u64 topo_mask_level_internal(topo_ptr topo, enum topo_level level);
@@ -40,7 +40,7 @@ struct topo_iter {
 	/* The current topology node. */
 	topo_ptr topo;
 	/*
-	 * The index for every node in the path of the tree for , -1 denotes levels > the current one. 
+	 * The index for every node in the path of the tree for , -1 denotes levels > the current one.
 	 * E.g., [0, 1, 2, 1, 2] means:
 	 * - index on level 0 (we only have one top-level node]
 	 * - index 1 on level 1 (the top-level node's second child)

--- a/scheds/include/lib/topology.h
+++ b/scheds/include/lib/topology.h
@@ -22,7 +22,7 @@ struct topology {
 	enum topo_level level;
 
 	/* Generic pointer, can be used for anything. */
-	void *data;
+	void __arena *data;
 };
 
 extern volatile topo_ptr topo_all;

--- a/scheds/rust/scx_wd40/src/main.rs
+++ b/scheds/rust/scx_wd40/src/main.rs
@@ -392,8 +392,22 @@ impl<'a> Scheduler<'a> {
     }
 
     fn setup_topology_node(skel: &mut BpfSkel<'a>, mask: &[u64]) -> Result<()> {
-        // Copy the address of ptr to the kernel to populate it from BPF with the arena pointer.
+
+        let mut args = types::arena_alloc_mask_args {
+            bitmap: 0 as c_ulong,
+        };
+
+        // XXX How do we get back a pointer? eBPF does copy the input context
+        // back to the user, does that mean the input context is basically
+        // passed by reference?
+
         let input = ProgramInput {
+            context_in: Some(unsafe {
+                std::slice::from_raw_parts_mut(
+                    &mut args as *mut _ as *mut u8,
+                    std::mem::size_of_val(&args),
+                )
+            }),
             ..Default::default()
         };
 
@@ -406,13 +420,23 @@ impl<'a> Scheduler<'a> {
         }
 
         let ptr = unsafe {
-            std::mem::transmute::<u64, &mut [u64; 10]>(skel.maps.bss_data.arena_topo_setup_ptr)
+            std::mem::transmute::<u64, &mut [u64; 10]>(args.bitmap)
         };
 
         let (valid_mask, _) = ptr.split_at_mut(mask.len());
         valid_mask.clone_from_slice(mask);
 
+        let mut args = types::arena_topology_node_init_args {
+            bitmap: args.bitmap as c_ulong
+        };
+
         let input = ProgramInput {
+            context_in: Some(unsafe {
+                std::slice::from_raw_parts_mut(
+                    &mut args as *mut _ as *mut u8,
+                    std::mem::size_of_val(&args),
+                )
+            }),
             ..Default::default()
         };
         let output = skel.progs.arena_topology_node_init.test_run(input)?;


### PR DESCRIPTION
Refactor and expand the function signatures of the BPF test programs used to initialize scheduler state on startup. First, refactor the code to not require bouncing allocated mask pointers through a temporary global variable. Also add a currently unused argument for allocating per-topology node state at node creation time.