### PR TITLE
scx_lavd: Correctly measure wake frequency. 

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -509,8 +509,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.preempt_shift = opts.preempt_shift;
         skel.maps.rodata_data.no_use_em = opts.no_use_em as u8;
 
-        skel.struct_ops.lavd_ops_mut().flags = *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP
-            | *compat::SCX_OPS_ENQ_EXITING
+        skel.struct_ops.lavd_ops_mut().flags = *compat::SCX_OPS_ENQ_EXITING
             | *compat::SCX_OPS_ENQ_LAST
             | *compat::SCX_OPS_ENQ_MIGRATION_DISABLED
             | *compat::SCX_OPS_KEEP_BUILTIN_IDLE;


### PR DESCRIPTION
When SCX_OPS_ALLOW_QUEUED_WAKEUP is set, wake-up operations are batch-processed in the kernel. Hence, @current is no longer a waker task, so we cannot correctly track the task's wake frequency. So we disable SCX_OPS_ALLOW_QUEUED_WAKEUP for now.

Also, we limit the wake frequency tracking within userspace tasks under the same parent. The kernel tasks are too broadly related.