### PR TITLE
lib/sdt_alloc: remove __hidden from scx_static_alloc

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -588,8 +588,8 @@ u64 scx_alloc_internal(struct scx_allocator *alloc)
 
 struct scx_static scx_static;
 
-__hidden
-void __arena *scx_static_alloc(size_t bytes, size_t alignment)
+__weak
+u64 scx_static_alloc_internal(size_t bytes, size_t alignment)
 {
 	void __arena *memory, *old;
 	size_t alloc_bytes;
@@ -609,7 +609,7 @@ void __arena *scx_static_alloc(size_t bytes, size_t alignment)
 		bpf_spin_unlock(&alloc_lock);
 		bpf_printk("invalid request %ld, max is %ld\n", alloc_bytes,
 			      scx_static.max_alloc_bytes);
-		return NULL;
+		return (u64)NULL;
 	}
 
 	/*
@@ -632,7 +632,7 @@ void __arena *scx_static_alloc(size_t bytes, size_t alignment)
 					       scx_static.max_alloc_bytes / PAGE_SIZE,
 					       NUMA_NO_NODE, 0);
 		if (!memory)
-			return NULL;
+			return (u64)NULL;
 
 		bpf_spin_lock(&alloc_lock);
 
@@ -642,7 +642,7 @@ void __arena *scx_static_alloc(size_t bytes, size_t alignment)
 			bpf_arena_free_pages(&arena, memory, scx_static.max_alloc_bytes);
 
 			bpf_printk("concurrent static memory allocations unsupported");
-			return NULL;
+			return (u64)NULL;
 		}
 
 		/*
@@ -665,7 +665,7 @@ void __arena *scx_static_alloc(size_t bytes, size_t alignment)
 
 	bpf_spin_unlock(&alloc_lock);
 
-	return ptr;
+	return (u64)ptr;
 }
 
 __weak

--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -53,7 +53,8 @@ int scx_alloc_free_idx(struct scx_allocator *alloc, __u64 idx);
 
 #define scx_alloc(alloc) ((struct sdt_data __arena *)scx_alloc_internal((alloc)))
 
-void __arena *scx_static_alloc(size_t bytes, size_t alignment);
+u64 scx_static_alloc_internal(size_t bytes, size_t alignment);
+#define scx_static_alloc(bytes, alignment) ((void __arena *)scx_static_alloc_internal((bytes), (alignment)))
 int scx_static_init(size_t max_alloc_pages);
 
 u64 scx_stk_alloc(struct scx_stk *stack);


### PR DESCRIPTION
Using __hidden on global functions allows us to return non-int types, but greatly complicates debigging inlining the global function's verification on each callsite. Since arena pointers and scalars can be freely typecasted, return the allocated pointer as a u64 add a macro for transparently typecasting it to the user.