### PR TITLE
scx_flash: Enable per-CPU DSQs and per-node DSQs

### DIFF
--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -171,7 +171,7 @@ struct Opts {
     /// Decreasing this value makes the scheduler more robust and fair.
     ///
     /// (0 = disable voluntary context switch prioritization).
-    #[clap(short = 'c', long, default_value = "128")]
+    #[clap(short = 'c', long, default_value = "0")]
     max_avg_nvcsw: u64,
 
     /// Throttle the running CPUs by periodically injecting idle cycles.

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -189,9 +189,9 @@ struct Opts {
     #[clap(short = 'I', long, allow_hyphen_values = true, default_value = "-1")]
     idle_resume_us: i64,
 
-    /// Enable per-CPU runqueues.
+    /// Use per-CPU runqueues only.
     ///
-    /// Use distinct per-CPU runqueues to reduce task migrations. This can help improve certain
+    /// Force using only the per-CPU runqueues to reduce task migrations. This can improve certain
     /// cache-sensitive workload at the cost of making the system less responsive.
     #[clap(short = 'C', long, action = clap::ArgAction::SetTrue)]
     cpu_runqueue: bool,

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -20,14 +20,14 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use clap::Parser;
 use crossbeam::channel::RecvTimeoutError;
 use libbpf_rs::OpenObject;
 use libbpf_rs::ProgramInput;
-use log::warn;
-use log::{debug, info};
+use log::{debug, info, warn};
 use scx_stats::prelude::*;
 use scx_utils::autopower::{fetch_power_profile, PowerProfile};
 use scx_utils::build_id;
@@ -191,10 +191,18 @@ struct Opts {
 
     /// Use per-CPU runqueues only.
     ///
-    /// Force using only the per-CPU runqueues to reduce task migrations. This can improve certain
-    /// cache-sensitive workload at the cost of making the system less responsive.
+    /// Force using only per-CPU runqueues to reduce task migrations. This can improve certain
+    /// cache-sensitive workloads at the cost of making the system less responsive.
     #[clap(short = 'C', long, action = clap::ArgAction::SetTrue)]
     cpu_runqueue: bool,
+
+    /// Use per-node runqueues only.
+    ///
+    /// Force using only per-node runqueues to maximize work conservation. This can improve
+    /// system responsiveness under saturation conditions at the cost of reducing performance for
+    /// cache-sensitive workloads.
+    #[clap(short = 'N', long, action = clap::ArgAction::SetTrue)]
+    node_runqueue: bool,
 
     /// Enable round-robin scheduling.
     ///
@@ -363,7 +371,6 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.debug = opts.debug;
         skel.maps.rodata_data.smt_enabled = smt_enabled;
         skel.maps.rodata_data.numa_disabled = opts.disable_numa;
-        skel.maps.rodata_data.pcpu_dsq = opts.cpu_runqueue;
         skel.maps.rodata_data.rr_sched = opts.rr_sched;
         skel.maps.rodata_data.local_pcpu = opts.local_pcpu;
         skel.maps.rodata_data.no_wake_sync = opts.no_wake_sync;
@@ -374,6 +381,19 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.run_lag = opts.run_us_lag * 1000;
         skel.maps.rodata_data.throttle_ns = opts.throttle_us * 1000;
         skel.maps.rodata_data.max_avg_nvcsw = opts.max_avg_nvcsw;
+
+        if !opts.cpu_runqueue && !opts.node_runqueue {
+            skel.maps.rodata_data.pcpu_dsq = true;
+            skel.maps.rodata_data.node_dsq = true;
+        } else if (opts.cpu_runqueue) {
+            skel.maps.rodata_data.pcpu_dsq = true;
+            skel.maps.rodata_data.node_dsq = false;
+        } else if (opts.node_runqueue) {
+            skel.maps.rodata_data.pcpu_dsq = false;
+            skel.maps.rodata_data.node_dsq = true;
+        } else {
+            bail!("--cpu-runqueue and --node-runqueue are mutually exclusive");
+        }
 
         // Implicitly enable direct dispatch of per-CPU kthreads if CPU throttling is enabled
         // (it's never a good idea to throttle per-CPU kthreads).


### PR DESCRIPTION
This helps reduce task migrations for interactive workloads, improving performance for those that are cache-sensitive or otherwise benefit from fewer migrations (e.g., gaming, audio).

It also introduces options to enable/disable per-CPU and per-node DSQs independently, providing a way to restore the previous behavior if desired.

By default, interactive tasks are dispatched to per-CPU DSQs, while non-interactive tasks go to per-node DSQs, ensuring natural load balancing across the system.

Test result (schbench):

- before:

```
    $ schbench -L -m 4 -M auto -t 64 -n 0
    auto pinning message and worker threads
    Pinning to message thread index 1 cpu 1
    Pinning to message thread index 2 cpu 2
    Pinning to message thread index 0 cpu 0
    Pinning to message thread index 3 cpu 3
    Wakeup Latencies percentiles (usec) runtime 10 (s) (5321096 total samples)
              50.0th: 82         (1582064 samples)
              90.0th: 229        (2125465 samples)
            * 99.0th: 469        (475328 samples)
              99.9th: 795        (47407 samples)
              min=1, max=2529
    Request Latencies percentiles (usec) runtime 10 (s) (5325641 total samples)
              50.0th: 216        (1579086 samples)
              90.0th: 368        (2123547 samples)
            * 99.0th: 476        (479839 samples)
              99.9th: 579        (46861 samples)
              min=102, max=1565
    RPS percentiles (requests) runtime 10 (s) (11 total samples)
              20.0th: 475648     (3 samples)
            * 50.0th: 547840     (3 samples)
              90.0th: 560128     (4 samples)
              min=467478, max=561539
    sched delay: message 166 (usec) worker 26 (usec)
    current rps: 552656.71
```

 - after:

```
    $ schbench -L -m 4 -M auto -t 64 -n 0
    auto pinning message and worker threads
    Pinning to message thread index 1 cpu 1
    Pinning to message thread index 0 cpu 0
    Pinning to message thread index 3 cpu 3
    Pinning to message thread index 2 cpu 2
    Wakeup Latencies percentiles (usec) runtime 10 (s) (14940922 total samples)
              50.0th: 12         (4426028 samples)
              90.0th: 25         (5891087 samples)
            * 99.0th: 47         (1197215 samples)
              99.9th: 128        (129406 samples)
              min=1, max=3263
    Request Latencies percentiles (usec) runtime 10 (s) (15119317 total samples)
              50.0th: 151        (4743909 samples)
              90.0th: 166        (5971740 samples)
            * 99.0th: 177        (1151492 samples)
              99.9th: 236        (124276 samples)
              min=102, max=11141
    RPS percentiles (requests) runtime 10 (s) (11 total samples)
              20.0th: 1484800    (3 samples)
            * 50.0th: 1521664    (7 samples)
              90.0th: 1521664    (0 samples)
              min=1471906, max=1523766
    sched delay: message 4 (usec) worker 4 (usec)
    current rps: 1522320.23
```