### PR TITLE
scx_flash: Introduce --rr-sched

### DIFF
--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -189,6 +189,13 @@ struct Opts {
     #[clap(short = 'I', long, allow_hyphen_values = true, default_value = "-1")]
     idle_resume_us: i64,
 
+    /// Enable round-robin scheduling.
+    ///
+    /// Each task is given a fixed time slice (defined by --slice-us-max) and run in a cyclic, fair
+    /// order.
+    #[clap(short = 'R', long, action = clap::ArgAction::SetTrue)]
+    rr_sched: bool,
+
     /// Enable per-CPU tasks prioritization.
     ///
     /// This allows to prioritize per-CPU tasks that usually tend to be de-prioritized (since they
@@ -349,6 +356,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.debug = opts.debug;
         skel.maps.rodata_data.smt_enabled = smt_enabled;
         skel.maps.rodata_data.numa_disabled = opts.disable_numa;
+        skel.maps.rodata_data.rr_sched = opts.rr_sched;
         skel.maps.rodata_data.local_pcpu = opts.local_pcpu;
         skel.maps.rodata_data.no_wake_sync = opts.no_wake_sync;
         skel.maps.rodata_data.native_priority = opts.native_priority;


### PR DESCRIPTION
Add an option to enable round-robin scheduling, where tasks are assigned a fixed time slice (specified by --slice-us-max) and run in a simple, cyclic order.

This policy ensures fair time sharing and can be effective for maximizing throughput in compute-heavy workloads where latency is not a concern.