### PR TITLE
scxtop: temporary fix for locale crash

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -40,7 +40,7 @@ use anyhow::{bail, Result};
 use glob::glob;
 use libbpf_rs::Link;
 use libbpf_rs::ProgramInput;
-use num_format::{SystemLocale, ToFormattedString};
+use num_format::{Locale, ToFormattedString};
 use ratatui::prelude::Constraint;
 use ratatui::{
     layout::{Alignment, Direction, Layout, Rect},
@@ -76,7 +76,7 @@ pub struct App<'a> {
     config: Config,
     hw_pressure: bool,
     localize: bool,
-    locale: SystemLocale,
+    locale: Locale,
     stats_client: Option<Arc<TokioMutex<StatsClient>>>,
     sched_stats_raw: String,
 
@@ -236,7 +236,7 @@ impl<'a> App<'a> {
             config,
             localize: true,
             hw_pressure,
-            locale: SystemLocale::default()?,
+            locale: Locale::en,
             stats_client,
             sched_stats_raw: "".to_string(),
             scheduler,


### PR DESCRIPTION
Several users from the community noted that scxtop crashed right after starting it (see #2209). With a helpful backtrace from @mati865, it became clear the root of the problem was in combining num_format::SystemLocale's separator with the way ratatui splits strings. The num_format library uses the short 3 byte whitespace character `\u{202f}` as a separator for certain regions (France, several European countries, and wherever they write one million as 1 000 000). However, ratatui assumes the whitespace characters are in 4 byte increments and was therefore panicking when it attempted to split_at() the whitespaces.

For a temporary fix, I'm going to fixe the locale to use Locale::en, which uses a `,` as a separator.

Test Plan:
- I put myself in the French locale using num_format::Locale::fr and reproduced the crash. The crash does not occur in regions with other separators.