### PR TITLE
scxtop: fix event clearing bug

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -303,6 +303,19 @@ impl<'a> App<'a> {
 
     /// Stop all active perf events.
     fn stop_perf_events(&mut self) {
+        let default_perf_event = self.config.default_perf_event();
+        let default_perf_event_parts: Vec<&str> = default_perf_event.split(':').collect();
+
+        // We have already checked that this was a valid perf event in new(), no
+        // need to check here.
+        let subsystem = default_perf_event_parts[0].to_string();
+        let event = default_perf_event_parts[1].to_string();
+        self.active_event = PerfEvent::new(subsystem.clone(), event.clone(), 0);
+
+        self.available_events = PerfEvent::default_events();
+        let config_events = PerfEvent::from_config(&self.config).unwrap();
+        self.available_events.extend(config_events);
+
         for cpu_data in self.cpu_data.values_mut() {
             cpu_data.data.clear();
         }

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -300,12 +300,16 @@ impl<'a> App<'a> {
     }
 
     /// Stop all active perf events.
-    fn stop_perf_events(&mut self) -> Result<()> {
+    fn stop_perf_events(&mut self) {
         for cpu_data in self.cpu_data.values_mut() {
             cpu_data.data.clear();
         }
         self.active_perf_events.clear();
+    }
 
+    /// Resets perf events to default
+    fn reset_perf_events(&mut self) -> Result<()> {
+        self.stop_perf_events();
         self.available_events = PerfEvent::default_events();
         let config_events = PerfEvent::from_config(&self.config).unwrap();
         self.available_events.extend(config_events);
@@ -351,10 +355,7 @@ impl<'a> App<'a> {
     /// Activates a perf event, stopping any active perf events.
     fn activate_perf_event(&mut self, perf_event: &PerfEvent) -> Result<()> {
         if !self.active_perf_events.is_empty() {
-            for cpu_data in self.cpu_data.values_mut() {
-                cpu_data.data.clear();
-            }
-            self.active_perf_events.clear();
+            self.stop_perf_events();
         }
         for cpu_id in self.topo.all_cpus.keys() {
             let mut event = perf_event.clone();
@@ -2613,7 +2614,7 @@ impl<'a> App<'a> {
             Action::HwPressure(a) => {
                 self.on_hw_pressure(a);
             }
-            Action::ClearEvent => self.stop_perf_events()?,
+            Action::ClearEvent => self.reset_perf_events()?,
             Action::ChangeTheme => {
                 self.set_theme(self.theme().next());
             }

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -1791,7 +1791,7 @@ impl<'a> App<'a> {
             )),
             Line::from(Span::styled(
                 format!(
-                    "{}: clear active perf event",
+                    "{}: clear active perf events",
                     self.config
                         .active_keymap
                         .action_keys_string(Action::ClearEvent),


### PR DESCRIPTION
Currently, pressing 'x' to clear events does not work as expected. It clears the data for the event, but leaves the event visible and present in the available_events array. This fix causes 'x' to fully clear whatever events have been added.

Also removed unused variable non_hw_event_active.