### PR TITLE
scx_cosmos: Use flat idle scan only when the system is sufficiently idle

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -318,7 +318,7 @@ static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, u64 wake_flags, bo
 	 * Use the lightweight idle CPU scanning if flat idle scan is
 	 * enabled and all the CPUs are included in the primary domain.
 	 */
-	if (flat_idle_scan && primary_all)
+	if (flat_idle_scan && primary_all && !is_system_busy())
 		return pick_idle_cpu_flat(p, prev_cpu);
 
 	/*


### PR DESCRIPTION
On systems with a many CPUs sharing a single LLC, enabling flat idle scanning (-i) can be really beneficial. However, as system load increases, scanning all CPUs to find an idle one becomes more costly than using the built-in cpumask-based method.

To find the optimal balance, use the global CPU load to decide whether to use the flat idle scanning or the built-in idle CPU selection policy: when the system is mostly idle (load below the busy threshold), use flat scanning for faster placement; otherwise, fall back to the default idle CPU selection policy.

This adaptive approach provides the advantages of both methods, especially on large systems with a flat topology.