### PR TITLE
layered/chaos: make --version and startup message uniform

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1892,6 +1892,10 @@ impl<'a> Scheduler<'a> {
         let mut skel_builder = BpfSkelBuilder::default();
         skel_builder.obj_builder.debug(opts.verbose > 1);
         init_libbpf_logging(None);
+        info!(
+            "Running scx_layered (build ID: {})",
+            build_id::full_version(env!("CARGO_PKG_VERSION"))
+        );
         let mut skel = scx_ops_open!(skel_builder, open_object, layered)?;
 
         // enable autoloads for conditionally loaded things


### PR DESCRIPTION
Add a startup message to layered/chaos in the same format as p2dq. This message contains the name of the scheduler and the version/git hash/triple. Useful when debugging.

Test plan:
- CI

```
jake@rooster:/data/users/jake/repos/scx/ > sudo target/release/scx_chaos --version
scx_chaos: 1.0.16-g1cafd127 x86_64-unknown-linux-gnu
jake@rooster:/data/users/jake/repos/scx/ > sudo target/release/scx_chaos
11:54:20 [INFO] Running scx_chaos (build ID: 1.0.16-g1cafd127 x86_64-unknown-linux-gnu)
11:54:20 [INFO] Builder { traits: [], verbose: 0, p2dq_opts: SchedulerOpts { disable_kthreads_local: false, autoslice: false, interactive_ratio: 10, deadline: false, eager_load_balance: false, freq_control: false, greedy_idle_disable: true, interactive_sticky: false, interactive_fifo: false, dispatch_pick2_disable: false, dispatch_lb_busy: 75, dispatch_lb_interactive: false, keep_running: false, wakeup_lb_busy: 0, wakeup_llc_migrations: false, select_idle_in_enqueue: false, idle_resume_us: None, max_dsq_pick2: false, min_slice_us: 100, lb_slack_factor: 5, min_llc_runs_pick2: 3, dsq_time_slices: [], dsq_shift: 4, min_nr_queued_pick2: 0, dumb_queues: 3, init_dsq_index: 0 }, requires_ppid: None }
11:54:20 [INFO] DSQ[0] slice_ns 100000
11:54:20 [INFO] DSQ[1] slice_ns 3200000
11:54:20 [INFO] DSQ[2] slice_ns 6400000
11:54:20 [INFO] libbpf: struct_ops chaos: member priv not found in kernel, skipping it as it's set to zero

11:54:20 [WARN] libbpf: prog 'scx_bitmap_from_bpf': relo #20: insn #8 (LDX/ST/STX) accesses field incorrectly. Make sure you are accessing pointers, unsigned integers, or fields of matching type and size.

^C%
jake@rooster:/data/users/jake/repos/scx/ > sudo target/release/scx_layered --run-example
11:54:28 [INFO] Topology awareness not specified, selecting enabled based on hardware
11:54:28 [INFO] CPUs: online/possible=96/96 nr_cores=48
11:54:28 [INFO] Running scx_layered (build ID: 1.0.14-g1cafd127 x86_64-unknown-linux-gnu)
11:54:29 [INFO] libbpf: struct_ops layered: member priv not found in kernel, skipping it as it's set to zero

11:54:29 [INFO] Layered Scheduler Attached. Run `scx_layered --monitor` for metrics.
^CEXIT: unregistered from user space
```