### PR TITLE
scx_lavd: Add 'slice_used' for '--monitor-sched-samples'

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -141,6 +141,7 @@ struct task_ctx {
 	u64	resched_interval;	/* reschedule interval in ns: [last running, this running] */
 	u32	cpu_id;			/* where a task is running now */
 	u32	suggested_cpu_id;	/* suggested CPU ID at ops.enqueue() and ops.select_cpu() */
+	u64	last_slice_used;	/* time(ns) used in last scheduled interval: [last running, last stopping] */
 	pid_t	waker_pid;		/* last waker's PID */
 	char	waker_comm[TASK_COMM_LEN + 1]; /* last waker's comm */
 };

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -463,6 +463,13 @@ static void update_stat_for_stopping(struct task_struct *p,
 	taskc->last_stopping_clk = now;
 
 	/*
+	 * Account for how much of the slice was used for this instance.
+	 */
+	if (is_monitored) {
+		taskc->last_slice_used = time_delta(now, taskc->last_running_clk);
+	}
+
+	/*
 	 * Reset waker's latency criticality here to limit the latency boost of
 	 * a task. A task will be latency-boosted only once after wake-up.
 	 */

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -587,6 +587,7 @@ impl<'a> Scheduler<'a> {
             nr_active: tx.nr_active,
             dsq_id: tx.dsq_id,
             dsq_consume_lat: tx.dsq_consume_lat,
+            slice_used: tc.last_slice_used,
         }) {
             Ok(()) | Err(TrySendError::Full(_)) => 0,
             Err(e) => panic!("failed to send on intrspc_tx ({})", e),

--- a/scheds/rust/scx_lavd/src/stats.rs
+++ b/scheds/rust/scx_lavd/src/stats.rs
@@ -154,6 +154,8 @@ pub struct SchedSample {
     pub waker_comm: String,
     #[stat(desc = "Assigned time slice")]
     pub slice: u64,
+    #[stat(desc = "Amount of time actually used by task in a slice")]
+    pub slice_used: u64,
     #[stat(desc = "Latency criticality of this task")]
     pub lat_cri: u32,
     #[stat(desc = "Average latency criticality in a system")]
@@ -194,7 +196,7 @@ impl SchedSample {
     pub fn format_header<W: Write>(w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "\x1b[93m| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:8} | {:17} | {:8} | {:8} | {:7} | {:8} | {:12} | {:12} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:9} | {:6} | {:6} | {:10} |\x1b[0m",
+            "\x1b[93m| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:8} | {:17} | {:8} | {:8} | {:8} | {:7} | {:8} | {:12} | {:12} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:9} | {:6} | {:6} | {:10} |\x1b[0m",
             "MSEQ",
             "PID",
             "COMM",
@@ -205,6 +207,7 @@ impl SchedSample {
             "WKER_PID",
             "WKER_COMM",
             "SLC_NS",
+            "SLC_USED_NS",
             "LAT_CRI",
             "AVG_LC",
             "ST_PRIO",
@@ -233,7 +236,7 @@ impl SchedSample {
 
         writeln!(
             w,
-            "| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:8} | {:17} | {:8} | {:8} | {:7} | {:8} | {:12} | {:12} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:9} | {:6} | {:12} | {:12} |",
+            "| {:6} | {:7} | {:17} | {:5} | {:4} | {:8} | {:8} | {:8} | {:17} | {:8} | {:8} | {:8} | {:7} | {:8} | {:12} | {:12} | {:9} | {:9} | {:9} | {:9} | {:8} | {:8} | {:8} | {:8} | {:9} | {:6} | {:12} | {:12} |",
             self.mseq,
             self.pid,
             self.comm,
@@ -244,6 +247,7 @@ impl SchedSample {
             self.waker_pid,
             self.waker_comm,
             self.slice,
+            self.slice_used,
             self.lat_cri,
             self.avg_lat_cri,
             self.static_prio,


### PR DESCRIPTION
In order to better monitor the effectiveness of slice_boost, measure how long the task ran for before it got scheduled out.