### PR TITLE
scxtop: fix dsq0 overflow

### DIFF
--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -162,6 +162,8 @@ static struct task_ctx *try_lookup_task_ctx(struct task_struct *p)
 		new_tctx.dsq_vtime = 0;
 		new_tctx.slice_ns = 0;
 		new_tctx.last_run_ns = 0;
+		new_tctx.dsq_insert_time = 0;
+		new_tctx.wakeup_ts = 0;
 
 		if (!bpf_map_update_elem(&task_data, &tptr, &new_tctx, BPF_ANY))
 			return NULL;


### PR DESCRIPTION
Previously, new task contexts where initialized without properly zero-ing out the data. This led to weird and incorrect results for dsq0, for example see dsq0 for dsq_lat_us here:

<img width="956" alt="Screenshot 2025-06-16 at 5 11 36 PM" src="https://github.com/user-attachments/assets/8c28b94c-1c20-4974-98f8-d8ae724bba7b" />

Now that the data is properly zero-ed out:

<img width="958" alt="Screenshot 2025-06-17 at 11 57 18 AM" src="https://github.com/user-attachments/assets/eca0dcca-767d-43f0-abbe-d66a7035f46e" />
