### PR TITLE
scxtop: avoid udnerflow when calculating DSQ vtime delta

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -2510,10 +2510,14 @@ impl<'a> App<'a> {
                     .last()
                     .copied()
                     .unwrap_or(0_u64);
-                if next_dsq_vtime - last < DSQ_VTIME_CUTOFF {
+                if next_dsq_vtime.saturating_sub(last) < DSQ_VTIME_CUTOFF {
                     next_dsq_data.add_event_data(
                         "dsq_vtime_delta",
-                        if last > 0 { *next_dsq_vtime - last } else { 0 },
+                        if last > 0 {
+                            next_dsq_vtime.saturating_sub(last)
+                        } else {
+                            0
+                        },
                     );
                 }
             }


### PR DESCRIPTION
I'm not sure about the correctness but fixes this crash when using debug builds:
```
thread 'main' panicked at tools/scxtop/src/app.rs:2513:20:
attempt to subtract with overflow
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/panicking.rs:75:14
   2: core::panicking::panic_const::panic_const_sub_overflow
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/panicking.rs:178:21
   3: <u64 as core::ops::arith::Sub>::sub
             at /home/mateusz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/arith.rs:215:45
   4: <&u64 as core::ops::arith::Sub<u64>>::sub
             at /home/mateusz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/internal_macros.rs:36:17
   5: scxtop::app::App::on_sched_switch
             at ./src/app.rs:2513:20
   6: scxtop::app::App::handle_action
             at ./src/app.rs:2712:17
   7: scxtop::run_tui::{{closure}}
             at ./src/main.rs:430:25
   8: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /home/mateusz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
   9: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /home/mateusz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/runtime/park.rs:284:63
  10: tokio::runtime::coop::with_budget
             at /home/mateusz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/runtime/coop.rs:107:5
  11: tokio::runtime::coop::budget
             at /home/mateusz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/runtime/coop.rs:73:5
  12: tokio::runtime::park::CachedParkThread::block_on
             at /home/mateusz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/runtime/park.rs:284:31
  13: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
             at /home/mateusz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/runtime/context/blocking.rs:66:9
  14: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
             at /home/mateusz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/runtime/scheduler/multi_thread/mod.rs:87:13
  15: tokio::runtime::context::runtime::enter_runtime
             at /home/mateusz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/runtime/context/runtime.rs:65:16
  16: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /home/mateusz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/runtime/scheduler/multi_thread/mod.rs:86:9
  17: tokio::runtime::runtime::Runtime::block_on_inner
             at /home/mateusz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/runtime/runtime.rs:370:45
  18: tokio::runtime::runtime::Runtime::block_on
             at /home/mateusz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/runtime/runtime.rs:340:13
  19: scxtop::run_tui
             at ./src/main.rs:291:5
  20: scxtop::main
             at ./src/main.rs:446:13
  21: core::ops::function::FnOnce::call_once
             at /home/mateusz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```