### PR TITLE
scx_layered: Add debugging for layer matching

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2418,6 +2418,7 @@ int match_layer(u32 layer_id, struct task_struct *p __arg_trusted, const char *c
 		}
 
 		if (matched) {
+			trace("MATCH %s-%d -> %s", p->comm, p->pid, layer->name);
 			if (enable_match_debug && (pid = p->pid))
 				bpf_map_update_elem(&layer_match_dbg, &pid, &layer_id, BPF_ANY);
 


### PR DESCRIPTION
Example output:
```
          <idle>-0       [121] d.s.1 592723.044697: bpf_trace_printk: MATCH kworker/121:2-3658196 -> normal
          <idle>-0       [125] d.s.1 592723.044698: bpf_trace_printk: MATCH kworker/125:2-3080077 -> normal
```