### PR TITLE
scxtop: refactor columns part 2

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -11,10 +11,11 @@ use crate::bpf_stats::BpfStats;
 use crate::config::get_config_path;
 use crate::config::Config;
 use crate::get_default_events;
+use crate::get_process_columns;
 use crate::util::{format_hz, read_file_string, sanitize_nbsp, u32_to_i32};
 use crate::AppState;
 use crate::AppTheme;
-use crate::Column;
+use crate::Columns;
 use crate::CpuData;
 use crate::CpuStatTracker;
 use crate::EventData;
@@ -36,7 +37,8 @@ use crate::{
     Action, CpuhpEnterAction, CpuhpExitAction, ExecAction, ExitAction, ForkAction, GpuMemAction,
     HwPressureAction, IPIAction, KprobeAction, MangoAppAction, SchedCpuPerfSetAction,
     SchedHangAction, SchedMigrateTaskAction, SchedSwitchAction, SchedWakeupAction,
-    SchedWakingAction, SoftIRQAction, TraceStartedAction, TraceStoppedAction, WaitAction,
+    SchedWakingAction, SoftIRQAction, TraceStartedAction, TraceStoppedAction,
+    UpdateColVisibilityAction, WaitAction,
 };
 
 use anyhow::{bail, Result};
@@ -98,7 +100,7 @@ pub struct App<'a> {
     large_core_count: bool,
     collect_cpu_freq: bool,
     collect_uncore_freq: bool,
-    process_columns: Vec<Column>,
+    process_columns: Columns,
 
     cpu_data: BTreeMap<usize, CpuData>,
     llc_data: BTreeMap<usize, LlcData>,
@@ -231,6 +233,8 @@ impl<'a> App<'a> {
         let trace_file_prefix = config.trace_file_prefix().to_string();
         let trace_manager = PerfettoTraceManager::new(trace_file_prefix, None);
 
+        let process_columns = Columns::new(get_process_columns());
+
         // There isn't a 'is_loaded' method on a prog in libbpf-rs so do the next best thing and
         // try to infer from the fd
         let hw_pressure = skel.progs.on_hw_pressure_update.as_fd().as_raw_fd() > 0;
@@ -257,7 +261,7 @@ impl<'a> App<'a> {
             topo,
             collect_cpu_freq: true,
             collect_uncore_freq: true,
-            process_columns: Self::create_process_columns(),
+            process_columns,
             cpu_data,
             llc_data,
             node_data,
@@ -2209,92 +2213,9 @@ impl<'a> App<'a> {
         Ok(())
     }
 
-    fn create_process_columns() -> Vec<Column> {
-        vec![
-            Column {
-                header: "TGID",
-                constraint: Constraint::Length(8),
-                visible: true,
-                value_fn: Box::new(|tgid, _| tgid.to_string()),
-            },
-            Column {
-                header: "Name",
-                constraint: Constraint::Length(15),
-                visible: true,
-                value_fn: Box::new(|_, data| data.process_name.clone()),
-            },
-            Column {
-                header: "Command Line",
-                constraint: Constraint::Fill(1),
-                visible: true,
-                value_fn: Box::new(|_, data| data.cmdline.join(" ")),
-            },
-            Column {
-                header: "Last DSQ",
-                constraint: Constraint::Length(18),
-                visible: true,
-                value_fn: Box::new(|_, data| {
-                    data.dsq.map_or(String::new(), |v| format!("0x{v:X}"))
-                }),
-            },
-            Column {
-                header: "Slice ns",
-                constraint: Constraint::Length(8),
-                visible: true,
-                value_fn: Box::new(|_, data| {
-                    let stats = VecStats::new(&data.event_data_immut("slice_consumed"), None);
-                    stats.avg.to_string()
-                }),
-            },
-            Column {
-                header: "Avg/Max Lat us",
-                constraint: Constraint::Length(14),
-                visible: true,
-                value_fn: Box::new(|_, data| {
-                    let stats = VecStats::new(&data.event_data_immut("lat_us"), None);
-                    format!("{}/{}", stats.avg, stats.max)
-                }),
-            },
-            Column {
-                header: "CPU",
-                constraint: Constraint::Length(3),
-                visible: true,
-                value_fn: Box::new(|_, data| data.cpu.to_string()),
-            },
-            Column {
-                header: "LLC",
-                constraint: Constraint::Length(3),
-                visible: true,
-                value_fn: Box::new(|_, data| data.llc.map_or(String::new(), |v| v.to_string())),
-            },
-            Column {
-                header: "NUMA",
-                constraint: Constraint::Length(4),
-                visible: true,
-                value_fn: Box::new(|_, data| data.node.map_or(String::new(), |v| v.to_string())),
-            },
-            Column {
-                header: "Threads",
-                constraint: Constraint::Length(7),
-                visible: true,
-                value_fn: Box::new(|_, data| data.threads.len().to_string()),
-            },
-            Column {
-                header: "CPU%",
-                constraint: Constraint::Length(4),
-                visible: true,
-                value_fn: Box::new(|_, data| format!("{:?}", data.cpu_util_perc)),
-            },
-        ]
-    }
-
     /// Render the process view.
     fn render_process_table(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        let visible_columns: Vec<&Column> = self
-            .process_columns
-            .iter()
-            .filter(|col| col.visible)
-            .collect();
+        let visible_columns: Vec<_> = self.process_columns.visible_columns().collect();
 
         let header = visible_columns
             .iter()
@@ -2919,6 +2840,22 @@ impl<'a> App<'a> {
         }
     }
 
+    /// Updates a column's visibility
+    pub fn update_col_visibility(&mut self, action: &UpdateColVisibilityAction) -> Result<()> {
+        let UpdateColVisibilityAction {
+            table,
+            col,
+            visible,
+        } = action;
+
+        match table.as_str() {
+            "Process" => self.process_columns.update_visibility(col, *visible),
+            _ => bail!("Invalid table name"),
+        };
+
+        Ok(())
+    }
+
     /// Updates the bpf bpf sampling rate.
     pub fn update_bpf_sample_rate(&mut self, sample_rate: u32) {
         self.skel.maps.data_data.as_mut().unwrap().sample_rate = sample_rate;
@@ -3042,6 +2979,9 @@ impl<'a> App<'a> {
                 self.on_kprobe(a);
             }
             Action::ClearEvent => self.reset_prof_events()?,
+            Action::UpdateColVisibility(a) => {
+                self.update_col_visibility(a)?;
+            }
             Action::ChangeTheme => {
                 self.set_theme(self.theme().next());
             }

--- a/tools/scxtop/src/columns.rs
+++ b/tools/scxtop/src/columns.rs
@@ -1,0 +1,222 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use crate::ProcData;
+use crate::VecStats;
+
+use ratatui::prelude::Constraint;
+use std::collections::HashMap;
+
+type ColumnFn = Box<dyn Fn(i32, &ProcData) -> String>;
+
+pub struct Column {
+    pub header: &'static str,
+    pub constraint: ratatui::prelude::Constraint,
+    pub visible: bool,
+    pub value_fn: ColumnFn,
+}
+
+pub struct Columns {
+    columns: Vec<Column>,
+    header_to_index: HashMap<&'static str, usize>,
+}
+
+impl Columns {
+    pub fn new(columns: Vec<Column>) -> Self {
+        let header_to_index = columns
+            .iter()
+            .enumerate()
+            .map(|(i, col)| (col.header, i))
+            .collect();
+
+        Self {
+            columns,
+            header_to_index,
+        }
+    }
+
+    /// Update visibility of a single column by header
+    pub fn update_visibility(&mut self, header: &str, visible: bool) -> bool {
+        if let Some(&idx) = self.header_to_index.get(header) {
+            self.columns[idx].visible = visible;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Return a slice of only the visible columns
+    pub fn visible_columns(&self) -> impl Iterator<Item = &Column> {
+        self.columns.iter().filter(|c| c.visible)
+    }
+
+    /// Return all columns
+    pub fn all_columns(&self) -> &[Column] {
+        &self.columns
+    }
+}
+
+pub fn get_process_columns() -> Vec<Column> {
+    vec![
+        Column {
+            header: "TGID",
+            constraint: Constraint::Length(8),
+            visible: true,
+            value_fn: Box::new(|tgid, _| tgid.to_string()),
+        },
+        Column {
+            header: "Name",
+            constraint: Constraint::Length(15),
+            visible: true,
+            value_fn: Box::new(|_, data| data.process_name.clone()),
+        },
+        Column {
+            header: "Command Line",
+            constraint: Constraint::Fill(1),
+            visible: true,
+            value_fn: Box::new(|_, data| data.cmdline.join(" ")),
+        },
+        Column {
+            header: "Last DSQ",
+            constraint: Constraint::Length(18),
+            visible: true,
+            value_fn: Box::new(|_, data| data.dsq.map_or(String::new(), |v| format!("0x{v:X}"))),
+        },
+        Column {
+            header: "Slice ns",
+            constraint: Constraint::Length(8),
+            visible: true,
+            value_fn: Box::new(|_, data| {
+                let stats = VecStats::new(&data.event_data_immut("slice_consumed"), None);
+                stats.avg.to_string()
+            }),
+        },
+        Column {
+            header: "Avg/Max Lat us",
+            constraint: Constraint::Length(14),
+            visible: true,
+            value_fn: Box::new(|_, data| {
+                let stats = VecStats::new(&data.event_data_immut("lat_us"), None);
+                format!("{}/{}", stats.avg, stats.max)
+            }),
+        },
+        Column {
+            header: "CPU",
+            constraint: Constraint::Length(3),
+            visible: true,
+            value_fn: Box::new(|_, data| data.cpu.to_string()),
+        },
+        Column {
+            header: "LLC",
+            constraint: Constraint::Length(3),
+            visible: true,
+            value_fn: Box::new(|_, data| data.llc.map_or(String::new(), |v| v.to_string())),
+        },
+        Column {
+            header: "NUMA",
+            constraint: Constraint::Length(4),
+            visible: true,
+            value_fn: Box::new(|_, data| data.node.map_or(String::new(), |v| v.to_string())),
+        },
+        Column {
+            header: "Threads",
+            constraint: Constraint::Length(7),
+            visible: true,
+            value_fn: Box::new(|_, data| data.threads.len().to_string()),
+        },
+        Column {
+            header: "CPU%",
+            constraint: Constraint::Length(4),
+            visible: true,
+            value_fn: Box::new(|_, data| format!("{:?}", data.cpu_util_perc)),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::prelude::Constraint;
+
+    fn make_column(header: &'static str, visible: bool) -> Column {
+        Column {
+            header,
+            constraint: Constraint::Length(10),
+            visible,
+            value_fn: Box::new(|_, _| format!("value")),
+        }
+    }
+
+    #[test]
+    fn test_new_columns_builds_header_index() {
+        let columns = vec![
+            make_column("PID", true),
+            make_column("Name", false),
+            make_column("CPU%", true),
+        ];
+        let c = Columns::new(columns);
+
+        assert_eq!(c.header_to_index["PID"], 0);
+        assert_eq!(c.header_to_index["Name"], 1);
+        assert_eq!(c.header_to_index["CPU%"], 2);
+    }
+
+    #[test]
+    fn test_visible_columns_filters_properly() {
+        let columns = vec![
+            make_column("PID", true),
+            make_column("Name", false),
+            make_column("CPU%", true),
+        ];
+        let c = Columns::new(columns);
+        let visible: Vec<&str> = c.visible_columns().map(|c| c.header).collect();
+
+        assert_eq!(visible, vec!["PID", "CPU%"]);
+    }
+
+    #[test]
+    fn test_update_visibility_success() {
+        let columns = vec![make_column("PID", true), make_column("Name", false)];
+        let mut c = Columns::new(columns);
+        let visible: Vec<&str> = c.visible_columns().map(|c| c.header).collect();
+        assert_eq!(visible, vec!["PID"]);
+
+        let updated = c.update_visibility("Name", true);
+
+        assert!(updated);
+        let visible: Vec<&str> = c.visible_columns().map(|c| c.header).collect();
+        assert_eq!(visible, vec!["PID", "Name"]);
+    }
+
+    #[test]
+    fn test_update_visibility_fails_gracefully() {
+        let columns = vec![make_column("PID", true)];
+        let mut c = Columns::new(columns);
+        let updated = c.update_visibility("Nonexistent", false);
+
+        assert!(!updated);
+        let visible: Vec<&str> = c.visible_columns().map(|c| c.header).collect();
+        assert_eq!(visible, vec!["PID"]);
+    }
+
+    #[test]
+    fn test_all_columns_returns_all() {
+        let columns = vec![make_column("A", true), make_column("B", false)];
+        let c = Columns::new(columns);
+        let headers: Vec<&str> = c.all_columns().iter().map(|c| c.header).collect();
+
+        assert_eq!(headers, vec!["A", "B"]);
+    }
+
+    #[test]
+    fn test_duplicate_headers_fail_to_map_properly() {
+        let columns = vec![make_column("A", true), make_column("A", false)];
+        let c = Columns::new(columns);
+
+        // Only the last one will remain in header_to_index
+        assert_eq!(c.header_to_index.len(), 1);
+        assert_eq!(c.header_to_index["A"], 1);
+    }
+}


### PR DESCRIPTION
This is part 2 of #2469. We now add the Columns struct, which maintains a hashmap of headers to their index so we can update a column in O(1) time, and also gives an easy way to get a visible columns iterator or all columns. This can now fully be used to turn on and off columns easily with the `UpdateColVisibilityAction` and is almost ready to be used for any ratatui table we will use in the future (ColumnFn's reliance on ProcData needs to be generalized).

