### PR TITLE
scx_p2dq: Add tracing on select_cpu

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -617,6 +617,8 @@ static __always_inline s32 p2dq_select_cpu_impl(struct task_struct *p, s32 prev_
 		stat_inc(P2DQ_STAT_IDLE);
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON|cpu, taskc->slice_ns, 0);
 	}
+	trace("SELECT [%d][%s] %i->%i idle %i",
+	      p->pid, p->comm, prev_cpu, cpu, is_idle);
 
 	return cpu;
 }


### PR DESCRIPTION
Add extra optional printk tracing on the select_cpu path. This is useful for debugging scheduler CPU selection.

The output format is as follows:
```
         bpftool-23099   [002] d..41 216538.437586: bpf_trace_printk: SELECT [23100][grep] 8->8 idle 1
            grep-23100   [008] d..41 216538.437596: bpf_trace_printk: SELECT [28086][kworker/u130:2] 12->12 idle 1
  kworker/u130:2-28086   [012] d..41 216538.437603: bpf_trace_printk: SELECT [3758][tmux: server] 3->3 idle 1
            grep-23100   [008] d..41 216538.437603: bpf_trace_printk: SELECT [26734][kworker/u130:3] 10->10 idle 1
         bpftool-23099   [002] d.h31 216538.437607: bpf_trace_printk: SELECT [24396][scx_p2dq] 2->16 idle 1
            grep-23100   [008] d..41 216538.437630: bpf_trace_printk: SELECT [28086][kworker/u130:2] 12->12 idle 1
```