### PR TITLE
scx_utils: Add an environment variable, SCX_SYSFS_PREFIX, for ease of debugging.

### DIFF
--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use libbpf_rs::libbpf_sys::*;
 use libbpf_rs::{AsRawLibbpf, OpenProgramImpl};
 use log::warn;
+use std::env;
 use std::ffi::c_void;
 use std::ffi::CStr;
 use std::ffi::CString;
@@ -40,6 +41,9 @@ lazy_static::lazy_static! {
         read_enum("scx_pick_idle_cpu_flags", "SCX_PICK_IDLE_CORE").unwrap_or(0);
     pub static ref SCX_PICK_IDLE_IN_NODE: u64 =
         read_enum("scx_pick_idle_cpu_flags", "SCX_PICK_IDLE_IN_NODE").unwrap_or(0);
+
+    pub static ref ROOT_PREFIX: String =
+        env::var("SCX_SYSFS_PREFIX").unwrap_or("".to_string());
 }
 
 fn load_vmlinux_btf() -> &'static mut btf {

--- a/rust/scx_utils/src/energy_model.rs
+++ b/rust/scx_utils/src/energy_model.rs
@@ -12,6 +12,7 @@
 //! which is loaded from debugfs.
 
 use crate::compat;
+use crate::compat::ROOT_PREFIX;
 use crate::misc::read_from_file;
 use crate::Cpumask;
 use anyhow::bail;
@@ -184,6 +185,11 @@ fn get_pd_paths() -> Result<Vec<(usize, String)>> {
 }
 
 fn get_em_root() -> Result<String> {
-    let root = compat::debugfs_mount().unwrap().join("energy_model");
-    Ok(root.display().to_string())
+    if *ROOT_PREFIX == "" {
+        let root = compat::debugfs_mount().unwrap().join("energy_model");
+        Ok(root.display().to_string())
+    } else {
+        let root = format!("{}/sys/kernel/debug/energy_model", *ROOT_PREFIX);
+        Ok(root)
+    }
 }

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -55,6 +55,7 @@ pub use user_exit_info::UEI_DUMP_PTR_MUTEX;
 
 pub mod build_id;
 pub mod compat;
+pub use compat::ROOT_PREFIX;
 
 mod libbpf_logger;
 pub use libbpf_logger::init_libbpf_logging;


### PR DESCRIPTION
Currently, Topology and  EnergyModel are created by reading information
under sysfs. The sysfs path names, like "/sys/devices/system/cpu/online"
or "sys/kernel/debug/energy_model" are hard-coded in the code. While there
is nothing wrong with this, it is inconvenient to debug and test the related
code, especially when access to the environment is not possible [1].

To mitigate such a problem for ease of debugging, an environment variable,
SCX_SYSFS_PREFIX, is added, denoting the prefix of the root path, which is
an empty string, "", when SCX_SYSFS_PREFIX is not defined. topology.rs and
energy_model.rs are updated to read relevant data from
$SCX_SYSFS_PREFIX + "/sys/...".

For example, if the SCX_SYSFS_PREFIX is modified as follows and the relevant
sysfs files are placed under "/pixel6", Topology and EnergyModel can be
tested easily.

    sudo  SCX_SYSFS_PREFIX="/pixel6" scx_lavd

[1] https://github.com/sched-ext/scx/pull/1992

