### PR TITLE
scx_chaos: cleanup skip_select_cpu check

### DIFF
--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -114,9 +114,7 @@ static __always_inline enum chaos_trait_kind choose_chaos(struct chaos_task_ctx 
 
 static __always_inline bool chaos_trait_skips_select_cpu(struct chaos_task_ctx *taskc)
 {
-	if (taskc->next_trait == CHAOS_TRAIT_RANDOM_DELAYS)
-		return true;
-	return false;
+	return taskc->next_trait == CHAOS_TRAIT_RANDOM_DELAYS;
 }
 
 static __always_inline u64 get_cpu_delay_dsq(int cpu_idx)


### PR DESCRIPTION
I generally assume the one liner is more readable/clean, but if this was on purpose, then let me know and I'll close this up.