### PR TITLE
lib: Suppress a possibly uninitialized variable warning.

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -1211,7 +1211,7 @@ u64 scx_buddy_chunk_alloc(scx_buddy_chunk_t *chunk, int order_req)
 {
 	scx_buddy_header_t *header;
 	u64 address;
-	u64 order;
+	u64 order = 0;
 	u32 idx;
 
 	bpf_for(order, order_req, SCX_BUDDY_CHUNK_MAX_ORDER) {

--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,8 @@
 project('sched_ext schedulers', 'c',
+        default_options : ['c_std=gnu11'], # Use gnu11 as the C standard to compile vmlinux.h without errors.
         version: '1.0.13',
         license: 'GPL-2.0',
-        meson_version : '>= 1.2.0',
-        default_options: ['c_std=gnu11'])
+        meson_version : '>= 1.2.0',)
 
 fs = import('fs')
 


### PR DESCRIPTION
The commit 1881d080 re-introduced the compiler error with the recent GCC (15) that was fixed by 9d3e0ab4. So let's revert the commit and fix the warning in a different way. Let's initialize the variable to make those GCC versions happy and compile the code without any warnings.

```
../lib/sdt_alloc.bpf.c: In function ‘scx_buddy_chunk_alloc’:
../lib/sdt_alloc.bpf.c:1227:37: warning: ‘order’ may be used uninitialized [-Wmaybe-uninitialized]
 1227 |         chunk->order_indices[order] = header->next_index;
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
../lib/sdt_alloc.bpf.c:1214:13: note: ‘order’ was declared here
 1214 |         u64 order;
      |             ^~~~~
```