### PR TITLE
scxtop: add cpu util events

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -11,6 +11,7 @@ use crate::bpf_stats::BpfStats;
 use crate::config::get_config_path;
 use crate::config::Config;
 use crate::format_hz;
+use crate::get_default_events;
 use crate::read_file_string;
 use crate::sanitize_nbsp;
 use crate::AppState;
@@ -162,24 +163,23 @@ impl<'a> App<'a> {
         let active_event =
             ProfilingEvent::Perf(PerfEvent::new(subsystem.clone(), event.clone(), 0));
         let mut active_prof_events = BTreeMap::new();
-        let mut default_perf_events = PerfEvent::default_events();
-        let config_perf_events = PerfEvent::from_config(&config)?;
-        default_perf_events.extend(config_perf_events);
-        let default_events_str: Vec<&str> = default_perf_events
-            .iter()
-            .map(|event| {
-                if !event.alias.is_empty() {
-                    event.alias.as_str()
-                } else {
-                    event.event.as_str()
-                }
-            })
-            .collect();
 
-        let default_events: Vec<ProfilingEvent> = default_perf_events
+        let cpu_stat_tracker = Arc::new(RwLock::new(CpuStatTracker::default()));
+        let mut default_events = get_default_events(cpu_stat_tracker.clone());
+
+        let config_perf_events = PerfEvent::from_config(&config)?;
+
+        default_events.extend(
+            config_perf_events
+                .iter()
+                .cloned()
+                .map(ProfilingEvent::Perf)
+                .collect::<Vec<_>>(),
+        );
+
+        let default_events_str: Vec<&str> = default_events
             .iter()
-            .cloned()
-            .map(ProfilingEvent::Perf)
+            .map(|event| event.event_name())
             .collect();
 
         for cpu in topo.all_cpus.values() {
@@ -192,12 +192,12 @@ impl<'a> App<'a> {
             cpu_data.insert(cpu.id, data);
         }
         for llc in topo.all_llcs.values() {
-            let mut data = LlcData::new(llc.id, llc.node_id, max_cpu_events);
+            let mut data = LlcData::new(llc.id, llc.node_id, llc.all_cpus.len(), max_cpu_events);
             data.initialize_events(&default_events_str);
             llc_data.insert(llc.id, data);
         }
         for node in topo.nodes.values() {
-            let mut data = NodeData::new(node.id, max_cpu_events);
+            let mut data = NodeData::new(node.id, node.all_cpus.len(), max_cpu_events);
             data.initialize_events(&default_events_str);
             node_data.insert(node.id, data);
         }
@@ -241,7 +241,7 @@ impl<'a> App<'a> {
             hw_pressure,
             locale: SystemLocale::default()?,
             stats_client,
-            cpu_stat_tracker: Arc::new(RwLock::new(CpuStatTracker::default())),
+            cpu_stat_tracker,
             sched_stats_raw: "".to_string(),
             scheduler,
             max_cpu_events,
@@ -337,15 +337,19 @@ impl<'a> App<'a> {
     fn reset_prof_events(&mut self) -> Result<()> {
         self.stop_prof_events();
         self.kprobe_links.clear();
-        let mut default_events = PerfEvent::default_events();
-        let config_events = PerfEvent::from_config(&self.config).unwrap();
-        default_events.extend(config_events);
 
-        self.available_events = default_events
-            .iter()
-            .cloned()
-            .map(ProfilingEvent::Perf)
-            .collect();
+        let mut default_events = get_default_events(self.cpu_stat_tracker.clone());
+        let config_perf_events = PerfEvent::from_config(&self.config)?;
+
+        default_events.extend(
+            config_perf_events
+                .iter()
+                .cloned()
+                .map(ProfilingEvent::Perf)
+                .collect::<Vec<_>>(),
+        );
+
+        self.available_events = default_events;
         self.active_hw_event_id = 0;
         let prof_event = &self.available_events[self.active_hw_event_id].clone();
         self.active_event = prof_event.clone();
@@ -403,6 +407,11 @@ impl<'a> App<'a> {
                     let mut k = k.clone();
                     k.cpu = cpu_id;
                     ProfilingEvent::Kprobe(k)
+                }
+                ProfilingEvent::CpuUtil(c) => {
+                    let mut c = c.clone();
+                    c.cpu = cpu_id;
+                    ProfilingEvent::CpuUtil(c)
                 }
             };
             self.active_prof_events.insert(cpu_id, event);
@@ -564,10 +573,7 @@ impl<'a> App<'a> {
         }
 
         for (cpu, event) in &mut self.active_prof_events {
-            let val = match event {
-                ProfilingEvent::Perf(p) => p.value(true)?,
-                ProfilingEvent::Kprobe(k) => k.value(true)?,
-            };
+            let val = event.value(true)?;
             let cpu_data = self
                 .cpu_data
                 .get_mut(cpu)
@@ -737,16 +743,21 @@ impl<'a> App<'a> {
 
     /// creates as sparkline for a llc.
     fn llc_sparkline(&self, llc: usize, max: u64, bottom_border: bool) -> Sparkline {
-        let data = if self.llc_data.contains_key(&llc) {
-            let llc_data = self
-                .llc_data
-                .get(&llc)
-                .expect("LlcData should have been present");
-            llc_data.event_data_immut(self.active_event.event_name())
-        } else {
-            Vec::new()
+        let llc_data = self
+            .llc_data
+            .get(&llc)
+            .expect("LlcData should have been present");
+        let divisor = match self.active_event {
+            ProfilingEvent::CpuUtil(_) => llc_data.num_cpus,
+            _ => 1,
         };
-        let stats = VecStats::new(&data, 1, None);
+        let data = llc_data
+            .event_data_immut(self.active_event.event_name())
+            .iter()
+            .map(|x| x / divisor as u64)
+            .collect();
+
+        let stats = VecStats::new(&data, None);
 
         Sparkline::default()
             .data(&data)
@@ -785,16 +796,21 @@ impl<'a> App<'a> {
 
     /// creates as sparkline for a node.
     fn node_sparkline(&self, node: usize, max: u64, bottom_border: bool) -> Sparkline {
-        let data = if self.node_data.contains_key(&node) {
-            let node_data = self
-                .node_data
-                .get(&node)
-                .expect("NodeData should have been present");
-            node_data.event_data_immut(self.active_event.event_name())
-        } else {
-            Vec::new()
+        let node_data = self
+            .node_data
+            .get(&node)
+            .expect("NodeData should have been present");
+        let divisor = match self.active_event {
+            ProfilingEvent::CpuUtil(_) => node_data.num_cpus,
+            _ => 1,
         };
-        let stats = VecStats::new(&data, 1, None);
+        let data = node_data
+            .event_data_immut(self.active_event.event_name())
+            .iter()
+            .map(|x| x / divisor as u64)
+            .collect();
+
+        let stats = VecStats::new(&data, None);
 
         Sparkline::default()
             .data(&data)
@@ -864,9 +880,19 @@ impl<'a> App<'a> {
         let llc_iter = self
             .llc_data
             .values()
-            .flat_map(|llc_data| llc_data.event_data_immut(self.active_event.event_name()))
+            .flat_map(|llc_data| {
+                let data = llc_data.event_data_immut(self.active_event.event_name());
+                let divisor = match self.active_event {
+                    ProfilingEvent::CpuUtil(_) => llc_data.num_cpus,
+                    _ => 1,
+                };
+                data.iter()
+                    .map(|&x| x / divisor as u64)
+                    .collect::<Vec<u64>>()
+            })
             .collect::<Vec<u64>>();
-        let stats = VecStats::new(&llc_iter, 1, None);
+
+        let stats = VecStats::new(&llc_iter, None);
 
         match self.view_state {
             ViewState::Sparkline => {
@@ -984,9 +1010,20 @@ impl<'a> App<'a> {
         let node_iter = self
             .node_data
             .values()
-            .flat_map(|node_data| node_data.event_data_immut(self.active_event.event_name()))
+            .flat_map(|node_data| {
+                let divisor = match self.active_event {
+                    ProfilingEvent::CpuUtil(_) => node_data.num_cpus,
+                    _ => 1,
+                };
+                node_data
+                    .event_data_immut(self.active_event.event_name())
+                    .iter()
+                    .map(|&x| x / divisor as u64)
+                    .collect::<Vec<u64>>()
+            })
             .collect::<Vec<u64>>();
-        let stats = VecStats::new(&node_iter, 1, None);
+
+        let stats = VecStats::new(&node_iter, None);
 
         match self.view_state {
             ViewState::Sparkline => {
@@ -1111,7 +1148,7 @@ impl<'a> App<'a> {
             Vec::new()
         };
         // XXX: this should be max across all CPUs
-        let stats = VecStats::new(&data, 1, None);
+        let stats = VecStats::new(&data, None);
         Sparkline::default()
             .data(&data)
             .max(stats.max)
@@ -1213,7 +1250,7 @@ impl<'a> App<'a> {
             .map(|(dsq_id, dsq_data)| {
                 let values = dsq_data.event_data_immut(event);
                 let value = values.last().copied().unwrap_or(0_u64);
-                let stats = VecStats::new(&values, 1, None);
+                let stats = VecStats::new(&values, None);
                 self.dsq_bar(*dsq_id, value, stats.avg, stats.max, stats.min)
             })
             .collect()
@@ -1247,9 +1284,17 @@ impl<'a> App<'a> {
             .iter()
             .filter(|(_llc_id, llc_data)| llc_data.data.data.contains_key(event))
             .map(|(llc_id, llc_data)| {
-                let values = llc_data.event_data_immut(event);
+                let divisor = match self.active_event {
+                    ProfilingEvent::CpuUtil(_) => llc_data.num_cpus,
+                    _ => 1,
+                };
+                let values = llc_data
+                    .event_data_immut(event)
+                    .iter()
+                    .map(|&x| x / divisor as u64)
+                    .collect::<Vec<u64>>();
                 let value = values.last().copied().unwrap_or(0_u64);
-                let stats = VecStats::new(&values, 1, None);
+                let stats = VecStats::new(&values, None);
                 self.event_bar(*llc_id, value, stats.avg, stats.max, stats.min)
             })
             .collect()
@@ -1261,9 +1306,17 @@ impl<'a> App<'a> {
             .iter()
             .filter(|(_node_id, node_data)| node_data.data.data.contains_key(event))
             .map(|(node_id, node_data)| {
-                let values = node_data.event_data_immut(event);
+                let divisor = match self.active_event {
+                    ProfilingEvent::CpuUtil(_) => node_data.num_cpus,
+                    _ => 1,
+                };
+                let values = node_data
+                    .event_data_immut(event)
+                    .iter()
+                    .map(|&x| x / divisor as u64)
+                    .collect::<Vec<u64>>();
                 let value = values.last().copied().unwrap_or(0_u64);
-                let stats = VecStats::new(&values, 1, None);
+                let stats = VecStats::new(&values, None);
                 self.event_bar(*node_id, value, stats.avg, stats.max, stats.min)
             })
             .collect()
@@ -1371,7 +1424,7 @@ impl<'a> App<'a> {
             .values()
             .flat_map(|dsq_data| dsq_data.event_data_immut(event))
             .collect::<Vec<u64>>();
-        let stats = VecStats::new(&dsq_global_iter, 1, None);
+        let stats = VecStats::new(&dsq_global_iter, None);
 
         let bar_block = Block::default()
             .title_top(
@@ -1488,7 +1541,7 @@ impl<'a> App<'a> {
                             cpu_data.event_data_immut(self.active_event.event_name())
                         })
                         .collect::<Vec<u64>>();
-                    let stats = VecStats::new(&node_iter, 1, None);
+                    let stats = VecStats::new(&node_iter, None);
 
                     let node_block = Block::bordered()
                         .title_top(
@@ -1609,7 +1662,7 @@ impl<'a> App<'a> {
                             cpu_data.event_data_immut(self.active_event.event_name())
                         })
                         .collect::<Vec<u64>>();
-                    let stats = VecStats::new(&node_iter, 1, None);
+                    let stats = VecStats::new(&node_iter, None);
 
                     let node_block = Block::bordered()
                         .title_top(

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -62,7 +62,7 @@ pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
-This software may be used and distributed according to the terms of the
+This software may be used and distributed according to the terms of the 
 GNU General Public License version 2.";
 pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -38,7 +38,8 @@ pub use llc_data::LlcData;
 pub use node_data::NodeData;
 pub use perfetto_trace::PerfettoTraceManager;
 pub use profiling_events::{
-    available_kprobe_events, available_perf_events, KprobeEvent, PerfEvent, ProfilingEvent,
+    available_kprobe_events, available_perf_events, get_default_events, KprobeEvent, PerfEvent,
+    ProfilingEvent,
 };
 pub use search::Search;
 pub use stats::StatAggregation;
@@ -61,7 +62,7 @@ pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
-This software may be used and distributed according to the terms of the 
+This software may be used and distributed according to the terms of the
 GNU General Public License version 2.";
 pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 

--- a/tools/scxtop/src/llc_data.rs
+++ b/tools/scxtop/src/llc_data.rs
@@ -13,13 +13,14 @@ use std::collections::VecDeque;
 pub struct LlcData {
     pub node: usize,
     pub llc: usize,
+    pub num_cpus: usize,
     pub data: EventData,
     pub max_data_size: usize,
 }
 
 impl LlcData {
     /// Creates a new NodeData.
-    pub fn new(llc: usize, node: usize, max_data_size: usize) -> LlcData {
+    pub fn new(llc: usize, node: usize, num_cpus: usize, max_data_size: usize) -> LlcData {
         let mut data = EventData::new(max_data_size);
         for event in PerfEvent::default_events() {
             data.event_data(&event.event);
@@ -28,6 +29,7 @@ impl LlcData {
         Self {
             llc,
             node,
+            num_cpus,
             data,
             max_data_size,
         }

--- a/tools/scxtop/src/node_data.rs
+++ b/tools/scxtop/src/node_data.rs
@@ -12,19 +12,21 @@ use std::collections::VecDeque;
 #[derive(Clone, Debug)]
 pub struct NodeData {
     pub node: usize,
+    pub num_cpus: usize,
     pub data: EventData,
     pub max_data_size: usize,
 }
 
 impl NodeData {
     /// Creates a new NodeData.
-    pub fn new(node: usize, max_data_size: usize) -> NodeData {
+    pub fn new(node: usize, num_cpus: usize, max_data_size: usize) -> NodeData {
         let mut data = EventData::new(max_data_size);
         for event in PerfEvent::default_events() {
             data.event_data(&event.event);
         }
         Self {
             node,
+            num_cpus,
             data,
             max_data_size,
         }

--- a/tools/scxtop/src/profiling_events/cpu_util.rs
+++ b/tools/scxtop/src/profiling_events/cpu_util.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use crate::CpuStatTracker;
+use anyhow::Result;
+use std::sync::{Arc, RwLock};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CpuUtilMetric {
+    Total,
+    User,
+    System,
+}
+
+impl CpuUtilMetric {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CpuUtilMetric::Total => "cpu_util_percent",
+            CpuUtilMetric::User => "cpu_user_util_percent",
+            CpuUtilMetric::System => "cpu_system_util_percent",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CpuUtilEvent {
+    pub cpu: usize,
+    pub metric: CpuUtilMetric,
+    pub tracker: Arc<RwLock<CpuStatTracker>>,
+}
+
+impl CpuUtilEvent {
+    pub fn new(cpu: usize, metric: CpuUtilMetric, tracker: Arc<RwLock<CpuStatTracker>>) -> Self {
+        Self {
+            cpu,
+            metric,
+            tracker: tracker.clone(),
+        }
+    }
+
+    /// Returns the set of default cpu metric events.
+    pub fn default_events(tracker: Arc<RwLock<CpuStatTracker>>) -> Vec<CpuUtilEvent> {
+        vec![
+            CpuUtilEvent::new(0, CpuUtilMetric::Total, tracker.clone()),
+            CpuUtilEvent::new(0, CpuUtilMetric::User, tracker.clone()),
+            CpuUtilEvent::new(0, CpuUtilMetric::System, tracker.clone()),
+        ]
+    }
+
+    pub fn event_name(&self) -> &str {
+        self.metric.as_str()
+    }
+
+    pub fn value(&self) -> Result<u64> {
+        let tracker = self.tracker.read().unwrap();
+        let prev = tracker.prev.get(&self.cpu).unwrap();
+        let current = tracker.current.get(&self.cpu).unwrap();
+        let total = current.total() - prev.total();
+        if total == 0 {
+            return Ok(0);
+        }
+
+        let value = match self.metric {
+            CpuUtilMetric::Total => current.active() - prev.active(),
+            CpuUtilMetric::User => current.user - prev.user,
+            CpuUtilMetric::System => current.system - prev.system,
+        };
+
+        Ok((value * 100) / total)
+    }
+}

--- a/tools/scxtop/src/profiling_events/cpu_util.rs
+++ b/tools/scxtop/src/profiling_events/cpu_util.rs
@@ -17,7 +17,7 @@ pub enum CpuUtilMetric {
 impl CpuUtilMetric {
     pub fn as_str(&self) -> &'static str {
         match self {
-            CpuUtilMetric::Total => "cpu_util_percent",
+            CpuUtilMetric::Total => "cpu_total_util_percent",
             CpuUtilMetric::User => "cpu_user_util_percent",
             CpuUtilMetric::System => "cpu_system_util_percent",
         }

--- a/tools/scxtop/src/profiling_events/mod.rs
+++ b/tools/scxtop/src/profiling_events/mod.rs
@@ -3,14 +3,21 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
+pub mod cpu_util;
 pub mod kprobe;
 pub mod perf;
 
+use std::sync::{Arc, RwLock};
+
+pub use cpu_util::CpuUtilEvent;
 pub use kprobe::{available_kprobe_events, KprobeEvent};
 pub use perf::{available_perf_events, PerfEvent};
 
+use crate::CpuStatTracker;
+
 #[derive(Clone, Debug)]
 pub enum ProfilingEvent {
+    CpuUtil(CpuUtilEvent),
     Perf(PerfEvent),
     Kprobe(KprobeEvent),
 }
@@ -18,6 +25,7 @@ pub enum ProfilingEvent {
 impl ProfilingEvent {
     pub fn event_name(&self) -> &str {
         match self {
+            ProfilingEvent::CpuUtil(c) => c.event_name(),
             ProfilingEvent::Perf(p) => p.event_name(),
             ProfilingEvent::Kprobe(k) => &k.event_name,
         }
@@ -25,8 +33,23 @@ impl ProfilingEvent {
 
     pub fn value(&mut self, reset: bool) -> anyhow::Result<u64> {
         match self {
+            ProfilingEvent::CpuUtil(c) => c.value(),
             ProfilingEvent::Perf(p) => p.value(reset),
             ProfilingEvent::Kprobe(k) => k.value(reset),
         }
     }
+}
+
+pub fn get_default_events(tracker: Arc<RwLock<CpuStatTracker>>) -> Vec<ProfilingEvent> {
+    let default_perf_events = PerfEvent::default_events()
+        .into_iter()
+        .map(ProfilingEvent::Perf);
+
+    let default_cpu_util_events = CpuUtilEvent::default_events(tracker)
+        .into_iter()
+        .map(ProfilingEvent::CpuUtil);
+
+    default_perf_events
+        .chain(default_cpu_util_events)
+        .collect::<Vec<ProfilingEvent>>()
 }

--- a/tools/scxtop/src/stats.rs
+++ b/tools/scxtop/src/stats.rs
@@ -64,13 +64,7 @@ pub struct VecStats {
 }
 
 impl VecStats {
-    pub fn new(
-        vec: &Vec<u64>,
-        divisor: u64,
-        percentiles: Option<HashSet<StatAggregation>>,
-    ) -> Self {
-        assert!(divisor != 0, "divisor must be non-zero");
-
+    pub fn new(vec: &Vec<u64>, percentiles: Option<HashSet<StatAggregation>>) -> Self {
         let mut min: u64 = u64::MAX;
         let mut max: u64 = 0;
         let mut sum: u64 = 0;
@@ -83,14 +77,11 @@ impl VecStats {
             }
             sum += val;
         }
-        min /= divisor;
-        max /= divisor;
-        sum /= divisor;
         match percentiles {
             Some(ref hashset) => {
                 let mut pmap = BTreeMap::new();
                 if !hashset.is_empty() && !vec.is_empty() {
-                    let mut sorted: Vec<u64> = vec.iter().map(|v| v / divisor).collect();
+                    let mut sorted = vec.clone();
                     sorted.sort_unstable();
 
                     let n = sorted.len();


### PR DESCRIPTION
Following on #2290, #2293, (and somewhat #2282, more on that later), this adds `CpuUtilEvent`'s to allow checking cpu utilization at the CPU, LLC, and Node level within the event pane. The main challenge with this addition was ensuring that the LLC and Node cpu utilization statistics were correct and properly normalized (i.e., that the summed utilization was accurately divided by the relevant number of CPUs). Previously, `VecStats` was only used for aggregating raw totals across LLC/Node's (such as total cycles), and not for computing percentage-based metrics like CPU utilization.

To enable this, a `num_cpus` field was added to the `LlcData` and `NodeData` structs. This allows us to normalize utilization values by dividing them by the number of CPUs that belong to a given LLC or node, prior to calculating aggregate statistics. #2282 explored handling the normalization inside `VecStats`, but it led to a more complex and less readable design.

Overall look:

https://github.com/user-attachments/assets/2a9a9f09-e5cc-4c78-8152-5643c093efde

Running `schbench -t 60`:

https://github.com/user-attachments/assets/d419a8a7-4c94-4b23-89cf-f529b79e90ba

