### PR TITLE
scx_bpf_compat: add crate to detect difficult kernel features and use in layered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,6 +2794,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scx_bpf_compat"
+version = "1.0.14"
+dependencies = [
+ "anyhow",
+ "libbpf-rs",
+ "log",
+ "once_cell",
+ "scx_utils",
+]
+
+[[package]]
 name = "scx_bpf_unittests"
 version = "0.1.0"
 dependencies = [
@@ -2922,6 +2933,7 @@ dependencies = [
  "nix 0.29.0",
  "nvml-wrapper",
  "once_cell",
+ "scx_bpf_compat",
  "scx_stats",
  "scx_stats_derive",
  "scx_utils",

--- a/rust/scx_bpf_compat/Cargo.toml
+++ b/rust/scx_bpf_compat/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "scx_bpf_compat"
+version = "1.0.14"
+edition = "2021"
+description = "BPF compatibility testing utilities for sched_ext"
+license = "GPL-2.0-only"
+authors = ["Jake Hillion <jake@hillion.co.uk>"]
+repository = "https://github.com/sched-ext/scx"
+homepage = "https://github.com/sched-ext/scx"
+
+[package.metadata.scx]
+ci.use_clippy = true
+
+[dependencies]
+scx_utils = { path = "../scx_utils", version = "1.0.17" }
+
+anyhow = "1.0.65"
+libbpf-rs = "=0.25.0"
+log = "0.4.17"
+once_cell = "1.20.2"
+
+[build-dependencies]
+scx_utils = { path = "../scx_utils", version = "1.0.17" }

--- a/rust/scx_bpf_compat/build.rs
+++ b/rust/scx_bpf_compat/build.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+fn main() {
+    scx_utils::BpfBuilder::new()
+        .unwrap()
+        .enable_skel("src/bpf/main.bpf.c", "bpf")
+        .compile_link_gen()
+        .unwrap();
+}

--- a/rust/scx_bpf_compat/src/bpf/main.bpf.c
+++ b/rust/scx_bpf_compat/src/bpf/main.bpf.c
@@ -1,0 +1,31 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+#include <vmlinux.h>
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+char _license[] SEC("license") = "GPL";
+
+/*
+ * Test program to verify if kfuncs are supported in syscall programs.
+ * This program tries to call bpf_cpumask_create() and bpf_cpumask_release()
+ * which are kfuncs that should be available if the kernel supports
+ * calling kfuncs from syscall programs (commit a8e03b6bbb2c).
+ */
+SEC("syscall")
+int BPF_PROG(kfuncs_test_syscall)
+{
+	struct bpf_cpumask *mask;
+
+	mask = bpf_cpumask_create();
+	if (!mask)
+		return -1;
+	bpf_cpumask_release(mask);
+
+	return 0;
+}

--- a/rust/scx_bpf_compat/src/bpf_skel.rs
+++ b/rust/scx_bpf_compat/src/bpf_skel.rs
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+
+include!(concat!(env!("OUT_DIR"), "/bpf_skel.rs"));

--- a/rust/scx_bpf_compat/src/lib.rs
+++ b/rust/scx_bpf_compat/src/lib.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+mod bpf_skel;
+
+use crate::bpf_skel::BpfSkelBuilder;
+
+use std::mem::MaybeUninit;
+
+use anyhow::Result;
+use libbpf_rs::skel::{OpenSkel, SkelBuilder};
+use libbpf_rs::ProgramType;
+use once_cell::sync::OnceCell;
+use scx_utils::compat::ksym_exists;
+
+/// Check if kernel supports calling kfuncs from SYSCALL programs.
+/// This was introduced in kernel commit a8e03b6bbb2c
+/// "bpf: Allow invoking kfuncs from BPF_PROG_TYPE_SYSCALL progs"
+pub fn kfuncs_supported_in_syscall() -> Result<bool> {
+    static MEMO: OnceCell<bool> = OnceCell::new();
+
+    MEMO.get_or_try_init(|| {
+        if !ProgramType::Syscall.is_supported()? {
+            return Ok(false);
+        }
+        if !ksym_exists("bpf_cpumask_create")? {
+            return Ok(false);
+        }
+        if !ksym_exists("bpf_cpumask_release")? {
+            return Ok(false);
+        }
+
+        let skel_builder = BpfSkelBuilder::default();
+        let mut open_object = MaybeUninit::uninit();
+
+        let mut open_skel = skel_builder.open(&mut open_object)?;
+        for mut prog in open_skel.open_object_mut().progs_mut() {
+            prog.set_autoload(prog.name() == "kfuncs_test_syscall");
+        }
+
+        let ret = match open_skel.load() {
+            Ok(_) => true,
+            Err(e) => {
+                log::trace!("rejecting program for `kfuncs_supported_in_syscall` with error: {e}");
+                false
+            }
+        };
+
+        Ok(ret)
+    })
+    .copied()
+}

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -19,6 +19,7 @@ lazy_static = "1.5.0"
 libbpf-rs = "=0.25.0"
 libc = "0.2.137"
 log = "0.4.17"
+scx_bpf_compat = { path = "../../../rust/scx_bpf_compat", version = "1.0.14" }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }


### PR DESCRIPTION
It is an unfortunate fact of the world that Frankenkernels exist. Often these are extremely hard to detect, particularly when it comes to the BPF verifier - the only reliable way is to load a BPF program and judge the behaviour.

In this initial example, layered fails to load on a kernel missing a8e03b6bbb2c: bpf: Allow invoking kfuncs from BPF_PROG_TYPE_SYSCALL progs. The workaround for this is pretty simple but regresses performance on kernels that don't need it.

Add a crate `scx_bpf_compat` with a generated skel that uses scx_utils BpfBuilder (the reason this utility isn't in scx_utils). It contains a function `kfuncs_supported_in_syscall` that can be used to test whether a kernel allows calling kfuncs inside a SYSCALL prog type.

Use this new utility in layered to upstream a patch needed for kernels like this.

Test plan:
- CI

On upstream 6.15.4:
```
jake@rooster:/data/users/jake/repos/scx/ > cargo build --release -p scx_layered && sudo target/release/scx_layered --run-example
warning: /data/users/jake/repos/scx/Cargo.toml: unused manifest key: profile.release-fast.target-cpu
warning: /data/users/jake/repos/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
    Finished `release` profile [optimized] target(s) in 0.17s
16:30:02 [INFO] Topology awareness not specified, selecting enabled based on hardware
16:30:02 [INFO] CPUs: online/possible=96/96 nr_cores=48
16:30:02 [INFO] Running scx_layered (build ID: 1.0.15-g6ac853b4 x86_64-unknown-linux-gnu)
16:30:03 [INFO] libbpf: struct_ops layered: member priv not found in kernel, skipping it as it's set to zero

16:30:03 [WARN] libbpf: map 'layered': BPF map skeleton link is uninitialized

16:30:03 [INFO] Layered Scheduler Attached. Run `scx_layered --monitor` for metrics.
^CEXIT: unregistered from user space
```

Modern kernel:
```
[jakehillion@devbig002]/data/users/jakehillion/scx% cargo build --release -p scx_layered && sudo target/release/scx_layered --run-example
warning: /data/users/jakehillion/scx/Cargo.toml: unused manifest key: profile.release-fast.target-cpu
warning: /data/users/jakehillion/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
    Finished `release` profile [optimized] target(s) in 0.11s
16:30:22 [INFO] Topology awareness not specified, selecting enabled based on hardware
16:30:22 [INFO] CPUs: online/possible=176/176 nr_cores=88
16:30:23 [INFO] Running scx_layered (build ID: 1.0.15-g6ac853b4 x86_64-unknown-linux-gnu)
16:30:23 [INFO] libbpf: struct_ops layered: member priv not found in kernel, skipping it as it's set to zero

16:30:23 [WARN] libbpf: map 'layered': BPF map skeleton link is uninitialized

16:30:23 [INFO] Layered Scheduler Attached. Run `scx_layered --monitor` for metrics.
^CEXIT: unregistered from user space
```

Frankenkernel:
```
[jakehillion@devbig036]/data/users/jakehillion/scx% cargo build --release -p scx_layered &&  sudo target/release/scx_layered --run-example
warning: /data/users/jakehillion/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
warning: /data/users/jakehillion/scx/Cargo.toml: unused manifest key: profile.release-fast.target-cpu
   Compiling scx_layered v1.0.15 (/data/users/jakehillion/scx/scheds/rust/scx_layered)
    Finished `release` profile [optimized] target(s) in 10.15s
16:32:12 [INFO] Topology awareness not specified, selecting enabled based on hardware
16:32:12 [INFO] CPUs: online/possible=80/80 nr_cores=40
16:32:12 [WARN] libbpf: prog 'kfuncs_test_syscall': BPF program load failed: Permission denied

16:32:12 [WARN] libbpf: prog 'kfuncs_test_syscall': -- BEGIN PROG LOAD LOG --
0: R1=ctx() R10=fp0
; mask = bpf_cpumask_create();
0: (85) call bpf_cpumask_create#67588
calling kernel function bpf_cpumask_create is not allowed
processed 1 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0
-- END PROG LOAD LOG --

16:32:12 [WARN] libbpf: prog 'kfuncs_test_syscall': failed to load: -13

16:32:12 [WARN] libbpf: failed to load object 'bpf_bpf'

16:32:12 [WARN] libbpf: failed to load BPF skeleton 'bpf_bpf': -13

16:32:12 [WARN] Using slow path: kfuncs not supported in syscall programs (a8e03b6bbb2c ∉ ker)
16:32:12 [INFO] Running scx_layered (build ID: 1.0.15-g6ac853b4 x86_64-unknown-linux-gnu)
16:32:12 [INFO] Kernel does not support queued wakeup optimization
16:32:14 [INFO] Layered Scheduler Attached. Run `scx_layered --monitor` for metrics.
^CEXIT: unregistered from user space
```