### PR TITLE
cargo: Update build profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,14 @@ resolver = "2"
 [profile.release]
 lto = "thin"
 
+[profile.release-tiny]
+inherits = "release"
+lto = "thin"
+strip = true
+incremental = true
+
 [profile.release-fast]
 inherits = "release"
 target-cpu = "native"
 lto = false
 incremental = true
-opt-level = 0
-debuginfo = 0


### PR DESCRIPTION
Update some of the cargo profiles and add a `release-tiny` profile that has stripped binaries. Some builds have gotten rather bloated and the release-tiny is for building binaries to run on machines with limited resources.

Tested with `scx_p2dq` as it is the largest scheduler binary.

before:
```
$ ls -la ./target/release/scx_p2dq
-rwxr-xr-x 2 hodgesd users 13081288 Jul 15 06:58 ./target/release/scx_p2dq
$ ls -la ./target/release-fast/scx_p2dq
-rwxr-xr-x 2 hodgesd users 19036784 Jul 15 07:01 ./target/release-fast/scx_p2dq
$ ls -la ./target/debug/scx_p2dq
-rwxr-xr-x 2 hodgesd users 138523616 Jul 15 07:06 ./target/debug/scx_p2dq
```

after:
```
$ ls -la ./target/release/scx_p2dq
-rwxr-xr-x 2 hodgesd users 13081280 Jul 15 07:43 ./target/release/scx_p2dq
$ ls -la ./target/debug/scx_p2dq
-rwxr-xr-x 2 hodgesd users 138523616 Jul 15 07:10 ./target/debug/scx_p2dq
$ ls -la ./target/release-fast/scx_p2dq
-rwxr-xr-x 2 hodgesd users 13052112 Jul 15 07:13 ./target/release-fast/scx_p2dq
$ ls -la ./target/release-tiny/scx_p2dq
-rwxr-xr-x 2 hodgesd users 11953704 Jul 15 07:15 ./target/release-tiny/scx_p2dq
```