### PR TITLE
scx_lib_selftests/Cargo: Bump edition to 2021

### DIFF
--- a/rust/scx_lib_selftests/Cargo.toml
+++ b/rust/scx_lib_selftests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scx_lib_selftests"
 version = "1.0.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.65"

--- a/rust/scx_lib_selftests/src/main.rs
+++ b/rust/scx_lib_selftests/src/main.rs
@@ -11,9 +11,9 @@ use anyhow::Context;
 
 use scx_utils::init_libbpf_logging;
 
-use libbpf_rs::ProgramInput;
 use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::SkelBuilder;
+use libbpf_rs::ProgramInput;
 
 fn main() {
     let mut open_object = MaybeUninit::uninit();


### PR DESCRIPTION
Switch to Rust 2021 edition to fix build failure.

See #2186.