### PR TITLE
scx_rusty: Suppress warning on aarch64

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -1261,6 +1261,7 @@ u32 dom_node_id(u32 dom_id)
 	return *nid_ptr;
 }
 
+#if !defined(__TARGET_ARCH_arm64) && ! defined(__TARGET_ARCH_riscv)
 /*
  * Returns the dom mask for a node.
  */
@@ -1279,7 +1280,6 @@ static u64 node_dom_mask(u32 node_id)
 	return mask;
 }
 
-#if !defined(__TARGET_ARCH_arm64) && ! defined(__TARGET_ARCH_riscv)
 /*
  * Sets the preferred domain mask according to the mempolicy. See man(2)
  * set_mempolicy for more details on mempolicy.


### PR DESCRIPTION
Warning:
```bash
warning: scx_rusty@1.0.13: src/bpf/main.bpf.c:1267:12: warning: unused function 'node_dom_mask' [-Wunused-function]
warning: scx_rusty@1.0.13:  1267 | static u64 node_dom_mask(u32 node_id)
warning: scx_rusty@1.0.13:       |            ^~~~~~~~~~~~~
warning: scx_rusty@1.0.13: 1 warning generated.
```

Test on:
```bash
OS: Ubuntu 25.04 aarch64
Kernel: Linux 6.14.0-15-generic
```

Edit: updated warning log