### PR TITLE
scxtop: add fields to process view

### DIFF
--- a/tools/scxtop/src/proc_data.rs
+++ b/tools/scxtop/src/proc_data.rs
@@ -107,4 +107,14 @@ impl ProcData {
             (delta as f64 / system_util as f64) * 100.0
         };
     }
+
+    /// Returns the data for an event and updates if no entry is present.
+    pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
+        self.data.event_data_immut(event)
+    }
+
+    /// Adds data for an event.
+    pub fn add_event_data(&mut self, event: &str, val: u64) {
+        self.data.add_event_data(event, val)
+    }
 }


### PR DESCRIPTION
This adds both an average slice duration (in ns) and maximum latency (in us) to the process view. Example:

<img width="863" height="739" alt="Screenshot 2025-07-22 at 12 32 39 PM" src="https://github.com/user-attachments/assets/656dff77-c7af-473c-ada4-80516579cd43" />


On my machine, with ~1000 processes running, I timed `render_process_table` and found that the entire method takes ~3.5 ms without these and 3.5-4 ms with it. As we'll probably continue to add data, we should keep an eye on this.