### PR TITLE
scx_lavd: Improve the ops.enqueue() path.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -133,6 +133,7 @@ struct task_ctx {
 	 * Task status
 	 */
 	volatile u64	flags;		/* LAVD_FLAG_* */
+	u32	suggested_cpu_id;	/* suggested CPU ID at ops.enqueue() and ops.select_cpu() */
 
 	/*
 	 * Additional information when the scheduler is monitored,
@@ -140,7 +141,6 @@ struct task_ctx {
 	 */
 	u64	resched_interval;	/* reschedule interval in ns: [last running, this running] */
 	u32	cpu_id;			/* where a task is running now */
-	u32	suggested_cpu_id;	/* suggested CPU ID at ops.enqueue() and ops.select_cpu() */
 	u64	last_slice_used;	/* time(ns) used in last scheduled interval: [last running, last stopping] */
 	pid_t	waker_pid;		/* last waker's PID */
 	char	waker_comm[TASK_COMM_LEN + 1]; /* last waker's comm */

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -83,6 +83,7 @@ enum consts_flags {
 	LAVD_FLAG_ON_BIG		= (0x1 << 6), /* can a task run on a big core? */
 	LAVD_FLAG_ON_LITTLE		= (0x1 << 7), /* can a task run on a little core? */
 	LAVD_FLAG_SLICE_BOOST		= (0x1 << 8), /* task's time slice is boosted. */
+	LAVD_FLAG_IDLE_CPU_PICKED	= (0x1 << 9), /* an idle CPU is picked at ops.select_cpu() */
 };
 
 /*
@@ -152,8 +153,8 @@ struct cpu_ctx {
 	volatile u64	running_clk;	/* when a task starts running */
 	volatile u64	est_stopping_clk; /* estimated stopping time */
 	volatile u64	flags;		/* cached copy of task's flags */
-	volatile s32	futex_op;	/* futex op in futex V1 */
 	volatile u32	nr_pinned_tasks; /* the number of pinned tasks waiting for running on this CPU */
+	volatile s32	futex_op;	/* futex op in futex V1 */
 	volatile u16	lat_cri;	/* latency criticality */
 	volatile u8	is_online;	/* is this CPU online? */
 


### PR DESCRIPTION
This PR improves the ops.enqueue() path in two ways:
1) Remove redundant pick_idle_cpu() selection when a CPU was already picked at ops.select_cpu().
2) Use the Power of 2 Random Choices technique when a proper CPU is not chosen to choose a less loaded CPU. 