### PR TITLE
scx_lavd: Limit the impact of latency criticality inheritance.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -43,7 +43,8 @@ enum consts_internal  {
 	LAVD_LC_RUNTIME_MAX		= LAVD_TIME_ONE_SEC,
 	LAVD_LC_WEIGHT_BOOST		= 128, /* 2^7 */
 	LAVD_LC_GREEDY_SHIFT		= 3, /* 12.5% */
-	LAVD_LC_INHERIT_SHIFT		= 3, /* 12.5% */
+	LAVD_LC_INH_WAKEE_SHIFT		= 2, /* 25.0% of wakee's latency criticality */
+	LAVD_LC_INH_WAKER_SHIFT		= 3, /* 12.5 of waker's latency criticality */
 
 	LAVD_CPU_UTIL_MAX_FOR_CPUPERF	= p2s(85), /* 85.0% */
 


### PR DESCRIPTION
The amount of the wakelet's latency criticality inherited needs to be limited, so the wakee's latency criticality portion should always be a dominant factor. In the current setting, 12.5% of the waker's latency criticality can be inherited up to 25% of the wakee's latency criticality.