### PR TITLE
scxtop: make generic kprobe handler sample

### DIFF
--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -196,7 +196,7 @@ int generic_kprobe(struct pt_regs *ctx)
 {
 	struct bpf_event *event;
 
-	if (!enable_bpf_events)
+	if (!enable_bpf_events || !should_sample())
 		return 0;
 
 	if (!(event = try_reserve_event()))


### PR DESCRIPTION
Now that we'll be using the bpf kprobe handler for the UI as well as tracing, it needs to sample data when we are using it for the UI.