### PR TITLE
scxtop: add generic bpf kprobe handler

### DIFF
--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -49,7 +49,7 @@ enum event_type {
 	TRACE_STARTED,
 	TRACE_STOPPED,
 	EVENT_MAX,
-	GENERIC_KPROBE,
+	KPROBE,
 };
 
 struct sched_switch_event {
@@ -151,7 +151,7 @@ struct pstate_sample_event {
 	u32             busy;
 };
 
-struct generic_kprobe_event {
+struct kprobe_event {
 	u32             pid;
 	u64             instruction_pointer;
 };
@@ -176,7 +176,7 @@ struct bpf_event {
 		struct	wakeup_event wakeup;
 		struct	wakeup_event waking;
 		struct  trace_started_event trace;
-		struct  generic_kprobe_event kprobe;
+		struct  kprobe_event kprobe;
 	} event;
 };
 

--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -49,6 +49,7 @@ enum event_type {
 	TRACE_STARTED,
 	TRACE_STOPPED,
 	EVENT_MAX,
+	GENERIC_KPROBE,
 };
 
 struct sched_switch_event {
@@ -150,6 +151,10 @@ struct pstate_sample_event {
 	u32             busy;
 };
 
+struct generic_kprobe_event {
+	u32             pid;
+};
+
 struct bpf_event {
 	int		type;
 	u64		ts;
@@ -170,6 +175,7 @@ struct bpf_event {
 		struct	wakeup_event wakeup;
 		struct	wakeup_event waking;
 		struct  trace_started_event trace;
+		struct  generic_kprobe_event kprobe;
 	} event;
 };
 

--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -153,6 +153,7 @@ struct pstate_sample_event {
 
 struct generic_kprobe_event {
 	u32             pid;
+	u64             instruction_pointer;
 };
 
 struct bpf_event {

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -204,6 +204,7 @@ int generic_kprobe(struct pt_regs *ctx)
 	event->cpu = bpf_get_smp_processor_id();
 	event->ts = bpf_ktime_get_ns();
 	event->event.kprobe.pid = bpf_get_current_pid_tgid() & 0xffffffff;
+	event->event.kprobe.instruction_pointer = PT_REGS_IP(ctx);
 
 	bpf_ringbuf_submit(event, 0);
 

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -200,7 +200,7 @@ int generic_kprobe(struct pt_regs *ctx)
 	if (!(event = try_reserve_event()))
 		return -ENOMEM;
 
-	event->type = GENERIC_KPROBE;
+	event->type = KPROBE;
 	event->cpu = bpf_get_smp_processor_id();
 	event->ts = bpf_ktime_get_ns();
 	event->event.kprobe.pid = bpf_get_current_pid_tgid() & 0xffffffff;

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -254,6 +254,7 @@ pub struct GenericKprobeAction {
     pub ts: u64,
     pub cpu: u32,
     pub pid: u32,
+    pub instruction_pointer: u64,
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -471,6 +472,7 @@ impl TryFrom<&bpf_event> for Action {
                     ts: event.ts,
                     cpu: event.cpu,
                     pid: generic_kprobe.pid,
+                    instruction_pointer: generic_kprobe.instruction_pointer,
                 }))
             }
             #[allow(non_upper_case_globals)]

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -59,7 +59,7 @@ pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
-This software may be used and distributed according to the terms of the
+This software may be used and distributed according to the terms of the 
 GNU General Public License version 2.";
 pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 
@@ -464,15 +464,15 @@ impl TryFrom<&bpf_event> for Action {
                 }))
             }
             #[allow(non_upper_case_globals)]
-            bpf_intf::event_type_GENERIC_KPROBE=> {
+            bpf_intf::event_type_GENERIC_KPROBE => {
                 let generic_kprobe = unsafe { &event.event.kprobe };
 
                 Ok(Action::GenericKprobe(GenericKprobeAction {
                     ts: event.ts,
                     cpu: event.cpu,
-                    pid: generic_kprobe.pid
+                    pid: generic_kprobe.pid,
                 }))
-            },
+            }
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_PSTATE_SAMPLE => Ok(Action::PstateSample(PstateSampleAction {
                 cpu: event.cpu,

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -59,7 +59,7 @@ pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
-This software may be used and distributed according to the terms of the
+This software may be used and distributed according to the terms of the 
 GNU General Public License version 2.";
 pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -59,7 +59,7 @@ pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
-This software may be used and distributed according to the terms of the 
+This software may be used and distributed according to the terms of the
 GNU General Public License version 2.";
 pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 
@@ -250,7 +250,7 @@ pub struct PstateSampleAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct GenericKprobeAction {
+pub struct KprobeAction {
     pub ts: u64,
     pub cpu: u32,
     pub pid: u32,
@@ -286,7 +286,7 @@ pub enum Action {
     Exec(ExecAction),
     Exit(ExitAction),
     Fork(ForkAction),
-    GenericKprobe(GenericKprobeAction),
+    Kprobe(KprobeAction),
     GpuMem(GpuMemAction),
     Help,
     HwPressure(HwPressureAction),
@@ -465,14 +465,14 @@ impl TryFrom<&bpf_event> for Action {
                 }))
             }
             #[allow(non_upper_case_globals)]
-            bpf_intf::event_type_GENERIC_KPROBE => {
-                let generic_kprobe = unsafe { &event.event.kprobe };
+            bpf_intf::event_type_KPROBE => {
+                let kprobe = unsafe { &event.event.kprobe };
 
-                Ok(Action::GenericKprobe(GenericKprobeAction {
+                Ok(Action::Kprobe(KprobeAction {
                     ts: event.ts,
                     cpu: event.cpu,
-                    pid: generic_kprobe.pid,
-                    instruction_pointer: generic_kprobe.instruction_pointer,
+                    pid: kprobe.pid,
+                    instruction_pointer: kprobe.instruction_pointer,
                 }))
             }
             #[allow(non_upper_case_globals)]


### PR DESCRIPTION
This is the first part of a multi-stage process that will eventually enable a scxtop user to select an arbitrary kprobe and view usage statistics/data on it in the terminal UI or in a perfetto trace.

This code adds the BPF generic handler that stores some basic data (more can be added as we see what is helpful) and also adds the Action in lib.rs so we can easily use the data in a trace or in the UI.