### PR TITLE
scx_layered: Refactor timer interface

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/timer.bpf.h
+++ b/scheds/rust/scx_layered/src/bpf/timer.bpf.h
@@ -28,13 +28,11 @@ struct layered_timer {
 };
 
 enum layer_timer_callbacks {
-	LAYERED_MONITOR,
 	ANTISTALL_TIMER,
-	NOOP_TIMER,
 	MAX_TIMERS,
 };
 
-bool run_timer_cb(int key);
+u64 run_timer_cb(int key);
 int start_layered_timers(void);
 
 extern struct layered_timer layered_timers[MAX_TIMERS];


### PR DESCRIPTION
Cleanup unused timers and refactor the layered_timer_cb function so that timers can dynamically set the next timer interval. This allows for non statically defined timer operation.

Running with `--disable-antisall`:
```
bpftool prog trace | grep TIMER
          <idle>-0       [007] ..s2.  6689.576296: bpf_trace_printk: TIMER 0 stopped 0

```
Running with antistall (default):
```
bpftool prog trace | grep TIMER
          <idle>-0       [007] ..s2.  6819.820958: bpf_trace_printk: TIMER 0 scheduled in 15000000000
```