### PR TITLE
p2dq: re-enable ci on 6.12

### DIFF
--- a/scheds/rust/scx_p2dq/Cargo.toml
+++ b/scheds/rust/scx_p2dq/Cargo.toml
@@ -6,9 +6,6 @@ edition = "2021"
 description = "scx_p2dq A simple pick two load balancing scheduler in BPF"
 license = "GPL-2.0-only"
 
-[package.metadata.scx]
-ci.kernel.blocklist = ["stable/6_12"]
-
 [dependencies]
 anyhow = "1.0.65"
 chrono = "0.4"


### PR DESCRIPTION
p2dq was disabled on 6.12 for affinitised task stalls. There have been a lot of changes to p2dq recently, let's re-enable it.

Closes #2075

Test plan:
- CI, repeatedly. Amended this commit several times and checked it always passed. It has the trailer that triggers 6.12 testing.

CI-Test-Kernel: stable/6_12