### PR TITLE
scx_cosmos: Enable long option --flat-idle-scan

### DIFF
--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -102,7 +102,7 @@ struct Opts {
     ///
     /// This option can help reducing some overhead when trying to allocate idle CPUs and it can be
     /// quite effective with simple CPU topologies.
-    #[arg(short = 'i', action = clap::ArgAction::SetTrue)]
+    #[arg(short = 'i', long, action = clap::ArgAction::SetTrue)]
     flat_idle_scan: bool,
 
     /// Enable preferred idle CPU scanning.


### PR DESCRIPTION
Flat idle CPU scanning can only be enabled via the short-form option. Allow to use also the long-form option.

Before:
```
 $ sudo scx_cosmos -h
 ...
  -i                                       Enable flat idle CPU scanning
```
After:
```
 $ sudo scx_cosmos -h
 ...
  -i, --flat-idle-scan                     Enable flat idle CPU scanning
```