### PR TITLE
atq: Add sized ATQ helper

### DIFF
--- a/lib/atq.bpf.c
+++ b/lib/atq.bpf.c
@@ -9,7 +9,7 @@
  */
 
 __weak
-u64 scx_atq_create_internal(bool fifo)
+u64 scx_atq_create_internal(bool fifo, size_t capacity)
 {
 	scx_atq_t *atq;
 
@@ -17,7 +17,7 @@ u64 scx_atq_create_internal(bool fifo)
 	if (!atq)
 		return (u64)NULL;
 
-	atq->heap = scx_minheap_alloc(SCX_ATQ_MAX_CAPACITY);
+	atq->heap = scx_minheap_alloc(capacity);
 	if (!atq->heap)
 		return (u64)NULL;
 

--- a/lib/selftests/st_atq.bpf.c
+++ b/lib/selftests/st_atq.bpf.c
@@ -273,6 +273,52 @@ int scx_selftest_atq_peek_empty(u64 unused)
 }
 
 __weak
+int scx_selftest_atq_sized(u64 unused)
+{
+	scx_atq_t *sized_fifo, *sized_vtime;
+	int ret;
+
+	sized_fifo = (scx_atq_t *)scx_atq_create_size(true, 1);
+	if (!sized_fifo) {
+		bpf_printk("ATQ failed to create sized fifo ATQ");
+		return -ENOMEM;
+	}
+
+	sized_vtime = (scx_atq_t *)scx_atq_create_size(false, 1);
+	if (!sized_vtime) {
+		bpf_printk("ATQ failed to create sized vtime ATQ");
+		return -ENOMEM;
+	}
+
+	ret = scx_atq_insert(sized_fifo, 1234);
+	if (ret) {
+		bpf_printk("ATQ failed to insert into sized fifo ATQ");
+		return -EINVAL;
+	}
+
+	ret = scx_atq_insert(sized_fifo, 5678);
+	if (!ret) {
+		bpf_printk("ATQ too many inserts into sized fifo ATQ");
+		return -EINVAL;
+	}
+
+	ret = scx_atq_insert_vtime(sized_vtime, 1234, 7890);
+	if (ret) {
+		bpf_printk("ATQ failed to insert into sized vtime ATQ");
+		return -EINVAL;
+	}
+
+	ret = scx_atq_insert_vtime(sized_vtime, 1111, 2222);
+	if (!ret) {
+		bpf_printk("ATQ too many inserts into sized vtime ATQ");
+		return -EINVAL;
+	}
+
+
+	return 0;
+}
+
+__weak
 int scx_selftest_atq(void)
 {
 	int i;
@@ -293,6 +339,7 @@ int scx_selftest_atq(void)
 	SCX_ATQ_SELFTEST(nr_queued);
 	SCX_ATQ_SELFTEST(peek_nodestruct);
 	SCX_ATQ_SELFTEST(peek_empty);
+	SCX_ATQ_SELFTEST(sized);
 
 	return 0;
 }

--- a/scheds/include/lib/atq.h
+++ b/scheds/include/lib/atq.h
@@ -17,8 +17,9 @@ struct scx_atq {
 
 typedef __arena scx_atq, scx_atq_t;
 
-u64 scx_atq_create_internal(bool fifo);
-#define scx_atq_create(fifo) (scx_atq_create_internal((fifo)))
+u64 scx_atq_create_internal(bool fifo, size_t capacity);
+#define scx_atq_create(fifo) scx_atq_create_internal((fifo), SCX_ATQ_MAX_CAPACITY)
+#define scx_atq_create_size(fifo, capacity) scx_atq_create_internal((fifo), (capacity))
 int scx_atq_insert(scx_atq *atq_ptr, u64 taskc_ptr);
 int scx_atq_insert_vtime(scx_atq_t *atq, u64 taskc_ptr, u64 vtime);
 int scx_atq_nr_queued(scx_atq_t *atq);


### PR DESCRIPTION
Add a helper method to create a sized ATQ. This is used in cases where an absolute size of the ATQ is useful, such as ATQs for load balancing.