### PR TITLE
scxtop: refactor search

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -12,6 +12,7 @@ use crate::config::get_config_path;
 use crate::config::Config;
 use crate::get_default_events;
 use crate::get_process_columns;
+use crate::search;
 use crate::util::{format_hz, read_file_string, sanitize_nbsp, u32_to_i32};
 use crate::AppState;
 use crate::AppTheme;
@@ -27,7 +28,6 @@ use crate::PerfEvent;
 use crate::PerfettoTraceManager;
 use crate::ProcData;
 use crate::ProfilingEvent;
-use crate::Search;
 use crate::VecStats;
 use crate::ViewState;
 use crate::APP;
@@ -114,8 +114,8 @@ pub struct App<'a> {
     active_prof_events: BTreeMap<usize, ProfilingEvent>,
     available_events: Vec<ProfilingEvent>,
     event_input_buffer: String,
-    perf_event_search: Search,
-    kprobe_event_search: Search,
+    perf_events: Vec<String>,
+    kprobe_events: Vec<String>,
     kprobe_links: Vec<Link>,
     filtered_events_state: Arc<StdMutex<FilteredEventState>>,
 
@@ -204,7 +204,7 @@ impl<'a> App<'a> {
             }
         }
 
-        let initial_perf_events_list: Vec<String> = available_perf_events()?
+        let mut initial_perf_events_list: Vec<String> = available_perf_events()?
             .iter()
             .flat_map(|(subsystem, events)| {
                 events
@@ -212,7 +212,10 @@ impl<'a> App<'a> {
                     .map(|event| format!("{}:{}", subsystem.clone(), event.clone()))
             })
             .collect();
-        let initial_kprobe_events_list = available_kprobe_events()?;
+        initial_perf_events_list.sort();
+
+        let mut initial_kprobe_events_list = available_kprobe_events()?;
+        initial_kprobe_events_list.sort();
 
         let filtered_events_state = Arc::new(StdMutex::new(FilteredEventState::default()));
 
@@ -272,8 +275,8 @@ impl<'a> App<'a> {
             active_prof_events,
             available_events: default_events,
             event_input_buffer: String::new(),
-            perf_event_search: Search::new(initial_perf_events_list),
-            kprobe_event_search: Search::new(initial_kprobe_events_list),
+            perf_events: initial_perf_events_list,
+            kprobe_events: initial_kprobe_events_list,
             kprobe_links: Vec::new(),
             filtered_events_state,
             events_list_size: 1,
@@ -2836,12 +2839,12 @@ impl<'a> App<'a> {
 
     pub fn filter_events(&mut self) {
         let filtered_events_list = match self.state {
-            AppState::PerfEvent => self
-                .perf_event_search
-                .fuzzy_search(&self.event_input_buffer),
-            AppState::KprobeEvent => self
-                .kprobe_event_search
-                .fuzzy_search(&self.event_input_buffer),
+            AppState::PerfEvent => {
+                search::fuzzy_search(&self.perf_events, &self.event_input_buffer)
+            }
+            AppState::KprobeEvent => {
+                search::fuzzy_search(&self.kprobe_events, &&self.event_input_buffer)
+            }
             _ => vec![],
         };
 

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -23,7 +23,7 @@ mod node_data;
 mod perfetto_trace;
 mod proc_data;
 pub mod profiling_events;
-mod search;
+pub mod search;
 mod stats;
 mod theme;
 mod thread_data;
@@ -49,7 +49,6 @@ pub use profiling_events::{
     available_kprobe_events, available_perf_events, get_default_events, KprobeEvent, PerfEvent,
     ProfilingEvent,
 };
-pub use search::Search;
 pub use stats::StatAggregation;
 pub use stats::VecStats;
 pub use theme::AppTheme;

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -10,6 +10,7 @@ use scxtop::config::Config;
 use scxtop::edm::{ActionHandler, BpfEventActionPublisher, BpfEventHandler, EventDispatchManager};
 use scxtop::layered_util;
 use scxtop::mangoapp::poll_mangoapp;
+use scxtop::search;
 use scxtop::tracer::Tracer;
 use scxtop::util::{get_clock_value, read_file_string};
 use scxtop::Action;
@@ -20,7 +21,6 @@ use scxtop::Key;
 use scxtop::KeyMap;
 use scxtop::MemStatSnapshot;
 use scxtop::PerfettoTraceManager;
-use scxtop::Search;
 use scxtop::SystemStatAction;
 use scxtop::Tui;
 use scxtop::SCHED_NAME_PATH;
@@ -153,9 +153,9 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
         ColorChoice::Auto,
     )?;
 
-    let kprobe_events = Search::new(available_kprobe_events()?);
-    kprobe_events
-        .contains_all(&trace_args.kprobes)
+    let mut kprobe_events = available_kprobe_events()?;
+    kprobe_events.sort();
+    search::sorted_contains_all(&kprobe_events, &trace_args.kprobes)
         .then_some(())
         .ok_or_else(|| anyhow!("Invalid kprobe events"))?;
 


### PR DESCRIPTION
Non-functional changes - this refactors the search code to not maintain state/be a struct. It wasn't really necessary from the beginning and makes it hard to use the search capabilities for constantly-changing list's. For example, when it comes to filtering processes, we want to be able to filter a constantly-changing list of processes. Even for kprobes and perf, maintaining the state in the Search struct offered minimal benefit over the refactored version.

Testing:
* Ran `scxtop` and manually tested search capabilities
* Ran `scxtop trace` with an invalid kprobe to ensure it still caught that