### PR TITLE
scxtop: switch cpu to procfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,6 +1260,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "fb_procfs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8748972699ec5b99570e031841f449612e266d2106de7482ad76de003cfddba"
+dependencies = [
+ "below-common",
+ "lazy_static",
+ "libc",
+ "nix 0.29.0",
+ "openat",
+ "parking_lot",
+ "serde",
+ "slog",
+ "thiserror 2.0.10",
+ "threadpool",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,7 +2803,7 @@ dependencies = [
  "combinations",
  "crossbeam",
  "ctrlc",
- "fb_procfs",
+ "fb_procfs 0.7.1",
  "gpoint",
  "hex",
  "itertools 0.13.0",
@@ -2813,7 +2831,7 @@ dependencies = [
  "crossbeam",
  "ctrlc",
  "fastrand",
- "fb_procfs",
+ "fb_procfs 0.7.1",
  "lazy_static",
  "libbpf-rs",
  "libc",
@@ -2869,7 +2887,7 @@ dependencies = [
  "cgroupfs",
  "clap",
  "ctrlc",
- "fb_procfs",
+ "fb_procfs 0.7.1",
  "itertools 0.13.0",
  "lazy_static",
  "libbpf-rs",
@@ -2891,7 +2909,7 @@ dependencies = [
  "clap",
  "crossbeam",
  "ctrlc",
- "fb_procfs",
+ "fb_procfs 0.7.1",
  "lazy_static",
  "libbpf-rs",
  "libc",
@@ -2964,7 +2982,7 @@ dependencies = [
  "clap",
  "crossbeam",
  "ctrlc",
- "fb_procfs",
+ "fb_procfs 0.7.1",
  "libbpf-rs",
  "libc",
  "log",
@@ -3086,6 +3104,7 @@ dependencies = [
  "config",
  "criterion",
  "crossterm 0.28.1",
+ "fb_procfs 0.9.0",
  "futures",
  "glob",
  "hashbrown 0.15.2",

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -23,6 +23,7 @@ clap = { version = "4.5.28", features = [
 clap_complete = "4.5.45"
 config = "0.14.1"
 crossterm = { version = "0.28.1", features = ["serde", "event-stream"] }
+fb_procfs = "0.9.0"
 futures = "0.3.31"
 glob = "0.3.2"
 libbpf-rs = "=0.25.0-beta.1"

--- a/tools/scxtop/src/cpu_stats.rs
+++ b/tools/scxtop/src/cpu_stats.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use fb_procfs::ProcReader;
 use std::collections::BTreeMap;
 

--- a/tools/scxtop/src/cpu_stats.rs
+++ b/tools/scxtop/src/cpu_stats.rs
@@ -50,6 +50,8 @@ impl CpuStatTracker {
                 let snapshot = procfs_cpu_to_stat_snapshot(stat);
                 self.current.insert(cpu as usize, snapshot);
             }
+        } else {
+            bail!("Failed to parse cpu stats from /proc/stat");
         }
 
         Ok(())


### PR DESCRIPTION
This uses the cleaner `fb_procfs` wrapper instead of manually parsing /proc/stats. Given that we are planning on adding more proc data, a "global" `proc_reader` was also added to the `App` struct.