### PR TITLE
percpu: Add helper to get cpufreq_policy

### DIFF
--- a/scheds/include/scx/percpu.bpf.h
+++ b/scheds/include/scx/percpu.bpf.h
@@ -24,51 +24,74 @@ extern struct sugov_cpu sugov_cpu __ksym __weak;
 extern struct psi_group_cpu psi_group_cpu __ksym __weak;
 extern struct kernel_stat kernel_stat __ksym __weak;
 extern struct kernel_cpustat kernel_cpustat __ksym __weak;
+extern struct cpufreq_policy* cpufreq_cpu_data __ksym __weak;
 
-#define DEFINE_PER_CPU_PTR_FUNC(func_name, type, var_name)        \
-type *func_name(s32 cpu) {                                        \
-    type *ptr;                                                    \
-    if (!&var_name)                                               \
-        return NULL;                                              \
-    ptr = bpf_per_cpu_ptr(&var_name, cpu);                        \
-    if (!ptr)                                                     \
-        return NULL;                                              \
-    return ptr;                                                   \
+
+#define DEFINE_PER_CPU_PTR_FUNC(func_name, type, var_name)	\
+type *func_name(s32 cpu)					\
+{								\
+	type *ptr;						\
+								\
+	if (!&var_name)						\
+		return NULL;					\
+								\
+	ptr = bpf_per_cpu_ptr(&var_name, cpu);			\
+	if (!ptr)						\
+		return NULL;					\
+	return ptr;						\
 }
 
-#define DEFINE_PER_CPU_VAL_FUNC(func_name, type, var_name)        \
-type func_name(s32 cpu) {                                         \
-    type *ptr;                                                    \
-    ptr = bpf_per_cpu_ptr(&var_name, cpu);                        \
-    if (!ptr)                                                     \
-        return -EINVAL;                                           \
-    return *ptr;                                                  \
+
+#define DEFINE_PER_CPU_PTR_PTR_FUNC(func_name, type, per_cpu_var_name)		\
+static __always_inline type func_name(s32 cpu)					\
+{										\
+	type *ptr_to_per_cpu_var = bpf_per_cpu_ptr(&per_cpu_var_name, cpu);	\
+										\
+	if (!ptr_to_per_cpu_var)                                                \
+		return NULL;							\
+	return *ptr_to_per_cpu_var;						\
+}
+
+
+#define DEFINE_PER_CPU_VAL_FUNC(func_name, type, var_name)	\
+type func_name(s32 cpu) {					\
+	type *ptr;						\
+								\
+	ptr = bpf_per_cpu_ptr(&var_name, cpu);			\
+	if (!ptr)						\
+		return -EINVAL;					\
+	return *ptr;						\
 }
 
 #define DEFINE_THIS_CPU_VAL_FUNC(orig_func_name)			\
 static inline typeof(orig_func_name(0)) this_##orig_func_name(void) {	\
-    return orig_func_name(bpf_get_smp_processor_id());			\
+	return orig_func_name(bpf_get_smp_processor_id());		\
 }
 
 #define DEFINE_THIS_CPU_PTR_FUNC(orig_func_name)			\
 static inline typeof(orig_func_name(0)) this_##orig_func_name(void) {	\
-    return orig_func_name(bpf_get_smp_processor_id());			\
+	return orig_func_name(bpf_get_smp_processor_id());		\
 }
 
 DEFINE_PER_CPU_VAL_FUNC(cpu_llc_size, int, sd_llc_size)
 DEFINE_PER_CPU_VAL_FUNC(cpu_llc_id, int, sd_llc_id)
 DEFINE_PER_CPU_VAL_FUNC(cpu_priority, int, sched_core_priority)
-DEFINE_PER_CPU_PTR_FUNC(cpu_sugov, struct sugov_cpu, sugov_cpu)
-DEFINE_PER_CPU_PTR_FUNC(cpu_psi_group, struct psi_group_cpu, psi_group_cpu)
-DEFINE_PER_CPU_PTR_FUNC(cpu_kernel_stat, struct kernel_stat, kernel_stat)
-DEFINE_PER_CPU_PTR_FUNC(cpu_kernel_cpustat, struct kernel_cpustat, kernel_cpustat)
 
-DEFINE_THIS_CPU_VAL_FUNC(cpu_llc_size)
+DEFINE_PER_CPU_PTR_PTR_FUNC(cpu_cpufreq_policy, struct cpufreq_policy*, cpufreq_cpu_data)
+
+DEFINE_PER_CPU_PTR_FUNC(cpu_kernel_cpustat, struct kernel_cpustat, kernel_cpustat)
+DEFINE_PER_CPU_PTR_FUNC(cpu_kernel_stat, struct kernel_stat, kernel_stat)
+DEFINE_PER_CPU_PTR_FUNC(cpu_psi_group, struct psi_group_cpu, psi_group_cpu)
+DEFINE_PER_CPU_PTR_FUNC(cpu_sugov, struct sugov_cpu, sugov_cpu)
+
 DEFINE_THIS_CPU_VAL_FUNC(cpu_llc_id)
+DEFINE_THIS_CPU_VAL_FUNC(cpu_llc_size)
 DEFINE_THIS_CPU_VAL_FUNC(cpu_priority)
-DEFINE_THIS_CPU_PTR_FUNC(cpu_sugov)
-DEFINE_THIS_CPU_PTR_FUNC(cpu_psi_group)
-DEFINE_THIS_CPU_PTR_FUNC(cpu_kernel_stat)
+
+DEFINE_THIS_CPU_PTR_FUNC(cpu_cpufreq_policy)
 DEFINE_THIS_CPU_PTR_FUNC(cpu_kernel_cpustat)
+DEFINE_THIS_CPU_PTR_FUNC(cpu_kernel_stat)
+DEFINE_THIS_CPU_PTR_FUNC(cpu_psi_group)
+DEFINE_THIS_CPU_PTR_FUNC(cpu_sugov)
 
 #endif /* BPF_PERCPU_H */


### PR DESCRIPTION
Add helper to return the percpu cpufreq_policy used by the cpufreq governor. Refactor the formatting of helper macros.

Test with the following patch:
```
diff --git a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
index cfed627e..6ce362f1 100644
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -2204,6 +2204,22 @@ static __always_inline s32 p2dq_init_impl()
        int i, ret;
        u64 dsq_id;

+       s32 cpu = bpf_get_smp_processor_id();
+       struct cpufreq_policy *freq_policy;
+       freq_policy = cpu_cpufreq_policy(cpu);
+       if (freq_policy) {
+               unsigned int min_freq = 0;
+               unsigned int max_freq = 0;
+               unsigned int cur_freq = 0;
+
+               bpf_probe_read_kernel(&min_freq, sizeof(min_freq), &freq_policy->min);
+               bpf_probe_read_kernel(&max_freq, sizeof(max_freq), &freq_policy->max);
+               bpf_probe_read_kernel(&cur_freq, sizeof(cur_freq), &freq_policy->cur);
+
+               trace("PERCPU cpu %d freq min/max/cur %d/%d/%d",
+                     cpu, min_freq, max_freq, cur_freq);
+       }
+
        tmp_big_cpumask = bpf_cpumask_create();
        if (!tmp_big_cpumask) {
                scx_bpf_error("failed to create big cpumask");
```

trace output:
```
 bpftool prog trace | grep PERCPU
           <...>-19754   [007] ...11 10516.279300: bpf_trace_printk: PERCPU cpu 7 freq min/max/cur 419175/5134889/419175
```