### PR TITLE
cargo_publish.py: switch from paths to crate names and use publish = …

### DIFF
--- a/cargo-publish.py
+++ b/cargo-publish.py
@@ -1,14 +1,13 @@
 #!/usr/bin/python
 
 import argparse
-import os
+import json
 import re
 import subprocess
 import sys
 
 priority=['scx_stats', 'scx_stats_derive', 'scx_utils', 'scx_userspace_arena',
           'scx_rustland_core', 'scx_p2dq']
-skip=['scx_mitosis']
 publish_args={'scx_rlfifo': ['--no-verify'],
               'scx_rustland': ['--no-verify']}
 
@@ -24,36 +23,21 @@ def dbg(line):
 def underline(string):
     return f'\033[4m{string}\033[0m'
 
-def get_rust_paths():
-    result = subprocess.run(['git', 'ls-files'], stdout=subprocess.PIPE)
-    lines = result.stdout.decode('utf-8').splitlines()
-    paths = []
-    for line in lines:
-        if line.endswith('Cargo.toml'):
-            paths.append(line)
-    return paths
+def get_crate_names():
+    metadata = subprocess.check_output(["cargo", "metadata", "--format-version", "1"])
+    metadata = json.loads(metadata)
 
-def cargo_path_to_crate(path):
-    return path.split('/')[-2]
+    default_members = set(metadata["workspace_default_members"])
 
-def cargo_is_workspace(path):
-    with open(path, 'r') as f:
-        lines = f.readlines()
+    for pkg in metadata["packages"]:
+        if pkg.get("publish") == []:
+            continue
+        if pkg["id"] in default_members:
+            yield pkg["name"]
 
-    for lineno, line in enumerate(lines):
-        workspace_re = r'(^\s*)(\[\s*workspace\s*\])(.*$)'
-
-        m = re.match(workspace_re, line)
-        if m:
-            dbg(f'[{path}:{lineno}] SKIP: {m.group(1)}{underline(m.group(2))}{m.group(3)}')
-            return True
-
-    return False
-
-def publish(path, extra_args, ignore_existing):
-    directory = os.path.dirname(path)
+def publish(crate, extra_args, ignore_existing):
     try:
-        proc = subprocess.run(['cargo', 'publish'] + extra_args, cwd=directory,
+        proc = subprocess.run(['cargo', 'publish', '-p', crate] + extra_args,
                               check=True, capture_output=True)
     except subprocess.CalledProcessError as e:
         stdout = e.stdout.decode('utf-8').splitlines()
@@ -90,44 +74,26 @@ def main():
     global verbose
     verbose = args.verbose
 
-    paths = get_rust_paths()
-    crate_path_args = {}
-    for path in paths:
-        if cargo_is_workspace(path):
-            continue
+    crates = set(get_crate_names())
 
-        crate = cargo_path_to_crate(path)
-        pargs = []
+    excess_publish_args = publish_args.keys() - crates
+    if excess_publish_args:
+        err(f'publish_args contains non-existent crates {excess_publish_args}')
 
-        if crate in publish_args:
-            pargs = publish_args[crate]
-            del publish_args[crate]
-
-        crate_path_args[crate] = [path, pargs]
-
-    if len(publish_args):
-        err(f'publish_args contains non-existent crates {publish_args}')
-
-    if args.start and args.start not in crate_path_args:
+    if args.start and args.start not in crates:
         err(f'--start specified non-existent crate {args.start}')
 
-    for crate in skip:
-        if crate not in crate_path_args:
-            err(f'{crate} is in skip list but does not exist')
-        del crate_path_args[crate]
-
-    # Fill targets in publishing order
     targets = []
 
+    # add priority crates first
     for pri in priority:
-        if pri not in crate_path_args:
-            err(f'cannot find cargo path for priority crate {pri}')
-        path_args = crate_path_args[pri]
-        targets.append([pri, [path_args[0], path_args[1]]])
-        del crate_path_args[pri]
+        if pri not in crates:
+            err(f'cannot find priority crate {pri}')
+        crates.remove(pri)
+        targets.append(pri)
 
-    for crate, path_args in sorted(crate_path_args.items()):
-        targets.append([crate, [path_args[0], path_args[1]]])
+    # sort remaining crates alphabetically
+    targets.extend(sorted(crates))
 
     # Publish
     start_from = args.start
@@ -136,9 +102,10 @@ def main():
             continue
         start_from = None
 
-        print(f'Publishing crate {target[0]} {" ".join(target[1][1])}')
+        pargs = publish_args.get(target, [])
+        print(f'Publishing crate {target} {" ".join(pargs)}')
         dbg(f'target: {target}')
         if not args.dry:
-            publish(target[1][0], target[1][1], args.ignore)
+            publish(target, pargs, args.ignore)
 
 main()

--- a/scheds/rust/scx_mitosis/Cargo.toml
+++ b/scheds/rust/scx_mitosis/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 description = "A dynamic affinity scheduler used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
 license = "GPL-2.0-only"
 
+publish = false
+
 [dependencies]
 anyhow = "1.0.65"
 bitvec = "1.0"


### PR DESCRIPTION
…false

Currently we use a skip list and a `git ls-files` in `cargo_publish.py` to find crates to publish. Change this to respect `publish = false` in each crate's Cargo.toml and use crate names instead.

Test plan:

```
jake@rooster:/data/users/jake/repos/scx/ > nix run nixpkgs#python3 -- cargo-publish.py --dry
Publishing crate scx_stats
Publishing crate scx_stats_derive
Publishing crate scx_utils
Publishing crate scx_userspace_arena
Publishing crate scx_rustland_core
Publishing crate scx_p2dq
Publishing crate scx_bpfland
Publishing crate scx_chaos
Publishing crate scx_flash
Publishing crate scx_lavd
Publishing crate scx_layered
Publishing crate scx_lib_selftests
Publishing crate scx_loader
Publishing crate scx_rlfifo --no-verify
Publishing crate scx_rustland --no-verify
Publishing crate scx_rusty
Publishing crate scx_tickless
Publishing crate scxctl
Publishing crate scxtop
Publishing crate vmlinux_docify
```

^still no scx_mitosis and ordering/args are still good.

Publishing by inspection, it should be fine but I don't want to publish anything uet.

Threw an extra package into publish_args, it fails as expected.