### PR TITLE
ci: enable scx_wd40

### DIFF
--- a/.github/include/list-integration-tests.py
+++ b/.github/include/list-integration-tests.py
@@ -132,6 +132,7 @@ def main():
             "scx_rustland",
             "scx_rusty",
             "scx_tickless",
+            "scx_wd40",
         ]:
             reqs = kernel_reqs.get(scheduler, {})
             allowlist = reqs.get("allowlist", [])

--- a/meson-scripts/stress_tests.ini
+++ b/meson-scripts/stress_tests.ini
@@ -10,6 +10,12 @@ sched_args: -v
 stress_cmd: stress-ng -t 31 --aggressive -M -c `nproc` -f `nproc` --affinity 1 --affinity-delay 1 --affinity-pin
 timeout_sec: 45
 
+[scx_wd40]
+sched: scx_wd40
+sched_args: -v
+stress_cmd: stress-ng -t 31 --aggressive -M -c `nproc` -f `nproc` --affinity 1 --affinity-delay 1 --affinity-pin
+timeout_sec: 45
+
 [scx_rustland]
 sched: scx_rustland
 sched_args: -v

--- a/meson-scripts/test_sched
+++ b/meson-scripts/test_sched
@@ -38,6 +38,7 @@ else
     SCHEDS["scx_pair"]="-v"
     SCHEDS["scx_rusty"]="-v"
     SCHEDS["scx_p2dq"]=""
+    SCHEDS["scx_wd40"]="-v"
     SCHEDS["scx_rustland"]="-v"
     SCHEDS["scx_bpfland"]="-v"
     SCHEDS["scx_layered"]="-v --run-example"

--- a/meson.build
+++ b/meson.build
@@ -368,7 +368,7 @@ if enable_rust
   run_target('fetch', command: [cargo_fetch, cargo], env: cargo_env)
 
   rust_scheds = ['scx_lavd', 'scx_bpfland', 'scx_rustland', 'scx_rlfifo',
-                 'scx_flash', 'scx_cosmos', 'scx_rusty', 'scx_p2dq',
+                 'scx_flash', 'scx_cosmos', 'scx_rusty', 'scx_wd40', 'scx_p2dq',
                  'scx_layered', 'scx_mitosis', 'scx_tickless', 'scx_chaos']
   rust_misc = ['scx_stats', 'scx_stats_derive', 'scx_utils',
                'scx_rustland_core']

--- a/scheds/rust/scx_wd40/Cargo.toml
+++ b/scheds/rust/scx_wd40/Cargo.toml
@@ -9,7 +9,8 @@ license = "GPL-2.0-only"
 publish = false
 
 [package.metadata.scx]
-ci.disable_veristat = true  # requires some changes to vmlinux handling, see https://github.com/sched-ext/scx/pull/2246
+ci.kernel.default = "bpf/bpf-next"
+ci.kernel.allowlist = ["bpf/bpf-next"]
 
 [dependencies]
 anyhow = "1.0.65"


### PR DESCRIPTION
Add `scx_wd40` to our CI runs. This needs a few new features to work properly. Namely:
- Add `metadata.scx.ci.kernel.default` to specify a different default kernel for pull requests when the usual default of `sched_ext/for-next` is inappropriate.
- Add `metadata.scx.ci.kernel.allowlist` to specify an acceptable set of kernels when many are inappropriate.
- Add similar `metadata.scx.ci.kernel.blocklist` to avoid testing on a kernel when its known to fail.

The new metadata is managed in each scheduler's Cargo.toml rather than having to change a central list in the CI spec and removes some edge cases.

Closes #1517

Test plan:
- Ran `.github/include/list-integration-tests.py` with various kernels. It worked.
- Checked the new `scx_wd40` entry on this PR. It selects the correct kernel in the "Load kernel" step.