### PR TITLE
scx_flash: Introduce --run-lag

### DIFF
--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -118,12 +118,19 @@ struct Opts {
     #[clap(short = 'S', long, default_value = "1000")]
     slice_us_min: u64,
 
-    /// Maximum time slice lag in microseconds.
+    /// Maximum runtime budget that a task can accumulate while sleeping (in microseconds).
     ///
     /// Increasing this value can help to enhance the responsiveness of interactive tasks, but it
     /// can also make performance more "spikey".
     #[clap(short = 'l', long, default_value = "20000")]
     slice_us_lag: u64,
+
+    /// Maximum runtime penalty that a task can accumulate while running (in microseconds).
+    ///
+    /// Increasing this value can help to enhance the responsiveness of interactive tasks, but it
+    /// can also make performance more "spikey".
+    #[clap(short = 'r', long, default_value = "20000")]
+    run_us_lag: u64,
 
     /// Maximum rate of voluntary context switches.
     ///
@@ -316,6 +323,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.slice_max = opts.slice_us * 1000;
         skel.maps.rodata_data.slice_min = opts.slice_us_min * 1000;
         skel.maps.rodata_data.slice_lag = opts.slice_us_lag * 1000;
+        skel.maps.rodata_data.run_lag = opts.run_us_lag * 1000;
         skel.maps.rodata_data.throttle_ns = opts.throttle_us * 1000;
         skel.maps.rodata_data.max_avg_nvcsw = opts.max_avg_nvcsw;
 


### PR DESCRIPTION
Currently, the --slice-lag parameter serves a dual purpose: it limits both the maximum vruntime credit a task can accumulate while sleeping and the maximum execution time debit it can accumulate while running (i.e., the runtime since the last sleep).

To improve flexibility, use --slice-lag to control only the vruntime credit during sleep and introduce a new parameter, --run-lag, to separately cap the execution time debit.

This change allows users to experiment more effectively with different limits for sleep and run durations.

Example use case:

  - Get a higher score with hackbench / perf bench, without compromising too much system responsiveness. :)

```
 $ perf bench -f simple sched messaging -t -g 24 -l 10000

                                              Time   | Responsiveness
 ------------------------------------------+---------+---------------
 scx_flash                                 |  14.8s  |  Good
 scx_flash --run-us-lag 0                  |   9.1s  |  Medium
 scx_flash --run-us-lag 0 --slice-us-lag 0 |   7.5s  |  Low
```