### PR TITLE
scx_p2dq: Allow load balancing interactive tasks by default in dispatch

### DIFF
--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -75,7 +75,7 @@ pub struct SchedulerOpts {
     pub dispatch_lb_busy: u64,
 
     /// Enables pick2 load balancing on the dispatch path for interactive tasks.
-    #[clap(long, action = clap::ArgAction::SetTrue)]
+    #[clap(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub dispatch_lb_interactive: bool,
 
     /// Enable tasks to run beyond their timeslice if the CPU is idle.


### PR DESCRIPTION
Update the dispatch_lb_interactive setting to be enabled by default. Interactive load balancing leads to more stable performance and better load balancing of interactive tasks.