### PR TITLE
ci: move chaos to linux-rolling-stable

### DIFF
--- a/.github/include/flake.nix
+++ b/.github/include/flake.nix
@@ -124,6 +124,8 @@
               pyproject = false;
               dontUnpack = true;
 
+              propagatedBuildInputs = with pkgs; [ cargo ];
+
               installPhase = "install -Dm755 ${./list-integration-tests.py} $out/bin/list-integration-tests";
             };
 

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -42,8 +42,6 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     needs: build-kernels
     secrets: inherit
-    with:
-      repo-name: sched_ext/for-next
 
   pages:
     runs-on: ubuntu-24.04

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,7 +4,6 @@ on:
   workflow_call:
     inputs:
       repo-name:
-        required: true
         type: string
 
 jobs:
@@ -42,16 +41,6 @@ jobs:
         with:
           cachix-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: Load kernel
-        run: |
-          if [ -n "${{ matrix.scheduler.kernel }}" ]; then
-            KERNEL_NAME="${{ matrix.scheduler.kernel }}"
-          else
-            KERNEL_NAME="${{ inputs.repo-name }}"
-          fi
-          echo "KERNEL_STORE_PATH=$(nix build --no-link --print-out-paths ./.github/include#"kernel_${KERNEL_NAME}")" >> $GITHUB_ENV
-          echo "KERNEL_HEADERS_STORE_PATH=$(nix build --no-link --print-out-paths ./.github/include#"kernel_${KERNEL_NAME}".headers)" >> $GITHUB_ENV
-
       - name: Install Veristat
         run: nix-env -i $(nix build --no-link --print-out-paths ./.github/include#veristat)
 
@@ -63,6 +52,27 @@ jobs:
           key: ${{ matrix.scheduler.name }}
           prefix-key: "4"
       - uses: ./.github/actions/install-deps-action
+
+      - name: Load kernel
+        run: |
+          if [ -n "${{ matrix.scheduler.kernel }}" ]; then
+            KERNEL_NAME="${{ matrix.scheduler.kernel }}"
+          elif [ -n "${{ inputs.repo-name }}" ]; then
+            KERNEL_NAME="${{ inputs.repo-name }}"
+          else
+            KERNEL_NAME=$(cargo metadata --format-version 1 --no-deps \
+              | jq -r --arg pkg "${{ matrix.scheduler.name }}" '
+                  .packages[]?
+                  | select(.name == $pkg)
+                  | .metadata.scx?.ci?.kernel?.default
+                  // "sched_ext/for-next"
+              ')
+          fi
+
+          echo "KERNEL_NAME=$KERNEL_NAME" >> $GITHUB_ENV
+          echo "KERNEL_STORE_PATH=$(nix build --no-link --print-out-paths ./.github/include#"kernel_${KERNEL_NAME}")" >> $GITHUB_ENV
+          echo "KERNEL_HEADERS_STORE_PATH=$(nix build --no-link --print-out-paths ./.github/include#"kernel_${KERNEL_NAME}".headers)" >> $GITHUB_ENV
+
       # cache virtiofsd (goes away w/ 24.04)
       - name: Cache virtiofsd
         id: cache-virtiofsd

--- a/scheds/rust/scx_chaos/Cargo.toml
+++ b/scheds/rust/scx_chaos/Cargo.toml
@@ -9,6 +9,9 @@ license = "GPL-2.0-only"
 [package.metadata.scx]
 ci.use_clippy = true
 
+ci.kernel.default = "stable/linux-rolling-stable"
+ci.kernel.blocklist = ["sched_ext/for-next"]
+
 [dependencies]
 scx_userspace_arena = { path = "../../../rust/scx_userspace_arena", version = "1.0.13" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.16" }

--- a/scheds/rust/scx_p2dq/Cargo.toml
+++ b/scheds/rust/scx_p2dq/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 description = "scx_p2dq A simple pick two load balancing scheduler in BPF"
 license = "GPL-2.0-only"
 
+[package.metadata.scx]
+ci.kernel.blocklist = ["stable/6_12"]
+
 [dependencies]
 anyhow = "1.0.65"
 chrono = "0.4"


### PR DESCRIPTION
For some reason chaos is failing with the latest sched_ext/for-next kernel, see
https://github.com/sched-ext/scx/actions/runs/15892717558/job/44818708334?pr=2253 for an example. This is fully reproducible it seems and it's unclear why it's happening.

As I don't have time to debug this at the minute, drop chaos to linux-rolling-stable (6.15.3 at the minute) where it does pass CI so we can deal with it later. Currently chaos is blocking the for-next import.

Changes to the CI to enable this:
- Add `metadata.scx.ci.kernel.default` to specify a different default kernel for pull requests when the usual default of `sched_ext/for-next` is inappropriate.
- Add `metadata.scx.ci.kernel.allowlist` to specify an acceptable set of kernels when many are inappropriate.
- Add similar `metadata.scx.ci.kernel.blocklist` to avoid testing on a kernel when it's known to fail.

The new metadata is managed in each scheduler's Cargo.toml rather than having to change a central list in the CI spec and removes some edge cases.

Most of this change was tested in #2246 but we can't land that yet due to vmlinux issues. Keep all the new behaviour, even though we don't need `allowlist` except for wd40.

Test plan:
- Ran `.github/include/list-integration-tests.py` with various kernels. It worked.
- Checked the new `scx_chaos` entry on this PR. It selects the correct kernel in the "Load kernel" step.