### PR TITLE
ci: move list-integration-tests.py to separate file

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import glob
 import json
 import os
 import random
@@ -48,8 +49,10 @@ def run_format():
     """Format all targets."""
     print("Running format...", flush=True)
 
-    run_command(["black", ".github/include/ci.py"])
-    run_command(["isort", ".github/include/ci.py"])
+    py_files = glob.glob(".github/include/**/*.py", recursive=True)
+    if py_files:
+        run_command(["black"] + py_files)
+        run_command(["isort"] + py_files)
 
     run_command(["cargo", "fmt"])
 

--- a/.github/include/flake.nix
+++ b/.github/include/flake.nix
@@ -106,12 +106,6 @@
                 jq
               ];
             };
-
-            gha-list-tests = pkgs.mkShellNoCC {
-              buildInputs = with pkgs; gha-common-pkgs ++ [
-                python3
-              ];
-            };
           };
 
           packages = {
@@ -123,6 +117,15 @@
               src = veristat-src;
             };
 
+            list-integration-tests = pkgs.python3Packages.buildPythonApplication rec {
+              pname = "list-integration-tests";
+              version = "git";
+
+              pyproject = false;
+              dontUnpack = true;
+
+              installPhase = "install -Dm755 ${./list-integration-tests.py} $out/bin/list-integration-tests";
+            };
 
             ci = pkgs.python3Packages.buildPythonApplication rec {
               pname = "ci";

--- a/.github/include/list-integration-tests.py
+++ b/.github/include/list-integration-tests.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import itertools
+import json
+import os
+import sys
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: list-integration-tests.py <kernel>", file=sys.stderr)
+        sys.exit(1)
+
+    kernel = sys.argv[1]
+
+    matrix = [
+        {"name": x, "flags": ""}
+        for x in [
+            "scx_bpfland",
+            "scx_chaos",
+            "scx_lavd",
+            "scx_rlfifo",
+            "scx_rustland",
+            "scx_rusty",
+            "scx_tickless",
+        ]
+    ]
+
+    # p2dq fails on 6.12, see https://github.com/sched-ext/scx/issues/2075 for more info
+    if kernel != "stable/6_12":
+        matrix.append({"name": "scx_p2dq", "flags": ""})
+
+    for flags in itertools.product(
+        ["--disable-topology=false", "--disable-topology=true"],
+        ["", "--disable-antistall"],
+    ):
+        matrix.append({"name": "scx_layered", "flags": " ".join(flags)})
+
+    print(f"matrix={json.dumps(matrix)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/include/update-kernels.py
+++ b/.github/include/update-kernels.py
@@ -70,8 +70,12 @@ if __name__ == "__main__":
         v["commitHash"] = new_hash
         v["lastModified"] = int(time.time())
 
-        print(f"Downloading and hashing kernel source for {k}. This will take a while...")
-        (narHash, kver) = get_nar_hash_and_version(v["repo"], v["branch"], v["commitHash"])
+        print(
+            f"Downloading and hashing kernel source for {k}. This will take a while..."
+        )
+        (narHash, kver) = get_nar_hash_and_version(
+            v["repo"], v["branch"], v["commitHash"]
+        )
         v["narHash"] = narHash
         v["kernelVersion"] = kver
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,44 +20,9 @@ jobs:
         with:
           cachix-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: Load dependencies
-        run: nix run ./.github/include#nix-develop-gha -- ./.github/include#gha-list-tests
-
       - name: List tests
         id: output
-        run: |
-          python3 - <<EOF
-          import itertools
-          import json
-          import os
-
-          kernel = "${{ inputs.repo-name }}"
-
-          matrix = [{ "name": x, "flags": "" } for x in [
-            "scx_bpfland",
-            "scx_chaos",
-            "scx_lavd",
-            "scx_rlfifo",
-            "scx_rustland",
-            "scx_rusty",
-            "scx_tickless",
-          ]]
-
-          # p2dq fails on 6.12, see https://github.com/sched-ext/scx/issues/2075 for more info
-          if kernel != "stable/6_12":
-            matrix.append({ "name": "scx_p2dq", "flags": "" })
-
-          for flags in itertools.product(
-              ["--disable-topology=false", "--disable-topology=true"],
-              ["", "--disable-antistall"]
-          ):
-            matrix.append({ "name": "scx_layered", "flags": " ".join(flags) })
-
-          output = f"matrix={json.dumps(matrix)}"
-          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-            print(output, file=f)
-
-          EOF
+        run: nix run ./.github/include#list-integration-tests -- "${{ inputs.repo-name }}" >> $GITHUB_OUTPUT
 
   integration-test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Currently the CI runs a Python step to decide what jobs to run in the matrix. It was inlined before as it was extremely simply and didn't need manual testing. Split this out so more complexity can be added and tested.

Expand the linting rules to all Python files in the `./github/include` directory and associated formatting changes. Separating this change to ease reviewing of the follow up that adds features to the script.

Test plan:
- CI