### PR TITLE
scxtop: fix trace

### DIFF
--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -921,7 +921,7 @@ int BPF_PROG(on_sched_exec, struct task_struct *p, u32 old_pid, struct linux_bin
 	return 0;
 }
 
-SEC("?tp_btf/sched_process_wait")
+SEC("tp_btf/sched_process_wait")
 int BPF_PROG(on_sched_wait, struct pid *pid)
 {
 	struct bpf_event *event;
@@ -938,9 +938,9 @@ int BPF_PROG(on_sched_wait, struct pid *pid)
 	event->ts = bpf_ktime_get_ns();
 	p = (struct task_struct *)bpf_get_current_task();
 	if (p) {
-		record_real_comm(event->event.wait.comm, p);
+		bpf_core_read_str(&event->event.wait.comm, sizeof(event->event.wait.comm), &p->comm);
 		event->event.wait.pid = BPF_CORE_READ(p, pid);
-		event->event.wait.prio = (int)p->prio;
+		event->event.wait.prio = BPF_CORE_READ(p, prio);
 	} else {
 		__builtin_memset(event->event.wait.comm, 0, MAX_COMM);
 		event->event.wait.pid = 0;

--- a/tools/scxtop/src/proc_data.rs
+++ b/tools/scxtop/src/proc_data.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use crate::EventData;
+use crate::ThreadData;
+
+use fb_procfs::PidState;
+use std::collections::BTreeMap;
+use std::collections::VecDeque;
+
+/// Container for per CPU data.
+#[derive(Clone, Debug)]
+pub struct ProcData {
+    pub tgid: i32,
+    pub process_name: String,
+    pub cpu: i32,
+    pub dsq: Option<usize>,
+    pub state: PidState,
+    pub cmdline: Vec<String>,
+    pub running_secs: u64,
+    pub threads: BTreeMap<i32, ThreadData>,
+    pub data: EventData,
+    pub max_data_size: usize,
+}
+
+impl ProcData {
+    /// Creates a new CpuData.
+    pub fn new(
+        tgid: i32,
+        process_name: String,
+        cpu: i32,
+        dsq: Option<usize>,
+        state: PidState,
+        cmdline: Vec<String>,
+        running_secs: u64,
+        max_data_size: usize,
+    ) -> ProcData {
+        Self {
+            tgid,
+            process_name,
+            cpu,
+            dsq,
+            state,
+            cmdline,
+            running_secs,
+            threads: BTreeMap::new(),
+            data: EventData::new(max_data_size),
+            max_data_size,
+        }
+    }
+
+    pub fn get_default_events(&self) -> Vec<String> {
+        vec!["cpu-utilization".to_string()]
+    }
+
+    /// Initializes events with default values.
+    pub fn initialize_events(&mut self, events: &[&str]) {
+        self.data.initialize_events(events);
+    }
+
+    /// Returns the data for an event and updates if no entry is present.
+    pub fn event_data(&mut self, event: &str) -> &VecDeque<u64> {
+        self.data.event_data(event)
+    }
+
+    /// Returns the data for an event and updates if no entry is present.
+    pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
+        self.data.event_data_immut(event)
+    }
+
+    /// Adds data for an event.
+    pub fn add_event_data(&mut self, event: &str, val: u64) {
+        self.data.add_event_data(event, val)
+    }
+}

--- a/tools/scxtop/src/thread_data.rs
+++ b/tools/scxtop/src/thread_data.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use crate::EventData;
+
+use std::collections::VecDeque;
+
+/// Container for per CPU data.
+#[derive(Clone, Debug)]
+pub struct ThreadData {
+    pub pid: i32,
+    pub tgid: i32,
+    pub data: EventData,
+    pub max_data_size: usize,
+}
+
+impl ThreadData {
+    /// Creates a new CpuData.
+    pub fn new(tgid: i32, pid: i32, max_data_size: usize) -> ThreadData {
+        Self {
+            pid,
+            tgid,
+            data: EventData::new(max_data_size),
+            max_data_size,
+        }
+    }
+
+    /// Initializes events with default values.
+    pub fn initialize_events(&mut self, events: &[&str]) {
+        self.data.initialize_events(events);
+    }
+
+    /// Returns the data for an event and updates if no entry is present.
+    pub fn event_data(&mut self, event: &str) -> &VecDeque<u64> {
+        self.data.event_data(event)
+    }
+
+    /// Returns the data for an event and updates if no entry is present.
+    pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
+        self.data.event_data_immut(event)
+    }
+
+    /// Adds data for an event.
+    pub fn add_event_data(&mut self, event: &str, val: u64) {
+        self.data.add_event_data(event, val)
+    }
+}


### PR DESCRIPTION
#2398 breaks `scxtop trace` with:
```
libbpf: prog 'on_sched_wait': can't attach BPF program without FD (was it loaded?)
Error: failed to attach BPF program

Caused by:
    Invalid argument (os error 22)
```
(I believe due to the `?` in the BPF method and not [autoloading](https://github.com/sched-ext/scx/blob/d4dd7b1bc73028af5e9a65ee409633cd00b5c8f2/rust/scx_utils/src/compat.rs#L233).) This fixes that by removing the cond (I don't see a reason for this to be cond) and satisfying the verifier.

We also should add the `scxtop trace` command to the CI to ensure it runs without errors (I incorrectly assumed that we did..).