### PR TITLE
scxtop: remove pstate

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -33,10 +33,9 @@ use crate::LICENSE;
 use crate::SCHED_NAME_PATH;
 use crate::{
     Action, CpuhpEnterAction, CpuhpExitAction, ExecAction, ExitAction, ForkAction, GpuMemAction,
-    HwPressureAction, IPIAction, KprobeAction, MangoAppAction, PstateSampleAction,
-    SchedCpuPerfSetAction, SchedHangAction, SchedMigrateTaskAction, SchedSwitchAction,
-    SchedWakeupAction, SchedWakingAction, SoftIRQAction, TraceStartedAction, TraceStoppedAction,
-    WaitAction,
+    HwPressureAction, IPIAction, KprobeAction, MangoAppAction, SchedCpuPerfSetAction,
+    SchedHangAction, SchedMigrateTaskAction, SchedSwitchAction, SchedWakeupAction,
+    SchedWakingAction, SoftIRQAction, TraceStartedAction, TraceStoppedAction, WaitAction,
 };
 
 use anyhow::{bail, Result};
@@ -98,7 +97,6 @@ pub struct App<'a> {
     large_core_count: bool,
     collect_cpu_freq: bool,
     collect_uncore_freq: bool,
-    pstate: bool,
 
     cpu_data: BTreeMap<usize, CpuData>,
     llc_data: BTreeMap<usize, LlcData>,
@@ -257,7 +255,6 @@ impl<'a> App<'a> {
             topo,
             collect_cpu_freq: true,
             collect_uncore_freq: true,
-            pstate: true,
             cpu_data,
             llc_data,
             node_data,
@@ -618,7 +615,7 @@ impl<'a> App<'a> {
         Bar::default()
             .value(value)
             .label(Line::from(format!(
-                "{}{}{}{}",
+                "{}{}{}",
                 cpu,
                 if self.collect_cpu_freq {
                     format!(
@@ -630,18 +627,6 @@ impl<'a> App<'a> {
                                 .copied()
                                 .unwrap_or(0)
                         )
-                    )
-                } else {
-                    "".to_string()
-                },
-                if self.pstate {
-                    format!(
-                        " {}",
-                        cpu_data
-                            .event_data_immut("pstate")
-                            .last()
-                            .copied()
-                            .unwrap_or(0)
                     )
                 } else {
                     "".to_string()
@@ -661,30 +646,16 @@ impl<'a> App<'a> {
 
     /// Creates a sparkline for a cpu.
     fn cpu_sparkline(&self, cpu: usize, max: u64, borders: Borders, small: bool) -> Sparkline {
-        let mut perf: u64 = 0;
         let mut cpu_freq: u64 = 0;
         let mut hw_pressure: u64 = 0;
-        let mut pstate: u64 = 0;
         let data = if self.cpu_data.contains_key(&cpu) {
             let cpu_data = self
                 .cpu_data
                 .get(&cpu)
                 .expect("CpuData should have been present");
-            perf = cpu_data
-                .event_data_immut("perf")
-                .last()
-                .copied()
-                .unwrap_or(0);
             if self.collect_cpu_freq {
                 cpu_freq = cpu_data
                     .event_data_immut("cpu_freq")
-                    .last()
-                    .copied()
-                    .unwrap_or(0);
-            }
-            if self.pstate {
-                pstate = cpu_data
-                    .event_data_immut("pstate")
                     .last()
                     .copied()
                     .unwrap_or(0);
@@ -709,21 +680,8 @@ impl<'a> App<'a> {
             .block(
                 Block::new()
                     .title(format!(
-                        "{} perf({}){}{}",
+                        "{}{}{}",
                         cpu,
-                        if perf == 0 {
-                            "".to_string()
-                        } else {
-                            format!(
-                                "{}{}",
-                                perf,
-                                if self.pstate {
-                                    format!("/{pstate}")
-                                } else {
-                                    "".to_string()
-                                }
-                            )
-                        },
                         if self.collect_cpu_freq {
                             format!(" {}", format_hz(cpu_freq))
                         } else {
@@ -2608,15 +2566,6 @@ impl<'a> App<'a> {
         cpu_data.add_event_data("perf", perf as u64);
     }
 
-    fn on_pstate_sample(&mut self, action: &PstateSampleAction) {
-        let PstateSampleAction { cpu, busy } = action;
-        let cpu_data = self
-            .cpu_data
-            .get_mut(&(*cpu as usize))
-            .expect("CpuData should have been present");
-        cpu_data.add_event_data("pstate", *busy as u64);
-    }
-
     fn on_exec(&mut self, action: &ExecAction) {
         let ExecAction { old_pid, pid, .. } = action;
 
@@ -2961,9 +2910,6 @@ impl<'a> App<'a> {
                 }
             }
             Action::NextViewState => self.next_view_state(),
-            Action::PstateSample(a) => {
-                self.on_pstate_sample(a);
-            }
             Action::SchedReg => {
                 self.on_scheduler_load()?;
             }

--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -40,7 +40,6 @@ enum event_type {
 	GPU_MEM,
 	HW_PRESSURE,
 	IPI,
-	PSTATE_SAMPLE,
 	SCHED_HANG,
     	SCHED_MIGRATE,
 	SCHED_REG,
@@ -170,10 +169,6 @@ struct trace_started_event {
 	bool		stop_scheduled;
 };
 
-struct pstate_sample_event {
-	u32             busy;
-};
-
 struct kprobe_event {
 	u32             pid;
 	u64             instruction_pointer;
@@ -193,7 +188,6 @@ struct bpf_event {
 		struct  cpuhp_enter_event chp;
 		struct  cpuhp_exit_event cxp;
 		struct	ipi_event ipi;
-		struct  pstate_sample_event pstate;
 		struct	sched_switch_event sched_switch;
 		struct	set_perf_event perf;
 		struct	softirq_event softirq;

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -1080,27 +1080,6 @@ int BPF_PROG(on_hw_pressure_update, u32 cpu, u64 hw_pressure)
 	return 0;
 }
 
-SEC("tp_btf/pstate_sample")
-int BPF_PROG(on_pstate_sample, u32 core_busy, u32 scaled_busy, u32 from, u32 to, u64 mperf, u64 aperf, u64 tsc, u32 freq, u32 io_boost)
-{
-	struct bpf_event *event;
-
-	if (!enable_bpf_events || !should_sample())
-		return 0;
-
-	if (!(event = try_reserve_event()))
-		return -ENOMEM;
-
-	event->type = PSTATE_SAMPLE;
-	event->cpu = bpf_get_smp_processor_id();
-	event->ts = bpf_ktime_get_ns();
-	event->event.pstate.busy = scaled_busy;
-
-	bpf_ringbuf_submit(event, 0);
-
-	return 0;
-}
-
 SEC("syscall")
 int BPF_PROG(scxtop_init)
 {

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -303,12 +303,6 @@ pub struct HwPressureAction {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct PstateSampleAction {
-    pub cpu: u32,
-    pub busy: u32,
-}
-
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct KprobeAction {
     pub ts: u64,
     pub cpu: u32,
@@ -368,7 +362,6 @@ pub enum Action {
     PageDown,
     PageUp,
     PrevEvent,
-    PstateSample(PstateSampleAction),
     Quit,
     RequestTrace,
     TraceStarted(TraceStartedAction),
@@ -576,11 +569,6 @@ impl TryFrom<&bpf_event> for Action {
                     instruction_pointer: kprobe.instruction_pointer,
                 }))
             }
-            #[allow(non_upper_case_globals)]
-            bpf_intf::event_type_PSTATE_SAMPLE => Ok(Action::PstateSample(PstateSampleAction {
-                cpu: event.cpu,
-                busy: unsafe { event.event.pstate.busy },
-            })),
             #[allow(non_upper_case_globals)]
             bpf_intf::event_type_SCHED_SWITCH => {
                 let sched_switch = unsafe { &event.event.sched_switch };

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -136,9 +136,6 @@ fn attach_progs(skel: &mut BpfSkel) -> Result<Vec<Link>> {
     if let Ok(link) = skel.progs.on_cpuhp_exit.attach() {
         links.push(link);
     }
-    if let Ok(link) = skel.progs.on_pstate_sample.attach() {
-        links.push(link);
-    }
 
     Ok(links)
 }


### PR DESCRIPTION
The event view is already quite dense with information and the pstate data was not super useful. This PR removes that data from the sparklines and the barchart. Before:

<img width="200" height="82" alt="Screenshot 2025-07-23 at 9 50 28 AM" src="https://github.com/user-attachments/assets/72fd548d-0282-4c68-98f2-1e9ae1bd76b0" />
<img width="206" height="370" alt="Screenshot 2025-07-23 at 9 50 12 AM" src="https://github.com/user-attachments/assets/61c07419-55ff-4275-8ade-f1dc535c1304" />


After:
<img width="92" height="56" alt="Screenshot 2025-07-23 at 9 54 07 AM" src="https://github.com/user-attachments/assets/caca19a7-90c3-4a1d-95bb-1142965f37ae" />
<img width="142" height="308" alt="Screenshot 2025-07-23 at 9 49 50 AM" src="https://github.com/user-attachments/assets/8f2416b7-6c3d-480a-8926-c4597fe303cb" />
