### PR TITLE
nix: switch to fenix to better pin rust dependencies

### DIFF
--- a/.github/include/flake.lock
+++ b/.github/include/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1752734526,
+        "narHash": "sha256-OIg7NwrqyYJVpXJdDgaagIzM0dtc4GghdncUrUsCgT8=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "f1526533e3a59a666dbae99594c9d29b201f302d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -56,10 +77,28 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "flake-utils": "flake-utils",
         "nix-develop-gha": "nix-develop-gha",
         "nixpkgs": "nixpkgs",
         "veristat-src": "veristat-src"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752687976,
+        "narHash": "sha256-juLg/AlXwda5fwewOJq42Q5T49wU131glK55BzKyhvU=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "152087654552a79f85e588da0a8de905436e62d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/scheds/rust/scx_chaos/src/lib.rs
+++ b/scheds/rust/scx_chaos/src/lib.rs
@@ -381,7 +381,7 @@ impl Builder<'_> {
                 skel.progs
                     .generic
                     .attach_kprobe(false, k)
-                    .context(format!("Failed to attach kprobe {:?}", k))?,
+                    .context(format!("Failed to attach kprobe {k:?}"))?,
             );
         }
         Ok(links)
@@ -859,7 +859,7 @@ pub fn run(args: Args) -> Result<()> {
     });
 
     if let Some(pid) = args.pid {
-        info!("Monitoring process with PID: {}", pid);
+        info!("Monitoring process with PID: {pid}");
 
         let is_process_running = |pid: libc::pid_t| -> bool {
             unsafe {

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -626,7 +626,7 @@ impl<'a> App<'a> {
                     "".to_string()
                 },
                 if self.hw_pressure && hw_pressure > 0 {
-                    format!("{}", hw_pressure)
+                    format!("{hw_pressure}")
                 } else {
                     "".to_string()
                 }
@@ -634,7 +634,7 @@ impl<'a> App<'a> {
             .text_value(if self.localize {
                 sanitize_nbsp(value.to_formatted_string(&self.locale))
             } else {
-                format!("{}", value)
+                format!("{value}")
             })
     }
 
@@ -697,7 +697,7 @@ impl<'a> App<'a> {
                                 "{}{}",
                                 perf,
                                 if self.pstate {
-                                    format!("/{}", pstate)
+                                    format!("/{pstate}")
                                 } else {
                                     "".to_string()
                                 }
@@ -709,7 +709,7 @@ impl<'a> App<'a> {
                             "".to_string()
                         },
                         if self.hw_pressure && hw_pressure > 0 {
-                            format!(" hw_pressure({})", hw_pressure)
+                            format!(" hw_pressure({hw_pressure})")
                         } else {
                             "".to_string()
                         }
@@ -1150,7 +1150,7 @@ impl<'a> App<'a> {
                         Line::from("".to_string())
                     })
                     .title_top(if render_title {
-                        Line::from(format!("{} ", event))
+                        Line::from(format!("{event} "))
                             .style(self.theme().title_style())
                             .left_aligned()
                     } else {
@@ -1213,12 +1213,12 @@ impl<'a> App<'a> {
                     sanitize_nbsp(min.to_formatted_string(&self.locale))
                 )
             } else {
-                format!("{:#X} avg {} max {} min {}", dsq, avg, max, min,)
+                format!("{dsq:#X} avg {avg} max {max} min {min}",)
             }))
             .text_value(if self.localize {
                 sanitize_nbsp(value.to_formatted_string(&self.locale))
             } else {
-                format!("{}", value)
+                format!("{value}")
             })
     }
 
@@ -1249,12 +1249,12 @@ impl<'a> App<'a> {
                     sanitize_nbsp(min.to_formatted_string(&self.locale))
                 )
             } else {
-                format!("{} avg {} max {} min {}", id, avg, max, min,)
+                format!("{id} avg {avg} max {max} min {min}",)
             }))
             .text_value(if self.localize {
                 sanitize_nbsp(value.to_formatted_string(&self.locale))
             } else {
-                format!("{}", value)
+                format!("{value}")
             })
     }
 
@@ -1427,7 +1427,7 @@ impl<'a> App<'a> {
                 .centered(),
             )
             .title_top(if render_sample_rate {
-                Line::from(format!("sample rate {}", sample_rate))
+                Line::from(format!("sample rate {sample_rate}"))
                     .style(self.theme().text_important_color())
                     .right_aligned()
             } else {

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -620,9 +620,9 @@ mod tests {
         assert!(config.tick_rate_ms.is_some());
         assert_eq!(config.tick_rate_ms.unwrap(), 250);
         assert!(config.debug.is_some());
-        assert_eq!(config.debug.unwrap(), false);
+        assert!(!config.debug.unwrap());
         assert!(config.exclude_bpf.is_some());
-        assert_eq!(config.exclude_bpf.unwrap(), false);
+        assert!(!config.exclude_bpf.unwrap());
 
         // Other fields should still be None or empty vec/KeyMap
         assert!(config.keymap.is_none());
@@ -816,11 +816,11 @@ mod tests {
         assert!(loaded_config
             .active_keymap
             .get(&parse_key("i").unwrap())
-            .map_or(false, |action| *action == Action::Quit));
+            .is_some_and(|action| *action == Action::Quit));
         assert!(loaded_config
             .active_keymap
             .get(&parse_key("2").unwrap())
-            .map_or(false, |action| *action == Action::Enter));
+            .is_some_and(|action| *action == Action::Enter));
     }
 
     #[test]
@@ -916,10 +916,10 @@ mod tests {
         assert!(config
             .active_keymap
             .get(&parse_key("i").unwrap())
-            .map_or(false, |action| *action == Action::Quit));
+            .is_some_and(|action| *action == Action::Quit));
         assert!(config
             .active_keymap
             .get(&parse_key("o").unwrap())
-            .map_or(false, |action| *action == Action::NextViewState));
+            .is_some_and(|action| *action == Action::NextViewState));
     }
 }

--- a/tools/scxtop/src/cpu_stats.rs
+++ b/tools/scxtop/src/cpu_stats.rs
@@ -198,7 +198,7 @@ mod tests {
 
         std::thread::sleep(std::time::Duration::from_secs(1));
 
-        tracker.update(&proc_reader, &mut *sys_guard)?;
+        tracker.update(&proc_reader, &mut sys_guard)?;
 
         assert!(!tracker.prev.is_empty());
         assert!(!tracker.current.is_empty());

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -22,8 +22,8 @@ pub enum Key {
 impl std::fmt::Display for Key {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Key::Char(c) => write!(f, "{}", c),
-            Key::Code(c) => write!(f, "{}", c),
+            Key::Char(c) => write!(f, "{c}"),
+            Key::Code(c) => write!(f, "{c}"),
         }
     }
 }
@@ -125,7 +125,7 @@ impl KeyMap {
     pub fn to_hashmap(&self) -> HashMap<String, String> {
         let mut map = HashMap::new();
         for (key, action) in &self.bindings {
-            map.insert(format!("{}", key), format!("{}", action));
+            map.insert(format!("{key}"), format!("{action}"));
         }
         map
     }
@@ -333,8 +333,7 @@ impl From<KeyCodeWrapper> for KeyCode {
 pub fn parse_key(key_str: &str) -> Result<Key> {
     if key_str.len() == 1 {
         Ok(Key::Char(key_str.chars().next().unwrap()))
-    } else if let Ok(keycode_wrapper) =
-        toml::from_str::<KeyCodeWrapper>(&format!("\"{}\"", key_str))
+    } else if let Ok(keycode_wrapper) = toml::from_str::<KeyCodeWrapper>(&format!("\"{key_str}\""))
     {
         Ok(Key::Code(keycode_wrapper.into()))
     } else {

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -645,7 +645,7 @@ impl std::fmt::Display for Action {
             Action::PageDown => write!(f, "PageDown"),
             Action::PageUp => write!(f, "PageUp"),
             Action::Enter => write!(f, "Enter"),
-            _ => write!(f, "{:?}", self),
+            _ => write!(f, "{self:?}"),
         }
     }
 }

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -283,7 +283,7 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
                             .expect("Action should have been resolved");
                     } else {
                         trace_manager.stop(trace_file, None).unwrap();
-                        info!("trace file compiled, collected {} events", count);
+                        info!("trace file compiled, collected {count} events");
                         break;
                     }
                 }
@@ -302,12 +302,12 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
             let results = join_all(handles).await;
             for result in results {
                 if let Err(e) = result {
-                    eprintln!("Task panicked: {}", e);
+                    eprintln!("Task panicked: {e}");
                 }
             }
 
             let stats = tracer.stats()?;
-            info!("{:?}", stats);
+            info!("{stats:?}");
 
             Ok(())
         })
@@ -499,7 +499,7 @@ fn main() -> Result<()> {
         }
         Commands::GenerateCompletions { shell, output } => {
             generate_completions(Cli::command(), *shell, output.clone())
-                .unwrap_or_else(|_| panic!("Failed to generate completions for {}", shell));
+                .unwrap_or_else(|_| panic!("Failed to generate completions for {shell}"));
         }
     }
     Ok(())

--- a/tools/scxtop/src/profiling_events/cpu_util.rs
+++ b/tools/scxtop/src/profiling_events/cpu_util.rs
@@ -238,7 +238,7 @@ mod tests {
 
         let tracker = Arc::new(RwLock::new(tracker));
         let event = CpuUtilEvent::new(0, CpuUtilMetric::Frequency, tracker);
-        println!("{:?}", event);
+        println!("{event:?}");
         println!("{:?}", event.value());
 
         assert_eq!(event.value().unwrap(), 75);

--- a/tools/scxtop/src/profiling_events/kprobe.rs
+++ b/tools/scxtop/src/profiling_events/kprobe.rs
@@ -45,7 +45,7 @@ fn resolve_kfunc_address(name: &str) -> Option<u64> {
         .expect("Failed to open /proc/kallsyms. Make sure CONFIG_KALLSYMS is enabled.");
     let reader = BufReader::new(file);
     for line in reader.lines().map_while(std::io::Result::ok) {
-        if line.ends_with(&format!(" {}", name)) {
+        if line.ends_with(&format!(" {name}")) {
             if let Some(addr_str) = line.split_whitespace().next() {
                 if let Ok(addr) = u64::from_str_radix(addr_str, 16) {
                     return Some(addr);

--- a/tools/scxtop/src/profiling_events/perf.rs
+++ b/tools/scxtop/src/profiling_events/perf.rs
@@ -36,7 +36,7 @@ pub fn read_file_u64<P: AsRef<Path>>(path: P) -> Result<u64> {
     let trimmed_contents = contents.trim();
 
     u64::from_str(trimmed_contents)
-        .with_context(|| format!("Failed to parse u64 from '{}'", contents))
+        .with_context(|| format!("Failed to parse u64 from '{contents}'"))
 }
 
 /// Returns the config value for the perf event.

--- a/tools/scxtop/src/search.rs
+++ b/tools/scxtop/src/search.rs
@@ -315,7 +315,7 @@ mod tests {
         let search = Search::new(events);
         let results = search.fuzzy_search("alarm");
 
-        let expected_matches = vec![
+        let expected_matches = [
             "alarmtimer:alarmtimer_suspend",
             "alarmtimer:alarmtimer_fired",
             "alarmtimer:alarmtimer_cancel",
@@ -324,8 +324,7 @@ mod tests {
         for expected in expected_matches.iter() {
             assert!(
                 results.contains(&expected.to_string()),
-                "Missing expected match: {}",
-                expected
+                "Missing expected match: {expected}"
             );
         }
 
@@ -374,7 +373,7 @@ mod tests {
         assert_eq!(results[0], "alarmtimer:alarmtimer_cancel".to_string());
 
         let results = search.fuzzy_search("alarm");
-        let expected_matches = vec![
+        let expected_matches = [
             "alarmtimer:alarmtimer_suspend",
             "alarmtimer:alarmtimer_fired",
             "alarmtimer:alarmtimer_cancel",
@@ -383,8 +382,7 @@ mod tests {
         for expected in expected_matches.iter() {
             assert!(
                 results.contains(&expected.to_string()),
-                "Missing expected match: {}",
-                expected
+                "Missing expected match: {expected}"
             );
         }
 

--- a/tools/scxtop/src/util.rs
+++ b/tools/scxtop/src/util.rs
@@ -19,7 +19,7 @@ pub fn read_file_string(path: &str) -> Result<String> {
 /// Formats a value in hz to human readable.
 pub fn format_hz(hz: u64) -> String {
     match hz {
-        0..=999 => format!("{}Hz", hz),
+        0..=999 => format!("{hz}Hz"),
         1_000..=999_999 => format!("{:.0}MHz", hz as f64 / 1_000.0),
         1_000_000..=999_999_999 => format!("{:.3}GHz", hz as f64 / 1_000_000.0),
         _ => format!("{:.3}THz", hz as f64 / 1_000_000_000.0),


### PR DESCRIPTION
Currently CI and anyone using the Nix flake gets their rust dependencies from nixpkgs. This is generally fine as they are locked, but we have less control over which version is selected than with tools like rustup.

Switch to fenix[1] which gives equivalent control to rustup. This enables testing on nightly toolchains with a simple change. It's mostly an ergonomic benefit for now. Required some minor clippy fixes for the updated clippy version.

Test plan:
- CI

[1] https://github.com/nix-community/fenix