### PR TITLE
scx_bpf_compat: use proper scx/common.bpf.h header

### DIFF
--- a/rust/scx_bpf_compat/src/bpf/main.bpf.c
+++ b/rust/scx_bpf_compat/src/bpf/main.bpf.c
@@ -3,11 +3,7 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
-#include <vmlinux.h>
-
-#include <bpf/bpf_core_read.h>
-#include <bpf/bpf_helpers.h>
-#include <bpf/bpf_tracing.h>
+#include <scx/common.bpf.h>
 
 char _license[] SEC("license") = "GPL";
 


### PR DESCRIPTION
We provide kfunc definitions in common.bpf.h. I'm not sure where this file was getting them from before but it doesn't seem to work in all environments. Use the scx/common.bpf.h header like everywhere else.

Test plan:
- CI