### PR TITLE
scx: add more unit testing

### DIFF
--- a/UNIT_TESTING_GUIDE.md
+++ b/UNIT_TESTING_GUIDE.md
@@ -1,0 +1,108 @@
+# Unit testing guide
+
+## Introduction
+
+This is a guide to lay out how to approach the unit testing of the BPF side of
+the sched_ext schedulers.  The user space components of the schedulers utilize
+the same patterns as their respective language's unit testing framework.
+
+## How do I run the existing tests
+
+Currently we create separate binaries for the BPF tests, and this is handled by
+`meson`. In the future the various Rust based schedulers will also automatically
+do the correct thing when running `cargo test`.  For now simply run
+
+```bash
+# If you haven't compiled yet you run the following
+meson setup build
+meson compile -C build
+
+# To run the tests, you can use the following command
+meson test -v -C
+```
+
+## The basic design
+
+Currently, the way to create a unit test of the BPF side of the schedulers is to
+add a new file along side the existing BPF code and include the C file into this
+test file.
+
+For example, if your main BPF file is `main.bpf.c`, you create a new file called
+`main.test.bpf.c` in the same directory and do something like this:
+
+```c
+#include <scx_test.h>
+
+#include "main.bpf.c"
+
+void test_my_function(void)
+{
+    scx_test_assert(my_function(5) == 5);
+}
+
+int main(int argc, char **argv)
+{
+    test_my_function();
+    return 0;
+}
+```
+
+A canonical example exists in `scheds/rust/scx_p2dq/src/bpf/main.test.bpf.c`.
+
+You must also include the following in your `meson.build` file to ensure that it
+is built properly and run when `meson test` is run
+
+```meson
+e = test_executable('scx_example_test',
+  ['path/to/main.test.bpf.c'],
+  dependencies: [scx_test_dep],
+  c_args: scx_test_c_args,
+  install: false,
+  build_by_default: false,
+)
+test('scx_example_test', e)
+```
+
+## Stubbing out BPF and kernel functions
+
+BPF programs are a rare beast, and thus creating stub functions for them is
+tricky.  There are a few things that need to be kept in mind.
+
+1. *Try not to modify the actual scheduler to fit the test*. This may not be
+   tenable in all cases, but this is a good rule of thumb. We want to keep the
+   core scheduler code as pristine as possible.
+
+2. *A lot of helpers are weak references, this will cause crashes if you miss
+   one*.  `libbpf` provides weak references to the BPF helpers, because the
+   compiler knows what to do when it's building a BPF binary. But in userspace
+   we need the actual symbol.  Sometimes you will get a `SIGSEGV` and `gdb` will
+   resolve the symbol to `???`. This is an indication you missed a function that
+   is required for your test, simply look at the frame before it to find out
+   which function is missing.
+
+3. *You must #define to override most BPF helpers*. This is because the BPF and
+   the `libbpf` helpers are often named the same thing, but the `libbpf`
+   versions interact with the kernel interface, they do not provide a userspace
+   implementation of that functionality.  Look at
+   [lib/scxtest/scx_test_map.h](lib/scxtest/scx_test_map.h) for an example of
+   what this looks like.
+
+4. *Some of the helpers are static functions*. This is the case for
+   `bpf_get_prandom_u32()`, you cannot simply create a stub for this to override
+   the behavior like you can with some helpers.  In this case you must override
+   them with a `#define`.
+
+5. *The rest of the BPF helpers can simply be stubbed out*. Look at
+   [lib/scxtest/overrides.c](lib/scxtest/overrides.c) for an examples of these
+   functions.  If you require a real implementation for these helpers simply
+   provide it alongside your test.
+
+## Outstanding items
+
+A lot of the sched_ext library helpers haven't been stubbed out yet. This is
+code like `sdt_task` and such. This will take some more care as they have
+private maps that are more difficult to provide clean stubs for.
+
+There currently is very limited functionality. `bpf_map` and `cpumask` have been
+mostly covered, but anything beyond that still requires some active work to
+provide stubs for.

--- a/lib/scxtest/meson.build
+++ b/lib/scxtest/meson.build
@@ -3,6 +3,7 @@ scxtest_lib = static_library(
   'scx_test.c',
   'overrides.c',
   'scx_test_map.c',
+  'scx_test_cpumask.c',
   c_args: ['-DTEST'],
 )
 

--- a/lib/scxtest/overrides.c
+++ b/lib/scxtest/overrides.c
@@ -37,12 +37,6 @@ s32 scx_bpf_task_cpu(const struct task_struct *p)
 }
 
 __weak
-bool bpf_cpumask_test_cpu(u32 cpu, const struct cpumask *cpumask)
-{
-	return false;
-}
-
-__weak
 struct task_struct *bpf_task_from_pid(s32 pid)
 {
 	return NULL;
@@ -57,12 +51,6 @@ s32 scx_bpf_dsq_nr_queued(u64 dsq_id)
 __weak
 void scx_bpf_kick_cpu(s32 cpu, u64 flags)
 {
-}
-
-__weak
-bool scx_bpf_test_and_clear_cpu_idle(s32 cpu)
-{
-	return false;
 }
 
 __weak
@@ -87,18 +75,6 @@ void bpf_cpumask_set_cpu(u32 cpu, struct bpf_cpumask *cpumask)
 }
 
 __weak
-s32 scx_bpf_pick_idle_cpu_node(const struct cpumask *cpus_allowed, int node, u64 flags)
-{
-	return -1;
-}
-
-__weak
-s32 scx_bpf_pick_idle_cpu(const struct cpumask *cpus_allowed, u64 flags)
-{
-	return -1;
-}
-
-__weak
 u32 bpf_cpumask_any_distribute(const struct cpumask *cpumask)
 {
 	return 0;
@@ -111,25 +87,12 @@ bool bpf_cpumask_and(struct bpf_cpumask *dst, const struct cpumask *src1, const 
 }
 
 __weak
-const struct cpumask *scx_bpf_get_idle_smtmask_node(int node)
-{
-	return NULL;
-}
-
-__weak
-const struct cpumask *scx_bpf_get_idle_smtmask(void)
-{
-	return NULL;
-}
-
-__weak
-const struct cpumask *scx_bpf_get_idle_cpumask(void)
-{
-	return NULL;
-}
-
-__weak
 u32 bpf_cpumask_weight(const struct cpumask *cpumask)
 {
 	return 0;
+}
+
+__weak
+void scx_bpf_put_cpumask(const struct cpumask *cpumask)
+{
 }

--- a/lib/scxtest/overrides.h
+++ b/lib/scxtest/overrides.h
@@ -22,3 +22,6 @@
 
 #define ARRAY_ELEM_PTR(arr, i, n) \
 	(typeof(arr[i]) *)((char *)(arr) + (i) * sizeof(typeof(*(arr))))
+
+/* This is a static helper for some reason, so we have to define it here. */
+#define bpf_get_prandom_u32() 0

--- a/lib/scxtest/scx_test_cpumask.c
+++ b/lib/scxtest/scx_test_cpumask.c
@@ -1,0 +1,112 @@
+#include <stdbool.h>
+
+#include "kern_types.h"
+
+#ifndef BITS_PER_LONG
+#define BITS_PER_LONG (sizeof(unsigned long) * 8)
+#endif
+
+#ifndef NR_CPUS
+#define NR_CPUS 128
+#endif
+
+struct cpumask {
+	unsigned long bits[128];
+};
+
+static struct cpumask all_cpus = { 0 };
+static struct cpumask idle_smtmask = { 0 };
+static struct cpumask idle_cpumask = { 0 };
+
+static void cpumask_set_cpu(int cpu, struct cpumask *mask)
+{
+	if (cpu < 0 || cpu >= NR_CPUS) {
+		return;
+	}
+	mask->bits[cpu / BITS_PER_LONG] |= (1UL << (cpu % BITS_PER_LONG));
+}
+
+static void cpumask_clear_cpu(int cpu, struct cpumask *mask)
+{
+	if (cpu < 0 || cpu >= NR_CPUS) {
+		return;
+	}
+	mask->bits[cpu / BITS_PER_LONG] &= ~(1UL << (cpu % BITS_PER_LONG));
+}
+
+static bool cpumask_test_cpu(int cpu, const struct cpumask *mask)
+{
+	if (cpu < 0 || cpu >= NR_CPUS) {
+		return false;
+	}
+	return (mask->bits[cpu / BITS_PER_LONG] & (1UL << (cpu % BITS_PER_LONG))) != 0;
+}
+
+void scx_test_set_all_cpumask(int cpu)
+{
+	cpumask_set_cpu(cpu, &all_cpus);
+}
+
+void scx_test_set_idle_smtmask(int cpu)
+{
+	cpumask_set_cpu(cpu, &idle_smtmask);
+}
+
+void scx_test_set_idle_cpumask(int cpu)
+{
+	cpumask_set_cpu(cpu, &idle_cpumask);
+}
+
+void scx_test_cpumask_set(int cpu, struct cpumask *cpumask)
+{
+	cpumask_set_cpu(cpu, cpumask);
+}
+
+const struct cpumask *scx_bpf_get_idle_smtmask_node(int node)
+{
+	return &idle_smtmask;
+}
+
+const struct cpumask *scx_bpf_get_idle_smtmask(void)
+{
+	return &idle_smtmask;
+}
+
+const struct cpumask *scx_bpf_get_idle_cpumask(void)
+{
+	return &idle_cpumask;
+}
+
+bool scx_bpf_test_and_clear_cpu_idle(s32 cpu)
+{
+	if (cpumask_test_cpu(cpu, &idle_cpumask)) {
+		cpumask_clear_cpu(cpu, &idle_cpumask);
+		return true;
+	}
+	return false;
+}
+
+bool bpf_cpumask_test_cpu(u32 cpu, const struct cpumask *cpumask)
+{
+	return cpumask_test_cpu(cpu, cpumask);
+}
+
+s32 scx_bpf_pick_idle_cpu_node(const struct cpumask *cpus_allowed, int node, u64 flags)
+{
+	for (int i = 0; i < NR_CPUS; i++) {
+		if (cpumask_test_cpu(i, cpus_allowed) && cpumask_test_cpu(i, &idle_cpumask)) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+s32 scx_bpf_pick_idle_cpu(const struct cpumask *cpus_allowed, u64 flags)
+{
+	for (int i = 0; i < NR_CPUS; i++) {
+		if (cpumask_test_cpu(i, cpus_allowed) && cpumask_test_cpu(i, &idle_cpumask)) {
+			return i;
+		}
+	}
+	return -1;
+}

--- a/lib/scxtest/scx_test_cpumask.h
+++ b/lib/scxtest/scx_test_cpumask.h
@@ -1,0 +1,8 @@
+#pragma once
+
+struct cpumask;
+
+void scx_test_set_all_cpumask(int cpu);
+void scx_test_set_idle_smtmask(int cpu);
+void scx_test_set_idle_cpumask(int cpu);
+void scx_test_cpumask_set(int cpu, struct cpumask *cpumask);

--- a/lib/scxtest/scx_test_map.h
+++ b/lib/scxtest/scx_test_map.h
@@ -23,6 +23,8 @@ struct scx_percpu_test_map *scx_alloc_percpu_test_map(int nr_cpus);
 void scx_init_percpu_test_map(struct scx_percpu_test_map *map, unsigned int max_entries,
 			      unsigned int key_size, unsigned int value_size);
 void scx_register_percpu_test_map(struct scx_percpu_test_map *map, void *map_ptr);
+void *scx_test_task_storage_get(void *map, const void *key, void *value,
+				unsigned long flags);
 
 /*
  * The kernel doesn't have this, it always does it on it's current CPU, but we
@@ -43,6 +45,16 @@ int scx_test_map_update_percpu_elem(void *map, const void *key, const void *valu
 		(map)->nr = 0; \
 	} while (0)
 
+#define INIT_SCX_TEST_MAP_FROM_TASK_STORAGE(map, bpfmap) \
+	do { \
+		(map)->values = NULL; \
+		(map)->keys = NULL; \
+		(map)->max_entries = 100; \
+		(map)->key_size = sizeof(typeof(*bpfmap.key)); \
+		(map)->value_size = sizeof(typeof(*bpfmap.value)); \
+		(map)->nr = 0; \
+	} while (0)
+
 #define INIT_SCX_PERCPU_TEST_MAP(map, bpfmap) \
 	scx_init_percpu_test_map(map, MAX_ENTRIES(bpfmap), \
 		sizeof(typeof(*bpfmap.key)), sizeof(typeof(*bpfmap.value)))
@@ -51,3 +63,5 @@ int scx_test_map_update_percpu_elem(void *map, const void *key, const void *valu
 #define bpf_map_lookup_percpu_elem(map, key, cpu) scx_test_map_lookup_percpu_elem(map, key, cpu)
 #define bpf_map_update_elem(map, key, value, flags) \
 	scx_test_map_update_elem(map, key, value, flags)
+#define bpf_task_storage_get(map, task, value, flags) \
+	scx_test_task_storage_get(map, task, value, flags)

--- a/scheds/rust/scx_p2dq/src/bpf/main.test.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.test.bpf.c
@@ -1,11 +1,69 @@
 #include <scx_test.h>
 #include <scx_test_map.h>
+#include <scx_test_cpumask.h>
 
 #include <string.h>
 
 #include "main.bpf.c"
 
 static struct scx_percpu_test_map *cpu_ctxs_map = NULL;
+static struct scx_test_map llc_ctxs_map = { 0 };
+static struct scx_test_map task_masks_map = { 0 };
+
+static void setup_task_wrapper(struct task_struct *p, struct cpumask *cpumask)
+{
+	struct mask_wrapper *wrapper;
+
+	wrapper = bpf_task_storage_get(&task_masks, p, NULL,
+				       BPF_LOCAL_STORAGE_GET_F_CREATE);
+	scx_test_assert(wrapper);
+	wrapper->mask = cpumask;
+}
+
+static void setup_llc(u64 dsqid, u32 id, u32 nr_cpus, struct cpumask *mask)
+{
+	struct llc_ctx my_llcx = { 0 };
+	my_llcx.id = id;
+	my_llcx.dsq = dsqid;
+	my_llcx.nr_cpus = nr_cpus;
+	my_llcx.cpumask = mask;
+
+	scx_test_assert(scx_test_map_update_elem(&llc_ctxs, &id, &my_llcx,
+						 BPF_ANY) == 0);
+}
+
+static void test_pick_idle_cpu(void)
+{
+	struct task_struct p = { 0 };
+	task_ctx my_taskc = { 0 };
+	struct cpumask llc_cpumask = { 0 };
+	u64 index = 0;
+	s32 idle_cpu;
+	bool is_idle = false;
+
+	my_taskc.llc_id = 1;
+	my_taskc.dsq_id = 1;
+
+	setup_llc(1, 1, NR_CPUS, &llc_cpumask);
+	setup_task_wrapper(&p, &llc_cpumask);
+
+	for (int i = 0; i < NR_CPUS; i++) {
+		scx_test_set_all_cpumask(i);
+		scx_test_cpumask_set(i, &llc_cpumask);
+	}
+
+	idle_cpu = pick_idle_cpu(&p, &my_taskc, 0, 0, &is_idle);
+	scx_test_assert(idle_cpu >= 0);
+	scx_test_assert(idle_cpu < NR_CPUS);
+
+	/* Set 3 as the only idle CPU */
+	is_idle = false;
+	scx_test_set_idle_cpumask(3);
+	scx_test_set_idle_smtmask(3);
+	idle_cpu = pick_idle_cpu(&p, &my_taskc, 0, 0, &is_idle);
+	scx_test_assert(idle_cpu == 3);
+	scx_test_assert(is_idle);
+}
 
 static void test_lookup_cpu_ctx(void)
 {
@@ -54,7 +112,14 @@ int main(int argc, char **argv)
 {
 	cpu_ctxs_map = scx_alloc_percpu_test_map(NR_CPUS);
 	INIT_SCX_PERCPU_TEST_MAP(cpu_ctxs_map, cpu_ctxs);
+
+	INIT_SCX_TEST_MAP(&llc_ctxs_map, llc_ctxs);
+	INIT_SCX_TEST_MAP_FROM_TASK_STORAGE(&task_masks_map, task_masks);
+
+	scx_test_map_register(&llc_ctxs_map, &llc_ctxs);
+	scx_test_map_register(&task_masks_map, &task_masks);
 	scx_register_percpu_test_map(cpu_ctxs_map, &cpu_ctxs);
 	test_is_interactive();
 	test_lookup_cpu_ctx();
+	test_pick_idle_cpu();
 }


### PR DESCRIPTION
This adds cpumask stuff and more complicated helpers. This also adds a basic unit test for p2dq's select idle function to take advantage of these new helpers.  I'm also getting ready to disappear for a month long vacation so I've added documentation on what I've been doing an how to go about expanding the work.