### PR TITLE
scx_mitosis: log global + per-cell queue counts.

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -34,6 +34,9 @@ enum consts {
 enum cell_stat_idx {
 	CSTAT_LOCAL,
 	CSTAT_GLOBAL,
+	CSTAT_LO_FALLBACK_Q,
+	CSTAT_HI_FALLBACK_Q,
+	CSTAT_DEFAULT_Q,
 	CSTAT_AFFN_VIOL,
 	NR_CSTATS,
 };

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -576,14 +576,17 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 
 	if (p->flags & PF_KTHREAD && p->nr_cpus_allowed == 1) {
 		scx_bpf_dsq_insert(p, HI_FALLBACK_DSQ, slice_ns, 0);
+		cstat_inc(CSTAT_HI_FALLBACK_Q, tctx->cell, cctx);
 	} else if (!tctx->all_cpus_allowed) {
 		// FIXME: With cpusets, most schedules will fall into this section and
 		// not actually get distributed to the correct cell. We need to loosen
 		// the check on tctx->all_cpus_allowed
 		scx_bpf_dsq_insert(p, LO_FALLBACK_DSQ, slice_ns, 0);
+		cstat_inc(CSTAT_LO_FALLBACK_Q, tctx->cell, cctx);
 	} else {
 		scx_bpf_dsq_insert_vtime(p, tctx->cell, slice_ns, vtime,
 					 enq_flags);
+		cstat_inc(CSTAT_DEFAULT_Q, tctx->cell, cctx);
 	}
 
 	/*


### PR DESCRIPTION
Adds functionality to print:

  • total queue placement decisions and share of global work
  • per-queue percentages (Local, Default, Hi, Lo)
  • affinity-violation percentage

Output is width-aligned and skips empty cells.

Output example:
Total Decisions:     6872 100.0% | L:92.7% D: 5.9% hi: 1.4% lo: 0.0% | V: 0.0%
Cell  0 Decisions:   6872 100.0% | L:92.7% D: 5.9% hi: 1.4% lo: 0.0% | V: 0.0%

Modifies BPF code to add three counters.
Modifies intf.h to extend cell_stat_idx enum.
Modifies main.rs to read maps, compute cell stat diffs, compute percentages, and log output.