### PR TITLE
meson: don't provide libbpf to cargo

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -336,7 +336,10 @@ if enable_rust
     cargo_env.append('BPF_BASE_CFLAGS', flag, separator: ' ')
   endforeach
 
-  if libbpf_a != ''
+  # Cargo already uses a vendored and locked libbpf in the form of libbpf-sys.
+  # Don't attempt to further complicate things by building one for them if we
+  # built it, but do still provide it if it was supplied by the user.
+  if libbpf_a != '' and not should_build_libbpf
     foreach header: libbpf_h
       cargo_env.append('BPF_EXTRA_CFLAGS_PRE_INCL', '-I' + header, separator: ' ')
     endforeach


### PR DESCRIPTION
There is currently a huge meson matrix, but one place that causes issues is the libbpf vendoring. libbpf is available to be vendored which is very important for c schedulers, but not important for Rust schedulers. This is because Rust already has a pinned and vendored libbpf in the form of libbpf-sys.

As part of the vendoring we have to work hard to select a correct set of compiler arguments. Although this appears to work just fine for C schedulers, it seems flaky for Rust schedulers, particularly with LTO.

Drop the vendored libbpf for Rust schedulers in the case where it wasn't specified. That is, no arguments now allows Rust to use the libbpf-sys version of libbpf, which sidesteps any compiler version issues.

Test plan:
- CI for usual checks
- Arch PKGBUILD with LTO. Failed without this on rust scheds, succeeds after.