### PR TITLE
scx_tickless: Remove unused variable

### DIFF
--- a/scheds/rust/scx_tickless/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_tickless/src/bpf/main.bpf.c
@@ -240,7 +240,6 @@ s32 BPF_STRUCT_OPS(tickless_select_cpu, struct task_struct *p, s32 prev_cpu, u64
 
 void BPF_STRUCT_OPS(tickless_enqueue, struct task_struct *p, u64 enq_flags)
 {
-	s32 cpu = scx_bpf_task_cpu(p);
 	struct task_ctx *tctx;
 	u64 deadline;
 


### PR DESCRIPTION
```c
 Compiling scx_tickless v1.0.5 (/home/eric-wcnlab/linux2025/scx/scheds/rust/scx_tickless)
warning: scx_tickless@1.0.5: src/bpf/main.bpf.c:243:6: warning: unused variable 'cpu' [-Wunused-variable]
warning: scx_tickless@1.0.5:   243 |         s32 cpu = scx_bpf_task_cpu(p);
warning: scx_tickless@1.0.5:       |             ^~~
warning: scx_tickless@1.0.5: 1 warning generated.
```