### PR TITLE
scxtop: fix tracing race bug

### DIFF
--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -213,6 +213,10 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
             let trace_file = trace_args.output_file.clone();
             let mut trace_manager = PerfettoTraceManager::new(trace_file_prefix, None);
             info!("warming up for {}ms", trace_args.warmup_ms);
+
+            let mut tracer = Tracer::new(skel);
+            tracer.trace_async(trace_dur).await?;
+            
             tokio::time::sleep(Duration::from_millis(trace_args.warmup_ms)).await;
             debug!("starting trace");
             let thread_warmup = warmup_done.clone();
@@ -236,9 +240,6 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
                     }
                 }
             });
-
-            let mut tracer = Tracer::new(skel);
-            tracer.trace_async(trace_dur).await?;
 
             // The order is important here:
             // 1) first drop the links to detach the attached BPF programs

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -212,11 +212,10 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
             let trace_file_prefix = config.trace_file_prefix().to_string();
             let trace_file = trace_args.output_file.clone();
             let mut trace_manager = PerfettoTraceManager::new(trace_file_prefix, None);
-            info!("warming up for {}ms", trace_args.warmup_ms);
-
-            let mut tracer = Tracer::new(skel);
+            let mut tracer = Tracer::new(skel);P
             tracer.trace_async(trace_dur).await?;
             
+            info!("warming up for {}ms", trace_args.warmup_ms);
             tokio::time::sleep(Duration::from_millis(trace_args.warmup_ms)).await;
             debug!("starting trace");
             let thread_warmup = warmup_done.clone();

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -239,6 +239,7 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
                 }
             });
 
+            tokio::time::sleep(Duration::from_millis(trace_args.trace_ms)).await;
             tracer.clear_links()?;
             // The order is important here:
             // 1) first drop the links to detach the attached BPF programs

--- a/tools/scxtop/src/tracer.rs
+++ b/tools/scxtop/src/tracer.rs
@@ -39,7 +39,7 @@ impl<'a> Tracer<'a> {
     }
 
     /// Starts the collection of a trace, does not stop the trace.
-    pub async fn trace_async(&mut self, dur: std::time::Duration) -> Result<()> {
+    pub fn trace(&mut self) -> Result<()> {
         self.skel.maps.data_data.sample_rate = 1;
         self.skel.maps.data_data.enable_bpf_events = true;
         self.attach_trace_progs()?;
@@ -48,7 +48,10 @@ impl<'a> Tracer<'a> {
             self.trace_links.len(),
             self.skel.maps.data_data.sample_rate
         );
-        tokio::time::sleep(dur).await;
+        Ok(())
+    }
+
+    pub fn clear_links(&mut self) -> Result<()> {
         self.trace_links.clear();
         Ok(())
     }


### PR DESCRIPTION
Previously, the tracer attached several programs only after the trace had completed (even though the trace_async method contained a timer), likely due to some race condition between attaching the programs to events and the timer. This caused all events that are attached in trace_async to not show up in perfetto/the trace. Now, we attach the programs earlier on and keep an explicit timer in the run_trace method (for clarity mainly).

Before:
<img width="1497" alt="Screenshot 2025-06-17 at 8 46 57 PM" src="https://github.com/user-attachments/assets/670c1dfe-72fe-462d-9ae6-3c86df4cc721" />

After (notice the additional statistics on the bottom - softirq_exit, etc.):
<img width="1493" alt="Screenshot 2025-06-17 at 8 42 28 PM" src="https://github.com/user-attachments/assets/1a51109d-e04a-4afd-8582-b1451494fc15" />

