### PR TITLE
/etc/default/scx: set scx_flash as default scheduler

### DIFF
--- a/services/scx
+++ b/services/scx
@@ -1,5 +1,5 @@
-# List of scx_schedulers: scx_bpfland scx_central scx_flash scx_lavd scx_layered scx_nest scx_qmap scx_rlfifo scx_rustland scx_rusty scx_simple scx_userland scx_p2dq scx_tickless
-SCX_SCHEDULER=scx_bpfland
+# List of scx_schedulers: scx_bpfland scx_central scx_flash scx_lavd scx_layered scx_nest scx_p2dq scx_qmap scx_rlfifo scx_rustland scx_rusty scx_simple scx_tickless scx_userland
+SCX_SCHEDULER=scx_flash
 
 # Set custom flags for each scheduler, below is an example of how to use
-#SCX_FLAGS='-p -m performance'
+#SCX_FLAGS='-m performance -D -L'


### PR DESCRIPTION
After the latest changes made before the release of version 1.0.14, scx_flash began to outperform scx_bpfland in terms of performance. The start of work on the new 1.0.15 release is a good time to try to make scx_flash the new suggested scheduler.