### PR TITLE
scx_p2dq: Allow direct dispatch of idle CPUs

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -688,17 +688,22 @@ static __always_inline void async_p2dq_enqueue(struct enqueue_promise *ret,
 			return;
 		}
 
-		taskc->dsq_id = cpu_dsq_id(taskc->dsq_index, cpuc);
 		update_vtime(p, cpuc, taskc, llcx->vtime);
+		if (is_idle) {
+			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON|cpu, taskc->slice_ns, enq_flags);
+			stat_inc(P2DQ_STAT_IDLE);
+			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+			ret->kind = P2DQ_ENQUEUE_PROMISE_COMPLETE;
+			return;
+		}
+
+		taskc->dsq_id = cpu_dsq_id(taskc->dsq_index, cpuc);
 		if (interactive_fifo && taskc->dsq_index == 0) {
 			scx_bpf_dsq_insert(p, taskc->dsq_id, taskc->slice_ns, enq_flags);
 		} else {
 			scx_bpf_dsq_insert_vtime(p, taskc->dsq_id, taskc->slice_ns, p->scx.dsq_vtime, enq_flags);
 		}
-		if (is_idle) {
-			stat_inc(P2DQ_STAT_IDLE);
-			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
-		}
+
 		ret->kind = P2DQ_ENQUEUE_PROMISE_COMPLETE;
 		return;
 	}
@@ -710,8 +715,15 @@ static __always_inline void async_p2dq_enqueue(struct enqueue_promise *ret,
 		return;
 	}
 
-	taskc->dsq_id = cpu_dsq_id(taskc->dsq_index, cpuc);
 	update_vtime(p, cpuc, taskc, llcx->vtime);
+	if (scx_bpf_test_and_clear_cpu_idle(cpu)) {
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON|cpu, taskc->slice_ns, enq_flags);
+		stat_inc(P2DQ_STAT_IDLE);
+		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+		ret->kind = P2DQ_ENQUEUE_PROMISE_COMPLETE;
+		return;
+	}
+	taskc->dsq_id = cpu_dsq_id(taskc->dsq_index, cpuc);
 
 	if (interactive_fifo && taskc->dsq_index == 0) {
 		ret->kind = P2DQ_ENQUEUE_PROMISE_FIFO;


### PR DESCRIPTION
During enqueue if the selected CPU is idle allow direct dispatch. This improves wakeup latency.

PR:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (413450 total samples)
          50.0th: 7          (221831 samples)
          90.0th: 10         (75951 samples)
        * 99.0th: 13         (23447 samples)
          99.9th: 24         (3716 samples)
          min=1, max=2014
Request Latencies percentiles (usec) runtime 30 (s) (414261 total samples)
          50.0th: 6584       (127703 samples)
          90.0th: 10320      (160235 samples)
        * 99.0th: 12176      (37249 samples)
          99.9th: 12720      (3428 samples)
          min=5815, max=20065
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13712      (7 samples)
        * 50.0th: 13808      (11 samples)
          90.0th: 13872      (11 samples)
          min=13575, max=13909
average rps: 13808.70
```
`main`:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (410693 total samples)
          50.0th: 7          (109157 samples)
          90.0th: 10         (105966 samples)
        * 99.0th: 14         (32542 samples)
          99.9th: 25         (3118 samples)
          min=1, max=844
Request Latencies percentiles (usec) runtime 30 (s) (411412 total samples)
          50.0th: 6600       (114318 samples)
          90.0th: 10416      (163560 samples)
        * 99.0th: 12208      (37067 samples)
          99.9th: 12784      (3377 samples)
          min=5818, max=19499
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13648      (10 samples)
        * 50.0th: 13712      (8 samples)
          90.0th: 13808      (10 samples)
          min=13465, max=13900
average rps: 13713.73
```