### PR TITLE
scx_p2dq: Add ATQ for interactive tasks

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -26,6 +26,7 @@ struct cpu_ctx {
 	u64				llc_dsq;
 	u64				max_load_dsq;
 
+	scx_atq_t			*intr_atq;
 	scx_atq_t			*mig_atq;
 };
 
@@ -51,6 +52,7 @@ struct llc_ctx {
 	struct bpf_cpumask __kptr	*little_cpumask;
 	struct bpf_cpumask __kptr	*node_cpumask;
 
+	scx_atq_t			*intr_atq;
 	scx_atq_t			*mig_atq;
 };
 


### PR DESCRIPTION
Add an ATQ for interactive tasks when running with --atq-enabled and --interactive-dsq (default true). Interactive ATQs are fixed size and when enqueueing to a full interactive ATQ tasks are enqueued into the LLC DSQ.