### PR TITLE
scxtop: make entering perf events easier

### DIFF
--- a/tools/scxtop/src/cli.rs
+++ b/tools/scxtop/src/cli.rs
@@ -62,7 +62,7 @@ pub struct TuiArgs {
     #[arg(long, default_value_t = -1)]
     pub process_id: i32,
     /// Custom perf events colon delimited (ex: "<event_name>:<event and umask ex: 0x023>:<event_type ex: 4>")
-    #[arg(long)]
+    #[arg(long, num_args = 1.., value_parser)]
     pub perf_events: Vec<String>,
     /// Default perf event colon delimited (ex: "<event_name>:<event and umask ex: 0x023>:<event_type ex: 4>")
     #[arg(long, default_value = "hw:cycles")]


### PR DESCRIPTION
This makes it so you can enter perf events without comma-delimiting and aligns the way we accept these args with krpobe args.