### PR TITLE
scxtop: add mem stats

### DIFF
--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -10,12 +10,13 @@ mod bpf_stats;
 pub mod cli;
 pub mod config;
 mod cpu_data;
-pub mod cpu_stats;
+mod cpu_stats;
 pub mod edm;
 mod event_data;
 mod keymap;
 mod llc_data;
 pub mod mangoapp;
+mod mem_stats;
 mod node_data;
 mod perfetto_trace;
 pub mod profiling_events;
@@ -35,6 +36,7 @@ pub use event_data::EventData;
 pub use keymap::Key;
 pub use keymap::KeyMap;
 pub use llc_data::LlcData;
+pub use mem_stats::MemStatSnapshot;
 pub use node_data::NodeData;
 pub use perfetto_trace::PerfettoTraceManager;
 pub use profiling_events::{
@@ -292,10 +294,11 @@ pub struct KprobeAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct CpuStatAction {
+pub struct SystemStatAction {
     pub ts: u64,
     pub cpu_data_prev: BTreeMap<usize, CpuStatSnapshot>,
     pub cpu_data_current: BTreeMap<usize, CpuStatSnapshot>,
+    pub mem_info: MemStatSnapshot,
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -318,7 +321,7 @@ pub enum Action {
     ClearEvent,
     CpuhpEnter(CpuhpEnterAction),
     CpuhpExit(CpuhpExitAction),
-    CpuStat(CpuStatAction),
+    SystemStat(SystemStatAction),
     DecBpfSampleRate,
     DecTickRate,
     Down,

--- a/tools/scxtop/src/mem_stats.rs
+++ b/tools/scxtop/src/mem_stats.rs
@@ -1,0 +1,95 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use anyhow::Result;
+use fb_procfs::ProcReader;
+
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct MemStatSnapshot {
+    pub total_kb: u64,
+    pub free_kb: u64,
+    pub available_kb: u64,
+    pub active_kb: u64,
+    pub inactive_kb: u64,
+    pub shmem_kb: u64,
+    pub swap_total_kb: u64,
+    pub swap_free_kb: u64,
+}
+
+impl MemStatSnapshot {
+    pub fn update(&mut self, proc_reader: &ProcReader) -> Result<()> {
+        let meminfo = proc_reader.read_meminfo()?;
+        self.total_kb = meminfo.total.expect("total memory should be present");
+        self.free_kb = meminfo.free.expect("free memory should be present");
+        self.available_kb = meminfo
+            .available
+            .expect("available memory should be present");
+        self.active_kb = meminfo.active.expect("active memory should be present");
+        self.inactive_kb = meminfo.inactive.expect("inactive memory should be present");
+        self.shmem_kb = meminfo.shmem.expect("shmem memory should be present");
+        self.swap_total_kb = meminfo
+            .swap_total
+            .expect("swap total memory should be present");
+        self.swap_free_kb = meminfo
+            .swap_free
+            .expect("swap free memory should be present");
+        Ok(())
+    }
+
+    pub fn free_ratio(&self) -> f64 {
+        if self.total_kb == 0 {
+            return 0.0;
+        }
+        self.free_kb as f64 / self.total_kb as f64
+    }
+
+    pub fn swap_ratio(&self) -> f64 {
+        if self.swap_total_kb == 0 {
+            return 0.0;
+        }
+        self.swap_free_kb as f64 / self.swap_total_kb as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_free_ratio() {
+        let snapshot = MemStatSnapshot {
+            total_kb: 8000000,
+            free_kb: 2000000,
+            ..Default::default()
+        };
+        assert_eq!(snapshot.free_ratio(), 0.25);
+    }
+
+    #[test]
+    fn test_swap_ratio() {
+        let snapshot = MemStatSnapshot {
+            swap_total_kb: 1000000,
+            swap_free_kb: 400000,
+            ..Default::default()
+        };
+        assert_eq!(snapshot.swap_ratio(), 0.4);
+    }
+
+    #[test]
+    fn test_zero_total_ratios() {
+        let snapshot = MemStatSnapshot::default();
+        assert_eq!(snapshot.free_ratio(), 0.0);
+        assert_eq!(snapshot.swap_ratio(), 0.0);
+    }
+
+    #[test]
+    fn test_update_integration_test() {
+        let proc_reader = ProcReader::new();
+        let mut snapshot = MemStatSnapshot::default();
+        snapshot.update(&proc_reader).unwrap();
+        assert!(snapshot.free_ratio() > 0.0);
+        assert!(snapshot.swap_ratio() > 0.0);
+    }
+}

--- a/tools/scxtop/src/mem_stats.rs
+++ b/tools/scxtop/src/mem_stats.rs
@@ -83,13 +83,4 @@ mod tests {
         assert_eq!(snapshot.free_ratio(), 0.0);
         assert_eq!(snapshot.swap_ratio(), 0.0);
     }
-
-    #[test]
-    fn test_update_integration_test() {
-        let proc_reader = ProcReader::new();
-        let mut snapshot = MemStatSnapshot::default();
-        snapshot.update(&proc_reader).unwrap();
-        assert!(snapshot.free_ratio() > 0.0);
-        assert!(snapshot.swap_ratio() > 0.0);
-    }
 }

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -16,9 +16,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::edm::ActionHandler;
 use crate::get_clock_value;
 use crate::{
-    Action, CpuStatAction, CpuhpEnterAction, CpuhpExitAction, ExecAction, ExitAction, ForkAction,
-    GpuMemAction, IPIAction, KprobeAction, SchedMigrateTaskAction, SchedSwitchAction,
-    SchedWakeupAction, SchedWakingAction, SoftIRQAction,
+    Action, CpuhpEnterAction, CpuhpExitAction, ExecAction, ExitAction, ForkAction, GpuMemAction,
+    IPIAction, KprobeAction, SchedMigrateTaskAction, SchedSwitchAction, SchedWakeupAction,
+    SchedWakingAction, SoftIRQAction, SystemStatAction,
 };
 
 use perfetto_protos::{
@@ -38,14 +38,15 @@ use perfetto_protos::{
         SchedProcessForkFtraceEvent, SchedSwitchFtraceEvent, SchedWakeupFtraceEvent,
         SchedWakingFtraceEvent,
     },
-    sys_stats::{sys_stats::CpuTimes, SysStats},
+    sys_stats::{sys_stats::CpuTimes, sys_stats::MeminfoValue, SysStats},
+    sys_stats_counters::MeminfoCounters,
     thread_descriptor::ThreadDescriptor,
     trace::Trace,
     trace_packet::{trace_packet, TracePacket},
     track_descriptor::{track_descriptor::Static_or_dynamic_name, TrackDescriptor},
     track_event::{track_event, TrackEvent},
 };
-use protobuf::{Message, SpecialFields};
+use protobuf::{EnumOrUnknown, Message, SpecialFields};
 
 /// Handler for perfetto traces. For details on data flow in perfetto see:
 /// https://perfetto.dev/docs/concepts/buffers and
@@ -68,6 +69,8 @@ pub struct PerfettoTraceManager {
     threads: HashMap<u64, ThreadDescriptor>,
     process_uuids: HashMap<i32, u64>,
     sys_stats: BTreeMap<u64, Vec<SysStats>>,
+    mem_events: BTreeMap<String, Vec<TrackEvent>>,
+    mem_uuids: HashMap<String, u64>,
 }
 
 impl PerfettoTraceManager {
@@ -79,6 +82,10 @@ impl PerfettoTraceManager {
                 .expect("Time went backwards")
                 .as_secs(),
         );
+
+        let mut mem_uuids = HashMap::new();
+        mem_uuids.insert("mem_ratio".to_string(), rng.next_u64());
+        mem_uuids.insert("swap_ratio".to_string(), rng.next_u64());
 
         Self {
             trace: Trace::default(),
@@ -94,6 +101,8 @@ impl PerfettoTraceManager {
             threads: HashMap::new(),
             process_uuids: HashMap::new(),
             sys_stats: BTreeMap::new(),
+            mem_events: BTreeMap::new(),
+            mem_uuids,
         }
     }
 
@@ -158,6 +167,25 @@ impl PerfettoTraceManager {
             });
 
             desc_map.insert(dsq_uuid, descs);
+        }
+
+        for (name, &uuid) in &self.mem_uuids {
+            let mut desc = Vec::new();
+
+            desc.push(TrackDescriptor {
+                uuid: Some(uuid),
+                counter: Some(CounterDescriptor {
+                    unit: Some(UNIT_COUNT.into()),
+                    unit_name: Some(format!("{name}")),
+                    is_incremental: Some(false),
+                    ..CounterDescriptor::default()
+                })
+                .into(),
+                static_or_dynamic_name: Some(Static_or_dynamic_name::StaticName(format!("{name}"))),
+                ..TrackDescriptor::default()
+            });
+
+            desc_map.insert(uuid, desc);
         }
 
         desc_map
@@ -388,6 +416,24 @@ impl PerfettoTraceManager {
                         ..TracePacket::default()
                     });
                 }
+            }
+        }
+
+        // mem events
+        for (_, events) in &mut self.mem_events {
+            let mem_sequence_id = self.rng.next_u32();
+            for mem_event in events.drain(..) {
+                let ts: u64 = timestamp_absolute_us(&mem_event) as u64 / 1_000;
+                self.trace.packet.push(TracePacket {
+                    data: Some(trace_packet::Data::TrackEvent(mem_event)),
+                    timestamp: Some(ts),
+                    optional_trusted_packet_sequence_id: Some(
+                        trace_packet::Optional_trusted_packet_sequence_id::TrustedPacketSequenceId(
+                            mem_sequence_id,
+                        ),
+                    ),
+                    ..TracePacket::default()
+                });
             }
         }
 
@@ -745,11 +791,20 @@ impl PerfettoTraceManager {
         });
     }
 
-    pub fn on_cpu_stat(&mut self, action: &CpuStatAction) {
-        let CpuStatAction {
+    fn meminfo_value(key: MeminfoCounters, value: u64) -> MeminfoValue {
+        MeminfoValue {
+            key: Some(EnumOrUnknown::new(key)),
+            value: Some(value),
+            special_fields: SpecialFields::default(),
+        }
+    }
+
+    pub fn on_sys_stat(&mut self, action: &SystemStatAction) {
+        let SystemStatAction {
             ts,
             cpu_data_prev,
             cpu_data_current,
+            mem_info,
         } = action;
 
         let mut cpufreq_khz = Vec::with_capacity(cpu_data_prev.len());
@@ -787,13 +842,61 @@ impl PerfettoTraceManager {
             cpu_stat.insert(*cpu, cpu_time);
         }
 
+        let mem_data = vec![
+            Self::meminfo_value(MeminfoCounters::MEMINFO_MEM_TOTAL, mem_info.total_kb),
+            Self::meminfo_value(MeminfoCounters::MEMINFO_MEM_FREE, mem_info.free_kb),
+            Self::meminfo_value(MeminfoCounters::MEMINFO_SWAP_TOTAL, mem_info.swap_total_kb),
+            Self::meminfo_value(MeminfoCounters::MEMINFO_SWAP_FREE, mem_info.swap_free_kb),
+        ];
+
         self.sys_stats.entry(*ts).or_default().push({
             SysStats {
                 cpu_stat,
                 cpufreq_khz,
+                meminfo: mem_data,
                 ..SysStats::default()
             }
         });
+
+        self.mem_events
+            .entry("mem_ratio".to_string())
+            .or_default()
+            .push(TrackEvent {
+                type_: Some(track_event::Type::TYPE_COUNTER.into()),
+                track_uuid: Some(
+                    self.mem_uuids
+                        .get("mem_ratio")
+                        .expect("Should have mem_ratio")
+                        .clone(),
+                ),
+                counter_value_field: Some(track_event::Counter_value_field::DoubleCounterValue(
+                    mem_info.free_ratio() * 100.0,
+                )),
+                timestamp: Some(track_event::Timestamp::TimestampAbsoluteUs(
+                    (*ts) as i64 / 1000,
+                )),
+                ..TrackEvent::default()
+            });
+
+        self.mem_events
+            .entry("swap_ratio".to_string())
+            .or_default()
+            .push(TrackEvent {
+                type_: Some(track_event::Type::TYPE_COUNTER.into()),
+                track_uuid: Some(
+                    self.mem_uuids
+                        .get("swap_ratio")
+                        .expect("Should have swap_ratio")
+                        .clone(),
+                ),
+                counter_value_field: Some(track_event::Counter_value_field::DoubleCounterValue(
+                    mem_info.swap_ratio() * 100.0,
+                )),
+                timestamp: Some(track_event::Timestamp::TimestampAbsoluteUs(
+                    (*ts) as i64 / 1000,
+                )),
+                ..TrackEvent::default()
+            });
     }
 
     /// Adds events for the sched_switch event.
@@ -926,8 +1029,8 @@ impl ActionHandler for PerfettoTraceManager {
             Action::Kprobe(a) => {
                 self.on_kprobe(a);
             }
-            Action::CpuStat(a) => {
-                self.on_cpu_stat(a);
+            Action::SystemStat(a) => {
+                self.on_sys_stat(a);
             }
             _ => {}
         }

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -176,12 +176,12 @@ impl PerfettoTraceManager {
                 uuid: Some(uuid),
                 counter: Some(CounterDescriptor {
                     unit: Some(UNIT_COUNT.into()),
-                    unit_name: Some(format!("{name}")),
+                    unit_name: Some(name.to_string()),
                     is_incremental: Some(false),
                     ..CounterDescriptor::default()
                 })
                 .into(),
-                static_or_dynamic_name: Some(Static_or_dynamic_name::StaticName(format!("{name}"))),
+                static_or_dynamic_name: Some(Static_or_dynamic_name::StaticName(name.to_string())),
                 ..TrackDescriptor::default()
             });
 
@@ -420,7 +420,7 @@ impl PerfettoTraceManager {
         }
 
         // mem events
-        for (_, events) in &mut self.mem_events {
+        for events in self.mem_events.values_mut() {
             let mem_sequence_id = self.rng.next_u32();
             for mem_event in events.drain(..) {
                 let ts: u64 = timestamp_absolute_us(&mem_event) as u64 / 1_000;
@@ -862,10 +862,10 @@ impl PerfettoTraceManager {
             .push(TrackEvent {
                 type_: Some(track_event::Type::TYPE_COUNTER.into()),
                 track_uuid: Some(
-                    self.mem_uuids
+                    *self
+                        .mem_uuids
                         .get("mem_ratio")
-                        .expect("Should have mem_ratio")
-                        .clone(),
+                        .expect("Should have mem_ratio"),
                 ),
                 counter_value_field: Some(track_event::Counter_value_field::DoubleCounterValue(
                     mem_info.free_ratio() * 100.0,
@@ -882,10 +882,10 @@ impl PerfettoTraceManager {
             .push(TrackEvent {
                 type_: Some(track_event::Type::TYPE_COUNTER.into()),
                 track_uuid: Some(
-                    self.mem_uuids
+                    *self
+                        .mem_uuids
                         .get("swap_ratio")
-                        .expect("Should have swap_ratio")
-                        .clone(),
+                        .expect("Should have swap_ratio"),
                 ),
                 counter_value_field: Some(track_event::Counter_value_field::DoubleCounterValue(
                     mem_info.swap_ratio() * 100.0,

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -843,9 +843,7 @@ impl PerfettoTraceManager {
         }
 
         let mem_data = vec![
-            Self::meminfo_value(MeminfoCounters::MEMINFO_MEM_TOTAL, mem_info.total_kb),
             Self::meminfo_value(MeminfoCounters::MEMINFO_MEM_FREE, mem_info.free_kb),
-            Self::meminfo_value(MeminfoCounters::MEMINFO_SWAP_TOTAL, mem_info.swap_total_kb),
             Self::meminfo_value(MeminfoCounters::MEMINFO_SWAP_FREE, mem_info.swap_free_kb),
         ];
 

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -83,6 +83,7 @@ impl PerfettoTraceManager {
                 .as_secs(),
         );
 
+        let mut rng = StdRng::seed_from_u64(trace_uuid);
         let mut mem_uuids = HashMap::new();
         mem_uuids.insert("mem_ratio".to_string(), rng.next_u64());
         mem_uuids.insert("swap_ratio".to_string(), rng.next_u64());
@@ -91,7 +92,7 @@ impl PerfettoTraceManager {
             trace: Trace::default(),
             trace_id: 0,
             trusted_pid: std::process::id() as i32,
-            rng: StdRng::seed_from_u64(trace_uuid),
+            rng,
             output_file_prefix,
             ftrace_events: BTreeMap::new(),
             dsq_uuids: BTreeMap::new(),

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -170,22 +170,23 @@ impl PerfettoTraceManager {
         }
 
         for (name, &uuid) in &self.mem_uuids {
-            let mut desc = Vec::new();
-
-            desc.push(TrackDescriptor {
-                uuid: Some(uuid),
-                counter: Some(CounterDescriptor {
-                    unit: Some(UNIT_COUNT.into()),
-                    unit_name: Some(name.to_string()),
-                    is_incremental: Some(false),
-                    ..CounterDescriptor::default()
-                })
-                .into(),
-                static_or_dynamic_name: Some(Static_or_dynamic_name::StaticName(name.to_string())),
-                ..TrackDescriptor::default()
-            });
-
-            desc_map.insert(uuid, desc);
+            desc_map.insert(
+                uuid,
+                vec![TrackDescriptor {
+                    uuid: Some(uuid),
+                    counter: Some(CounterDescriptor {
+                        unit: Some(UNIT_COUNT.into()),
+                        unit_name: Some(name.to_string()),
+                        is_incremental: Some(false),
+                        ..CounterDescriptor::default()
+                    })
+                    .into(),
+                    static_or_dynamic_name: Some(Static_or_dynamic_name::StaticName(
+                        name.to_string(),
+                    )),
+                    ..TrackDescriptor::default()
+                }],
+            );
         }
 
         desc_map


### PR DESCRIPTION
This adds a `MemStatSnapshot` struct to collect memory data that can be used for both the TUI and the trace. For now, it will just be added into the trace, with `free` and`swap_free`, as well as with the ratios for those, `mem_ratio` and `swap_ratio`:

<img width="1498" height="362" alt="Screenshot 2025-07-14 at 5 26 40 PM" src="https://github.com/user-attachments/assets/25ba6932-74c5-4abe-a100-df80147cf300" />

