### PR TITLE
scx.service: drop ConditionPathIsDirectory

### DIFF
--- a/services/systemd/scx.service
+++ b/services/systemd/scx.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Start scx_scheduler
-ConditionPathIsDirectory=/sys/kernel/sched_ext
 StartLimitIntervalSec=30
 StartLimitBurst=2
 


### PR DESCRIPTION
`ConditionPathIsDirectory` was added at a time when sched-ext was not yet upstream (around kernel version 6.7) as a safeguard against running this on LTS version 6.6. Since the latest LTS kernel having sched-ext is 6.12 we can simplify the syntax of the systemd service.

The scx_loader.service also has no such protection and no errors have been reported because of this.