### PR TITLE
scxtop: fix perf event attach

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -2728,14 +2728,10 @@ impl<'a> App<'a> {
                 }
             }
             Action::NextEvent => {
-                if self.next_event().is_err() {
-                    // XXX handle error
-                }
+                self.next_event()?;
             }
             Action::PrevEvent => {
-                if self.prev_event().is_err() {
-                    // XXX handle error
-                }
+                self.prev_event()?;
             }
             Action::NextViewState => self.next_view_state(),
             Action::PstateSample(a) => {

--- a/tools/scxtop/src/profiling_events/perf.rs
+++ b/tools/scxtop/src/profiling_events/perf.rs
@@ -123,8 +123,6 @@ impl PerfEvent {
             PerfEvent::new("hw".to_string(), "cache-references".to_string(), 0),
             PerfEvent::new("hw".to_string(), "instructions".to_string(), 0),
             PerfEvent::new("hw".to_string(), "ref-cycles".to_string(), 0),
-            PerfEvent::new("hw".to_string(), "stalled-cycles-backend".to_string(), 0),
-            PerfEvent::new("hw".to_string(), "stalled-cycles-frontend".to_string(), 0),
             PerfEvent::new("hw".to_string(), "bus-cycles".to_string(), 0),
             PerfEvent::new("hw".to_string(), "L1-dcache-load-misses".to_string(), 0),
         ]
@@ -191,12 +189,6 @@ impl PerfEvent {
                     }
                     "ref-cycles" => {
                         attrs.config = perf::bindings::PERF_COUNT_HW_REF_CPU_CYCLES as u64;
-                    }
-                    "stalled-cycles-backend" => {
-                        attrs.config = perf::bindings::PERF_COUNT_HW_STALLED_CYCLES_BACKEND as u64;
-                    }
-                    "stalled-cycles-frontend" => {
-                        attrs.config = perf::bindings::PERF_COUNT_HW_STALLED_CYCLES_FRONTEND as u64;
                     }
                     "bus-cycles" | "bus_cycles" => {
                         attrs.config = perf::bindings::PERF_COUNT_HW_BUS_CYCLES as u64;


### PR DESCRIPTION
Here, we remove the code that suppressed the error coming from attempting to attach `hw:stalled-cycles-backend` and `hw:stalled-cycles-frontend`. Once removing that, the error from attempting to attach these events crashes the TUI, so we'll remove those for now.