### PR TITLE
scx_rusty: Propagate format() error

### DIFF
--- a/scheds/rust/scx_rusty/src/stats.rs
+++ b/scheds/rust/scx_rusty/src/stats.rs
@@ -269,7 +269,8 @@ pub fn monitor(intv: Duration, shutdown: Arc<AtomicBool>) -> Result<()> {
                 dt.to_rfc2822(),
                 (cst.lb_at_us as i64 - cst.at_us as i64) as f64 / 1000.0
             );
-            cst.format(&mut std::io::stdout())
+            cst.format(&mut std::io::stdout())?;
+            Ok(())
         },
     )
 }


### PR DESCRIPTION
The monitor callback previously ignored a fallible operation's result. Add a `?` to propagate any I/O errors handling.