### PR TITLE
ci: add CI-Test-Kernel trailers

### DIFF
--- a/.github/include/list-integration-tests.py
+++ b/.github/include/list-integration-tests.py
@@ -3,19 +3,75 @@
 import itertools
 import json
 import os
+import subprocess
 import sys
+
+
+def get_kernel_trailers_from_commits():
+    """Get CI-Test-Kernel trailers from commits between current HEAD and base branch."""
+    # In GitHub Actions, GITHUB_BASE_REF contains the target branch name
+    # Default to main branch if not in a PR context
+    base_ref = os.environ.get("GITHUB_BASE_REF", "main")
+    if not base_ref:
+        base_ref = "main"
+
+    result = subprocess.run(
+        ["git", "log", "--format=%B%n---ENDOFCOMMIT---", f"origin/{base_ref}..HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    if not result.stdout.strip():
+        return set()
+
+    kernels = set()
+
+    commit_messages = result.stdout.split("---ENDOFCOMMIT---")
+    for commit_message in commit_messages:
+        commit_message = commit_message.strip()
+        if not commit_message:
+            continue
+
+        lines = commit_message.split("\n")
+
+        # Start from the last line and work backwards, collecting trailers
+        for i in range(len(lines) - 1, -1, -1):
+            line = lines[i].strip()
+
+            if not line:
+                continue
+
+            if ":" not in line:
+                break
+
+            if line.startswith("CI-Test-Kernel:"):
+                kernel = line.split(":", 1)[1].strip()
+                kernels.add(kernel)
+
+    return kernels
 
 
 def main():
     if len(sys.argv) != 2:
-        print("Usage: list-integration-tests.py <kernel>", file=sys.stderr)
+        print("Usage: list-integration-tests.py <default-kernel>", file=sys.stderr)
         sys.exit(1)
 
-    kernel = sys.argv[1]
+    default_kernel = sys.argv[1]
 
-    matrix = [
-        {"name": x, "flags": ""}
-        for x in [
+    trailer_kernels = get_kernel_trailers_from_commits()
+
+    kernels_to_test = {default_kernel}
+    kernels_to_test.update(trailer_kernels)
+
+    matrix = []
+
+    for kernel in kernels_to_test:
+        # use a blank kernel name for the default, as the common case is to have
+        # no trailers and it makes the matrix names harder to read.
+        kernel_name = "" if kernel == default_kernel else kernel
+
+        for scheduler in [
             "scx_bpfland",
             "scx_chaos",
             "scx_lavd",
@@ -23,18 +79,20 @@ def main():
             "scx_rustland",
             "scx_rusty",
             "scx_tickless",
-        ]
-    ]
+        ]:
+            matrix.append({"name": scheduler, "flags": "", "kernel": kernel_name})
 
-    # p2dq fails on 6.12, see https://github.com/sched-ext/scx/issues/2075 for more info
-    if kernel != "stable/6_12":
-        matrix.append({"name": "scx_p2dq", "flags": ""})
+        # p2dq fails on 6.12, see https://github.com/sched-ext/scx/issues/2075 for more info
+        if kernel != "stable/6_12":
+            matrix.append({"name": "scx_p2dq", "flags": "", "kernel": kernel_name})
 
-    for flags in itertools.product(
-        ["--disable-topology=false", "--disable-topology=true"],
-        ["", "--disable-antistall"],
-    ):
-        matrix.append({"name": "scx_layered", "flags": " ".join(flags)})
+        for flags in itertools.product(
+            ["--disable-topology=false", "--disable-topology=true"],
+            ["", "--disable-antistall"],
+        ):
+            matrix.append(
+                {"name": "scx_layered", "flags": " ".join(flags), "kernel": kernel_name}
+            )
 
     print(f"matrix={json.dumps(matrix)}")
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,8 +42,13 @@ jobs:
 
       - name: Load kernel
         run: |
-          echo "KERNEL_STORE_PATH=$(nix build --no-link --print-out-paths ./.github/include#'kernel_${{ inputs.repo-name }}')" >> $GITHUB_ENV
-          echo "KERNEL_HEADERS_STORE_PATH=$(nix build --no-link --print-out-paths ./.github/include#'kernel_${{ inputs.repo-name }}'.headers)" >> $GITHUB_ENV
+          if [ -n "${{ matrix.scheduler.kernel }}" ]; then
+            KERNEL_NAME="${{ matrix.scheduler.kernel }}"
+          else
+            KERNEL_NAME="${{ inputs.repo-name }}"
+          fi
+          echo "KERNEL_STORE_PATH=$(nix build --no-link --print-out-paths ./.github/include#"kernel_${KERNEL_NAME}")" >> $GITHUB_ENV
+          echo "KERNEL_HEADERS_STORE_PATH=$(nix build --no-link --print-out-paths ./.github/include#"kernel_${KERNEL_NAME}".headers)" >> $GITHUB_ENV
 
       - name: Install Veristat
         run: nix-env -i $(nix build --no-link --print-out-paths ./.github/include#veristat)
@@ -95,11 +100,20 @@ jobs:
       # no symlink following here (to avoid cycle`s)
       - run: sudo find '/home/runner/' -iname '*.ci.log' -exec mv {} ./log_save/ \;
         if: always()
+      - name: Set artifact name
+        if: always()
+        run: |
+          KERNEL_SUFFIX=""
+          if [ -n "${{ matrix.scheduler.kernel }}" ]; then
+            KERNEL_CLEAN=$(echo "${{ matrix.scheduler.kernel }}" | tr '/' '_')
+            KERNEL_SUFFIX="_${KERNEL_CLEAN}"
+          fi
+          echo "ARTIFACT_NAME=${{ matrix.scheduler['name'] }}${{ matrix.scheduler['flags'] }}${KERNEL_SUFFIX}_logs_${{ github.run_id }}_${{ github.run_attempt }}" >> $GITHUB_ENV
       - name: upload debug logs, bpftrace, veristat, dmesg, etc.
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.scheduler['name'] }}${{ matrix.scheduler['flags'] }}_logs_${{ github.run_id }}_${{ github.run_attempt }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: ./log_save/*.ci.log
           # it's all txt files w/ 90 day retention, lets be nice.
           compression-level: 9


### PR DESCRIPTION
Currently our CI gates PRs/the merge queue based on whether schedulers succeed under the sched_ext/for-next tracked kernel. This is good for most code changes, but doesn't do what we need when making a change for a specific kernel or updating the kernel locks themselves. An update to the sched_ext/for-next kernel that breaks will stop at the PR, but an update to bpf/bpf-next will go in and fail at the next CI run.

Add support for trailers in commit messages requesting a specific kernel be tested. Expand our testing matrix to include this kernel for each scheduler as well as the kernel being tested in that run. Include this trailer in the automatically generated update commits so the kernel(s) that are being updated get tested at PR time.

Test plan:
- This PR tests with the bpf/bpf-next kernel as well as the default sched_ext/for-next.
- It's unclear how this interacts with the merge queue/already merged commits, we may need some extra variable to track the merge base properly. Unfortunately merge queue stuff is nearly impossible to test, so will follow up with fixes if needed. Worst case we test too many kernels until this is patched.

CI-Test-Kernel: bpf/bpf-next