### PR TITLE
scx_flash: Handle NULL scx_bpf_cpu_rq() return

### DIFF
--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -1986,11 +1986,14 @@ static int tickless_timerfn(void *map, int *key, struct bpf_timer *timer)
 	bpf_rcu_read_lock();
 	bpf_for(cpu, 0, nr_cpu_ids) {
 		struct task_struct *p;
+		struct rq *rq = scx_bpf_cpu_rq(cpu);
 
+		if (!rq)
+			continue;
 		/*
 		 * Ignore CPU if idle task is running.
 		 */
-		p = scx_bpf_cpu_rq(cpu)->curr;
+		p = rq->curr;
 		if (p->flags & PF_IDLE)
 			continue;
 


### PR DESCRIPTION
scx_bpf_cpu_rq() may return NULL on invalid CPU.
Check for NULL accordingly.

Signed-off-by: Christian Loehle <christian.loehle@arm.com>