### PR TITLE
lib: Separate out cpumask helpers that depend on bpf_cpumask_populate

### DIFF
--- a/lib/cpumask.bpf.c
+++ b/lib/cpumask.bpf.c
@@ -87,23 +87,6 @@ scx_bitmap_vacate_cpu(scx_bitmap_t __arg_arena mask, s32 cpu)
 	return 0;
 }
 
-__weak int
-scx_bitmap_to_bpf(struct bpf_cpumask __kptr *bpfmask __arg_trusted,
-		   scx_bitmap_t __arg_arena scx_bitmap)
-{
-	struct scx_bitmap *tmp;
-	int ret;
-
-	tmp = scx_percpu_scx_bitmap_stack();
-	scx_bitmap_copy_to_stack(tmp, scx_bitmap);
-
-	ret = bpf_cpumask_populate((struct cpumask *)bpfmask, tmp->bits, sizeof(tmp->bits));
-	if (unlikely(ret))
-		scx_bpf_error("error %d when calling bpf_cpumask_populate", ret);
-
-	return 0;
-}
-
 __weak
 bool scx_bitmap_subset_cpumask(scx_bitmap_t __arg_arena big, const struct cpumask *small __arg_trusted)
 {
@@ -138,49 +121,3 @@ int scx_bitmap_and_cpumask(scx_bitmap_t dst __arg_arena,
 	return 0;
 }
 
-__weak
-s32 scx_bitmap_pick_idle_cpu(scx_bitmap_t mask __arg_arena, int flags)
-{
-	struct bpf_cpumask __kptr *bpf = scx_percpu_bpfmask();
-	s32 cpu;
-
-	if (!bpf)
-		return -1;
-
-	scx_bitmap_to_bpf(bpf, mask);
-	cpu = scx_bpf_pick_idle_cpu(cast_mask(bpf), flags);
-
-	scx_bitmap_from_bpf(mask, cast_mask(bpf));
-
-	return cpu;
-}
-
-__weak
-s32 scx_bitmap_any_distribute(scx_bitmap_t mask __arg_arena)
-{
-	struct bpf_cpumask __kptr *bpf = scx_percpu_bpfmask();
-	s32 cpu;
-
-	if (!bpf)
-		return -1;
-
-	scx_bitmap_to_bpf(bpf, mask);
-	cpu = bpf_cpumask_any_distribute(cast_mask(bpf));
-
-	return cpu;
-}
-
-__weak
-s32 scx_bitmap_any_and_distribute(scx_bitmap_t scx __arg_arena, const struct cpumask *bpf)
-{
-	struct bpf_cpumask *tmp = scx_percpu_bpfmask();
-	s32 cpu;
-
-	if (!bpf || !tmp)
-		return -1;
-
-	scx_bitmap_to_bpf(tmp, scx);
-	cpu = bpf_cpumask_any_and_distribute(cast_mask(tmp), bpf);
-
-	return cpu;
-}

--- a/lib/cpumask_bpf.bpf.c
+++ b/lib/cpumask_bpf.bpf.c
@@ -1,0 +1,70 @@
+#include <scx/common.bpf.h>
+#include <lib/sdt_task.h>
+
+#include <lib/cpumask.h>
+#include <lib/percpu.h>
+
+__weak int
+scx_bitmap_to_bpf(struct bpf_cpumask __kptr *bpfmask __arg_trusted,
+		   scx_bitmap_t __arg_arena scx_bitmap)
+{
+	struct scx_bitmap *tmp;
+	int ret;
+
+	tmp = scx_percpu_scx_bitmap_stack();
+	scx_bitmap_copy_to_stack(tmp, scx_bitmap);
+
+	ret = bpf_cpumask_populate((struct cpumask *)bpfmask, tmp->bits, sizeof(tmp->bits));
+	if (unlikely(ret))
+		scx_bpf_error("error %d when calling bpf_cpumask_populate", ret);
+
+	return 0;
+}
+
+__weak
+s32 scx_bitmap_pick_idle_cpu(scx_bitmap_t mask __arg_arena, int flags)
+{
+	struct bpf_cpumask __kptr *bpf = scx_percpu_bpfmask();
+	s32 cpu;
+
+	if (!bpf)
+		return -1;
+
+	scx_bitmap_to_bpf(bpf, mask);
+	cpu = scx_bpf_pick_idle_cpu(cast_mask(bpf), flags);
+
+	scx_bitmap_from_bpf(mask, cast_mask(bpf));
+
+	return cpu;
+}
+
+__weak
+s32 scx_bitmap_any_distribute(scx_bitmap_t mask __arg_arena)
+{
+	struct bpf_cpumask __kptr *bpf = scx_percpu_bpfmask();
+	s32 cpu;
+
+	if (!bpf)
+		return -1;
+
+	scx_bitmap_to_bpf(bpf, mask);
+	cpu = bpf_cpumask_any_distribute(cast_mask(bpf));
+
+	return cpu;
+}
+
+
+__weak
+s32 scx_bitmap_any_and_distribute(scx_bitmap_t scx __arg_arena, const struct cpumask *bpf)
+{
+	struct bpf_cpumask *tmp = scx_percpu_bpfmask();
+	s32 cpu;
+
+	if (!bpf || !tmp)
+		return -1;
+
+	scx_bitmap_to_bpf(tmp, scx);
+	cpu = bpf_cpumask_any_and_distribute(cast_mask(tmp), bpf);
+
+	return cpu;
+}

--- a/scheds/rust/scx_wd40/build.rs
+++ b/scheds/rust/scx_wd40/build.rs
@@ -16,6 +16,7 @@ fn main() {
         .add_source("../../../lib/arena.bpf.c")
         .add_source("../../../lib/bitmap.bpf.c")
         .add_source("../../../lib/cpumask.bpf.c")
+        .add_source("../../../lib/cpumask_bpf.bpf.c")
         .add_source("../../../lib/sdt_task.bpf.c")
         .add_source("../../../lib/sdt_alloc.bpf.c")
         .add_source("../../../lib/topology.bpf.c")


### PR DESCRIPTION
On older kernels `bpf_cpumask_populate` is not available. Split out the arena cpumask helpers into a separate file for schedulers that need to convert arena cpumasks into bpf cpumasks (wd40). This provides better compatibility for schedulers that only need arena cpumask operations without the need of converting arena cpumasks into bpf cpumasks.