### PR TITLE
scx_cosmos: Introduce flat idle CPU scan

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -27,6 +27,7 @@
 #include "user_exit_info.bpf.h"
 #include "enum_defs.autogen.h"
 
+#define PF_IDLE				0x00000002	/* I am an IDLE thread */
 #define PF_IO_WORKER			0x00000010	/* Task is an IO worker */
 #define PF_WQ_WORKER			0x00000020	/* I'm a workqueue worker */
 #define PF_KCOMPACTD			0x00010000      /* I am kcompactd */

--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -36,6 +36,11 @@ private(COSMOS) struct bpf_cpumask __kptr *primary_cpumask;
 const volatile bool primary_all = true;
 
 /*
+ * Enable flat iteration to find idle CPUs (fast but inaccurate).
+ */
+const volatile bool flat_idle_scan = true;
+
+/*
  * Enable cpufreq integration.
  */
 const volatile bool cpufreq_enabled = true;
@@ -235,6 +240,69 @@ static inline u64 shared_dsq(s32 cpu)
 }
 
 /*
+ * Return true if @p can only run on a single CPU, false otherwise.
+ */
+static inline bool is_pcpu_task(const struct task_struct *p)
+{
+	return p->nr_cpus_allowed == 1 || is_migration_disabled(p);
+}
+
+/*
+ * Return true if the system is busy, false otherwise.
+ *
+ * This function determines when the scheduler needs to switch to
+ * deadline-mode (using a shared DSQ) vs round-robin mode (using per-CPU
+ * local DSQs).
+ */
+static inline bool is_system_busy(void)
+{
+	return cpu_util >= busy_threshold;
+}
+
+/*
+ * Return true if the CPU is running the idle thread, false otherwise.
+ */
+static inline bool is_cpu_idle(s32 cpu)
+{
+	return scx_bpf_cpu_rq(cpu)->curr->flags & PF_IDLE;
+}
+
+/*
+ * Find an idle CPU iterating over the available CPUs, instead of relying
+ * on the idle cpumasks.
+ *
+ * This method might be inaccurate, but it's less expensive than operating
+ * on cpumasks with simple topologies, especially under light or moderate
+ * load.
+ */
+static s32 pick_idle_cpu_flat(struct task_struct *p, s32 prev_cpu)
+{
+	static s32 last_cpu;
+	s32 i;
+
+	if (is_cpu_idle(prev_cpu))
+		return prev_cpu;
+
+	if (is_pcpu_task(p))
+		return -EBUSY;
+
+	bpf_for(i, 0, nr_cpu_ids) {
+		s32 cpu = (last_cpu + i) % nr_cpu_ids;
+
+		if (cpu == prev_cpu)
+			continue;
+
+		if (bpf_cpumask_test_cpu(cpu, p->cpus_ptr) &&
+		    is_cpu_idle(cpu)) {
+			last_cpu = (cpu + 1) % nr_cpu_ids;
+			return cpu;
+		}
+	}
+
+	return -EBUSY;
+}
+
+/*
  * Pick an optimal idle CPU for task @p (as close as possible to
  * @prev_cpu).
  *
@@ -244,6 +312,13 @@ static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, u64 wake_flags, bo
 {
 	const struct cpumask *mask = cast_mask(primary_cpumask);
 	s32 cpu;
+
+	/*
+	 * Use the lightweight idle CPU scanning if flat idle scan is
+	 * enabled and all the CPUs are included in the primary domain.
+	 */
+	if (flat_idle_scan && primary_all && !is_system_busy())
+		return pick_idle_cpu_flat(p, prev_cpu);
 
 	/*
 	 * Clear the wake sync bit if synchronous wakeups are disabled.
@@ -285,11 +360,41 @@ static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, u64 wake_flags, bo
 }
 
 /*
- * Return true if @p can only run on a single CPU, false otherwise.
+ * Return a time slice scaled by the task's weight.
  */
-static inline bool is_pcpu_task(const struct task_struct *p)
+static u64 task_slice(const struct task_struct *p)
 {
-	return p->nr_cpus_allowed == 1 || is_migration_disabled(p);
+	return scale_by_task_weight(p, slice_ns);
+}
+
+/*
+ * Calculate and return the virtual deadline for the given task.
+ *
+ * The goal is to limit how much virtual time budget a sleeping task can
+ * accumulate.
+ *
+ * This budget is:
+ *   - proportional to the task's weight (heavier tasks get more),
+ *   - inversely proportional to the amount of CPU time the task has
+ *     accumulated since it last slept (exec_runtime).
+ *
+ * As a result:
+ *   - tasks that sleep often are rewarded with a longer budget,
+ *   - CPU-bound tasks accumulate less budget.
+ *
+ * Then the vruntime is clamped to a minimum value using this budget,
+ * preventing it from falling too far behind to avoid starvation and
+ * preserving fairness over time.
+ */
+static u64 task_dl(const struct task_struct *p, struct task_ctx *tctx)
+{
+	u64 vsleep_max = scale_by_task_weight(p, slice_lag - tctx->exec_runtime);
+	u64 vtime_min = vtime_now - vsleep_max;
+
+	if (time_before(tctx->vtime, vtime_min))
+		tctx->vtime = vtime_min;
+
+	return tctx->vtime;
 }
 
 /*
@@ -356,7 +461,7 @@ static int wakeup_timerfn(void *map, int *key, struct bpf_timer *timer)
 	 * wake-up the CPUs from there to reduce overhead in the hot path.
          */
 	bpf_for(cpu, 0, nr_cpu_ids)
-		if (scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | cpu))
+		if (scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | cpu) && is_cpu_idle(cpu))
 			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 
 	/*
@@ -367,56 +472,6 @@ static int wakeup_timerfn(void *map, int *key, struct bpf_timer *timer)
 		scx_bpf_error("Failed to re-arm wakeup timer");
 
 	return 0;
-}
-
-/*
- * Calculate and return the virtual deadline for the given task.
- *
- * The goal is to limit how much virtual time budget a sleeping task can
- * accumulate.
- *
- * This budget is:
- *   - proportional to the task's weight (heavier tasks get more),
- *   - inversely proportional to the amount of CPU time the task has
- *     accumulated since it last slept (exec_runtime).
- *
- * As a result:
- *   - tasks that sleep often are rewarded with a longer budget,
- *   - CPU-bound tasks accumulate less budget.
- *
- * Then the vruntime is clamped to a minimum value using this budget,
- * preventing it from falling too far behind to avoid starvation and
- * preserving fairness over time.
- */
-static u64 task_dl(const struct task_struct *p, struct task_ctx *tctx)
-{
-	u64 vsleep_max = scale_by_task_weight(p, slice_lag - tctx->exec_runtime);
-	u64 vtime_min = vtime_now - vsleep_max;
-
-	if (time_before(tctx->vtime, vtime_min))
-		tctx->vtime = vtime_min;
-
-	return tctx->vtime;
-}
-
-/*
- * Return a time slice scaled by the task's weight.
- */
-static u64 task_slice(const struct task_struct *p)
-{
-	return scale_by_task_weight(p, slice_ns);
-}
-
-/*
- * Return true if the system is busy, false otherwise.
- *
- * This function determines when the scheduler needs to switch to
- * deadline-mode (using a shared DSQ) vs round-robin mode (using per-CPU
- * local DSQs).
- */
-static inline bool is_system_busy(void)
-{
-	return cpu_util >= busy_threshold;
 }
 
 /*

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -98,6 +98,15 @@ struct Opts {
     #[clap(short = 'f', long, action = clap::ArgAction::SetTrue)]
     disable_cpufreq: bool,
 
+    /// Enable flat idle CPU scanning.
+    ///
+    /// This option can help reducing some overhead when trying to allocate idle CPUs and it can be
+    /// quite effective with simple CPU topologies.
+    ///
+    /// This option is automatically disabled if --primary-domain is used.
+    #[arg(short = 'i', action = clap::ArgAction::SetTrue)]
+    flat_idle_scan: bool,
+
     /// Disable direct dispatch during synchronous wakeups.
     ///
     /// Enabling this option can lead to a more uniform load distribution across available cores,
@@ -275,6 +284,7 @@ impl<'a> Scheduler<'a> {
         rodata.slice_ns = opts.slice_us * 1000;
         rodata.slice_lag = opts.slice_lag_us * 1000;
         rodata.cpufreq_enabled = !opts.disable_cpufreq;
+        rodata.flat_idle_scan = opts.flat_idle_scan;
         rodata.numa_enabled = opts.enable_numa;
         rodata.no_wake_sync = opts.no_wake_sync;
 


### PR DESCRIPTION
On systems with simple topologies, such as those without SMT and with all the CPUs on a single last-level cache (LLC), sequentially scanning CPUs can be more efficient than using cpumasks to locate idle ones.

Therefore, introduces the new option --flat-idle-scan / -i to enable such lightweight idle CPU scanning.

This mode can introduce inaccuracy and unbalanced CPU usage, but it can provide consistent improvements with certain benchmarks (i.e., heavy message passing workloads).