### PR TITLE
scxtop: add config tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,6 +3139,7 @@ dependencies = [
  "signal-hook",
  "simplelog",
  "smartstring",
+ "tempfile",
  "tokio",
  "tokio-util",
  "toml",
@@ -3503,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -52,6 +52,7 @@ nix = { version = "0.29", features = ["time"] }
 
 [dev-dependencies]
 criterion = "0.6.0"
+tempfile = "3.20.0"
 
 [[bench]]
 name = "search_benchmark"

--- a/tools/scxtop/src/cli.rs
+++ b/tools/scxtop/src/cli.rs
@@ -62,7 +62,7 @@ pub struct TuiArgs {
     #[arg(long, default_value_t = -1)]
     pub process_id: i32,
     /// Custom perf events colon delimited (ex: "<event_name>:<event and umask ex: 0x023>:<event_type ex: 4>")
-    #[arg(long)]
+    #[arg(long, num_args = 1.., value_parser)]
     pub perf_events: Vec<String>,
     /// Default perf event colon delimited (ex: "<event_name>:<event and umask ex: 0x023>:<event_type ex: 4>")
     #[arg(long, default_value = "hw:cycles")]

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -210,7 +210,10 @@ impl Config {
 
     /// Duration of trace in ns.
     pub fn trace_duration_ns(&self) -> u64 {
-        self.trace_duration_ms.unwrap_or(1_250) * 1_000_000
+        self.trace_duration_ms
+            .or(self.trace_ticks.map(|t| (t * self.tick_rate_ms()) as u64))
+            .unwrap_or(1_250)
+            * 1_000_000
     }
 
     /// Number of worker threads
@@ -227,7 +230,12 @@ impl Config {
 
     /// Duration to warmup a trace before collecting in ns.
     pub fn trace_warmup_ns(&self) -> u64 {
-        self.trace_warmup_ms.unwrap_or(750) * 1_000_000
+        self.trace_warmup_ms
+            .or(self
+                .trace_tick_warmup
+                .map(|t| (t * self.tick_rate_ms()) as u64))
+            .unwrap_or(750)
+            * 1_000_000
     }
 
     /// Returns a config with nothing set.

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -865,7 +865,9 @@ mod tests {
 
         let contents = fs::read_to_string(&config_path).expect("Failed to read file");
         let mut loaded_config: Config = toml::from_str(&contents).expect("Failed to deserialize");
-        loaded_config.resolve_keymap().expect("Failed to resolve keymap");
+        loaded_config
+            .resolve_keymap()
+            .expect("Failed to resolve keymap");
 
         let tui_args = TuiArgs::try_parse_from(vec![
             "scxtop",

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -210,10 +210,7 @@ impl Config {
 
     /// Duration of trace in ns.
     pub fn trace_duration_ns(&self) -> u64 {
-        self.trace_duration_ms
-            .or(self.trace_ticks.map(|t| (t * self.tick_rate_ms()) as u64))
-            .unwrap_or(1_250)
-            * 1_000_000
+        self.trace_duration_ms.unwrap_or(1_250) * 1_000_000
     }
 
     /// Number of worker threads
@@ -230,12 +227,7 @@ impl Config {
 
     /// Duration to warmup a trace before collecting in ns.
     pub fn trace_warmup_ns(&self) -> u64 {
-        self.trace_warmup_ms
-            .or(self
-                .trace_tick_warmup
-                .map(|t| (t * self.tick_rate_ms()) as u64))
-            .unwrap_or(750)
-            * 1_000_000
+        self.trace_warmup_ms.unwrap_or(750) * 1_000_000
     }
 
     /// Returns a config with nothing set.
@@ -286,8 +278,13 @@ impl Config {
     }
 
     /// Loads the config from XDG configuration.
-    pub fn load() -> Result<Config> {
+    pub fn load_or_default() -> Result<Config> {
         let config_path = get_config_path()?;
+
+        if !config_path.exists() {
+            return Ok(Config::default_config());
+        }
+
         let contents = fs::read_to_string(config_path)?;
         let mut config: Config = toml::from_str(&contents)?;
 
@@ -321,6 +318,10 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Action;
+    use clap::Parser;
+    use std::path::Path;
+    use tempfile::tempdir;
 
     #[test]
     fn test_merge_configs() {
@@ -342,5 +343,555 @@ mod tests {
         assert_eq!(merged.tick_rate_ms(), 114);
         assert!(merged.debug());
         assert!(!merged.exclude_bpf());
+    }
+
+    #[test]
+    fn test_config_from_tui_args() {
+        let args = TuiArgs::try_parse_from(vec![
+            "scxtop",
+            "--debug",
+            "true",
+            "--exclude-bpf",
+            "true",
+            "--perf-events",
+            "cpu:cycles",
+            "mem:faults",
+            "--stats-socket-path",
+            "/tmp/my_socket",
+            "--tick-rate-ms",
+            "100",
+            "--trace-file-prefix",
+            "/var/log/trace",
+            "--trace-warmup-ms",
+            "500",
+            "--trace-duration-ms",
+            "1000",
+            "--worker-threads",
+            "8",
+            "--default-perf-event",
+            "cpu:instructions",
+        ])
+        .unwrap();
+
+        let config: Config = args.into();
+
+        assert!(config.debug.unwrap());
+        assert!(config.exclude_bpf.unwrap());
+        assert_eq!(
+            config.perf_events,
+            vec!["cpu:cycles".to_string(), "mem:faults".to_string()]
+        );
+        assert_eq!(
+            config.stats_socket_path.unwrap(),
+            "/tmp/my_socket".to_string()
+        );
+        assert_eq!(config.tick_rate_ms.unwrap(), 100);
+        assert_eq!(
+            config.trace_file_prefix.unwrap(),
+            "/var/log/trace".to_string()
+        );
+        assert_eq!(config.trace_duration_ms.unwrap(), 1000);
+        assert_eq!(config.worker_threads.unwrap(), 8);
+        assert_eq!(
+            config.default_perf_event.unwrap(),
+            "cpu:instructions".to_string()
+        );
+        assert!(config.keymap.is_none());
+        assert!(config.active_keymap.is_empty());
+        assert!(config.theme.is_none());
+    }
+
+    #[test]
+    fn test_config_from_tui_args_defaults() {
+        let args = TuiArgs::try_parse_from(vec!["scxtop"]).unwrap();
+
+        let config: Config = args.into();
+
+        assert!(config.debug.is_none());
+        assert!(config.exclude_bpf.is_none());
+        assert!(config.perf_events.is_empty());
+        assert!(config.stats_socket_path.is_none());
+        assert!(config.tick_rate_ms.is_none());
+        assert!(config.trace_file_prefix.is_none());
+        assert!(config.trace_warmup_ms.is_none());
+        assert!(config.trace_ticks.is_none());
+        assert!(config.trace_duration_ms.is_none());
+        assert!(config.worker_threads.is_none());
+        assert_eq!(config.default_perf_event.unwrap(), "hw:cycles".to_string());
+    }
+
+    #[test]
+    fn test_merge_configs_no_overwrite() {
+        let mut a = Config::empty_config();
+        a.theme = Some(AppTheme::MidnightGreen);
+        a.tick_rate_ms = Some(100);
+        a.debug = Some(true);
+        a.exclude_bpf = Some(true);
+        a.perf_events = vec!["event_a".to_string()];
+        a.stats_socket_path = Some("/path/a".to_string());
+        a.trace_file_prefix = Some("prefix_a".to_string());
+        a.trace_ticks = Some(5);
+        a.trace_duration_ms = Some(500);
+        a.worker_threads = Some(2);
+        a.trace_warmup_ms = Some(100);
+        a.default_perf_event = Some("default_a".to_string());
+
+        let mut b = Config::empty_config();
+        b.theme = Some(AppTheme::IAmBlue);
+        b.tick_rate_ms = Some(200);
+        b.debug = Some(false);
+        b.exclude_bpf = Some(false);
+        b.perf_events = vec!["event_b".to_string()];
+        b.stats_socket_path = Some("/path/b".to_string());
+        b.trace_file_prefix = Some("prefix_b".to_string());
+        b.trace_ticks = Some(10);
+        b.trace_duration_ms = Some(1000);
+        b.worker_threads = Some(4);
+        b.trace_warmup_ms = Some(200);
+        b.default_perf_event = Some("default_b".to_string());
+
+        // Test `or` method
+        let merged_or = a.clone().or(b.clone());
+
+        assert_eq!(merged_or.theme(), &AppTheme::MidnightGreen);
+        assert_eq!(merged_or.tick_rate_ms(), 100);
+        assert!(merged_or.debug());
+        assert!(merged_or.exclude_bpf());
+        assert_eq!(merged_or.perf_events, vec!["event_a".to_string()]);
+        assert_eq!(merged_or.stats_socket_path(), "/path/a");
+        assert_eq!(merged_or.trace_file_prefix(), "prefix_a");
+        assert_eq!(merged_or.trace_ticks, Some(5));
+        assert_eq!(merged_or.trace_duration_ms, Some(500));
+        assert_eq!(merged_or.worker_threads(), 2);
+        assert_eq!(merged_or.trace_warmup_ms, Some(100));
+        assert_eq!(merged_or.default_perf_event(), "default_a");
+
+        // Test `merge` method
+        let merged = Config::merge([a, b]);
+
+        assert_eq!(merged.theme(), &AppTheme::MidnightGreen);
+        assert_eq!(merged.tick_rate_ms(), 100);
+        assert!(merged.debug());
+        assert!(merged.exclude_bpf());
+        assert_eq!(merged.perf_events, vec!["event_a".to_string()]);
+        assert_eq!(merged.stats_socket_path(), "/path/a");
+        assert_eq!(merged.trace_file_prefix(), "prefix_a");
+        assert_eq!(merged.trace_ticks, Some(5));
+        assert_eq!(merged.trace_duration_ms, Some(500));
+        assert_eq!(merged.worker_threads(), 2);
+        assert_eq!(merged.trace_warmup_ms, Some(100));
+        assert_eq!(merged.default_perf_event(), "default_a");
+    }
+
+    #[test]
+    fn test_merge_configs_overwrite() {
+        // Test with some None values
+        let mut a = Config::empty_config();
+        a.theme = None;
+        a.debug = None;
+        a.tick_rate_ms = Some(300);
+        a.exclude_bpf = Some(true);
+        a.perf_events = vec![];
+
+        let mut b = Config::empty_config();
+        b.theme = Some(AppTheme::IAmBlue);
+        b.tick_rate_ms = None;
+        b.debug = Some(false);
+        b.exclude_bpf = Some(false);
+        b.perf_events = vec!["event_d".to_string()];
+
+        let merged_or = a.clone().or(b.clone());
+        assert_eq!(merged_or.theme(), &AppTheme::IAmBlue);
+        assert_eq!(merged_or.tick_rate_ms(), 300);
+        assert!(!merged_or.debug());
+        assert!(merged_or.exclude_bpf());
+        assert_eq!(merged_or.perf_events, vec!["event_d".to_string()]);
+    }
+
+    #[test]
+    fn test_config_getters_and_setters() {
+        let mut config = Config::empty_config();
+
+        // Theme
+        assert_eq!(config.theme(), &AppTheme::Default);
+        config.set_theme(AppTheme::IAmBlue);
+        assert_eq!(config.theme(), &AppTheme::IAmBlue);
+
+        // Tick Rate
+        assert_eq!(config.tick_rate_ms(), 250);
+        config.set_tick_rate_ms(500);
+        assert_eq!(config.tick_rate_ms(), 500);
+
+        // Debug
+        assert!(!config.debug());
+        config.debug = Some(true);
+        assert!(config.debug());
+
+        // Exclude BPF
+        assert!(!config.exclude_bpf());
+        config.exclude_bpf = Some(true);
+        assert!(config.exclude_bpf());
+
+        // Stats Socket Path
+        assert_eq!(config.stats_socket_path(), STATS_SOCKET_PATH);
+        config.stats_socket_path = Some("/tmp/custom_socket".to_string());
+        assert_eq!(config.stats_socket_path(), "/tmp/custom_socket");
+
+        // Trace File Prefix
+        assert_eq!(config.trace_file_prefix(), TRACE_FILE_PREFIX);
+        config.trace_file_prefix = Some("/tmp/custom_trace".to_string());
+        assert_eq!(config.trace_file_prefix(), "/tmp/custom_trace");
+
+        // Trace Duration NS
+        config.trace_duration_ms = Some(2000);
+        assert_eq!(config.trace_duration_ns(), 2000 * 1_000_000);
+
+        // Worker Threads
+        assert_eq!(config.worker_threads(), 4);
+        config.worker_threads = Some(8);
+        assert_eq!(config.worker_threads(), 8);
+
+        // Default Perf Event
+        assert_eq!(config.default_perf_event(), "hw:cycles".to_string());
+        config.default_perf_event = Some("cpu:instructions".to_string());
+        assert_eq!(config.default_perf_event(), "cpu:instructions".to_string());
+
+        // Trace Warmup NS
+        config.trace_warmup_ms = Some(1500);
+        assert_eq!(config.trace_warmup_ns(), 1500 * 1_000_000);
+    }
+
+    #[test]
+    fn test_empty_config() {
+        let config = Config::empty_config();
+
+        assert!(config.keymap.is_none());
+        assert!(config.active_keymap.is_empty());
+        assert!(config.theme.is_none());
+        assert!(config.tick_rate_ms.is_none());
+        assert!(config.debug.is_none());
+        assert!(config.perf_events.is_empty());
+        assert!(config.exclude_bpf.is_none());
+        assert!(config.stats_socket_path.is_none());
+        assert!(config.trace_file_prefix.is_none());
+        assert!(config.trace_ticks.is_none());
+        assert!(config.trace_duration_ms.is_none());
+        assert!(config.worker_threads.is_none());
+        assert!(config.trace_tick_warmup.is_none());
+        assert!(config.trace_warmup_ms.is_none());
+        assert!(config.default_perf_event.is_none());
+
+        // Check getters return defaults
+        assert_eq!(config.theme(), &AppTheme::Default);
+        assert_eq!(config.tick_rate_ms(), 250);
+        assert!(!config.debug());
+        assert!(!config.exclude_bpf());
+        assert_eq!(config.stats_socket_path(), STATS_SOCKET_PATH);
+        assert_eq!(config.trace_file_prefix(), TRACE_FILE_PREFIX);
+        assert_eq!(config.trace_duration_ns(), 1250 * 1_000_000);
+        assert_eq!(config.worker_threads(), 4);
+        assert_eq!(config.default_perf_event(), "hw:cycles".to_string());
+        assert_eq!(config.trace_warmup_ns(), 750 * 1_000_000);
+    }
+
+    #[test]
+    fn test_default_config() {
+        let config = Config::default_config();
+
+        // Check that optional fields that have defaults are Some(default_value)
+        assert!(config.tick_rate_ms.is_some());
+        assert_eq!(config.tick_rate_ms.unwrap(), 250);
+        assert!(config.debug.is_some());
+        assert_eq!(config.debug.unwrap(), false);
+        assert!(config.exclude_bpf.is_some());
+        assert_eq!(config.exclude_bpf.unwrap(), false);
+
+        // Other fields should still be None or empty vec/KeyMap
+        assert!(config.keymap.is_none());
+        assert!(!config.active_keymap.is_empty()); // Should be default KeyMap, which is not empty
+        assert!(config.theme.is_none());
+        assert!(config.perf_events.is_empty());
+        assert!(config.stats_socket_path.is_none());
+        assert!(config.trace_file_prefix.is_none());
+        assert!(config.trace_ticks.is_none());
+        assert!(config.trace_duration_ms.is_none());
+        assert!(config.worker_threads.is_none());
+        assert!(config.trace_tick_warmup.is_none());
+        assert!(config.trace_warmup_ms.is_none());
+        assert!(config.default_perf_event.is_none());
+    }
+
+    // Helper to mock xdg::BaseDirectories for testing file paths
+    struct MockXdgBaseDirectories {
+        config_home: PathBuf,
+    }
+
+    impl MockXdgBaseDirectories {
+        fn new(base_path: &Path) -> Self {
+            MockXdgBaseDirectories {
+                config_home: base_path.join(".config"),
+            }
+        }
+
+        fn get_config_file(&self, file_name: &str) -> PathBuf {
+            self.config_home.join("scxtop").join(file_name)
+        }
+    }
+
+    // Mocking get_config_path for isolated testing
+    // This would typically involve dependency injection or using a library
+    // that allows mocking static functions, which is more complex in Rust.
+    // For demonstration, we'll create a test function that would set up
+    // a temporary directory and simulate the config path.
+    fn get_mock_config_path(temp_dir_path: &Path) -> Result<PathBuf> {
+        let mock_xdg_dirs = MockXdgBaseDirectories::new(temp_dir_path);
+        Ok(mock_xdg_dirs.get_config_file("scxtop.toml"))
+    }
+
+    #[test]
+    fn test_load_and_save_config() {
+        let dir = tempdir().expect("Failed to create temporary directory");
+        let config_path = get_mock_config_path(dir.path()).expect("Failed to get mock config path");
+
+        // Ensure the parent directory exists for saving
+        let config_parent_dir = config_path.parent().unwrap();
+        fs::create_dir_all(config_parent_dir)
+            .expect("Failed to create parent directory for config");
+
+        let mut config_to_save = Config::default_config();
+        config_to_save.set_theme(AppTheme::MidnightGreen);
+        config_to_save.set_tick_rate_ms(5000);
+        config_to_save.debug = Some(true);
+        config_to_save.exclude_bpf = Some(true);
+        config_to_save.perf_events = vec!["custom:event".to_string()];
+        config_to_save.stats_socket_path = Some("/my/socket".to_string());
+        config_to_save.trace_file_prefix = Some("my_trace".to_string());
+        config_to_save.trace_duration_ms = Some(2000);
+        config_to_save.worker_threads = Some(6);
+        config_to_save.trace_warmup_ms = Some(500);
+        config_to_save.default_perf_event = Some("another:event".to_string());
+
+        let mut test_keymap = HashMap::new();
+        test_keymap.insert("i".to_string(), "Quit".to_string());
+        test_keymap.insert("2".to_string(), "AppStateHelp".to_string());
+        config_to_save.keymap = Some(test_keymap.clone());
+
+        let mut active_keymap_for_save = KeyMap::empty();
+        active_keymap_for_save.insert(parse_key("i").unwrap(), parse_action("Quit").unwrap());
+        active_keymap_for_save.insert(
+            parse_key("2").unwrap(),
+            parse_action("AppStateHelp").unwrap(),
+        );
+        config_to_save.active_keymap = active_keymap_for_save;
+
+        // Simulate save by writing to the mock path
+        let saved_config_str =
+            toml::to_string(&config_to_save).expect("Failed to serialize config");
+        fs::write(&config_path, saved_config_str)
+            .expect("Failed to write config to mock path for saving test");
+
+        // For this test, we cannot directly call `Config::load()` as it uses the real `get_config_path()`.
+        // Instead, we will simulate the loading process here directly using the mock path.
+        let saved_content =
+            fs::read_to_string(&config_path).expect("Failed to read saved config file");
+        let loaded_from_file: Config =
+            toml::from_str(&saved_content).expect("Failed to deserialize saved config");
+
+        assert_eq!(loaded_from_file.theme, config_to_save.theme);
+        assert_eq!(loaded_from_file.tick_rate_ms, config_to_save.tick_rate_ms);
+        assert_eq!(loaded_from_file.debug, config_to_save.debug);
+        assert_eq!(loaded_from_file.exclude_bpf, config_to_save.exclude_bpf);
+        assert_eq!(loaded_from_file.perf_events, config_to_save.perf_events);
+        assert_eq!(
+            loaded_from_file.stats_socket_path,
+            config_to_save.stats_socket_path
+        );
+        assert_eq!(
+            loaded_from_file.trace_file_prefix,
+            config_to_save.trace_file_prefix
+        );
+        assert_eq!(
+            loaded_from_file.trace_duration_ms,
+            config_to_save.trace_duration_ms
+        );
+        assert_eq!(
+            loaded_from_file.worker_threads,
+            config_to_save.worker_threads
+        );
+        assert_eq!(
+            loaded_from_file.trace_warmup_ms,
+            config_to_save.trace_warmup_ms
+        );
+        assert_eq!(
+            loaded_from_file.default_perf_event,
+            config_to_save.default_perf_event
+        );
+        assert_eq!(loaded_from_file.keymap, Some(test_keymap));
+    }
+
+    #[test]
+    fn test_load_config() {
+        let dir = tempdir().expect("Failed to create temporary directory");
+        let config_path = get_mock_config_path(dir.path()).expect("Failed to get mock config path");
+
+        // Ensure the parent directory exists for saving
+        let config_parent_dir = config_path.parent().unwrap();
+        fs::create_dir_all(config_parent_dir)
+            .expect("Failed to create parent directory for config");
+
+        // Create a dummy config file in the temporary directory
+        let config_content = r#"
+        theme = "IAmBlue"
+        tick_rate_ms = 123
+        debug = true
+        exclude_bpf = true
+        worker_threads = 5
+        perf_events = ["my_event_1", "my_event_2"]
+        stats_socket_path = "/test/socket"
+        trace_file_prefix = "test_trace"
+        trace_duration_ms = 1000
+        trace_warmup_ms = 200
+        default_perf_event = "cpu:cycles"
+        [keymap]
+        i = "Quit"
+        2 = "Enter"
+        "#;
+        fs::write(&config_path, config_content).expect("Failed to write dummy config file");
+
+        let contents =
+            fs::read_to_string(&config_path).expect("Failed to read file for loading test");
+        let mut loaded_config: Config =
+            toml::from_str(&contents).expect("Failed to deserialize for loading test");
+
+        // Manually parse keymap as load() does
+        if let Some(keymap_config) = &loaded_config.keymap {
+            let mut keymap = KeyMap::default();
+            for (key_str, action_str) in keymap_config {
+                let key = parse_key(key_str).expect("Failed to parse key");
+                let action = parse_action(action_str).expect("Failed to parse action");
+                keymap.insert(key, action);
+            }
+            loaded_config.active_keymap = keymap;
+        } else {
+            loaded_config.active_keymap = KeyMap::default();
+        }
+
+        assert_eq!(loaded_config.theme(), &AppTheme::IAmBlue);
+        assert_eq!(loaded_config.tick_rate_ms(), 123);
+        assert!(loaded_config.debug());
+        assert!(loaded_config.exclude_bpf());
+        assert_eq!(loaded_config.worker_threads(), 5);
+        assert_eq!(
+            loaded_config.perf_events,
+            vec!["my_event_1".to_string(), "my_event_2".to_string()]
+        );
+        assert_eq!(loaded_config.stats_socket_path(), "/test/socket");
+        assert_eq!(loaded_config.trace_file_prefix(), "test_trace");
+        assert_eq!(loaded_config.trace_duration_ms, Some(1000));
+        assert_eq!(loaded_config.trace_warmup_ms, Some(200));
+        assert_eq!(loaded_config.default_perf_event(), "cpu:cycles".to_string());
+
+        // Verify active_keymap
+        assert!(loaded_config
+            .active_keymap
+            .get(&parse_key("i").unwrap())
+            .map_or(false, |action| *action == Action::Quit));
+        assert!(loaded_config
+            .active_keymap
+            .get(&parse_key("2").unwrap())
+            .map_or(false, |action| *action == Action::Enter));
+    }
+
+    fn test_config_integration_test_complex() {
+        let dir = tempdir().expect("Failed to create temporary directory");
+        let config_path = get_mock_config_path(dir.path()).expect("Failed to get mock config path");
+
+        // Ensure the parent directory exists for saving
+        let config_parent_dir = config_path.parent().unwrap();
+        fs::create_dir_all(config_parent_dir)
+            .expect("Failed to create parent directory for config");
+
+        // Create a dummy config file in the temporary directory
+        let saved_config = r#""
+        perf_events = []
+        theme = "MidnightGreen"
+        tick_rate_ms = 500
+        debug = false
+        exclude_bpf = true
+        default_perf_event = "mem:faults"
+
+        [keymap]
+        S = "SaveConfig"
+        "+" = "IncTickRate"
+        "[" = "DecBpfSampleRate"
+        h = "AppStateHelp"
+        Esc = "Esc"
+        o = "NextViewState"
+        P = "ToggleHwPressure"
+        k = "NextEvent"
+        Enter = "Enter"
+        "]" = "IncBpfSampleRate"
+        "?" = "AppStateHelp"
+        u = "ToggleUncoreFreq"
+        f = "ToggleCpuFreq"
+        "Page Down" = "PageDown"
+        Down = "Down"
+        j = "PrevEvent"
+        x = "ClearEvent"
+        "Page Up" = "PageUp"
+        l = "AppStateLlc"
+        n = "AppStateNode"
+        s = "AppStateScheduler"
+        d = "AppStateDefault"
+        m = "SetState(MangoApp)"
+        a = "RequestTrace"
+        K = "SetState(KprobeEvent)"
+        L = "ToggleLocalization"
+        Backspace = "Backspace"
+        - = "DecTickRate"
+        Up = "Up"
+        t = "ChangeTheme"
+        i = "Quit"
+        e = "AppStatePerfEvent"
+        "#;
+
+        fs::write(&config_path, saved_config).expect("Failed to write dummy config file");
+
+        let contents = fs::read_to_string(&config_path).expect("Failed to read file");
+        let loaded_config: Config = toml::from_str(&contents).expect("Failed to deserialize");
+
+        let tui_args = TuiArgs::try_parse_from(vec![
+            "scxtop",
+            "--debug",
+            "true",
+            "--perf-events",
+            "cpu:cycles",
+            "mem:faults",
+            "--default-perf-event",
+            "cpu:instructions",
+        ])
+        .unwrap();
+
+        // This is how the config is loaded in main
+        let config = Config::merge([Config::from(tui_args.clone()), loaded_config]);
+
+        assert_eq!(config.theme(), &AppTheme::MidnightGreen);
+        assert_eq!(config.tick_rate_ms(), 500);
+        assert!(config.debug());
+        assert!(config.exclude_bpf());
+        assert_eq!(
+            config.perf_events,
+            vec!["cpu:cycles".to_string(), "mem:faults".to_string()]
+        );
+        assert_eq!(config.default_perf_event(), "cpu:instructions".to_string());
+
+        assert!(config
+            .active_keymap
+            .get(&parse_key("i").unwrap())
+            .map_or(false, |action| *action == Action::Quit));
+        assert!(config
+            .active_keymap
+            .get(&parse_key("o").unwrap())
+            .map_or(false, |action| *action == Action::NextViewState));
     }
 }

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -81,6 +81,16 @@ impl KeyMap {
         KeyMap { bindings }
     }
 
+    /// Returns if the KeyMap is empty.
+    pub fn is_empty(&self) -> bool {
+        self.bindings.is_empty()
+    }
+
+    // Returns an Action for a Key.
+    pub fn get(&self, key: &Key) -> Option<&Action> {
+        self.bindings.get(key)
+    }
+
     /// Maps the Key to an Action.
     pub fn action(&self, key: &Key) -> Action {
         self.bindings.get(key).cloned().unwrap_or(Action::None)
@@ -328,12 +338,14 @@ pub fn parse_key(key_str: &str) -> Result<Key> {
     {
         Ok(Key::Code(keycode_wrapper.into()))
     } else {
-        match key_str {
-            "Page Up" | "PageUp" => Ok(Key::Code(KeyCode::PageUp)),
-            "Page Down" | "PageDown" => Ok(Key::Code(KeyCode::PageDown)),
-            "Up" => Ok(Key::Code(KeyCode::Up)),
-            "Down" => Ok(Key::Code(KeyCode::Down)),
-            "Enter" => Ok(Key::Code(KeyCode::Enter)),
+        match key_str.to_lowercase().as_str() {
+            "page up" | "pageup" => Ok(Key::Code(KeyCode::PageUp)),
+            "page down" | "pagedown" => Ok(Key::Code(KeyCode::PageDown)),
+            "up" => Ok(Key::Code(KeyCode::Up)),
+            "down" => Ok(Key::Code(KeyCode::Down)),
+            "enter" => Ok(Key::Code(KeyCode::Enter)),
+            "backspace" => Ok(Key::Code(KeyCode::Backspace)),
+            "esc" | "escape" => Ok(Key::Code(KeyCode::Esc)),
             _ => Err(anyhow!("Invalid key: {}", key_str)),
         }
     }
@@ -371,6 +383,8 @@ pub fn parse_action(action_str: &str) -> Result<Action> {
         "PageDown" => Ok(Action::PageDown),
         "PageUp" => Ok(Action::PageUp),
         "Enter" => Ok(Action::Enter),
+        "Esc" => Ok(Action::Esc),
+        "Backspace" => Ok(Action::Backspace),
         _ => Err(anyhow!("Invalid action: {}", action_str)),
     }
 }

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -581,6 +581,8 @@ impl std::fmt::Display for Action {
         match self {
             Action::SetState(AppState::Default) => write!(f, "AppStateDefault"),
             Action::SetState(AppState::PerfEvent) => write!(f, "AppStatePerfEvent"),
+            Action::SetState(AppState::KprobeEvent) => write!(f, "AppStateKprobeEvent"),
+            Action::SetState(AppState::MangoApp) => write!(f, "AppStateMangoApp"),
             Action::ToggleCpuFreq => write!(f, "ToggleCpuFreq"),
             Action::ToggleUncoreFreq => write!(f, "ToggleUncoreFreq"),
             Action::ToggleLocalization => write!(f, "ToggleLocalization"),

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -284,7 +284,7 @@ fn run_tui(tui_args: &TuiArgs) -> Result<()> {
 
     let config = Config::merge([
         Config::from(tui_args.clone()),
-        Config::load().unwrap_or(Config::default_config()),
+        Config::load_or_default().expect("Failed to load config or load default config"),
     ]);
     let keymap = config.active_keymap.clone();
 


### PR DESCRIPTION
Non-functional changes. Relies on #2347, #2348, #2349. This adds tests and the necessary helper methods to `config.rs`.