### PR TITLE
scx_wd40: use topology IDs

### DIFF
--- a/lib/topology.bpf.c
+++ b/lib/topology.bpf.c
@@ -53,7 +53,7 @@ topo_ptr topo_node(topo_ptr parent, scx_bitmap_t mask, u64 id)
 		return NULL;
 	}
 
-	if (id >= TOPO_MAX_CHILDREN) {
+	if (id >= NR_CPUS) {
 		scx_bpf_error("invalid node id");
 		return NULL;
 	}

--- a/lib/topology.bpf.c
+++ b/lib/topology.bpf.c
@@ -13,7 +13,7 @@ volatile topo_ptr topo_all;
  * will just keep a CPU id to CPU topology node array, but for
  * now we will have an array for each level.
  */
-topo_ptr topo_nodes[TOPO_MAX_LEVEL][NR_CPUS];
+u64 topo_nodes[TOPO_MAX_LEVEL][NR_CPUS];
 
 __weak
 int topo_contains(topo_ptr topo, u32 cpu)
@@ -58,7 +58,7 @@ topo_ptr topo_node(topo_ptr parent, scx_bitmap_t mask, u64 id)
 		return NULL;
 	}
 
-	topo_nodes[topo->level][topo->id] = topo;
+	topo_nodes[topo->level][topo->id] = (u64)topo;
 
 	return topo;
 }

--- a/scheds/include/lib/topology.h
+++ b/scheds/include/lib/topology.h
@@ -77,4 +77,4 @@ static inline int topo_iter_start(struct topo_iter *iter)
 #define TOPO_FOR_EACH_CORE(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_CORE)
 #define TOPO_FOR_EACH_CPU(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_CPU)
 
-extern topo_ptr topo_nodes[TOPO_MAX_LEVEL][NR_CPUS];
+extern u64 topo_nodes[TOPO_MAX_LEVEL][NR_CPUS];

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.bpf.c
@@ -6,7 +6,9 @@
 
 #include <scx/common.bpf.h>
 #include <scx/ravg_impl.bpf.h>
+#include <lib/cpumask.h>
 #include <lib/sdt_task.h>
+#include <lib/topology.h>
 
 #include <scx/bpf_arena_common.h>
 #include <scx/bpf_arena_spin_lock.h>
@@ -36,7 +38,6 @@ struct {
 
 volatile scx_bitmap_t node_data[MAX_NUMA_NODES];
 
-volatile dom_ptr dom_ctxs[MAX_DOMS];
 struct scx_stk lb_domain_allocator;
 
 /*
@@ -115,7 +116,7 @@ dom_ptr try_lookup_dom_ctx(u32 dom_id)
 	if (dom_id >= MAX_DOMS)
 		return NULL;
 
-	return dom_ctxs[dom_id];
+	return (dom_ptr)topo_nodes[TOPO_LLC][dom_id];
 }
 
 __hidden
@@ -307,7 +308,7 @@ __weak s32 alloc_dom(u32 dom_id)
 	if (!domc)
 		return -ENOMEM;
 
-	dom_ctxs[dom_id] = domc;
+	topo_nodes[TOPO_LLC][dom_id] = (u64)domc;
 
 	return 0;
 }

--- a/scheds/rust/scx_wd40/src/bpf/lb_domain.h
+++ b/scheds/rust/scx_wd40/src/bpf/lb_domain.h
@@ -2,8 +2,6 @@
 
 #include <lib/sdt_task.h>
 
-extern volatile dom_ptr dom_ctxs[MAX_DOMS];
-
 int lb_domain_init(void);
 dom_ptr lb_domain_alloc(u32 dom_id);
 void lb_domain_free(dom_ptr domc);

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -875,8 +875,9 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(wd40_init)
 		if (ret)
 			return ret;
 
-		scx_bitmap_or(all_cpumask, all_cpumask, dom_ctxs[i]->cpumask);
 	}
+
+	scx_bitmap_or(all_cpumask, all_cpumask, topo_all->mask);
 
 	bpf_for(i, 0, nr_cpu_ids) {
 

--- a/scheds/rust/scx_wd40/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/main.bpf.c
@@ -75,7 +75,6 @@ UEI_DEFINE(uei);
 /*
  * Domains and cpus
  */
-const volatile u32 cpu_dom_id_map[MAX_CPUS];
 const volatile u32 wd40_perf_mode;
 
 const volatile bool kthreads_local;
@@ -113,20 +112,33 @@ scx_bitmap_t all_cpumask;
 scx_bitmap_t direct_greedy_cpumask;
 scx_bitmap_t kick_greedy_cpumask;
 
-static u32 cpu_to_dom_id(s32 cpu)
+static inline u32 cpu_to_dom_id(u32 cpu)
 {
-	const volatile u32 *dom_idp;
+	topo_ptr topo;
+	u32 id;
 
-	dom_idp = MEMBER_VPTR(cpu_dom_id_map, [cpu]);
-	if (!dom_idp)
+	if (cpu >= NR_CPUS) {
+		scx_bpf_error("invalid CPU ID");
 		return MAX_DOMS;
+	}
 
-	return *dom_idp;
+	topo = (topo_ptr)topo_nodes[TOPO_CPU][cpu];
+	if (!topo) {
+		scx_bpf_error("cpu is offline");
+		return MAX_DOMS;
+	}
+
+	id = topo->parent->parent->id;
+	if (id >= MAX_DOMS) {
+		scx_bpf_error("invalid domain id");
+	}
+
+	return id;
 }
 
 static inline bool is_offline_cpu(s32 cpu)
 {
-	return cpu_to_dom_id(cpu) > MAX_DOMS;
+	return topo_nodes[TOPO_CPU] == NULL;
 }
 
 static s32 try_sync_wakeup(struct task_struct *p, task_ptr taskc,
@@ -563,6 +575,8 @@ void BPF_STRUCT_OPS(wd40_dispatch, s32 cpu, struct task_struct *prev)
 {
 	u32 curr_dom = cpu_to_dom_id(cpu);
 	struct pcpu_ctx *pcpuc;
+
+	scx_arena_subprog_init();
 
 	/*
 	 * In older kernels, we may receive an ops.dispatch() callback when a

--- a/scheds/rust/scx_wd40/src/load_balance.rs
+++ b/scheds/rust/scx_wd40/src/load_balance.rs
@@ -626,7 +626,10 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
 
         // Read active_tasks and update read_idx and gen.
         const MAX_TPTRS: u64 = bpf_intf::consts_MAX_DOM_ACTIVE_TPTRS as u64;
-        let dom_ctx = unsafe { &mut *self.skel.maps.bss_data.dom_ctxs[dom.id] };
+
+        let types::topo_level(index) = types::topo_level::TOPO_LLC;
+        let ptr = self.skel.maps.bss_data.topo_nodes[index as usize][dom.id];
+        let dom_ctx = unsafe { std::mem::transmute::<u64, &mut types::dom_ctx>(ptr) };
         let active_tasks = &mut dom_ctx.active_tasks;
 
         let (mut ridx, widx) = (active_tasks.read_idx, active_tasks.write_idx);

--- a/scheds/rust/scx_wd40/src/main.rs
+++ b/scheds/rust/scx_wd40/src/main.rs
@@ -560,22 +560,6 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.nr_doms = domains.nr_doms() as u32;
         skel.maps.rodata_data.nr_cpu_ids = *NR_CPU_IDS as u32;
 
-        // Any CPU with dom > MAX_DOMS is considered offline by default. There
-        // are a few places in the BPF code where we skip over offlined CPUs
-        // (e.g. when initializing or refreshing tune params), and elsewhere the
-        // scheduler will error if we try to schedule from them.
-        for cpu in 0..*NR_CPU_IDS {
-            skel.maps.rodata_data.cpu_dom_id_map[cpu] = u32::MAX;
-        }
-
-        for (id, dom) in domains.doms().iter() {
-            for cpu in dom.mask().iter() {
-                skel.maps.rodata_data.cpu_dom_id_map[cpu] = (*id)
-                    .try_into()
-                    .expect("Domain ID could not fit into 32 bits");
-            }
-        }
-
         if opts.partial {
             skel.struct_ops.wd40_mut().flags |= *compat::SCX_OPS_SWITCH_PARTIAL;
         }

--- a/scheds/rust/scx_wd40/src/main.rs
+++ b/scheds/rust/scx_wd40/src/main.rs
@@ -391,7 +391,12 @@ impl<'a> Scheduler<'a> {
         Ok(())
     }
 
-    fn setup_topology_node(skel: &mut BpfSkel<'a>, mask: &[u64], data_size: usize, id: u64) -> Result<()> {
+    fn setup_topology_node(
+        skel: &mut BpfSkel<'a>,
+        mask: &[u64],
+        data_size: usize,
+        id: u64,
+    ) -> Result<()> {
         let mut args = types::arena_alloc_mask_args {
             bitmap: 0 as c_ulong,
         };
@@ -422,7 +427,7 @@ impl<'a> Scheduler<'a> {
         let mut args = types::arena_topology_node_init_args {
             bitmap: args.bitmap as c_ulong,
             data_size: data_size as c_ulong,
-            id: id as c_ulong
+            id: id as c_ulong,
         };
 
         let input = ProgramInput {
@@ -461,7 +466,7 @@ impl<'a> Scheduler<'a> {
                     .expect("missing llc")
                     .span
                     .as_raw_slice(),
-                    0, 
+                0,
                 0,
             )?;
         }
@@ -472,7 +477,7 @@ impl<'a> Scheduler<'a> {
                     .expect("missing core")
                     .span
                     .as_raw_slice(),
-                    0,
+                0,
                 0,
             )?;
         }
@@ -582,8 +587,8 @@ impl<'a> Scheduler<'a> {
 
         Self::setup_arenas(&mut skel)?;
 
-        println!(
-            "Mask length {} NR_CPU_IDS {}",
+        info!(
+            "Mask length {}, number of possible CPUs {}",
             skel.maps.bss_data.mask_size, skel.maps.rodata_data.nr_cpu_ids
         );
         // Read the mask length chosen by BPF. We count elements in the u64 array, like the BPF


### PR DESCRIPTION
Adjust scx_wd40 to use the node indices we added for the topology library, replacing scx_wd40's own arrays used for indexing. This also serves as a case study on how to use the topology indices on other schedulers.