### PR TITLE
scx_p2dq: Use max slice for idle deadline scheduling

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -352,6 +352,8 @@ static void set_deadline_slice(struct task_struct *p, task_ctx *taskc,
 	if (nr_queued > nr_idle) {
 		slice_ns = (max_dsq_time_slice() * nr_idle) / nr_queued;
 		taskc->slice_ns = clamp_slice(slice_ns);
+	} else {
+		taskc->slice_ns = max_dsq_time_slice();
 	}
 }
 


### PR DESCRIPTION
When using deadline scheduling use the max slice length when there are idle CPUs. This improves throughput by lowering the amount of context switches.