### PR TITLE
scxtop: fix number overflow errors

### DIFF
--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -531,7 +531,21 @@ int BPF_PROG(on_sched_switch, bool preempt, struct task_struct *prev,
 		event->cpu = bpf_get_smp_processor_id();
 		event->ts = now;
 
-		next_tctx = try_lookup_task_ctx(next);
+		event->event.sched_switch.preempt = preempt;
+		event->event.sched_switch.prev_pid = prev->pid;
+		event->event.sched_switch.prev_tgid = prev->tgid;
+		event->event.sched_switch.prev_prio = (int)prev->prio;
+		event->event.sched_switch.prev_state = prev_state;
+		event->event.sched_switch.prev_used_slice_ns = now - prev_tctx->last_run_ns;
+		event->event.sched_switch.prev_dsq_id = prev_tctx->dsq_id;
+		event->event.sched_switch.prev_slice_ns = prev_tctx->slice_ns;
+		record_real_comm(event->event.sched_switch.prev_comm, prev);
+
+		prev_tctx->dsq_id = SCX_DSQ_INVALID;
+		prev_tctx->dsq_vtime = 0;
+		prev_tctx->wakeup_ts = 0;
+		prev_tctx->dsq_insert_time = 0;
+		prev_tctx->last_run_ns = 0;
 
 		/*
 		* Tracking vtime **and** the dsq a task was inserted to is kind of
@@ -542,11 +556,13 @@ int BPF_PROG(on_sched_switch, bool preempt, struct task_struct *prev,
 		* store it in a map for the task. There still needs to be handling for
 		* when tasks are moved from iterators.
 		*/
-		event->event.sched_switch.preempt = preempt;
 		if (next) {
+			next_tctx = try_lookup_task_ctx(next);
 			event->event.sched_switch.next_pid = next->pid;
 			event->event.sched_switch.next_tgid = next->tgid;
 			event->event.sched_switch.next_prio = (int)next->prio;
+			record_real_comm(event->event.sched_switch.next_comm, next);
+
 			if (next_tctx && next_tctx->dsq_insert_time > 0) {
 				event->event.sched_switch.next_dsq_lat_us =
 					(now - next_tctx->dsq_insert_time) / 1000;
@@ -567,29 +583,13 @@ int BPF_PROG(on_sched_switch, bool preempt, struct task_struct *prev,
 				event->event.sched_switch.next_dsq_nr = 0;
 				event->event.sched_switch.next_dsq_vtime = 0;
 			}
-			record_real_comm(event->event.sched_switch.next_comm, next);
 		} else {
 			event->event.sched_switch.next_dsq_lat_us = 0;
 			event->event.sched_switch.next_pid = 0;
 			event->event.sched_switch.next_tgid = 0;
 		}
 
-		event->event.sched_switch.prev_pid = prev->pid;
-		event->event.sched_switch.prev_tgid = prev->tgid;
-		event->event.sched_switch.prev_prio = (int)prev->prio;
-		event->event.sched_switch.prev_state = prev_state;
-		event->event.sched_switch.prev_used_slice_ns = now - prev_tctx->last_run_ns;
-		event->event.sched_switch.prev_dsq_id = prev_tctx->dsq_id;
-		event->event.sched_switch.prev_slice_ns = prev_tctx->slice_ns;
-		record_real_comm(event->event.sched_switch.prev_comm, prev);
-
 		bpf_ringbuf_submit(event, 0);
-
-		prev_tctx->dsq_id = SCX_DSQ_INVALID;
-		prev_tctx->dsq_vtime = 0;
-		prev_tctx->wakeup_ts = 0;
-		prev_tctx->dsq_insert_time = 0;
-		prev_tctx->last_run_ns = 0;
 	}
 
 	// Here, we'll determine if we should kick off the next sample


### PR DESCRIPTION
Previously, scxtop's dsq_slice_consumed overflowed and the logic needed to be slightly updated to accurately get the data for both the beginning of a slice and the end of a slice. One of the bugs was that we randomly sampled events, often missing the tail-end of a slice. Another bug included incorrect operand ordering for a subtraction.

To ensure we don't miss the tail-end of a slice, we always check if the previous task is the tail end of a slice and perform all necessary calculations if so, regardless of whether we are currently sampling. After that, we determine if we should sample the incoming task based on the sample rate.

Before:
<img width="958" alt="Screenshot 2025-06-16 at 5 13 41 PM" src="https://github.com/user-attachments/assets/2a804f44-753a-4f60-bd4c-5c8c1164e9b1" />

After:
<img width="956" alt="Screenshot 2025-06-16 at 5 11 36 PM" src="https://github.com/user-attachments/assets/1d4c0979-6d38-4dfc-909f-863f21768a5e" />

(Note: There is still a bug with dsq 0 for dsq_lat_us.)