### PR TITLE
scxtop: add cpu stats to trace

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -531,10 +531,11 @@ impl<'a> App<'a> {
         // always grab updated stats
         self.bpf_stats = BpfStats::get_from_skel(&self.skel)?;
         {
+            let mut system_guard = self.sys.lock().unwrap();
             self.cpu_stat_tracker
                 .write()
                 .unwrap()
-                .update(&self.proc_reader, self.sys.clone())?;
+                .update(&self.proc_reader, &mut system_guard)?;
         }
 
         if self.state == AppState::Scheduler {

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -431,7 +431,7 @@ impl<'a> App<'a> {
                 .cpu_data
                 .get_mut(cpu_id)
                 .expect("CpuData should have been present");
-            cpu_data.add_event_data("cpu_freq", data.freq * 1000);
+            cpu_data.add_event_data("cpu_freq", data.freq_khz * 1000);
         }
         Ok(())
     }

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -451,7 +451,7 @@ static __always_inline int __on_sched_wakeup(struct task_struct *p)
 	struct task_ctx *tctx;
 	struct bpf_event *event;
 
-	if (!p || !should_sample())
+	if (!enable_bpf_events || !p || !should_sample())
 		return 0;
 
 	u64 now = bpf_ktime_get_ns();

--- a/tools/scxtop/src/cpu_stats.rs
+++ b/tools/scxtop/src/cpu_stats.rs
@@ -37,7 +37,7 @@ impl CpuUtilData {
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct CpuStatSnapshot {
     pub cpu_util_data: CpuUtilData,
-    pub freq: u64, // in kHz
+    pub freq_khz: u64,
 }
 
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -62,7 +62,7 @@ impl CpuStatTracker {
                 );
                 let snapshot = CpuStatSnapshot {
                     cpu_util_data,
-                    freq: cpu.frequency(),
+                    freq_khz: cpu.frequency(),
                 };
                 self.current.insert(i, snapshot);
             }

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::bpf_skel::types::bpf_event;
 pub use app::App;
 pub use bpf_skel::*;
 pub use cpu_data::CpuData;
-pub use cpu_stats::CpuStatTracker;
+pub use cpu_stats::{CpuStatSnapshot, CpuStatTracker};
 pub use event_data::EventData;
 pub use keymap::Key;
 pub use keymap::KeyMap;
@@ -48,6 +48,7 @@ pub use theme::AppTheme;
 pub use tui::Event;
 pub use tui::Tui;
 pub use util::format_hz;
+pub use util::get_clock_value;
 pub use util::read_file_string;
 pub use util::sanitize_nbsp;
 
@@ -56,13 +57,14 @@ pub use plain::Plain;
 unsafe impl Plain for crate::bpf_skel::types::bpf_event {}
 
 use smartstring::alias::String as SsoString;
+use std::collections::BTreeMap;
 
 pub const APP: &str = "scxtop";
 pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
-This software may be used and distributed according to the terms of the 
+This software may be used and distributed according to the terms of the
 GNU General Public License version 2.";
 pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 
@@ -290,6 +292,13 @@ pub struct KprobeAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CpuStatAction {
+    pub ts: u64,
+    pub cpu_data_prev: BTreeMap<usize, CpuStatSnapshot>,
+    pub cpu_data_current: BTreeMap<usize, CpuStatSnapshot>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct MangoAppAction {
     pub pid: u32,
     pub vis_frametime: u64,
@@ -309,6 +318,7 @@ pub enum Action {
     ClearEvent,
     CpuhpEnter(CpuhpEnterAction),
     CpuhpExit(CpuhpExitAction),
+    CpuStat(CpuStatAction),
     DecBpfSampleRate,
     DecTickRate,
     Down,

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -64,7 +64,7 @@ pub const TRACE_FILE_PREFIX: &str = "scxtop_trace";
 pub const STATS_SOCKET_PATH: &str = "/var/run/scx/root/stats";
 pub const LICENSE: &str = "Copyright (c) Meta Platforms, Inc. and affiliates.
 
-This software may be used and distributed according to the terms of the
+This software may be used and distributed according to the terms of the 
 GNU General Public License version 2.";
 pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -31,7 +31,6 @@ use anyhow::anyhow;
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use futures::future::join_all;
-use futures::future::join_all;
 use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::SkelBuilder;
 use libbpf_rs::Link;
@@ -192,7 +191,7 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
             links.push(skel.progs.on_sched_exec.attach()?);
             links.push(skel.progs.on_sched_exit.attach()?);
 
-            let bpf_publisher = BpfEventActionPublisher::new(action_tx);
+            let bpf_publisher = BpfEventActionPublisher::new(action_tx.clone());
 
             // Set up the event buffer
             let mut event_rbb = RingBufferBuilder::new();

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -763,7 +763,7 @@ impl PerfettoTraceManager {
         for (cpu, data) in cpu_data_current.iter() {
             cpufreq_khz.insert(
                 *cpu,
-                (data.freq * 1000)
+                (data.freq_khz * 1000)
                     .try_into()
                     .expect("Should have been able to convert u64 to u32"),
             );

--- a/tools/scxtop/src/profiling_events/cpu_util.rs
+++ b/tools/scxtop/src/profiling_events/cpu_util.rs
@@ -62,7 +62,7 @@ impl CpuUtilEvent {
         let current = tracker.current.get(&self.cpu).unwrap();
 
         if self.metric == CpuUtilMetric::Frequency {
-            return Ok(current.freq);
+            return Ok(current.freq_khz);
         }
 
         let total = current.cpu_util_data.total_util() - prev.cpu_util_data.total_util();

--- a/tools/scxtop/src/profiling_events/cpu_util.rs
+++ b/tools/scxtop/src/profiling_events/cpu_util.rs
@@ -91,7 +91,7 @@ mod tests {
     use super::*;
     use std::sync::{Arc, RwLock};
 
-    fn create_snapshot(user: u64, system: u64, idle: u64, freq: u64) -> CpuStatSnapshot {
+    fn create_snapshot(user: u64, system: u64, idle: u64, freq_khz: u64) -> CpuStatSnapshot {
         CpuStatSnapshot {
             cpu_util_data: CpuUtilData {
                 user,
@@ -105,7 +105,7 @@ mod tests {
                 guest: 0,
                 guest_nice: 0,
             },
-            freq,
+            freq_khz,
         }
     }
 

--- a/tools/scxtop/src/util.rs
+++ b/tools/scxtop/src/util.rs
@@ -25,6 +25,15 @@ pub fn format_hz(hz: u64) -> String {
     }
 }
 
+/// Returns the current clock_id time in nanoseconds.
+pub fn get_clock_value(clock_id: libc::c_int) -> u64 {
+    let mut ts: libc::timespec = unsafe { std::mem::zeroed() };
+    if unsafe { libc::clock_gettime(clock_id, &mut ts) } != 0 {
+        return 0;
+    }
+    (ts.tv_sec as u64 * 1_000_000_000) + ts.tv_nsec as u64
+}
+
 /// Replaces non-breaking spaces with regular spaces. [TEMPORARY]
 pub fn sanitize_nbsp(s: String) -> String {
     s.replace('\u{202F}', " ")

--- a/tools/scxtop/src/util.rs
+++ b/tools/scxtop/src/util.rs
@@ -4,6 +4,7 @@
 // GNU General Public License version 2.
 
 use anyhow::Result;
+use nix::time::{clock_gettime, ClockId};
 use std::fs;
 use std::io::Read;
 
@@ -27,11 +28,8 @@ pub fn format_hz(hz: u64) -> String {
 
 /// Returns the current clock_id time in nanoseconds.
 pub fn get_clock_value(clock_id: libc::c_int) -> u64 {
-    let mut ts: libc::timespec = unsafe { std::mem::zeroed() };
-    if unsafe { libc::clock_gettime(clock_id, &mut ts) } != 0 {
-        return 0;
-    }
-    (ts.tv_sec as u64 * 1_000_000_000) + ts.tv_nsec as u64
+    let ts = clock_gettime(ClockId::from_raw(clock_id)).expect("Failed to get clock time");
+    (ts.tv_sec() as u64 * 1_000_000_000) + ts.tv_nsec() as u64
 }
 
 /// Replaces non-breaking spaces with regular spaces. [TEMPORARY]


### PR DESCRIPTION
Now that scxtop keeps all cpu stats in `CpuStatTracker`, we can add that data to the trace. 

Cpu Frequency:
<img width="1350" height="417" alt="Screenshot 2025-07-11 at 3 56 48 PM" src="https://github.com/user-attachments/assets/573a9e17-39ab-4cf5-9965-5a4a98b05782" />

Cpu Utilization (example is idle ns):
<img width="1482" height="363" alt="Screenshot 2025-07-11 at 3 57 05 PM" src="https://github.com/user-attachments/assets/1b7b9e60-76fb-4d78-89eb-feedc9172aae" />
