### PR TITLE
scx_flash: Tune defaults

### DIFF
--- a/rust/scx_loader/configuration.md
+++ b/rust/scx_loader/configuration.md
@@ -39,9 +39,9 @@ powersave_mode = ["--powersave"]
 
 [scheds.scx_flash]
 auto_mode = []
-gaming_mode = ["-m", "performance"]
-lowlatency_mode = ["-s", "5000", "-S", "500", "-l", "5000", "-m", "performance"]
-powersave_mode = ["-m", "powersave"]
+gaming_mode = ["-m", "all", "-w", "-p"]
+lowlatency_mode = ["-m", "performance", "-w", "-p", "-C", "0"]
+powersave_mode = ["-m", "powersave", "-I", "10000", "-t", "10000", "-s", "10000", "-S", "1000"]
 
 [scheds.scx_p2dq]
 auto_mode = []

--- a/rust/scx_loader/src/config.rs
+++ b/rust/scx_loader/src/config.rs
@@ -205,12 +205,21 @@ fn get_default_scx_flags_for_mode(scx_sched: &SupportedSched, sched_mode: SchedM
         // scx_rusty doesn't support any of these modes
         SupportedSched::Rusty => vec![],
         SupportedSched::Flash => match sched_mode {
-            SchedMode::Gaming => vec!["-m", "performance"],
-            SchedMode::LowLatency => {
-                vec!["-s", "5000", "-S", "500", "-l", "5000", "-m", "performance"]
-            }
-            SchedMode::PowerSave => vec!["-m", "powersave"],
-            SchedMode::Server => vec!["-p", "-c", "0"],
+            SchedMode::Gaming => vec!["-m", "all", "-w", "-p"],
+            SchedMode::LowLatency => vec!["-m", "performance", "-w", "-p", "-C", "0"],
+            SchedMode::PowerSave => vec![
+                "-m",
+                "powersave",
+                "-I",
+                "10000",
+                "-t",
+                "10000",
+                "-s",
+                "10000",
+                "-S",
+                "1000",
+            ],
+            SchedMode::Server => vec!["-m", "all", "-s", "20000", "-S", "1000", "-I", "-1"],
             SchedMode::Auto => vec![],
         },
         SupportedSched::P2DQ => match sched_mode {
@@ -264,10 +273,10 @@ server_mode = []
 
 [scheds.scx_flash]
 auto_mode = []
-gaming_mode = ["-m", "performance"]
-lowlatency_mode = ["-s", "5000", "-S", "500", "-l", "5000", "-m", "performance"]
-powersave_mode = ["-m", "powersave"]
-server_mode = ["-p", "-c", "0"]
+gaming_mode = ["-m", "all", "-w", "-p"]
+lowlatency_mode = ["-m", "performance", "-w", "-p", "-C", "0"]
+powersave_mode = ["-m", "powersave", "-I", "10000", "-t", "10000", "-s", "10000", "-S", "1000"]
+server_mode = ["-m", "all", "-s", "20000", "-S", "1000", "-I", "-1"]
 
 [scheds.scx_p2dq]
 auto_mode = []

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -41,25 +41,25 @@ const volatile bool primary_all = true;
 /*
  * Default task time slice.
  */
-const volatile u64 slice_max = 20ULL * NSEC_PER_MSEC;
+const volatile u64 slice_max = 4096ULL * NSEC_PER_USEC;
 
 /*
  * Time slice used when system is over commissioned.
  */
-const volatile u64 slice_min = 1ULL * NSEC_PER_MSEC;
+const volatile u64 slice_min = 128ULL * NSEC_PER_USEC;
 
 /*
  * Maximum runtime budget that a task can accumulate while sleeping (used
  * to determine the task's minimum vruntime).
  */
-const volatile u64 slice_lag = 20ULL * NSEC_PER_MSEC;
+const volatile u64 slice_lag = 4096ULL * NSEC_PER_USEC;
 
 /*
  * Maximum runtime penalty that a task can accumulate while running (used
  * to determine the task's maximum exec_vruntime: accumulated vruntime
  * since last sleep).
  */
-const volatile u64 run_lag = 200ULL * NSEC_PER_MSEC;
+const volatile u64 run_lag = 32768ULL * NSEC_PER_USEC;
 
 /*
  * Maximum amount of voluntary context switches (this limit allows to prevent

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -145,25 +145,25 @@ struct Opts {
     exit_dump_len: u32,
 
     /// Maximum scheduling slice duration in microseconds.
-    #[clap(short = 's', long, default_value = "20000")]
+    #[clap(short = 's', long, default_value = "4096")]
     slice_us: u64,
 
     /// Minimum scheduling slice duration in microseconds.
-    #[clap(short = 'S', long, default_value = "1000")]
+    #[clap(short = 'S', long, default_value = "128")]
     slice_us_min: u64,
 
     /// Maximum runtime budget that a task can accumulate while sleeping (in microseconds).
     ///
     /// Increasing this value can help to enhance the responsiveness of interactive tasks, but it
     /// can also make performance more "spikey".
-    #[clap(short = 'l', long, default_value = "20000")]
+    #[clap(short = 'l', long, default_value = "4096")]
     slice_us_lag: u64,
 
     /// Maximum runtime penalty that a task can accumulate while running (in microseconds).
     ///
     /// Increasing this value can help to enhance the responsiveness of interactive tasks, but it
     /// can also make performance more "spikey".
-    #[clap(short = 'r', long, default_value = "200000")]
+    #[clap(short = 'r', long, default_value = "32768")]
     run_us_lag: u64,
 
     /// Maximum rate of voluntary context switches.
@@ -202,7 +202,7 @@ struct Opts {
     /// Setting a lower latency value makes CPUs less likely to enter deeper idle states, enhancing
     /// performance at the cost of higher power consumption. Alternatively, increasing the latency
     /// value may reduce performance, but also improve power efficiency.
-    #[clap(short = 'I', long, allow_hyphen_values = true, default_value = "-1")]
+    #[clap(short = 'I', long, allow_hyphen_values = true, default_value = "32")]
     idle_resume_us: i64,
 
     /// Enable tickless mode.

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -215,7 +215,7 @@ struct Opts {
 
     /// Enable round-robin scheduling.
     ///
-    /// Each task is given a fixed time slice (defined by --slice-us-max) and run in a cyclic, fair
+    /// Each task is given a fixed time slice (defined by --slice-us) and run in a cyclic, fair
     /// order.
     #[clap(short = 'R', long, action = clap::ArgAction::SetTrue)]
     rr_sched: bool,


### PR DESCRIPTION
Adjust the default parameters to prioritize system responsiveness and update scx_loader performance profiles to reflect all the recent changes in the scheduler.