### PR TITLE
scx_chaos: also skip select_cpu if next_trait is CHAOS_TRAIT_KPROBE_RANDOM_DELAYS

### DIFF
--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -116,7 +116,8 @@ static __always_inline enum chaos_trait_kind choose_chaos(struct chaos_task_ctx 
 
 static __always_inline bool chaos_trait_skips_select_cpu(struct chaos_task_ctx *taskc)
 {
-	return taskc->next_trait == CHAOS_TRAIT_RANDOM_DELAYS;
+	return taskc->next_trait == CHAOS_TRAIT_RANDOM_DELAYS || 
+		taskc->next_trait == CHAOS_TRAIT_KPROBE_RANDOM_DELAYS;
 }
 
 static __always_inline u64 get_cpu_delay_dsq(int cpu_idx)


### PR DESCRIPTION
scx_chaos only skips `select_cpu` when `next_trait` is `CHAOS_TRAIT_RANDOM_DELAYS`. 