### PR TITLE
ci: add all-success job to simplify github branch rules

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -117,3 +117,16 @@ jobs:
           path: ./log_save/*.ci.log
           # it's all txt files w/ 90 day retention, lets be nice.
           compression-level: 9
+
+  all-success:
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64" ]') || 'ubuntu-latest' }}
+    needs: integration-test
+    if: always()
+    steps:
+      - name: Check all jobs succeeded
+        run: |
+          if [[ "${{ needs.integration-test.result }}" != "success" ]]; then
+            echo "Integration tests failed or were cancelled"
+            exit 1
+          fi
+          echo "All integration tests passed successfully"


### PR DESCRIPTION
Currently any changes to the CI jobs requires a manual change to the setings in the GitHub UI. This is a poor user experience, as only maintainers can do this, and it detaches the code change from the change in experience.

Add an `all-success` job to the `integration-tests` workflow. This job relies on the success of every matrix step. We can then require only this job (and `rust-tests`) in the CI, and any changes to the matrix will automatically be required. This means that the new `CI-Test-Kernel` trailers will work as intended and make that kernel's success affect the PR/merge queue status.

Will bed this in for a couple of days then change the job requirements in the UI to avoid most people having to rebase explicitly.

Test plan:
- Pushed this with a code change to deliberately break `scx_lavd`. The new job failed.
- CI - the new job succeeds.