### PR TITLE
scx_cosmos: Introduce mm affinity

### DIFF
--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -128,6 +128,15 @@ struct Opts {
     #[clap(short = 'w', long, action = clap::ArgAction::SetTrue)]
     no_wake_sync: bool,
 
+    /// Enable address space affinity.
+    ///
+    /// This option allows to keep tasks that share the same address space (e.g., threads of the
+    /// same process) on the same CPU across wakeups.
+    ///
+    /// This can improve locality and performance in certain cache-sensitive workloads.
+    #[clap(short = 'a', long, action = clap::ArgAction::SetTrue)]
+    mm_affinity: bool,
+
     /// Enable stats monitoring with the specified interval.
     #[clap(long)]
     stats: Option<f64>,
@@ -307,6 +316,7 @@ impl<'a> Scheduler<'a> {
         rodata.smt_enabled = smt_enabled;
         rodata.numa_enabled = opts.enable_numa;
         rodata.no_wake_sync = opts.no_wake_sync;
+        rodata.mm_affinity = opts.mm_affinity;
 
         // Normalize CPU busy threshold in the range [0 .. 1024].
         rodata.busy_threshold = opts.cpu_busy_thresh * 1024 / 100;


### PR DESCRIPTION
Introduce a new --mm-affinity option to improve cache locality by keeping threads of the same process (e.g., tasks sharing the same mm_struct) on the same CPU across wakeups.

When enabled, if the waker and wakee share the same address space and were both running on the same CPU, the scheduler will prefer to keep the wakee on that CPU.

The optimization speculates on the fact that a wakee sharing the address space and CPU of the waker will likely find hot cache data on that CPU.

Since the impact is highly workload-dependent and may degrade performance in some cases, this optimization is provided as an option and is disabled by default.

Enabling this option resulted in a consistent 2.5%-5% throughput improvement (operations/sec) with Redis and MySQL benchmarks.