### PR TITLE
scx_layered: Implement LayerKind::Grouped::util_includes_open_cputime

### DIFF
--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -163,6 +163,8 @@ pub enum LayerKind {
     Grouped {
         util_range: (f64, f64),
         #[serde(default)]
+        util_includes_open_cputime: bool,
+        #[serde(default)]
         cpus_range: Option<(usize, usize)>,
 
         #[serde(default)]
@@ -211,6 +213,16 @@ impl LayerKind {
                 Some(*util_range)
             }
             _ => None,
+        }
+    }
+
+    pub fn util_includes_open_cputime(&self) -> bool {
+        match self {
+            LayerKind::Grouped {
+                util_includes_open_cputime,
+                ..
+            } => *util_includes_open_cputime,
+            _ => false,
         }
     }
 }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1102,7 +1102,6 @@ impl Layer {
             LayerKind::Confined {
                 cpus_range,
                 cpus_range_frac,
-                util_range,
                 common: LayerCommon { nodes, llcs, .. },
                 ..
             } => {
@@ -1131,15 +1130,6 @@ impl Layer {
                             }
                         }
                     }
-                }
-
-                if util_range.0 < 0.0
-                    || util_range.0 > 1.0
-                    || util_range.1 < 0.0
-                    || util_range.1 > 1.0
-                    || util_range.0 >= util_range.1
-                {
-                    bail!("invalid util_range {:?}", util_range);
                 }
             }
             LayerKind::Grouped {
@@ -1171,6 +1161,17 @@ impl Layer {
                         }
                     }
                 }
+            }
+        }
+
+        if let Some(util_range) = kind.util_range() {
+            if util_range.0 < 0.0
+                || util_range.0 > 1.0
+                || util_range.1 < 0.0
+                || util_range.1 > 1.0
+                || util_range.0 >= util_range.1
+            {
+                bail!("invalid util_range {:?}", util_range);
             }
         }
 

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -215,6 +215,7 @@ lazy_static! {
                 kind: LayerKind::Grouped {
                     cpus_range: None,
                     util_range: (0.5, 0.6),
+                    util_includes_open_cputime: true,
                     protected: false,
                     cpus_range_frac: None,
                     common: LayerCommon {
@@ -1164,13 +1165,10 @@ impl Layer {
             }
         }
 
+        // Util can be above 1.0 for grouped layers if
+        // util_includes_open_cputime is set.
         if let Some(util_range) = kind.util_range() {
-            if util_range.0 < 0.0
-                || util_range.0 > 1.0
-                || util_range.1 < 0.0
-                || util_range.1 > 1.0
-                || util_range.0 >= util_range.1
-            {
+            if util_range.0 < 0.0 || util_range.1 < 0.0 || util_range.0 >= util_range.1 {
                 bail!("invalid util_range {:?}", util_range);
             }
         }
@@ -2208,16 +2206,15 @@ impl<'a> Scheduler<'a> {
                     cpus_range_frac,
                     ..
                 } => {
-                    // Guide layer sizing by utilization within each layer
-                    // to avoid oversizing grouped layers. As an empty layer
-                    // can only get CPU time through fallback (counted as
-                    // owned) or open execution, add open cputime for empty
-                    // layers.
+                    // A grouped layer can choose to include open cputime
+                    // for sizing. Also, as an empty layer can only get CPU
+                    // time through fallback (counted as owned) or open
+                    // execution, add open cputime for empty layers.
                     let owned = utils[idx][LAYER_USAGE_OWNED];
                     let open = utils[idx][LAYER_USAGE_OPEN];
 
                     let mut util = owned;
-                    if layer.nr_cpus == 0 {
+                    if layer.kind.util_includes_open_cputime() || layer.nr_cpus == 0 {
                         util += open;
                     }
 


### PR DESCRIPTION
52e3ace ("scx_layered: Use only owned execution time when sizing
grouped layers") made grouped layers exclude open execution time when
determining the target number of CPUs. This was primarily to avoid
osciallting the sizes of grouped layers when confined layers' owned
protection statuses fluctuate; however, bb600e6 ("scx_layered: Simplify
owned execution protection") removed the source of most of such fluctuations
and the exclusion of open cputime made configuring grouped layers more
difficult as how much a layer open executes isn't something the user has
much control over.

Add a layer option to include open cputime in grouped layer sizing. We
should transition to make this the default behavior and eventually drop the
option.

Note that the upper bound of 1.0 for util_range is removed as a grouped
layer can legimitately target >1.0 util when including open cputime.