### PR TITLE
lib: add selftests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,6 +2833,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scx_lib_selftests"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "libbpf-rs",
+ "scx_utils",
+]
+
+[[package]]
 name = "scx_loader"
 version = "1.0.12"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "rust/scx_lib_selftests",
     "rust/scx_loader",
     "rust/scx_rustland_core",
     "rust/scx_stats",

--- a/lib/arena.bpf.c
+++ b/lib/arena.bpf.c
@@ -77,4 +77,3 @@ int arena_topology_print(void)
 
 	return 0;
 }
-

--- a/lib/selftests/selftest.bpf.c
+++ b/lib/selftests/selftest.bpf.c
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+ */
+#include <scx/common.bpf.h>
+
+#include "selftest.h"
+
+SEC("syscall")
+int arena_selftest(void)
+{
+	int ret;
+
+	ret = scx_selftest_bitmap();
+	if (ret)
+		return ret;
+
+	return 0;
+}

--- a/lib/selftests/selftest.h
+++ b/lib/selftests/selftest.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int scx_selftest_bitmap(void);

--- a/lib/selftests/st_bitmap.bpf.c
+++ b/lib/selftests/st_bitmap.bpf.c
@@ -1,0 +1,71 @@
+#include <scx/common.bpf.h>
+#include <lib/sdt_task.h>
+
+#include <lib/cpumask.h>
+
+static
+int scx_selftest_bitmap_clear()
+{
+	return -EOPNOTSUPP;
+}
+
+static
+int scx_selftest_bitmap_and()
+{
+	return -EOPNOTSUPP;
+}
+
+static
+int scx_selftest_bitmap_empty()
+{
+	return -EOPNOTSUPP;
+}
+
+static
+int scx_selftest_bitmap_copy()
+{
+	return -EOPNOTSUPP;
+}
+
+static
+int scx_selftest_bitmap_from_bpf()
+{
+	return -EOPNOTSUPP;
+}
+
+static
+int scx_selftest_bitmap_subset()
+{
+	return -EOPNOTSUPP;
+}
+
+static
+int scx_selftest_bitmap_intersects()
+{
+	return -EOPNOTSUPP;
+}
+
+#define SCX_SELFTEST(func)		\
+	do {				\
+		int ret = func();	\
+		if (ret) {		\
+			bpf_printk("SELFTEST %s FAIL: %d" #func, ret);	\
+			return ret;	\
+		}			\
+	} while (0)
+
+#define SCX_BITMAP_SELFTEST(suffix) SCX_SELFTEST(scx_selftest_bitmap_ ## suffix)
+
+__weak
+int scx_selftest_bitmap(void)
+{
+	SCX_BITMAP_SELFTEST(clear);
+	SCX_BITMAP_SELFTEST(and);
+	SCX_BITMAP_SELFTEST(empty);
+	SCX_BITMAP_SELFTEST(copy);
+	SCX_BITMAP_SELFTEST(from_bpf);
+	SCX_BITMAP_SELFTEST(subset);
+	SCX_BITMAP_SELFTEST(intersects);
+
+	return 0;
+}

--- a/rust/scx_lib_selftests/Cargo.toml
+++ b/rust/scx_lib_selftests/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "scx_lib_selftests"
+version = "1.0.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1.0.65"
+libbpf-rs = "=0.25.0-beta.1"
+scx_utils = { path = "../scx_utils", version = "1.0.15" }
+
+[build-dependencies]
+scx_utils = { path = "../scx_utils", version = "1.0.15" }

--- a/rust/scx_lib_selftests/README.md
+++ b/rust/scx_lib_selftests/README.md
@@ -1,0 +1,7 @@
+LIBRARY SELFTESTS
+=================
+
+Simple crate for invoking the selftests for lib/ code. Library code is
+complex, and will be load bearing in the future. Parts of it are also not widely
+exercised and so can stay latent for a long time. This crate solves the problem
+by letting us automatically invoke selftests for the library code.

--- a/rust/scx_lib_selftests/build.rs
+++ b/rust/scx_lib_selftests/build.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+fn main() {
+    scx_utils::BpfBuilder::new()
+        .unwrap()
+        .enable_skel("src/bpf/main.bpf.c", "main")
+        .add_source("../../lib/selftests/selftest.bpf.c")
+        .add_source("../../lib/selftests/st_bitmap.bpf.c")
+        .compile_link_gen()
+        .unwrap();
+}

--- a/rust/scx_lib_selftests/src/bpf/main.bpf.c
+++ b/rust/scx_lib_selftests/src/bpf/main.bpf.c
@@ -1,0 +1,4 @@
+#include <scx/common.bpf.h>
+
+char _license[] SEC("license") = "GPL";
+

--- a/rust/scx_lib_selftests/src/bpf_skel.rs
+++ b/rust/scx_lib_selftests/src/bpf_skel.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+// We can't directly include the generated skeleton in main.rs as it may
+// contain compiler attributes that can't be `include!()`ed via macro and we
+// can't use the `#[path = "..."]` because `concat!(env!("OUT_DIR"),
+// "/bpf.skel.rs")` does not work inside the path attribute yet (see
+// https://github.com/rust-lang/rust/pull/83366).
+
+include!(concat!(env!("OUT_DIR"), "/bpf_skel.rs"));

--- a/rust/scx_lib_selftests/src/main.rs
+++ b/rust/scx_lib_selftests/src/main.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+mod bpf_skel;
+pub use bpf_skel::*;
+
+use std::mem::MaybeUninit;
+
+use anyhow::Context;
+
+use scx_utils::init_libbpf_logging;
+
+use libbpf_rs::ProgramInput;
+use libbpf_rs::skel::OpenSkel;
+use libbpf_rs::skel::SkelBuilder;
+
+fn main() {
+    let mut open_object = MaybeUninit::uninit();
+    let mut builder = BpfSkelBuilder::default();
+
+    builder.obj_builder.debug(true);
+    init_libbpf_logging(None);
+
+    let skel = builder
+        .open(&mut open_object)
+        .context("Failed to open BPF program")
+        .unwrap();
+    let skel = skel.load().context("Failed to load BPF program").unwrap();
+
+    let input = ProgramInput {
+        ..Default::default()
+    };
+
+    let output = skel.progs.arena_selftest.test_run(input).unwrap();
+    if output.return_value != 0 {
+        println!(
+            "Selftest returned {}, please check bpf tracelog for more details.",
+            output.return_value as i32
+        );
+    }
+}


### PR DESCRIPTION
Add a helper crate for running selftests on the code in. the lib/ crate. Also add selftest stubs for the bitmap crate that we will flesh out later, so that the crate is immediately usable.