### PR TITLE
scx_p2dq: Update dispatch DSQ selection to use DSQ iterators

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -19,7 +19,6 @@ struct cpu_ctx {
 	bool				is_big;
 	u64				ran_for;
 	u32				node_id;
-	u64				affn_max_vtime;
 	u64				dsqs[MAX_DSQS_PER_LLC];
 	u64				max_load_dsq;
 };
@@ -35,9 +34,7 @@ struct llc_ctx {
 	u32				index;
 	bool				all_big;
 	u64				affn_load;
-	u64				affn_max_vtime;
 	u64				dsqs[MAX_DSQS_PER_LLC];
-	u64				dsq_max_vtime[MAX_DSQS_PER_LLC];
 	u64				dsq_load[MAX_DSQS_PER_LLC];
 	struct bpf_cpumask __kptr	*cpumask;
 	struct bpf_cpumask __kptr	*big_cpumask;


### PR DESCRIPTION
Use a DSQ iterator to find the min vtime across DSQs. This makes DSQ selection more fair during dispatch and removes extra DSQ tracking code. This uses a similar idea as #2180