### PR TITLE
scxtop: add kprobe events to TUI

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -2263,7 +2263,7 @@ impl<'a> App<'a> {
                 let prev_state = self.prev_state.clone();
                 self.prev_state = self.state.clone();
                 self.state = prev_state;
-                self.available_events.push(prof_event.clone());
+                self.available_events.push(prof_event);
             }
         }
 

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -3,6 +3,7 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
+use crate::available_kprobe_events;
 use crate::available_perf_events;
 use crate::bpf_intf;
 use crate::bpf_skel::BpfSkel;
@@ -16,6 +17,7 @@ use crate::AppTheme;
 use crate::CpuData;
 use crate::EventData;
 use crate::FilteredEventState;
+use crate::KprobeEvent;
 use crate::LlcData;
 use crate::NodeData;
 use crate::PerfEvent;
@@ -29,9 +31,9 @@ use crate::LICENSE;
 use crate::SCHED_NAME_PATH;
 use crate::{
     Action, CpuhpEnterAction, CpuhpExitAction, ExecAction, ExitAction, ForkAction, GpuMemAction,
-    HwPressureAction, IPIAction, MangoAppAction, PstateSampleAction, SchedCpuPerfSetAction,
-    SchedMigrateTaskAction, SchedSwitchAction, SchedWakeupAction, SchedWakingAction, SoftIRQAction,
-    TraceStartedAction, TraceStoppedAction,
+    HwPressureAction, IPIAction, KprobeAction, MangoAppAction, PstateSampleAction,
+    SchedCpuPerfSetAction, SchedMigrateTaskAction, SchedSwitchAction, SchedWakeupAction,
+    SchedWakingAction, SoftIRQAction, TraceStartedAction, TraceStoppedAction,
 };
 
 use anyhow::{bail, Result};
@@ -92,18 +94,22 @@ pub struct App<'a> {
     collect_cpu_freq: bool,
     collect_uncore_freq: bool,
     pstate: bool,
+
+    cpu_data: BTreeMap<usize, CpuData>,
+    llc_data: BTreeMap<usize, LlcData>,
+    node_data: BTreeMap<usize, NodeData>,
+    dsq_data: BTreeMap<u64, EventData>,
+
+    // Event related
     active_event: ProfilingEvent,
     active_hw_event_id: usize,
     active_prof_events: BTreeMap<usize, ProfilingEvent>,
     available_events: Vec<ProfilingEvent>,
     event_input_buffer: String,
     perf_event_search: Search,
-
+    kprobe_event_search: Search,
+    kprobe_links: Vec<Link>,
     filtered_events_state: Arc<StdMutex<FilteredEventState>>,
-    cpu_data: BTreeMap<usize, CpuData>,
-    llc_data: BTreeMap<usize, LlcData>,
-    node_data: BTreeMap<usize, NodeData>,
-    dsq_data: BTreeMap<u64, EventData>,
 
     // stats from scxtop's bpf side
     bpf_stats: BpfStats,
@@ -201,6 +207,7 @@ impl<'a> App<'a> {
                     .map(|event| format!("{}:{}", subsystem.clone(), event.clone()))
             })
             .collect();
+        let initial_kprobe_events_list = available_kprobe_events()?;
 
         let filtered_events_state = Arc::new(StdMutex::new(FilteredEventState::default()));
 
@@ -255,7 +262,9 @@ impl<'a> App<'a> {
             active_prof_events,
             available_events: default_events,
             event_input_buffer: String::new(),
-            perf_event_search: Search::new(initial_perf_events_list.clone()),
+            perf_event_search: Search::new(initial_perf_events_list),
+            kprobe_event_search: Search::new(initial_kprobe_events_list),
+            kprobe_links: Vec::new(),
             filtered_events_state,
             events_list_size: 1,
             prev_bpf_sample_rate: sample_rate,
@@ -280,12 +289,15 @@ impl<'a> App<'a> {
 
     /// Sets the state of the application.
     pub fn set_state(&mut self, state: AppState) {
-        if self.state != AppState::Help && self.state != AppState::PerfEvent {
+        if self.state != AppState::Help
+            && self.state != AppState::PerfEvent
+            && self.state != AppState::KprobeEvent
+        {
             self.prev_state = self.state.clone();
         }
         self.state = state;
 
-        if self.state == AppState::PerfEvent {
+        if self.state == AppState::PerfEvent || self.state == AppState::KprobeEvent {
             self.filter_events();
         }
 
@@ -320,6 +332,7 @@ impl<'a> App<'a> {
     /// Resets profiling events to default
     fn reset_prof_events(&mut self) -> Result<()> {
         self.stop_prof_events();
+        self.kprobe_links.clear();
         let mut default_events = PerfEvent::default_events();
         let config_events = PerfEvent::from_config(&self.config).unwrap();
         default_events.extend(config_events);
@@ -373,6 +386,7 @@ impl<'a> App<'a> {
         if !self.active_prof_events.is_empty() {
             self.stop_prof_events();
         }
+
         for &cpu_id in self.topo.all_cpus.keys() {
             let event = match prof_event {
                 ProfilingEvent::Perf(p) => {
@@ -380,6 +394,11 @@ impl<'a> App<'a> {
                     p.cpu = cpu_id;
                     p.attach(self.process_id)?;
                     ProfilingEvent::Perf(p)
+                }
+                ProfilingEvent::Kprobe(k) => {
+                    let mut k = k.clone();
+                    k.cpu = cpu_id;
+                    ProfilingEvent::Kprobe(k)
                 }
             };
             self.active_prof_events.insert(cpu_id, event);
@@ -547,6 +566,7 @@ impl<'a> App<'a> {
         for (cpu, event) in &mut self.active_prof_events {
             let val = match event {
                 ProfilingEvent::Perf(p) => p.value(true)?,
+                ProfilingEvent::Kprobe(k) => k.value(true)?,
             };
             let cpu_data = self
                 .cpu_data
@@ -1799,11 +1819,19 @@ impl<'a> App<'a> {
             )),
             Line::from(Span::styled(
                 format!(
-                    "{}: show CPU perf event menu ({})",
+                    "{}: show CPU perf event menu",
                     self.config
                         .active_keymap
-                        .action_keys_string(Action::SetState(AppState::PerfEvent)),
-                    self.active_event.event_name()
+                        .action_keys_string(Action::SetState(AppState::PerfEvent))
+                ),
+                Style::default(),
+            )),
+            Line::from(Span::styled(
+                format!(
+                    "{}: show kprobe event menu",
+                    self.config
+                        .active_keymap
+                        .action_keys_string(Action::SetState(AppState::KprobeEvent))
                 ),
                 Style::default(),
             )),
@@ -1956,6 +1984,7 @@ impl<'a> App<'a> {
 
         let list_type = match self.state {
             AppState::PerfEvent => "perf",
+            AppState::KprobeEvent => "kprobe",
             _ => bail!("Invalid AppState in event list"),
         };
 
@@ -1991,7 +2020,7 @@ impl<'a> App<'a> {
             })
             .collect();
 
-        let paragraph = Paragraph::new(events.clone())
+        let paragraph = Paragraph::new(events)
             .style(default_style)
             .scroll((filtered_state.scroll, 0));
         frame.render_widget(paragraph, chunks[1]);
@@ -2119,7 +2148,7 @@ impl<'a> App<'a> {
     pub fn render(&mut self, frame: &mut Frame) -> Result<()> {
         match self.state {
             AppState::Help => self.render_help(frame),
-            AppState::PerfEvent => self.render_event_list(frame),
+            AppState::PerfEvent | AppState::KprobeEvent => self.render_event_list(frame),
             AppState::MangoApp => self.render_mangoapp(frame),
             AppState::Node => self.render_node(frame),
             AppState::Llc => self.render_llc(frame),
@@ -2140,7 +2169,9 @@ impl<'a> App<'a> {
     /// Updates app state when the down arrow or mapped key is pressed.
     fn on_down(&mut self) {
         let mut filtered_state = self.filtered_events_state.lock().unwrap();
-        if self.state == AppState::PerfEvent && filtered_state.scroll < filtered_state.count - 1 {
+        if (self.state == AppState::PerfEvent || self.state == AppState::KprobeEvent)
+            && filtered_state.scroll < filtered_state.count - 1
+        {
             filtered_state.scroll += 1;
             filtered_state.selected += 1;
         }
@@ -2149,7 +2180,9 @@ impl<'a> App<'a> {
     /// Updates app state when the up arrow or mapped key is pressed.
     fn on_up(&mut self) {
         let mut filtered_state = self.filtered_events_state.lock().unwrap();
-        if self.state == AppState::PerfEvent && filtered_state.scroll > 0 {
+        if (self.state == AppState::PerfEvent || self.state == AppState::KprobeEvent)
+            && filtered_state.scroll > 0
+        {
             filtered_state.scroll -= 1;
             filtered_state.selected -= 1;
         }
@@ -2158,7 +2191,7 @@ impl<'a> App<'a> {
     /// Updates app state when page down or mapped key is pressed.
     fn on_pg_down(&mut self) {
         let mut filtered_state = self.filtered_events_state.lock().unwrap();
-        if self.state == AppState::PerfEvent
+        if (self.state == AppState::PerfEvent || self.state == AppState::KprobeEvent)
             && filtered_state.scroll <= filtered_state.count - self.events_list_size
         {
             filtered_state.scroll += self.events_list_size - 1;
@@ -2169,7 +2202,7 @@ impl<'a> App<'a> {
     /// Updates app state when page up or mapped key is pressed.
     fn on_pg_up(&mut self) {
         let mut filtered_state = self.filtered_events_state.lock().unwrap();
-        if self.state == AppState::PerfEvent {
+        if self.state == AppState::PerfEvent || self.state == AppState::KprobeEvent {
             if filtered_state.scroll > self.events_list_size {
                 filtered_state.scroll -= self.events_list_size - 1;
                 filtered_state.selected -= (self.events_list_size - 1) as usize;
@@ -2181,12 +2214,12 @@ impl<'a> App<'a> {
     }
 
     /// Updates app state when the enter key is pressed.
-    fn on_enter(&mut self) {
-        if self.state == AppState::PerfEvent {
+    fn on_enter(&mut self) -> Result<()> {
+        if self.state == AppState::PerfEvent || self.state == AppState::KprobeEvent {
             let selected = {
                 let mut filtered_state = self.filtered_events_state.lock().unwrap();
                 if filtered_state.list.is_empty() {
-                    return;
+                    return Ok(());
                 }
                 let selected = filtered_state.list[filtered_state.selected].clone();
                 filtered_state.reset();
@@ -2201,10 +2234,29 @@ impl<'a> App<'a> {
                         0,
                     ))
                 }),
+                AppState::KprobeEvent => Some(ProfilingEvent::Kprobe(KprobeEvent::new(
+                    selected.to_string(),
+                    0,
+                ))),
                 _ => None,
             };
 
             if let Some(prof_event) = event {
+                if let ProfilingEvent::Kprobe(ref k) = prof_event {
+                    let already_exists = self.available_events.iter().any(
+                        |e| matches!(e, ProfilingEvent::Kprobe(x) if x.event_name == k.event_name),
+                    );
+
+                    if !already_exists {
+                        self.kprobe_links.push(
+                            self.skel
+                                .progs
+                                .generic_kprobe
+                                .attach_kprobe(false, &k.event_name)?,
+                        );
+                    };
+                };
+
                 self.active_prof_events.clear();
                 self.active_event = prof_event.clone();
                 let _ = self.activate_prof_event(&prof_event);
@@ -2214,6 +2266,8 @@ impl<'a> App<'a> {
                 self.available_events.push(prof_event.clone());
             }
         }
+
+        Ok(())
     }
 
     /// Attaches any BPF programs required for perfetto traces.
@@ -2546,10 +2600,25 @@ impl<'a> App<'a> {
         cpu_data.add_event_data("hw_pressure", *hw_pressure);
     }
 
+    /// Handles kprobe events.
+    pub fn on_kprobe(&mut self, action: &KprobeAction) {
+        let cpu = action.cpu as usize;
+        let sample_rate = self.skel.maps.data_data.sample_rate as u64;
+
+        if let Some(ProfilingEvent::Kprobe(kprobe)) = self.active_prof_events.get_mut(&cpu) {
+            if kprobe.instruction_pointer == Some(action.instruction_pointer) {
+                kprobe.increment_by(sample_rate);
+            }
+        }
+    }
+
     pub fn filter_events(&mut self) {
         let filtered_events_list = match self.state {
             AppState::PerfEvent => self
                 .perf_event_search
+                .fuzzy_search(&self.event_input_buffer),
+            AppState::KprobeEvent => self
+                .kprobe_event_search
                 .fuzzy_search(&self.event_input_buffer),
             _ => vec![],
         };
@@ -2583,7 +2652,10 @@ impl<'a> App<'a> {
             Action::Up => self.on_up(),
             Action::PageUp => self.on_pg_up(),
             Action::PageDown => self.on_pg_down(),
-            Action::Enter => self.on_enter(),
+            Action::Enter => {
+                self.on_enter()?;
+                self.event_input_buffer.clear();
+            }
             Action::SetState(state) => {
                 if *state == self.state {
                     self.set_state(self.prev_state.clone());
@@ -2591,7 +2663,6 @@ impl<'a> App<'a> {
                     self.set_state(state.clone());
                 }
             }
-
             Action::NextEvent => {
                 if self.next_event().is_err() {
                     // XXX handle error
@@ -2679,6 +2750,9 @@ impl<'a> App<'a> {
             Action::HwPressure(a) => {
                 self.on_hw_pressure(a);
             }
+            Action::Kprobe(a) => {
+                self.on_kprobe(a);
+            }
             Action::ClearEvent => self.reset_prof_events()?,
             Action::ChangeTheme => {
                 self.set_theme(self.theme().next());
@@ -2724,7 +2798,7 @@ impl<'a> App<'a> {
                 self.filter_events();
             }
             Action::Esc => match self.state() {
-                AppState::PerfEvent => {
+                AppState::PerfEvent | AppState::KprobeEvent => {
                     self.event_input_buffer.clear();
                     self.filter_events();
                     self.handle_action(&Action::SetState(self.prev_state.clone()))?;

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -39,6 +39,7 @@ impl Default for KeyMap {
         let mut bindings = HashMap::new();
         bindings.insert(Key::Char('d'), Action::SetState(AppState::Default));
         bindings.insert(Key::Char('e'), Action::SetState(AppState::PerfEvent));
+        bindings.insert(Key::Char('K'), Action::SetState(AppState::KprobeEvent));
         bindings.insert(Key::Char('f'), Action::ToggleCpuFreq);
         bindings.insert(Key::Char('u'), Action::ToggleUncoreFreq);
         bindings.insert(Key::Char('L'), Action::ToggleLocalization);
@@ -343,6 +344,7 @@ pub fn parse_action(action_str: &str) -> Result<Action> {
     match action_str {
         "AppStateDefault" => Ok(Action::SetState(AppState::Default)),
         "AppStatePerfEvent" => Ok(Action::SetState(AppState::PerfEvent)),
+        "AppStateKprobeEvent" => Ok(Action::SetState(AppState::KprobeEvent)),
         "ToggleCpuFreq" => Ok(Action::ToggleCpuFreq),
         "ToggleUncoreFreq" => Ok(Action::ToggleUncoreFreq),
         "ToggleLocalization" => Ok(Action::ToggleLocalization),

--- a/tools/scxtop/src/kprobe_event.rs
+++ b/tools/scxtop/src/kprobe_event.rs
@@ -41,7 +41,8 @@ impl KprobeEvent {
 }
 
 fn resolve_kfunc_address(name: &str) -> Option<u64> {
-    let file = File::open("/proc/kallsyms").unwrap();
+    let file = File::open("/proc/kallsyms")
+        .expect("Failed to open /proc/kallsyms. Make sure CONFIG_KALLSYMS is enabled.");
     let reader = BufReader::new(file);
     for line in reader.lines().map_while(std::io::Result::ok) {
         if line.ends_with(&format!(" {}", name)) {
@@ -65,7 +66,9 @@ pub fn available_kprobe_events() -> Result<Vec<String>> {
 
     for line in reader.lines() {
         let line = line?;
-        events.push(line);
+        if let Some(func) = line.split_whitespace().next() {
+            events.push(func.to_string());
+        }
     }
 
     Ok(events)

--- a/tools/scxtop/src/kprobe_event.rs
+++ b/tools/scxtop/src/kprobe_event.rs
@@ -8,6 +8,53 @@ use scx_utils::compat::tracefs_mount;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
+#[derive(Debug, Clone)]
+pub struct KprobeEvent {
+    pub cpu: usize,
+    pub event_name: String,
+    pub count: u64,
+    pub instruction_pointer: Option<u64>,
+}
+
+impl KprobeEvent {
+    pub fn new(event_name: String, cpu: usize) -> Self {
+        let instruction_pointer = resolve_kfunc_address(&event_name);
+        Self {
+            event_name,
+            cpu,
+            count: 0,
+            instruction_pointer,
+        }
+    }
+
+    pub fn increment_by(&mut self, stride: u64) {
+        self.count += stride;
+    }
+
+    pub fn value(&mut self, reset: bool) -> Result<u64> {
+        let count = self.count;
+        if reset {
+            self.count = 0;
+        }
+        Ok(count)
+    }
+}
+
+fn resolve_kfunc_address(name: &str) -> Option<u64> {
+    let file = File::open("/proc/kallsyms").unwrap();
+    let reader = BufReader::new(file);
+    for line in reader.lines().map_while(std::io::Result::ok) {
+        if line.ends_with(&format!(" {}", name)) {
+            if let Some(addr_str) = line.split_whitespace().next() {
+                if let Ok(addr) = u64::from_str_radix(addr_str, 16) {
+                    return Some(addr);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Returns the available kprobe events on the system from tracefs.
 pub fn available_kprobe_events() -> Result<Vec<String>> {
     let path = tracefs_mount()?;

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -35,6 +35,7 @@ pub use event_data::EventData;
 pub use keymap::Key;
 pub use keymap::KeyMap;
 pub use kprobe_event::available_kprobe_events;
+pub use kprobe_event::KprobeEvent;
 pub use llc_data::LlcData;
 pub use node_data::NodeData;
 pub use perf_event::available_perf_events;
@@ -61,7 +62,7 @@ pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
-This software may be used and distributed according to the terms of the 
+This software may be used and distributed according to the terms of the
 GNU General Public License version 2.";
 pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 
@@ -71,6 +72,8 @@ pub enum AppState {
     Default,
     /// Application is in the PerfEvent list state.
     PerfEvent,
+    /// Application is in the KprobeEvent list state.
+    KprobeEvent,
     /// Application is in the help state.
     Help,
     /// Application is in the Llc state.
@@ -130,18 +133,21 @@ impl FilteredEventState {
 #[derive(Clone, Debug)]
 pub enum ProfilingEvent {
     Perf(PerfEvent),
+    Kprobe(KprobeEvent),
 }
 
 impl ProfilingEvent {
     pub fn event_name(&self) -> &str {
         match self {
             ProfilingEvent::Perf(p) => p.event_name(),
+            ProfilingEvent::Kprobe(k) => &k.event_name,
         }
     }
 
     pub fn value(&mut self, reset: bool) -> anyhow::Result<u64> {
         match self {
             ProfilingEvent::Perf(p) => p.value(reset),
+            ProfilingEvent::Kprobe(k) => k.value(reset),
         }
     }
 }

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -62,7 +62,7 @@ pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
-This software may be used and distributed according to the terms of the
+This software may be used and distributed according to the terms of the 
 GNU General Public License version 2.";
 pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -58,7 +58,7 @@ fn get_action(app: &App, keymap: &KeyMap, event: Event) -> Action {
         }
         Event::Key(key) => handle_key_event(app, keymap, key),
         Event::Paste(paste) => match app.state() {
-            AppState::PerfEvent => Action::InputEntry(paste),
+            AppState::PerfEvent | AppState::KprobeEvent => Action::InputEntry(paste),
             _ => Action::None,
         },
         _ => Action::None,
@@ -68,7 +68,7 @@ fn get_action(app: &App, keymap: &KeyMap, event: Event) -> Action {
 fn handle_key_event(app: &App, keymap: &KeyMap, key: KeyEvent) -> Action {
     match key.code {
         Char(c) => match app.state() {
-            AppState::PerfEvent => Action::InputEntry(c.to_string()),
+            AppState::PerfEvent | AppState::KprobeEvent => Action::InputEntry(c.to_string()),
             _ => keymap.action(&Key::Char(c)),
         },
         _ => keymap.action(&Key::Code(key.code)),


### PR DESCRIPTION
With PR's #2225, #2229, #2230, and #2234, we can now add the ability to monitor an arbitrary number of kprobes from the TUI. The kprobe event list is separate from perf events list and can be rendered by pressing 'K'. Performance is more important with kprobe events than perf events as (on my machine) there are about 60k kfuncs, so even a basic substring search can take >6ms.

Test Plan: 
1) Attached a kprobe to `schedule` kfunc, ensured using `sudo bpftool link show` that a single kprobe was properly attached and then properly de-attached when pressing 'x'.
2) Tested multiple kprobes on different functions while perf events were also selected (once again, using `sudo bpftool link show` to ensure the kprobes were properly attached). Ensured data was only being counted for the proper kfunc (the kfunc instruction pointer address that matches the bpf event's instruction pointer address).

Demo (selecting `schedule` kfunc):

https://github.com/user-attachments/assets/598215e3-10ae-4f40-b792-75ad8bb8cc2e

Part 2 (also selecting `__alloc_pages` kfunc and moving between that and `schedule` kprobe):

https://github.com/user-attachments/assets/fe8ea0a3-5d0f-4218-be50-c270d640a123


