### PR TITLE
scxctl: update README.md

### DIFF
--- a/tools/scxctl/README.md
+++ b/tools/scxctl/README.md
@@ -15,12 +15,6 @@
 
 ## Installation
 
-### Arch Linux
-
-`scxctl` is available on the AUR as [scxctl](https://aur.archlinux.org/packages/scxctl)
-
-### Other Distros
-
 `scxctl` can be installed from crates.io through cargo
 
 ```

--- a/tools/scxctl/README.md
+++ b/tools/scxctl/README.md
@@ -85,3 +85,9 @@ Switch to lavd with verbose and performance flags
 ```
 scxctl switch -s lavd -a="-v,--performance"
 ```
+
+Switch to flash and increase the maximum time slice from 4ms (default) to 20ms
+
+```
+scxctl switch -s flash -a="-s,20000"
+```


### PR DESCRIPTION
The manual was somewhat outdated and incomplete.


- `scxctl` is no longer in AUR as a standalone package

- was missing an example of using a numeric value in a parameter


Now the instruction should be a bit more complete and up-to-date, as the user has an example of how to customize the numeric values in the parameter to suit their needs.