### PR TITLE
scx_lavd: Mostly refactoring and clean up, and one preemption optimization.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -145,10 +145,10 @@ struct cpu_ctx {
 	 * Information of a current running task for preemption
 	 */
 	volatile u64	stopping_tm_est_ns; /* estimated stopping time */
+	volatile u64	flags;		/* cached copy of task's flags */
 	volatile s32	futex_op;	/* futex op in futex V1 */
 	volatile u16	lat_cri;	/* latency criticality */
 	volatile u8	is_online;	/* is this CPU online? */
-	volatile u8	lock_holder;	/* is a lock holder running */
 
 	/*
 	 * Information for CPU frequency scaling

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -144,7 +144,7 @@ struct cpu_ctx {
 	/*
 	 * Information of a current running task for preemption
 	 */
-	volatile u64	stopping_tm_est_ns; /* estimated stopping time */
+	volatile u64	est_stopping_clk; /* estimated stopping time */
 	volatile u64	flags;		/* cached copy of task's flags */
 	volatile s32	futex_op;	/* futex op in futex V1 */
 	volatile u16	lat_cri;	/* latency criticality */

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -144,6 +144,7 @@ struct cpu_ctx {
 	/*
 	 * Information of a current running task for preemption
 	 */
+	volatile u64	running_clk;	/* when a task starts running */
 	volatile u64	est_stopping_clk; /* estimated stopping time */
 	volatile u64	flags;		/* cached copy of task's flags */
 	volatile s32	futex_op;	/* futex op in futex V1 */

--- a/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
@@ -18,7 +18,7 @@ static void __inc_futex_boost(struct cpu_ctx *cpuc)
 
 		if (cpuc) {
 			set_task_flag(taskc, LAVD_FLAG_FUTEX_BOOST);
-			cpuc->lock_holder = true;
+			cpuc->flags = taskc->flags;
 		}
 	}
 	/*
@@ -37,7 +37,7 @@ static void __dec_futex_boost(struct cpu_ctx *cpuc)
 
 		if (cpuc) {
 			reset_task_flag(taskc, LAVD_FLAG_FUTEX_BOOST);
-			cpuc->lock_holder = false;
+			cpuc->flags = taskc->flags;
 		}
 	}
 	/*
@@ -61,7 +61,7 @@ static void reset_lock_futex_boost(struct task_ctx *taskc, struct cpu_ctx *cpuc)
 		set_task_flag(taskc, LAVD_FLAG_NEED_LOCK_BOOST);
 
 	reset_task_flag(taskc, LAVD_FLAG_FUTEX_BOOST);
-	cpuc->lock_holder = false;
+	cpuc->flags = taskc->flags;
 }
 
 /**

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -904,6 +904,7 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 	 */
 	cpuc->flags = taskc->flags;
 	cpuc->lat_cri = taskc->lat_cri;
+	cpuc->running_clk = now;
 	cpuc->est_stopping_clk = get_est_stopping_clk(taskc, now);
 
 	/*
@@ -978,6 +979,7 @@ unlock_out:
 	cpuc->flags = 0;
 	cpuc->idle_start_clk = 0;
 	cpuc->lat_cri = 0;
+	cpuc->running_clk = 0;
 	cpuc->est_stopping_clk = SCX_SLICE_INF;
 	WRITE_ONCE(cpuc->online_clk, now);
 	barrier();
@@ -1004,6 +1006,7 @@ unlock_out:
 	barrier();
 
 	cpuc->lat_cri = 0;
+	cpuc->running_clk = 0;
 	cpuc->est_stopping_clk = SCX_SLICE_INF;
 }
 
@@ -1430,6 +1433,7 @@ static s32 init_per_cpu_ctx(u64 now)
 		cpuc->cpu_id = cpu;
 		cpuc->idle_start_clk = 0;
 		cpuc->lat_cri = 0;
+		cpuc->running_clk = 0;
 		cpuc->est_stopping_clk = SCX_SLICE_INF;
 		cpuc->online_clk = now;
 		cpuc->offline_clk = now;

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -574,7 +574,7 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 	 * from dsq_id. The kick will be done asynchronously.
 	 */
 	if (!no_preemption)
-		try_find_and_kick_victim_cpu(p, taskc, dsq_id);
+		try_find_and_kick_victim_cpu(p, taskc, cpu, dsq_id);
 }
 
 void BPF_STRUCT_OPS(lavd_dispatch, s32 cpu, struct task_struct *prev)

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -904,7 +904,7 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 	 */
 	cpuc->flags = taskc->flags;
 	cpuc->lat_cri = taskc->lat_cri;
-	cpuc->stopping_tm_est_ns = get_est_stopping_time(taskc, now);
+	cpuc->est_stopping_clk = get_est_stopping_clk(taskc, now);
 
 	/*
 	 * If there is a relevant introspection command with @p, process it.
@@ -978,7 +978,7 @@ unlock_out:
 	cpuc->flags = 0;
 	cpuc->idle_start_clk = 0;
 	cpuc->lat_cri = 0;
-	cpuc->stopping_tm_est_ns = SCX_SLICE_INF;
+	cpuc->est_stopping_clk = SCX_SLICE_INF;
 	WRITE_ONCE(cpuc->online_clk, now);
 	barrier();
 
@@ -1004,7 +1004,7 @@ unlock_out:
 	barrier();
 
 	cpuc->lat_cri = 0;
-	cpuc->stopping_tm_est_ns = SCX_SLICE_INF;
+	cpuc->est_stopping_clk = SCX_SLICE_INF;
 }
 
 void BPF_STRUCT_OPS(lavd_cpu_online, s32 cpu)
@@ -1430,7 +1430,7 @@ static s32 init_per_cpu_ctx(u64 now)
 		cpuc->cpu_id = cpu;
 		cpuc->idle_start_clk = 0;
 		cpuc->lat_cri = 0;
-		cpuc->stopping_tm_est_ns = SCX_SLICE_INF;
+		cpuc->est_stopping_clk = SCX_SLICE_INF;
 		cpuc->online_clk = now;
 		cpuc->offline_clk = now;
 		cpuc->cpu_release_clk = now;

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -300,25 +300,6 @@ static void update_stat_for_running(struct task_struct *p,
 	struct cpu_ctx *prev_cpuc;
 
 	/*
-	 * If the sched_ext core directly dispatched a task, calculating the
-	 * task's deadline and time slice was also skipped. In this case, we
-	 * set the deadline and time slice here.
-	 *
-	 * Note that this is necessary when the kernel does not support
-	 * SCX_OPS_ENQ_MIGRATION_DISABLED or SCX_OPS_ENQ_MIGRATION_DISABLED
-	 * is not turned on.
-	 */
-	if (p->scx.slice == SCX_SLICE_DFL) {
-		p->scx.dsq_vtime = READ_ONCE(cur_logical_clk);
-		p->scx.slice = calc_time_slice(taskc);
-	}
-
-	/*
-	 * Update the current logical clock.
-	 */
-	advance_cur_logical_clk(p);
-
-	/*
 	 * Since this is the start of a new schedule for @p, we update run
 	 * frequency in a second using an exponential weighted moving average.
 	 */
@@ -361,7 +342,7 @@ static void update_stat_for_running(struct task_struct *p,
 	cpuc->nr_sched++;
 
 	/*
-	 * Update per-CPU performanc criticality information
+	 * Update per-CPU performance criticality information
 	 * for every-scheduled tasks.
 	 */
 	if (have_little_core) {
@@ -371,6 +352,14 @@ static void update_stat_for_running(struct task_struct *p,
 			cpuc->min_perf_cri = taskc->perf_cri;
 		cpuc->sum_perf_cri += taskc->perf_cri;
 	}
+
+	/*
+	 * Update running task's information for preemption
+	 */
+	cpuc->flags = taskc->flags;
+	cpuc->lat_cri = taskc->lat_cri;
+	cpuc->running_clk = now;
+	cpuc->est_stopping_clk = get_est_stopping_clk(taskc, now);
 
 	/*
 	 * Update statistics information.
@@ -491,7 +480,7 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 
 		if (!scx_bpf_dsq_nr_queued(dsq_id)) {
 			p->scx.dsq_vtime = calc_when_to_run(p, taskc);
-			p->scx.slice = calc_time_slice(taskc);
+			p->scx.slice = LAVD_SLICE_MAX_NS_DFL;
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, p->scx.slice, 0);
 			goto out;
 		}
@@ -541,7 +530,7 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 
 		p->scx.dsq_vtime = calc_when_to_run(p, taskc);
 	}
-	p->scx.slice = calc_time_slice(taskc);
+	p->scx.slice = LAVD_SLICE_MAX_NS_DFL;
 
 	/*
 	 * Find a proper DSQ for the task, which is either the task's
@@ -874,9 +863,6 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 	struct task_ctx *taskc;
 	u64 now = scx_bpf_now();
 
-	/*
-	 * Update task statistics
-	 */
 	cpuc = get_cpu_ctx_task(p);
 	taskc = get_task_ctx(p);
 	if (!cpuc || !taskc) {
@@ -884,12 +870,33 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 		return;
 	}
 
-	update_stat_for_running(p, taskc, cpuc, now);
+	/*
+	 * If the sched_ext core directly dispatched a task, calculating the
+	 * task's deadline and time slice was also skipped. In this case, we
+	 * set the deadline to the current logical lock.
+	 *
+	 * Note that this is necessary when the kernel does not support
+	 * SCX_OPS_ENQ_MIGRATION_DISABLED or SCX_OPS_ENQ_MIGRATION_DISABLED
+	 * is not turned on.
+	 */
+	if (p->scx.slice == SCX_SLICE_DFL)
+		p->scx.dsq_vtime = READ_ONCE(cur_logical_clk);
 
 	/*
-	 * Calculate the task's time slice.
+	 * Calculate the task's time slice here,
+	 * as it depends on the system load.
 	 */
 	p->scx.slice = calc_time_slice(taskc);
+
+	/*
+	 * Update the current logical clock.
+	 */
+	advance_cur_logical_clk(p);
+
+	/*
+	 * Update task statistics
+	 */
+	update_stat_for_running(p, taskc, cpuc, now);
 
 	/*
 	 * Calculate the task's CPU performance target and update if the new
@@ -898,14 +905,6 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 	 * gradually according to EWMA of past performance targets.
 	 */
 	update_cpuperf_target(cpuc);
-
-	/*
-	 * Update running task's information for preemption
-	 */
-	cpuc->flags = taskc->flags;
-	cpuc->lat_cri = taskc->lat_cri;
-	cpuc->running_clk = now;
-	cpuc->est_stopping_clk = get_est_stopping_clk(taskc, now);
 
 	/*
 	 * If there is a relevant introspection command with @p, process it.

--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -95,8 +95,7 @@ static bool is_perf_cri(struct task_ctx *taskc)
 	if (!have_little_core)
 		return true;
 
-	if (test_task_flag(taskc, LAVD_FLAG_ON_BIG) &&
-	    test_task_flag(taskc, LAVD_FLAG_ON_LITTLE))
+	if (test_task_flag(taskc, LAVD_FLAG_ON_BIG | LAVD_FLAG_ON_LITTLE))
 		return taskc->perf_cri >= sys_stat.thr_perf_cri;
 
 	return test_task_flag(taskc, LAVD_FLAG_ON_BIG);

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -14,7 +14,7 @@ struct preemption_info {
 
 static u64 get_est_stopping_clk(struct task_ctx *taskc, u64 now)
 {
-	return now + taskc->avg_runtime;
+	return now + min(taskc->avg_runtime, taskc->slice_ns);
 }
 
 static bool can_x_kick_y(struct preemption_info *prm_x,

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -57,7 +57,7 @@ static bool can_cpu1_kick_cpu2(struct preemption_info *prm_cpu1,
 	/*
 	 * Never preeempt a CPU running a lock holder.
 	 */
-	if (prm_cpu2->cpuc->lock_holder)
+	if (is_lock_holder_running(prm_cpu2->cpuc))
 		return false;
 
 	/*
@@ -285,6 +285,7 @@ static void reset_cpu_preemption_info(struct cpu_ctx *cpuc, bool released)
 		 * When the CPU is taken by high priority scheduler,
 		 * set things impossible to preempt.
 		 */
+		cpuc->flags = 0;
 		cpuc->lat_cri = SCX_SLICE_INF;
 		cpuc->stopping_tm_est_ns = 0;
 	} else {
@@ -292,6 +293,7 @@ static void reset_cpu_preemption_info(struct cpu_ctx *cpuc, bool released)
 		 * When the CPU is idle,
 		 * set things easy to preempt.
 		 */
+		cpuc->flags = 0;
 		cpuc->lat_cri = 0;
 		cpuc->stopping_tm_est_ns = SCX_SLICE_INF;
 	}

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -166,7 +166,7 @@ static bool is_pinned(const struct task_struct *p)
 
 static inline bool test_task_flag(struct task_ctx *taskc, u64 flag)
 {
-	return taskc->flags & flag;
+	return (taskc->flags & flag) == flag;
 }
 
 static inline void set_task_flag(struct task_ctx *taskc, u64 flag)

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -189,6 +189,11 @@ static bool is_lock_holder(struct task_ctx *taskc)
 	return test_task_flag(taskc, LAVD_FLAG_FUTEX_BOOST);
 }
 
+static bool is_lock_holder_running(struct cpu_ctx *cpuc)
+{
+	return cpuc->flags & LAVD_FLAG_FUTEX_BOOST;
+}
+
 static bool have_scheduled(struct task_ctx *taskc)
 {
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -26,12 +26,13 @@ struct sys_stat	sys_stat;
 /*
  * Options
  */
-volatile bool		no_preemption;
-volatile bool		no_wake_sync;
-volatile bool		no_core_compaction;
-volatile bool		no_freq_scaling;
 volatile bool		is_powersave_mode;
 volatile bool		reinit_cpumask_for_performance;
+volatile bool		no_preemption;
+volatile bool		no_core_compaction;
+volatile bool		no_freq_scaling;
+
+const volatile bool	no_wake_sync;
 const volatile bool	is_autopilot_on;
 const volatile u8	verbose;
 const volatile u8	preempt_shift;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -501,7 +501,6 @@ impl<'a> Scheduler<'a> {
     fn init_globals(skel: &mut OpenBpfSkel, opts: &Opts, order: &CpuOrder) {
         let bss_data = skel.maps.bss_data.as_mut().unwrap();
         bss_data.no_preemption = opts.no_preemption;
-        bss_data.no_wake_sync = opts.no_wake_sync;
         bss_data.no_core_compaction = opts.no_core_compaction;
         bss_data.no_freq_scaling = opts.no_freq_scaling;
         bss_data.is_powersave_mode = opts.powersave;
@@ -514,6 +513,7 @@ impl<'a> Scheduler<'a> {
         rodata.slice_min_ns = opts.slice_min_us * 1000;
         rodata.preempt_shift = opts.preempt_shift;
         rodata.no_use_em = opts.no_use_em as u8;
+        rodata.no_wake_sync = opts.no_wake_sync;
 
         skel.struct_ops.lavd_ops_mut().flags = *compat::SCX_OPS_ENQ_EXITING
             | *compat::SCX_OPS_ENQ_LAST


### PR DESCRIPTION
This PR includes the refactoring and clean-up patches, which do not cause any functional & behavioral changes, as follows:
- scx_lavd: Add const to no_wake_sync. 
- scx_lavd: Extend test_task_flag() for multi-bit testing. 
- scx_lavd: Keep running task's flag on cpu_ctx.
- scx_lavd: Rename cpuc->stopping_tm_est_ns to cpuc->est_stopping_clk. 
- scx_lavd: Keep track of running_clk at cpu_ctx. 
- scx_lavd: Refactoring greedy penalty calculation.
- scx_lavd: Refactoring preemption-related code.
- scx_lavd: Remove redundant time slice calculation. 

Additionally, it includes one optimization for preemption: when a particular CPU is chosen for an enqueuing task, consider that CPU as a preemption candidate. This way, we can increase the chance that the enqueued task runs on the chosen CPU.
- scx_lavd: Prioritize the chosen CPU for preemption. 