### PR TITLE
scxtop: generalize perf events -> profiling events

### DIFF
--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -38,7 +38,7 @@ impl Default for KeyMap {
     fn default() -> Self {
         let mut bindings = HashMap::new();
         bindings.insert(Key::Char('d'), Action::SetState(AppState::Default));
-        bindings.insert(Key::Char('e'), Action::SetState(AppState::Event));
+        bindings.insert(Key::Char('e'), Action::SetState(AppState::PerfEvent));
         bindings.insert(Key::Char('f'), Action::ToggleCpuFreq);
         bindings.insert(Key::Char('u'), Action::ToggleUncoreFreq);
         bindings.insert(Key::Char('L'), Action::ToggleLocalization);
@@ -342,7 +342,7 @@ pub fn parse_key(key_str: &str) -> Result<Key> {
 pub fn parse_action(action_str: &str) -> Result<Action> {
     match action_str {
         "AppStateDefault" => Ok(Action::SetState(AppState::Default)),
-        "AppStateEvent" => Ok(Action::SetState(AppState::Event)),
+        "AppStatePerfEvent" => Ok(Action::SetState(AppState::PerfEvent)),
         "ToggleCpuFreq" => Ok(Action::ToggleCpuFreq),
         "ToggleUncoreFreq" => Ok(Action::ToggleUncoreFreq),
         "ToggleLocalization" => Ok(Action::ToggleLocalization),

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -69,8 +69,8 @@ pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 pub enum AppState {
     /// Application is in the default state.
     Default,
-    /// Application is in the event state.
-    Event,
+    /// Application is in the PerfEvent list state.
+    PerfEvent,
     /// Application is in the help state.
     Help,
     /// Application is in the Llc state.
@@ -124,6 +124,25 @@ impl FilteredEventState {
         self.count = 0;
         self.scroll = 0;
         self.selected = 0;
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum ProfilingEvent {
+    Perf(PerfEvent),
+}
+
+impl ProfilingEvent {
+    pub fn event_name(&self) -> &str {
+        match self {
+            ProfilingEvent::Perf(p) => p.event_name(),
+        }
+    }
+
+    pub fn value(&mut self, reset: bool) -> anyhow::Result<u64> {
+        match self {
+            ProfilingEvent::Perf(p) => p.value(reset),
+        }
     }
 }
 
@@ -577,7 +596,7 @@ impl std::fmt::Display for Action {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Action::SetState(AppState::Default) => write!(f, "AppStateDefault"),
-            Action::SetState(AppState::Event) => write!(f, "AppStateEvent"),
+            Action::SetState(AppState::PerfEvent) => write!(f, "AppStatePerfEvent"),
             Action::ToggleCpuFreq => write!(f, "ToggleCpuFreq"),
             Action::ToggleUncoreFreq => write!(f, "ToggleUncoreFreq"),
             Action::ToggleLocalization => write!(f, "ToggleLocalization"),

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -58,7 +58,7 @@ fn get_action(app: &App, keymap: &KeyMap, event: Event) -> Action {
         }
         Event::Key(key) => handle_key_event(app, keymap, key),
         Event::Paste(paste) => match app.state() {
-            AppState::Event => Action::InputEntry(paste),
+            AppState::PerfEvent => Action::InputEntry(paste),
             _ => Action::None,
         },
         _ => Action::None,
@@ -68,7 +68,7 @@ fn get_action(app: &App, keymap: &KeyMap, event: Event) -> Action {
 fn handle_key_event(app: &App, keymap: &KeyMap, key: KeyEvent) -> Action {
     match key.code {
         Char(c) => match app.state() {
-            AppState::Event => Action::InputEntry(c.to_string()),
+            AppState::PerfEvent => Action::InputEntry(c.to_string()),
             _ => keymap.action(&Key::Char(c)),
         },
         _ => keymap.action(&Key::Code(key.code)),


### PR DESCRIPTION
Non-functional changes, mostly renaming from perf->prof. Main idea here is to generalize from perf events to any profiling event. To do this, an enum is added with two methods (value and name). With that and a few match clauses in App, we can now stick in any profiling event.

This should clear the path to easily add in kprobe events by just adding it to the ProfilingEvent enum and to the match clauses.