### PR TITLE
ci: add required-checks job

### DIFF
--- a/.github/include/flake.nix
+++ b/.github/include/flake.nix
@@ -96,7 +96,6 @@
               buildInputs = with pkgs; gha-common-pkgs ++ [
                 gawk
                 jq
-                jq
               ];
             };
 

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -45,6 +45,19 @@ jobs:
     needs: build-kernels
     secrets: inherit
 
+  required-checks:
+    needs: [
+      rust-tests,
+      integration-test,
+    ]
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64", "metal:nixos" ]') || 'ubuntu-latest' }}
+    if: always()
+    env:
+      NEEDS_CONTEXT: ${{ toJSON(needs) }}
+    steps:
+      - run: nix run ./.github/include#nix-develop-gha -- ./.github/include#gha-build-kernels
+      - run: echo "$NEEDS_CONTEXT" | jq -e 'to_entries | all(.value.result == "success")'
+
   pages:
     runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -133,14 +133,11 @@ jobs:
           compression-level: 9
 
   all-success:
-    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64", "metal:nixos" ]') || 'ubuntu-latest' }}
     needs: integration-test
+    runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64", "metal:nixos" ]') || 'ubuntu-latest' }}
     if: always()
+    env:
+      NEEDS_CONTEXT: ${{ toJSON(needs) }}
     steps:
-      - name: Check all jobs succeeded
-        run: |
-          if [[ "${{ needs.integration-test.result }}" != "success" ]]; then
-            echo "Integration tests failed or were cancelled"
-            exit 1
-          fi
-          echo "All integration tests passed successfully"
+      - run: nix run ./.github/include#nix-develop-gha -- ./.github/include#gha-build-kernels
+      - run: echo "$NEEDS_CONTEXT" | jq -e 'to_entries | all(.value.result == "success")'


### PR DESCRIPTION
GitHub branch protection rules aren't defined in the code and changes to them have to be made by administrators instead of the usual code review process. This is inconvenient for two reasons: external contributors can't help with many CI changes, and any changes to them require every PR to be rebased before it'll pass the CI.

Add a `required-checks` job to replace the `rust-tests` and `integration-test/all-success` requirements currently in the branch rule. `integration-test/all-success` already partially covers this for adding/removing integration tests, but we don't have an equivalent for caching-build. Adding this job and making it the requirement makes splitting `rust-tests` for better parallelism less annoying, for example. Will enable this check in the CI after this has bedded in for a few days so most contributions will already have it.

Test plan:
- CI