### PR TITLE
scx_p2dq: Refactor interactive handling

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -63,6 +63,7 @@ struct task_p2dq {
 	u64 			last_run_at;
 	u64			llc_runs; /* how many runs on the current LLC */
 	int			last_dsq_index;
+	bool			interactive;
 
 	/* The task is a workqueue worker thread */
 	bool			is_kworker;


### PR DESCRIPTION
Make interactive a first class field on the task_ctx. This cleans up many parts of the code which use a helper function or do manual/inconsistent checks. This improves overall code quality.