### PR TITLE
nix: fix veristat build

### DIFF
--- a/.github/include/flake.lock
+++ b/.github/include/flake.lock
@@ -80,11 +80,11 @@
     "veristat-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1751555249,
-        "narHash": "sha256-7NbKM9GA2N2CZGXZKllh00bqWGKb8+ftG/lGG/JNPng=",
+        "lastModified": 1736364478,
+        "narHash": "sha256-07awVCMrFFG69cGtucLYGT+mqcRZ9F9ZHvxARLLYpM0=",
         "owner": "libbpf",
         "repo": "veristat",
-        "rev": "1b386f2cd5d798bc74dba1af5208f5273aba2b9d",
+        "rev": "3bf5cdf98b05faf53dca21492e69ffb4605c6d42",
         "type": "github"
       },
       "original": {

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,7 +42,9 @@ jobs:
           cachix-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Install Veristat
-        run: nix-env -i $(nix build --no-link --print-out-paths ./.github/include#veristat)
+        run: |
+          VERISTAT_PATH=$(nix build --no-link --print-out-paths ./.github/include#veristat)
+          nix-env -i "$VERISTAT_PATH"
 
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar


### PR DESCRIPTION
Veristat build broke with the last flake update because it's not compatible with the nixpkgs libbpf. Fix the CI to fail in this case (it should have before but was getting lost in a subshell), and temporarily revert veristat so it builds again.

Test plan:
- Made the CI change first, pushed it, and everything went red.
- CI with the fix.