### PR TITLE
scx_p2dq: Add migration DSQs

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/intf.h
+++ b/scheds/rust/scx_p2dq/src/bpf/intf.h
@@ -37,6 +37,8 @@ enum consts {
 
 	LOAD_BALANCE_SLACK	= 20ULL,
 
+	P2DQ_MIG_DSQ		= 1LLU << 60,
+
 	// kernel definitions
 	CLOCK_BOOTTIME		= 7,
 

--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -19,6 +19,7 @@ struct cpu_ctx {
 	bool				is_big;
 	u64				ran_for;
 	u32				node_id;
+	u64				mig_dsq;
 	u64				dsqs[MAX_DSQS_PER_LLC];
 	u64				max_load_dsq;
 };
@@ -34,6 +35,7 @@ struct llc_ctx {
 	u32				index;
 	bool				all_big;
 	u64				affn_load;
+	u64				mig_dsq;
 	u64				dsqs[MAX_DSQS_PER_LLC];
 	u64				dsq_load[MAX_DSQS_PER_LLC];
 	struct bpf_cpumask __kptr	*cpumask;


### PR DESCRIPTION
Add a migration DSQ for tasks that are eligible to be load balanced. Previously when iterating across all DSQs the time complexity is O(N) across all N tasks in the worst case. The migration eligible DSQ allows for O(logN) lookups when doing LLC migrations, where N is the number of eligible tasks for migration.

Refactor p2dq_dispatch_impl to only lookup the llc_ctx context when needed in order to reduce map lookups in the dispatch path.