### PR TITLE
scx_mitosis: fix bpf verifier error

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -858,11 +858,13 @@ static inline int cgroup_init_with_cpuset(struct cgrp_ctx *cgc,
 
 	int err;
 	if (bpf_core_type_matches(struct cpuset___cpumask_arr)) {
-		struct cpuset___cpumask_arr *cpuset_typed = (void *)cpuset;
+		struct cpuset___cpumask_arr *cpuset_typed =
+			(void *)bpf_core_cast(cpuset, struct cpuset);
 		err = bpf_core_read(&entry->cpumask, runtime_cpumask_size,
 				    &cpuset_typed->cpus_allowed);
 	} else if (bpf_core_type_matches(struct cpuset___cpumask_ptr)) {
-		struct cpuset___cpumask_ptr *cpuset_typed = (void *)cpuset;
+		struct cpuset___cpumask_ptr *cpuset_typed =
+			(void *)bpf_core_cast(cpuset, struct cpuset);
 		err = bpf_core_read(&entry->cpumask, runtime_cpumask_size,
 				    cpuset_typed->cpus_allowed);
 	} else {


### PR DESCRIPTION
With recent kernels I'm getting a verifier error when trying to load scx_mitosis.

91: (b7) r1 = 1024                    ; R1_w=1024
; if (runtime_cpumask_size > CPUMASK_SIZE) { @ mitosis.bpf.c:853
92: (a6) if w1 < 0x401 goto pc+7      ; R1_w=1024
; scx_bpf_error("all_cpumask should not be NULL"); @ mitosis.bpf.c:885
100: (b7) r1 = 0                      ; R1_w=0
; if (bpf_core_type_matches(struct cpuset___cpumask_arr)) { @ mitosis.bpf.c:860
101: (16) if w1 == 0x0 goto pc+3      ; R1_w=0
; } else if (bpf_core_type_matches(struct cpuset___cpumask_ptr)) { @ mitosis.bpf.c:864
105: (b7) r1 = 1                      ; R1_w=1
106: (16) if w1 == 0x0 goto pc+29     ; R1_w=1
; err = bpf_core_read(&entry->cpumask, runtime_cpumask_size, @ mitosis.bpf.c:866
107: (79) r8 = *(u64 *)(r8 +216)
access beyond struct cgroup_subsys_state at off 216 size 8

This is because we still think cpuset is a struct cgroup_subsys_state. Cast cpuset to struct cpuset then do the bpf_core_read().  This allows scx_mitosis to load.  Thanks to Kumar Dwivedi for explaining this to me.