### PR TITLE
nix: update veristat

### DIFF
--- a/.github/include/flake.lock
+++ b/.github/include/flake.lock
@@ -39,6 +39,22 @@
         "type": "github"
       }
     },
+    "libbpf-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752884596,
+        "narHash": "sha256-atjH2mL5PreCPj+VcJ//U9bdv4gAd57VU60KhbS7IqE=",
+        "owner": "libbpf",
+        "repo": "libbpf",
+        "rev": "58dd1f58b57294b2e59482245b29e46f1812b82d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "libbpf",
+        "repo": "libbpf",
+        "type": "github"
+      }
+    },
     "nix-develop-gha": {
       "inputs": {
         "nixpkgs": [
@@ -79,6 +95,7 @@
       "inputs": {
         "fenix": "fenix",
         "flake-utils": "flake-utils",
+        "libbpf-src": "libbpf-src",
         "nix-develop-gha": "nix-develop-gha",
         "nixpkgs": "nixpkgs",
         "veristat-src": "veristat-src"
@@ -119,11 +136,11 @@
     "veristat-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1736364478,
-        "narHash": "sha256-07awVCMrFFG69cGtucLYGT+mqcRZ9F9ZHvxARLLYpM0=",
+        "lastModified": 1751555249,
+        "narHash": "sha256-7NbKM9GA2N2CZGXZKllh00bqWGKb8+ftG/lGG/JNPng=",
         "owner": "libbpf",
         "repo": "veristat",
-        "rev": "3bf5cdf98b05faf53dca21492e69ffb4605c6d42",
+        "rev": "1b386f2cd5d798bc74dba1af5208f5273aba2b9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update veristat. This requires pulling a new version of libbpf too, which makes sense. Best to keep them in sync. This solves a problem where veristat would SEGV on p2dq.

The current veristat jobs don't fail CI but future ones will. Not making that change at the same time as this update.

Test plan:
- CI for build
- https://github.com/sched-ext/scx/actions/runs/16575334043/job/46878140361 - job from main failed silently and SEGV'd on p2dq (look for veristat). -
https://github.com/sched-ext/scx/actions/runs/16574842176/job/46876476270 - job with this update succeeded at veristat.