### PR TITLE
percpu: Add common helpers for reading percpu data

### DIFF
--- a/scheds/include/scx/percpu.bpf.h
+++ b/scheds/include/scx/percpu.bpf.h
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2025 Daniel Hodges <hodgesd@meta.com>
+ */
+#ifndef BPF_PERCPU_H
+#define BPF_PERCPU_H
+
+#ifdef LSP
+#define __bpf__
+#include "../vmlinux.h"
+#else
+#include "vmlinux.h"
+#endif
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+
+
+extern int sd_llc_size __ksym __weak;
+extern int sd_llc_id __ksym __weak;
+extern int sched_core_priority __ksym __weak;
+extern struct sugov_cpu sugov_cpu __ksym __weak;
+extern struct psi_group_cpu psi_group_cpu __ksym __weak;
+extern struct kernel_stat kernel_stat __ksym __weak;
+extern struct kernel_cpustat kernel_cpustat __ksym __weak;
+
+#define DEFINE_PER_CPU_PTR_FUNC(func_name, type, var_name)        \
+type *func_name(s32 cpu) {                                        \
+    type *ptr;                                                    \
+    if (!&var_name)                                               \
+        return NULL;                                              \
+    ptr = bpf_per_cpu_ptr(&var_name, cpu);                        \
+    if (!ptr)                                                     \
+        return NULL;                                              \
+    return ptr;                                                   \
+}
+
+#define DEFINE_PER_CPU_VAL_FUNC(func_name, type, var_name)        \
+type func_name(s32 cpu) {                                         \
+    type *ptr;                                                    \
+    ptr = bpf_per_cpu_ptr(&var_name, cpu);                        \
+    if (!ptr)                                                     \
+        return -EINVAL;                                           \
+    return *ptr;                                                  \
+}
+
+#define DEFINE_THIS_CPU_VAL_FUNC(orig_func_name)			\
+static inline typeof(orig_func_name(0)) this_##orig_func_name(void) {	\
+    return orig_func_name(bpf_get_smp_processor_id());			\
+}
+
+#define DEFINE_THIS_CPU_PTR_FUNC(orig_func_name)			\
+static inline typeof(orig_func_name(0)) this_##orig_func_name(void) {	\
+    return orig_func_name(bpf_get_smp_processor_id());			\
+}
+
+DEFINE_PER_CPU_VAL_FUNC(cpu_llc_size, int, sd_llc_size)
+DEFINE_PER_CPU_VAL_FUNC(cpu_llc_id, int, sd_llc_id)
+DEFINE_PER_CPU_VAL_FUNC(cpu_priority, int, sched_core_priority)
+DEFINE_PER_CPU_PTR_FUNC(cpu_sugov, struct sugov_cpu, sugov_cpu)
+DEFINE_PER_CPU_PTR_FUNC(cpu_psi_group, struct psi_group_cpu, psi_group_cpu)
+DEFINE_PER_CPU_PTR_FUNC(cpu_kernel_stat, struct kernel_stat, kernel_stat)
+DEFINE_PER_CPU_PTR_FUNC(cpu_kernel_cpustat, struct kernel_cpustat, kernel_cpustat)
+
+DEFINE_THIS_CPU_VAL_FUNC(cpu_llc_size)
+DEFINE_THIS_CPU_VAL_FUNC(cpu_llc_id)
+DEFINE_THIS_CPU_VAL_FUNC(cpu_priority)
+DEFINE_THIS_CPU_PTR_FUNC(cpu_sugov)
+DEFINE_THIS_CPU_PTR_FUNC(cpu_psi_group)
+DEFINE_THIS_CPU_PTR_FUNC(cpu_kernel_stat)
+DEFINE_THIS_CPU_PTR_FUNC(cpu_kernel_cpustat)
+
+#endif /* BPF_PERCPU_H */


### PR DESCRIPTION
Add various helpers using bpf_per_cpu_ptr to read common percpu data structures for schedulers. This allows for better interoperability between schedulers and existing kernel data structures.

Tested with the following patch to `p2dq`:
```
diff --git a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
index c54f05fe..b1611e59 100644
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -11,6 +11,7 @@
 #define __bpf__
 #include "../../../../include/scx/common.bpf.h"
 #include "../../../../include/scx/bpf_arena_common.bpf.h"
+#include "../../../../include/scx/percpu.bpf.h"
 #include "../../../../include/lib/atq.h"
 #include "../../../../include/lib/cpumask.h"
 #include "../../../../include/lib/minheap.h"
@@ -20,6 +21,7 @@
 #else
 #include <scx/common.bpf.h>
 #include <scx/bpf_arena_common.bpf.h>
+#include <scx/percpu.bpf.h>
 #include <lib/atq.h>
 #include <lib/cpumask.h>
 #include <lib/minheap.h>
@@ -319,7 +321,7 @@ static struct cpu_ctx *lookup_cpu_ctx(int cpu)
 	return cpuc;
 }
 
-static inline int cpu_priority(s32 cpu)
+static inline int __cpu_priority(s32 cpu)
 {
 	bool itmt_enabled;
 	int *prio;
@@ -1725,7 +1727,7 @@ void BPF_STRUCT_OPS(p2dq_update_idle, s32 cpu, bool idle)
 	 * consider the last time the CPU went idle in the future.
 	 */
 
-	priority = cpu_priority(cpu);
+	priority = __cpu_priority(cpu);
 	if (priority < 0)
 		priority = 1;
 
@@ -2220,6 +2222,38 @@ static __always_inline s32 p2dq_init_impl()
 	struct cpu_ctx *cpuc;
 	int i, ret;
 	u64 dsq_id;
+	s32 cpu = bpf_get_smp_processor_id();
+
+	struct sugov_cpu *sugov;
+	sugov = cpu_sugov(cpu);
+	if (sugov)
+		trace("PERCPU SUGOV [%d] util %llu last update %llu",
+		      sugov->cpu, sugov->util, sugov->last_update);
+
+	struct psi_group_cpu *psi_group;
+	psi_group = cpu_psi_group(cpu);
+	if (psi_group)
+		trace("PERCPU cpu %d psi state start %llu",
+		      cpu, psi_group->state_start);
+
+	struct kernel_stat *kstat;
+	kstat = cpu_kernel_stat(cpu);
+	if (kstat)
+		trace("PERCPU kstat cpu %d irqs_sum %llu",
+		      cpu, kstat->irqs_sum);
+
+	struct kernel_cpustat *k_cpustat;
+	k_cpustat = cpu_kernel_cpustat(cpu);
+	if (k_cpustat)
+		trace("PERCPU k_cpustat cpu %d softirq %llu iowait %llu",
+		      cpu, k_cpustat->cpustat[CPUTIME_SOFTIRQ],
+		      k_cpustat->cpustat[CPUTIME_IOWAIT]);
+
+	trace("PERCPU cpu %d llc %d", cpu, cpu_llc_id(cpu));
+
+	trace("PERCPU cpu %d llc size %d", cpu, cpu_llc_size(cpu));
+
+	trace("PERCPU cpu %d priority %d", cpu, cpu_priority(cpu));
 
 	tmp_big_cpumask = bpf_cpumask_create();
 	if (!tmp_big_cpumask) {
```
Ran scheduler with verbose output:
```
bpftool prog trace | grep PERCPU
           <...>-17779   [010] ...11 10207.385373: bpf_trace_printk: PERCPU SUGOV [10] util 0 last update 0
           <...>-17779   [010] ...11 10207.385386: bpf_trace_printk: PERCPU k_cpustat cpu 10 softirq 93000000 iowait 13753000000
           <...>-17779   [010] ...11 10207.385387: bpf_trace_printk: PERCPU cpu 10 llc 0
           <...>-17779   [010] ...11 10207.385388: bpf_trace_printk: PERCPU cpu 10 llc size 16
           <...>-17779   [010] ...11 10207.385388: bpf_trace_printk: PERCPU cpu 10 priority -22
```

This is just an initial example, more helpers will be added in the future.