### PR TITLE
scx_chaos: update runnable logic

### DIFF
--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -507,11 +507,7 @@ void BPF_STRUCT_OPS(chaos_runnable, struct task_struct *p, u64 enq_flags)
 	if (!(wakee_ctx = lookup_create_chaos_task_ctx(p)))
 		return;
 
-	enum chaos_trait_kind t = choose_chaos(wakee_ctx);
-	if (t == CHAOS_TRAIT_NONE)
-		return;
-
-	wakee_ctx->next_trait = t;
+	wakee_ctx->next_trait = choose_chaos(wakee_ctx);
 }
 
 void BPF_STRUCT_OPS(chaos_running, struct task_struct *p)


### PR DESCRIPTION
When entering runnable, next_trait should be updated to CHAOS_NONE_TRAIT if that is the result of choose_chaos. At the moment, it is only reset if it was previously set at CHAOS_TRAIT_RANDOM_DELAYS in enqueue_chaotic.