### PR TITLE
scxtop: intercept sched_process_hang trace event.

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -35,8 +35,9 @@ use crate::SCHED_NAME_PATH;
 use crate::{
     Action, CpuhpEnterAction, CpuhpExitAction, ExecAction, ExitAction, ForkAction, GpuMemAction,
     HwPressureAction, IPIAction, KprobeAction, MangoAppAction, PstateSampleAction,
-    SchedCpuPerfSetAction, SchedMigrateTaskAction, SchedSwitchAction, SchedWakeupAction,
-    SchedWakingAction, SoftIRQAction, TraceStartedAction, TraceStoppedAction, WaitAction,
+    SchedCpuPerfSetAction, SchedHangAction, SchedMigrateTaskAction, SchedSwitchAction,
+    SchedWakeupAction, SchedWakingAction, SoftIRQAction, TraceStartedAction, TraceStoppedAction,
+    WaitAction,
 };
 
 use anyhow::{bail, Result};
@@ -2624,6 +2625,12 @@ impl<'a> App<'a> {
         }
     }
 
+    fn on_sched_hang(&mut self, action: &SchedHangAction) {
+        if self.state == AppState::Tracing && action.ts > self.trace_start {
+            self.trace_manager.on_sched_hang(action);
+        }
+    }
+
     // Groups built-in dsq's (GLOBAL, LOCAL, and LOCAL-ON)
     fn classify_dsq(dsq_id: u64) -> u64 {
         if dsq_id & scx_enums.SCX_DSQ_FLAG_BUILTIN == 0 {
@@ -2802,6 +2809,9 @@ impl<'a> App<'a> {
             }
             Action::SchedMigrateTask(a) => {
                 self.on_sched_migrate(a);
+            }
+            Action::SchedHang(a) => {
+                self.on_sched_hang(a);
             }
             Action::SoftIRQ(a) => {
                 self.on_softirq(a);

--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -41,6 +41,7 @@ enum event_type {
 	HW_PRESSURE,
 	IPI,
 	PSTATE_SAMPLE,
+	SCHED_HANG,
     	SCHED_MIGRATE,
 	SCHED_REG,
 	SCHED_SWITCH,
@@ -126,6 +127,11 @@ struct wait_event {
 	int             prio;
 };
 
+struct hang_event {
+	u8              comm[MAX_COMM];
+	u32             pid;
+};
+
 struct ipi_event {
 	u32		pid;
 	u32		target_cpu;
@@ -192,6 +198,7 @@ struct bpf_event {
 		struct	wakeup_event wakeup;
 		struct	wakeup_event waking;
 		struct  migrate_event migrate;
+		struct  hang_event hang;
 		struct  trace_started_event trace;
 		struct  kprobe_event kprobe;
 	} event;

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -226,6 +226,14 @@ pub struct SchedMigrateTaskAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SchedHangAction {
+    pub ts: u64,
+    pub cpu: u32,
+    pub comm: SsoString,
+    pub pid: u32,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct SoftIRQAction {
     pub cpu: u32,
     pub pid: u32,
@@ -362,6 +370,7 @@ pub enum Action {
     ReloadStatsClient,
     SaveConfig,
     SchedCpuPerfSet(SchedCpuPerfSetAction),
+    SchedHang(SchedHangAction),
     SchedMigrateTask(SchedMigrateTaskAction),
     SchedReg,
     SchedStats(String),
@@ -499,6 +508,19 @@ impl TryFrom<&bpf_event> for Action {
                     pid: migrate.pid,
                     prio: migrate.prio,
                     comm: comm.into(),
+                }))
+            }
+            #[allow(non_upper_case_globals)]
+            bpf_intf::event_type_SCHED_HANG => {
+                let hang = unsafe { &event.event.hang };
+
+                let comm = String::from_utf8_lossy(&hang.comm);
+
+                Ok(Action::SchedHang(SchedHangAction {
+                    ts: event.ts,
+                    cpu: event.cpu,
+                    comm: comm.into(),
+                    pid: hang.pid,
                 }))
             }
             bpf_intf::event_type_EXEC => Ok(Action::Exec(ExecAction {

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -191,6 +191,7 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
             links.push(skel.progs.on_sched_exec.attach()?);
             links.push(skel.progs.on_sched_exit.attach()?);
             links.push(skel.progs.on_sched_wait.attach()?);
+            links.push(skel.progs.on_sched_hang.attach()?);
 
             let bpf_publisher = BpfEventActionPublisher::new(action_tx.clone());
 

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -18,8 +18,8 @@ use crate::edm::ActionHandler;
 use crate::get_clock_value;
 use crate::{
     Action, CpuhpEnterAction, CpuhpExitAction, ExecAction, ExitAction, ForkAction, GpuMemAction,
-    IPIAction, KprobeAction, SchedMigrateTaskAction, SchedSwitchAction, SchedWakeupAction,
-    SchedWakingAction, SoftIRQAction, SystemStatAction, WaitAction,
+    IPIAction, KprobeAction, SchedHangAction, SchedMigrateTaskAction, SchedSwitchAction,
+    SchedWakeupAction, SchedWakingAction, SoftIRQAction, SystemStatAction, WaitAction,
 };
 
 use perfetto_protos::{
@@ -37,8 +37,8 @@ use perfetto_protos::{
     process_tree::{process_tree::Process, ProcessTree},
     sched::{
         SchedMigrateTaskFtraceEvent, SchedProcessExecFtraceEvent, SchedProcessExitFtraceEvent,
-        SchedProcessForkFtraceEvent, SchedProcessWaitFtraceEvent, SchedSwitchFtraceEvent,
-        SchedWakeupFtraceEvent, SchedWakingFtraceEvent,
+        SchedProcessForkFtraceEvent, SchedProcessHangFtraceEvent, SchedProcessWaitFtraceEvent,
+        SchedSwitchFtraceEvent, SchedWakeupFtraceEvent, SchedWakingFtraceEvent,
     },
     sys_stats::{sys_stats::CpuTimes, sys_stats::MeminfoValue, SysStats},
     sys_stats_counters::MeminfoCounters,
@@ -698,6 +698,26 @@ impl PerfettoTraceManager {
                         prio: Some(*prio),
                         dest_cpu: Some((*dest_cpu).try_into().unwrap()),
                         ..SchedMigrateTaskFtraceEvent::default()
+                    },
+                )),
+                ..FtraceEvent::default()
+            }
+        });
+    }
+
+    /// Adds events for on sched_hang.
+    pub fn on_sched_hang(&mut self, action: &SchedHangAction) {
+        let SchedHangAction { ts, cpu, comm, pid } = action;
+
+        self.ftrace_events.entry(*cpu).or_default().push({
+            FtraceEvent {
+                timestamp: Some(*ts),
+                pid: Some(*pid),
+                event: Some(ftrace_event::Event::SchedProcessHang(
+                    SchedProcessHangFtraceEvent {
+                        comm: Some(comm.as_str().to_string()),
+                        pid: Some((*pid).try_into().unwrap()),
+                        special_fields: SpecialFields::new(),
                     },
                 )),
                 ..FtraceEvent::default()


### PR DESCRIPTION
for unresponsive tasks for an extended period.