### PR TITLE
p2dq: only declare each module once

### DIFF
--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -3,9 +3,8 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 pub mod bpf_intf;
-
-mod bpf_skel;
-pub use bpf_skel::*;
+pub mod bpf_skel;
+pub use bpf_skel::types;
 
 pub use scx_utils::CoreType;
 use scx_utils::Topology;

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -2,10 +2,6 @@
 
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
-mod bpf_skel;
-pub use bpf_skel::*;
-
-pub mod bpf_intf;
 pub mod stats;
 use stats::Metrics;
 
@@ -54,6 +50,8 @@ use bpf_intf::stat_idx_P2DQ_STAT_SELECT_PICK2;
 use bpf_intf::stat_idx_P2DQ_STAT_WAKE_LLC;
 use bpf_intf::stat_idx_P2DQ_STAT_WAKE_MIG;
 use bpf_intf::stat_idx_P2DQ_STAT_WAKE_PREV;
+use scx_p2dq::bpf_intf;
+use scx_p2dq::bpf_skel::*;
 use scx_p2dq::SchedulerOpts;
 use scx_p2dq::TOPO;
 


### PR DESCRIPTION
Currently p2dq declares the `bpf_intf` and `bpf_skel` modules in both main.rs and lib.rs. This means they get built twice in two different contexts, which is wasteful and incorrect. As they're both needed in lib.rs, move them both to lib.rs and clean up the second version in main.rs.

Drive-by: remove the `pub use bpf_skel::*;` in p2dq(lib) because that makes the public interface really wide.

Test plan:
- It builds.
- CI