### PR TITLE
rust-toolchains: Add rustfmt and clippy components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Ensure required developer tools are installed with the stable toolchain.