### PR TITLE
lib/bitmap: Use bpf_probe_read_kernel() to safely read cpumask bits

### DIFF
--- a/lib/bitmap.bpf.c
+++ b/lib/bitmap.bpf.c
@@ -178,11 +178,13 @@ __weak int
 scx_bitmap_from_bpf(scx_bitmap_t __arg_arena scx_bitmap, const cpumask_t *bpfmask __arg_trusted)
 {
 	int i;
+	u64 tmp;
 
 	for (i = 0; i < sizeof(cpumask_t) / 8 && can_loop; i++) {
 		if (i >= mask_size)
 			break;
-		scx_bitmap->bits[i] = bpfmask->bits[i];
+		bpf_probe_read_kernel(&tmp, sizeof(tmp), &bpfmask->bits[i]);
+		scx_bitmap->bits[i] = (u64)tmp;
 	}
 
 	return 0;


### PR DESCRIPTION
Direct access to bpfmask->bits[i] triggered a libbpf relocation warning due to incomplete BTF metadata for cpumask_t. Replace it with bpf_probe_read_kernel() to safely read the data and ensure verifier compatibility across kernels.

This [WARN] appears in both `scx_chaos` and `scx_p2dq`
```sh
13:18:10 [INFO] Builder { traits: [RandomDelays { frequency: 0.5, min_us: 1000, max_us: 2000 }], verbose: 0, p2dq_opts: SchedulerOpts { disable_kthreads_local: false, autoslice: false, interactive_ratio: 10, eager_load_balance: false, freq_control: false, greedy_idle_disable: false, interactive_sticky: false, interactive_fifo: false, dispatch_pick2_disable: false, dispatch_lb_busy: 75, dispatch_lb_interactive: false, keep_running: false, wakeup_lb_busy: 0, wakeup_llc_migrations: false, select_idle_in_enqueue: false, idle_resume_us: None, max_dsq_pick2: false, min_slice_us: 100, lb_slack_factor: 5, min_llc_runs_pick2: 0, dsq_time_slices: [], dsq_shift: 4, min_nr_queued_pick2: 0, dumb_queues: 3, init_dsq_index: 0 }, requires_ppid: None }
13:18:10 [INFO] DSQ[0] slice_ns 100000
13:18:10 [INFO] DSQ[1] slice_ns 3200000
13:18:10 [INFO] DSQ[2] slice_ns 6400000
13:18:10 [WARN] libbpf: prog 'scx_bitmap_from_bpf': relo #20: insn #8 (LDX/ST/STX) accesses field incorrectly. Make sure you are accessing pointers, unsigned integers, or fields of matching type and size.

stress-ng: info:  [173] setting to a 31 secs run per stressor
stress-ng: info:  [173] dispatching hogs: 10 cpu, 10 fork, 1 affinity
stress-ng: info:  [173] note: /proc/sys/kernel/sched_autogroup_enabled is 1 and this can impact scheduling throughput for processes not attached to a tty. Setting this to 0 may improve performance metrics
13:18:11 [WARN] libbpf: map 'chaos': BPF skeleton version is old, skipping map auto-attachment...
```