### PR TITLE
scx_chaos: add kprobe delays

### DIFF
--- a/scheds/rust/scx_chaos/src/bpf/intf.h
+++ b/scheds/rust/scx_chaos/src/bpf/intf.h
@@ -38,6 +38,7 @@ struct chaos_task_ctx {
 	enum chaos_match	match;
 
 	enum chaos_trait_kind	next_trait;
+	enum chaos_trait_kind	pending_trait;
 	u64			enq_flags;
 	u64			p2dq_vtime;
 };

--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -91,6 +91,24 @@ static __always_inline void chaos_stat_inc(enum chaos_stat_idx stat)
 		(*cnt_p)++;
 }
 
+SEC("kprobe/generic")
+int generic(struct pt_regs *ctx)
+{
+	struct task_struct *p;
+	struct chaos_task_ctx *taskc;
+
+	p = (struct task_struct *)bpf_get_current_task_btf();
+	if (!p)
+		return -EINVAL;
+
+	if (!(taskc = lookup_create_chaos_task_ctx(p)))
+		return -EINVAL;
+
+	taskc->next_trait = CHAOS_TRAIT_RANDOM_DELAYS;
+
+	return 0;
+}
+
 static __always_inline enum chaos_trait_kind choose_chaos(struct chaos_task_ctx *taskc)
 {
 	if (taskc->match & CHAOS_MATCH_EXCLUDED) {

--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -599,7 +599,6 @@ int generic(struct pt_regs *ctx)
 	u32 roll = bpf_get_prandom_u32();
 	if (roll < kprobe_delays_freq_frac32) {
 		taskc->next_trait = CHAOS_TRAIT_RANDOM_DELAYS;
-		p->scx.slice = 0;
 		dbg("GENERIC: setting next_trait to RANDOM_DELAYS - task[%d]", p->pid);
 	}
 

--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -589,7 +589,7 @@ SCX_OPS_DEFINE(chaos,
 	       .init_task		= (void *)chaos_init_task,
 	       .runnable		= (void *)chaos_runnable,
 	       .select_cpu		= (void *)chaos_select_cpu,
-		.tick 			= (void *)chaos_tick,
+	       .tick 		    	= (void *)chaos_tick,
 
 	       .exit_task		= (void *)p2dq_exit_task,
 	       .exit			= (void *)p2dq_exit,

--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -564,7 +564,7 @@ void BPF_STRUCT_OPS(chaos_tick, struct task_struct *p)
 	if (!(taskc = lookup_create_chaos_task_ctx(p)))
 		return;
 
-	if (taskc->pending_trait)
+	if (taskc->pending_trait == CHAOS_TRAIT_RANDOM_DELAYS)
 		p->scx.slice = 0;
 }
 

--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -589,7 +589,7 @@ SCX_OPS_DEFINE(chaos,
 	       .init_task		= (void *)chaos_init_task,
 	       .runnable		= (void *)chaos_runnable,
 	       .select_cpu		= (void *)chaos_select_cpu,
-		   .tick 			= (void *)chaos_tick,
+		.tick 			= (void *)chaos_tick,
 
 	       .exit_task		= (void *)p2dq_exit_task,
 	       .exit			= (void *)p2dq_exit,
@@ -614,7 +614,7 @@ int generic(struct pt_regs *ctx)
 		return -EINVAL;
 
 	u32 roll = bpf_get_prandom_u32();
-	if (roll < kprobe_delays_freq_frac32) {
+	if (roll <= kprobe_delays_freq_frac32) {
 		taskc->pending_trait = CHAOS_TRAIT_RANDOM_DELAYS;
 		dbg("GENERIC: setting pending_trait to RANDOM_DELAYS - task[%d]", p->pid);
 	}

--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -599,6 +599,7 @@ int generic(struct pt_regs *ctx)
 	u32 roll = bpf_get_prandom_u32();
 	if (roll < kprobe_delays_freq_frac32) {
 		taskc->next_trait = CHAOS_TRAIT_RANDOM_DELAYS;
+		p->scx.slice = 0;
 		dbg("GENERIC: setting next_trait to RANDOM_DELAYS - task[%d]", p->pid);
 	}
 

--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -616,7 +616,7 @@ int generic(struct pt_regs *ctx)
 	u32 roll = bpf_get_prandom_u32();
 	if (roll < kprobe_delays_freq_frac32) {
 		taskc->pending_trait = CHAOS_TRAIT_RANDOM_DELAYS;
-		dbg("GENERIC: setting next_trait to RANDOM_DELAYS - task[%d]", p->pid);
+		dbg("GENERIC: setting pending_trait to RANDOM_DELAYS - task[%d]", p->pid);
 	}
 
 	return 0;


### PR DESCRIPTION
This adds the ability to introduce delays whenever a provided kprobe is hit. kprobes and a desired delay frequency can be passed in via the command line.

Testing: 
1) Ensured that only using kprobe-frequency arg causes stops scheduler from starting.
2) Ensured multiple kprobes can be attached at different frequencies. Used `bpftool link show` to verify all kprobes were attaching properly. Used dbg to ensure BPF handler was properly executing.
3) Ensured that program correctly exits immediately if kprobes fail validation.
4) Works with only --kprobes set (uses default frequency of .1)