### PR TITLE
scx_loader: add bundled configuration like for scx.service

### DIFF
--- a/services/scx_loader.toml
+++ b/services/scx_loader.toml
@@ -1,0 +1,2 @@
+# This field specifies the scheduler that will be started automatically when scx_loader starts (e.g., on boot).
+default_sched = "scx_flash"

--- a/services/systemd/meson.build
+++ b/services/systemd/meson.build
@@ -10,5 +10,8 @@ install_data('scx_loader.service', install_dir: systemd_system_unit_dir)
 # Install the 'org.scx.Loader.service' file to the dbus system services directory
 install_data('org.scx.Loader.service', install_dir: '/usr/share/dbus-1/system-services')
 
+# Install the default 'scx_loader' config file to the '/usr/share/scx_loader' directory
+install_data('../scx_loader.toml', rename: 'config.toml', install_dir: '/usr/share/scx_loader')
+
 # Install the 'scx' file to the '/etc/default' directory
 install_data('../scx', install_dir: '/etc/default')


### PR DESCRIPTION
Adding bundled configuration for scx_loader also means that whenever a user or application(e.g. scxctl,scx-manager) asks scx_loader, it will already start the scheduler