### PR TITLE
scx_lavd: Suppress warning

### DIFF
--- a/scheds/rust/scx_lavd/src/cpu_order.rs
+++ b/scheds/rust/scx_lavd/src/cpu_order.rs
@@ -64,6 +64,7 @@ pub struct ComputeDomain {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct PerfCpuOrder {
     pub perf_cap: usize,                 // performance in capacity
     pub perf_util: f32,                  // performance in utilization, [0, 1]
@@ -72,6 +73,7 @@ pub struct PerfCpuOrder {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct CpuOrder {
     pub all_cpus_mask: Cpumask,
     pub cpuids: Vec<CpuId>,
@@ -655,7 +657,7 @@ impl<'a> EnergyModelOptimizer<'a> {
 
         // Find the best performance domains for each system utilization target.
         for &util in utils.iter() {
-            let mut best_pdsi: Option<PDSetInfo<'a>> = None;
+            let mut best_pdsi: Option<PDSetInfo<'a>>;
             let mut del_pdsi: Option<PDSetInfo<'a>> = None;
 
             match self.perf_pdsi.borrow().last_key_value() {


### PR DESCRIPTION
```rust
warning: value assigned to `best_pdsi` is never read
   --> scheds/rust/scx_lavd/src/cpu_order.rs:658:21
    |
658 |             let mut best_pdsi: Option<PDSetInfo<'a>> = None;
    |                     ^^^^^^^^^
    |
    = help: maybe it is overwritten before being read?
    = note: `#[warn(unused_assignments)]` on by default

warning: field `perf_util` is never read
  --> scheds/rust/scx_lavd/src/cpu_order.rs:69:9
   |
67 | pub struct PerfCpuOrder {
   |            ------------ field in this struct
68 |     pub perf_cap: usize,                 // performance in capacity
69 |     pub perf_util: f32,                  // performance in utilization, [0, 1]
   |         ^^^^^^^^^
   |
   = note: `PerfCpuOrder` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` on by default

warning: field `has_biglittle` is never read
  --> scheds/rust/scx_lavd/src/cpu_order.rs:81:9
   |
75 | pub struct CpuOrder {
   |            -------- field in this struct
...
81 |     pub has_biglittle: bool,
   |         ^^^^^^^^^^^^^
   |
   = note: `CpuOrder` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis

warning: `scx_lavd` (bin "scx_lavd") generated 3 warnings
```