### PR TITLE
scx_mitosis: Use local time for log timestamps

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -700,7 +700,7 @@ fn main() -> Result<()> {
 
     let mut lcfg = simplelog::ConfigBuilder::new();
     lcfg.set_time_offset_to_local()
-        .unwrap()
+        .expect("Failed to set local time offset")
         .set_time_level(simplelog::LevelFilter::Error)
         .set_location_level(simplelog::LevelFilter::Off)
         .set_target_level(simplelog::LevelFilter::Off)

--- a/scheds/rust/scx_chaos/src/main.rs
+++ b/scheds/rust/scx_chaos/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> anyhow::Result<()> {
         llv,
         simplelog::ConfigBuilder::new()
             .set_time_offset_to_local()
-            .unwrap()
+            .expect("Failed to set local time offset")
             .set_time_level(simplelog::LevelFilter::Error)
             .set_location_level(simplelog::LevelFilter::Off)
             .set_target_level(simplelog::LevelFilter::Off)

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -702,7 +702,7 @@ fn main() -> Result<()> {
 
     let mut lcfg = simplelog::ConfigBuilder::new();
     lcfg.set_time_offset_to_local()
-        .unwrap()
+        .expect("Failed to set local time offset")
         .set_time_level(simplelog::LevelFilter::Error)
         .set_location_level(simplelog::LevelFilter::Off)
         .set_target_level(simplelog::LevelFilter::Off)

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -1014,7 +1014,7 @@ fn init_log(opts: &Opts) {
     };
     let mut lcfg = simplelog::ConfigBuilder::new();
     lcfg.set_time_offset_to_local()
-        .unwrap()
+        .expect("Failed to set local time offset")
         .set_time_level(simplelog::LevelFilter::Error)
         .set_location_level(simplelog::LevelFilter::Off)
         .set_target_level(simplelog::LevelFilter::Off)

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -2983,7 +2983,7 @@ fn main() -> Result<()> {
     };
     let mut lcfg = simplelog::ConfigBuilder::new();
     lcfg.set_time_offset_to_local()
-        .unwrap()
+        .expect("Failed to set local time offset")
         .set_time_level(simplelog::LevelFilter::Error)
         .set_location_level(simplelog::LevelFilter::Off)
         .set_target_level(simplelog::LevelFilter::Off)

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -219,7 +219,9 @@ fn main() -> Result<()> {
         _ => simplelog::LevelFilter::Trace,
     };
     let mut lcfg = simplelog::ConfigBuilder::new();
-    lcfg.set_time_level(simplelog::LevelFilter::Error)
+    lcfg.set_time_offset_to_local()
+        .expect("Failed to set local time offset")
+        .set_time_level(simplelog::LevelFilter::Error)
         .set_location_level(simplelog::LevelFilter::Off)
         .set_target_level(simplelog::LevelFilter::Off)
         .set_thread_level(simplelog::LevelFilter::Off);

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -355,7 +355,7 @@ fn main() -> Result<()> {
     };
     let mut lcfg = simplelog::ConfigBuilder::new();
     lcfg.set_time_offset_to_local()
-        .unwrap()
+        .expect("Failed to set local time offset")
         .set_time_level(simplelog::LevelFilter::Error)
         .set_location_level(simplelog::LevelFilter::Off)
         .set_target_level(simplelog::LevelFilter::Off)

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -405,7 +405,7 @@ fn main() -> Result<()> {
 
     let mut lcfg = simplelog::ConfigBuilder::new();
     lcfg.set_time_offset_to_local()
-        .unwrap()
+        .expect("Failed to set local time offset")
         .set_time_level(simplelog::LevelFilter::Error)
         .set_location_level(simplelog::LevelFilter::Off)
         .set_target_level(simplelog::LevelFilter::Off)

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -646,7 +646,7 @@ fn main() -> Result<()> {
     };
     let mut lcfg = simplelog::ConfigBuilder::new();
     lcfg.set_time_offset_to_local()
-        .unwrap()
+        .expect("Failed to set local time offset")
         .set_time_level(simplelog::LevelFilter::Error)
         .set_location_level(simplelog::LevelFilter::Off)
         .set_target_level(simplelog::LevelFilter::Off)

--- a/scheds/rust/scx_tickless/src/main.rs
+++ b/scheds/rust/scx_tickless/src/main.rs
@@ -283,7 +283,7 @@ fn main() -> Result<()> {
 
     let mut lcfg = simplelog::ConfigBuilder::new();
     lcfg.set_time_offset_to_local()
-        .unwrap()
+        .expect("Failed to set local time offset")
         .set_time_level(simplelog::LevelFilter::Error)
         .set_location_level(simplelog::LevelFilter::Off)
         .set_target_level(simplelog::LevelFilter::Off)

--- a/scheds/rust/scx_wd40/src/main.rs
+++ b/scheds/rust/scx_wd40/src/main.rs
@@ -821,7 +821,7 @@ fn main() -> Result<()> {
     };
     let mut lcfg = simplelog::ConfigBuilder::new();
     lcfg.set_time_offset_to_local()
-        .unwrap()
+        .expect("Failed to set local time offset")
         .set_time_level(simplelog::LevelFilter::Error)
         .set_location_level(simplelog::LevelFilter::Off)
         .set_target_level(simplelog::LevelFilter::Off)


### PR DESCRIPTION
Log timestamps in local time rather than UTC.

Ref: #2081 (I forgot to update `scx_mitosis` :sweat_smile:)