### PR TITLE
scx_layered: Replenish slice for protected layers

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2134,7 +2134,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 
 			/* CPU is in a protected layer, do not pull from other layers. */
 			if (owner_layer->is_protected)
-				return;
+				goto replenish;
 		}
 
 		/* try grouped/open preempting if not tried yet */
@@ -2149,9 +2149,9 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 			return;
 	}
 
+replenish:
 	if (!tried_lo_fb && scx_bpf_dsq_move_to_local(cpuc->lo_fb_dsq_id))
 		return;
-
 	/* !NULL prev_taskc indicates runnable prev */
 	if (prev_taskc && prev_layer)
 		prev->scx.slice = prev_layer->slice_ns;


### PR DESCRIPTION
When there's excessive yields from a task that is not sharing its CPU with others, and yield_ignore is not 1, we enter the dispatch path and fail the keep_running() check, but the expectation is that, after checking our DSQs, we'll end up replenishing the slice, because we're the only task running on this CPU. However, we short circuit layer DSQ draining for protected layers, as we don't want to pull tasks from other layers onto our CPUs, and only check and consume our own DSQs.

Returning early causes the process to be enqueued again instead of being reenqueued into the local DSQ by default, since it's time slice has been exhausted. We must replenish it before return to restore the correct behavior.

Given we would have checked lo_fb again if this worked properly, place the jump label above the tried_lo_fb check and test it, and then fall through to the point where we replenish the slice for the previous task.

Fixes: c37b64c5bf90 ("scx_layered: introduce protected layers")