### PR TITLE
rust utils: addressing clippy warnings

### DIFF
--- a/rust/scx_stats/scx_stats_derive/src/lib.rs
+++ b/rust/scx_stats/scx_stats_derive/src/lib.rs
@@ -95,7 +95,7 @@ pub fn stat_doc(
                         Ok(())
                     })
                     .unwrap_or_else(|err| {
-                        panic!("Failed to parse the stat attribute: {}", err);
+                        panic!("Failed to parse the stat attribute: {err}");
                     });
                 }
                 new_attrs.push(attr);

--- a/rust/scx_stats/src/server.rs
+++ b/rust/scx_stats/src/server.rs
@@ -313,15 +313,15 @@ where
         let mut first = true;
         self.visit_meta(from, &mut |m| {
             if !first {
-                writeln!(w, "")?;
+                writeln!(w)?;
             }
             first = false;
 
             write!(w, "[{:nw$}]", m.name, nw = nwidth)?;
             if let Some(desc) = &m.attrs.desc {
-                write!(w, " {}", desc)?;
+                write!(w, " {desc}")?;
             }
-            writeln!(w, "")?;
+            writeln!(w)?;
 
             for (fname, f) in m.fields.iter() {
                 write!(
@@ -333,9 +333,9 @@ where
                     dw = dwidth
                 )?;
                 if let Some(desc) = &f.attrs.desc {
-                    write!(w, " : {}", desc)?;
+                    write!(w, " : {desc}")?;
                 }
-                writeln!(w, "")?;
+                writeln!(w)?;
             }
             Ok(())
         })
@@ -560,16 +560,16 @@ where
                     let (req_pair, res_pair) = ChannelPair::<Req, Res>::bidi();
                     match add_req.send(res_pair) {
                         Ok(()) => debug!("sent new channel to proxy"),
-                        Err(e) => warn!("StatsServer::proxy() failed ({})", e),
+                        Err(e) => warn!("StatsServer::proxy() failed ({e})"),
                     }
 
                     spawn(move || {
                         if let Err(e) = Self::serve(stream, data, req_pair, exit) {
-                            warn!("stat communication errored ({})", e);
+                            warn!("stat communication errored ({e})");
                         }
                     });
                 }
-                Err(e) => warn!("failed to accept stat connection ({})", e),
+                Err(e) => warn!("failed to accept stat connection ({e})"),
             }
         }
     }
@@ -641,18 +641,18 @@ where
         let path = &self.path.as_ref().unwrap();
 
         if let Some(dir) = path.parent() {
-            std::fs::create_dir_all(dir).with_context(|| format!("creating {:?}", dir))?;
+            std::fs::create_dir_all(dir).with_context(|| format!("creating {dir:?}"))?;
         }
 
         let res = std::fs::remove_file(path);
         if let std::io::Result::Err(e) = &res {
             if e.kind() != std::io::ErrorKind::NotFound {
-                res.with_context(|| format!("deleting {:?}", path))?;
+                res.with_context(|| format!("deleting {path:?}"))?;
             }
         }
 
         let listener =
-            UnixListener::bind(path).with_context(|| format!("creating UNIX socket {:?}", path))?;
+            UnixListener::bind(path).with_context(|| format!("creating UNIX socket {path:?}"))?;
 
         let inner = StatsServerInner::new(
             listener,

--- a/rust/scx_stats/src/stats.rs
+++ b/rust/scx_stats/src/stats.rs
@@ -57,7 +57,7 @@ impl std::fmt::Display for StatsKind {
             Self::U64 => write!(f, "u64"),
             Self::Float => write!(f, "float"),
             Self::String => write!(f, "string"),
-            Self::Struct(name) => write!(f, "{}", name),
+            Self::Struct(name) => write!(f, "{name}"),
         }
     }
 }
@@ -181,9 +181,9 @@ impl StatsData {
 impl std::fmt::Display for StatsData {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::Datum(kind) => write!(f, "{}", kind),
-            Self::Array(kind) => write!(f, "[{}]", kind),
-            Self::Dict { key, datum } => write!(f, "{{{}:{}}}", key, datum),
+            Self::Datum(kind) => write!(f, "{kind}"),
+            Self::Array(kind) => write!(f, "[{kind}]"),
+            Self::Dict { key, datum } => write!(f, "{{{key}:{datum}}}"),
         }
     }
 }
@@ -256,7 +256,7 @@ impl StatsFieldAttrs {
                         }
                         v => Err(Error::new(
                             attr.span(),
-                            format!("Not a field attribute: {:?}", v),
+                            format!("Not a field attribute: {v:?}"),
                         ))?,
                     }
                 }

--- a/rust/scx_utils/src/bpf_builder.rs
+++ b/rust/scx_utils/src/bpf_builder.rs
@@ -389,8 +389,8 @@ impl BpfBuilder {
             None => return Ok(()),
         };
 
-        let obj = self.out_dir.join(format!("{}.bpf.o", name));
-        let skel_path = self.out_dir.join(format!("{}_skel.rs", name));
+        let obj = self.out_dir.join(format!("{name}.bpf.o"));
+        let skel_path = self.out_dir.join(format!("{name}_skel.rs"));
 
         with_clang_warnings(|| {
             SkeletonBuilder::new()
@@ -414,7 +414,7 @@ impl BpfBuilder {
             .to_str()
             .ok_or(anyhow!("Parent dir of {:?} isn't a UTF-8 string", c_path))?;
 
-        for path in glob(&format!("{}/*.[hc]", dir))?.filter_map(Result::ok) {
+        for path in glob(&format!("{dir}/*.[hc]"))?.filter_map(Result::ok) {
             deps.insert(
                 path.to_str()
                     .ok_or(anyhow!("Path {:?} is not a valid string", path))?
@@ -433,12 +433,12 @@ impl BpfBuilder {
         println!("cargo:rerun-if-env-changed=BPF_EXTRA_CFLAGS_POST_INCL");
         if let Some(deps) = dependencies {
             for dep in deps.iter() {
-                println!("cargo:rerun-if-changed={}", dep);
+                println!("cargo:rerun-if-changed={dep}");
             }
         };
 
         for source in self.sources.iter() {
-            println!("cargo:rerun-if-changed={}", source);
+            println!("cargo:rerun-if-changed={source}");
         }
 
         Ok(())
@@ -490,7 +490,7 @@ mod tests {
         unsafe { std::env::set_var("OUT_DIR", td.path()) };
 
         let res = super::BpfBuilder::new();
-        assert!(res.is_ok(), "Failed to create BpfBuilder ({:?})", res);
+        assert!(res.is_ok(), "Failed to create BpfBuilder ({res:?})");
     }
 
     #[test]

--- a/rust/scx_utils/src/builder.rs
+++ b/rust/scx_utils/src/builder.rs
@@ -21,7 +21,7 @@ impl Builder {
 
     fn gen_bpf_h(&self) {
         let out_dir = env::var("OUT_DIR").unwrap();
-        let file = File::create(PathBuf::from(&out_dir).join(format!("{}.tar", BPF_H))).unwrap();
+        let file = File::create(PathBuf::from(&out_dir).join(format!("{BPF_H}.tar"))).unwrap();
         let mut ar = tar::Builder::new(file);
 
         ar.follow_symlinks(false);

--- a/rust/scx_utils/src/clang_info.rs
+++ b/rust/scx_utils/src/clang_info.rs
@@ -41,7 +41,7 @@ impl ClangInfo {
         let mut clang_args = vec!["--version".to_string()];
 
         if let Ok(target) = env::var("TARGET") {
-            clang_args.push(format!("--target={}", target));
+            clang_args.push(format!("--target={target}"));
         }
 
         let clang = env::var("BPF_CLANG").unwrap_or("clang".into());
@@ -167,7 +167,7 @@ impl ClangInfo {
             .collect();
         cflags.push(format!("-D__TARGET_ARCH_{}", &kernel_target));
         cflags.push("-mcpu=v3".into());
-        cflags.push(format!("-m{}-endian", endian));
+        cflags.push(format!("-m{endian}-endian"));
         cflags.append(
             &mut sys_incls
                 .into_iter()

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -237,7 +237,7 @@ pub fn cond_kprobe_enable<T>(sym: &str, prog_ptr: &OpenProgramImpl<T>) -> Result
         }
         return Ok(true);
     } else {
-        warn!("symbol {} is missing, kprobe not loaded", sym);
+        warn!("symbol {sym} is missing, kprobe not loaded");
     }
 
     Ok(false)
@@ -247,7 +247,7 @@ pub fn cond_kprobes_enable<T>(kprobes: Vec<(&str, &OpenProgramImpl<T>)>) -> Resu
     // Check if all the symbols exist.
     for (sym, _) in kprobes.iter() {
         if in_kallsyms(sym)? == false {
-            warn!("symbol {} is missing, kprobe not loaded", sym);
+            warn!("symbol {sym} is missing, kprobe not loaded");
             return Ok(false);
         }
     }
@@ -269,10 +269,7 @@ pub fn cond_tracepoint_enable<T>(tracepoint: &str, prog_ptr: &OpenProgramImpl<T>
         }
         return Ok(true);
     } else {
-        warn!(
-            "tradepoint {} is missing, tracepoint not loaded",
-            tracepoint
-        );
+        warn!("tradepoint {tracepoint} is missing, tracepoint not loaded");
     }
 
     Ok(false)
@@ -282,7 +279,7 @@ pub fn cond_tracepoints_enable<T>(tracepoints: Vec<(&str, &OpenProgramImpl<T>)>)
     // Check if all the tracepoints exist.
     for (tp, _) in tracepoints.iter() {
         if tracepoint_exists(tp)? == false {
-            warn!("tradepoint {} is missing, tracepoint not loaded", tp);
+            warn!("tradepoint {tp} is missing, tracepoint not loaded");
             return Ok(false);
         }
     }

--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -110,8 +110,8 @@ impl Cpumask {
             }
             tmp_str
         };
-        let byte_vec = hex::decode(&hex_str)
-            .with_context(|| format!("Failed to parse cpumask: {}", cpumask))?;
+        let byte_vec =
+            hex::decode(&hex_str).with_context(|| format!("Failed to parse cpumask: {cpumask}"))?;
 
         let mut mask = bitvec![u64, Lsb0; 0; *NR_CPU_IDS];
         for (index, &val) in byte_vec.iter().rev().enumerate() {
@@ -323,8 +323,8 @@ impl Cpumask {
         // The rest in descending order.
         for submask in masks.iter().rev() {
             match case {
-                'x' => write!(f, ",{:08x}", submask)?,
-                'X' => write!(f, ",{:08X}", submask)?,
+                'x' => write!(f, ",{submask:08x}")?,
+                'X' => write!(f, ",{submask:08X}")?,
                 _ => unreachable!(),
             }
         }

--- a/rust/scx_utils/src/energy_model.rs
+++ b/rust/scx_utils/src/energy_model.rs
@@ -120,7 +120,7 @@ impl PerfDomain {
         let util = clamp(util, 0.0, 100.0);
         let (perf_max, _) = self.perf_table.last_key_value().unwrap();
         let perf_max = *perf_max as f32;
-        let req_perf = (perf_max as f32 * (util / 100.0)) as usize;
+        let req_perf = (perf_max * (util / 100.0)) as usize;
         for (perf, ps) in self.perf_table.iter() {
             if *perf >= req_perf {
                 return Some(ps);
@@ -172,7 +172,7 @@ impl PartialEq for PerfState {
 impl fmt::Display for EnergyModel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (_, pd) in self.perf_doms.iter() {
-            writeln!(f, "{:#}", pd)?;
+            writeln!(f, "{pd:#}")?;
         }
         Ok(())
     }
@@ -183,7 +183,7 @@ impl fmt::Display for PerfDomain {
         writeln!(f, "# perf domain: {:#}, cpus: {:#}", self.id, self.span)?;
         writeln!(f, "cost, frequency, inefficient, performance, power")?;
         for (_, ps) in self.perf_table.iter() {
-            writeln!(f, "{:#}", ps)?;
+            writeln!(f, "{ps:#}")?;
         }
         Ok(())
     }
@@ -238,7 +238,7 @@ fn get_pd_paths() -> Result<Vec<(usize, String)>> {
 }
 
 fn get_em_root() -> Result<String> {
-    if *ROOT_PREFIX == "" {
+    if ROOT_PREFIX.is_empty() {
         let root = compat::debugfs_mount().unwrap().join("energy_model");
         Ok(root.display().to_string())
     } else {

--- a/rust/scx_utils/src/libbpf_logger.rs
+++ b/rust/scx_utils/src/libbpf_logger.rs
@@ -7,9 +7,9 @@ use libbpf_rs::{set_print, PrintLevel};
 
 fn print_to_log(level: PrintLevel, msg: String) {
     match level {
-        PrintLevel::Debug => log::debug!("{}", msg),
-        PrintLevel::Info => log::info!("{}", msg),
-        PrintLevel::Warn => log::warn!("{}", msg),
+        PrintLevel::Debug => log::debug!("{msg}"),
+        PrintLevel::Info => log::info!("{msg}"),
+        PrintLevel::Warn => log::warn!("{msg}"),
     }
 }
 

--- a/rust/scx_utils/src/misc.rs
+++ b/rust/scx_utils/src/misc.rs
@@ -46,12 +46,12 @@ where
                 Ok(v) => v,
                 Err(e) => match e.downcast_ref::<std::io::Error>() {
                     Some(ioe) => {
-                        info!("Connection to stats_server failed ({})", ioe);
+                        info!("Connection to stats_server failed ({ioe})");
                         sleep(Duration::from_secs(1));
                         break;
                     }
                     None => {
-                        warn!("error on handling stats_server result {}", e);
+                        warn!("error on handling stats_server result {e}");
                         sleep(Duration::from_secs(1));
                         break;
                     }
@@ -74,7 +74,7 @@ pub fn set_rlimit_infinity() {
         };
         let res = libc::setrlimit(libc::RLIMIT_MEMLOCK, &new_rlimit);
         if res != 0 {
-            panic!("setrlimit failed with error code: {}", res);
+            panic!("setrlimit failed with error code: {res}");
         }
     };
 }

--- a/rust/scx_utils/src/pm.rs
+++ b/rust/scx_utils/src/pm.rs
@@ -30,13 +30,10 @@ pub fn update_cpu_idle_resume_latency(cpu_num: usize, value_us: i32) -> Result<(
         return Err(anyhow!("Latency value must be non-negative"));
     }
 
-    let path = format!(
-        "/sys/devices/system/cpu/cpu{}/power/pm_qos_resume_latency_us",
-        cpu_num
-    );
+    let path = format!("/sys/devices/system/cpu/cpu{cpu_num}/power/pm_qos_resume_latency_us");
 
     let mut file = File::create(Path::new(&path))?;
-    write!(file, "{}", value_us)?;
+    write!(file, "{value_us}")?;
     Ok(())
 }
 

--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -526,7 +526,7 @@ fn create_insert_cpu(
         llc_id: *llc_id,
         node_id: node.id,
         kernel_id: core_kernel_id,
-        cluster_id: cluster_id,
+        cluster_id,
     }));
     let core_mut = Arc::get_mut(core).unwrap();
 
@@ -572,7 +572,7 @@ fn read_cpu_ids() -> Result<Vec<usize>> {
     let cpu_paths = glob(&path)?;
     for cpu_path in cpu_paths.filter_map(Result::ok) {
         let cpu_str = cpu_path.to_str().unwrap().trim();
-        if *ROOT_PREFIX == "" {
+        if ROOT_PREFIX.is_empty() {
             match sscanf!(cpu_str, "/sys/devices/system/cpu/cpu{usize}") {
                 Ok(val) => cpu_ids.push(val),
                 Err(_) => {
@@ -750,7 +750,7 @@ fn create_numa_nodes(
     let numa_paths = glob(&path)?;
     for numa_path in numa_paths.filter_map(Result::ok) {
         let numa_str = numa_path.to_str().unwrap().trim();
-        let node_id = if *ROOT_PREFIX == "" {
+        let node_id = if ROOT_PREFIX.is_empty() {
             match sscanf!(numa_str, "/sys/devices/system/node/node{usize}") {
                 Ok(val) => val,
                 Err(_) => {
@@ -801,7 +801,7 @@ fn create_numa_nodes(
         let mut cpu_ids = vec![];
         for cpu_path in cpu_paths.filter_map(Result::ok) {
             let cpu_str = cpu_path.to_str().unwrap().trim();
-            let cpu_id = if *ROOT_PREFIX == "" {
+            let cpu_id = if ROOT_PREFIX.is_empty() {
                 match sscanf!(cpu_str, "/sys/devices/system/node/node{usize}/cpu{usize}") {
                     Ok((_, val)) => val,
                     Err(_) => {

--- a/rust/scx_utils/src/user_exit_info.rs
+++ b/rust/scx_utils/src/user_exit_info.rs
@@ -199,23 +199,23 @@ impl UserExitInfo {
             eprintln!(
                 "================================================================================\n"
             );
-            eprintln!("{}", dump);
+            eprintln!("{dump}");
             eprintln!(
                 "================================================================================\n"
             );
         }
 
         let why = match (&self.reason, &self.msg) {
-            (Some(reason), None) => format!("EXIT: {}", reason),
-            (Some(reason), Some(msg)) => format!("EXIT: {} ({})", reason, msg),
+            (Some(reason), None) => format!("EXIT: {reason}"),
+            (Some(reason), Some(msg)) => format!("EXIT: {reason} ({msg})"),
             _ => "<UNKNOWN>".into(),
         };
 
         if self.kind <= ScxExitKind::UnregKern as i32 {
-            eprintln!("{}", why);
+            eprintln!("{why}");
             Ok(())
         } else {
-            bail!("{}", why)
+            bail!("{why}")
         }
     }
 


### PR DESCRIPTION
mostly string formats and variables/const, useless cast after var shadowing first cast and more rust idioms usage overall.