### PR TITLE
scxctl/scx_loader: Report current scheduler args

### DIFF
--- a/tools/scx_loader/org.scx.Loader.xml
+++ b/tools/scx_loader/org.scx.Loader.xml
@@ -31,6 +31,14 @@
     <property name="SchedulerMode" type="u" access="read"/>
 
     <!--
+        CurrentSchedulerArgs:
+
+        The arguments used for the currently running scheduler. If no scheduler
+        is active or the scheduler was started with a predefined mode (not custom
+        arguments), this property will return an empty array.
+    -->
+    <property name="CurrentSchedulerArgs" type="as" access="read"/>
+    <!--
         SupportedSchedulers:
 
         A list of the schedulers currently supported by the Scheduler Loader.

--- a/tools/scx_loader/src/dbus.rs
+++ b/tools/scx_loader/src/dbus.rs
@@ -54,6 +54,12 @@ pub trait LoaderClient {
     #[zbus(property)]
     fn scheduler_mode(&self) -> zbus::Result<SchedMode>;
 
+    /// The arguments used for the currently running scheduler. If no scheduler
+    /// is active or the scheduler was started with a predefined mode (not custom
+    /// arguments), this property will return an empty array.
+    #[zbus(property)]
+    fn current_scheduler_args(&self) -> zbus::Result<Vec<String>>;
+
     /// A list of the schedulers currently supported by the Scheduler Loader.
     /// The names of the supported schedulers will be listed as strings in
     /// this array.

--- a/tools/scx_loader/src/main.rs
+++ b/tools/scx_loader/src/main.rs
@@ -56,6 +56,7 @@ enum RunnerMessage {
 struct ScxLoader {
     current_scx: Option<SupportedSched>,
     current_mode: SchedMode,
+    current_args: Option<Vec<String>>,
     channel: UnboundedSender<ScxMessage>,
 }
 
@@ -85,6 +86,12 @@ impl ScxLoader {
         self.current_mode.clone()
     }
 
+    /// Get arguments used for currently running scheduler
+    #[zbus(property)]
+    async fn current_scheduler_args(&self) -> Vec<String> {
+        self.current_args.clone().unwrap_or_default()
+    }
+
     /// Get list of supported schedulers
     #[zbus(property)]
     async fn supported_schedulers(&self) -> Vec<&str> {
@@ -99,7 +106,6 @@ impl ScxLoader {
             "scx_rusty",
         ]
     }
-
     async fn start_scheduler(
         &mut self,
         scx_name: SupportedSched,
@@ -113,6 +119,7 @@ impl ScxLoader {
         )));
         self.current_scx = Some(scx_name);
         self.current_mode = sched_mode;
+        self.current_args = None;
 
         Ok(())
     }
@@ -126,10 +133,11 @@ impl ScxLoader {
 
         let _ = self
             .channel
-            .send(ScxMessage::StartSchedArgs((scx_name.clone(), scx_args)));
+            .send(ScxMessage::StartSchedArgs((scx_name.clone(), scx_args.clone())));
         self.current_scx = Some(scx_name);
         // reset mode to auto
         self.current_mode = SchedMode::Auto;
+        self.current_args = Some(scx_args);
 
         Ok(())
     }
@@ -147,6 +155,7 @@ impl ScxLoader {
         )));
         self.current_scx = Some(scx_name);
         self.current_mode = sched_mode;
+        self.current_args = None;
 
         Ok(())
     }
@@ -160,10 +169,11 @@ impl ScxLoader {
 
         let _ = self
             .channel
-            .send(ScxMessage::SwitchSchedArgs((scx_name.clone(), scx_args)));
+            .send(ScxMessage::SwitchSchedArgs((scx_name.clone(), scx_args.clone())));
         self.current_scx = Some(scx_name);
         // reset mode to auto
         self.current_mode = SchedMode::Auto;
+        self.current_args = Some(scx_args);
 
         Ok(())
     }
@@ -175,6 +185,7 @@ impl ScxLoader {
             log::info!("stopping {scx_name:?}..");
             let _ = self.channel.send(ScxMessage::StopSched);
             self.current_scx = None;
+            self.current_args = None;
         }
 
         Ok(())
@@ -287,6 +298,7 @@ async fn main() -> Result<()> {
             ScxLoader {
                 current_scx: None,
                 current_mode: SchedMode::Auto,
+                current_args: None,
                 channel: channel.clone(),
             },
         )

--- a/tools/scxctl/src/cli.rs
+++ b/tools/scxctl/src/cli.rs
@@ -59,7 +59,7 @@ pub struct SwitchArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    #[command(about = "Get the current scheduler and mode")]
+    #[command(about = "Get the info on the running scheduler")]
     Get,
     #[command(about = "List all supported schedulers")]
     List,

--- a/tools/scxctl/src/main.rs
+++ b/tools/scxctl/src/main.rs
@@ -8,13 +8,23 @@ use std::process::exit;
 use zbus::blocking::Connection;
 
 fn cmd_get(scx_loader: LoaderClientProxyBlocking) -> Result<(), Box<dyn std::error::Error>> {
-    let current_scheduler: String = scx_loader.current_scheduler().unwrap();
-    let sched_mode: SchedMode = scx_loader.scheduler_mode().unwrap();
+    let current_scheduler: String = scx_loader.current_scheduler()?;
+
     match current_scheduler.as_str() {
         "unknown" => println!("no scx scheduler running"),
         _ => {
-            let sched = SupportedSched::try_from(current_scheduler.as_str()).unwrap();
-            println!("running {sched:?} in {sched_mode:?} mode");
+            let sched = SupportedSched::try_from(current_scheduler.as_str())?;
+            let current_args: Vec<String> = scx_loader.current_scheduler_args()?;
+
+            if current_args.is_empty() {
+                let sched_mode: SchedMode = scx_loader.scheduler_mode()?;
+                println!("running {sched:?} in {sched_mode:?} mode");
+            } else {
+                println!(
+                    "running {sched:?} with arguments \"{}\"",
+                    current_args.join(" ")
+                );
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
Adds a CurrentSchedulerArgs property to scx_loader, and adds the proper handling for `scxctl get` to print them 