### PR TITLE
p2dq/chaos: switch more enqueue cases to be async

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/intf.h
+++ b/scheds/rust/scx_p2dq/src/bpf/intf.h
@@ -77,10 +77,4 @@ enum scheduler_mode {
 	MODE_PERFORMANCE,
 };
 
-enum enqueue_promise_kind {
-	P2DQ_ENQUEUE_PROMISE_COMPLETE,
-	P2DQ_ENQUEUE_PROMISE_VTIME,
-	P2DQ_ENQUEUE_PROMISE_FIFO,
-};
-
 #endif /* __P2DQ_INTF_H */

--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -78,6 +78,13 @@ struct task_p2dq {
 
 typedef struct task_p2dq __arena task_ctx;
 
+enum enqueue_promise_kind {
+	P2DQ_ENQUEUE_PROMISE_COMPLETE,
+	P2DQ_ENQUEUE_PROMISE_VTIME,
+	P2DQ_ENQUEUE_PROMISE_FIFO,
+	P2DQ_ENQUEUE_PROMISE_FAILED,
+};
+
 struct enqueue_promise_vtime {
 	u64	dsq_id;
 	u64	enq_flags;
@@ -91,8 +98,15 @@ struct enqueue_promise_fifo {
 	u64	slice_ns;
 };
 
+// This struct is zeroed at the beginning of `async_p2dq_enqueue` and only
+// relevant fields are set, so assume 0 as default when adding fields.
 struct enqueue_promise {
 	enum enqueue_promise_kind	kind;
+
+	s32				cpu;
+	bool				kick_idle;
+	bool				has_cleared_idle;
+
 	union {
 		struct enqueue_promise_vtime	vtime;
 		struct enqueue_promise_fifo	fifo;


### PR DESCRIPTION
p2dq's enqueue has diverged from the implementation when chaos was initially implemented. Then, we had P2DQ_ENQUEUE_COMPLETE but only based on a fixed task condition. Now, _COMPLETE gets hit based on a variety of conditions, many of which include the idle state of the machine. As this state can change, we started hitting complete in dispatch (delayed enqueue) even though we didn't hit it in enqueue the first time around. This meant that tasks weren't being enqueued properly the second time, and tasks were stalling.

Implement `kick_if_idle` for the enqueue promise and cover many of the remaining p2dq cases. I left the per-CPU kthread for now in the hope it includes BPF timers, as delaying BPF timers would prevent forward progress in chaos and lead to stalls. This also required the destruction of a promise if it's not executed, as p2dq might have already set the CPU to not idle. After discussion with @arighi, this is undone by kicking the CPU, which resets the idle state.

Test plan:
- CI
- `sudo target/release/scx_chaos --random-delay-frequency 0.5 --random-delay-min-us 500000 --random-delay-max-us 750000` - ran for about half an hour and all was fine on my machine.