### PR TITLE
ci: append nix paths to formatter

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -73,10 +73,13 @@ def run_format():
 
     run_command(["cargo", "fmt"])
 
-    run_command(
-        ["nix", "--extra-experimental-features", "nix-command flakes", "fmt"],
-        cwd=".github/include",
-    )
+    nix_files = glob.glob("**/*.nix", root_dir=".github/include/", recursive=True)
+    if nix_files:
+        run_command(
+            ["nix", "--extra-experimental-features", "nix-command flakes", "fmt"]
+            + nix_files,
+            cwd=".github/include",
+        )
 
     run_command(["git", "diff", "--exit-code"])
     print("✓ Format completed successfully", flush=True)


### PR DESCRIPTION
The formatter works fine in the CI for Nix files, but when I try to run it locally it hangs forever. This is a bug in a specific version of Nix that means it waits forever for stdin if given no paths (it should format everything). Small quality of life improvement to add the Nix paths so it doesn't hang and I can format things locally.

Test plan:
- CI
- Ran locally. Works now.