### PR TITLE
lib/sdt_alloc: Fix inverted null check in free path

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -421,7 +421,7 @@ int scx_alloc_free_idx(struct scx_allocator *alloc, __u64 idx)
 
 	pos = idx & mask;
 	data = chunk->data[pos];
-	if (likely(!data)) {
+	if (likely(data)) {
 
 		data[pos] = (struct sdt_data) {
 			.tid.genn = data->tid.genn + 1,

--- a/scheds/rust/scx_rusty/src/bpf/sdt_alloc.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/sdt_alloc.bpf.c
@@ -465,7 +465,7 @@ int sdt_free_idx(struct sdt_allocator *alloc, __u64 idx)
 
 	pos = idx & mask;
 	data = chunk->data[pos];
-	if (likely(!data)) {
+	if (likely(data)) {
 		cast_kern(data);
 
 		data[pos] = (struct sdt_data) {


### PR DESCRIPTION
Fix a logic bug where a null pointer could be dereferenced during freeing due to an inverted condition.