### PR TITLE
scxtop: fix kprobe instuction pointer

### DIFF
--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -206,7 +206,7 @@ int generic_kprobe(struct pt_regs *ctx)
 	event->cpu = bpf_get_smp_processor_id();
 	event->ts = bpf_ktime_get_ns();
 	event->event.kprobe.pid = bpf_get_current_pid_tgid() & 0xffffffff;
-	event->event.kprobe.instruction_pointer = PT_REGS_IP(ctx);
+	event->event.kprobe.instruction_pointer = bpf_get_func_ip(ctx);
 
 	bpf_ringbuf_submit(event, 0);
 


### PR DESCRIPTION
[PT_REGS_IP](https://docs.ebpf.io/ebpf-library/libbpf/ebpf/PT_REGS_IP/) gives the instruction directly after the ctx (addr + 1) while [bpf_get_func_ip](https://docs.ebpf.io/linux/helper-function/bpf_get_func_ip/) gives the exact address. When using the instruction pointer for matching purposes, the exact address is needed.