### PR TITLE
ci: filter on metal:nixos github runners

### DIFF
--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-kernels:
-    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64" ]') || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64", "metal:nixos" ]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
 
   rust-tests:
-    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64" ]') || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64", "metal:nixos" ]') || 'ubuntu-latest' }}
     needs: build-kernels
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   list-tests:
-    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64" ]') || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64", "metal:nixos" ]') || 'ubuntu-latest' }}
     outputs:
       matrix: ${{ steps.output.outputs.matrix }}
     steps:
@@ -131,7 +131,7 @@ jobs:
           compression-level: 9
 
   all-success:
-    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64" ]') || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64", "metal:nixos" ]') || 'ubuntu-latest' }}
     needs: integration-test
     if: always()
     steps:

--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   list-kernels:
-    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64" ]') || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64", "metal:nixos" ]') || 'ubuntu-latest' }}
     outputs:
       matrix: ${{ steps.output.outputs.matrix }}
     steps:
@@ -28,7 +28,7 @@ jobs:
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
   update-kernels:
-    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64" ]') || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64", "metal:nixos" ]') || 'ubuntu-latest' }}
     needs: list-kernels
     strategy:
       matrix:


### PR DESCRIPTION
CI currently filters on self-hosted/linux/x64 runners. I plan to mess around with a different type of runner being available, and need a way to filter that out. Added a "metal:nixos" tag to the existing runners and filtering on that too.

Test plan:
- CI
- Rest by extension