### PR TITLE
ci: reduce number of runs

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -1,9 +1,11 @@
 name: build-and-test
 
 on:
-  push:
   pull_request:
   merge_group:
+  push:
+    branches-ignore:
+      - gh-readonly-queue/main/**
 
 jobs:
   build-kernels:


### PR DESCRIPTION
Currently a commit gets 3/4 CI runs before being merged (assuming no amends of course):
- 1 on the original push, if you push to the main repo.
- 1 on the PR update.
- 1 when the merge queue bot creates a temporary branch for the merge queue state.
- 1 when merge queue checks occur.

The 2 merge queue related events happen very close together which means there's often a little queueing. This isn't painful, just inefficient.

Add the GitHub managed merge queue branches to `branches-ignore` of push and rely on the `merge_group` event instead.

Test plan:
- CI. If this doesn't merge then it doesn't work.