### PR TITLE
scx_utils/topo: Remove unused import

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -82,7 +82,6 @@ use log::warn;
 use sscanf::sscanf;
 use std::collections::BTreeMap;
 use std::path::Path;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 #[cfg(feature = "gpu-topology")]


### PR DESCRIPTION
```rust
$ cargo check
warning: /home/eric-wcnlab/linux2025/scx/Cargo.toml: unused manifest key: profile.release-fast.target-cpu
warning: /home/eric-wcnlab/linux2025/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
   Compiling scx_utils v1.0.17 (/home/eric-wcnlab/linux2025/scx/rust/scx_utils)
warning: unused import: `std::path::PathBuf`
  --> rust/scx_utils/src/topology.rs:85:5
   |
85 | use std::path::PathBuf;
   |     ^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: `scx_utils` (lib) generated 1 warning (run `cargo fix --lib -p scx_utils` to apply 1 suggestion)
warning: `scx_utils` (lib) generated 1 warning (1 duplicate)
   Compiling scx_rustland_core v2.3.3 (/home/eric-wcnlab/linu
```