### PR TITLE
scx_lavd: Sample dsq_consume latencies

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -159,6 +159,8 @@ struct task_ctx_x {
 	u32	avg_lat_cri;	/* average latency criticality */
 	u32	nr_active;	/* number of active cores */
 	u32	cpuperf_cur;	/* CPU's current performance target */
+	u64	dsq_id;		/* CPU's associated DSQ */
+	u64	dsq_consume_lat; /* DSQ's consume latency */
 };
 
 

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -101,6 +101,7 @@ struct cpdom_ctx {
 	u32	cur_util_sum;			    /* the sum of CPU utilization in the current interval */
 	u32	cap_sum_active_cpus;		    /* the sum of capacities of active CPUs in this domain */
 	u32	cap_sum_temp;			    /* temp for cap_sum_active_cpus */
+	u32	dsq_consume_lat;		    /* latency to consume from dsq, shows how contended the dsq is */
 	u8	nr_neighbors[LAVD_CPDOM_MAX_DIST];  /* number of neighbors per distance */
 	u64	neighbor_bits[LAVD_CPDOM_MAX_DIST]; /* bitmask of neighbor bitmask per distance */
 	u64	__cpumask[LAVD_CPU_ID_MAX/64];	    /* cpumasks belongs to this compute domain */

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -579,6 +579,8 @@ impl<'a> Scheduler<'a> {
             cpu_util: tx.cpu_util,
             cpu_sutil: tx.cpu_sutil,
             nr_active: tx.nr_active,
+            dsq_id: tx.dsq_id,
+            dsq_consume_lat: tx.dsq_consume_lat,
         }) {
             Ok(()) | Err(TrySendError::Full(_)) => 0,
             Err(e) => panic!("failed to send on intrspc_tx ({})", e),

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -184,13 +184,17 @@ pub struct SchedSample {
     pub cpu_sutil: u64,
     #[stat(desc = "Number of active CPUs when core compaction is enabled")]
     pub nr_active: u32,
+    #[stat(desc = "DSQ ID where this task was dispatched from")]
+    pub dsq_id: u64,
+    #[stat(desc = "Consume latency of this DSQ (shows how contended the DSQ is)")]
+    pub dsq_consume_lat: u64,
 }
 
 impl SchedSample {
     pub fn format_header<W: Write>(w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "\x1b[93m| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:8} | {:17} | {:8} | {:8} | {:7} | {:8} | {:12} | {:12} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:9} | {:6} |\x1b[0m",
+            "\x1b[93m| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:8} | {:17} | {:8} | {:8} | {:7} | {:8} | {:12} | {:12} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:9} | {:6} | {:6} | {:10} |\x1b[0m",
             "MSEQ",
             "PID",
             "COMM",
@@ -216,6 +220,8 @@ impl SchedSample {
             "CPU_UTIL",
             "CPU_SUTIL",
             "NR_ACT",
+            "DSQ_ID",
+            "DSQ_LAT_NS",
         )?;
         Ok(())
     }
@@ -227,7 +233,7 @@ impl SchedSample {
 
         writeln!(
             w,
-            "| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:8} | {:17} | {:8} | {:8} | {:7} | {:8} | {:12} | {:12} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:9} | {:6} |",
+            "| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:8} | {:17} | {:8} | {:8} | {:7} | {:8} | {:12} | {:12} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:9} | {:6} | {:12} | {:12} |",
             self.mseq,
             self.pid,
             self.comm,
@@ -253,6 +259,8 @@ impl SchedSample {
             self.cpu_util,
             self.cpu_sutil,
             self.nr_active,
+            self.dsq_id,
+            self.dsq_consume_lat,
         )?;
         Ok(())
     }


### PR DESCRIPTION
Sample time for scx_bpf_dsq_move_to_local() latencies to determine how much contention is happening at each DSQ.