### PR TITLE
scx_wd40: fix build and build in CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3170,6 +3170,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "scx_wd40"
+version = "1.0.14"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "crossbeam",
+ "ctrlc",
+ "fb_procfs 0.7.1",
+ "libbpf-rs",
+ "log",
+ "nix 0.29.0",
+ "ordered-float",
+ "scx_stats",
+ "scx_stats_derive",
+ "scx_utils",
+ "serde",
+ "simplelog",
+ "sorted-vec",
+ "static_assertions",
+]
+
+[[package]]
 name = "scxctl"
 version = "1.0.14"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "scheds/rust/scx_rustland",
     "scheds/rust/scx_rusty",
     "scheds/rust/scx_tickless",
+    "scheds/rust/scx_wd40",
     "tools/scxctl",
     "tools/scxtop",
     "tools/vmlinux_docify",

--- a/scheds/rust/scx_wd40/Cargo.toml
+++ b/scheds/rust/scx_wd40/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 description = "An experimental fork of the scx_rusty scheduler that uses BPF arenas to simplify scheduler development. Found in: https://github.com/sched-ext/scx/tree/main"
 license = "GPL-2.0-only"
 
+publish = false
+
 [dependencies]
 anyhow = "1.0.65"
 chrono = "0.4"
@@ -33,5 +35,3 @@ enable_backtrace = []
 
 [lints.clippy]
 non_canonical_partial_ord_impl = "allow"
-
-[workspace]

--- a/scheds/rust/scx_wd40/src/load_balance.rs
+++ b/scheds/rust/scx_wd40/src/load_balance.rs
@@ -556,7 +556,7 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
     fn calculate_load_avgs(&mut self) -> Result<LoadLedger> {
         const NUM_BUCKETS: u64 = bpf_intf::consts_LB_LOAD_BUCKETS as u64;
         let now_mono = now_monotonic();
-        let load_half_life = self.skel.maps.rodata_data.load_half_life;
+        let load_half_life = self.skel.maps.rodata_data.as_ref().unwrap().load_half_life;
 
         let mut aggregator =
             LoadAggregator::new(self.dom_group.weight(), !self.lb_apply_weight.clone());
@@ -627,7 +627,7 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
         const MAX_TPTRS: u64 = bpf_intf::consts_MAX_DOM_ACTIVE_TPTRS as u64;
 
         let types::topo_level(index) = types::topo_level::TOPO_LLC;
-        let ptr = self.skel.maps.bss_data.topo_nodes[index as usize][dom.id];
+        let ptr = self.skel.maps.bss_data.as_ref().unwrap().topo_nodes[index as usize][dom.id];
         let dom_ctx = unsafe { std::mem::transmute::<u64, &mut types::dom_ctx>(ptr) };
         let active_tasks = &mut dom_ctx.active_tasks;
 
@@ -640,7 +640,7 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
         }
 
         // Read task_ctx and load.
-        let load_half_life = self.skel.maps.rodata_data.load_half_life;
+        let load_half_life = self.skel.maps.rodata_data.as_ref().unwrap().load_half_life;
         let now_mono = now_monotonic();
 
         for idx in ridx..widx {

--- a/scheds/rust/scx_wd40/src/tuner.rs
+++ b/scheds/rust/scx_wd40/src/tuner.rs
@@ -168,14 +168,9 @@ impl Tuner {
             }
         }
 
-        update_bpf_mask(
-            skel.maps.bss_data.direct_greedy_cpumask,
-            &self.direct_greedy_mask,
-        )?;
-        update_bpf_mask(
-            skel.maps.bss_data.kick_greedy_cpumask,
-            &self.kick_greedy_mask,
-        )?;
+        let bss_data = skel.maps.bss_data.as_mut().unwrap();
+        update_bpf_mask(bss_data.direct_greedy_cpumask, &self.direct_greedy_mask)?;
+        update_bpf_mask(bss_data.kick_greedy_cpumask, &self.kick_greedy_mask)?;
 
         if self.fully_utilized {
             self.slice_ns = self.overutil_slice_ns;
@@ -183,7 +178,7 @@ impl Tuner {
             self.slice_ns = self.underutil_slice_ns;
         }
 
-        skel.maps.bss_data.slice_ns = self.slice_ns;
+        bss_data.slice_ns = self.slice_ns;
 
         // For domain in domains
         // Get the dom_ctx and the internal mask


### PR DESCRIPTION
libbpf-cargo was updated in #2397. This was very invasive and I missed wd40 while doing this because `cargo build` & the CI don't build wd40.

Fix the build, and add wd40 to the Cargo workspace and therefore the CI builds. This doesn't test wd40 but does build it. This will prevent silly regressions like this in the future.

Test plan:
- CI