### PR TITLE
scx_bpf_unittests: Filter invalid symbol names in test codegen

### DIFF
--- a/rust/scx_bpf_unittests/build.rs
+++ b/rust/scx_bpf_unittests/build.rs
@@ -86,7 +86,7 @@ fn main() {
                 };
 
                 // unclear where the empty name comes from, filter it out
-                if name != "" {
+                if symbol.is_definition() {
                     tests.push(name);
                 }
             }


### PR DESCRIPTION
## Issue
I encountered a compilation error when running `cargo test` in the repo, specifically in `scx_bpf_unittests` due to an unexpanded `$x` in `gen_tests.rs`.

I used `git bisect` to trace the issue and it seems to be introduced in #2365 .

<details>
<summary>Error msg</summary>

```rust
 ~/eric/scx  @7d9b2cc2 bisect  cargo test                                                                ok | underdog@arm-server  22:33:49 
warning: /home/underdog/eric/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
warning: /home/underdog/eric/scx/Cargo.toml: unused manifest key: profile.release-fast.debuginfo
warning: /home/underdog/eric/scx/Cargo.toml: unused manifest key: profile.release-fast.target-cpu
   Compiling scx_bpf_unittests v0.1.0 (/home/underdog/eric/scx/rust/scx_bpf_unittests)
   Compiling scx_utils v1.0.17 (/home/underdog/eric/scx/rust/scx_utils)
error: expected identifier, found `$`
 --> /home/underdog/eric/scx/target/debug/build/scx_bpf_unittests-ab79004b444a02a9/out/gen_tests.rs:1:17
  |
1 | extern "C" { fn $x() -> i32; }
  |            -    ^            - the item list ends here
  |            |    |
  |            |    expected identifier
  |            while parsing this item list starting here

error: missing parameters for function definition
 --> /home/underdog/eric/scx/target/debug/build/scx_bpf_unittests-ab79004b444a02a9/out/gen_tests.rs:3:9
  |
3 | fn p2dq_$x() -> ::std::result::Result<(), i32> {
  |         ^
  |
help: add a parameter list
  |
3 | fn p2dq_()$x() -> ::std::result::Result<(), i32> {
  |         ++

error: expected one of `->`, `<`, `where`, or `{`, found `$`
 --> /home/underdog/eric/scx/target/debug/build/scx_bpf_unittests-ab79004b444a02a9/out/gen_tests.rs:3:9
  |
3 | fn p2dq_$x() -> ::std::result::Result<(), i32> {
  |         ^ expected one of `->`, `<`, `where`, or `{`

error: could not compile `scx_bpf_unittests` (lib test) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
```
</details>

## Fix
Commit 7d9b2cc2 introduced a build issue where invalid symbols like "$x" from the `.scxtest` ELF section could be inserted into the generated `gen_tests.rs`, leading to compilation failures.

This patch filters out any non-identifier-compatible symbol names before generating test wrappers.

Fixes: 7d9b2cc26473 ("scx_bpf_unittests: add crate to drive BPF unittests")