### PR TITLE
scx_p2dq: Fix initialization

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -950,6 +950,7 @@ static __always_inline void async_p2dq_enqueue(struct enqueue_promise *ret,
 		scx_bpf_error("invalid lookup");
 		return;
 	}
+	ret->cpu = cpuc->id;
 
 	if (cpuc->nice_task)
 		enq_flags |= SCX_ENQ_PREEMPT;

--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -237,6 +237,8 @@ macro_rules! init_open_skel {
             // p2dq config
             $skel.maps.rodata_data.p2dq_config.interactive_ratio = opts.interactive_ratio as u32;
             $skel.maps.rodata_data.p2dq_config.dsq_shift = opts.dsq_shift as u64;
+            $skel.maps.rodata_data.p2dq_config.interactive_dsq =
+                MaybeUninit::new(opts.interactive_dsq);
             $skel.maps.rodata_data.p2dq_config.kthreads_local =
                 MaybeUninit::new(!opts.disable_kthreads_local);
             $skel.maps.rodata_data.p2dq_config.nr_dsqs_per_llc = opts.dumb_queues as u32;


### PR DESCRIPTION
Fix missing initialization of `interactive_dsq` config.