### PR TITLE
scx_flash: Handle migration-disabled tasks in direct dispatch

### DIFF
--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -1037,7 +1037,7 @@ static bool try_direct_dispatch(struct task_struct *p, struct task_ctx *tctx,
 	 * If the task can only run on a single CPU and that CPU is idle,
 	 * perform a direct dispatch.
 	 */
-	if (p->nr_cpus_allowed == 1) {
+	if (p->nr_cpus_allowed == 1 || is_migration_disabled(p)) {
 		if (scx_bpf_test_and_clear_cpu_idle(cpu) && can_direct_dispatch(cpu)) {
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, slice_max, enq_flags);
 			__sync_fetch_and_add(&nr_direct_dispatches, 1);


### PR DESCRIPTION
Attempting to move migration-disabled tasks on other CPUs during direct dispatch can triggere errors like the following:

  runtime error (SCX_DSQ_LOCAL[_ON] cannot move migration disabled coordinator[41400] from CPU 63 to 9)

Fix by properly handling migration-disabled tasks during direct dispatch and avoid migrating them.