### PR TITLE
scx_flash: add to integration-tests

### DIFF
--- a/.github/include/list-integration-tests.py
+++ b/.github/include/list-integration-tests.py
@@ -125,6 +125,7 @@ def main():
             "scx_bpfland",
             "scx_chaos",
             "scx_cosmos",
+            "scx_flash",
             "scx_lavd",
             "scx_p2dq",
             "scx_rlfifo",


### PR DESCRIPTION
As was mentioned here https://github.com/sched-ext/scx/pull/2401#issuecomment-3078053586, scx_flash was never added to integration-tests. Let's fix this.