### PR TITLE
scx_lavd: Handling the CPU utilization spikes in autopilot mode.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -48,6 +48,9 @@ enum consts_internal  {
 	LAVD_SYS_STAT_DECAY_TIMES	= ((2ULL * LAVD_TIME_ONE_SEC) / LAVD_SYS_STAT_INTERVAL_NS),
 
 	LAVD_CC_PER_CORE_SHIFT		= 1,  /* 50%: maximum per-core CPU utilization */
+	LAVD_CC_UTIL_SPIKE		= p2s(90), /* When the CPU utilization is almost full (90%),
+						      it is likely that the actual utilization is even
+						      higher than that. */
 	LAVD_CC_CPU_PIN_INTERVAL	= (250ULL * NSEC_PER_MSEC),
 	LAVD_CC_CPU_PIN_INTERVAL_DIV	= (LAVD_CC_CPU_PIN_INTERVAL / LAVD_SYS_STAT_INTERVAL_NS),
 


### PR DESCRIPTION
When a CPU is almost fully utilized (say 90%) during a period, we may underestimate the utilization. For example, when the measured CPU utilization is 100%, there is a possibility that the actual utilization is actually higher, such as 130%.

To handle such utilization spike cases, we give a 50% premium for the scaled CPU time where the CPU is almost fully utilized. This overestimates the scaled CPU utilization and the required compute capacity. Then, this finally allocates more active CPUs. The over-allocated CPUs become the breathing room.