### PR TITLE
macros: add ifndef to all likely/unlikely definitions

### DIFF
--- a/scheds/include/scx/bpf_arena_spin_lock.h
+++ b/scheds/include/scx/bpf_arena_spin_lock.h
@@ -70,8 +70,12 @@ struct arena_qnode {
 #define _Q_LOCKED_VAL		(1U << _Q_LOCKED_OFFSET)
 #define _Q_PENDING_VAL		(1U << _Q_PENDING_OFFSET)
 
+#ifndef likely
 #define likely(x) __builtin_expect(!!(x), 1)
+#endif
+#ifndef unlikely
 #define unlikely(x) __builtin_expect(!!(x), 0)
+#endif
 
 static struct arena_qnode __arena qnodes[_Q_MAX_CPUS][_Q_MAX_NODES];
 

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -582,9 +582,15 @@ static inline bool time_in_range_open(u64 a, u64 b, u64 c)
  */
 
 /* useful compiler attributes */
+#ifndef likely
 #define likely(x) __builtin_expect(!!(x), 1)
+#endif
+#ifndef unlikely
 #define unlikely(x) __builtin_expect(!!(x), 0)
+#endif
+#ifndef __maybe_unused
 #define __maybe_unused __attribute__((__unused__))
+#endif
 
 /*
  * READ/WRITE_ONCE() are from kernel (include/asm-generic/rwonce.h). They


### PR DESCRIPTION
We're providing the standard definitions for likely/unlikely/__maybe_unused in certain headers but they're not gated on already existing. This can cause a compiler error depending on the order of includes. Add an `ifndef` to ensure these macros are only defined once.

Test plan:
- CI