### PR TITLE
scx_utils: Avoid divide-by-zero when "PSS Support" is disabled.

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -77,6 +77,7 @@ use crate::Cpumask;
 use anyhow::bail;
 use anyhow::Result;
 use glob::glob;
+use log::warn;
 use sscanf::sscanf;
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -645,10 +646,11 @@ fn get_capacity_source() -> Option<CapacitySource> {
         nr_cpus += 1;
     }
 
-    if nr_cpus == 0 {
+    if nr_cpus == 0 || max_rcap == 0 {
         suffix = "";
         avg_rcap = 1024;
         max_rcap = 1024;
+        warn!("CPU capacity information is not available under sysfs.");
     } else {
         avg_rcap /= nr_cpus;
         // We consider a system to have a heterogeneous CPU architecture only


### PR DESCRIPTION
When "PSS Support" is disabled in the BIOS, there are no CPU frequency and capacity-related files under sysfs, as the OS does not have control over the processor's performance and power. In this case, the max_rcap of the previous code will be zero, causing a divide-by-zero error. To avoid this, let's choose the default value (1024) for max_rcap, etc. when no capacity-related information is available.