### PR TITLE
percpu: Add helper to get cpu sched_domain

### DIFF
--- a/scheds/include/scx/percpu.bpf.h
+++ b/scheds/include/scx/percpu.bpf.h
@@ -25,6 +25,7 @@ extern struct psi_group_cpu psi_group_cpu __ksym __weak;
 extern struct kernel_stat kernel_stat __ksym __weak;
 extern struct kernel_cpustat kernel_cpustat __ksym __weak;
 extern struct cpufreq_policy* cpufreq_cpu_data __ksym __weak;
+extern struct sched_domain* sd_llc __ksym __weak;
 
 
 #define DEFINE_PER_CPU_PTR_FUNC(func_name, type, var_name)	\
@@ -78,6 +79,7 @@ DEFINE_PER_CPU_VAL_FUNC(cpu_llc_id, int, sd_llc_id)
 DEFINE_PER_CPU_VAL_FUNC(cpu_priority, int, sched_core_priority)
 
 DEFINE_PER_CPU_PTR_PTR_FUNC(cpu_cpufreq_policy, struct cpufreq_policy*, cpufreq_cpu_data)
+DEFINE_PER_CPU_PTR_PTR_FUNC(cpu_llc_dom, struct sched_domain*, sd_llc)
 
 DEFINE_PER_CPU_PTR_FUNC(cpu_kernel_cpustat, struct kernel_cpustat, kernel_cpustat)
 DEFINE_PER_CPU_PTR_FUNC(cpu_kernel_stat, struct kernel_stat, kernel_stat)
@@ -92,6 +94,7 @@ DEFINE_THIS_CPU_PTR_FUNC(cpu_cpufreq_policy)
 DEFINE_THIS_CPU_PTR_FUNC(cpu_kernel_cpustat)
 DEFINE_THIS_CPU_PTR_FUNC(cpu_kernel_stat)
 DEFINE_THIS_CPU_PTR_FUNC(cpu_psi_group)
+DEFINE_THIS_CPU_PTR_FUNC(cpu_llc_dom)
 DEFINE_THIS_CPU_PTR_FUNC(cpu_sugov)
 
 #endif /* BPF_PERCPU_H */


### PR DESCRIPTION
Add a helper to get the per-CPU helper for accessing the `struct sched_domain` for the CPU.

Tested with patch:
```
diff --git a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
index cfed627e..8eac1e98 100644
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -2204,6 +2204,20 @@ static __always_inline s32 p2dq_init_impl()
        int i, ret;
        u64 dsq_id;

+       s32 cpu = bpf_get_smp_processor_id();
+       struct sched_domain *llc_dom;
+       llc_dom = cpu_llc_dom(cpu);
+       if (llc_dom) {
+               u64 min_intrvl_ms;
+               u64 max_intrvl_ms;
+
+               bpf_probe_read_kernel(&min_intrvl_ms, sizeof(min_intrvl_ms), &llc_dom->min_interval);
+               bpf_probe_read_kernel(&max_intrvl_ms, sizeof(max_intrvl_ms), &llc_dom->max_interval);
+
+               trace("PERCPU %d llc interval_ms min/max %llu/%llu",
+                     cpu, min_intrvl_ms, max_intrvl_ms);
+       }
+
```
output:
```
 bpftool prog trace | grep PERCPU
           <...>-28298   [017] ...11 4148768.282533: bpf_trace_printk: PERCPU 17 llc interval_ms min/max 16/32
```