### PR TITLE
layered: have template layers act as regular layers when no cgroup

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -3061,8 +3061,8 @@ fn main() -> Result<()> {
                         // Push the generated layer into the config
                         layer_config.specs.push(genspec);
                     }
-                    // in the absence of cpusets, have template layers
-                    // behave like non-template layers.
+                    // in the absence of matching cgroups, have template layers
+                    // behave as non-template layers do.
                     if matches.len() == 0 {
                         layer_config.specs.push(spec);
                     }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -3043,7 +3043,7 @@ fn main() -> Result<()> {
             match spec.template {
                 Some(ref rule) => {
                     let matches = expand_template(&rule)?;
-                    for (mt, mask) in matches {
+                    for (mt, mask) in matches.clone() {
                         let mut genspec = spec.clone();
 
                         genspec.cpuset = Some(mask);
@@ -3060,6 +3060,11 @@ fn main() -> Result<()> {
 
                         // Push the generated layer into the config
                         layer_config.specs.push(genspec);
+                    }
+                    // in the absence of cpusets, have template layers
+                    // behave like non-template layers.
+                    if matches.len() == 0 {
+                        layer_config.specs.push(spec);
                     }
                 }
 

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -3043,28 +3043,29 @@ fn main() -> Result<()> {
             match spec.template {
                 Some(ref rule) => {
                     let matches = expand_template(&rule)?;
-                    for (mt, mask) in matches.clone() {
-                        let mut genspec = spec.clone();
-
-                        genspec.cpuset = Some(mask);
-
-                        // Push the new "and" rule into each "or" term.
-                        for orterm in &mut genspec.matches {
-                            orterm.push(mt.clone());
-                        }
-
-                        match &mt {
-                            LayerMatch::CgroupSuffix(cgroup) => genspec.name.push_str(cgroup),
-                            _ => bail!("Template match has unexpected type"),
-                        }
-
-                        // Push the generated layer into the config
-                        layer_config.specs.push(genspec);
-                    }
                     // in the absence of matching cgroups, have template layers
                     // behave as non-template layers do.
-                    if matches.len() == 0 {
+                    if matches.is_empty() {
                         layer_config.specs.push(spec);
+                    } else {
+                        for (mt, mask) in matches {
+                            let mut genspec = spec.clone();
+
+                            genspec.cpuset = Some(mask);
+
+                            // Push the new "and" rule into each "or" term.
+                            for orterm in &mut genspec.matches {
+                                orterm.push(mt.clone());
+                            }
+
+                            match &mt {
+                                LayerMatch::CgroupSuffix(cgroup) => genspec.name.push_str(cgroup),
+                                _ => bail!("Template match has unexpected type"),
+                            }
+
+                            // Push the generated layer into the config
+                            layer_config.specs.push(genspec);
+                        }
                     }
                 }
 


### PR DESCRIPTION
This PR makes cgroup template layers behave like regular layers when matching cgroups are not present.

For example, main does this when ran with template.json:
```
###### Wed, 11 Jun 2025 12:30:12 -0400 ######
tot=      5 local_sel/enq=100.0/ 0.00 open_idle= 0.00 affn_viol= 0.00 hi/lo= 0.00/ 0.00
busy=  0.0 util/hi/lo=    0.2/ 0.00/ 0.00 fallback_cpu/util=  0/ 0.0 proc=0ms
excl_coll=0.00 excl_preempt=0.00 excl_idle=0.00 excl_wakeup=0.00
skip_preempt=0 antistall=0 fixup_vtime=0
  the rest: util/open/frac=   0.2/100.0/  100.0 prot/prot_preempt= 0.00/ 0.00 tasks=   290
            tot=      5 local_sel/enq=100.0/ 0.00 enq_dsq= 0.00 wake/exp/reenq= 0.00/ 0.00/ 0.00
            keep/max/busy= 0.00/ 0.00/ 0.00 yield/ign= 0.00/    0 
            open_idle= 0.00 mig= 0.00 xnuma_mig= 0.00 xllc_mig/skip= 0.00/ 0.00 affn_viol= 0.00
            preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00
            xlayer_wake/re= 0.00/ 0.00 llc_drain/try= 0.00/ 0.00 skip_rnode= 0.00
            slice=20ms min_exec= 0.00/   0.00ms
            cpus=  0 [  0,  0] 00000000,00000000
            [LLC] nr_cpus: sched% lat_ms
            [000]  0: 0.00%   0.00 |  0: 0.00%   0.00 |  0: 0.00%   0.00 |  0: 0.00%   0.00
```

This PR makes the following occur instead:
```
###### Wed, 11 Jun 2025 12:27:17 -0400 ######
tot=   4199 local_sel/enq=89.55/ 3.91 open_idle= 0.00 affn_viol= 0.00 hi/lo= 0.00/ 0.00
busy=  0.2 util/hi/lo=   11.8/ 0.00/ 0.00 fallback_cpu/util=  0/ 0.0 proc=2ms
excl_coll=0.00 excl_preempt=0.00 excl_idle=0.00 excl_wakeup=0.00
skip_preempt=0 antistall=0 fixup_vtime=0
  template: util/open/frac=   0.0/ 0.00/    0.0 prot/prot_preempt= 0.00/ 0.00 tasks=     0
            tot=      0 local_sel/enq= 0.00/ 0.00 enq_dsq= 0.00 wake/exp/reenq= 0.00/ 0.00/ 0.00
            keep/max/busy= 0.00/ 0.00/ 0.00 yield/ign= 0.00/    0 
            open_idle= 0.00 mig= 0.00 xnuma_mig= 0.00 xllc_mig/skip= 0.00/ 0.00 affn_viol= 0.00
            preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00
            xlayer_wake/re= 0.00/ 0.00 llc_drain/try= 0.00/ 0.00 skip_rnode= 0.00
            slice=20ms min_exec= 0.00/   0.00ms
            cpus= 16 [ 16, 16] ff000000,ff000000
            [LLC] nr_cpus: sched% lat_ms
            [000]  0: 0.00%   0.00 |  0: 0.00%   0.00 |  0: 0.00%   0.00 | 16: 0.00%   0.00
  the rest: util/open/frac=  11.8/ 0.01/  100.0 prot/prot_preempt= 0.01/13.19 tasks=   608
            tot=   4199 local_sel/enq=89.55/ 3.91 enq_dsq= 0.26 wake/exp/reenq= 6.55/ 0.00/ 0.00
            keep/max/busy= 0.00/ 0.00/ 0.00 yield/ign= 0.19/    0 
            open_idle= 0.00 mig= 3.19 xnuma_mig= 0.00 xllc_mig/skip= 0.02/ 0.00 affn_viol= 0.00
            preempt/first/xllc/xnuma/idle/fail= 0.00/ 0.00/ 0.00/ 0.00/ 0.00/ 0.00
            xlayer_wake/re= 0.02/ 0.02 llc_drain/try= 0.00/ 0.00 skip_rnode= 0.00
            slice=20ms min_exec= 0.00/   0.00ms
            cpus= 48 [ 48, 48] 00ffffff,00ffffff
            [LLC] nr_cpus: sched% lat_ms
            [000]  0:36.36%   3.69 |  0:54.55%   5.24 |  0: 9.09%   2.70 |  0: 0.00%   4.72
^CEXIT: unregistered from user space
```