### PR TITLE
scxtop: add pause to help

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -1982,7 +1982,7 @@ impl<'a> App<'a> {
                 Style::default(),
             )),
             Line::from(Span::styled(
-                format!("{}: press to pause/unpause", pause),
+                format!("{pause}: press to pause/unpause"),
                 Style::default(),
             )),
             Line::from(Span::styled(


### PR DESCRIPTION
Forgot to add the pause/unpause to the help page. Just having an empty character space is pretty confusing for a newcomer (it shows up as empty space), so if it is set as a lone empty character, we'll switch it to use the string "Space". If it's set to something else, or if it is set to multiple things (via config), it should be a bit clearer and we don't need to change it to "Space".