### PR TITLE
scx_mitosis: sync cells from bpf

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -50,4 +50,16 @@ struct cgrp_ctx {
 	bool cell_owner;
 };
 
+/*
+ * cell is the per-cell book-keeping
+*/
+struct cell {
+	// current vtime of the cell
+	u64 vtime_now;
+	// which dsq the cell uses
+	u32 dsq;
+	// Whether or not the cell is used or not
+	u32 in_use;
+};
+
 #endif /* __INTF_H */


### PR DESCRIPTION
This adds a rust-side cell representation back into mitosis and tracks cpus.


For now, we just add it to the debug dump:

```
20:52:55 [TRACE] CELL[0]: 0000,f80000f8,0000c000,000000f8,0000f800,00c00000
20:52:55 [TRACE] CELL[1]: 0000,00000000,000007ff,ff000000,00000000,0007ffff
20:52:55 [TRACE] CELL[2]: 0000,00000007,ffff0000,00000000,000007ff,ff000000
20:52:55 [TRACE] CELL[3]: 0000,07ffff00,00000000,00000007,ffff0000,00000000
20:52:55 [TRACE] CELL[4]: ffff,00000000,00003800,00ffff00,00000000,00380000
```