### PR TITLE
scx_p2dq: Refactor min_llc_runs_pick2 to scale with load

### DIFF
--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -141,7 +141,7 @@ pub struct SchedulerOpts {
     #[clap(short = 's', long, default_value = "100")]
     pub min_slice_us: u64,
 
-    /// Load balance mode
+    /// ***DEPRECATED*** Load balance mode
     #[arg(value_enum, long, default_value_t = LbMode::Load)]
     pub lb_mode: LbMode,
 
@@ -260,7 +260,6 @@ macro_rules! init_open_skel {
             rodata.lb_config.slack_factor = opts.lb_slack_factor;
             rodata.lb_config.min_nr_queued_pick2 = opts.min_nr_queued_pick2;
             rodata.lb_config.max_dsq_pick2 = MaybeUninit::new(opts.max_dsq_pick2);
-            rodata.lb_config.pick2_mode = opts.lb_mode.as_i32();
             rodata.lb_config.eager_load_balance = MaybeUninit::new(!opts.eager_load_balance);
             rodata.lb_config.dispatch_pick2_disable = MaybeUninit::new(opts.dispatch_pick2_disable);
             rodata.lb_config.dispatch_lb_busy = opts.dispatch_lb_busy;


### PR DESCRIPTION
Refactor min_llc_runs_pick2 to be dynamic based on utilization. Add a boolean that tracks whether the system is saturated based on idle CPUs. Remove some heuristics in can_migrate to scale based on utilization. This slightly improves throughput at saturation and improves performance at moderate load

Remove the pick2_mode option to improve throughput at saturation by making load balancing take into consideration both load and queue depth.