### PR TITLE
scx_flash: CPU stickiness

### DIFF
--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -81,11 +81,14 @@ const volatile bool local_kthreads;
 /*
  * Prioritize per-CPU tasks (tasks that can only run on a single CPU).
  *
- * This allows to prioritize per-CPU tasks that usually tend to be
- * de-prioritized (since they can't be migrated when their only usable CPU
- * is busy). Enabling this option can introduce unfairness and potentially
- * trigger stalls, but it can improve performance of server-type workloads
- * (such as large parallel builds).
+ * Enabling this option allows to prioritize per-CPU tasks that usually
+ * tend to be de-prioritized, since they can't be migrated when their only
+ * usable CPU is busy.
+ *
+ * This is implemented by disabling direct dispatch when there are tasks
+ * queued to the per-CPU DSQ or the per-node DSQ. In this way, per-CPU
+ * tasks waiting in those queues are scheduled based solely on their
+ * deadline, avoiding further delays caused by direct dispatches.
  */
 const volatile bool local_pcpu;
 

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -661,6 +661,9 @@ static bool cpus_share_llc(s32 this_cpu, s32 that_cpu)
 	const struct cpumask *llc_mask;
 	struct cpu_ctx *cctx;
 
+	if (this_cpu == that_cpu)
+		return true;
+
 	cctx = try_lookup_cpu_ctx(that_cpu);
 	if (!cctx)
 		return false;

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -646,23 +646,7 @@ static bool is_wake_sync(const struct task_struct *current,
 	if (no_wake_sync)
 		return false;
 
-	if ((wake_flags & SCX_WAKE_SYNC) && !(current->flags & PF_EXITING))
-		return true;
-
-	/*
-	 * If the current task is a per-CPU kthread running on the wakee's
-	 * previous CPU, treat it as a synchronous wakeup.
-	 *
-	 * The assumption is that the wakee had queued work for the per-CPU
-	 * kthread, which has now finished, making the wakeup effectively
-	 * synchronous. An example of this behavior is seen in IO
-	 * completions.
-	 */
-	if (is_kthread(current) && (current->nr_cpus_allowed == 1) &&
-	    (prev_cpu == this_cpu))
-		return true;
-
-	return false;
+	return (wake_flags & SCX_WAKE_SYNC) && !(current->flags & PF_EXITING);
 }
 
 /*

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -845,6 +845,18 @@ static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, u64 wake_flags, bo
 				goto out_put_cpumask;
 			}
 		}
+
+		/*
+		 * Search for any full-idle CPU usable by the task.
+		 */
+		if (p_mask != p->cpus_ptr) {
+			cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(p->cpus_ptr, node,
+						SCX_PICK_IDLE_CORE);
+			if (cpu >= 0) {
+				*is_idle = true;
+				goto out_put_cpumask;
+			}
+		}
 	}
 
 	/*

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -222,10 +222,11 @@ struct Opts {
 
     /// Enable per-CPU tasks prioritization.
     ///
-    /// This allows to prioritize per-CPU tasks that usually tend to be de-prioritized (since they
-    /// can't be migrated when their only usable CPU is busy). Enabling this option can introduce
-    /// unfairness and potentially trigger stalls, but it can improve performance of server-type
-    /// workloads (such as large parallel builds).
+    /// Enabling this option allows to prioritize per-CPU tasks that usually tend to be
+    /// de-prioritized, since they can't be migrated when their only usable CPU is busy. This
+    /// improves fairness, but it can also reduce the overall system throughput.
+    ///
+    /// This option is recommended for gaming or latency-sensitive workloads.
     #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
     local_pcpu: bool,
 

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -230,6 +230,13 @@ struct Opts {
     #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
     local_pcpu: bool,
 
+    /// Enable CPU stickiness.
+    ///
+    /// Enabling this option can reduce the amount of task migrations, but it can also make
+    /// performance less consistent on systems with hybrid cores.
+    #[clap(short = 'y', long, action = clap::ArgAction::SetTrue)]
+    sticky_cpu: bool,
+
     /// Native tasks priorities.
     ///
     /// By default, the scheduler normalizes task priorities to avoid large gaps that could lead to
@@ -391,6 +398,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.numa_disabled = opts.disable_numa;
         skel.maps.rodata_data.rr_sched = opts.rr_sched;
         skel.maps.rodata_data.local_pcpu = opts.local_pcpu;
+        skel.maps.rodata_data.sticky_cpu = opts.sticky_cpu;
         skel.maps.rodata_data.no_wake_sync = opts.no_wake_sync;
         skel.maps.rodata_data.tickless_sched = opts.tickless;
         skel.maps.rodata_data.native_priority = opts.native_priority;


### PR DESCRIPTION
A set of changes to make tasks more sticky to their CPU, improving cache locality, without regressing work conservation or responsiveness under high load.

The key idea is to favor per-CPU DSQs over per-node DSQs, as long as the CPU isn't saturated. This helps avoid unnecessary migrations. Example: when a short per-CPU kthread interrupts a task for a really short amount of time, the task is queued to a per-node DSQ and potentially picked up by another CPU, triggering a migration.

Instead, when the CPU becomes saturated, the scheduler switches to using per-node DSQs, increasing the chances of task migration. This boosts work conservation and maintains responsiveness under high load conditions.

To determine when a CPU becomes saturated the scheduler dynamically adjusts the saturation threshold using this heuristic: a CPU is considered saturated based on the formula `100% - user utilization %`; as a result, CPUs spending more time idle or in system mode will favor task stickiness, while those spending more time in user mode will promote migration.

User can also set a fixed saturation threshold using the option `--cpu-busy-thresh N` (with `N` being the saturation percentage).

Results:
  - before:
```
> ./schbench -L -m 4 -M auto -t 64 -n 0
auto pinning message and worker threads
Pinning to message thread index 1 cpu 1
Pinning to message thread index 2 cpu 2
Pinning to message thread index 0 cpu 0
Pinning to message thread index 3 cpu 3
Wakeup Latencies percentiles (usec) runtime 10 (s) (4642619 total samples)
	  50.0th: 55         (1384351 samples)
	  90.0th: 138        (1845799 samples)
	* 99.0th: 793        (415669 samples)
	  99.9th: 2356       (41705 samples)
	  min=1, max=15438
Request Latencies percentiles (usec) runtime 10 (s) (4649089 total samples)
	  50.0th: 339        (1399920 samples)
	  90.0th: 464        (1852548 samples)
	* 99.0th: 861        (415980 samples)
	  99.9th: 2468       (41626 samples)
	  min=102, max=11639
RPS percentiles (requests) runtime 10 (s) (11 total samples)
	  20.0th: 246528     (3 samples)
	* 50.0th: 518656     (3 samples)
	  90.0th: 543744     (4 samples)
	  min=246025, max=545217
sched delay: message 167 (usec) worker 87 (usec)
current rps: 529253.71
```

 - after:
```
> ./schbench -L -m 4 -M auto -t 64 -n 0
auto pinning message and worker threads
Pinning to message thread index 0 cpu 0
Pinning to message thread index 1 cpu 1
Pinning to message thread index 2 cpu 2
Pinning to message thread index 3 cpu 3
Wakeup Latencies percentiles (usec) runtime 10 (s) (13924693 total samples)
	  50.0th: 13         (3996277 samples)
	  90.0th: 42         (5561462 samples)
	* 99.0th: 123        (1240745 samples)
	  99.9th: 162        (120024 samples)
	  min=1, max=5372
Request Latencies percentiles (usec) runtime 10 (s) (14079726 total samples)
	  50.0th: 150        (4426557 samples)
	  90.0th: 167        (5386080 samples)
	* 99.0th: 193        (1261018 samples)
	  99.9th: 252        (117497 samples)
	  min=103, max=5432
RPS percentiles (requests) runtime 10 (s) (11 total samples)
	  20.0th: 996352     (3 samples)
	* 50.0th: 1538048    (4 samples)
	  90.0th: 1542144    (3 samples)
	  min=989399, max=1544828
sched delay: message 3 (usec) worker 5 (usec)
current rps: 1543326.27
```

In this case, with schbench, it's highly beneficial for tasks to remain on the same CPU, as the workload involves mostly inter-task synchronization (mostly CPU system time).

At the same time, the typical “gaming while recompiling the kernel” scenario still performs well, maintaining stable FPS without regressions, because when the CPUs get saturated with user CPU activity, the scheduler automatically falls back to using per-node DSQs.