### PR TITLE
ci: fix update-kernels workflow for previous script changes

### DIFF
--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -49,16 +49,18 @@ jobs:
 
       - name: Update kernel
         run: |
-          git switch -c "deps/kernel/${{ matrix.version }}"
-          nix run ./.github/include#update-kernels -- ${{ matrix.version }}
-          git diff --exit-code || echo 'modified=true' >> $GITHUB_ENV
-
-      - name: Commit
-        if: env.modified == 'true'
-        run: |
           git config --global user.email "ci-bot@sched-ext.com"
           git config --global user.name "sched-ext CI Bot"
-          git commit -am "chore(deps): update ${{ matrix.version }} kernel"
+
+          INITIAL_COMMIT=$(git rev-parse HEAD)
+
+          git switch -c "deps/kernel/${{ matrix.version }}"
+          nix run ./.github/include#update-kernels -- ${{ matrix.version }}
+
+          FINAL_COMMIT=$(git rev-parse HEAD)
+          if [ "$INITIAL_COMMIT" != "$FINAL_COMMIT" ]; then
+            echo 'modified=true' >> $GITHUB_ENV
+          fi
 
       - name: Open PR
         if: env.modified == 'true'


### PR DESCRIPTION
5b462bc updated the update-kernels.py script to commit with special trailers that trigger the CI for named kernels. Unfortunately I forgot that the CI workflow expects to make the commit itself. Update the CI workflow to assume the script creates the commit.

Test plan:
- CI. Triggered this workflow on `push` to confirm it works.