### PR TITLE
lib: dynamically allocate minheap and add minheap/ATQ fixups

### DIFF
--- a/lib/atq.bpf.c
+++ b/lib/atq.bpf.c
@@ -17,7 +17,7 @@ u64 scx_atq_create_internal(bool fifo)
 	if (!atq)
 		return (u64)NULL;
 
-	atq->heap = scx_minheap_alloc(SCX_MINHEAP_MAX_CAPACITY);
+	atq->heap = scx_minheap_alloc(SCX_ATQ_MAX_CAPACITY);
 	if (!atq->heap)
 		return (u64)NULL;
 

--- a/lib/minheap.bpf.c
+++ b/lib/minheap.bpf.c
@@ -122,3 +122,15 @@ int scx_minheap_insert(void __arena *heap_ptr __arg_arena, u64 elem, u64 weight)
 
 	return 0;
 }
+
+__hidden
+int scx_minheap_dump(scx_minheap_t *heap __arg_arena)
+{
+	int i;
+
+	bpf_printk("HEAP %p SIZE %ld", heap, heap->size);
+	for (i = 0; i < heap->size && can_loop; i++)
+		bpf_printk("[0] (0x%lx, %ld)", heap->helems[i].elem, heap->helems[i].weight);
+
+	return 0;
+}

--- a/lib/minheap.bpf.c
+++ b/lib/minheap.bpf.c
@@ -133,7 +133,7 @@ int scx_minheap_pop(void __arena *heap_ptr __arg_arena, struct scx_minheap_elem 
 		return -EINVAL;
 
 	helem->elem = heap->helems[0].elem;
-	helem->weight = heap->helems[0].elem;
+	helem->weight = heap->helems[0].weight;
 
 	heap->helems[0].elem = heap->helems[heap->size - 1].elem;
 	heap->helems[0].weight = heap->helems[heap->size - 1].weight;

--- a/lib/minheap.bpf.c
+++ b/lib/minheap.bpf.c
@@ -16,12 +16,18 @@ u64 scx_minheap_alloc_internal(size_t capacity)
 	size_t alloc_size = sizeof(scx_minheap_t);
 	scx_minheap_t *heap;
 
-	if (capacity > SCX_MINHEAP_MAX_CAPACITY)
-		return (u64)NULL;
-
 	heap = scx_static_alloc(alloc_size, 1);
 	if (!heap)
 		return (u64)NULL;
+
+	heap->helems = scx_static_alloc(capacity * sizeof(*heap->helems), 1);
+	if (!heap->helems) {
+		/* 
+		 * XXXETSAL: Once we move on from the static alloc,
+		 * properly free the initial allocation.
+		 */
+		return (u64)NULL;
+	}
 
 	heap->capacity = capacity;
 	heap->size = 0;
@@ -50,9 +56,8 @@ int scx_minheap_balance_top_down(void __arena *heap_ptr __arg_arena)
 			if (child >= heap->size)
 				continue;
 
-			if (heap->weights[next] <= heap->weights[child])
+			if (heap->helems[next].weight <= heap->helems[child].weight)
 				continue;
-
 
 			next = child;
 		}
@@ -60,14 +65,14 @@ int scx_minheap_balance_top_down(void __arena *heap_ptr __arg_arena)
 		if (next == ind)
 			break;
 
-		elem = heap->elems[next];
-		weight = heap->weights[next];
+		elem = heap->helems[next].elem;
+		weight = heap->helems[next].weight;
 
-		heap->elems[next] = heap->elems[ind];
-		heap->weights[next] = heap->weights[ind];
+		heap->helems[next].elem = heap->helems[ind].elem;
+		heap->helems[next].weight = heap->helems[ind].weight;
 
-		heap->elems[ind] = elem;
-		heap->weights[ind] = weight;
+		heap->helems[ind].elem = elem;
+		heap->helems[ind].weight= weight;
 	}
 
 	return 0;
@@ -84,17 +89,17 @@ int scx_minheap_balance_bottom_up(void __arena *heap_ptr __arg_arena)
 	for (ind = heap->size - 1; ind > 0 && can_loop; ind = parent) {
 		parent = ind % 2 ? ind / 2 : ind / 2 - 1;
 
-		if (heap->weights[parent] <= heap->weights[ind])
+		if (heap->helems[parent].weight <= heap->helems[ind].weight)
 			break;
 
-		elem = heap->elems[parent];
-		weight = heap->weights[parent];
+		elem = heap->helems[parent].elem;
+		weight = heap->helems[parent].weight;
 
-		heap->elems[parent] = heap->elems[ind];
-		heap->weights[parent] = heap->weights[ind];
+		heap->helems[parent].elem = heap->helems[ind].elem;
+		heap->helems[parent].weight = heap->helems[ind].weight;
 
-		heap->elems[ind] = elem;
-		heap->weights[ind] = weight;
+		heap->helems[ind].elem = elem;
+		heap->helems[ind].weight = weight;
 	}
 
 	return 0;
@@ -108,8 +113,8 @@ int scx_minheap_insert(void __arena *heap_ptr __arg_arena, u64 elem, u64 weight)
 	if (heap->size == heap->capacity)
 		return -ENOSPC;
 
-	heap->elems[heap->size] = elem;
-	heap->weights[heap->size] = weight;
+	heap->helems[heap->size].elem = elem;
+	heap->helems[heap->size].weight = weight;
 
 	heap->size += 1;
 
@@ -117,4 +122,3 @@ int scx_minheap_insert(void __arena *heap_ptr __arg_arena, u64 elem, u64 weight)
 
 	return 0;
 }
-

--- a/lib/minheap.bpf.c
+++ b/lib/minheap.bpf.c
@@ -123,6 +123,28 @@ int scx_minheap_insert(void __arena *heap_ptr __arg_arena, u64 elem, u64 weight)
 	return 0;
 }
 
+/* Inlined because we are passing a non-arena pointer argument. */
+__hidden
+int scx_minheap_pop(void __arena *heap_ptr __arg_arena, struct scx_minheap_elem *helem __arg_trusted)
+{
+	scx_minheap_t *heap = (scx_minheap_t *)heap_ptr;
+
+	if (heap->size == 0)
+		return -EINVAL;
+
+	helem->elem = heap->helems[0].elem;
+	helem->weight = heap->helems[0].elem;
+
+	heap->helems[0].elem = heap->helems[heap->size - 1].elem;
+	heap->helems[0].weight = heap->helems[heap->size - 1].weight;
+
+	heap->size -= 1;
+
+	scx_minheap_balance_top_down(heap);
+
+	return 0;
+}
+
 __hidden
 int scx_minheap_dump(scx_minheap_t *heap __arg_arena)
 {

--- a/lib/selftests/st_atq.bpf.c
+++ b/lib/selftests/st_atq.bpf.c
@@ -101,8 +101,10 @@ int scx_selftest_atq_common(bool isfifo)
 		taskc = (task_ctx *)scx_atq_pop(atq);
 		if (isfifo && taskc->pid != i) {
 			bpf_printk("Popped out unexpected element from FIFO atq (pid %ld, vtime %ld), expected %d", taskc->pid, taskc->vtime, i);
+			scx_minheap_dump(atq->heap);
 			return -EINVAL;
 		} else if (!isfifo && taskc->vtime < vtime) {
+			scx_minheap_dump(atq->heap);
 			bpf_printk("Popped out unexpected element from PRIO atq (pid %ld, vtime %ld)", taskc->pid, taskc->vtime);
 			return -EINVAL;
 		}

--- a/lib/selftests/st_minheap.bpf.c
+++ b/lib/selftests/st_minheap.bpf.c
@@ -202,6 +202,37 @@ int scx_selftest_minheap_random(scx_minheap_t *heap)
 	return 0;
 }
 
+static
+int scx_selftest_minheap_read_back(scx_minheap_t *heap)
+{
+	struct scx_minheap_elem helem;
+	u64 elem = 5;
+	u64 weight = 12;
+	int ret;
+
+	if (heap->size)
+		return -EINVAL;
+
+	ret = scx_minheap_insert(heap, elem, weight);
+	if (ret)
+		return ret;
+
+	ret = scx_minheap_pop(heap, &helem);
+	if (ret)
+		return ret;
+
+	if (helem.elem != elem) {
+		bpf_printk("Expected elem %ld, found %d", elem, helem.elem);
+		return -EINVAL;
+	}
+
+	if (helem.weight != weight) {
+		bpf_printk("Expected elem %ld, found %d", weight, helem.weight);
+		return -EINVAL;
+	}
+
+	return 0;
+}
 #define SCX_MINHEAP_SELFTEST(suffix) SCX_SELFTEST(scx_selftest_minheap_ ## suffix, heap)
 
 __weak
@@ -216,6 +247,7 @@ int scx_selftest_minheap(void)
 	}
 
 	SCX_MINHEAP_SELFTEST(empty);
+	SCX_MINHEAP_SELFTEST(read_back);
 	SCX_MINHEAP_SELFTEST(ascending);
 	SCX_MINHEAP_SELFTEST(descending);
 	SCX_MINHEAP_SELFTEST(alternating);

--- a/lib/selftests/st_minheap.bpf.c
+++ b/lib/selftests/st_minheap.bpf.c
@@ -202,18 +202,6 @@ int scx_selftest_minheap_random(scx_minheap_t *heap)
 	return 0;
 }
 
-static
-int scx_selftest_minheap_toolarge(scx_minheap_t *heap)
-{
-	void __arena *heap2;
-
-	heap2 = scx_minheap_alloc(SCX_MINHEAP_MAX_CAPACITY + 1);
-	if (heap2)
-		return -EINVAL;
-
-	return 0;
-}
-
 #define SCX_MINHEAP_SELFTEST(suffix) SCX_SELFTEST(scx_selftest_minheap_ ## suffix, heap)
 
 __weak
@@ -232,7 +220,6 @@ int scx_selftest_minheap(void)
 	SCX_MINHEAP_SELFTEST(descending);
 	SCX_MINHEAP_SELFTEST(alternating);
 	SCX_MINHEAP_SELFTEST(random);
-	SCX_MINHEAP_SELFTEST(toolarge);
 
 	return 0;
 }

--- a/rust/scx_lib_selftests/src/main.rs
+++ b/rust/scx_lib_selftests/src/main.rs
@@ -24,7 +24,7 @@ use libbpf_rs::PrintLevel;
 use libbpf_rs::ProgramInput;
 
 fn setup_arenas(skel: &mut BpfSkel<'_>) -> Result<()> {
-    const STATIC_ALLOC_PAGES_GRANULARITY: c_ulong = 1;
+    const STATIC_ALLOC_PAGES_GRANULARITY: c_ulong = 512;
     const TASK_SIZE: c_ulong = 42;
 
     // Allocate the arena memory from the BPF side so userspace initializes it before starting

--- a/scheds/include/lib/atq.h
+++ b/scheds/include/lib/atq.h
@@ -6,6 +6,8 @@
 
 #include <lib/minheap.h>
 
+#define SCX_ATQ_MAX_CAPACITY (65536)
+
 struct scx_atq {
 	scx_minheap_t *heap;
 	arena_spinlock_t lock;

--- a/scheds/include/lib/minheap.h
+++ b/scheds/include/lib/minheap.h
@@ -5,19 +5,10 @@ struct scx_minheap_elem {
 	u64 weight;
 };
 
-#define SCX_MINHEAP_MAX_CAPACITY (128)
-
-/*
- * XXXETSAL: We are currently splitting the keys and values into two arrays
- * because of verifier pain. The solution we need is to use an array of
- * scx_minheap_elem data structures whose size we adjust as needed.
- */
-
 struct scx_minheap {
 	u64				size;
 	u64				capacity;
-	u64				elems[SCX_MINHEAP_MAX_CAPACITY];
-	u64				weights[SCX_MINHEAP_MAX_CAPACITY];
+	struct scx_minheap_elem		__arena *helems;
 };
 
 typedef struct scx_minheap __arena scx_minheap_t;
@@ -37,11 +28,11 @@ int scx_minheap_pop(void __arena *heap_ptr __arg_arena, struct scx_minheap_elem 
 	if (heap->size == 0)
 		return -EINVAL;
 
-	helem->elem = heap->elems[0];
-	helem->weight = heap->elems[0];
+	helem->elem = heap->helems[0].elem;
+	helem->weight = heap->helems[0].elem;
 
-	heap->elems[0] = heap->elems[heap->size - 1];
-	heap->weights[0] = heap->weights[heap->size - 1];
+	heap->helems[0].elem = heap->helems[heap->size - 1].elem;
+	heap->helems[0].weight = heap->helems[heap->size - 1].weight;
 
 	heap->size -= 1;
 

--- a/scheds/include/lib/minheap.h
+++ b/scheds/include/lib/minheap.h
@@ -19,26 +19,4 @@ u64 scx_minheap_alloc_internal(size_t capacity);
 int scx_minheap_balance_top_down(void __arena *heap_ptr __arg_arena);
 int scx_minheap_insert(void __arena *heap_ptr __arg_arena, u64 elem, u64 weight);
 int scx_minheap_dump(scx_minheap_t *heap __arg_arena);
-
-/* Inlined because we are passing a non-arena pointer argument. */
-static inline
-int scx_minheap_pop(void __arena *heap_ptr __arg_arena, struct scx_minheap_elem *helem __arg_trusted)
-{
-	scx_minheap_t *heap = (scx_minheap_t *)heap_ptr;
-
-	if (heap->size == 0)
-		return -EINVAL;
-
-	helem->elem = heap->helems[0].elem;
-	helem->weight = heap->helems[0].elem;
-
-	heap->helems[0].elem = heap->helems[heap->size - 1].elem;
-	heap->helems[0].weight = heap->helems[heap->size - 1].weight;
-
-	heap->size -= 1;
-
-	scx_minheap_balance_top_down(heap);
-
-	return 0;
-}
-
+int scx_minheap_pop(void __arena *heap_ptr __arg_arena, struct scx_minheap_elem *helem __arg_trusted);

--- a/scheds/include/lib/minheap.h
+++ b/scheds/include/lib/minheap.h
@@ -18,6 +18,7 @@ u64 scx_minheap_alloc_internal(size_t capacity);
 
 int scx_minheap_balance_top_down(void __arena *heap_ptr __arg_arena);
 int scx_minheap_insert(void __arena *heap_ptr __arg_arena, u64 elem, u64 weight);
+int scx_minheap_dump(scx_minheap_t *heap __arg_arena);
 
 /* Inlined because we are passing a non-arena pointer argument. */
 static inline


### PR DESCRIPTION
Minheaps are currently statically allocated because the verifier does not accept data structures with a variable array at the end. Bite the bullet and make the minheap's element array into a separate allocation referred to with a pointer. This allows us to bump the maximum task capacity of an ATQ significantly. Also add a method for dumping the minheap's contents to help with debugging, and fix a minheap bug assigning elem to the weight field of an helem.