### PR TITLE
scx_cosmos: Allow disabling deferred wakeups

### DIFF
--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -128,6 +128,13 @@ struct Opts {
     #[clap(short = 'w', long, action = clap::ArgAction::SetTrue)]
     no_wake_sync: bool,
 
+    /// Disable deferred wakeups.
+    ///
+    /// Enabling this option can reduce throughput and performance for certain workloads, but it
+    /// can also reduce power consumption (useful on battery-powered systems).
+    #[clap(short = 'd', long, action = clap::ArgAction::SetTrue)]
+    no_deferred_wakeup: bool,
+
     /// Enable address space affinity.
     ///
     /// This option allows to keep tasks that share the same address space (e.g., threads of the
@@ -312,6 +319,7 @@ impl<'a> Scheduler<'a> {
         rodata.slice_ns = opts.slice_us * 1000;
         rodata.slice_lag = opts.slice_lag_us * 1000;
         rodata.cpufreq_enabled = !opts.disable_cpufreq;
+        rodata.deferred_wakeups = !opts.no_deferred_wakeup;
         rodata.flat_idle_scan = opts.flat_idle_scan;
         rodata.smt_enabled = smt_enabled;
         rodata.numa_enabled = opts.enable_numa;


### PR DESCRIPTION
The mechanism of doing deferred wakeups using a BPF timer can help making the hot path in ops.enqueue() faster, but it can also increase power consumption due to the timer that is contantly checking if there are tasks waiting on the local DSQs.

This might be problematic on battery-powered devices, so introduce the option --no-deferred-wakeups to disable this behavior and wake up CPUs synchronously in ops.enqueue().

This can reduce performance and throughput in certain workloads, but it helps reducing power consumption.

Example on an AMD Ryzen AI 9 HX 370 laptop:

 - scx_cosmos:
```
  $ sudo turbostat -S -s PkgWatt,CorWatt
   CorWatt	PkgWatt
   1.99		5.78
   2.00		5.75
   2.01		5.32
   1.99		5.78
   2.01		5.79
```
 - scx_cosmos --no-deferred-wakeups:
```
  $ sudo turbostat -S -s PkgWatt,CorWatt
  CorWatt	PkgWatt
  0.11		1.57
  0.14		1.77
  0.17		1.40
  0.14		1.24
  0.17		1.20
```