### PR TITLE
scx_p2dq: Add affinitized per CPU DSQs

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -10,12 +10,16 @@ struct p2dq_timer {
 struct cpu_ctx {
 	int				id;
 	u32				llc_id;
-	u32				node_id;
-	u64				dsq_index;
+	u64				affn_dsq;
+	u32				dsq_index;
+	u64				dsq_id;
+	u64				slice_ns;
 	u32				perf;
 	bool				interactive;
 	bool				is_big;
 	u64				ran_for;
+	u32				node_id;
+	u64				affn_max_vtime;
 	u64				dsqs[MAX_DSQS_PER_LLC];
 	u64				max_load_dsq;
 };
@@ -28,9 +32,10 @@ struct llc_ctx {
 	u32				lb_llc_id;
 	u64				last_period_ns;
 	u64				load;
-	u64				affn_load;
 	u32				index;
 	bool				all_big;
+	u64				affn_load;
+	u64				affn_max_vtime;
 	u64				dsqs[MAX_DSQS_PER_LLC];
 	u64				dsq_max_vtime[MAX_DSQS_PER_LLC];
 	u64				dsq_load[MAX_DSQS_PER_LLC];


### PR DESCRIPTION
Rather than doing direct dispatch for affinitized tasks use a vtime based per CPU DSQ. This leads to more fair scheduling of affinitized tasks. Add accounting for affinitized task vtime for proper selection of DSQs during dispatch.

Mostly idle, non affinitized system:
```
	kipmi0-2138    [000] d...1 357632.146718: bpf_trace_printk: DISPATCH cpu[0] vtime 651682411 affn_vtime 914542 min_vtime 651682411 dsq_id 2048
	kipmi0-2138    [000] d...1 357632.146924: bpf_trace_printk: DISPATCH cpu[0] vtime 651686658 affn_vtime 914542 min_vtime 651686658 dsq_id 2048
	kipmi0-2138    [000] d...1 357632.147099: bpf_trace_printk: DISPATCH cpu[0] vtime 651691505 affn_vtime 914542 min_vtime 651691505 dsq_id 2048
	kipmi0-2138    [000] d...1 357632.147305: bpf_trace_printk: DISPATCH cpu[0] vtime 651695842 affn_vtime 914542 min_vtime 651695842 dsq_id 2048
	kipmi0-2138    [000] d...1 357632.147511: bpf_trace_printk: DISPATCH cpu[0] vtime 651720550 affn_vtime 914542 min_vtime 651720550 dsq_id 2048
```
High load using stress-ng for affinitized tasks:
```
	stress-ng-affin-1326638 [000] dN..1 357669.841560: bpf_trace_printk: DISPATCH cpu[0] vtime 22682698954 affn_vtime 22682502322 min_vtime 22225079788 dsq_id 3
	stress-ng-affin-1327010 [000] dN..1 357669.841574: bpf_trace_printk: DISPATCH cpu[0] vtime 22682736984 affn_vtime 22682508702 min_vtime 22225079788 dsq_id 3
	   <...>-1326898 [000] d...1 357669.841604: bpf_trace_printk: DISPATCH cpu[0] vtime 22682803205 affn_vtime 22682547323 min_vtime 22225079788 dsq_id 3
	stress-ng-affin-1326882 [000] dN..1 357669.841617: bpf_trace_printk: DISPATCH cpu[0] vtime 22682851299 affn_vtime 22682556657 min_vtime 22225079788 dsq_id 3
	stress-ng-affin-1326927 [000] d...1 357669.841645: bpf_trace_printk: DISPATCH cpu[0] vtime 22682903900 affn_vtime 22682578401 min_vtime 22225079788 dsq_id 3
```

From the trace output the preferred DSQ for dispatch is displayed based on the minimum vtime per DSQ.


Performance tests (PR):
```
$ stress-ng -t 31 --aggressive -M -c 100 --affinity 50 --affinity-delay 1  --affinity-rand --affinity-sleep 1 --affinity-pin
stress-ng: info:  [1378198] setting to a 31 secs run per stressor
stress-ng: info:  [1378198] dispatching hogs: 100 cpu, 50 affinity
stress-ng: metrc: [1378198] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s CPU used per       RSS Max
stress-ng: metrc: [1378198]                           (secs)    (secs)    (secs)   (real time) (usr+sys time) instance (%)          (KB)
stress-ng: metrc: [1378198] cpu             3005112     31.00   2295.82      3.22     96933.86        1307.11        74.16          4224
stress-ng: metrc: [1378198] affinity       22091195     31.01     32.80    245.61    712449.27       79347.81        17.96          1408
stress-ng: info:  [1378198] skipped: 0
stress-ng: info:  [1378198] passed: 149: cpu (99) affinity (50)
stress-ng: info:  [1378198] failed: 0
stress-ng: info:  [1378198] metrics untrustworthy: 0
stress-ng: info:  [1378198] successful run completed in 31.03 secs
$ ./schbench -t 100
...
Wakeup Latencies percentiles (usec) runtime 30 (s) (412377 total samples)
          50.0th: 7          (114844 samples)
          90.0th: 10         (108218 samples)
        * 99.0th: 14         (35028 samples)
          99.9th: 24         (3669 samples)
          min=1, max=1412
Request Latencies percentiles (usec) runtime 30 (s) (413412 total samples)
          50.0th: 6600       (123744 samples)
          90.0th: 10352      (161647 samples)
        * 99.0th: 12208      (37111 samples)
          99.9th: 12784      (3656 samples)
          min=5821, max=19762
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13712      (9 samples)
        * 50.0th: 13776      (7 samples)
          90.0th: 13872      (14 samples)
          min=13564, max=13891
average rps: 13780.40
```
`eevdf`:
```
$ stress-ng -t 31 --aggressive -M -c 100 --affinity 50 --affinity-delay 1  --affinity-rand --affinity-sleep 1 --affinity-pin
stress-ng: info:  [1374063] setting to a 31 secs run per stressor
stress-ng: info:  [1374063] dispatching hogs: 100 cpu, 50 affinity
stress-ng: metrc: [1374063] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s CPU used per       RSS Max
stress-ng: metrc: [1374063]                           (secs)    (secs)    (secs)   (real time) (usr+sys time) instance (%)          (KB)
stress-ng: metrc: [1374063] cpu             2552393     31.00   1935.39      3.82     82326.89        1316.20        62.55          4224
stress-ng: metrc: [1374063] affinity       22479724     31.01     89.91    859.46    724894.33       23678.48        61.23          1408
stress-ng: info:  [1374063] skipped: 0
stress-ng: info:  [1374063] passed: 149: cpu (99) affinity (50)
stress-ng: info:  [1374063] failed: 0
stress-ng: info:  [1374063] metrics untrustworthy: 0
stress-ng: info:  [1374063] successful run completed in 31.05 secs
$ ./schbench -t 100
...
Wakeup Latencies percentiles (usec) runtime 30 (s) (396455 total samples)
          50.0th: 5          (155054 samples)
          90.0th: 7          (129300 samples)
        * 99.0th: 10         (20233 samples)
          99.9th: 22         (2550 samples)
          min=1, max=3259
Request Latencies percentiles (usec) runtime 30 (s) (397203 total samples)
          50.0th: 6536       (113014 samples)
          90.0th: 11760      (156216 samples)
        * 99.0th: 12496      (33708 samples)
          99.9th: 13168      (3526 samples)
          min=5831, max=32314
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 12880      (7 samples)
        * 50.0th: 13296      (9 samples)
          90.0th: 13680      (14 samples)
          min=11755, max=13812
average rps: 13240.10