### PR TITLE
meson.build: Force to use gnu11 as C standard.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -54,6 +54,8 @@ scx_lib_path = join_paths(meson.current_build_dir(), 'lib/', scx_lib_name)
 compile_scx_lib = find_program(join_paths(meson.current_source_dir(),
                                       'meson-scripts/compile_scx_lib'))
 
+# Use gnu11 as the C standard to compile vmlinux.h without errors.
+add_project_arguments('-std=gnu11', language : 'c')
 
 bpf_clang_ver = run_command(get_clang_ver, bpf_clang, check: true).stdout().strip()
 if bpf_clang_ver == ''


### PR DESCRIPTION
We should use gnu11 as the C standard (the same version with Linux kernel) when compiling the C code. That's because `vmlinux.h` is not compilable with a newer version of C standard, e.g., C23. For example, the keywords in C23 include bool/true/false, which are defined in vmlinux.h. The C standard for compilation needs to be explicitly described, as recent GCC (e.g., version 15) uses gnu23 (C23 with GNU extensions) as the default.

Without specifying the C standard, it gives the following compilation errors:

```
[2/40] Compiling C object lib/libscxlib_test.a.p/arena.bpf.c.o
FAILED: lib/libscxlib_test.a.p/arena.bpf.c.o
cc -Ilib/libscxlib_test.a.p -Ilib -I../lib -Ilib/scxtest -I../lib/scxtest -I../build/libbpf/src/usr/include -I../build/libbpf/include/uapi -I../scheds/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O3 -fPIC -DTEST -Wno-attributes -Wno-unknown-pragmas -MD -MQ lib/libscxlib_test.a.p/arena.bpf.c.o -MF lib/libscxlib_test.a.p/arena.bpf.c.o.d -o lib/libscxlib_test.a.p/arena.bpf.c.o -c ../lib/arena.bpf.c
In file included from ../scheds/include/scx/common.bpf.h:21,
                 from ../lib/arena.bpf.c:6:
../scheds/include/vmlinux.h:9037:9: error: cannot use keyword ‘false’ as enumeration constant
 9037 |         false = 0,
      |         ^~~~~
../scheds/include/vmlinux.h:9037:9: note: ‘false’ is a keyword with ‘-std=c23’ onwards
../scheds/include/vmlinux.h:32230:15: error: ‘bool’ cannot be defined via ‘typedef’
32230 | typedef _Bool bool;
      |               ^~~~
../scheds/include/vmlinux.h:32230:15: note: ‘bool’ is a keyword with ‘-std=c23’ onwards
../scheds/include/vmlinux.h:32230:1: warning: useless type name in empty declaration
32230 | typedef _Bool bool;
      | ^~~~~~~
```