### PR TITLE
scx_layered: Idle rnode cleanup

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1340,7 +1340,10 @@ static void kick_idle_cpu(struct task_struct *p, struct layer *layer)
 
 	if (!(idle_smtmask = scx_bpf_get_idle_smtmask()))
 		return;
-
+	
+	/*
+	 * XXX: this should account for cpuset also.
+	 */
 	if (!(cpuc = lookup_cpu_ctx(-1)) || !(cand_cpumask = bpf_cpumask_create())) {
 		scx_bpf_put_idle_cpumask(idle_smtmask);
 		return;
@@ -2976,7 +2979,7 @@ void BPF_STRUCT_OPS(layered_update_idle, s32 cpu, bool idle)
 
 	bpf_for(layer_id, 0, nr_layers) {
 		/*
-		* XXX this should account for cpuset also.
+		* XXX: this should account for cpuset also.
 		*/
 		if((layer = lookup_layer(layer_id)) && 
 			layer->skip_remote_node && 

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1341,7 +1341,7 @@ static void kick_idle_cpu(struct task_struct *p, struct layer *layer)
 	if (!(idle_smtmask = scx_bpf_get_idle_smtmask()))
 		return;
 
-	if (!(cand_cpumask = bpf_cpumask_create()) || !(cpuc = lookup_cpu_ctx(-1))) {
+	if (!(cpuc = lookup_cpu_ctx(-1)) || !(cand_cpumask = bpf_cpumask_create())) {
 		scx_bpf_put_idle_cpumask(idle_smtmask);
 		return;
 	}

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1337,7 +1337,7 @@ static void kick_idle_cpu(struct task_struct *p, struct layer *layer, struct tas
 	struct cpu_ctx *cpuc;
 	s32 cpu;
 
-	if (!(idle_smtmask = scx_bpf_get_idle_smtmask()))
+	if (!(idle_smtmask = scx_bpf_get_idle_smtmask()) || !taskc)
 		return;
 	
 	if (!(cpuc = lookup_cpu_ctx(-1))) {
@@ -1353,7 +1353,7 @@ static void kick_idle_cpu(struct task_struct *p, struct layer *layer, struct tas
 			return;
 		}
 
-		if (layer->skip_remote_node && taskc && taskc->layered_node_mask && (cand_cpumask = bpf_cpumask_create())) {
+		if (layer->skip_remote_node && taskc->layered_node_mask && (cand_cpumask = bpf_cpumask_create())) {
 			bpf_cpumask_and(cand_cpumask, layer_cpumask, cast_mask(taskc->layered_node_mask));
 			lstat_inc(LSTAT_SKIP_REMOTE_NODE, layer, cpuc);
 			cpu = pick_idle_cpu_from(cast_mask(cand_cpumask), 0, idle_smtmask, layer);
@@ -1362,7 +1362,7 @@ static void kick_idle_cpu(struct task_struct *p, struct layer *layer, struct tas
 			cpu = pick_idle_cpu_from(layer_cpumask, 0, idle_smtmask, layer);
 		}
 	} else {
-		if (layer->skip_remote_node && taskc && taskc->layered_node_mask && (cand_cpumask = bpf_cpumask_create())) {
+		if (layer->skip_remote_node && taskc->layered_node_mask && (cand_cpumask = bpf_cpumask_create())) {
 			bpf_cpumask_and(cand_cpumask, p->cpus_ptr, cast_mask(taskc->layered_node_mask));
 			lstat_inc(LSTAT_SKIP_REMOTE_NODE, layer, cpuc);
 			cpu = pick_idle_cpu_from(cast_mask(cand_cpumask), 0, idle_smtmask, layer);

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1375,11 +1375,11 @@ static void kick_idle_cpu(struct task_struct *p, struct layer *layer)
 		}
 	}
 
-	bpf_cpumask_release(cand_cpumask);
-	scx_bpf_put_idle_cpumask(idle_smtmask);
-
 	if (cpu >= 0)
 		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+	
+	bpf_cpumask_release(cand_cpumask);
+	scx_bpf_put_idle_cpumask(idle_smtmask);
 }
 
 void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2955,7 +2955,9 @@ void BPF_STRUCT_OPS(layered_update_idle, s32 cpu, bool idle)
 		*/
 		if((layer = lookup_layer(layer_id)) && 
 			layer->skip_remote_node && 
-			(layer_cpumask = lookup_layer_cpumask(layer_id)) && 
+			(layer_cpumask = lookup_layer_cpumask(layer_id)) &&
+			// verifier
+			nctx->cpumask && 
 			!bpf_cpumask_intersects(layer_cpumask, cast_mask(nctx->cpumask))) {
 			lstat_inc(LSTAT_SKIP_REMOTE_NODE, layer, cpuc);
 			continue;


### PR DESCRIPTION
update idle interlocking paths to account for skip-rnode constraints.

we probably want (need?) this to account for cpuset also, but, for now just deal with node constraints.