### PR TITLE
scx_loader: add config search path for distributions

### DIFF
--- a/rust/scx_loader/configuration.md
+++ b/rust/scx_loader/configuration.md
@@ -8,6 +8,8 @@ The `scx_loader` can be configured using a TOML file. This file allows you to cu
 
 1. `/etc/scx_loader/config.toml`
 2. `/etc/scx_loader.toml`
+3. `/usr/share/scx_loader/config.toml`
+4. `/usr/share/scx_loader.toml`
 
 If no configuration file is found at any of these paths, `scx_loader` will use the built-in default configuration.
 

--- a/rust/scx_loader/src/config.rs
+++ b/rust/scx_loader/src/config.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 //
-// Copyright (c) 2024 Vladislav Nepogodin <vnepogodin@cachyos.org>
+// Copyright (c) 2024-2025 Vladislav Nepogodin <vnepogodin@cachyos.org>
 
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
@@ -50,8 +50,12 @@ pub fn parse_config_file(filepath: &str) -> Result<Config> {
 pub fn get_config_path() -> Result<String> {
     // Search in system directories
     let check_paths = [
+        // locations for user config
         "/etc/scx_loader/config.toml".to_owned(),
         "/etc/scx_loader.toml".to_owned(),
+        // locations for distributions to ship default configuration
+        "/usr/share/scx_loader/config.toml".to_owned(),
+        "/usr/share/scx_loader.toml".to_owned(),
     ];
     for check_path in check_paths {
         if !Path::new(&check_path).exists() {


### PR DESCRIPTION
that allows distributions to ship with default config at:
- /usr/share/scx_loader/config.toml
- /usr/share/scx_loader.toml

user can overwrite it with own configuration at existing paths:
- /etc/scx_loader/config.toml
- /etc/scx_loader.toml