### PR TITLE
chaos: re-enable on sched_ext/for-next kernel

### DIFF
--- a/scheds/rust/scx_chaos/Cargo.toml
+++ b/scheds/rust/scx_chaos/Cargo.toml
@@ -9,9 +9,6 @@ license = "GPL-2.0-only"
 [package.metadata.scx]
 ci.use_clippy = true
 
-ci.kernel.default = "stable/linux-rolling-stable"
-ci.kernel.blocklist = ["sched_ext/for-next"]
-
 [dependencies]
 scx_userspace_arena = { path = "../../../rust/scx_userspace_arena", version = "1.0.14" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }


### PR DESCRIPTION
Chaos was disabled on the sched_ext/for-next kernel a while ago because of RCU stalls that appeared after a kernel update. There have been many changes and fixes to chaos, particularly around the p2dq interrop recently, so let's try running on this kernel again as it's the most useful to track.

Closes #2272

Test plan:
- CI, several times.