### PR TITLE
Rework scx_flash

### DIFF
--- a/rust/scx_loader/configuration.md
+++ b/rust/scx_loader/configuration.md
@@ -39,9 +39,9 @@ powersave_mode = ["--powersave"]
 
 [scheds.scx_flash]
 auto_mode = []
-gaming_mode = []
-lowlatency_mode = []
-powersave_mode = []
+gaming_mode = ["-m", "performance"]
+lowlatency_mode = ["-s", "5000", "-S", "500", "-l", "5000", "-m", "performance"]
+powersave_mode = ["-m", "powersave"]
 
 [scheds.scx_p2dq]
 auto_mode = []

--- a/rust/scx_loader/src/config.rs
+++ b/rust/scx_loader/src/config.rs
@@ -204,8 +204,15 @@ fn get_default_scx_flags_for_mode(scx_sched: &SupportedSched, sched_mode: SchedM
         },
         // scx_rusty doesn't support any of these modes
         SupportedSched::Rusty => vec![],
-        // scx_flash doesn't support any of these modes
-        SupportedSched::Flash => vec![],
+        SupportedSched::Flash => match sched_mode {
+            SchedMode::Gaming => vec!["-m", "performance"],
+            SchedMode::LowLatency => {
+                vec!["-s", "5000", "-S", "500", "-l", "5000", "-m", "performance"]
+            }
+            SchedMode::PowerSave => vec!["-m", "powersave"],
+            SchedMode::Server => vec!["-p", "-c", "0"],
+            SchedMode::Auto => vec![],
+        },
         SupportedSched::P2DQ => match sched_mode {
             SchedMode::Gaming => vec![],
             SchedMode::LowLatency => vec!["-y"],
@@ -257,10 +264,10 @@ server_mode = []
 
 [scheds.scx_flash]
 auto_mode = []
-gaming_mode = []
-lowlatency_mode = []
-powersave_mode = []
-server_mode = []
+gaming_mode = ["-m", "performance"]
+lowlatency_mode = ["-s", "5000", "-S", "500", "-l", "5000", "-m", "performance"]
+powersave_mode = ["-m", "powersave"]
+server_mode = ["-p", "-c", "0"]
 
 [scheds.scx_p2dq]
 auto_mode = []

--- a/scheds/rust/scx_flash/Cargo.toml
+++ b/scheds/rust/scx_flash/Cargo.toml
@@ -15,7 +15,7 @@ libbpf-rs = "=0.25.0-beta.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.12" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.12" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.15", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 

--- a/scheds/rust/scx_flash/src/bpf/intf.h
+++ b/scheds/rust/scx_flash/src/bpf/intf.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (c) 2024 Andrea Righi <arighi@nvidia.com>
+ * Copyright (c) 2024 Andrea Righi <andrea.righi@linux.dev>
  *
  * This software may be used and distributed according to the terms of the GNU
  * General Public License version 2.
@@ -19,6 +19,9 @@ enum consts {
 	NSEC_PER_USEC = 1000ULL,
 	NSEC_PER_MSEC = (1000ULL * NSEC_PER_USEC),
 	NSEC_PER_SEC = (1000ULL * NSEC_PER_MSEC),
+
+	/* Kernel definitions */
+	CLOCK_BOOTTIME		= 7,
 };
 
 #ifndef __VMLINUX_H__
@@ -35,7 +38,12 @@ typedef signed long s64;
 typedef int pid_t;
 #endif /* __VMLINUX_H__ */
 
+struct cpu_arg {
+	s32 cpu_id;
+};
+
 struct domain_arg {
+	s32 lvl_id;
 	s32 cpu_id;
 	s32 sibling_cpu_id;
 };

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -1301,7 +1301,7 @@ void BPF_STRUCT_OPS(flash_stopping, struct task_struct *p, bool runnable)
 	/*
 	 * Evaluate the time slice used by the task.
 	 */
-	slice = now - tctx->last_run_at;
+	slice = MIN(now - tctx->last_run_at, slice_max);
 
 	/*
 	 * Update task's execution time (exec_runtime), but never account

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -35,7 +35,7 @@ const volatile u64 slice_min = 1ULL * NSEC_PER_MSEC;
  * tasks at the cost of making regular and newly created tasks less responsive
  * (0 = disabled).
  */
-const volatile s64 slice_lag = 20ULL * NSEC_PER_MSEC;
+const volatile u64 slice_lag = 20ULL * NSEC_PER_MSEC;
 
 /*
  * Ignore synchronous wakeup events.
@@ -391,20 +391,14 @@ static u64 task_deadline(const struct task_struct *p, struct task_ctx *tctx)
 
 	/*
 	 * Cap the vruntime budget that an idle task can accumulate to
-	 * slice_lag, preventing sleeping tasks from gaining excessive
-	 * priority.
+	 * the scaled @slice_lag, preventing sleeping tasks from gaining
+	 * excessive priority.
 	 *
-	 * A larger slice_lag favors tasks that sleep longer by allowing
+	 * A larger @slice_lag favors tasks that sleep longer by allowing
 	 * them to accumulate more credit, leading to shorter deadlines and
-	 * earlier execution. A smaller slice_lag reduces the advantage of
+	 * earlier execution. A smaller @slice_lag reduces the advantage of
 	 * long sleeps, treating short and long sleeps equally once they
 	 * exceed the threshold.
-	 *
-	 * If slice_lag is negative, it can be used to de-emphasize the
-	 * deadline-based scheduling altogether by charging all tasks a
-	 * fixed vruntime penalty (equal to the absolute value of
-	 * slice_lag), effectively approximating FIFO behavior as the
-	 * penalty increases.
 	 */
 	vtime_min = vtime_now - slice_lag;
 	if (time_before(tctx->deadline, vtime_min))

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -1,26 +1,49 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (c) 2024 Andrea Righi <arighi@nvidia.com>
+ * Copyright (c) 2024 Andrea Righi <andrea.righi@linux.dev>
  */
 #include <scx/common.bpf.h>
 #include "intf.h"
 
+const volatile u64 __COMPAT_SCX_PICK_IDLE_IN_NODE;
+
 char _license[] SEC("license") = "GPL";
 
-/*
- * Maximum amount of voluntary context switches (this limit allows to prevent
- * spikes or abuse of the nvcsw dynamic).
- */
-#define MAX_AVG_NVCSW		128
+/* Allow to use bpf_printk() only when @debug is set */
+#define dbg_msg(_fmt, ...) do {				\
+	if (debug)					\
+		bpf_printk(_fmt, ##__VA_ARGS__);	\
+} while(0)
+
+ /* Report additional debugging information */
+const volatile bool debug;
 
 /*
- * Task time slice range.
+ * Default task time slice.
  */
 const volatile u64 slice_max = 20ULL * NSEC_PER_MSEC;
-const volatile u64 slice_lag = 20ULL * NSEC_PER_MSEC;
 
 /*
- * When enabled always dispatch all kthreads directly.
+ * Time slice used when system is over commissioned.
+ */
+const volatile u64 slice_min = 1ULL * NSEC_PER_MSEC;
+
+/*
+ * Maximum time slice lag.
+ *
+ * Increasing this value can help to increase the responsiveness of interactive
+ * tasks at the cost of making regular and newly created tasks less responsive
+ * (0 = disabled).
+ */
+const volatile s64 slice_lag = 20ULL * NSEC_PER_MSEC;
+
+/*
+ * Ignore synchronous wakeup events.
+ */
+const volatile bool no_wake_sync;
+
+/*
+ * When enabled always dispatch per-CPU kthreads directly.
  *
  * This allows to prioritize critical kernel threads that may potentially slow
  * down the entire system if they are blocked for too long, but it may also
@@ -30,9 +53,59 @@ const volatile u64 slice_lag = 20ULL * NSEC_PER_MSEC;
 const volatile bool local_kthreads;
 
 /*
+ * Prioritize per-CPU tasks (tasks that can only run on a single CPU).
+ *
+ * This allows to prioritize per-CPU tasks that usually tend to be
+ * de-prioritized (since they can't be migrated when their only usable CPU
+ * is busy). Enabling this option can introduce unfairness and potentially
+ * trigger stalls, but it can improve performance of server-type workloads
+ * (such as large parallel builds).
+ */
+const volatile bool local_pcpu;
+
+/*
+ * The CPU frequency performance level: a negative value will not affect the
+ * performance level and will be ignored.
+ */
+volatile s64 cpufreq_perf_lvl;
+
+/*
  * Scheduling statistics.
  */
 volatile u64 nr_kthread_dispatches, nr_direct_dispatches, nr_shared_dispatches;
+
+/*
+ * Amount of currently running tasks.
+ */
+volatile u64 nr_running;
+
+/*
+ * Amount of online CPUs.
+ */
+volatile u64 nr_online_cpus;
+
+/*
+ * Maximum possible CPU number.
+ */
+static u64 nr_cpu_ids;
+
+/*
+ * Runtime throttling.
+ *
+ * Throttle the CPUs by injecting @throttle_ns idle time every @slice_max.
+ */
+const volatile u64 throttle_ns;
+static volatile bool cpus_throttled;
+
+static inline bool is_throttled(void)
+{
+	return READ_ONCE(cpus_throttled);
+}
+
+static inline void set_throttled(bool state)
+{
+	WRITE_ONCE(cpus_throttled, state);
+}
 
 /*
  * Exit information.
@@ -40,9 +113,20 @@ volatile u64 nr_kthread_dispatches, nr_direct_dispatches, nr_shared_dispatches;
 UEI_DEFINE(uei);
 
 /*
+ * Mask of CPUs that the scheduler can use until the system becomes saturated,
+ * at which point tasks may overflow to other available CPUs.
+ */
+private(FLASH) struct bpf_cpumask __kptr *primary_cpumask;
+
+/*
  * CPUs in the system have SMT is enabled.
  */
 const volatile bool smt_enabled = true;
+
+/*
+ * Disable NUMA rebalancing.
+ */
+const volatile bool numa_disabled = false;
 
 /*
  * Current global vruntime.
@@ -50,9 +134,107 @@ const volatile bool smt_enabled = true;
 static u64 vtime_now;
 
 /*
- * Maximum possible CPU number.
+ * Timer used to update NUMA statistics.
  */
-static u64 nr_cpu_ids;
+struct numa_timer {
+	struct bpf_timer timer;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct numa_timer);
+} numa_timer SEC(".maps");
+
+/*
+ * Timer used to inject idle cycles when CPU throttling is enabled.
+ */
+struct throttle_timer {
+	struct bpf_timer timer;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct throttle_timer);
+} throttle_timer SEC(".maps");
+
+/*
+ * Per-node context.
+ */
+struct node_ctx {
+	u64 tot_perf_lvl;
+	u64 nr_cpus;
+	u64 perf_lvl;
+	bool need_rebalance;
+};
+
+/* CONFIG_NODES_SHIFT should be always <= 10 */
+#define MAX_NUMA_NODES	1024
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, int);
+	__type(value, struct node_ctx);
+	__uint(max_entries, MAX_NUMA_NODES);
+	__uint(map_flags, 0);
+} node_ctx_stor SEC(".maps");
+
+/*
+ * Return a node context.
+ */
+struct node_ctx *try_lookup_node_ctx(int node)
+{
+	return bpf_map_lookup_elem(&node_ctx_stor, &node);
+}
+
+/*
+ * Return true if @node needs a rebalance, false otherwise.
+ */
+static bool node_rebalance(int node)
+{
+	const struct node_ctx *nctx;
+
+	if (numa_disabled)
+		return false;
+
+	nctx = try_lookup_node_ctx(node);
+	if (!nctx)
+		return false;
+
+	return nctx->need_rebalance;
+}
+
+/*
+ * Per-CPU context.
+ */
+struct cpu_ctx {
+	u64 tot_runtime;
+	u64 prev_runtime;
+	u64 last_running;
+	u64 perf_lvl;
+	struct bpf_cpumask __kptr *smt_cpumask;
+	struct bpf_cpumask __kptr *l2_cpumask;
+	struct bpf_cpumask __kptr *l3_cpumask;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__type(key, u32);
+	__type(value, struct cpu_ctx);
+	__uint(max_entries, 1);
+} cpu_ctx_stor SEC(".maps");
+
+/*
+ * Return a CPU context.
+ */
+struct cpu_ctx *try_lookup_cpu_ctx(s32 cpu)
+{
+	const u32 idx = 0;
+	return bpf_map_lookup_percpu_elem(&cpu_ctx_stor, &idx, cpu);
+}
 
 /*
  * Per-task local storage.
@@ -61,11 +243,11 @@ static u64 nr_cpu_ids;
  */
 struct task_ctx {
 	/*
-	 * Voluntary context switches metrics.
+	 * Temporary cpumask for calculating scheduling domains.
 	 */
-	u64 nvcsw;
-	u64 nvcsw_ts;
-	u64 avg_nvcsw;
+	struct bpf_cpumask __kptr *cpumask;
+	struct bpf_cpumask __kptr *l2_cpumask;
+	struct bpf_cpumask __kptr *l3_cpumask;
 
 	/*
 	 * Task's average used time slice.
@@ -74,9 +256,32 @@ struct task_ctx {
 	u64 last_run_at;
 
 	/*
-	 * Task's deadline.
+	 * Task's deadline, defined as:
+	 *
+	 *   deadline = vruntime + exec_vruntime
+	 *
+	 * Here, vruntime represents the task's total runtime, scaled inversely by
+	 * its weight, while exec_vruntime accounts for the vruntime accumulated
+	 * from the moment the task becomes runnable until it voluntarily releases
+	 * the CPU.
+	 *
+	 * Fairness is ensured through vruntime, whereas exec_vruntime helps in
+	 * prioritizing latency-sensitive tasks: tasks that are frequently blocked
+	 * waiting for an event (typically latency sensitive) will accumulate a
+	 * smaller exec_vruntime, compared to tasks that continuously consume CPU
+	 * without interruption.
+	 *
+	 * As a result, tasks with a smaller exec_vruntime will have a shorter
+	 * deadline and will be dispatched earlier, ensuring better responsiveness
+	 * for latency-sensitive tasks.
 	 */
 	u64 deadline;
+
+	/*
+	 * Task's recently used CPU: used to determine whether we need to
+	 * refresh the task's cpumasks.
+	 */
+	s32 recent_used_cpu;
 };
 
 /* Map that contains task-local storage. */
@@ -97,44 +302,7 @@ struct task_ctx *try_lookup_task_ctx(const struct task_struct *p)
 }
 
 /*
- * Prevent excessive prioritization of tasks performing massive fsync()
- * operations on the filesystem. These tasks can degrade system responsiveness
- * by not being inherently latency-sensitive.
- */
-SEC("?kprobe/vfs_fsync_range")
-int kprobe_vfs_fsync_range(struct file *file, u64 start, u64 end, int datasync)
-{
-	struct task_struct *p = (void *)bpf_get_current_task_btf();
-	struct task_ctx *tctx;
-
-	tctx = try_lookup_task_ctx(p);
-	if (tctx)
-		tctx->avg_nvcsw = 0;
-	return 0;
-}
-
-/*
- * Exponential weighted moving average (EWMA).
- *
- * Copied from scx_lavd. Returns the new average as:
- *
- *	new_avg := (old_avg * .75) + (new_val * .25);
- */
-static u64 calc_avg(u64 old_val, u64 new_val)
-{
-	return (old_val - (old_val >> 2)) + (new_val >> 2);
-}
-
-/*
- * Evaluate the EWMA limited to the range [low ... high]
- */
-static u64 calc_avg_clamp(u64 old_val, u64 new_val, u64 low, u64 high)
-{
-	return CLAMP(calc_avg(old_val, new_val), low, high);
-}
-
-/*
- * Return true if the target task @p is a kernel thread, false instead.
+ * Return true if the target task @p is a kernel thread.
  */
 static inline bool is_kthread(const struct task_struct *p)
 {
@@ -142,11 +310,76 @@ static inline bool is_kthread(const struct task_struct *p)
 }
 
 /*
- * Return the amount of tasks that are waiting to run.
+ * Return true if @p still wants to run, false otherwise.
  */
-static inline u64 nr_tasks_waiting(int node)
+static bool is_queued(const struct task_struct *p)
+{
+	return p->scx.flags & SCX_TASK_QUEUED;
+}
+
+/*
+ * Return true if @cpu is in a full-idle physical core,
+ * false otherwise.
+ */
+static bool is_fully_idle(s32 cpu)
+{
+	const struct cpumask *idle_smtmask;
+	int node = __COMPAT_scx_bpf_cpu_node(cpu);
+	bool is_idle;
+
+	idle_smtmask = __COMPAT_scx_bpf_get_idle_smtmask_node(node);
+	is_idle = bpf_cpumask_test_cpu(cpu, idle_smtmask);
+	scx_bpf_put_cpumask(idle_smtmask);
+
+	return is_idle;
+}
+
+/*
+ * Allocate/re-allocate a new cpumask.
+ */
+static int calloc_cpumask(struct bpf_cpumask **p_cpumask)
+{
+	struct bpf_cpumask *cpumask;
+
+	cpumask = bpf_cpumask_create();
+	if (!cpumask)
+		return -ENOMEM;
+
+	cpumask = bpf_kptr_xchg(p_cpumask, cpumask);
+	if (cpumask)
+		bpf_cpumask_release(cpumask);
+
+	return 0;
+}
+
+/*
+ * Return the total amount of tasks that are currently waiting to be scheduled.
+ */
+static u64 nr_tasks_waiting(int node)
 {
 	return scx_bpf_dsq_nr_queued(node) + 1;
+}
+
+/*
+ * Scale a value inversely proportional to the task's normalized weight.
+ */
+static inline u64 scale_by_task_normalized_weight_inverse(const struct task_struct *p, u64 value)
+{
+	/*
+	 * Original weight range:   [1, 10000], default = 100
+	 * Normalized weight range: [1, 128], default = 64
+	 *
+	 * This normalization reduces the impact of extreme weight differences,
+	 * preventing highly prioritized tasks from starving lower-priority ones.
+	 *
+	 * The goal is to ensure a more balanced scheduling that is
+	 * influenced more by the task's behavior rather than its priority
+	 * difference and prevent potential stalls due to large priority
+	 * gaps.
+	*/
+	u64 weight = 1 + (127 * log2_u64(p->scx.weight) / log2_u64(10000));
+
+	return value * 64 / weight;
 }
 
 /*
@@ -157,36 +390,417 @@ static u64 task_deadline(const struct task_struct *p, struct task_ctx *tctx)
 	u64 vtime_min;
 
 	/*
-	 * Limit the amount of vtime budget that an idling task can
-	 * accumulate to prevent excessive prioritization of sleeping
-	 * tasks.
+	 * Cap the vruntime budget that an idle task can accumulate to
+	 * slice_lag, preventing sleeping tasks from gaining excessive
+	 * priority.
 	 *
-	 * Tasks with a higher nvcsw rate get a bigger "bucket" for their
-	 * allowed accumulated time budget.
+	 * A larger slice_lag favors tasks that sleep longer by allowing
+	 * them to accumulate more credit, leading to shorter deadlines and
+	 * earlier execution. A smaller slice_lag reduces the advantage of
+	 * long sleeps, treating short and long sleeps equally once they
+	 * exceed the threshold.
+	 *
+	 * If slice_lag is negative, it can be used to de-emphasize the
+	 * deadline-based scheduling altogether by charging all tasks a
+	 * fixed vruntime penalty (equal to the absolute value of
+	 * slice_lag), effectively approximating FIFO behavior as the
+	 * penalty increases.
 	 */
-	vtime_min = vtime_now - slice_lag * tctx->avg_nvcsw;
+	vtime_min = vtime_now - slice_lag;
 	if (time_before(tctx->deadline, vtime_min))
 		tctx->deadline = vtime_min;
 
 	/*
 	 * Add the execution vruntime to the deadline.
 	 */
-	return tctx->deadline + scale_by_task_weight_inverse(p, tctx->exec_runtime);
+	tctx->deadline += scale_by_task_normalized_weight_inverse(p, tctx->exec_runtime);
+
+	return tctx->deadline;
+}
+
+static void task_update_domain(struct task_struct *p, struct task_ctx *tctx,
+			       s32 cpu, const struct cpumask *cpumask)
+{
+	struct bpf_cpumask *primary, *l2_domain, *l3_domain;
+	struct bpf_cpumask *p_mask, *l2_mask, *l3_mask;
+	struct cpu_ctx *cctx;
+
+	/*
+	 * Refresh task's recently used CPU every time the task's domain
+	 * is updated.
+	 */
+	tctx->recent_used_cpu = cpu;
+
+	cctx = try_lookup_cpu_ctx(cpu);
+	if (!cctx)
+		return;
+
+	primary = primary_cpumask;
+	if (!primary)
+		return;
+
+	l2_domain = cctx->l2_cpumask;
+	l3_domain = cctx->l3_cpumask;
+
+	p_mask = tctx->cpumask;
+	if (!p_mask) {
+		scx_bpf_error("cpumask not initialized");
+		return;
+	}
+
+	l2_mask = tctx->l2_cpumask;
+	if (!l2_mask) {
+		scx_bpf_error("l2 cpumask not initialized");
+		return;
+	}
+
+	l3_mask = tctx->l3_cpumask;
+	if (!l3_mask) {
+		scx_bpf_error("l3 cpumask not initialized");
+		return;
+	}
+
+	/*
+	 * Determine the task's scheduling domain.
+	 * idle CPU, re-try again with the primary scheduling domain.
+	 */
+	bpf_cpumask_and(p_mask, cpumask, cast_mask(primary));
+
+	/*
+	 * Determine the L2 cache domain as the intersection of the task's
+	 * primary cpumask and the L2 cache domain mask of the previously used
+	 * CPU.
+	 */
+	if (l2_domain)
+		bpf_cpumask_and(l2_mask, cast_mask(p_mask), cast_mask(l2_domain));
+
+	/*
+	 * Determine the L3 cache domain as the intersection of the task's
+	 * primary cpumask and the L3 cache domain mask of the previously used
+	 * CPU.
+	 */
+	if (l3_domain)
+		bpf_cpumask_and(l3_mask, cast_mask(p_mask), cast_mask(l3_domain));
 }
 
 /*
- * Evaluate task's time slice in function of the total amount of tasks that
- * are waiting to be dispatched and the task's weight.
+ * Return true if all the CPUs in the LLC of @cpu are busy, false
+ * otherwise.
  */
-static u64 task_slice(const struct task_struct *p,
-		      const struct task_ctx *tctx, int node)
+static bool is_llc_busy(s32 cpu)
+{
+	const struct cpumask *primary, *l3_mask, *idle_cpumask;
+	struct cpu_ctx *cctx;
+	int node;
+	bool ret;
+
+	primary = cast_mask(primary_cpumask);
+	if (!primary)
+		return false;
+
+	cctx = try_lookup_cpu_ctx(cpu);
+	if (!cctx)
+		return false;
+
+	l3_mask = cast_mask(cctx->l3_cpumask);
+	if (!l3_mask)
+		l3_mask = primary;
+
+	node = __COMPAT_scx_bpf_cpu_node(cpu);
+	idle_cpumask = __COMPAT_scx_bpf_get_idle_cpumask_node(node);
+
+	ret = !bpf_cpumask_intersects(l3_mask, idle_cpumask);
+
+	scx_bpf_put_cpumask(idle_cpumask);
+
+	return ret;
+}
+
+/*
+ * Return true if the waker commits to release the CPU after waking up @p,
+ * false otherwise.
+ */
+static bool is_wake_sync(s32 prev_cpu, s32 this_cpu, u64 wake_flags)
+{
+	const struct task_struct *current = (void *)bpf_get_current_task_btf();
+
+	if (no_wake_sync)
+		return false;
+
+	if ((wake_flags & SCX_WAKE_SYNC) && !(current->flags & PF_EXITING))
+		return true;
+
+	/*
+	 * If the current task is a per-CPU kthread running on the wakee's
+	 * previous CPU, treat it as a synchronous wakeup.
+	 *
+	 * The assumption is that the wakee had queued work for the per-CPU
+	 * kthread, which has now finished, making the wakeup effectively
+	 * synchronous. An example of this behavior is seen in IO
+	 * completions.
+	 */
+	if (is_kthread(current) && (current->nr_cpus_allowed == 1) &&
+	    (prev_cpu == this_cpu))
+		return true;
+
+	return false;
+}
+
+/*
+ * Return true if @this_cpu and @that_cpu shares the same LLC, false
+ * otherwise.
+ */
+static bool cpus_share_llc(s32 this_cpu, s32 that_cpu)
+{
+	const struct cpumask *llc_mask;
+	struct cpu_ctx *cctx;
+
+	cctx = try_lookup_cpu_ctx(that_cpu);
+	if (!cctx)
+		return false;
+
+	/*
+	 * If the L3 cpumask isn't defined, it means that either all CPUs
+	 * share the same L3 cache or the scheduler is running with
+	 * --disable-l3.
+	 *
+	 * In both cases, treat the CPUs as if they share the same LLC (the
+	 * --disable-l3 option, in this case, is interpreted as merging all
+	 *  L3 caches into a single virtual LLC).
+	 */
+	llc_mask = cast_mask(cctx->l3_cpumask);
+	if (!llc_mask)
+		return true;
+
+	return bpf_cpumask_test_cpu(this_cpu, llc_mask);
+}
+
+/*
+ * Find an idle CPU in the system.
+ *
+ * NOTE: the idle CPU selection doesn't need to be formally perfect, it is
+ * totally fine to accept racy conditions and potentially make mistakes, by
+ * picking CPUs that are not idle or even offline, the logic has been designed
+ * to handle these mistakes in favor of a more efficient response and a reduced
+ * scheduling overhead.
+ */
+static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, u64 wake_flags, bool *is_idle)
+{
+	const struct cpumask *idle_smtmask, *idle_cpumask;
+	const struct cpumask *primary, *p_mask, *l2_mask, *l3_mask;
+	struct task_ctx *tctx;
+	int node;
+	s32 this_cpu = bpf_get_smp_processor_id(), cpu;
+	bool is_prev_allowed;
+
+	primary = cast_mask(primary_cpumask);
+	if (!primary)
+		return -EINVAL;
+
+	tctx = try_lookup_task_ctx(p);
+	if (!tctx)
+		return -ENOENT;
+
+	/*
+	 * Get the task's primary scheduling domain.
+	 */
+	p_mask = cast_mask(tctx->cpumask);
+	is_prev_allowed = p_mask && bpf_cpumask_test_cpu(prev_cpu, p_mask);
+
+	/*
+	 * In case of a sync wakeup, attempt to run the wakee on the
+	 * waker's CPU if possible, as it's going to release the CPU right
+	 * after the wakeup, so it can be considered as idle and, possibly,
+	 * cache hot.
+	 */
+	if (is_wake_sync(prev_cpu, this_cpu, wake_flags)) {
+		/*
+		 * If @prev_cpu is idle, keep using it, since there is no guarantee
+		 * that the cache hot data from the waker's CPU is more important
+		 * than cache hot data in the wakee's CPU.
+		 */
+		if (is_prev_allowed && cpus_share_llc(prev_cpu, this_cpu) &&
+		    scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
+			*is_idle = true;
+			return prev_cpu;
+		}
+
+		/*
+		 * Migrate the wakee to the waker's CPU, but only if the
+		 * waker's LLC is not completely saturated, to prevent
+		 * wakers/wakees abusing this mechanism and potentially
+		 * starving other tasks.
+		 */
+		if (p_mask && bpf_cpumask_test_cpu(this_cpu, p_mask) &&
+		    !scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | this_cpu) &&
+		    !is_llc_busy(this_cpu)) {
+			*is_idle = true;
+			return this_cpu;
+		}
+	}
+
+	/*
+	 * Refresh task domain based on the previously used cpu. If we keep
+	 * selecting the same CPU, the task's domain doesn't need to be
+	 * updated and we can save some cpumask ops.
+	 */
+	if (tctx->recent_used_cpu != prev_cpu)
+		task_update_domain(p, tctx, prev_cpu, p->cpus_ptr);
+
+	l2_mask = cast_mask(tctx->l2_cpumask);
+	l3_mask = cast_mask(tctx->l3_cpumask);
+
+	/*
+	 * Acquire the CPU masks to determine the idle CPUs in the system.
+	 */
+	node = __COMPAT_scx_bpf_cpu_node(prev_cpu);
+	idle_smtmask = __COMPAT_scx_bpf_get_idle_smtmask_node(node);
+	idle_cpumask = __COMPAT_scx_bpf_get_idle_cpumask_node(node);
+
+	/*
+	 * Find the best idle CPU, prioritizing full idle cores in SMT systems.
+	 */
+	if (smt_enabled) {
+		/*
+		 * If the task can still run on the previously used CPU and
+		 * it's a full-idle core, keep using it.
+		 */
+		if (is_prev_allowed &&
+		    bpf_cpumask_test_cpu(prev_cpu, idle_smtmask) &&
+		    scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
+			cpu = prev_cpu;
+			*is_idle = true;
+			goto out_put_cpumask;
+		}
+
+		/*
+		 * Search for any full-idle CPU in the primary domain that
+		 * shares the same L2 cache.
+		 */
+		if (l2_mask) {
+			cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(l2_mask, node,
+						SCX_PICK_IDLE_CORE | __COMPAT_SCX_PICK_IDLE_IN_NODE);
+			if (cpu >= 0) {
+				*is_idle = true;
+				goto out_put_cpumask;
+			}
+		}
+
+		/*
+		 * Search for any full-idle CPU in the primary domain that
+		 * shares the same L3 cache.
+		 */
+		if (l3_mask) {
+			cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(l3_mask, node,
+						SCX_PICK_IDLE_CORE | __COMPAT_SCX_PICK_IDLE_IN_NODE);
+			if (cpu >= 0) {
+				*is_idle = true;
+				goto out_put_cpumask;
+			}
+		}
+
+		/*
+		 * Search for any full-idle CPU in the primary domain.
+		 *
+		 * If the current node needs a rebalance, look for any
+		 * full-idle CPU also on different nodes.
+		 */
+		if (p_mask) {
+			u64 flags = SCX_PICK_IDLE_CORE;
+
+			if (!node_rebalance(node))
+				flags |= __COMPAT_SCX_PICK_IDLE_IN_NODE;
+
+			cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(p_mask, node, flags);
+			if (cpu >= 0) {
+				*is_idle = true;
+				goto out_put_cpumask;
+			}
+		}
+	}
+
+	/*
+	 * If a full-idle core can't be found (or if this is not an SMT system)
+	 * try to re-use the same CPU, even if it's not in a full-idle core.
+	 */
+	if (is_prev_allowed &&
+	    scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
+		cpu = prev_cpu;
+		*is_idle = true;
+		goto out_put_cpumask;
+	}
+
+	/*
+	 * Search for any idle CPU in the primary domain that shares the same
+	 * L2 cache.
+	 */
+	if (l2_mask && !node_rebalance(node)) {
+		cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(l2_mask, node,
+						__COMPAT_SCX_PICK_IDLE_IN_NODE);
+		if (cpu >= 0) {
+			*is_idle = true;
+			goto out_put_cpumask;
+		}
+	}
+
+	/*
+	 * Search for any idle CPU in the primary domain that shares the same
+	 * L3 cache.
+	 */
+	if (l3_mask && !node_rebalance(node)) {
+		cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(l3_mask, node,
+						__COMPAT_SCX_PICK_IDLE_IN_NODE);
+		if (cpu >= 0) {
+			*is_idle = true;
+			goto out_put_cpumask;
+		}
+	}
+
+	/*
+	 * Search for any idle CPU in the scheduling domain.
+	 */
+	if (p_mask) {
+		cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(p_mask, node, 0);
+		if (cpu >= 0) {
+			*is_idle = true;
+			goto out_put_cpumask;
+		}
+	}
+
+	/*
+	 * Search for any idle CPU usable by the task.
+	 */
+	cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(p->cpus_ptr, node, 0);
+	if (cpu >= 0) {
+		*is_idle = true;
+		goto out_put_cpumask;
+	}
+
+out_put_cpumask:
+	scx_bpf_put_cpumask(idle_cpumask);
+	scx_bpf_put_cpumask(idle_smtmask);
+
+	/*
+	 * If we couldn't find any CPU, or in case of error, return the
+	 * previously used CPU.
+	 */
+	if (cpu < 0)
+		cpu = prev_cpu;
+
+	return cpu;
+}
+
+/*
+ * Return true if we can perform a direct dispatch on @node, false
+ * otherwise.
+ */
+static bool can_direct_dispatch(int node)
 {
 	/*
-	 * Assign a time slice proportional to the task weight and inversely
-	 * proportional to the total amount of tasks that are waiting to be
-	 * scheduled.
+	 * Allow direct dispatch when @local_pcpu is enabled, or when there
+	 * are no tasks queued in the node DSQ.
 	 */
-	return scale_by_task_weight(p, slice_max / nr_tasks_waiting(node));
+	return local_pcpu || !scx_bpf_dsq_nr_queued(node);
 }
 
 /*
@@ -196,19 +810,202 @@ static u64 task_slice(const struct task_struct *p,
  * dispatched directly to the CPU returned by this callback.
  */
 s32 BPF_STRUCT_OPS(flash_select_cpu, struct task_struct *p,
-		   s32 prev_cpu, u64 wake_flags)
+			s32 prev_cpu, u64 wake_flags)
 {
-	int node = __COMPAT_scx_bpf_cpu_node(prev_cpu);
 	bool is_idle = false;
 	s32 cpu;
 
-	cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
-	if (is_idle && !scx_bpf_dsq_nr_queued(node)) {
-		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL, 0);
-		__sync_fetch_and_add(&nr_direct_dispatches, 1);
+	if (is_throttled())
+		return prev_cpu;
+
+	cpu = pick_idle_cpu(p, prev_cpu, wake_flags, &is_idle);
+	if (is_idle) {
+		int node = __COMPAT_scx_bpf_cpu_node(cpu);
+
+		if (can_direct_dispatch(node)) {
+			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, slice_max, 0);
+			__sync_fetch_and_add(&nr_direct_dispatches, 1);
+		}
 	}
 
 	return cpu;
+}
+
+/*
+ * Try to wake up an idle CPU that can immediately process the task.
+ *
+ * Return true if a CPU has been kicked, false otherwise.
+ */
+static bool kick_idle_cpu(const struct task_struct *p, const struct task_ctx *tctx,
+			  s32 prev_cpu, bool idle_smt)
+{
+	const struct cpumask *mask;
+	u64 flags = idle_smt ? SCX_PICK_IDLE_CORE : 0;
+	s32 cpu = scx_bpf_task_cpu(p);
+	int node = __COMPAT_scx_bpf_cpu_node(cpu);
+
+	if (is_throttled())
+		return false;
+
+	/*
+	 * No need to look for full-idle SMT cores if SMT is disabled.
+	 */
+	if (idle_smt && !smt_enabled)
+		return false;
+
+	/*
+	 * Try to reuse the same CPU if idle.
+	 */
+	if (!idle_smt || is_fully_idle(prev_cpu)) {
+		if (scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
+			scx_bpf_kick_cpu(prev_cpu, SCX_KICK_IDLE);
+			return true;
+		}
+	}
+
+	/*
+	 * Look for any idle CPU usable by the task that can immediately
+	 * execute the task, prioritizing SMT isolation and cache locality.
+	 */
+	mask = cast_mask(tctx->l2_cpumask);
+	if (mask) {
+		cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(mask, node,
+					flags | __COMPAT_SCX_PICK_IDLE_IN_NODE);
+		if (cpu >= 0) {
+			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+			return true;
+		}
+	}
+	mask = cast_mask(tctx->l3_cpumask);
+	if (mask) {
+		cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(mask, node,
+					flags | __COMPAT_SCX_PICK_IDLE_IN_NODE);
+		if (cpu >= 0) {
+			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/*
+ * Attempt to dispatch a task directly to its assigned CPU.
+ *
+ * Return true if the task is dispatched, false otherwise.
+ */
+static bool try_direct_dispatch(struct task_struct *p, struct task_ctx *tctx,
+				s32 prev_cpu, u64 slice, u64 enq_flags)
+{
+	/*
+	 * If a task has been re-enqueued because its assigned CPU has been
+	 * taken by a higher priority scheduling class, force it to follow
+	 * the regular scheduling path and give it a chance to run on a
+	 * different CPU.
+	 */
+	if (enq_flags & SCX_ENQ_REENQ)
+		return false;
+
+	/*
+	 * If local_kthread is specified dispatch per-CPU kthreads
+	 * directly on their assigned CPU.
+	 */
+	if (local_kthreads && is_kthread(p) && p->nr_cpus_allowed == 1) {
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, slice_max, enq_flags);
+		__sync_fetch_and_add(&nr_kthread_dispatches, 1);
+
+		return true;
+	}
+
+	/*
+	 * Skip direct dispatch if the CPUs are forced to stay idle.
+	 */
+	if (is_throttled())
+		return false;
+
+	/*
+	 * If ops.select_cpu() has been skipped, try direct dispatch.
+	 */
+	if (!__COMPAT_is_enq_cpu_selected(enq_flags)) {
+		int node = __COMPAT_scx_bpf_cpu_node(prev_cpu);
+
+		/*
+		 * Stop here if direct dispatch is not allowed in the
+		 * target node.
+		 */
+		if (!can_direct_dispatch(node))
+			return false;
+
+		/*
+		 * If local_pcpu is enabled always dispatch tasks that can
+		 * only run on one CPU directly.
+		 *
+		 * This can help to improve I/O workloads (like large
+		 * parallel builds).
+		 */
+		if (local_pcpu && p->nr_cpus_allowed == 1) {
+			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, slice, enq_flags);
+			__sync_fetch_and_add(&nr_direct_dispatches, 1);
+
+			return true;
+		}
+
+		/*
+		 * If the task can only run on a single CPU and that CPU is
+		 * idle, perform a direct dispatch.
+		 */
+		if (p->nr_cpus_allowed == 1 || is_migration_disabled(p)) {
+			if (scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
+				scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL,
+						   slice_max, enq_flags);
+				__sync_fetch_and_add(&nr_direct_dispatches, 1);
+
+				return true;
+			}
+
+			/*
+			 * No need to check for other CPUs if the task can
+			 * only run on a single one.
+			 */
+			return false;
+		}
+
+		/*
+		 * For tasks that are not limited to run on a single CPU,
+		 * check if their previously used CPU is a full-idle SMT
+		 * core and in that case perform a direct dispatch.
+		 */
+		if (is_fully_idle(prev_cpu)) {
+			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | prev_cpu,
+					   slice_max, enq_flags);
+			__sync_fetch_and_add(&nr_direct_dispatches, 1);
+
+			return true;
+		}
+
+		/*
+		 * In case of a remote wakeup (ttwu_queue), attempt a task
+		 * migration.
+		 */
+		if (!scx_bpf_task_running(p)) {
+			bool is_idle = false;
+			s32 cpu;
+
+			cpu = pick_idle_cpu(p, prev_cpu, 0, &is_idle);
+			if (is_idle) {
+				scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, slice_max, 0);
+				__sync_fetch_and_add(&nr_direct_dispatches, 1);
+
+				return true;
+			}
+		}
+	}
+
+	/*
+	 * Direct dispatch not possible, follow the regular scheduling
+	 * path.
+	 */
+	return false;
 }
 
 /*
@@ -217,50 +1014,98 @@ s32 BPF_STRUCT_OPS(flash_select_cpu, struct task_struct *p,
  */
 void BPF_STRUCT_OPS(flash_enqueue, struct task_struct *p, u64 enq_flags)
 {
-	s32 cpu = scx_bpf_task_cpu(p);
-	int node = __COMPAT_scx_bpf_cpu_node(cpu);
+	const struct cpumask *idle_cpumask;
 	struct task_ctx *tctx;
+	u64 slice, deadline;
+	s32 prev_cpu = scx_bpf_task_cpu(p);
+	int node = __COMPAT_scx_bpf_cpu_node(prev_cpu);
 
 	/*
-	 * Per-CPU kthreads can be critical for system responsiveness, when
-	 * local_kthreads is specified they are always dispatched directly
-	 * before any other task.
-	 */
-	if (local_kthreads && is_kthread(p) && (p->nr_cpus_allowed == 1)) {
-		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL,
-				   enq_flags | SCX_ENQ_PREEMPT);
-		__sync_fetch_and_add(&nr_kthread_dispatches, 1);
-		return;
-	}
-
-	/*
-	 * Enqueue the task to the global DSQ. The task will be dispatched on
-	 * the first CPU that becomes available.
+	 * Dispatch regular tasks to the shared DSQ.
 	 */
 	tctx = try_lookup_task_ctx(p);
 	if (!tctx)
 		return;
+	deadline = task_deadline(p, tctx);
+	slice = CLAMP(slice_max / nr_tasks_waiting(node), slice_min, slice_max);
 
-	scx_bpf_dsq_insert_vtime(p, node, task_slice(p, tctx, node),
-				 task_deadline(p, tctx), enq_flags);
+	/*
+	 * Try to dispatch the task directly, if possible.
+	 */
+	if (try_direct_dispatch(p, tctx, prev_cpu, slice, enq_flags))
+		return;
+
+	scx_bpf_dsq_insert_vtime(p, node, slice, deadline, enq_flags);
 	__sync_fetch_and_add(&nr_shared_dispatches, 1);
 
 	/*
-	 * Ensure the CPU currently used by the task is awake.
-	 *
-	 * We don't want to be overly proactive at waking idle CPUs here to
-	 * increase the likelihood that CPU-intensive tasks remain on the
-	 * same CPU if the system is not fully saturated (which should
-	 * benefit cache-sensitive workloads), since they are re-enqueued
-	 * directly via ops.enqueue() on slice exhaustion.
-	 *
-	 * While this may reduce work conservation for CPU-intensive tasks,
-	 * it should also ensures that interactive tasks have more
-	 * opportunities to find an idle CPU via ops.select_cpu(),
-	 * improving their responsiveness.
+	 * If there are idle CPUs in the system try to proactively wake up
+	 * one, so that it can immediately execute the task in case its
+	 * current CPU is busy (always prioritizing full-idle SMT cores
+	 * first, if present).
 	 */
-	if (scx_bpf_test_and_clear_cpu_idle(cpu))
-		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+	idle_cpumask = __COMPAT_scx_bpf_get_idle_cpumask_node(node);
+	if (!bpf_cpumask_empty(idle_cpumask))
+		if (!kick_idle_cpu(p, tctx, prev_cpu, true))
+			kick_idle_cpu(p, tctx, prev_cpu, false);
+	scx_bpf_put_cpumask(idle_cpumask);
+}
+
+/*
+ * Return true if the task can keep running on its current CPU, false if
+ * the task should migrate.
+ */
+static bool keep_running(const struct task_struct *p, s32 cpu)
+{
+	int node = __COMPAT_scx_bpf_cpu_node(cpu);
+	const struct cpumask *primary = cast_mask(primary_cpumask), *smt;
+	const struct cpumask *idle_smtmask, *idle_cpumask;
+	struct cpu_ctx *cctx;
+	bool ret;
+
+	/* Do not keep running if the task doesn't need to run */
+	if (!is_queued(p))
+		return false;
+
+	/* Do not keep running if the CPU is not in the primary domain */
+	if (!primary || !bpf_cpumask_test_cpu(cpu, primary))
+		return false;
+
+	/*
+	 * Keep running only if the task is on a full-idle SMT core (or SMT
+	 * is disabled).
+	 */
+	if (!smt_enabled)
+		return true;
+
+	/*
+	 * If the task can only run on this CPU, keep it running.
+	 */
+	if (p->nr_cpus_allowed == 1)
+		return true;
+
+	cctx = try_lookup_cpu_ctx(cpu);
+	if (!cctx)
+		return false;
+
+	smt = cast_mask(cctx->smt_cpumask);
+	if (!smt)
+		return false;
+
+	idle_smtmask = __COMPAT_scx_bpf_get_idle_smtmask_node(node);
+	idle_cpumask = __COMPAT_scx_bpf_get_idle_cpumask_node(node);
+
+	/*
+	 * If the task is running in a full-idle SMT core or if all the SMT
+	 * cores in the system are busy (they all have at least one busy
+	 * sibling), keep the task running on its current CPU.
+	 */
+	ret = bpf_cpumask_subset(smt, idle_cpumask) || bpf_cpumask_empty(idle_smtmask);
+
+	scx_bpf_put_cpumask(idle_cpumask);
+	scx_bpf_put_cpumask(idle_smtmask);
+
+	return ret;
 }
 
 void BPF_STRUCT_OPS(flash_dispatch, s32 cpu, struct task_struct *prev)
@@ -268,7 +1113,14 @@ void BPF_STRUCT_OPS(flash_dispatch, s32 cpu, struct task_struct *prev)
 	int node = __COMPAT_scx_bpf_cpu_node(cpu);
 
 	/*
-	 * Select a new task to run.
+	 * Let the CPU go idle if the system is throttled.
+	 */
+	if (is_throttled())
+		return;
+
+	/*
+	 * Consume regular tasks from the shared DSQ, transferring them to the
+	 * local CPU DSQ.
 	 */
 	if (scx_bpf_dsq_move_to_local(node))
 		return;
@@ -278,24 +1130,61 @@ void BPF_STRUCT_OPS(flash_dispatch, s32 cpu, struct task_struct *prev)
 	 * to run, simply replenish its time slice and let it run for another
 	 * round on the same CPU.
 	 */
-	if (prev && (prev->scx.flags & SCX_TASK_QUEUED))
-		prev->scx.slice = SCX_SLICE_DFL;
+	if (prev && keep_running(prev, cpu))
+		prev->scx.slice = slice_max;
 }
 
-void BPF_STRUCT_OPS(flash_runnable, struct task_struct *p, u64 enq_flags)
+/*
+ * Update CPU load and scale target performance level accordingly.
+ */
+static void update_cpu_load(struct task_struct *p, struct task_ctx *tctx)
 {
-	struct task_ctx *tctx;
+	u64 now = scx_bpf_now();
+	s32 cpu = scx_bpf_task_cpu(p);
+	u64 perf_lvl, delta_runtime, delta_t;
+	struct cpu_ctx *cctx;
 
-	tctx = try_lookup_task_ctx(p);
-	if (!tctx)
+	/*
+	 * For non-interactive tasks determine their cpufreq scaling factor as
+	 * a function of their CPU utilization.
+	 */
+	cctx = try_lookup_cpu_ctx(cpu);
+	if (!cctx)
 		return;
 
-	tctx->exec_runtime = 0;
+	/*
+	 * Evaluate dynamic cpuperf scaling factor using the average CPU
+	 * utilization, normalized in the range [0 .. SCX_CPUPERF_ONE].
+	 */
+	delta_t = now - cctx->last_running;
+	if (!delta_t)
+		return;
+
+	/*
+	 * Refresh target performance level, if utilization is above 75%
+	 * bump up the performance level to the max.
+	 */
+	delta_runtime = cctx->tot_runtime - cctx->prev_runtime;
+	perf_lvl = MIN(delta_runtime * SCX_CPUPERF_ONE / delta_t, SCX_CPUPERF_ONE);
+	if (perf_lvl >= SCX_CPUPERF_ONE - SCX_CPUPERF_ONE / 4)
+		perf_lvl = SCX_CPUPERF_ONE;
+	cctx->perf_lvl = perf_lvl;
+
+	/*
+	 * Refresh the dynamic cpuperf scaling factor if needed.
+	 */
+	if (cpufreq_perf_lvl < 0)
+		scx_bpf_cpuperf_set(cpu, cctx->perf_lvl);
+
+	cctx->last_running = now;
+	cctx->prev_runtime = cctx->tot_runtime;
 }
 
 void BPF_STRUCT_OPS(flash_running, struct task_struct *p)
 {
 	struct task_ctx *tctx;
+
+	__sync_fetch_and_add(&nr_running, 1);
 
 	tctx = try_lookup_task_ctx(p);
 	if (!tctx)
@@ -303,16 +1192,30 @@ void BPF_STRUCT_OPS(flash_running, struct task_struct *p)
 	tctx->last_run_at = scx_bpf_now();
 
 	/*
-	 * Update global vruntime.
+	 * Adjust target CPU frequency before the task starts to run.
+	 */
+	update_cpu_load(p, tctx);
+
+	/*
+	 * Update the global vruntime as a new task is starting to use a
+	 * CPU.
 	 */
 	if (time_before(vtime_now, tctx->deadline))
 		vtime_now = tctx->deadline;
 }
 
+/*
+ * Update task statistics when the task is releasing the CPU (either
+ * voluntarily or because it expires its assigned time slice).
+ */
 void BPF_STRUCT_OPS(flash_stopping, struct task_struct *p, bool runnable)
 {
+	u64 now = scx_bpf_now(), slice, delta_runtime;
+	s32 cpu = scx_bpf_task_cpu(p);
+	struct cpu_ctx *cctx;
 	struct task_ctx *tctx;
-	u64 slice;
+
+	__sync_fetch_and_sub(&nr_running, 1);
 
 	tctx = try_lookup_task_ctx(p);
 	if (!tctx)
@@ -321,7 +1224,7 @@ void BPF_STRUCT_OPS(flash_stopping, struct task_struct *p, bool runnable)
 	/*
 	 * Evaluate the time slice used by the task.
 	 */
-	slice = scx_bpf_now() - tctx->last_run_at;
+	slice = now - tctx->last_run_at;
 
 	/*
 	 * Update task's execution time (exec_runtime), but never account
@@ -335,76 +1238,27 @@ void BPF_STRUCT_OPS(flash_stopping, struct task_struct *p, bool runnable)
 	/*
 	 * Update task's vruntime.
 	 */
-	tctx->deadline += scale_by_task_weight_inverse(p, slice);
+	tctx->deadline += scale_by_task_normalized_weight_inverse(p, slice);
+
+	/*
+	 * Update CPU runtime.
+	 */
+	cctx = try_lookup_cpu_ctx(cpu);
+	if (!cctx)
+		return;
+	delta_runtime = now - cctx->last_running;
+	cctx->tot_runtime += delta_runtime;
 }
 
-void BPF_STRUCT_OPS(flash_quiescent, struct task_struct *p, u64 deq_flags)
+void BPF_STRUCT_OPS(flash_runnable, struct task_struct *p, u64 enq_flags)
 {
-	u64 now = scx_bpf_now();
-	s64 delta_t;
 	struct task_ctx *tctx;
 
 	tctx = try_lookup_task_ctx(p);
 	if (!tctx)
 		return;
 
-	/*
-	 * Increase the counter of voluntary context switches.
-	 */
-	tctx->nvcsw++;
-
-	/*
-	 * Refresh voluntary context switch metrics.
-	 *
-	 * Evaluate the average number of voluntary context switches per second
-	 * using an exponentially weighted moving average, see calc_avg().
-	 */
-	delta_t = (s64)(now - tctx->nvcsw_ts);
-	if (delta_t > NSEC_PER_SEC) {
-		u64 avg_nvcsw = tctx->nvcsw * NSEC_PER_SEC / delta_t;
-
-		tctx->nvcsw = 0;
-		tctx->nvcsw_ts = now;
-
-		/*
-		 * Evaluate the latency weight of the task as its average rate
-		 * of voluntary context switches (limited to to prevent
-		 * excessive spikes).
-		 */
-		tctx->avg_nvcsw = calc_avg_clamp(tctx->avg_nvcsw, avg_nvcsw,
-						 0, MAX_AVG_NVCSW);
-	}
-}
-
-void BPF_STRUCT_OPS(flash_enable, struct task_struct *p)
-{
-	struct task_ctx *tctx;
-
-	tctx = try_lookup_task_ctx(p);
-	if (!tctx) {
-		scx_bpf_error("incorrectly initialized task: %d (%s)",
-			      p->pid, p->comm);
-		return;
-	}
-	tctx->deadline = vtime_now;
-
-	/*
-	 * Assume new tasks will use the minimum allowed time slice.
-	 */
-	tctx->nvcsw_ts = scx_bpf_now();
-}
-
-s32 BPF_STRUCT_OPS(flash_init_task, struct task_struct *p,
-		   struct scx_init_task_args *args)
-{
-	struct task_ctx *tctx;
-
-	tctx = bpf_task_storage_get(&task_ctx_stor, p, 0,
-				    BPF_LOCAL_STORAGE_GET_F_CREATE);
-	if (!tctx)
-		return -ENOMEM;
-
-	return 0;
+	tctx->exec_runtime = 0;
 }
 
 void BPF_STRUCT_OPS(flash_cpu_release, s32 cpu, struct scx_cpu_release_args *args)
@@ -417,15 +1271,362 @@ void BPF_STRUCT_OPS(flash_cpu_release, s32 cpu, struct scx_cpu_release_args *arg
 	scx_bpf_reenqueue_local();
 }
 
-s32 BPF_STRUCT_OPS_SLEEPABLE(flash_init)
+void BPF_STRUCT_OPS(flash_set_cpumask, struct task_struct *p,
+		    const struct cpumask *cpumask)
 {
-	int err, node;
+	s32 cpu = bpf_get_smp_processor_id();
+	struct task_ctx *tctx;
 
-	/* Initialize the amount of possible CPUs */
-	nr_cpu_ids = scx_bpf_nr_cpu_ids();
+	tctx = try_lookup_task_ctx(p);
+	if (!tctx)
+		return;
+
+	task_update_domain(p, tctx, cpu, cpumask);
+}
+
+void BPF_STRUCT_OPS(flash_enable, struct task_struct *p)
+{
+	struct task_ctx *tctx;
+
+	/* Initialize voluntary context switch timestamp */
+	tctx = try_lookup_task_ctx(p);
+	if (!tctx)
+		return;
 
 	/*
-	 * Create a separate DSQ for each NUMA node.
+	 * Initialize the task vruntime to the current global vruntime.
+	 */
+	tctx->deadline = vtime_now;
+}
+
+s32 BPF_STRUCT_OPS(flash_init_task, struct task_struct *p,
+		   struct scx_init_task_args *args)
+{
+	s32 cpu = bpf_get_smp_processor_id();
+	struct task_ctx *tctx;
+	struct bpf_cpumask *cpumask;
+
+	tctx = bpf_task_storage_get(&task_ctx_stor, p, 0,
+				    BPF_LOCAL_STORAGE_GET_F_CREATE);
+	if (!tctx)
+		return -ENOMEM;
+	/*
+	 * Create task's primary cpumask.
+	 */
+	cpumask = bpf_cpumask_create();
+	if (!cpumask)
+		return -ENOMEM;
+	cpumask = bpf_kptr_xchg(&tctx->cpumask, cpumask);
+	if (cpumask)
+		bpf_cpumask_release(cpumask);
+	/*
+	 * Create task's L2 cache cpumask.
+	 */
+	cpumask = bpf_cpumask_create();
+	if (!cpumask)
+		return -ENOMEM;
+	cpumask = bpf_kptr_xchg(&tctx->l2_cpumask, cpumask);
+	if (cpumask)
+		bpf_cpumask_release(cpumask);
+	/*
+	 * Create task's L3 cache cpumask.
+	 */
+	cpumask = bpf_cpumask_create();
+	if (!cpumask)
+		return -ENOMEM;
+	cpumask = bpf_kptr_xchg(&tctx->l3_cpumask, cpumask);
+	if (cpumask)
+		bpf_cpumask_release(cpumask);
+
+	task_update_domain(p, tctx, cpu, p->cpus_ptr);
+
+	return 0;
+}
+
+/*
+ * Evaluate the amount of online CPUs.
+ */
+s32 get_nr_online_cpus(void)
+{
+	const struct cpumask *online_cpumask;
+	int cpus;
+
+	online_cpumask = scx_bpf_get_online_cpumask();
+	cpus = bpf_cpumask_weight(online_cpumask);
+	scx_bpf_put_cpumask(online_cpumask);
+
+	return cpus;
+}
+
+static int init_cpumask(struct bpf_cpumask **cpumask)
+{
+	struct bpf_cpumask *mask;
+	int err = 0;
+
+	/*
+	 * Do nothing if the mask is already initialized.
+	 */
+	mask = *cpumask;
+	if (mask)
+		return 0;
+	/*
+	 * Create the CPU mask.
+	 */
+	err = calloc_cpumask(cpumask);
+	if (!err)
+		mask = *cpumask;
+	if (!mask)
+		err = -ENOMEM;
+
+	return err;
+}
+
+SEC("syscall")
+int enable_sibling_cpu(struct domain_arg *input)
+{
+	struct cpu_ctx *cctx;
+	struct bpf_cpumask *mask, **pmask;
+	int err = 0;
+
+	cctx = try_lookup_cpu_ctx(input->cpu_id);
+	if (!cctx)
+		return -ENOENT;
+
+	/* Make sure the target CPU mask is initialized */
+	switch (input->lvl_id) {
+	case 0:
+		pmask = &cctx->smt_cpumask;
+		break;
+	case 2:
+		pmask = &cctx->l2_cpumask;
+		break;
+	case 3:
+		pmask = &cctx->l3_cpumask;
+		break;
+	default:
+		return -EINVAL;
+	}
+	err = init_cpumask(pmask);
+	if (err)
+		return err;
+
+	bpf_rcu_read_lock();
+	mask = *pmask;
+	if (mask)
+		bpf_cpumask_set_cpu(input->sibling_cpu_id, mask);
+	bpf_rcu_read_unlock();
+
+	return err;
+}
+
+SEC("syscall")
+int enable_primary_cpu(struct cpu_arg *input)
+{
+	struct bpf_cpumask *mask;
+	int err = 0;
+
+	/* Make sure the primary CPU mask is initialized */
+	err = init_cpumask(&primary_cpumask);
+	if (err)
+		return err;
+	/*
+	 * Enable the target CPU in the primary scheduling domain. If the
+	 * target CPU is a negative value, clear the whole mask (this can be
+	 * used to reset the primary domain).
+	 */
+	bpf_rcu_read_lock();
+	mask = primary_cpumask;
+	if (mask) {
+		s32 cpu = input->cpu_id;
+
+		if (cpu < 0)
+			bpf_cpumask_clear(mask);
+		else
+			bpf_cpumask_set_cpu(cpu, mask);
+	}
+	bpf_rcu_read_unlock();
+
+	return err;
+}
+
+/*
+ * Initialize cpufreq performance level on all the online CPUs.
+ */
+static void init_cpuperf_target(void)
+{
+	const struct cpumask *online_cpumask;
+	struct node_ctx *nctx;
+	u64 perf_lvl;
+	int node;
+	s32 cpu;
+
+	online_cpumask = scx_bpf_get_online_cpumask();
+	bpf_for (cpu, 0, nr_cpu_ids) {
+		if (!bpf_cpumask_test_cpu(cpu, online_cpumask))
+			continue;
+
+		/* Set the initial cpufreq performance level  */
+		if (cpufreq_perf_lvl < 0)
+			perf_lvl = SCX_CPUPERF_ONE;
+		else
+			perf_lvl = MIN(cpufreq_perf_lvl, SCX_CPUPERF_ONE);
+		scx_bpf_cpuperf_set(cpu, perf_lvl);
+
+		/* Evaluate the amount of online CPUs for each node */
+		node = __COMPAT_scx_bpf_cpu_node(cpu);
+		nctx = try_lookup_node_ctx(node);
+		if (nctx)
+			nctx->nr_cpus++;
+	}
+	scx_bpf_put_cpumask(online_cpumask);
+}
+
+/*
+ * Throttle timer used to inject idle time across all the CPUs.
+ */
+static int throttle_timerfn(void *map, int *key, struct bpf_timer *timer)
+{
+	bool throttled = is_throttled();
+	u64 flags, duration;
+	s32 cpu;
+	int err;
+
+	/*
+	 * Stop the CPUs sending a preemption IPI (SCX_KICK_PREEMPT) if we
+	 * need to interrupt the running tasks and inject the idle sleep.
+	 *
+	 * Otherwise, send a wakeup IPI to resume from the injected idle
+	 * sleep.
+	 */
+	if (throttled) {
+		flags = SCX_KICK_IDLE;
+		duration = slice_max;
+	} else {
+		flags = SCX_KICK_PREEMPT;
+		duration = throttle_ns;
+	}
+
+	/*
+	 * Flip the throttled state.
+	 */
+	set_throttled(!throttled);
+
+	bpf_for(cpu, 0, nr_cpu_ids)
+		scx_bpf_kick_cpu(cpu, flags);
+
+	/*
+	 * Re-arm the duty-cycle timer setting the runtime or the idle time
+	 * duration.
+	 */
+	err = bpf_timer_start(timer, duration, 0);
+	if (err)
+		scx_bpf_error("Failed to re-arm duty cycle timer");
+
+	return 0;
+}
+
+/*
+ * Refresh NUMA statistics.
+ */
+static int numa_timerfn(void *map, int *key, struct bpf_timer *timer)
+{
+	const struct cpumask *online_cpumask;
+	struct node_ctx *nctx;
+	int node, err;
+	bool has_idle_nodes = false;
+	s32 cpu;
+
+	/*
+	 * Update node statistics.
+	 */
+	online_cpumask = scx_bpf_get_online_cpumask();
+	bpf_for (cpu, 0, nr_cpu_ids) {
+		struct cpu_ctx *cctx;
+
+		if (!bpf_cpumask_test_cpu(cpu, online_cpumask))
+			continue;
+
+		cctx = try_lookup_cpu_ctx(cpu);
+		if (!cctx)
+			continue;
+
+		node = __COMPAT_scx_bpf_cpu_node(cpu);
+		nctx = try_lookup_node_ctx(node);
+		if (!nctx)
+			continue;
+
+		nctx->tot_perf_lvl += cctx->perf_lvl;
+	}
+	scx_bpf_put_cpumask(online_cpumask);
+
+	/*
+	 * Update node utilization.
+	 */
+	bpf_for(node, 0, __COMPAT_scx_bpf_nr_node_ids()) {
+		nctx = try_lookup_node_ctx(node);
+		if (!nctx || !nctx->nr_cpus)
+			continue;
+
+		/*
+		 * Evaluate node utilization as the average perf_lvl among
+		 * its CPUs.
+		 */
+		nctx->perf_lvl = nctx->tot_perf_lvl / nctx->nr_cpus;
+
+		/*
+		 * System has at least one idle node if its current
+		 * utilization is 25% or below.
+		 */
+		if (nctx->perf_lvl <= SCX_CPUPERF_ONE / 4)
+			has_idle_nodes = true;
+
+		/*
+		 * Reset partial performance level.
+		 */
+		nctx->tot_perf_lvl = 0;
+	}
+
+	/*
+	 * Determine nodes that need a rebalance.
+	 */
+	bpf_for(node, 0, __COMPAT_scx_bpf_nr_node_ids()) {
+		nctx = try_lookup_node_ctx(node);
+		if (!nctx)
+			continue;
+
+		/*
+		 * If the current node utilization is 50% or more and there
+		 * is at least an idle node in the system, trigger a
+		 * rebalance.
+		 */
+		nctx->need_rebalance = has_idle_nodes && nctx->perf_lvl >= SCX_CPUPERF_ONE / 2;
+
+		dbg_msg("node %d util %llu rebalance %d",
+			   node, nctx->perf_lvl, nctx->need_rebalance);
+	}
+
+	err = bpf_timer_start(timer, NSEC_PER_SEC, 0);
+	if (err)
+		scx_bpf_error("Failed to start NUMA timer");
+
+	return 0;
+}
+
+s32 BPF_STRUCT_OPS_SLEEPABLE(flash_init)
+{
+	struct bpf_timer *timer;
+	int err, node;
+	u32 key = 0;
+
+	/* Initialize amount of online and possible CPUs */
+	nr_online_cpus = get_nr_online_cpus();
+	nr_cpu_ids = scx_bpf_nr_cpu_ids();
+
+	/* Initialize CPUs and NUMA properties */
+	init_cpuperf_target();
+
+	/*
+	 * Create the global shared DSQ.
 	 */
 	bpf_for(node, 0, __COMPAT_scx_bpf_nr_node_ids()) {
 		err = scx_bpf_create_dsq(node, node);
@@ -433,6 +1634,48 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(flash_init)
 			scx_bpf_error("failed to create DSQ %d: %d", node, err);
 			return err;
 		}
+	}
+
+	/* Initialize the primary scheduling domain */
+	err = init_cpumask(&primary_cpumask);
+	if (err)
+		return err;
+
+	timer = bpf_map_lookup_elem(&throttle_timer, &key);
+	if (!timer) {
+		scx_bpf_error("Failed to lookup throttle timer");
+		return -ESRCH;
+	}
+
+	/*
+	 * Fire the throttle timer if CPU throttling is enabled.
+	 */
+	if (throttle_ns) {
+		bpf_timer_init(timer, &throttle_timer, CLOCK_BOOTTIME);
+		bpf_timer_set_callback(timer, throttle_timerfn);
+		err = bpf_timer_start(timer, slice_max, 0);
+		if (err) {
+			scx_bpf_error("Failed to arm throttle timer");
+			return err;
+		}
+	}
+
+	/* Do not update NUMA statistics if there's only one node */
+	if (numa_disabled || __COMPAT_scx_bpf_nr_node_ids() <= 1)
+		return 0;
+
+	timer = bpf_map_lookup_elem(&numa_timer, &key);
+	if (!timer) {
+		scx_bpf_error("Failed to lookup NUMA timer");
+		return -ESRCH;
+	}
+
+	bpf_timer_init(timer, &numa_timer, CLOCK_BOOTTIME);
+	bpf_timer_set_callback(timer, numa_timerfn);
+	err = bpf_timer_start(timer, NSEC_PER_SEC, 0);
+	if (err) {
+		scx_bpf_error("Failed to start NUMA timer");
+		return err;
 	}
 
 	return 0;
@@ -447,14 +1690,14 @@ SCX_OPS_DEFINE(flash_ops,
 	       .select_cpu		= (void *)flash_select_cpu,
 	       .enqueue			= (void *)flash_enqueue,
 	       .dispatch		= (void *)flash_dispatch,
-	       .runnable		= (void *)flash_runnable,
 	       .running			= (void *)flash_running,
 	       .stopping		= (void *)flash_stopping,
-	       .quiescent		= (void *)flash_quiescent,
+	       .runnable		= (void *)flash_runnable,
+	       .cpu_release		= (void *)flash_cpu_release,
+	       .set_cpumask		= (void *)flash_set_cpumask,
 	       .enable			= (void *)flash_enable,
 	       .init_task		= (void *)flash_init_task,
-	       .cpu_release		= (void *)flash_cpu_release,
 	       .init			= (void *)flash_init,
 	       .exit			= (void *)flash_exit,
-	       .timeout_ms		= 5000U,
+	       .timeout_ms		= 5000,
 	       .name			= "flash");

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -11,6 +11,9 @@ pub mod bpf_intf;
 pub use bpf_intf::*;
 
 mod stats;
+use std::collections::BTreeMap;
+use std::ffi::c_int;
+use std::fmt::Write;
 use std::mem::MaybeUninit;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -21,26 +24,86 @@ use anyhow::Context;
 use anyhow::Result;
 use clap::Parser;
 use crossbeam::channel::RecvTimeoutError;
-use libbpf_rs::libbpf_sys::bpf_program__set_autoload;
-use libbpf_rs::AsRawLibbpf;
 use libbpf_rs::OpenObject;
-use log::info;
+use libbpf_rs::ProgramInput;
 use log::warn;
+use log::{debug, info};
 use scx_stats::prelude::*;
+use scx_utils::autopower::{fetch_power_profile, PowerProfile};
 use scx_utils::build_id;
 use scx_utils::compat;
+use scx_utils::pm::{cpu_idle_resume_latency_supported, update_cpu_idle_resume_latency};
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
 use scx_utils::set_rlimit_infinity;
 use scx_utils::uei_exited;
 use scx_utils::uei_report;
+use scx_utils::CoreType;
+use scx_utils::Cpumask;
 use scx_utils::Topology;
 use scx_utils::UserExitInfo;
+use scx_utils::NR_CPU_IDS;
 use stats::Metrics;
 
-const SCHEDULER_NAME: &'static str = "scx_flash";
+const SCHEDULER_NAME: &str = "scx_flash";
 
+#[derive(PartialEq)]
+enum Powermode {
+    Performance,
+    Powersave,
+    Any,
+}
+
+fn get_primary_cpus(mode: Powermode) -> std::io::Result<Vec<usize>> {
+    let topo = Topology::new().unwrap();
+
+    let cpus: Vec<usize> = topo
+        .all_cores
+        .values()
+        .flat_map(|core| &core.cpus)
+        .filter_map(|(cpu_id, cpu)| match (&mode, &cpu.core_type) {
+            // Performance mode: add all the Big CPUs (either Turbo or non-Turbo)
+            (Powermode::Performance, CoreType::Big { .. }) |
+            // Powersave mode: add all the Little CPUs
+            (Powermode::Powersave, CoreType::Little) => Some(*cpu_id),
+            (Powermode::Any, ..) => Some(*cpu_id),
+            _ => None,
+        })
+        .collect();
+
+    Ok(cpus)
+}
+
+// Convert an array of CPUs to the corresponding cpumask of any arbitrary size.
+fn cpus_to_cpumask(cpus: &Vec<usize>) -> String {
+    if cpus.is_empty() {
+        return String::from("none");
+    }
+
+    // Determine the maximum CPU ID to create a sufficiently large byte vector.
+    let max_cpu_id = *cpus.iter().max().unwrap();
+
+    // Create a byte vector with enough bytes to cover all CPU IDs.
+    let mut bitmask = vec![0u8; (max_cpu_id + 1 + 7) / 8];
+
+    // Set the appropriate bits for each CPU ID.
+    for cpu_id in cpus {
+        let byte_index = cpu_id / 8;
+        let bit_index = cpu_id % 8;
+        bitmask[byte_index] |= 1 << bit_index;
+    }
+
+    // Convert the byte vector to a hexadecimal string.
+    let hex_str: String = bitmask.iter().rev().fold(String::new(), |mut f, byte| {
+        let _ = write!(&mut f, "{:02x}", byte);
+        f
+    });
+
+    format!("0x{}", hex_str)
+}
+
+/// scx_flash: a deadline-based sched_ext scheduler that prioritizes interactive workloads.
 #[derive(Debug, Parser)]
 struct Opts {
     /// Exit debug dump buffer length. 0 indicates default.
@@ -49,22 +112,101 @@ struct Opts {
 
     /// Maximum scheduling slice duration in microseconds.
     #[clap(short = 's', long, default_value = "20000")]
-    slice_us_max: u64,
+    slice_us: u64,
+
+    /// Minimum scheduling slice duration in microseconds.
+    #[clap(short = 'S', long, default_value = "1000")]
+    slice_us_min: u64,
 
     /// Maximum time slice lag in microseconds.
     ///
-    /// Increasing this value can help to enhance the responsiveness of interactive tasks, but it
-    /// can also make performance more "spikey".
-    #[clap(short = 'l', long, default_value = "20000")]
-    slice_us_lag: u64,
-
-    /// Enable kthreads prioritization.
+    /// A positive value can help to enhance the responsiveness of interactive tasks, but it can
+    /// also make performance more "spikey".
     ///
-    /// Enabling this can improve system performance, but it may also introduce interactivity
-    /// issues or unfairness in scenarios with high kthread activity, such as heavy I/O or network
-    /// traffic.
+    /// A negative value can make performance more consistent, but it can also reduce the
+    /// responsiveness of interactive tasks (by smoothing the effect of the vruntime scheduling and
+    /// making the task ordering closer to a FIFO).
+    #[clap(short = 'l', long, allow_hyphen_values = true, default_value = "5000")]
+    slice_us_lag: i64,
+
+    /// Throttle the running CPUs by periodically injecting idle cycles.
+    ///
+    /// This option can help extend battery life on portable devices, reduce heating, fan noise
+    /// and overall energy consumption (0 = disable).
+    #[clap(short = 't', long, default_value = "0")]
+    throttle_us: u64,
+
+    /// Set CPU idle QoS resume latency in microseconds (-1 = disabled).
+    ///
+    /// Setting a lower latency value makes CPUs less likely to enter deeper idle states, enhancing
+    /// performance at the cost of higher power consumption. Alternatively, increasing the latency
+    /// value may reduce performance, but also improve power efficiency.
+    #[clap(short = 'I', long, allow_hyphen_values = true, default_value = "-1")]
+    idle_resume_us: i64,
+
+    /// Enable per-CPU tasks prioritization.
+    ///
+    /// This allows to prioritize per-CPU tasks that usually tend to be de-prioritized (since they
+    /// can't be migrated when their only usable CPU is busy). Enabling this option can introduce
+    /// unfairness and potentially trigger stalls, but it can improve performance of server-type
+    /// workloads (such as large parallel builds).
+    #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
+    local_pcpu: bool,
+
+    /// Enable kthreads prioritization (EXPERIMENTAL).
+    ///
+    /// Enabling this can improve system performance, but it may also introduce noticeable
+    /// interactivity issues or unfairness in scenarios with high kthread activity, such as heavy
+    /// I/O or network traffic.
+    ///
+    /// Use it only when conducting specific experiments or if you have a clear understanding of
+    /// its implications.
     #[clap(short = 'k', long, action = clap::ArgAction::SetTrue)]
     local_kthreads: bool,
+
+    /// Disable direct dispatch during synchronous wakeups.
+    ///
+    /// Enabling this option can lead to a more uniform load distribution across available cores,
+    /// potentially improving performance in certain scenarios. However, it may come at the cost of
+    /// reduced efficiency for pipe-intensive workloads that benefit from tighter producer-consumer
+    /// coupling.
+    #[clap(short = 'w', long, action = clap::ArgAction::SetTrue)]
+    no_wake_sync: bool,
+
+    /// Specifies the initial set of CPUs, represented as a bitmask in hex (e.g., 0xff), that the
+    /// scheduler will use to dispatch tasks, until the system becomes saturated, at which point
+    /// tasks may overflow to other available CPUs.
+    ///
+    /// Special values:
+    ///  - "auto" = automatically detect the CPUs based on the active power profile
+    ///  - "performance" = automatically detect and prioritize the fastest CPUs
+    ///  - "powersave" = automatically detect and prioritize the slowest CPUs
+    ///  - "all" = all CPUs assigned to the primary domain
+    ///  - "none" = no prioritization, tasks are dispatched on the first CPU available
+    #[clap(short = 'm', long, default_value = "auto")]
+    primary_domain: String,
+
+    /// Disable L2 cache awareness.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    disable_l2: bool,
+
+    /// Disable L3 cache awareness.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    disable_l3: bool,
+
+    /// Disable SMT awareness.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    disable_smt: bool,
+
+    /// Disable NUMA rebalancing.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    disable_numa: bool,
+
+    /// Enable CPU frequency control (only with schedutil governor).
+    ///
+    /// With this option enabled the CPU frequency will be automatically scaled based on the load.
+    #[clap(short = 'f', long, action = clap::ArgAction::SetTrue)]
+    cpufreq: bool,
 
     /// Enable stats monitoring with the specified interval.
     #[clap(long)]
@@ -74,6 +216,10 @@ struct Opts {
     /// is not launched.
     #[clap(long)]
     monitor: Option<f64>,
+
+    /// Enable BPF debugging via /sys/kernel/tracing/trace_pipe.
+    #[clap(short = 'd', long, action = clap::ArgAction::SetTrue)]
+    debug: bool,
 
     /// Enable verbose output, including libbpf details.
     #[clap(short = 'v', long, action = clap::ArgAction::SetTrue)]
@@ -91,27 +237,46 @@ struct Opts {
 struct Scheduler<'a> {
     skel: BpfSkel<'a>,
     struct_ops: Option<libbpf_rs::Link>,
+    opts: &'a Opts,
+    topo: Topology,
+    power_profile: PowerProfile,
     stats_server: StatsServer<(), Metrics>,
+    user_restart: bool,
 }
 
 impl<'a> Scheduler<'a> {
     fn init(opts: &'a Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
         set_rlimit_infinity();
 
+        // Validate command line arguments.
+        assert!(opts.slice_us >= opts.slice_us_min);
+
         // Initialize CPU topology.
         let topo = Topology::new().unwrap();
 
         // Check host topology to determine if we need to enable SMT capabilities.
+        let smt_enabled = !opts.disable_smt && topo.smt_enabled;
+
         info!(
             "{} {} {}",
             SCHEDULER_NAME,
             build_id::full_version(env!("CARGO_PKG_VERSION")),
-            if topo.smt_enabled {
-                "SMT on"
-            } else {
-                "SMT off"
-            }
+            if smt_enabled { "SMT on" } else { "SMT off" }
         );
+
+        if opts.idle_resume_us >= 0 {
+            if !cpu_idle_resume_latency_supported() {
+                warn!("idle resume latency not supported");
+            } else {
+                info!("Setting idle QoS to {} us", opts.idle_resume_us);
+                for cpu in topo.all_cpus.values() {
+                    update_cpu_idle_resume_latency(
+                        cpu.id,
+                        opts.idle_resume_us.try_into().unwrap(),
+                    )?;
+                }
+            }
+        }
 
         // Initialize BPF connector.
         let mut skel_builder = BpfSkelBuilder::default();
@@ -121,31 +286,29 @@ impl<'a> Scheduler<'a> {
         skel.struct_ops.flash_ops_mut().exit_dump_len = opts.exit_dump_len;
 
         // Override default BPF scheduling parameters.
-        skel.maps.rodata_data.slice_max = opts.slice_us_max * 1000;
+        skel.maps.rodata_data.debug = opts.debug;
+        skel.maps.rodata_data.smt_enabled = smt_enabled;
+        skel.maps.rodata_data.numa_disabled = opts.disable_numa;
+        skel.maps.rodata_data.local_pcpu = opts.local_pcpu;
+        skel.maps.rodata_data.no_wake_sync = opts.no_wake_sync;
+        skel.maps.rodata_data.slice_max = opts.slice_us * 1000;
+        skel.maps.rodata_data.slice_min = opts.slice_us_min * 1000;
         skel.maps.rodata_data.slice_lag = opts.slice_us_lag * 1000;
-        skel.maps.rodata_data.local_kthreads = opts.local_kthreads;
+        skel.maps.rodata_data.throttle_ns = opts.throttle_us * 1000;
 
-        skel.maps.rodata_data.smt_enabled = topo.smt_enabled;
+        // Implicitly enable direct dispatch of per-CPU kthreads if CPU throttling is enabled
+        // (it's never a good idea to throttle per-CPU kthreads).
+        skel.maps.rodata_data.local_kthreads = opts.local_kthreads || opts.throttle_us > 0;
 
-        // Conditionally load the kprobes used by the scheduler.
-        if compat::ksym_exists("vfs_fsync_range").unwrap_or(false) {
-            unsafe {
-                bpf_program__set_autoload(
-                    skel.progs
-                        .kprobe_vfs_fsync_range
-                        .as_libbpf_object()
-                        .as_ptr(),
-                    true,
-                );
-            }
-        } else {
-            warn!("vfs_fsync_range symbol is missing")
-        }
+        // Set scheduler compatibility flags.
+        skel.maps.rodata_data.__COMPAT_SCX_PICK_IDLE_IN_NODE = *compat::SCX_PICK_IDLE_IN_NODE;
 
         // Set scheduler flags.
         skel.struct_ops.flash_ops_mut().flags = *compat::SCX_OPS_ENQ_EXITING
             | *compat::SCX_OPS_ENQ_LAST
-            | *compat::SCX_OPS_ENQ_MIGRATION_DISABLED;
+            | *compat::SCX_OPS_ENQ_MIGRATION_DISABLED
+            | *compat::SCX_OPS_BUILTIN_IDLE_PER_NODE
+            | *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP;
         info!(
             "scheduler flags: {:#x}",
             skel.struct_ops.flash_ops_mut().flags
@@ -154,6 +317,32 @@ impl<'a> Scheduler<'a> {
         // Load the BPF program for validation.
         let mut skel = scx_ops_load!(skel, flash_ops, uei)?;
 
+        // Initialize the primary scheduling domain and the preferred domain.
+        let power_profile = Self::power_profile();
+        if let Err(err) = Self::init_energy_domain(&mut skel, &opts.primary_domain, power_profile) {
+            warn!("failed to initialize primary domain: error {}", err);
+        }
+        if let Err(err) = Self::init_cpufreq_perf(&mut skel, &opts.primary_domain, opts.cpufreq) {
+            warn!(
+                "failed to initialize cpufreq performance level: error {}",
+                err
+            );
+        }
+
+        // Initialize SMT domains.
+        if smt_enabled {
+            Self::init_smt_domains(&mut skel, &topo)?;
+        }
+
+        // Initialize L2 cache domains.
+        if !opts.disable_l2 {
+            Self::init_l2_cache_domains(&mut skel, &topo)?;
+        }
+        // Initialize L3 cache domains.
+        if !opts.disable_l3 {
+            Self::init_l3_cache_domains(&mut skel, &topo)?;
+        }
+
         // Attach the scheduler.
         let struct_ops = Some(scx_ops_attach!(skel, flash_ops)?);
         let stats_server = StatsServer::new(stats::server_data()).launch()?;
@@ -161,12 +350,269 @@ impl<'a> Scheduler<'a> {
         Ok(Self {
             skel,
             struct_ops,
+            opts,
+            topo,
+            power_profile,
             stats_server,
+            user_restart: false,
+        })
+    }
+
+    fn enable_primary_cpu(skel: &mut BpfSkel<'_>, cpu: i32) -> Result<(), u32> {
+        let prog = &mut skel.progs.enable_primary_cpu;
+        let mut args = cpu_arg {
+            cpu_id: cpu as c_int,
+        };
+        let input = ProgramInput {
+            context_in: Some(unsafe {
+                std::slice::from_raw_parts_mut(
+                    &mut args as *mut _ as *mut u8,
+                    std::mem::size_of_val(&args),
+                )
+            }),
+            ..Default::default()
+        };
+        let out = prog.test_run(input).unwrap();
+        if out.return_value != 0 {
+            return Err(out.return_value);
+        }
+
+        Ok(())
+    }
+
+    fn epp_to_cpumask(profile: Powermode) -> Result<Cpumask> {
+        let mut cpus = get_primary_cpus(profile).unwrap_or_default();
+        if cpus.is_empty() {
+            cpus = get_primary_cpus(Powermode::Any).unwrap_or_default();
+        }
+        Cpumask::from_str(&cpus_to_cpumask(&cpus))
+    }
+
+    fn init_energy_domain(
+        skel: &mut BpfSkel<'_>,
+        primary_domain: &str,
+        power_profile: PowerProfile,
+    ) -> Result<()> {
+        let domain = match primary_domain {
+            "powersave" => Self::epp_to_cpumask(Powermode::Powersave)?,
+            "performance" => Self::epp_to_cpumask(Powermode::Performance)?,
+            "auto" => match power_profile {
+                PowerProfile::Powersave => Self::epp_to_cpumask(Powermode::Powersave)?,
+                PowerProfile::Balanced { power: true } => {
+                    Self::epp_to_cpumask(Powermode::Powersave)?
+                }
+                PowerProfile::Balanced { power: false } => Self::epp_to_cpumask(Powermode::Any)?,
+                PowerProfile::Performance => Self::epp_to_cpumask(Powermode::Any)?,
+                PowerProfile::Unknown => Self::epp_to_cpumask(Powermode::Any)?,
+            },
+            "all" => Self::epp_to_cpumask(Powermode::Any)?,
+            &_ => Cpumask::from_str(primary_domain)?,
+        };
+
+        info!("primary CPU domain = 0x{:x}", domain);
+
+        // Clear the primary domain by passing a negative CPU id.
+        if let Err(err) = Self::enable_primary_cpu(skel, -1) {
+            warn!("failed to reset primary domain: error {}", err);
+        }
+        // Update primary scheduling domain.
+        for cpu in 0..*NR_CPU_IDS {
+            if domain.test_cpu(cpu) {
+                if let Err(err) = Self::enable_primary_cpu(skel, cpu as i32) {
+                    warn!("failed to add CPU {} to primary domain: error {}", cpu, err);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    // Update hint for the cpufreq governor.
+    fn init_cpufreq_perf(
+        skel: &mut BpfSkel<'_>,
+        primary_domain: &String,
+        auto: bool,
+    ) -> Result<()> {
+        // If we are using the powersave profile always scale the CPU frequency to the minimum,
+        // otherwise use the maximum, unless automatic frequency scaling is enabled.
+        let perf_lvl: i64 = match primary_domain.as_str() {
+            "powersave" => 0,
+            _ if auto => -1,
+            _ => 1024,
+        };
+        info!(
+            "cpufreq performance level: {}",
+            match perf_lvl {
+                1024 => "max".into(),
+                0 => "min".into(),
+                n if n < 0 => "auto".into(),
+                _ => perf_lvl.to_string(),
+            }
+        );
+        skel.maps.bss_data.cpufreq_perf_lvl = perf_lvl;
+
+        Ok(())
+    }
+
+    fn power_profile() -> PowerProfile {
+        let profile = fetch_power_profile(true);
+        if profile == PowerProfile::Unknown {
+            fetch_power_profile(false)
+        } else {
+            profile
+        }
+    }
+
+    fn refresh_sched_domain(&mut self) -> bool {
+        if self.power_profile != PowerProfile::Unknown {
+            let power_profile = Self::power_profile();
+            if power_profile != self.power_profile {
+                self.power_profile = power_profile;
+
+                if self.opts.primary_domain == "auto" {
+                    return true;
+                }
+                if let Err(err) = Self::init_cpufreq_perf(
+                    &mut self.skel,
+                    &self.opts.primary_domain,
+                    self.opts.cpufreq,
+                ) {
+                    warn!("failed to refresh cpufreq performance level: error {}", err);
+                }
+            }
+        }
+
+        false
+    }
+
+    fn enable_sibling_cpu(
+        skel: &mut BpfSkel<'_>,
+        lvl: usize,
+        cpu: usize,
+        sibling_cpu: usize,
+    ) -> Result<(), u32> {
+        let prog = &mut skel.progs.enable_sibling_cpu;
+        let mut args = domain_arg {
+            lvl_id: lvl as c_int,
+            cpu_id: cpu as c_int,
+            sibling_cpu_id: sibling_cpu as c_int,
+        };
+        let input = ProgramInput {
+            context_in: Some(unsafe {
+                std::slice::from_raw_parts_mut(
+                    &mut args as *mut _ as *mut u8,
+                    std::mem::size_of_val(&args),
+                )
+            }),
+            ..Default::default()
+        };
+        let out = prog.test_run(input).unwrap();
+        if out.return_value != 0 {
+            return Err(out.return_value);
+        }
+
+        Ok(())
+    }
+
+    fn init_smt_domains(skel: &mut BpfSkel<'_>, topo: &Topology) -> Result<(), std::io::Error> {
+        let smt_siblings = topo.sibling_cpus();
+
+        info!("SMT sibling CPUs: {:?}", smt_siblings);
+        for (cpu, sibling_cpu) in smt_siblings.iter().enumerate() {
+            Self::enable_sibling_cpu(skel, 0, cpu, *sibling_cpu as usize).unwrap();
+        }
+
+        Ok(())
+    }
+
+    fn are_smt_siblings(topo: &Topology, cpus: &[usize]) -> bool {
+        // Single CPU or empty array are considered siblings.
+        if cpus.len() <= 1 {
+            return true;
+        }
+
+        // Check if each CPU is a sibling of the first CPU.
+        let first_cpu = cpus[0];
+        let smt_siblings = topo.sibling_cpus();
+        cpus.iter().all(|&cpu| {
+            cpu == first_cpu
+                || smt_siblings[cpu] == first_cpu as i32
+                || (smt_siblings[first_cpu] >= 0 && smt_siblings[first_cpu] == cpu as i32)
+        })
+    }
+
+    fn init_cache_domains(
+        skel: &mut BpfSkel<'_>,
+        topo: &Topology,
+        cache_lvl: usize,
+        enable_sibling_cpu_fn: &dyn Fn(&mut BpfSkel<'_>, usize, usize, usize) -> Result<(), u32>,
+    ) -> Result<(), std::io::Error> {
+        // Determine the list of CPU IDs associated to each cache node.
+        let mut cache_id_map: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+        for core in topo.all_cores.values() {
+            for (cpu_id, cpu) in &core.cpus {
+                let cache_id = match cache_lvl {
+                    2 => cpu.l2_id,
+                    3 => cpu.llc_id,
+                    _ => panic!("invalid cache level {}", cache_lvl),
+                };
+                cache_id_map.entry(cache_id).or_default().push(*cpu_id);
+            }
+        }
+
+        // Update the BPF cpumasks for the cache domains.
+        for (cache_id, cpus) in cache_id_map {
+            // Ignore the cache domain if it includes a single CPU.
+            if cpus.len() <= 1 {
+                continue;
+            }
+
+            // Ignore the cache domain if all the CPUs are part of the same SMT core.
+            if Self::are_smt_siblings(topo, &cpus) {
+                continue;
+            }
+
+            info!(
+                "L{} cache ID {}: sibling CPUs: {:?}",
+                cache_lvl, cache_id, cpus
+            );
+            for cpu in &cpus {
+                for sibling_cpu in &cpus {
+                    if enable_sibling_cpu_fn(skel, cache_lvl, *cpu, *sibling_cpu).is_err() {
+                        warn!(
+                            "L{} cache ID {}: failed to set CPU {} sibling {}",
+                            cache_lvl, cache_id, *cpu, *sibling_cpu
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn init_l2_cache_domains(
+        skel: &mut BpfSkel<'_>,
+        topo: &Topology,
+    ) -> Result<(), std::io::Error> {
+        Self::init_cache_domains(skel, topo, 2, &|skel, lvl, cpu, sibling_cpu| {
+            Self::enable_sibling_cpu(skel, lvl, cpu, sibling_cpu)
+        })
+    }
+
+    fn init_l3_cache_domains(
+        skel: &mut BpfSkel<'_>,
+        topo: &Topology,
+    ) -> Result<(), std::io::Error> {
+        Self::init_cache_domains(skel, topo, 3, &|skel, lvl, cpu, sibling_cpu| {
+            Self::enable_sibling_cpu(skel, lvl, cpu, sibling_cpu)
         })
     }
 
     fn get_metrics(&self) -> Metrics {
         Metrics {
+            nr_running: self.skel.maps.bss_data.nr_running,
+            nr_cpus: self.skel.maps.bss_data.nr_online_cpus,
             nr_kthread_dispatches: self.skel.maps.bss_data.nr_kthread_dispatches,
             nr_direct_dispatches: self.skel.maps.bss_data.nr_direct_dispatches,
             nr_shared_dispatches: self.skel.maps.bss_data.nr_shared_dispatches,
@@ -180,6 +626,10 @@ impl<'a> Scheduler<'a> {
     fn run(&mut self, shutdown: Arc<AtomicBool>) -> Result<UserExitInfo> {
         let (res_ch, req_ch) = self.stats_server.channels();
         while !shutdown.load(Ordering::Relaxed) && !self.exited() {
+            if self.refresh_sched_domain() {
+                self.user_restart = true;
+                break;
+            }
             match req_ch.recv_timeout(Duration::from_secs(1)) {
                 Ok(()) => res_ch.send(self.get_metrics())?,
                 Err(RecvTimeoutError::Timeout) => {}
@@ -195,6 +645,16 @@ impl<'a> Scheduler<'a> {
 impl Drop for Scheduler<'_> {
     fn drop(&mut self) {
         info!("Unregister {} scheduler", SCHEDULER_NAME);
+
+        // Restore default CPU idle QoS resume latency.
+        if self.opts.idle_resume_us >= 0 {
+            if cpu_idle_resume_latency_supported() {
+                for cpu in self.topo.all_cpus.values() {
+                    update_cpu_idle_resume_latency(cpu.id, cpu.pm_qos_resume_latency_us as i32)
+                        .unwrap();
+                }
+            }
+        }
     }
 }
 
@@ -241,7 +701,17 @@ fn main() -> Result<()> {
     if let Some(intv) = opts.monitor.or(opts.stats) {
         let shutdown_copy = shutdown.clone();
         let jh = std::thread::spawn(move || {
-            stats::monitor(Duration::from_secs_f64(intv), shutdown_copy).unwrap()
+            match stats::monitor(Duration::from_secs_f64(intv), shutdown_copy) {
+                Ok(_) => {
+                    debug!("stats monitor thread finished successfully")
+                }
+                Err(error_object) => {
+                    warn!(
+                        "stats monitor thread finished because of an error {}",
+                        error_object
+                    )
+                }
+            }
         });
         if opts.monitor.is_some() {
             let _ = jh.join();
@@ -253,6 +723,9 @@ fn main() -> Result<()> {
     loop {
         let mut sched = Scheduler::init(&opts, &mut open_object)?;
         if !sched.run(shutdown.clone())?.should_restart() {
+            if sched.user_restart {
+                continue;
+            }
             break;
         }
     }

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -279,6 +279,12 @@ impl<'a> Scheduler<'a> {
             if smt_enabled { "SMT on" } else { "SMT off" }
         );
 
+        // Print command line.
+        info!(
+            "scheduler options: {}",
+            std::env::args().collect::<Vec<_>>().join(" ")
+        );
+
         if opts.idle_resume_us >= 0 {
             if !cpu_idle_resume_latency_supported() {
                 warn!("idle resume latency not supported");

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -125,6 +125,17 @@ struct Opts {
     #[clap(short = 'l', long, default_value = "20000")]
     slice_us_lag: u64,
 
+    /// Maximum rate of voluntary context switches.
+    ///
+    /// Increasing this value can help prioritize interactive tasks with a higher sleep frequency
+    /// over interactive tasks with lower sleep frequency.
+    ///
+    /// Decreasing this value makes the scheduler more robust and fair.
+    ///
+    /// (0 = disable voluntary context switch prioritization).
+    #[clap(short = 'c', long, default_value = "128")]
+    max_avg_nvcsw: u64,
+
     /// Throttle the running CPUs by periodically injecting idle cycles.
     ///
     /// This option can help extend battery life on portable devices, reduce heating, fan noise
@@ -281,6 +292,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.slice_min = opts.slice_us_min * 1000;
         skel.maps.rodata_data.slice_lag = opts.slice_us_lag * 1000;
         skel.maps.rodata_data.throttle_ns = opts.throttle_us * 1000;
+        skel.maps.rodata_data.max_avg_nvcsw = opts.max_avg_nvcsw;
 
         // Implicitly enable direct dispatch of per-CPU kthreads if CPU throttling is enabled
         // (it's never a good idea to throttle per-CPU kthreads).

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -151,6 +151,15 @@ struct Opts {
     #[clap(short = 'I', long, allow_hyphen_values = true, default_value = "-1")]
     idle_resume_us: i64,
 
+    /// Enable per-CPU tasks prioritization.
+    ///
+    /// This allows to prioritize per-CPU tasks that usually tend to be de-prioritized (since they
+    /// can't be migrated when their only usable CPU is busy). Enabling this option can introduce
+    /// unfairness and potentially trigger stalls, but it can improve performance of server-type
+    /// workloads (such as large parallel builds).
+    #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
+    local_pcpu: bool,
+
     /// Enable kthreads prioritization (EXPERIMENTAL).
     ///
     /// Enabling this can improve system performance, but it may also introduce noticeable
@@ -287,6 +296,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.debug = opts.debug;
         skel.maps.rodata_data.smt_enabled = smt_enabled;
         skel.maps.rodata_data.numa_disabled = opts.disable_numa;
+        skel.maps.rodata_data.local_pcpu = opts.local_pcpu;
         skel.maps.rodata_data.no_wake_sync = opts.no_wake_sync;
         skel.maps.rodata_data.slice_max = opts.slice_us * 1000;
         skel.maps.rodata_data.slice_min = opts.slice_us_min * 1000;

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -140,15 +140,6 @@ struct Opts {
     #[clap(short = 'I', long, allow_hyphen_values = true, default_value = "-1")]
     idle_resume_us: i64,
 
-    /// Enable per-CPU tasks prioritization.
-    ///
-    /// This allows to prioritize per-CPU tasks that usually tend to be de-prioritized (since they
-    /// can't be migrated when their only usable CPU is busy). Enabling this option can introduce
-    /// unfairness and potentially trigger stalls, but it can improve performance of server-type
-    /// workloads (such as large parallel builds).
-    #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
-    local_pcpu: bool,
-
     /// Enable kthreads prioritization (EXPERIMENTAL).
     ///
     /// Enabling this can improve system performance, but it may also introduce noticeable
@@ -285,7 +276,6 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.debug = opts.debug;
         skel.maps.rodata_data.smt_enabled = smt_enabled;
         skel.maps.rodata_data.numa_disabled = opts.disable_numa;
-        skel.maps.rodata_data.local_pcpu = opts.local_pcpu;
         skel.maps.rodata_data.no_wake_sync = opts.no_wake_sync;
         skel.maps.rodata_data.slice_max = opts.slice_us * 1000;
         skel.maps.rodata_data.slice_min = opts.slice_us_min * 1000;

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -120,14 +120,10 @@ struct Opts {
 
     /// Maximum time slice lag in microseconds.
     ///
-    /// A positive value can help to enhance the responsiveness of interactive tasks, but it can
-    /// also make performance more "spikey".
-    ///
-    /// A negative value can make performance more consistent, but it can also reduce the
-    /// responsiveness of interactive tasks (by smoothing the effect of the vruntime scheduling and
-    /// making the task ordering closer to a FIFO).
-    #[clap(short = 'l', long, allow_hyphen_values = true, default_value = "5000")]
-    slice_us_lag: i64,
+    /// Increasing this value can help to enhance the responsiveness of interactive tasks, but it
+    /// can also make performance more "spikey".
+    #[clap(short = 'l', long, default_value = "20000")]
+    slice_us_lag: u64,
 
     /// Throttle the running CPUs by periodically injecting idle cycles.
     ///

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -160,6 +160,14 @@ struct Opts {
     #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
     local_pcpu: bool,
 
+    /// Native tasks priorities.
+    ///
+    /// By default, the scheduler normalizes task priorities to avoid large gaps that could lead to
+    /// stalls or starvation. This option disables normalization and uses the default Linux priority
+    /// range instead.
+    #[clap(short = 'n', long, action = clap::ArgAction::SetTrue)]
+    native_priority: bool,
+
     /// Enable kthreads prioritization (EXPERIMENTAL).
     ///
     /// Enabling this can improve system performance, but it may also introduce noticeable
@@ -298,6 +306,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.numa_disabled = opts.disable_numa;
         skel.maps.rodata_data.local_pcpu = opts.local_pcpu;
         skel.maps.rodata_data.no_wake_sync = opts.no_wake_sync;
+        skel.maps.rodata_data.native_priority = opts.native_priority;
         skel.maps.rodata_data.slice_max = opts.slice_us * 1000;
         skel.maps.rodata_data.slice_min = opts.slice_us_min * 1000;
         skel.maps.rodata_data.slice_lag = opts.slice_us_lag * 1000;


### PR DESCRIPTION
As making changes to scx_bpfland without regressing someone’s workload has become increasingly difficult, I've decided to revamp scx_flash (which has been inactive for a while), port all the recent changes/features from scx_bpfland and re-align the two schedulers, so that we can use scx_flash as a playground to test new experimental changes.

This gives us a solid and stable baseline (scx_bpfland) to easily evaluate whether experimental changes in scx_flash are beneficial or not, comparing the two schedulers.

The core logic of tracking the rate of voluntary context switches to prioritize latency-sensitive tasks remains intact and is layered on top of scx_bpfland’s scheduling policy, see commit `8f7bd412 ("scx_flash: Reintroduce voluntary context switch-based prioritization"). Therefore the original design and goals of scx_flash are still preserved with this rework.