### PR TITLE
scxtop: prevent trace crash

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -295,6 +295,10 @@ impl<'a> App<'a> {
 
     /// Sets the state of the application.
     pub fn set_state(&mut self, state: AppState) {
+        if self.state == AppState::Tracing {
+            return;
+        }
+
         if self.state != AppState::Help
             && self.state != AppState::PerfEvent
             && self.state != AppState::KprobeEvent


### PR DESCRIPTION
Previously, one was allowed to switch views while tracing. This led to strange behavior - when the trace completes, it returns to the previous state, which in the case of one who switched away from the trace means they are returned to the trace screen even though it has completed (and they are stuck there until they click a new key). 

This restricts switching the view while the 1 second trace occurs.