### PR TITLE
scxtop: update help with filtering

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -1968,9 +1968,7 @@ impl<'a> App<'a> {
             Line::from(Span::styled(
                 format!(
                     "{}: filter processes",
-                    self.config
-                        .active_keymap
-                        .action_keys_string(Action::Filter)
+                    self.config.active_keymap.action_keys_string(Action::Filter)
                 ),
                 Style::default(),
             )),

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -1962,7 +1962,16 @@ impl<'a> App<'a> {
                 Style::default(),
             )),
             Line::from(Span::styled(
-                format!("{pause}: press to pause/unpause"),
+                format!("{pause}: pause/unpause"),
+                Style::default(),
+            )),
+            Line::from(Span::styled(
+                format!(
+                    "{}: filter processes",
+                    self.config
+                        .active_keymap
+                        .action_keys_string(Action::Filter)
+                ),
                 Style::default(),
             )),
             Line::from(Span::styled(


### PR DESCRIPTION
Adds the new filter process feature key to the help page.