### PR TITLE
scxtop: sanitize no break space

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -12,6 +12,7 @@ use crate::config::get_config_path;
 use crate::config::Config;
 use crate::format_hz;
 use crate::read_file_string;
+use crate::sanitize_nbsp;
 use crate::AppState;
 use crate::AppTheme;
 use crate::CpuData;
@@ -40,7 +41,7 @@ use anyhow::{bail, Result};
 use glob::glob;
 use libbpf_rs::Link;
 use libbpf_rs::ProgramInput;
-use num_format::{Locale, ToFormattedString};
+use num_format::{SystemLocale, ToFormattedString};
 use ratatui::prelude::Constraint;
 use ratatui::{
     layout::{Alignment, Direction, Layout, Rect},
@@ -76,7 +77,7 @@ pub struct App<'a> {
     config: Config,
     hw_pressure: bool,
     localize: bool,
-    locale: Locale,
+    locale: SystemLocale,
     stats_client: Option<Arc<TokioMutex<StatsClient>>>,
     sched_stats_raw: String,
 
@@ -236,7 +237,7 @@ impl<'a> App<'a> {
             config,
             localize: true,
             hw_pressure,
-            locale: Locale::en,
+            locale: SystemLocale::default()?,
             stats_client,
             sched_stats_raw: "".to_string(),
             scheduler,
@@ -646,7 +647,7 @@ impl<'a> App<'a> {
                 }
             )))
             .text_value(if self.localize {
-                value.to_formatted_string(&self.locale)
+                sanitize_nbsp(value.to_formatted_string(&self.locale))
             } else {
                 format!("{}", value)
             })
@@ -760,9 +761,9 @@ impl<'a> App<'a> {
                             format!(
                                 "LLC {} avg {} max {} min {}",
                                 llc,
-                                stats.avg.to_formatted_string(&self.locale),
-                                stats.max.to_formatted_string(&self.locale),
-                                stats.min.to_formatted_string(&self.locale)
+                                sanitize_nbsp(stats.avg.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.max.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.min.to_formatted_string(&self.locale))
                             )
                         } else {
                             format!(
@@ -824,9 +825,9 @@ impl<'a> App<'a> {
                             format!(
                                 "Node {} avg {} max {} min {}",
                                 node,
-                                stats.avg.to_formatted_string(&self.locale),
-                                stats.max.to_formatted_string(&self.locale),
-                                stats.min.to_formatted_string(&self.locale)
+                                sanitize_nbsp(stats.avg.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.max.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.min.to_formatted_string(&self.locale))
                             )
                         } else {
                             format!(
@@ -872,9 +873,9 @@ impl<'a> App<'a> {
                             format!(
                                 "LLCs ({}) avg {} max {} min {}",
                                 self.active_event.event_name(),
-                                stats.avg.to_formatted_string(&self.locale),
-                                stats.max.to_formatted_string(&self.locale),
-                                stats.min.to_formatted_string(&self.locale)
+                                sanitize_nbsp(stats.avg.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.max.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.min.to_formatted_string(&self.locale))
                             )
                         } else {
                             format!(
@@ -914,9 +915,9 @@ impl<'a> App<'a> {
                             format!(
                                 "LLCs ({}) avg {} max {} min {}",
                                 self.active_event.event_name(),
-                                stats.avg.to_formatted_string(&self.locale),
-                                stats.max.to_formatted_string(&self.locale),
-                                stats.min.to_formatted_string(&self.locale),
+                                sanitize_nbsp(stats.avg.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.max.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.min.to_formatted_string(&self.locale))
                             )
                         } else {
                             format!(
@@ -1001,9 +1002,9 @@ impl<'a> App<'a> {
                             format!(
                                 "Node ({}) avg {} max {} min {}",
                                 self.active_event.event_name(),
-                                stats.avg.to_formatted_string(&self.locale),
-                                stats.max.to_formatted_string(&self.locale),
-                                stats.min.to_formatted_string(&self.locale)
+                                sanitize_nbsp(stats.avg.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.max.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.min.to_formatted_string(&self.locale))
                             )
                         } else {
                             format!(
@@ -1040,9 +1041,9 @@ impl<'a> App<'a> {
                             format!(
                                 "NUMA Nodes ({}) avg {} max {} min {}",
                                 self.active_event.event_name(),
-                                stats.avg.to_formatted_string(&self.locale),
-                                stats.max.to_formatted_string(&self.locale),
-                                stats.min.to_formatted_string(&self.locale),
+                                sanitize_nbsp(stats.avg.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.max.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.min.to_formatted_string(&self.locale))
                             )
                         } else {
                             format!(
@@ -1134,9 +1135,9 @@ impl<'a> App<'a> {
                             format!(
                                 "dsq {:#X} avg {} max {} min {}",
                                 dsq_id,
-                                stats.avg.to_formatted_string(&self.locale),
-                                stats.max.to_formatted_string(&self.locale),
-                                stats.min.to_formatted_string(&self.locale),
+                                sanitize_nbsp(stats.avg.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.max.to_formatted_string(&self.locale)),
+                                sanitize_nbsp(stats.min.to_formatted_string(&self.locale))
                             )
                         } else {
                             format!(
@@ -1181,15 +1182,15 @@ impl<'a> App<'a> {
                 format!(
                     "{:#X} avg {} max {} min {}",
                     dsq,
-                    avg.to_formatted_string(&self.locale),
-                    max.to_formatted_string(&self.locale),
-                    min.to_formatted_string(&self.locale)
+                    sanitize_nbsp(avg.to_formatted_string(&self.locale)),
+                    sanitize_nbsp(max.to_formatted_string(&self.locale)),
+                    sanitize_nbsp(min.to_formatted_string(&self.locale))
                 )
             } else {
                 format!("{:#X} avg {} max {} min {}", dsq, avg, max, min,)
             }))
             .text_value(if self.localize {
-                value.to_formatted_string(&self.locale)
+                sanitize_nbsp(value.to_formatted_string(&self.locale))
             } else {
                 format!("{}", value)
             })
@@ -1217,15 +1218,15 @@ impl<'a> App<'a> {
                 format!(
                     "{} avg {} max {} min {}",
                     id,
-                    avg.to_formatted_string(&self.locale),
-                    max.to_formatted_string(&self.locale),
-                    min.to_formatted_string(&self.locale)
+                    sanitize_nbsp(avg.to_formatted_string(&self.locale)),
+                    sanitize_nbsp(max.to_formatted_string(&self.locale)),
+                    sanitize_nbsp(min.to_formatted_string(&self.locale))
                 )
             } else {
                 format!("{} avg {} max {} min {}", id, avg, max, min,)
             }))
             .text_value(if self.localize {
-                value.to_formatted_string(&self.locale)
+                sanitize_nbsp(value.to_formatted_string(&self.locale))
             } else {
                 format!("{}", value)
             })
@@ -1370,9 +1371,9 @@ impl<'a> App<'a> {
                         "{} {} avg {} max {} min {}",
                         self.scheduler,
                         event,
-                        stats.avg.to_formatted_string(&self.locale),
-                        stats.max.to_formatted_string(&self.locale),
-                        stats.min.to_formatted_string(&self.locale),
+                        sanitize_nbsp(stats.avg.to_formatted_string(&self.locale)),
+                        sanitize_nbsp(stats.max.to_formatted_string(&self.locale)),
+                        sanitize_nbsp(stats.min.to_formatted_string(&self.locale))
                     )
                 } else {
                     format!(
@@ -1487,9 +1488,9 @@ impl<'a> App<'a> {
                                     "Node{} ({}) avg {} max {} min {}",
                                     node.id,
                                     self.active_event.event_name(),
-                                    stats.avg.to_formatted_string(&self.locale),
-                                    stats.max.to_formatted_string(&self.locale),
-                                    stats.min.to_formatted_string(&self.locale)
+                                    sanitize_nbsp(stats.avg.to_formatted_string(&self.locale)),
+                                    sanitize_nbsp(stats.max.to_formatted_string(&self.locale)),
+                                    sanitize_nbsp(stats.min.to_formatted_string(&self.locale))
                                 )
                             } else {
                                 format!(
@@ -1608,9 +1609,9 @@ impl<'a> App<'a> {
                                     "Node{} ({}) avg {} max {} min {}",
                                     node.id,
                                     self.active_event.event_name(),
-                                    stats.avg.to_formatted_string(&self.locale),
-                                    stats.max.to_formatted_string(&self.locale),
-                                    stats.min.to_formatted_string(&self.locale)
+                                    sanitize_nbsp(stats.avg.to_formatted_string(&self.locale)),
+                                    sanitize_nbsp(stats.max.to_formatted_string(&self.locale)),
+                                    sanitize_nbsp(stats.min.to_formatted_string(&self.locale))
                                 )
                             } else {
                                 format!(

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -63,7 +63,7 @@ pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
-This software may be used and distributed according to the terms of the
+This software may be used and distributed according to the terms of the 
 GNU General Public License version 2.";
 pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -50,6 +50,7 @@ pub use tui::Event;
 pub use tui::Tui;
 pub use util::format_hz;
 pub use util::read_file_string;
+pub use util::sanitize_nbsp;
 
 pub use plain::Plain;
 // Generate serialization types for handling events from the bpf ring buffer.
@@ -62,7 +63,7 @@ pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
-This software may be used and distributed according to the terms of the 
+This software may be used and distributed according to the terms of the
 GNU General Public License version 2.";
 pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 

--- a/tools/scxtop/src/util.rs
+++ b/tools/scxtop/src/util.rs
@@ -24,3 +24,8 @@ pub fn format_hz(hz: u64) -> String {
         _ => format!("{:.3}THz", hz as f64 / 1_000_000_000.0),
     }
 }
+
+/// Replaces non-breaking spaces with regular spaces. [TEMPORARY]
+pub fn sanitize_nbsp(s: String) -> String {
+    s.replace('\u{202F}', " ")
+}


### PR DESCRIPTION
Following up from #2209 and #2248, this fix allows us to return to using SystemLocale to better suit each user's preferences. A more permanent fix will come with the next ratatui version (see [issue](https://github.com/ratatui/ratatui/issues/1928), [PR](https://github.com/ratatui/ratatui/pull/1934)), but it's unclear exactly when that might happen.

Testing:

Used Locale::fr to ensure that narrow no-break whitespaces (\u{202F}) were being properly replaced with standard whitespaces. Ex.:
<img width="689" alt="Screenshot 2025-06-26 at 3 04 15 PM" src="https://github.com/user-attachments/assets/41e68590-60ea-4af0-a039-0b2154de9852" />
