### PR TITLE
scxtop: adding sched_process_wait trace point.

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -36,7 +36,7 @@ use crate::{
     Action, CpuhpEnterAction, CpuhpExitAction, ExecAction, ExitAction, ForkAction, GpuMemAction,
     HwPressureAction, IPIAction, KprobeAction, MangoAppAction, PstateSampleAction,
     SchedCpuPerfSetAction, SchedMigrateTaskAction, SchedSwitchAction, SchedWakeupAction,
-    SchedWakingAction, SoftIRQAction, TraceStartedAction, TraceStoppedAction,
+    SchedWakingAction, SoftIRQAction, TraceStartedAction, TraceStoppedAction, WaitAction,
 };
 
 use anyhow::{bail, Result};
@@ -2331,6 +2331,7 @@ impl<'a> App<'a> {
             self.skel.progs.on_sched_fork.attach()?,
             self.skel.progs.on_sched_exec.attach()?,
             self.skel.progs.on_sched_exit.attach()?,
+            self.skel.progs.on_sched_wait.attach()?,
         ];
 
         Ok(())
@@ -2478,6 +2479,12 @@ impl<'a> App<'a> {
     fn on_fork(&mut self, action: &ForkAction) {
         if self.state == AppState::Tracing && action.ts > self.trace_start {
             self.trace_manager.on_fork(action);
+        }
+    }
+
+    fn on_wait(&mut self, action: &WaitAction) {
+        if self.state == AppState::Tracing && action.ts > self.trace_start {
+            self.trace_manager.on_wait(action);
         }
     }
 
@@ -2774,6 +2781,9 @@ impl<'a> App<'a> {
             }
             Action::Fork(a) => {
                 self.on_fork(a);
+            }
+            Action::Wait(a) => {
+                self.on_wait(a);
             }
             Action::IPI(a) => {
                 self.on_ipi(a);

--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -36,11 +36,12 @@ enum event_type {
 	EXEC,
 	EXIT,
 	FORK,
+	WAIT,
 	GPU_MEM,
 	HW_PRESSURE,
 	IPI,
 	PSTATE_SAMPLE,
-    SCHED_MIGRATE,
+    	SCHED_MIGRATE,
 	SCHED_REG,
 	SCHED_SWITCH,
 	SCHED_UNREG,
@@ -119,6 +120,12 @@ struct exec_event {
 	u32             pid;
 };
 
+struct wait_event {
+	u8              comm[MAX_COMM];
+	u32             pid;
+	int             prio;
+};
+
 struct ipi_event {
 	u32		pid;
 	u32		target_cpu;
@@ -172,6 +179,7 @@ struct bpf_event {
 		struct  exit_event exit;
 		struct  fork_event fork;
 		struct  exec_event exec;
+		struct  wait_event wait;
 		struct  hw_pressure_event hwp;
 		struct  gpu_mem_event gm;
 		struct  cpuhp_enter_event chp;

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -191,6 +191,7 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
             links.push(skel.progs.on_sched_fork.attach()?);
             links.push(skel.progs.on_sched_exec.attach()?);
             links.push(skel.progs.on_sched_exit.attach()?);
+            links.push(skel.progs.on_sched_wait.attach()?);
 
             let bpf_publisher = BpfEventActionPublisher::new(action_tx.clone());
 


### PR DESCRIPTION
the process has been stopped to avoid cpu cycles waste unless the needed resource is available