### PR TITLE
scx_p2dq: Use SCX_DSQ_LOCAL for select_cpu

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -604,7 +604,7 @@ static __always_inline s32 p2dq_select_cpu_impl(struct task_struct *p, s32 prev_
 
 	if (is_idle) {
 		stat_inc(P2DQ_STAT_IDLE);
-		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON|cpu, taskc->slice_ns, 0);
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, taskc->slice_ns, 0);
 	}
 	trace("SELECT [%d][%s] %i->%i idle %i",
 	      p->pid, p->comm, prev_cpu, cpu, is_idle);


### PR DESCRIPTION
Use SCX_DSQ_LOCAL when dispatching to local CPU in select_cpu.