### PR TITLE
scx_flash: Improve CPU locality

### DIFF
--- a/rust/scx_loader/src/config.rs
+++ b/rust/scx_loader/src/config.rs
@@ -186,8 +186,8 @@ fn get_default_scx_flags_for_mode(scx_sched: &SupportedSched, sched_mode: SchedM
         // scx_rusty doesn't support any of these modes
         SupportedSched::Rusty => vec![],
         SupportedSched::Flash => match sched_mode {
-            SchedMode::Gaming => vec!["-m", "all", "-w", "-p"],
-            SchedMode::LowLatency => vec!["-m", "performance", "-w", "-p", "-C", "0"],
+            SchedMode::Gaming => vec!["-m", "all"],
+            SchedMode::LowLatency => vec!["-m", "performance", "-w", "-C", "0"],
             SchedMode::PowerSave => vec![
                 "-m",
                 "powersave",
@@ -200,7 +200,9 @@ fn get_default_scx_flags_for_mode(scx_sched: &SupportedSched, sched_mode: SchedM
                 "-S",
                 "1000",
             ],
-            SchedMode::Server => vec!["-m", "all", "-s", "20000", "-S", "1000", "-I", "-1"],
+            SchedMode::Server => vec![
+                "-m", "all", "-s", "20000", "-S", "1000", "-I", "-1", "-D", "-L",
+            ],
             SchedMode::Auto => vec![],
         },
         SupportedSched::P2DQ => match sched_mode {
@@ -263,10 +265,10 @@ server_mode = []
 
 [scheds.scx_flash]
 auto_mode = []
-gaming_mode = ["-m", "all", "-w", "-p"]
-lowlatency_mode = ["-m", "performance", "-w", "-p", "-C", "0"]
+gaming_mode = ["-m", "all"]
+lowlatency_mode = ["-m", "performance", "-w", "-C", "0"]
 powersave_mode = ["-m", "powersave", "-I", "10000", "-t", "10000", "-s", "10000", "-S", "1000"]
-server_mode = ["-m", "all", "-s", "20000", "-S", "1000", "-I", "-1"]
+server_mode = ["-m", "all", "-s", "20000", "-S", "1000", "-I", "-1", "-D", "-L"]
 
 [scheds.scx_p2dq]
 auto_mode = []

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -1470,13 +1470,10 @@ static void update_cpu_load(struct task_struct *p, struct task_ctx *tctx)
 		return;
 
 	/*
-	 * Refresh target performance level, if utilization is above 75%
-	 * bump up the performance level to the max.
+	 * Refresh target performance level.
 	 */
 	delta_runtime = cctx->tot_runtime - cctx->prev_runtime;
 	perf_lvl = MIN(delta_runtime * SCX_CPUPERF_ONE / delta_t, SCX_CPUPERF_ONE);
-	if (perf_lvl >= SCX_CPUPERF_ONE - SCX_CPUPERF_ONE / 4)
-		perf_lvl = SCX_CPUPERF_ONE;
 
 	/*
 	 * Use a moving average to evalute the target performance level,

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -239,6 +239,13 @@ struct Opts {
     #[clap(short = 'R', long, action = clap::ArgAction::SetTrue)]
     rr_sched: bool,
 
+    /// Disable in-kernel idle CPU selection policy.
+    ///
+    /// Set this option to disable the in-kernel built-in idle CPU selection policy and rely on the
+    /// custom CPU selection policy.
+    #[clap(short = 'b', long, action = clap::ArgAction::SetTrue)]
+    no_builtin_idle: bool,
+
     /// Enable per-CPU tasks prioritization.
     ///
     /// Enabling this option allows to prioritize per-CPU tasks that usually tend to be
@@ -460,6 +467,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.tickless_sched = opts.tickless;
         skel.maps.rodata_data.native_priority = opts.native_priority;
         skel.maps.rodata_data.slice_lag_scaling = opts.slice_lag_scaling;
+        skel.maps.rodata_data.builtin_idle = !opts.no_builtin_idle;
         skel.maps.rodata_data.slice_max = opts.slice_us * 1000;
         skel.maps.rodata_data.slice_min = opts.slice_us_min * 1000;
         skel.maps.rodata_data.slice_lag = opts.slice_us_lag * 1000;

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -249,6 +249,19 @@ struct Opts {
     #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
     local_pcpu: bool,
 
+    /// Always allow direct dispatch to idle CPUs.
+    ///
+    /// By default tasks are not directly dispatched to idle CPUs if there are other tasks waiting
+    /// in the scheduler's queues. This prevents potential starvation of the already queued tasks.
+    ///
+    /// Enabling this option allows tasks to be always dispatched directly to idle CPUs,
+    /// potentially bypassing the scheduler queues.
+    ///
+    /// This allows to improve system throughput, especially with server workloads, but it can
+    /// introduce unfairness and potentially trigger stall conditions.
+    #[clap(short = 'D', long, action = clap::ArgAction::SetTrue)]
+    direct_dispatch: bool,
+
     /// Enable CPU stickiness.
     ///
     /// Enabling this option can reduce the amount of task migrations, but it can also make
@@ -441,6 +454,7 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.numa_disabled = numa_disabled;
         skel.maps.rodata_data.rr_sched = opts.rr_sched;
         skel.maps.rodata_data.local_pcpu = opts.local_pcpu;
+        skel.maps.rodata_data.direct_dispatch = opts.direct_dispatch;
         skel.maps.rodata_data.sticky_cpu = opts.sticky_cpu;
         skel.maps.rodata_data.no_wake_sync = opts.no_wake_sync;
         skel.maps.rodata_data.tickless_sched = opts.tickless;


### PR DESCRIPTION
A set of changes aimed to improve CPU locality without regressing work conservation and system responsiveness when the system becomes saturated or overcommitted.

These changes are still following the idea of keeping tasks running on the same CPU (as long as the CPU is sufficiently idle), using per-CPU DSQs, and move tasks to the per-node DSQs when their CPU becomes busy.

A set of new options have been added to better adapt the scheduler to different workloads:
- `--slice-lag-scaling`: Dynamically adjusts the maximum sleep-time budget based on CPU load. When CPUs are mostly idle, the budget shrinks, making the scheduler behave more like FIFO. When the system is busy, the budget increases to better differentiate between interactive and CPU-intensive tasks.
- `--direct-dispatch`: Enables immediate dispatching to idle CPUs. By default, direct dispatch only occurs after draining both the per-CPU and per-node DSQs to avoid starvation. Enabling this option allows to always dispatch directly to idle CPUs.
- `--no-builtin-idle`: Now, by default, the scheduler uses the in-kernel built-in idle CPU selection policy (if `scx_bpf_select_cpu_and()` is available). This option disables that behavior and falls back to the custom selection policy.

Round-robin mode has also been refined, yielding interesting performance results on interactive workloads, as long as the system is not overcommitted.

Finally, the `scx_loader` performance profiles have been updated to reflect the new options and behaviors.