### PR TITLE
scx_flash: Remove unnecessary parentheses

### DIFF
--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -385,10 +385,10 @@ impl<'a> Scheduler<'a> {
         if !opts.cpu_runqueue && !opts.node_runqueue {
             skel.maps.rodata_data.pcpu_dsq = true;
             skel.maps.rodata_data.node_dsq = true;
-        } else if (opts.cpu_runqueue) {
+        } else if opts.cpu_runqueue {
             skel.maps.rodata_data.pcpu_dsq = true;
             skel.maps.rodata_data.node_dsq = false;
-        } else if (opts.node_runqueue) {
+        } else if opts.node_runqueue {
             skel.maps.rodata_data.pcpu_dsq = false;
             skel.maps.rodata_data.node_dsq = true;
         } else {


### PR DESCRIPTION
```shell
warning: unnecessary parentheses around `if` condition
   --> scheds/rust/scx_flash/src/main.rs:388:19
    |
388 |         } else if (opts.cpu_runqueue) {
    |                   ^                 ^
    |
    = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
    |
388 -         } else if (opts.cpu_runqueue) {
388 +         } else if opts.cpu_runqueue {
    |

warning: unnecessary parentheses around `if` condition
   --> scheds/rust/scx_flash/src/main.rs:391:19
    |
391 |         } else if (opts.node_runqueue) {
    |                   ^                  ^
    |
help: remove these parentheses
    |
391 -         } else if (opts.node_runqueue) {
391 +         } else if opts.node_runqueue {
    |

warning: `scx_flash` (bin "scx_flash") generated 2 warnings (run `cargo fix --bin "scx_flash"` to apply 2 suggestions)
```