### PR TITLE
ci: run scx_lib_selftests and disable it publishing

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -165,6 +165,8 @@ def run_tests_in_vm():
         ]
     )
 
+    run_command(["target/debug/scx_lib_selftests"])
+
 
 def run_all():
     """Run all CI steps in the correct order."""

--- a/rust/scx_lib_selftests/Cargo.toml
+++ b/rust/scx_lib_selftests/Cargo.toml
@@ -3,6 +3,8 @@ name = "scx_lib_selftests"
 version = "1.0.0"
 edition = "2021"
 
+publish = false
+
 [dependencies]
 anyhow = "1.0.65"
 libbpf-rs = "=0.25.0-beta.1"


### PR DESCRIPTION
`scx_lib_selftests` is a crate provided to run selftests written in BPF for the lib code. Run this in the CI so it doesn't regress. We already build all of the Rust crates in the workspace and have a VM (selftests need root) so simply throw running the binary in the VM inner logic.

This only runs on our sched_ext/for-next kernel for now. It's pretty easy to extend, but we currently only spin up the for-next VM in this step. Easy to extend later on.

Drive-by: disable publishing on `scx_lib_selftests` crate. I don't think we need to publish this, it's effectively an internal crate for testing.

Test plan:
- CI