### PR TITLE
README: add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sched_ext Schedulers and Tools
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sched-ext/scx)
+
 [sched_ext](https://github.com/sched-ext/scx) is a Linux kernel feature
 which enables implementing kernel thread schedulers in BPF and dynamically
 loading them. This repository contains various scheduler implementations and


### PR DESCRIPTION
We've seen some success with deepwiki documenting code and control flow of sched_ext. Add the DeepWiki badge to the README, which according to previous documentation will enable auto-refresh, and provide a link to people interested.