### PR TITLE
scxtest/overrides.c: Fix Clang -Wvisibility warning

### DIFF
--- a/lib/scxtest/overrides.c
+++ b/lib/scxtest/overrides.c
@@ -8,6 +8,7 @@ __weak unsigned long CONFIG_NR_CPUS = 1024;
 
 struct cpumask;
 struct task_struct;
+struct scx_minheap_elem;
 
 __weak
 void scx_bpf_error_bstr(char *fmt __attribute__((unused)),
@@ -113,7 +114,7 @@ void *scx_task_data(struct task_struct *p __attribute__((unused)))
 
 __weak
 int scx_minheap_pop(void *heap_ptr __attribute__((unused)),
-		    struct scx_minheap_elemen *helem __attribute__((unused)))
+		    struct scx_minheap_elem *helem __attribute__((unused)))
 {
 	return 0;
 }


### PR DESCRIPTION
Rename `scx_minheap_elemen` to `scx_minheap_elem` and add a forward declaration so the type is visible ouside the function scope.

warning
```c
   Compiling scx_bpf_unittests v0.1.0 (/home/eric-wcnlab/linux2025/scx/rust/scx_bpf_unittests)
warning: scx_bpf_unittests@0.1.0: /home/eric-wcnlab/linux2025/scx/rust/scx_bpf_unittests/../../lib/scxtest/overrides.c:116:14: warning: declaration of 'struct scx_minheap_elemen' will not be visible outside of this function [-Wvisibility]
warning: scx_bpf_unittests@0.1.0:   116 |                     struct scx_minheap_elemen *helem __attribute__((unused)))
warning: scx_bpf_unittests@0.1.0:       |                            ^
warning: scx_bpf_unittests@0.1.0: 1 warning generated.
```

```shell
$ git grep -o 'scx_minheap_elem\b'   | wc -l 
14
$ git grep -o 'scx_minheap_elemen\b'   | wc -l  
1
```
