### PR TITLE
scxtop: fix dsq_nr_queued tracing

### DIFF
--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -371,10 +371,10 @@ impl PerfettoTraceManager {
         // dsq nr_queued tracks
         for dsq in &trace_dsqs {
             if let Some(events) = self.dsq_nr_queued_events.remove(dsq) {
-                for dsq_lat_event in events {
-                    let ts: u64 = timestamp_absolute_us(&dsq_lat_event) as u64 / 1_000;
+                for dsq_nr_queued_event in events {
+                    let ts: u64 = timestamp_absolute_us(&dsq_nr_queued_event) as u64 / 1_000;
                     self.trace.packet.push(TracePacket {
-                        data: Some(trace_packet::Data::TrackEvent(dsq_lat_event)),
+                        data: Some(trace_packet::Data::TrackEvent(dsq_nr_queued_event)),
                         timestamp: Some(ts),
                         optional_trusted_packet_sequence_id: Some(
                             trace_packet::Optional_trusted_packet_sequence_id::TrustedPacketSequenceId(
@@ -817,7 +817,7 @@ impl PerfettoTraceManager {
             .push({
                 TrackEvent {
                     type_: Some(track_event::Type::TYPE_COUNTER.into()),
-                    track_uuid: Some(*next_dsq_uuid),
+                    track_uuid: Some(*next_dsq_uuid + 1),
                     // Each track needs a separate unique UUID, so we'll add one to the dsq for
                     // the nr_queued events.
                     counter_value_field: Some(track_event::Counter_value_field::CounterValue(


### PR DESCRIPTION
Previously `dsq_nr_queued` seemed to be missing from the perfetto trace. After looking around, it was actually getting combined with `dsq_latency_ns` due to having identical `track_uuid`'s. This caused the `dsq_nr_queued` stat to be omitted and also misconstrued the `ds_latency_ns` data (as `dsq_nr_queued` is generally 0). Now, `nr_queued` and `latency_ns` are properly seperated.

Before: 
<img width="1263" alt="Screenshot 2025-07-02 at 2 02 36 PM" src="https://github.com/user-attachments/assets/f0792ebe-03a1-40bc-b074-a0b6d00c2160" />

After:
<img width="1498" alt="Screenshot 2025-07-02 at 1 54 26 PM" src="https://github.com/user-attachments/assets/2b5c202f-6494-4999-9454-5ea5d96c74a0" />
