### PR TITLE
scx_tickless: Add support for preferred cores

### DIFF
--- a/scheds/rust/scx_tickless/src/bpf/intf.h
+++ b/scheds/rust/scx_tickless/src/bpf/intf.h
@@ -8,6 +8,9 @@
 #ifndef __INTF_H
 #define __INTF_H
 
+#define MAX(x, y) ((x) > (y) ? (x) : (y))
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
+
 #ifndef __VMLINUX_H__
 typedef unsigned char u8;
 typedef unsigned short u16;


### PR DESCRIPTION
Since the scheduler already dispatches tasks by iterating over all CPUs, implementing preferred core prioritization is straightforward.

This change introduces a simple mechanism to prefer higher-capacity CPUs (based on capacity information provided by the topology crate). More exactly, the scheduler prioritizes dispatching to the fastest full-idle SMT cores first, followed by the fastest idle CPUs.

CPU capacity is currently evaluated only at scheduler startup, so runtime capacity changes are not handled unless the scheduler is restarted.