### PR TITLE
scx_flash: Handle empty NUMA nodes

### DIFF
--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -381,7 +381,12 @@ impl<'a> Scheduler<'a> {
             }
         }
 
-        let nr_nodes = topo.nodes.len();
+        // Determine the amount of non-empty NUMA nodes in the system.
+        let nr_nodes = topo
+            .nodes
+            .values()
+            .filter(|node| !node.all_cpus.is_empty())
+            .count();
         info!("NUMA nodes: {}", nr_nodes);
 
         // Automatically disable NUMA optimizations when running on non-NUMA systems.


### PR DESCRIPTION
Certain systems may have NUMA nodes that don't have any CPU assigned to them. These empty nodes shouldn't be counted when determining the total number of NUMA nodes in the system.