### PR TITLE
scx_flash: Always update task domain before proactive wakeup

### DIFF
--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -1115,6 +1115,16 @@ void BPF_STRUCT_OPS(flash_enqueue, struct task_struct *p, u64 enq_flags)
 	__sync_fetch_and_add(&nr_shared_dispatches, 1);
 
 	/*
+	 * Refresh the task domain if it was migrated to a different CPU,
+	 * without going through ops.select_cpu().
+	 *
+	 * This ensures the proactive wakeup (see below) will target a CPU
+	 * near the one the task was most recently running on.
+	 */
+	if (tctx->recent_used_cpu != prev_cpu)
+		task_update_domain(p, tctx, prev_cpu, p->cpus_ptr);
+
+	/*
 	 * If there are idle CPUs in the system try to proactively wake up
 	 * one, so that it can immediately execute the task in case its
 	 * current CPU is busy (always prioritizing full-idle SMT cores


### PR DESCRIPTION
After a task is enqueued to the per-node DSQ we proactively wakeup an idle CPU usable by the task, potentially giving a quicker opportunity for the task to be consumed.

Like any idle CPU selection, we take into account the CPU previously used by the task as a preference. However, in this case, the task's domain might be not updated if the task has bounced across different CPUs without going through ops.select_cpu(), that is the only place where we refresh the preferred domains.

Therefore, make sure to refresh the task's preferred domains before applying the proactive wakeup logic.