### PR TITLE
lib/topology: add user-provided ids to topology nodes

### DIFF
--- a/lib/arena.bpf.c
+++ b/lib/arena.bpf.c
@@ -61,7 +61,7 @@ int arena_topology_node_init(struct arena_topology_node_init_args *args)
 	scx_bitmap_t bitmap = (scx_bitmap_t)container_of(args->bitmap, struct scx_bitmap, bits);
 	int ret;
 
-	ret = topo_init(bitmap, args->data_size);
+	ret = topo_init(bitmap, args->data_size, args->id);
 	if (ret)
 		return ret;
 

--- a/scheds/include/lib/arena.h
+++ b/scheds/include/lib/arena.h
@@ -16,6 +16,7 @@ int arena_alloc_mask(struct arena_alloc_mask_args *args);
 struct arena_topology_node_init_args {
 	u64 bitmap;
 	u64 data_size;
+	u64 id;
 };
 
 int arena_topology_node_init(struct arena_topology_node_init_args *args);

--- a/scheds/include/lib/topology.h
+++ b/scheds/include/lib/topology.h
@@ -20,6 +20,7 @@ struct topology {
 	size_t nr_children;
 	scx_bitmap_t mask;
 	enum topo_level level;
+	u64 id;
 
 	/* Generic pointer, can be used for anything. */
 	void __arena *data;
@@ -27,7 +28,7 @@ struct topology {
 
 extern volatile topo_ptr topo_all;
 
-int topo_init(scx_bitmap_t __arg_arena mask, u64 data_size);
+int topo_init(scx_bitmap_t __arg_arena mask, u64 data_size, u64 id);
 int topo_contains(topo_ptr topo, u32 cpu);
 
 u64 topo_mask_level_internal(topo_ptr topo, enum topo_level level);
@@ -75,3 +76,5 @@ static inline int topo_iter_start(struct topo_iter *iter)
 #define TOPO_FOR_EACH_LLC(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_LLC)
 #define TOPO_FOR_EACH_CORE(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_CORE)
 #define TOPO_FOR_EACH_CPU(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_CPU)
+
+extern topo_ptr topo_nodes[TOPO_MAX_LEVEL][NR_CPUS];

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -35,6 +35,10 @@
 #define PF_EXITING			0x00000004
 #define CLOCK_MONOTONIC			1
 
+#ifndef NR_CPUS
+#define NR_CPUS 1024
+#endif
+
 #ifndef NUMA_NO_NODE
 #define	NUMA_NO_NODE	(-1)
 #endif

--- a/scheds/rust/scx_chaos/src/lib.rs
+++ b/scheds/rust/scx_chaos/src/lib.rs
@@ -242,6 +242,7 @@ impl Builder<'_> {
         let mut args = types::arena_topology_node_init_args {
             bitmap: args.bitmap as c_ulong,
             data_size: 0 as c_ulong,
+            id: 0 as c_ulong,
         };
 
         let input = ProgramInput {

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -223,6 +223,7 @@ impl<'a> Scheduler<'a> {
         let mut args = types::arena_topology_node_init_args {
             bitmap: args.bitmap as c_ulong,
             data_size: 0 as c_ulong,
+            id: 0 as c_ulong,
         };
 
         let input = ProgramInput {


### PR DESCRIPTION
Topology nodes do not currently have identifiers, but existing code assumes they do. We do not fundamentally need identifiers because nodes are arena-based, so we can just hold a pointer to them. However, all existing schedulers add ids to LLCs/nodes/CPUs because they retrieve them from BPF arrays and maps. This mismatch makes integrating topologies with existing schedulers more complicated.

As a temporary measure, introduce a global indexing structure for accessing topology nodes. These are functionally identical to the arrays of structs used by existing schedulers, and should make it easier to adapt existing code to use topology nodes.