### PR TITLE
scx_lavd: Add 'rerunnable_interval' for '--monitor-sched-samples'

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -104,10 +104,10 @@ struct task_ctx {
 	/*
 	 * Clocks when a task state transition happens for task statistics calculation
 	 */
-	u64	last_runnable_clk;	/* last time when a task wakes up others */
+	u64	last_runnable_clk;	/* last time when a task became runnable */
 	u64	last_running_clk;	/* last time when scheduled in */
 	u64	last_stopping_clk;	/* last time when scheduled out */
-	u64	last_quiescent_clk;	/* last time when a task waits for an event */
+	u64	last_quiescent_clk;	/* last time when a task became asleep */
 
 	/*
 	 * Task running statistics for latency criticality calculation
@@ -140,7 +140,7 @@ struct task_ctx {
 	 * Additional information when the scheduler is monitored,
 	 * so it is updated only when is_monitored is true.
 	 */
-	u64	resched_interval;	/* reschedule interval in ns */
+	u64	resched_interval;	/* reschedule interval in ns: [last running, this running] */
 	u32	cpu_id;			/* where a task ran */
 	u32	prev_cpu_id;		/* where a task ran last time */
 	u32	suggested_cpu_id;	/* suggested CPU ID at ops.enqueue() and ops.select_cpu() */
@@ -158,6 +158,7 @@ struct task_ctx_x {
 	u16	static_prio;	/* nice priority */
 	u64	cpu_util;	/* cpu utilization in [0..100] */
 	u64	cpu_sutil;	/* scaled cpu utilization in [0..100] */
+	u64	rerunnable_interval;	/* rerunnable interval in ns: [last quiescent, last runnable] */
 	u32	thr_perf_cri;	/* performance criticality threshold */
 	u32	avg_lat_cri;	/* average latency criticality */
 	u32	nr_active;	/* number of active cores */

--- a/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
@@ -43,6 +43,7 @@ int submit_task_ctx(struct task_struct *p, struct task_ctx *taskc, u32 cpu_id)
 	m->taskc_x.static_prio = get_nice_prio(p);
 	m->taskc_x.cpu_util = s2p(cpuc->avg_util);
 	m->taskc_x.cpu_sutil = s2p(cpuc->avg_sc_util);
+	m->taskc_x.rerunnable_interval = time_delta(taskc->last_quiescent_clk, taskc->last_runnable_clk);
 	m->taskc_x.avg_lat_cri = sys_stat.avg_lat_cri;
 	m->taskc_x.thr_perf_cri = sys_stat.thr_perf_cri;
 	m->taskc_x.nr_active = sys_stat.nr_active;

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1201,8 +1201,10 @@ static void init_task_ctx(struct task_struct *p, struct task_ctx *taskc)
 
 	__builtin_memset(taskc, 0, sizeof(*taskc));
 	taskc->is_affinitized = bpf_cpumask_weight(p->cpus_ptr) != nr_cpu_ids;
+	taskc->last_runnable_clk = now;
 	taskc->last_running_clk = now; /* for avg_runtime */
 	taskc->last_stopping_clk = now; /* for avg_runtime */
+	taskc->last_quiescent_clk = now;
 	taskc->avg_runtime = slice_max_ns;
 	taskc->svc_time = sys_stat.avg_svc_time;
 

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -561,6 +561,7 @@ impl<'a> Scheduler<'a> {
             lat_cri: tc.lat_cri,
             avg_lat_cri: tx.avg_lat_cri,
             static_prio: tx.static_prio,
+            rerunnable_interval: tx.rerunnable_interval,
             resched_interval: tc.resched_interval,
             run_freq: tc.run_freq,
             avg_runtime: tc.avg_runtime,

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -160,6 +160,8 @@ pub struct SchedSample {
     pub avg_lat_cri: u32,
     #[stat(desc = "Static priority (20 == nice 0)")]
     pub static_prio: u16,
+    #[stat(desc = "Time interval from the last quiescent time to this runnable time.")]
+    pub rerunnable_interval: u64,
     #[stat(desc = "Time interval from the last stopped time.")]
     pub resched_interval: u64,
     #[stat(desc = "How often this task is scheduled per second")]
@@ -188,7 +190,7 @@ impl SchedSample {
     pub fn format_header<W: Write>(w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "\x1b[93m| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:8} | {:17} | {:8} | {:8} | {:7} | {:8} | {:10} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:6} |\x1b[0m",
+            "\x1b[93m| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:8} | {:17} | {:8} | {:8} | {:7} | {:8} | {:12} | {:12} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:9} | {:6} |\x1b[0m",
             "MSEQ",
             "PID",
             "COMM",
@@ -202,6 +204,7 @@ impl SchedSample {
             "LAT_CRI",
             "AVG_LC",
             "ST_PRIO",
+            "RERNBL_NS",
             "RESCHD_NS",
             "RUN_FREQ",
             "RUN_TM_NS",
@@ -224,7 +227,7 @@ impl SchedSample {
 
         writeln!(
             w,
-            "| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:8} | {:17} | {:8} | {:8} | {:7} | {:8} | {:10} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:8} | {:6} |",
+            "| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:8} | {:17} | {:8} | {:8} | {:7} | {:8} | {:12} | {:12} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:9} | {:6} |",
             self.mseq,
             self.pid,
             self.comm,
@@ -238,6 +241,7 @@ impl SchedSample {
             self.lat_cri,
             self.avg_lat_cri,
             self.static_prio,
+            self.rerunnable_interval,
             self.resched_interval,
             self.run_freq,
             self.avg_runtime,


### PR DESCRIPTION
Let's collect the time duration from when a task becomes quiescent to when it becomes runnable again.