### PR TITLE
scx_p2dq: Add deadline scheduling

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/intf.h
+++ b/scheds/rust/scx_p2dq/src/bpf/intf.h
@@ -33,6 +33,8 @@ enum consts {
 	MSEC_PER_SEC		= 1000ULL,
 	NSEC_PER_SEC		= NSEC_PER_MSEC * MSEC_PER_SEC,
 
+	MIN_SLICE_USEC		= 10ULL,
+
 	LOAD_BALANCE_SLACK	= 20ULL,
 
 	// kernel definitions

--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -40,6 +40,10 @@ pub struct SchedulerOpts {
     #[clap(short = 'r', long, default_value = "10")]
     pub interactive_ratio: usize,
 
+    /// Enables deadline scheduling
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub deadline: bool,
+
     /// *DEPRECATED* Disables eager pick2 load balancing.
     #[clap(short = 'e', long, help="DEPRECATED", action = clap::ArgAction::SetTrue)]
     pub eager_load_balance: bool,
@@ -208,6 +212,7 @@ macro_rules! init_open_skel {
 
             $skel.maps.rodata_data.autoslice = opts.autoslice;
             $skel.maps.rodata_data.debug = verbose as u32;
+            $skel.maps.rodata_data.deadline_scheduling = opts.deadline;
             $skel.maps.rodata_data.dispatch_pick2_disable = opts.dispatch_pick2_disable;
             $skel.maps.rodata_data.dispatch_lb_busy = opts.dispatch_lb_busy;
             $skel.maps.rodata_data.dispatch_lb_interactive = opts.dispatch_lb_interactive;


### PR DESCRIPTION
Add initial support for deadline scheduling based on the max DSQ timeslice. Deadline scheduling can potentially improve throughput during saturation. When doing pick two load balancing properly check the slack factor to ensure that load balancing is not overly aggressive.

`main` full saturation:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (410496 total samples)
          50.0th: 17         (112341 samples)
          90.0th: 124        (158688 samples)
        * 99.0th: 933        (36907 samples)
          99.9th: 1674       (3685 samples)
          min=1, max=5013
Request Latencies percentiles (usec) runtime 30 (s) (410930 total samples)
          50.0th: 12304      (125048 samples)
          90.0th: 14192      (162320 samples)
        * 99.0th: 23584      (36780 samples)
          99.9th: 34496      (3626 samples)
          min=6201, max=61446
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13616      (8 samples)
        * 50.0th: 13680      (9 samples)
          90.0th: 13744      (12 samples)
          min=13541, max=13769
average rps: 13697.67
```
PR:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (413504 total samples)
          50.0th: 19         (108353 samples)
          90.0th: 59         (164422 samples)
        * 99.0th: 831        (36590 samples)
          99.9th: 1338       (3710 samples)
          min=1, max=7345
Request Latencies percentiles (usec) runtime 30 (s) (413831 total samples)
          50.0th: 12336      (122168 samples)
          90.0th: 13488      (165753 samples)
        * 99.0th: 21600      (35380 samples)
          99.9th: 33984      (3672 samples)
          min=6068, max=129685
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13712      (8 samples)
        * 50.0th: 13808      (11 samples)
          90.0th: 13904      (11 samples)
          min=13062, max=13929
average rps: 13794.37
```
PR with `--deadline` enabled:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (411998 total samples)
          50.0th: 17         (102690 samples)
          90.0th: 83         (163713 samples)
        * 99.0th: 847        (37043 samples)
          99.9th: 1390       (3708 samples)
          min=1, max=4326
Request Latencies percentiles (usec) runtime 30 (s) (412397 total samples)
          50.0th: 12336      (121686 samples)
          90.0th: 13584      (163265 samples)
        * 99.0th: 23712      (36414 samples)
          99.9th: 35392      (3694 samples)
          min=6025, max=76113
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13648      (7 samples)
        * 50.0th: 13808      (10 samples)
          90.0th: 13872      (13 samples)
          min=12897, max=13905
average rps: 13746.57
```
`eevdf`:
```
Wakeup Latencies percentiles (usec) runtime 30 (s) (412707 total samples)
          50.0th: 7          (74835 samples)
          90.0th: 44         (151951 samples)
        * 99.0th: 1182       (36509 samples)
          99.9th: 3892       (3715 samples)
          min=1, max=9969
Request Latencies percentiles (usec) runtime 30 (s) (413638 total samples)
          50.0th: 12432      (116022 samples)
          90.0th: 13552      (165820 samples)
        * 99.0th: 23008      (36577 samples)
          99.9th: 36160      (3720 samples)
          min=6088, max=83853
RPS percentiles (requests) runtime 30 (s) (31 total samples)
          20.0th: 13648      (7 samples)
        * 50.0th: 13776      (9 samples)
          90.0th: 13904      (13 samples)
          min=13387, max=13938
average rps: 13787.93
```
