### PR TITLE
scxtop: update default event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,6 +3168,7 @@ dependencies = [
  "simplelog",
  "smartstring",
  "sysinfo 0.35.2",
+ "tempfile",
  "tokio",
  "tokio-util",
  "toml",
@@ -3532,9 +3533,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -54,6 +54,7 @@ nix = { version = "0.29", features = ["time"] }
 
 [dev-dependencies]
 criterion = "0.6.0"
+tempfile = "3.20.0"
 
 [[bench]]
 name = "search_benchmark"

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -155,8 +155,10 @@ impl<'a> App<'a> {
         let mut llc_data = BTreeMap::new();
         let mut node_data = BTreeMap::new();
         let cpu_stat_tracker = Arc::new(RwLock::new(CpuStatTracker::default()));
-        let active_event =
-            ProfilingEvent::from_str(&config.default_profiling_event(), cpu_stat_tracker.clone())?;
+        let active_event = ProfilingEvent::from_str(
+            &config.default_profiling_event(),
+            Some(cpu_stat_tracker.clone()),
+        )?;
 
         let mut active_prof_events = BTreeMap::new();
         let mut default_events = get_default_events(cpu_stat_tracker.clone());
@@ -177,7 +179,7 @@ impl<'a> App<'a> {
             .collect();
 
         for cpu in topo.all_cpus.values() {
-            let event = active_event.start(cpu.id, process_id);
+            let event = active_event.start(cpu.id, process_id)?;
             active_prof_events.insert(cpu.id, event);
             let mut data =
                 CpuData::new(cpu.id, cpu.core_id, cpu.llc_id, cpu.node_id, max_cpu_events);
@@ -390,7 +392,7 @@ impl<'a> App<'a> {
         }
 
         for &cpu_id in self.topo.all_cpus.keys() {
-            let event = prof_event.start(cpu_id, self.process_id);
+            let event = prof_event.start(cpu_id, self.process_id)?;
             self.active_prof_events.insert(cpu_id, event);
         }
         Ok(())

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -155,7 +155,7 @@ impl<'a> App<'a> {
         let mut llc_data = BTreeMap::new();
         let mut node_data = BTreeMap::new();
         let cpu_stat_tracker = Arc::new(RwLock::new(CpuStatTracker::default()));
-        let active_event = ProfilingEvent::from_str(
+        let active_event = ProfilingEvent::from_str_args(
             &config.default_profiling_event(),
             Some(cpu_stat_tracker.clone()),
         )?;

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -179,7 +179,7 @@ impl<'a> App<'a> {
             .collect();
 
         for cpu in topo.all_cpus.values() {
-            let event = active_event.start(cpu.id, process_id)?;
+            let event = active_event.initialize_for_cpu(cpu.id, process_id)?;
             active_prof_events.insert(cpu.id, event);
             let mut data =
                 CpuData::new(cpu.id, cpu.core_id, cpu.llc_id, cpu.node_id, max_cpu_events);
@@ -392,7 +392,7 @@ impl<'a> App<'a> {
         }
 
         for &cpu_id in self.topo.all_cpus.keys() {
-            let event = prof_event.start(cpu_id, self.process_id)?;
+            let event = prof_event.initialize_for_cpu(cpu_id, self.process_id)?;
             self.active_prof_events.insert(cpu_id, event);
         }
         Ok(())

--- a/tools/scxtop/src/cli.rs
+++ b/tools/scxtop/src/cli.rs
@@ -64,9 +64,10 @@ pub struct TuiArgs {
     /// Custom perf events colon delimited (ex: "<event_name>:<event and umask ex: 0x023>:<event_type ex: 4>")
     #[arg(long, num_args = 1.., value_parser)]
     pub perf_events: Vec<String>,
-    /// Default perf event colon delimited (ex: "<event_name>:<event and umask ex: 0x023>:<event_type ex: 4>")
-    #[arg(long, default_value = "hw:cycles")]
-    pub default_perf_event: String,
+    /// Default profiling event colon delimited (ex: "<source>:<event>")
+    /// where source is one of 'kprobe', 'perf', 'cpu'. Ex: "cpu:cpu_total_util_percent", "perf:hw:cycles"
+    #[arg(long, default_value = "cpu:cpu_total_util_percent")]
+    pub default_profiling_event: String,
 
     /// Automatically start a trace when a function takes too long to return.
     #[arg(

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -92,8 +92,9 @@ pub struct Config {
     trace_tick_warmup: Option<usize>,
     /// Duration to warmup a trace before collecting in ms.
     trace_warmup_ms: Option<u64>,
-    /// Default perf event
-    default_perf_event: Option<String>,
+    /// Default profiling event string, in the format <source>:<event>
+    /// where `source` is one of kprobe, perf, or cpu.
+    default_profiling_event: Option<String>,
 }
 
 impl From<TuiArgs> for Config {
@@ -113,7 +114,7 @@ impl From<TuiArgs> for Config {
             trace_ticks: args.trace_ticks,
             trace_duration_ms: args.trace_duration_ms,
             worker_threads: args.worker_threads,
-            default_perf_event: Some(args.default_perf_event),
+            default_profiling_event: Some(args.default_profiling_event),
         }
     }
 }
@@ -155,7 +156,7 @@ impl Config {
             worker_threads: self.worker_threads.or(rhs.worker_threads),
             trace_tick_warmup: self.trace_tick_warmup.or(rhs.trace_tick_warmup),
             trace_warmup_ms: self.trace_warmup_ms.or(rhs.trace_warmup_ms),
-            default_perf_event: self.default_perf_event.or(rhs.default_perf_event),
+            default_profiling_event: self.default_profiling_event.or(rhs.default_profiling_event),
         }
     }
 
@@ -218,11 +219,11 @@ impl Config {
         self.worker_threads.unwrap_or(4)
     }
 
-    /// Default perf event
-    pub fn default_perf_event(&self) -> String {
-        self.default_perf_event
+    /// Default event
+    pub fn default_profiling_event(&self) -> String {
+        self.default_profiling_event
             .clone()
-            .unwrap_or("hw:cycles".to_string())
+            .unwrap_or("cpu:cpu_total_util_percent".to_string())
     }
 
     /// Duration to warmup a trace before collecting in ns.
@@ -247,7 +248,7 @@ impl Config {
             worker_threads: None,
             trace_tick_warmup: None,
             trace_warmup_ms: None,
-            default_perf_event: None,
+            default_profiling_event: None,
         }
     }
 
@@ -268,7 +269,7 @@ impl Config {
             worker_threads: None,
             trace_tick_warmup: None,
             trace_warmup_ms: None,
-            default_perf_event: None,
+            default_profiling_event: None,
         };
         config.tick_rate_ms = Some(config.tick_rate_ms());
         config.debug = Some(config.debug());
@@ -344,5 +345,571 @@ mod tests {
         assert_eq!(merged.tick_rate_ms(), 114);
         assert!(merged.debug());
         assert!(!merged.exclude_bpf());
+    }
+
+    #[test]
+    fn test_config_from_tui_args() {
+        let args = TuiArgs::try_parse_from(vec![
+            "scxtop",
+            "--debug",
+            "true",
+            "--exclude-bpf",
+            "true",
+            "--perf-events",
+            "cpu:cycles",
+            "mem:faults",
+            "--stats-socket-path",
+            "/tmp/my_socket",
+            "--tick-rate-ms",
+            "100",
+            "--trace-file-prefix",
+            "/var/log/trace",
+            "--trace-warmup-ms",
+            "500",
+            "--trace-duration-ms",
+            "1000",
+            "--worker-threads",
+            "8",
+            "--default-perf-event",
+            "cpu:instructions",
+        ])
+        .unwrap();
+
+        let config: Config = args.into();
+
+        assert!(config.debug.unwrap());
+        assert!(config.exclude_bpf.unwrap());
+        assert_eq!(
+            config.perf_events,
+            vec!["cpu:cycles".to_string(), "mem:faults".to_string()]
+        );
+        assert_eq!(
+            config.stats_socket_path.unwrap(),
+            "/tmp/my_socket".to_string()
+        );
+        assert_eq!(config.tick_rate_ms.unwrap(), 100);
+        assert_eq!(
+            config.trace_file_prefix.unwrap(),
+            "/var/log/trace".to_string()
+        );
+        assert_eq!(config.trace_duration_ms.unwrap(), 1000);
+        assert_eq!(config.worker_threads.unwrap(), 8);
+        assert_eq!(
+            config.default_profiling_event.unwrap(),
+            "cpu:instructions".to_string()
+        );
+        assert!(config.keymap.is_none());
+        assert!(config.active_keymap.is_empty());
+        assert!(config.theme.is_none());
+    }
+
+    #[test]
+    fn test_config_from_tui_args_defaults() {
+        let args = TuiArgs::try_parse_from(vec!["scxtop"]).unwrap();
+
+        let config: Config = args.into();
+
+        assert!(config.debug.is_none());
+        assert!(config.exclude_bpf.is_none());
+        assert!(config.perf_events.is_empty());
+        assert!(config.stats_socket_path.is_none());
+        assert!(config.tick_rate_ms.is_none());
+        assert!(config.trace_file_prefix.is_none());
+        assert!(config.trace_warmup_ms.is_none());
+        assert!(config.trace_ticks.is_none());
+        assert!(config.trace_duration_ms.is_none());
+        assert!(config.worker_threads.is_none());
+        assert_eq!(
+            config.default_profiling_event.unwrap(),
+            "hw:cycles".to_string()
+        );
+    }
+
+    #[test]
+    fn test_merge_configs_no_overwrite() {
+        let mut a = Config::empty_config();
+        a.theme = Some(AppTheme::MidnightGreen);
+        a.tick_rate_ms = Some(100);
+        a.debug = Some(true);
+        a.exclude_bpf = Some(true);
+        a.perf_events = vec!["event_a".to_string()];
+        a.stats_socket_path = Some("/path/a".to_string());
+        a.trace_file_prefix = Some("prefix_a".to_string());
+        a.trace_ticks = Some(5);
+        a.trace_duration_ms = Some(500);
+        a.worker_threads = Some(2);
+        a.trace_warmup_ms = Some(100);
+        a.default_profiling_event = Some("default_a".to_string());
+
+        let mut b = Config::empty_config();
+        b.theme = Some(AppTheme::IAmBlue);
+        b.tick_rate_ms = Some(200);
+        b.debug = Some(false);
+        b.exclude_bpf = Some(false);
+        b.perf_events = vec!["event_b".to_string()];
+        b.stats_socket_path = Some("/path/b".to_string());
+        b.trace_file_prefix = Some("prefix_b".to_string());
+        b.trace_ticks = Some(10);
+        b.trace_duration_ms = Some(1000);
+        b.worker_threads = Some(4);
+        b.trace_warmup_ms = Some(200);
+        b.default_profiling_event = Some("default_b".to_string());
+
+        // Test `or` method
+        let merged_or = a.clone().or(b.clone());
+
+        assert_eq!(merged_or.theme(), &AppTheme::MidnightGreen);
+        assert_eq!(merged_or.tick_rate_ms(), 100);
+        assert!(merged_or.debug());
+        assert!(merged_or.exclude_bpf());
+        assert_eq!(merged_or.perf_events, vec!["event_a".to_string()]);
+        assert_eq!(merged_or.stats_socket_path(), "/path/a");
+        assert_eq!(merged_or.trace_file_prefix(), "prefix_a");
+        assert_eq!(merged_or.trace_ticks, Some(5));
+        assert_eq!(merged_or.trace_duration_ms, Some(500));
+        assert_eq!(merged_or.worker_threads(), 2);
+        assert_eq!(merged_or.trace_warmup_ms, Some(100));
+        assert_eq!(merged_or.default_profiling_event(), "default_a");
+
+        // Test `merge` method
+        let merged = Config::merge([a, b]);
+
+        assert_eq!(merged.theme(), &AppTheme::MidnightGreen);
+        assert_eq!(merged.tick_rate_ms(), 100);
+        assert!(merged.debug());
+        assert!(merged.exclude_bpf());
+        assert_eq!(merged.perf_events, vec!["event_a".to_string()]);
+        assert_eq!(merged.stats_socket_path(), "/path/a");
+        assert_eq!(merged.trace_file_prefix(), "prefix_a");
+        assert_eq!(merged.trace_ticks, Some(5));
+        assert_eq!(merged.trace_duration_ms, Some(500));
+        assert_eq!(merged.worker_threads(), 2);
+        assert_eq!(merged.trace_warmup_ms, Some(100));
+        assert_eq!(merged.default_profiling_event(), "default_a");
+    }
+
+    #[test]
+    fn test_merge_configs_overwrite() {
+        // Test with some None values
+        let mut a = Config::empty_config();
+        a.theme = None;
+        a.debug = None;
+        a.tick_rate_ms = Some(300);
+        a.exclude_bpf = Some(true);
+        a.perf_events = vec![];
+
+        let mut b = Config::empty_config();
+        b.theme = Some(AppTheme::IAmBlue);
+        b.tick_rate_ms = None;
+        b.debug = Some(false);
+        b.exclude_bpf = Some(false);
+        b.perf_events = vec!["event_d".to_string()];
+
+        let merged_or = a.clone().or(b.clone());
+        assert_eq!(merged_or.theme(), &AppTheme::IAmBlue);
+        assert_eq!(merged_or.tick_rate_ms(), 300);
+        assert!(!merged_or.debug());
+        assert!(merged_or.exclude_bpf());
+        assert_eq!(merged_or.perf_events, vec!["event_d".to_string()]);
+    }
+
+    #[test]
+    fn test_config_getters_and_setters() {
+        let mut config = Config::empty_config();
+
+        // Theme
+        assert_eq!(config.theme(), &AppTheme::Default);
+        config.set_theme(AppTheme::IAmBlue);
+        assert_eq!(config.theme(), &AppTheme::IAmBlue);
+
+        // Tick Rate
+        assert_eq!(config.tick_rate_ms(), 250);
+        config.set_tick_rate_ms(500);
+        assert_eq!(config.tick_rate_ms(), 500);
+
+        // Debug
+        assert!(!config.debug());
+        config.debug = Some(true);
+        assert!(config.debug());
+
+        // Exclude BPF
+        assert!(!config.exclude_bpf());
+        config.exclude_bpf = Some(true);
+        assert!(config.exclude_bpf());
+
+        // Stats Socket Path
+        assert_eq!(config.stats_socket_path(), STATS_SOCKET_PATH);
+        config.stats_socket_path = Some("/tmp/custom_socket".to_string());
+        assert_eq!(config.stats_socket_path(), "/tmp/custom_socket");
+
+        // Trace File Prefix
+        assert_eq!(config.trace_file_prefix(), TRACE_FILE_PREFIX);
+        config.trace_file_prefix = Some("/tmp/custom_trace".to_string());
+        assert_eq!(config.trace_file_prefix(), "/tmp/custom_trace");
+
+        // Trace Duration NS
+        config.trace_duration_ms = Some(2000);
+        assert_eq!(config.trace_duration_ns(), 2000 * 1_000_000);
+
+        // Worker Threads
+        assert_eq!(config.worker_threads(), 4);
+        config.worker_threads = Some(8);
+        assert_eq!(config.worker_threads(), 8);
+
+        // Default Perf Event
+        assert_eq!(config.default_profiling_event(), "hw:cycles".to_string());
+        config.default_profiling_event = Some("cpu:instructions".to_string());
+        assert_eq!(
+            config.default_profiling_event(),
+            "cpu:instructions".to_string()
+        );
+
+        // Trace Warmup NS
+        config.trace_warmup_ms = Some(1500);
+        assert_eq!(config.trace_warmup_ns(), 1500 * 1_000_000);
+    }
+
+    #[test]
+    fn test_empty_config() {
+        let config = Config::empty_config();
+
+        assert!(config.keymap.is_none());
+        assert!(config.active_keymap.is_empty());
+        assert!(config.theme.is_none());
+        assert!(config.tick_rate_ms.is_none());
+        assert!(config.debug.is_none());
+        assert!(config.perf_events.is_empty());
+        assert!(config.exclude_bpf.is_none());
+        assert!(config.stats_socket_path.is_none());
+        assert!(config.trace_file_prefix.is_none());
+        assert!(config.trace_ticks.is_none());
+        assert!(config.trace_duration_ms.is_none());
+        assert!(config.worker_threads.is_none());
+        assert!(config.trace_tick_warmup.is_none());
+        assert!(config.trace_warmup_ms.is_none());
+        assert!(config.default_profiling_event.is_none());
+
+        // Check getters return defaults
+        assert_eq!(config.theme(), &AppTheme::Default);
+        assert_eq!(config.tick_rate_ms(), 250);
+        assert!(!config.debug());
+        assert!(!config.exclude_bpf());
+        assert_eq!(config.stats_socket_path(), STATS_SOCKET_PATH);
+        assert_eq!(config.trace_file_prefix(), TRACE_FILE_PREFIX);
+        assert_eq!(config.trace_duration_ns(), 1250 * 1_000_000);
+        assert_eq!(config.worker_threads(), 4);
+        assert_eq!(config.default_profiling_event(), "hw:cycles".to_string());
+        assert_eq!(config.trace_warmup_ns(), 750 * 1_000_000);
+    }
+
+    #[test]
+    fn test_default_config() {
+        let config = Config::default_config();
+
+        // Check that optional fields that have defaults are Some(default_value)
+        assert!(config.tick_rate_ms.is_some());
+        assert_eq!(config.tick_rate_ms.unwrap(), 250);
+        assert!(config.debug.is_some());
+        assert_eq!(config.debug.unwrap(), false);
+        assert!(config.exclude_bpf.is_some());
+        assert_eq!(config.exclude_bpf.unwrap(), false);
+
+        // Other fields should still be None or empty vec/KeyMap
+        assert!(config.keymap.is_none());
+        assert!(!config.active_keymap.is_empty()); // Should be default KeyMap, which is not empty
+        assert!(config.theme.is_none());
+        assert!(config.perf_events.is_empty());
+        assert!(config.stats_socket_path.is_none());
+        assert!(config.trace_file_prefix.is_none());
+        assert!(config.trace_ticks.is_none());
+        assert!(config.trace_duration_ms.is_none());
+        assert!(config.worker_threads.is_none());
+        assert!(config.trace_tick_warmup.is_none());
+        assert!(config.trace_warmup_ms.is_none());
+        assert!(config.default_profiling_event.is_none());
+    }
+
+    // Helper to mock xdg::BaseDirectories for testing file paths
+    struct MockXdgBaseDirectories {
+        config_home: PathBuf,
+    }
+
+    impl MockXdgBaseDirectories {
+        fn new(base_path: &Path) -> Self {
+            MockXdgBaseDirectories {
+                config_home: base_path.join(".config"),
+            }
+        }
+
+        fn get_config_file(&self, file_name: &str) -> PathBuf {
+            self.config_home.join("scxtop").join(file_name)
+        }
+    }
+
+    // Mocking get_config_path for isolated testing
+    // This would typically involve dependency injection or using a library
+    // that allows mocking static functions, which is more complex in Rust.
+    // For demonstration, we'll create a test function that would set up
+    // a temporary directory and simulate the config path.
+    fn get_mock_config_path(temp_dir_path: &Path) -> Result<PathBuf> {
+        let mock_xdg_dirs = MockXdgBaseDirectories::new(temp_dir_path);
+        Ok(mock_xdg_dirs.get_config_file("scxtop.toml"))
+    }
+
+    #[test]
+    fn test_load_and_save_config() {
+        let dir = tempdir().expect("Failed to create temporary directory");
+        let config_path = get_mock_config_path(dir.path()).expect("Failed to get mock config path");
+
+        // Ensure the parent directory exists for saving
+        let config_parent_dir = config_path.parent().unwrap();
+        fs::create_dir_all(config_parent_dir)
+            .expect("Failed to create parent directory for config");
+
+        let mut config_to_save = Config::default_config();
+        config_to_save.set_theme(AppTheme::MidnightGreen);
+        config_to_save.set_tick_rate_ms(5000);
+        config_to_save.debug = Some(true);
+        config_to_save.exclude_bpf = Some(true);
+        config_to_save.perf_events = vec!["custom:event".to_string()];
+        config_to_save.stats_socket_path = Some("/my/socket".to_string());
+        config_to_save.trace_file_prefix = Some("my_trace".to_string());
+        config_to_save.trace_duration_ms = Some(2000);
+        config_to_save.worker_threads = Some(6);
+        config_to_save.trace_warmup_ms = Some(500);
+        config_to_save.default_profiling_event = Some("another:event".to_string());
+
+        let mut test_keymap = HashMap::new();
+        test_keymap.insert("i".to_string(), "Quit".to_string());
+        test_keymap.insert("2".to_string(), "AppStateHelp".to_string());
+        config_to_save.keymap = Some(test_keymap.clone());
+
+        let mut active_keymap_for_save = KeyMap::empty();
+        active_keymap_for_save.insert(parse_key("i").unwrap(), parse_action("Quit").unwrap());
+        active_keymap_for_save.insert(
+            parse_key("2").unwrap(),
+            parse_action("AppStateHelp").unwrap(),
+        );
+        config_to_save.active_keymap = active_keymap_for_save;
+
+        // Simulate save by writing to the mock path
+        let saved_config_str =
+            toml::to_string(&config_to_save).expect("Failed to serialize config");
+        fs::write(&config_path, saved_config_str)
+            .expect("Failed to write config to mock path for saving test");
+
+        // For this test, we cannot directly call `Config::load()` as it uses the real `get_config_path()`.
+        // Instead, we will simulate the loading process here directly using the mock path.
+        let saved_content =
+            fs::read_to_string(&config_path).expect("Failed to read saved config file");
+        let loaded_from_file: Config =
+            toml::from_str(&saved_content).expect("Failed to deserialize saved config");
+
+        assert_eq!(loaded_from_file.theme, config_to_save.theme);
+        assert_eq!(loaded_from_file.tick_rate_ms, config_to_save.tick_rate_ms);
+        assert_eq!(loaded_from_file.debug, config_to_save.debug);
+        assert_eq!(loaded_from_file.exclude_bpf, config_to_save.exclude_bpf);
+        assert_eq!(loaded_from_file.perf_events, config_to_save.perf_events);
+        assert_eq!(
+            loaded_from_file.stats_socket_path,
+            config_to_save.stats_socket_path
+        );
+        assert_eq!(
+            loaded_from_file.trace_file_prefix,
+            config_to_save.trace_file_prefix
+        );
+        assert_eq!(
+            loaded_from_file.trace_duration_ms,
+            config_to_save.trace_duration_ms
+        );
+        assert_eq!(
+            loaded_from_file.worker_threads,
+            config_to_save.worker_threads
+        );
+        assert_eq!(
+            loaded_from_file.trace_warmup_ms,
+            config_to_save.trace_warmup_ms
+        );
+        assert_eq!(
+            loaded_from_file.default_profiling_event,
+            config_to_save.default_profiling_event
+        );
+        assert_eq!(loaded_from_file.keymap, Some(test_keymap));
+    }
+
+    #[test]
+    fn test_load_config() {
+        let dir = tempdir().expect("Failed to create temporary directory");
+        let config_path = get_mock_config_path(dir.path()).expect("Failed to get mock config path");
+
+        // Ensure the parent directory exists for saving
+        let config_parent_dir = config_path.parent().unwrap();
+        fs::create_dir_all(config_parent_dir)
+            .expect("Failed to create parent directory for config");
+
+        // Create a dummy config file in the temporary directory
+        let config_content = r#"
+        theme = "IAmBlue"
+        tick_rate_ms = 123
+        debug = true
+        exclude_bpf = true
+        worker_threads = 5
+        perf_events = ["my_event_1", "my_event_2"]
+        stats_socket_path = "/test/socket"
+        trace_file_prefix = "test_trace"
+        trace_duration_ms = 1000
+        trace_warmup_ms = 200
+        default_profiling_event = "cpu:cycles"
+        [keymap]
+        i = "Quit"
+        2 = "Enter"
+        "#;
+        fs::write(&config_path, config_content).expect("Failed to write dummy config file");
+
+        let contents =
+            fs::read_to_string(&config_path).expect("Failed to read file for loading test");
+        let mut loaded_config: Config =
+            toml::from_str(&contents).expect("Failed to deserialize for loading test");
+
+        // Manually parse keymap as load() does
+        if let Some(keymap_config) = &loaded_config.keymap {
+            let mut keymap = KeyMap::default();
+            for (key_str, action_str) in keymap_config {
+                let key = parse_key(key_str).expect("Failed to parse key");
+                let action = parse_action(action_str).expect("Failed to parse action");
+                keymap.insert(key, action);
+            }
+            loaded_config.active_keymap = keymap;
+        } else {
+            loaded_config.active_keymap = KeyMap::default();
+        }
+
+        assert_eq!(loaded_config.theme(), &AppTheme::IAmBlue);
+        assert_eq!(loaded_config.tick_rate_ms(), 123);
+        assert!(loaded_config.debug());
+        assert!(loaded_config.exclude_bpf());
+        assert_eq!(loaded_config.worker_threads(), 5);
+        assert_eq!(
+            loaded_config.perf_events,
+            vec!["my_event_1".to_string(), "my_event_2".to_string()]
+        );
+        assert_eq!(loaded_config.stats_socket_path(), "/test/socket");
+        assert_eq!(loaded_config.trace_file_prefix(), "test_trace");
+        assert_eq!(loaded_config.trace_duration_ms, Some(1000));
+        assert_eq!(loaded_config.trace_warmup_ms, Some(200));
+        assert_eq!(
+            loaded_config.default_profiling_event(),
+            "cpu:cycles".to_string()
+        );
+
+        // Verify active_keymap
+        assert!(loaded_config
+            .active_keymap
+            .get(&parse_key("i").unwrap())
+            .map_or(false, |action| *action == Action::Quit));
+        assert!(loaded_config
+            .active_keymap
+            .get(&parse_key("2").unwrap())
+            .map_or(false, |action| *action == Action::Enter));
+    }
+
+    #[test]
+    fn test_config_integration_test_complex() {
+        let dir = tempdir().expect("Failed to create temporary directory");
+        let config_path = get_mock_config_path(dir.path()).expect("Failed to get mock config path");
+
+        // Ensure the parent directory exists for saving
+        let config_parent_dir = config_path.parent().unwrap();
+        fs::create_dir_all(config_parent_dir)
+            .expect("Failed to create parent directory for config");
+
+        // Create a dummy config file in the temporary directory
+        let saved_config = r#"
+        perf_events = []
+        theme = "MidnightGreen"
+        tick_rate_ms = 500
+        debug = false
+        exclude_bpf = true
+        default_profiling_event = "mem:faults"
+
+        [keymap]
+        S = "SaveConfig"
+        "+" = "IncTickRate"
+        "[" = "DecBpfSampleRate"
+        h = "AppStateHelp"
+        Esc = "Esc"
+        o = "NextViewState"
+        P = "ToggleHwPressure"
+        k = "NextEvent"
+        Enter = "Enter"
+        "]" = "IncBpfSampleRate"
+        "?" = "AppStateHelp"
+        u = "ToggleUncoreFreq"
+        f = "ToggleCpuFreq"
+        "Page Down" = "PageDown"
+        Down = "Down"
+        j = "PrevEvent"
+        x = "ClearEvent"
+        "Page Up" = "PageUp"
+        l = "AppStateLlc"
+        n = "AppStateNode"
+        s = "AppStateScheduler"
+        d = "AppStateDefault"
+        m = "AppStateMangoApp"
+        a = "RequestTrace"
+        K = "AppStateKprobeEvent"
+        L = "ToggleLocalization"
+        Backspace = "Backspace"
+        - = "DecTickRate"
+        Up = "Up"
+        t = "ChangeTheme"
+        i = "Quit"
+        e = "AppStatePerfEvent"
+        "#;
+
+        fs::write(&config_path, saved_config).expect("Failed to write dummy config file");
+
+        let contents = fs::read_to_string(&config_path).expect("Failed to read file");
+        let mut loaded_config: Config = toml::from_str(&contents).expect("Failed to deserialize");
+        loaded_config
+            .resolve_keymap()
+            .expect("Failed to resolve keymap");
+
+        let tui_args = TuiArgs::try_parse_from(vec![
+            "scxtop",
+            "--debug",
+            "true",
+            "--perf-events",
+            "cpu:cycles",
+            "mem:faults",
+            "--default-perf-event",
+            "cpu:instructions",
+        ])
+        .unwrap();
+
+        // This is how the config is loaded in main
+        let config = Config::merge([Config::from(tui_args.clone()), loaded_config]);
+
+        assert_eq!(config.theme(), &AppTheme::MidnightGreen);
+        assert_eq!(config.tick_rate_ms(), 500);
+        assert!(config.debug());
+        assert!(config.exclude_bpf());
+        assert_eq!(
+            config.perf_events,
+            vec!["cpu:cycles".to_string(), "mem:faults".to_string()]
+        );
+        assert_eq!(
+            config.default_profiling_event(),
+            "cpu:instructions".to_string()
+        );
+
+        assert!(config
+            .active_keymap
+            .get(&parse_key("i").unwrap())
+            .map_or(false, |action| *action == Action::Quit));
+        assert!(config
+            .active_keymap
+            .get(&parse_key("o").unwrap())
+            .map_or(false, |action| *action == Action::NextViewState));
     }
 }

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -324,6 +324,10 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Action;
+    use clap::Parser;
+    use std::path::Path;
+    use tempfile::tempdir;
 
     #[test]
     fn test_merge_configs() {
@@ -370,8 +374,8 @@ mod tests {
             "1000",
             "--worker-threads",
             "8",
-            "--default-perf-event",
-            "cpu:instructions",
+            "--default-profiling-event",
+            "perf:cpu:instructions",
         ])
         .unwrap();
 
@@ -396,7 +400,7 @@ mod tests {
         assert_eq!(config.worker_threads.unwrap(), 8);
         assert_eq!(
             config.default_profiling_event.unwrap(),
-            "cpu:instructions".to_string()
+            "perf:cpu:instructions".to_string()
         );
         assert!(config.keymap.is_none());
         assert!(config.active_keymap.is_empty());
@@ -421,7 +425,7 @@ mod tests {
         assert!(config.worker_threads.is_none());
         assert_eq!(
             config.default_profiling_event.unwrap(),
-            "hw:cycles".to_string()
+            "cpu:cpu_total_util_percent".to_string()
         );
     }
 
@@ -557,11 +561,14 @@ mod tests {
         assert_eq!(config.worker_threads(), 8);
 
         // Default Perf Event
-        assert_eq!(config.default_profiling_event(), "hw:cycles".to_string());
-        config.default_profiling_event = Some("cpu:instructions".to_string());
         assert_eq!(
             config.default_profiling_event(),
-            "cpu:instructions".to_string()
+            "cpu:cpu_total_util_percent".to_string()
+        );
+        config.default_profiling_event = Some("perf:cpu:instructions".to_string());
+        assert_eq!(
+            config.default_profiling_event(),
+            "perf:cpu:instructions".to_string()
         );
 
         // Trace Warmup NS
@@ -598,7 +605,10 @@ mod tests {
         assert_eq!(config.trace_file_prefix(), TRACE_FILE_PREFIX);
         assert_eq!(config.trace_duration_ns(), 1250 * 1_000_000);
         assert_eq!(config.worker_threads(), 4);
-        assert_eq!(config.default_profiling_event(), "hw:cycles".to_string());
+        assert_eq!(
+            config.default_profiling_event(),
+            "cpu:cpu_total_util_percent".to_string()
+        );
         assert_eq!(config.trace_warmup_ns(), 750 * 1_000_000);
     }
 
@@ -830,7 +840,7 @@ mod tests {
         tick_rate_ms = 500
         debug = false
         exclude_bpf = true
-        default_profiling_event = "mem:faults"
+        default_profiling_event = "perf:mem:faults"
 
         [keymap]
         S = "SaveConfig"
@@ -882,8 +892,8 @@ mod tests {
             "--perf-events",
             "cpu:cycles",
             "mem:faults",
-            "--default-perf-event",
-            "cpu:instructions",
+            "--default-profiling-event",
+            "perf:cpu:instructions",
         ])
         .unwrap();
 
@@ -900,7 +910,7 @@ mod tests {
         );
         assert_eq!(
             config.default_profiling_event(),
-            "cpu:instructions".to_string()
+            "perf:cpu:instructions".to_string()
         );
 
         assert!(config

--- a/tools/scxtop/src/cpu_stats.rs
+++ b/tools/scxtop/src/cpu_stats.rs
@@ -35,7 +35,7 @@ impl CpuUtilData {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct CpuStatSnapshot {
     pub cpu_util_data: CpuUtilData,
     pub freq: u64,

--- a/tools/scxtop/src/cpu_stats.rs
+++ b/tools/scxtop/src/cpu_stats.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use sysinfo::System;
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct CpuUtilData {
     pub user: u64,
     pub nice: u64,
@@ -41,7 +41,7 @@ pub struct CpuStatSnapshot {
     pub freq: u64,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct CpuStatTracker {
     pub prev: BTreeMap<usize, CpuStatSnapshot>,
     pub current: BTreeMap<usize, CpuStatSnapshot>,

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -81,6 +81,16 @@ impl KeyMap {
         KeyMap { bindings }
     }
 
+    /// Returns if the KeyMap is empty.
+    pub fn is_empty(&self) -> bool {
+        self.bindings.is_empty()
+    }
+
+    // Returns an Action for a Key.
+    pub fn get(&self, key: &Key) -> Option<&Action> {
+        self.bindings.get(key)
+    }
+
     /// Maps the Key to an Action.
     pub fn action(&self, key: &Key) -> Action {
         self.bindings.get(key).cloned().unwrap_or(Action::None)

--- a/tools/scxtop/src/profiling_events/cpu_util.rs
+++ b/tools/scxtop/src/profiling_events/cpu_util.rs
@@ -7,6 +7,7 @@ use crate::CpuStatTracker;
 use anyhow::{bail, Result};
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
+use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -17,6 +18,19 @@ pub enum CpuUtilMetric {
     Frequency,
 }
 
+impl FromStr for CpuUtilMetric {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "cpu_total_util_percent" => Ok(CpuUtilMetric::Total),
+            "cpu_user_util_percent" => Ok(CpuUtilMetric::User),
+            "cpu_system_util_percent" => Ok(CpuUtilMetric::System),
+            _ => Err(anyhow::anyhow!("Invalid CPU util metric: {}", s)),
+        }
+    }
+}
+
 impl CpuUtilMetric {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -24,15 +38,6 @@ impl CpuUtilMetric {
             CpuUtilMetric::User => "cpu_user_util_percent",
             CpuUtilMetric::System => "cpu_system_util_percent",
             CpuUtilMetric::Frequency => "cpu_frequency_mhz",
-        }
-    }
-
-    pub fn from_str(s: &str) -> Result<Self> {
-        match s {
-            "cpu_total_util_percent" => Ok(CpuUtilMetric::Total),
-            "cpu_user_util_percent" => Ok(CpuUtilMetric::User),
-            "cpu_system_util_percent" => Ok(CpuUtilMetric::System),
-            _ => Err(anyhow::anyhow!("Invalid CPU util metric: {}", s)),
         }
     }
 }

--- a/tools/scxtop/src/profiling_events/kprobe.rs
+++ b/tools/scxtop/src/profiling_events/kprobe.rs
@@ -8,7 +8,7 @@ use scx_utils::compat::tracefs_mount;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct KprobeEvent {
     pub cpu: usize,
     pub event_name: String,

--- a/tools/scxtop/src/profiling_events/mod.rs
+++ b/tools/scxtop/src/profiling_events/mod.rs
@@ -13,6 +13,7 @@ pub use cpu_util::CpuUtilEvent;
 pub use kprobe::{available_kprobe_events, KprobeEvent};
 pub use perf::{available_perf_events, PerfEvent};
 
+use crate::profiling_events::cpu_util::CpuUtilMetric;
 use crate::CpuStatTracker;
 
 #[derive(Clone, Debug)]
@@ -31,11 +32,50 @@ impl ProfilingEvent {
         }
     }
 
+    pub fn start(&self, cpu: usize, process: i32) -> ProfilingEvent {
+        match self {
+            ProfilingEvent::Perf(p) => {
+                let mut p = p.clone();
+                p.cpu = cpu;
+                p.attach(process)
+                    .expect("Failed to attach perf event to process");
+                ProfilingEvent::Perf(p)
+            }
+            ProfilingEvent::Kprobe(k) => {
+                let mut k = k.clone();
+                k.cpu = cpu;
+                ProfilingEvent::Kprobe(k)
+            }
+            ProfilingEvent::CpuUtil(c) => {
+                let mut c = c.clone();
+                c.cpu = cpu;
+                ProfilingEvent::CpuUtil(c)
+            }
+        }
+    }
+
     pub fn value(&mut self, reset: bool) -> anyhow::Result<u64> {
         match self {
             ProfilingEvent::CpuUtil(c) => c.value(),
             ProfilingEvent::Perf(p) => p.value(reset),
             ProfilingEvent::Kprobe(k) => k.value(reset),
+        }
+    }
+
+    pub fn from_str(s: &str, tracker: Arc<RwLock<CpuStatTracker>>) -> anyhow::Result<Self> {
+        let (source, event) = s.split_once(':').expect("Invalid profiling event");
+        match source {
+            "cpu" => Ok(ProfilingEvent::CpuUtil(CpuUtilEvent::new(
+                0,
+                CpuUtilMetric::from_str(event)?,
+                tracker,
+            ))),
+            "perf" => Ok(ProfilingEvent::Perf(PerfEvent::from_str(event)?)),
+            "kprobe" => Ok(ProfilingEvent::Kprobe(KprobeEvent::new(
+                event.to_string(),
+                0,
+            ))),
+            _ => Err(anyhow::anyhow!("Invalid profiling event: {}", s)),
         }
     }
 }
@@ -52,4 +92,83 @@ pub fn get_default_events(tracker: Arc<RwLock<CpuStatTracker>>) -> Vec<Profiling
     default_perf_events
         .chain(default_cpu_util_events)
         .collect::<Vec<ProfilingEvent>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_tracker() -> Arc<RwLock<CpuStatTracker>> {
+        Arc::new(RwLock::new(CpuStatTracker::default()))
+    }
+
+    #[test]
+    fn test_cpu_event_parsing() {
+        let tracker = dummy_tracker();
+        let result =
+            ProfilingEvent::from_str("cpu:cpu_total_util_percent", tracker.clone()).unwrap();
+
+        let expected = ProfilingEvent::CpuUtil(CpuUtilEvent::new(
+            0,
+            CpuUtilMetric::from_str("cpu_total_util_percent").unwrap(),
+            tracker,
+        ));
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_perf_event_parsing() {
+        let tracker = dummy_tracker();
+        let result = ProfilingEvent::from_str("perf:hw:cycles", tracker).unwrap();
+
+        let expected = ProfilingEvent::Perf(PerfEvent::from_str("hw:cycles").unwrap());
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_kprobe_event_parsing() {
+        let tracker = dummy_tracker();
+        let result = ProfilingEvent::from_str("kprobe:vfs_read", tracker).unwrap();
+
+        let expected = ProfilingEvent::Kprobe(KprobeEvent::new("vfs_read", 0).unwrap());
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_invalid_format_missing_colon() {
+        let tracker = dummy_tracker();
+        let err = ProfilingEvent::from_str("invalid_format", tracker);
+        assert!(err.is_err(),);
+    }
+
+    #[test]
+    fn test_invalid_source_type() {
+        let tracker = dummy_tracker();
+        let err = ProfilingEvent::from_str("foo:bar", tracker);
+        assert!(err.is_err(),);
+    }
+
+    #[test]
+    fn test_invalid_cpu_metric() {
+        let tracker = dummy_tracker();
+        let result = ProfilingEvent::from_str("cpu:not_a_real_metric", tracker);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_perf_event() {
+        let tracker = dummy_tracker();
+        let result = ProfilingEvent::from_str("perf:", tracker);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_kprobe_event() {
+        let tracker = dummy_tracker();
+        let result = ProfilingEvent::from_str("kprobe:", tracker);
+        assert!(result.is_err());
+    }
 }

--- a/tools/scxtop/src/profiling_events/mod.rs
+++ b/tools/scxtop/src/profiling_events/mod.rs
@@ -33,7 +33,7 @@ impl ProfilingEvent {
         }
     }
 
-    pub fn start(&self, cpu: usize, process: i32) -> Result<ProfilingEvent> {
+    pub fn initialize_for_cpu(&self, cpu: usize, process: i32) -> Result<ProfilingEvent> {
         match self {
             ProfilingEvent::Perf(p) => {
                 let mut p = p.clone();

--- a/tools/scxtop/src/profiling_events/perf.rs
+++ b/tools/scxtop/src/profiling_events/perf.rs
@@ -114,7 +114,7 @@ impl PerfEvent {
     }
 
     /// Returns a perf event from a string.
-    pub fn from_str(event: &str, cpu: usize) -> Result<Self> {
+    pub fn from_str_args(event: &str, cpu: usize) -> Result<Self> {
         let event_parts: Vec<&str> = event.split(':').collect();
         if event_parts.len() != 2 {
             anyhow::bail!("Invalid perf event: {}", event);
@@ -348,7 +348,7 @@ mod tests {
     fn test_valid_event_parsing() {
         let cpu_stat_tracker = Arc::new(RwLock::new(CpuStatTracker::default()));
         let input = "perf:cpu:cycles";
-        let parsed = ProfilingEvent::from_str(input, Some(cpu_stat_tracker)).unwrap();
+        let parsed = ProfilingEvent::from_str_args(input, Some(cpu_stat_tracker)).unwrap();
         let expected =
             ProfilingEvent::Perf(PerfEvent::new("cpu".to_string(), "cycles".to_string(), 0));
         assert_eq!(parsed, expected);
@@ -356,19 +356,19 @@ mod tests {
 
     #[test]
     fn test_invalid_event_empty_string() {
-        let result = PerfEvent::from_str("", 0);
+        let result = PerfEvent::from_str_args("", 0);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_invalid_event_only_one_part() {
-        let result = PerfEvent::from_str("cpu", 0);
+        let result = PerfEvent::from_str_args("cpu", 0);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_invalid_event_with_more_colons() {
-        let parsed = PerfEvent::from_str("intel:uncore:llc-misses", 0);
+        let parsed = PerfEvent::from_str_args("intel:uncore:llc-misses", 0);
         assert!(parsed.is_err());
     }
 }

--- a/tools/scxtop/src/util.rs
+++ b/tools/scxtop/src/util.rs
@@ -5,7 +5,10 @@
 
 use anyhow::Result;
 use std::fs;
+use std::fs::OpenOptions;
 use std::io::Read;
+use std::io::Write;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Returns the file content as a String.
 pub fn read_file_string(path: &str) -> Result<String> {

--- a/tools/scxtop/src/util.rs
+++ b/tools/scxtop/src/util.rs
@@ -5,10 +5,7 @@
 
 use anyhow::Result;
 use std::fs;
-use std::fs::OpenOptions;
 use std::io::Read;
-use std::io::Write;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Returns the file content as a String.
 pub fn read_file_string(path: &str) -> Result<String> {


### PR DESCRIPTION
Majority of this is tests (for config and the event structs). The main functional change here is to generalize the default event so it can be any of the current event types (krpobe, perf, or cpu) or any other future event type. This also allows us to clean up the `app.rs` file a bit. To do this, the config will now require a <source> prefix and a `from_str` method was added to the `ProfilingEvent` enum. For example, this is what default events can now look like:
* `perf:hw:cycles`
* `cpu:cpu_total_util_percent`
* `kprobe:vfs_read`

Now that it is generalized, we will also switch to using `cpu:cpu_total_util_percent` to show cpu utilization, at least until this gets it's own dedicated pane.