### PR TITLE
meson.build: Suppress warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,8 @@
 project('sched_ext schedulers', 'c',
         version: '1.0.13',
         license: 'GPL-2.0',
-        meson_version : '>= 1.2.0',)
+        meson_version : '>= 1.2.0',
+        default_options: ['c_std=gnu11'])
 
 fs = import('fs')
 
@@ -53,9 +54,6 @@ scx_lib_name = 'lib'
 scx_lib_path = join_paths(meson.current_build_dir(), 'lib/', scx_lib_name)
 compile_scx_lib = find_program(join_paths(meson.current_source_dir(),
                                       'meson-scripts/compile_scx_lib'))
-
-# Use gnu11 as the C standard to compile vmlinux.h without errors.
-add_project_arguments('-std=gnu11', language : 'c')
 
 bpf_clang_ver = run_command(get_clang_ver, bpf_clang, check: true).stdout().strip()
 if bpf_clang_ver == ''


### PR DESCRIPTION
Suppress the warning

```rust
meson.build:58: WARNING: Consider using the built-in option for language standard version instead of using "-std=gnu11".
```