### PR TITLE
scx_lavd: turn on libbpf error logging for verifier failures

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -12,6 +12,7 @@ pub mod bpf_intf;
 pub use bpf_intf::*;
 
 mod cpu_order;
+use scx_utils::init_libbpf_logging;
 mod stats;
 use std::ffi::c_int;
 use std::ffi::CStr;
@@ -36,6 +37,7 @@ use crossbeam::channel::RecvTimeoutError;
 use crossbeam::channel::Sender;
 use crossbeam::channel::TrySendError;
 use libbpf_rs::OpenObject;
+use libbpf_rs::PrintLevel;
 use libbpf_rs::ProgramInput;
 use libc::c_char;
 use log::debug;
@@ -335,6 +337,8 @@ impl<'a> Scheduler<'a> {
         // Open the BPF prog first for verification.
         let mut skel_builder = BpfSkelBuilder::default();
         skel_builder.obj_builder.debug(opts.verbose > 0);
+        init_libbpf_logging(Some(PrintLevel::Debug));
+
         let mut skel = scx_ops_open!(skel_builder, open_object, lavd_ops)?;
 
         // Enable futex tracing using ftrace if available. If the ftrace is not


### PR DESCRIPTION
Turn on libbpf logging for scx_lavd. This enables both setup-related warnings and emitting the verifier log in case of verification failures by default and independently of any scheduler-related diagnostics.