### PR TITLE
scx_flash: Re-introduce tickless timer

### DIFF
--- a/scheds/rust/scx_flash/src/bpf/intf.h
+++ b/scheds/rust/scx_flash/src/bpf/intf.h
@@ -19,9 +19,6 @@ enum consts {
 	NSEC_PER_USEC = 1000ULL,
 	NSEC_PER_MSEC = (1000ULL * NSEC_PER_USEC),
 	NSEC_PER_SEC = (1000ULL * NSEC_PER_MSEC),
-
-	/* Kernel definitions */
-	CLOCK_BOOTTIME		= 7,
 };
 
 #ifndef __VMLINUX_H__


### PR DESCRIPTION
In tickless mode, allowing preemption of SCX_SLICE_INF tasks in ops.enqueue() is not sufficient to avoid stalls. A race condition can still occur between enqueue and direct dispatch via ops.select_cpu():
```
  CPU0                           CPU1
  :                              :
  ops.enqueue()                  idle
  check if CPU1 is idle: true    ...
  enqueue to CPU1                ops.select_cpu()
                                 direct dispatch to CPU1 (SCX_SLICE_INF)
                                 <potential stall>
```
In this scenario, if no further enqueue operations target CPU1, the waiting task may stall indefinitely.

To mitigate this, reintroduce a BPF timer that periodically checks whether a CPU is running a SCX_SLICE_INF task while other tasks are waiting. If so, it adjusts the running task's time slice to a finite value (slice_min) to re-enable preemption, preventing the stall.

Also switch from CLOCK_BOOTTIME to CLOCK_MONOTONIC, because we don't need to account time during suspend (the scheduler is just restarted on suspend/resume events).

Fixes: cd6cfb10 ("scx_flash: Remove the tickless timer")