### PR TITLE
scxtop: re-add sample rate

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -2268,6 +2268,14 @@ impl<'a> App<'a> {
                     ),
                 ])
                 .left_aligned(),
+            )
+            .title_top(
+                Line::from(format!(
+                    "sample rate {}",
+                    self.skel.maps.data_data.as_ref().unwrap().sample_rate
+                ))
+                .style(self.theme().text_important_color())
+                .right_aligned(),
             );
 
         // We want to hold the lock for as short as possible


### PR DESCRIPTION
Adds back bpf sample rate so the user can see what the current sample rate is.

Example (top right corner):

<img width="960" height="545" alt="Screenshot 2025-08-01 at 12 53 42 PM" src="https://github.com/user-attachments/assets/a977f1ff-cd4e-4dee-9fec-1714be28b210" />
