### PR TITLE
scxtop: fix trace

### DIFF
--- a/tools/scxtop/src/cli.rs
+++ b/tools/scxtop/src/cli.rs
@@ -103,9 +103,6 @@ pub struct TraceArgs {
     /// Trace duration.
     #[arg(short = 'd', long, default_value_t = 1000)]
     pub trace_ms: u64,
-    /// Trace warmup duration, make sure this is long enough or events may have poor data quality.
-    #[arg(short = 'w', long, default_value_t = 5000)]
-    pub warmup_ms: u64,
     /// Trace output file.
     #[arg(short = 'o', long)]
     pub output_file: Option<String>,


### PR DESCRIPTION
Previously, the ring buffer was not cleared before stopping the trace and the receiver was not given time to process all events, leading to event being missed. The warmup period was also unnecessary.

Now, we `consume` the ring buffer and wait for the receiver to return `None`, signaling all channels have been closed and no more messages are waiting to be received.