### PR TITLE
nix: remove nested attrset in kernels

### DIFF
--- a/.github/actions/build-kernel/action.yml
+++ b/.github/actions/build-kernel/action.yml
@@ -10,13 +10,13 @@ runs:
   steps:
     - name: Get Nix store path
       run: |
-        echo "KERNEL_STORE_PATH=$(nix eval --raw ./.github/include#kernels.'${{ inputs.repo-name }}'.outPath)" >> $GITHUB_ENV
-        echo "KERNEL_HEADERS_STORE_PATH=$(nix eval --raw ./.github/include#kernels.'${{ inputs.repo-name }}'.headers.outPath)" >> $GITHUB_ENV
+        echo "KERNEL_STORE_PATH=$(nix eval --raw ./.github/include#'kernel_${{ inputs.repo-name }}'.outPath)" >> $GITHUB_ENV
+        echo "KERNEL_HEADERS_STORE_PATH=$(nix eval --raw ./.github/include#'kernel_${{ inputs.repo-name }}'.headers.outPath)" >> $GITHUB_ENV
       shell: bash
 
     - name: Build kernel
       shell: bash
-      run: nix build --no-link ./.github/include#kernels.'${{ inputs.repo-name }}'{,.headers}
+      run: nix build --no-link ./.github/include#'kernel_${{ inputs.repo-name }}'{,.headers}
 
     - name: Explicitly push to cachix
       shell: bash

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -48,7 +48,7 @@ both updating the kernel lock and making necessary fixes to the codebase.
 We use `virtme-ng` for testing in the CI environment, and it should be possible
 to reproduce behaviour locally with the same pinned kernels. To get an identical
 kernel to the CI with Nix installed, run:
-    nix build ./.github/include#kernels.sched_ext/for-next
+    nix build ./.github/include#kernel_sched_ext/for-next
 And the kernel image will be available at `result/bzImage`. Alternatively you
 can clone the repo/commit from `kernel-versions.json`, but this isn't guaranteed
 to be reproducible.


### PR DESCRIPTION
The Nix flake currently presents our tracked kernels and they're accessible with commands like `nix build ./.github/include#kernels.sched_ext/for-next`. This is non-standard and breaks tools like `nix flake show` which can't understand that an attrset is present where it expects a string value.

Flatten this hierarchy and make kernels available at `#kernel_sched_ext/for-next`.

Test plan:
- Built a kernel. It works.
- `nix flake show` now passes.
- CI

```
jake@rooster:/data/users/jake/repos/scx/ > nix flake show ./.github/include
git+file:///data/users/jake/repos/scx?dir=.github/include&ref=refs/heads/jakehillion/better-nix-kernels&rev=9a182f0ba95596f352ea3c89f0b8abeafda9dc79
├───apps
│   ├───aarch64-darwin
│   │   └───update-kernels: app
│   ├───aarch64-linux
│   │   └───update-kernels: app
│   ├───x86_64-darwin
│   │   └───update-kernels: app
│   └───x86_64-linux
│       └───update-kernels: app
├───devShells
│   └───x86_64-linux
│       ├───default: development environment 'nix-shell'
│       ├───gha-common: development environment 'nix-shell'
│       ├───gha-list-tests: development environment 'nix-shell'
│       └───gha-update-kernels: development environment 'nix-shell'
├───formatter
│   ├───aarch64-darwin omitted (use '--all-systems' to show)
│   ├───aarch64-linux omitted (use '--all-systems' to show)
│   ├───x86_64-darwin omitted (use '--all-systems' to show)
│   └───x86_64-linux: package 'nixpkgs-fmt-1.3.0'
└───packages
    └───x86_64-linux
        ├───bpf-clang: package 'bpf-clang-19.1.7'
        ├───ci: package 'ci-git'
        ├───"kernel_bpf/bpf-next": package 'linux-6.15.0'
        ├───"kernel_sched_ext/for-next": package 'linux-6.14.0'
        ├───"kernel_stable/6_12": package 'linux-6.12.31'
        ├───"kernel_stable/linux-rolling-stable": package 'linux-6.14.9'
        ├───nix-develop-gha: package 'nix-develop-gha'
        └───veristat: package 'veristat-git'
```