### PR TITLE
lib/cpumask: Fix cmpxchg failure detection

### DIFF
--- a/lib/cpumask.bpf.c
+++ b/lib/cpumask.bpf.c
@@ -30,7 +30,7 @@ scx_bitmap_pick_any_cpu_once(scx_bitmap_t __arg_arena mask, u64 __arg_arena *sta
 
 		cpu = scx_ffs(old);
 		new = old & ~(1ULL << cpu);
-		if (cmpxchg(&mask->bits[ind], old, new) == old)
+		if (cmpxchg(&mask->bits[ind], old, new) != old)
 			return -EAGAIN;
 
 		*start = ind;


### PR DESCRIPTION
cmpxchg returns the previous value, not the new one. To check for failure, the return value should not equal the expected old value.

Ref: PR #2102 