### PR TITLE
ci: build kernel directly in ci script

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -39,10 +39,6 @@ jobs:
         with:
           cachix-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: Load kernel
-        run: |
-          echo "KERNEL_STORE_PATH=$(nix build --no-link --print-out-paths ./.github/include#'kernel_sched_ext/for-next')" >> $GITHUB_ENV
-          echo "KERNEL_HEADERS_STORE_PATH=$(nix build --no-link --print-out-paths ./.github/include#'kernel_sched_ext/for-next'.headers)" >> $GITHUB_ENV
 
       - name: Build
         run: nix run ./.github/include#ci -- build


### PR DESCRIPTION
Currently we build the kernels into an env variable in the CI workflow and use that where available. This is not ideal as it makes the CI flow harder to reproduce locally & constrains us to a single kernel. Add a helper function to build a named kernel and use in the script (still with a single hardcoded kernel for now). We can add a command line argument if this becomes useful but it isn't needed yet as this is only for the cargo tests that don't require a specific kernel.

Test plan:
- CI