### PR TITLE
scx_loader: fix typos and and unification of descriptions

### DIFF
--- a/meson-scripts/install_rust_user_scheds
+++ b/meson-scripts/install_rust_user_scheds
@@ -7,12 +7,6 @@ for manifest in "$MESON_SOURCE_ROOT"/scheds/rust/*/Cargo.toml; do
     target_dir="${MESON_BUILD_ROOT}"
     name="${source_dir##*/}"
 
-    # Skip scx_mitosis and scx_wd40
-    if [ "$name" = "scx_mitosis" ] || [ "$name" = "scx_wd40" ]; then
-        echo "Skipping installation of $name"
-        continue
-    fi
-
     bins=($(ls -t "${target_dir}/"*"/${name}"))
     if [ ${#bins[@]} -lt 1 ]; then
         echo "Cannot find a binary for $name under $target_dir" 1>&2

--- a/rust/scx_loader/configuration.md
+++ b/rust/scx_loader/configuration.md
@@ -90,6 +90,13 @@ gaming_mode = []
 lowlatency_mode = []
 powersave_mode = []
 server_mode = []
+
+[scheds.scx_wd40]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
 ```
 
 **`default_sched`:**
@@ -150,6 +157,8 @@ The example configuration above shows how to set custom flags for different sche
     * Low Latency mode: `-y`
     * Server mode: `--keep-running`
 * For `scx_mitosis`:
+    * No custom flags are defined, so the default flags for each mode will be used.
+* For `scx_wd40`:
     * No custom flags are defined, so the default flags for each mode will be used.
 
 ## Fallback Behavior

--- a/rust/scx_loader/configuration.md
+++ b/rust/scx_loader/configuration.md
@@ -76,6 +76,13 @@ gaming_mode = []
 lowlatency_mode = []
 powersave_mode = []
 server_mode = []
+
+[scheds.scx_chaos]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = ["-y"]
+powersave_mode = []
+server_mode = ["--keep-running"]
 ```
 
 **`default_sched`:**
@@ -132,6 +139,9 @@ The example configuration above shows how to set custom flags for different sche
     * No custom flags are defined, so the default flags for each mode will be used.
 * For `scx_cosmos`:
     * No custom flags are defined, so the default flags for each mode will be used.
+* For `scx_chaos`:
+    * Low Latency mode: `-y`
+    * Server mode: `--keep-running`
 
 ## Fallback Behavior
 

--- a/rust/scx_loader/configuration.md
+++ b/rust/scx_loader/configuration.md
@@ -83,6 +83,13 @@ gaming_mode = []
 lowlatency_mode = ["-y"]
 powersave_mode = []
 server_mode = ["--keep-running"]
+
+[scheds.scx_mitosis]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
 ```
 
 **`default_sched`:**
@@ -142,6 +149,8 @@ The example configuration above shows how to set custom flags for different sche
 * For `scx_chaos`:
     * Low Latency mode: `-y`
     * Server mode: `--keep-running`
+* For `scx_mitosis`:
+    * No custom flags are defined, so the default flags for each mode will be used.
 
 ## Fallback Behavior
 

--- a/rust/scx_loader/src/config.rs
+++ b/rust/scx_loader/src/config.rs
@@ -87,6 +87,7 @@ pub fn get_default_config() -> Config {
         SupportedSched::Tickless,
         SupportedSched::Rustland,
         SupportedSched::Cosmos,
+        SupportedSched::Chaos,
     ];
     let scheds_map = HashMap::from(supported_scheds.map(|x| init_default_config_entry(x)));
     Config {
@@ -229,6 +230,13 @@ fn get_default_scx_flags_for_mode(scx_sched: &SupportedSched, sched_mode: SchedM
         SupportedSched::Rustland => vec![],
         // scx_cosmos doesn't support any of these modes
         SupportedSched::Cosmos => vec![],
+        SupportedSched::Chaos => match sched_mode {
+            SchedMode::Gaming => vec![],
+            SchedMode::LowLatency => vec!["-y"],
+            SchedMode::PowerSave => vec![],
+            SchedMode::Server => vec!["--keep-running"],
+            SchedMode::Auto => vec![],
+        },
     }
 }
 
@@ -305,6 +313,13 @@ gaming_mode = []
 lowlatency_mode = []
 powersave_mode = []
 server_mode = []
+
+[scheds.scx_chaos]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = ["-y"]
+powersave_mode = []
+server_mode = ["--keep-running"]
 "#;
 
         let parsed_config = parse_config_content(config_str).expect("Failed to parse config");

--- a/rust/scx_loader/src/config.rs
+++ b/rust/scx_loader/src/config.rs
@@ -88,6 +88,7 @@ pub fn get_default_config() -> Config {
         SupportedSched::Rustland,
         SupportedSched::Cosmos,
         SupportedSched::Chaos,
+        SupportedSched::Mitosis,
     ];
     let scheds_map = HashMap::from(supported_scheds.map(|x| init_default_config_entry(x)));
     Config {
@@ -237,6 +238,8 @@ fn get_default_scx_flags_for_mode(scx_sched: &SupportedSched, sched_mode: SchedM
             SchedMode::Server => vec!["--keep-running"],
             SchedMode::Auto => vec![],
         },
+        // scx_mitosis doesn't support any of these modes
+        SupportedSched::Mitosis => vec![],
     }
 }
 
@@ -320,6 +323,13 @@ gaming_mode = []
 lowlatency_mode = ["-y"]
 powersave_mode = []
 server_mode = ["--keep-running"]
+
+[scheds.scx_mitosis]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
 "#;
 
         let parsed_config = parse_config_content(config_str).expect("Failed to parse config");

--- a/rust/scx_loader/src/config.rs
+++ b/rust/scx_loader/src/config.rs
@@ -89,6 +89,7 @@ pub fn get_default_config() -> Config {
         SupportedSched::Cosmos,
         SupportedSched::Chaos,
         SupportedSched::Mitosis,
+        SupportedSched::WD40,
     ];
     let scheds_map = HashMap::from(supported_scheds.map(|x| init_default_config_entry(x)));
     Config {
@@ -240,6 +241,8 @@ fn get_default_scx_flags_for_mode(scx_sched: &SupportedSched, sched_mode: SchedM
         },
         // scx_mitosis doesn't support any of these modes
         SupportedSched::Mitosis => vec![],
+        // scx_wd40 doesn't support any of these modes
+        SupportedSched::WD40 => vec![],
     }
 }
 
@@ -325,6 +328,13 @@ powersave_mode = []
 server_mode = ["--keep-running"]
 
 [scheds.scx_mitosis]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+server_mode = []
+
+[scheds.scx_wd40]
 auto_mode = []
 gaming_mode = []
 lowlatency_mode = []

--- a/rust/scx_loader/src/lib.rs
+++ b/rust/scx_loader/src/lib.rs
@@ -38,6 +38,8 @@ pub enum SupportedSched {
     Cosmos,
     #[serde(rename = "scx_chaos")]
     Chaos,
+    #[serde(rename = "scx_mitosis")]
+    Mitosis,
 }
 
 impl FromStr for SupportedSched {
@@ -50,6 +52,7 @@ impl FromStr for SupportedSched {
             "scx_cosmos" => Ok(SupportedSched::Cosmos),
             "scx_flash" => Ok(SupportedSched::Flash),
             "scx_lavd" => Ok(SupportedSched::Lavd),
+            "scx_mitosis" => Ok(SupportedSched::Mitosis),
             "scx_p2dq" => Ok(SupportedSched::P2DQ),
             "scx_tickless" => Ok(SupportedSched::Tickless),
             "scx_rustland" => Ok(SupportedSched::Rustland),
@@ -74,6 +77,7 @@ impl From<SupportedSched> for &str {
             SupportedSched::Cosmos => "scx_cosmos",
             SupportedSched::Flash => "scx_flash",
             SupportedSched::Lavd => "scx_lavd",
+            SupportedSched::Mitosis => "scx_mitosis",
             SupportedSched::P2DQ => "scx_p2dq",
             SupportedSched::Tickless => "scx_tickless",
             SupportedSched::Rustland => "scx_rustland",

--- a/rust/scx_loader/src/lib.rs
+++ b/rust/scx_loader/src/lib.rs
@@ -40,6 +40,8 @@ pub enum SupportedSched {
     Chaos,
     #[serde(rename = "scx_mitosis")]
     Mitosis,
+    #[serde(rename = "scx_wd40")]
+    WD40,
 }
 
 impl FromStr for SupportedSched {
@@ -57,6 +59,7 @@ impl FromStr for SupportedSched {
             "scx_tickless" => Ok(SupportedSched::Tickless),
             "scx_rustland" => Ok(SupportedSched::Rustland),
             "scx_rusty" => Ok(SupportedSched::Rusty),
+            "scx_wd40" => Ok(SupportedSched::WD40),
             _ => Err(anyhow::anyhow!("{scx_name} is not supported")),
         }
     }
@@ -82,6 +85,7 @@ impl From<SupportedSched> for &str {
             SupportedSched::Tickless => "scx_tickless",
             SupportedSched::Rustland => "scx_rustland",
             SupportedSched::Rusty => "scx_rusty",
+            SupportedSched::WD40 => "scx_wd40",
         }
     }
 }

--- a/rust/scx_loader/src/lib.rs
+++ b/rust/scx_loader/src/lib.rs
@@ -36,6 +36,8 @@ pub enum SupportedSched {
     Rustland,
     #[serde(rename = "scx_cosmos")]
     Cosmos,
+    #[serde(rename = "scx_chaos")]
+    Chaos,
 }
 
 impl FromStr for SupportedSched {
@@ -44,6 +46,7 @@ impl FromStr for SupportedSched {
     fn from_str(scx_name: &str) -> anyhow::Result<SupportedSched> {
         match scx_name {
             "scx_bpfland" => Ok(SupportedSched::Bpfland),
+            "scx_chaos" => Ok(SupportedSched::Chaos),
             "scx_cosmos" => Ok(SupportedSched::Cosmos),
             "scx_flash" => Ok(SupportedSched::Flash),
             "scx_lavd" => Ok(SupportedSched::Lavd),
@@ -67,6 +70,7 @@ impl From<SupportedSched> for &str {
     fn from(scx_name: SupportedSched) -> Self {
         match scx_name {
             SupportedSched::Bpfland => "scx_bpfland",
+            SupportedSched::Chaos => "scx_chaos",
             SupportedSched::Cosmos => "scx_cosmos",
             SupportedSched::Flash => "scx_flash",
             SupportedSched::Lavd => "scx_lavd",

--- a/rust/scx_loader/src/main.rs
+++ b/rust/scx_loader/src/main.rs
@@ -90,6 +90,7 @@ impl ScxLoader {
     async fn supported_schedulers(&self) -> Vec<&str> {
         vec![
             "scx_bpfland",
+            "scx_chaos",
             "scx_cosmos",
             "scx_flash",
             "scx_lavd",

--- a/rust/scx_loader/src/main.rs
+++ b/rust/scx_loader/src/main.rs
@@ -94,6 +94,7 @@ impl ScxLoader {
             "scx_cosmos",
             "scx_flash",
             "scx_lavd",
+            "scx_mitosis",
             "scx_p2dq",
             "scx_tickless",
             "scx_rustland",

--- a/rust/scx_loader/src/main.rs
+++ b/rust/scx_loader/src/main.rs
@@ -99,6 +99,7 @@ impl ScxLoader {
             "scx_tickless",
             "scx_rustland",
             "scx_rusty",
+            "scx_wd40",
         ]
     }
 


### PR DESCRIPTION
A few typos and inconsistencies in the description have crept into the configuration.md file, it is time to fix this.