### PR TITLE
scx_layered: Synchronize among competing preemptors

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -42,6 +42,7 @@ enum consts {
 	USAGE_HALF_LIFE		= 100000000,	/* 100ms */
 	RUNTIME_DECAY_FACTOR	= 4,
 	LAYER_LAT_DECAY_FACTOR	= 32,
+	CLEAR_PREEMPTING_AFTER	= 10000000,	/* 10ms */
 
 	DSQ_ID_SPECIAL_MASK	= 0xc0000000,
 	HI_FB_DSQ_BASE		= 0x40000000,
@@ -105,6 +106,7 @@ enum global_stat_id {
 	GSTAT_ANTISTALL,
 	GSTAT_SKIP_PREEMPT,
 	GSTAT_FIXUP_VTIME,
+	GSTAT_PREEMPTING_MISMATCH,
 	NR_GSTATS,
 };
 
@@ -168,6 +170,8 @@ struct cpu_ctx {
 	bool			yielding;
 	bool			try_preempt_first;
 	bool			is_big;
+	struct task_struct	*preempting_task;
+	u64			preempting_at;
 
 	bool			protect_owned;
 	bool			protect_owned_preempt;

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -40,6 +40,8 @@ const GSTAT_FB_CPU_USAGE: usize = bpf_intf::global_stat_id_GSTAT_FB_CPU_USAGE as
 const GSTAT_ANTISTALL: usize = bpf_intf::global_stat_id_GSTAT_ANTISTALL as usize;
 const GSTAT_SKIP_PREEMPT: usize = bpf_intf::global_stat_id_GSTAT_SKIP_PREEMPT as usize;
 const GSTAT_FIXUP_VTIME: usize = bpf_intf::global_stat_id_GSTAT_FIXUP_VTIME as usize;
+const GSTAT_PREEMPTING_MISMATCH: usize =
+    bpf_intf::global_stat_id_GSTAT_PREEMPTING_MISMATCH as usize;
 
 const LSTAT_SEL_LOCAL: usize = bpf_intf::layer_stat_id_LSTAT_SEL_LOCAL as usize;
 const LSTAT_ENQ_LOCAL: usize = bpf_intf::layer_stat_id_LSTAT_ENQ_LOCAL as usize;
@@ -504,6 +506,8 @@ pub struct SysStats {
     pub skip_preempt: u64,
     #[stat(desc = "Number of times vtime was out of range and fixed up")]
     pub fixup_vtime: u64,
+    #[stat(desc = "Number of times cpuc->preempting_task didn't come on the CPU")]
+    pub preempting_mismatch: u64,
     #[stat(desc = "fallback CPU")]
     pub fallback_cpu: u32,
     #[stat(desc = "per-layer statistics")]
@@ -561,6 +565,7 @@ impl SysStats {
             antistall: stats.bpf_stats.gstats[GSTAT_ANTISTALL],
             skip_preempt: stats.bpf_stats.gstats[GSTAT_SKIP_PREEMPT],
             fixup_vtime: stats.bpf_stats.gstats[GSTAT_FIXUP_VTIME],
+            preempting_mismatch: stats.bpf_stats.gstats[GSTAT_PREEMPTING_MISMATCH],
             fallback_cpu: fallback_cpu as u32,
             fallback_cpu_util: stats.bpf_stats.gstats[GSTAT_FB_CPU_USAGE] as f64
                 / elapsed_ns as f64
@@ -602,8 +607,8 @@ impl SysStats {
 
         writeln!(
             w,
-            "skip_preempt={} antistall={} fixup_vtime={}",
-            self.skip_preempt, self.antistall, self.fixup_vtime
+            "skip_preempt={} antistall={} fixup_vtime={} preempting_mismatch={}",
+            self.skip_preempt, self.antistall, self.fixup_vtime, self.preempting_mismatch
         )?;
 
         Ok(())


### PR DESCRIPTION
Multiple preemptors can race and pick the same victim CPU and end up queueing multiple tasks on the same local DSQ severely impacting scheduling latencies.

While preemption, as implemented in scx_layered, has always been racy, c66e2c374904 ("scx_layered: Reimplement preemption using direct dispatch to foreign local DSQs") made it significantly worse. Before, the race would just fail to kick enough CPUs but the preempting task would still be picked up relatively quickly as CPUs enter dispatch path after finishing their current tasks. After, the preempting tasks end up queued on a specific local DSQ.

Fix it by using cpu_ctx->preempting_task to synchronize preemptors. The field is claimed in try_preempt_cpu() and cleared from running() when the task goes on the CPU. There are cases that the task may not go on the victim CPU even after being enqueued on its local DSQ - e.g. when the task gets reenqueued due to cpu_release(). Clear cpu_ctx->preempting_task from any task to avoid blocking preemption on the CPU for too long.

Direct dispatch, regular dispatch and preemption can still race each other after this and we likely need kernel side update to remove races completely. For now, add opportunistic tests to significantly reduce incidence rate.