### PR TITLE
scxtop: make frame rate configurable

### DIFF
--- a/tools/scxtop/src/cli.rs
+++ b/tools/scxtop/src/cli.rs
@@ -31,7 +31,7 @@ pub struct TuiArgs {
     /// App tick rate in milliseconds.
     #[arg(short = 'r', long, default_missing_value = "250")]
     pub tick_rate_ms: Option<usize>,
-    /// App render rate in milliseconds.
+    /// App render rate in milliseconds (min=15).
     #[arg(short = 'f', long, default_missing_value = "250")]
     pub frame_rate_ms: Option<usize>,
     /// Extra verbose output.

--- a/tools/scxtop/src/cli.rs
+++ b/tools/scxtop/src/cli.rs
@@ -31,6 +31,9 @@ pub struct TuiArgs {
     /// App tick rate in milliseconds.
     #[arg(short = 'r', long, default_missing_value = "250")]
     pub tick_rate_ms: Option<usize>,
+    /// App render rate in milliseconds.
+    #[arg(short = 'f', long, default_missing_value = "250")]
+    pub frame_rate_ms: Option<usize>,
     /// Extra verbose output.
     #[arg(short, long, default_missing_value = "false")]
     pub debug: Option<bool>,

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -25,6 +25,7 @@ use xdg;
 /// ```text
 /// theme = "IAmBlue"
 /// tick_rate_ms = 250
+/// frame_rate_ms =
 /// debug = false
 /// exclude_bpf = false
 /// worker_threads = 4
@@ -74,6 +75,8 @@ pub struct Config {
     theme: Option<AppTheme>,
     /// App tick rate in milliseconds.
     tick_rate_ms: Option<usize>,
+    /// App render rate in milliseconds.
+    frame_rate_ms: Option<usize>,
     /// Extra verbose output.
     debug: Option<bool>,
     /// Exclude bpf event tracking.
@@ -108,6 +111,7 @@ impl From<TuiArgs> for Config {
             stats_socket_path: args.stats_socket_path,
             theme: None,
             tick_rate_ms: args.tick_rate_ms,
+            frame_rate_ms: args.frame_rate_ms,
             trace_file_prefix: args.trace_file_prefix,
             trace_tick_warmup: args.trace_tick_warmup,
             trace_warmup_ms: args.trace_warmup_ms,
@@ -142,6 +146,7 @@ impl Config {
             active_keymap,
             theme: self.theme.or(rhs.theme),
             tick_rate_ms: self.tick_rate_ms.or(rhs.tick_rate_ms),
+            frame_rate_ms: self.frame_rate_ms.or(rhs.frame_rate_ms),
             debug: self.debug.or(rhs.debug),
             exclude_bpf: self.exclude_bpf.or(rhs.exclude_bpf),
             perf_events: if !self.perf_events.is_empty() {
@@ -176,6 +181,11 @@ impl Config {
     /// App tick rate in milliseconds.
     pub fn tick_rate_ms(&self) -> usize {
         self.tick_rate_ms.unwrap_or(250)
+    }
+
+    /// App render rate in milliseconds.
+    pub fn frame_rate_ms(&self) -> usize {
+        self.frame_rate_ms.unwrap_or(250)
     }
 
     /// Set app tick rate in milliseconds.
@@ -238,6 +248,7 @@ impl Config {
             active_keymap: KeyMap::empty(),
             theme: None,
             tick_rate_ms: None,
+            frame_rate_ms: None,
             debug: None,
             perf_events: vec![],
             exclude_bpf: None,
@@ -259,6 +270,7 @@ impl Config {
             active_keymap: KeyMap::default(),
             theme: None,
             tick_rate_ms: None,
+            frame_rate_ms: None,
             debug: None,
             exclude_bpf: None,
             perf_events: vec![],
@@ -272,6 +284,7 @@ impl Config {
             default_profiling_event: None,
         };
         config.tick_rate_ms = Some(config.tick_rate_ms());
+        config.frame_rate_ms = Some(config.frame_rate_ms());
         config.debug = Some(config.debug());
         config.exclude_bpf = Some(config.exclude_bpf());
 
@@ -366,6 +379,8 @@ mod tests {
             "/tmp/my_socket",
             "--tick-rate-ms",
             "100",
+            "--frame-rate-ms",
+            "10",
             "--trace-file-prefix",
             "/var/log/trace",
             "--trace-warmup-ms",
@@ -392,6 +407,7 @@ mod tests {
             "/tmp/my_socket".to_string()
         );
         assert_eq!(config.tick_rate_ms.unwrap(), 100);
+        assert_eq!(config.frame_rate_ms.unwrap(), 10);
         assert_eq!(
             config.trace_file_prefix.unwrap(),
             "/var/log/trace".to_string()
@@ -417,6 +433,7 @@ mod tests {
         assert!(config.exclude_bpf.is_none());
         assert!(config.perf_events.is_empty());
         assert!(config.stats_socket_path.is_none());
+        assert!(config.tick_rate_ms.is_none());
         assert!(config.tick_rate_ms.is_none());
         assert!(config.trace_file_prefix.is_none());
         assert!(config.trace_warmup_ms.is_none());
@@ -584,6 +601,7 @@ mod tests {
         assert!(config.active_keymap.is_empty());
         assert!(config.theme.is_none());
         assert!(config.tick_rate_ms.is_none());
+        assert!(config.frame_rate_ms.is_none());
         assert!(config.debug.is_none());
         assert!(config.perf_events.is_empty());
         assert!(config.exclude_bpf.is_none());
@@ -599,6 +617,7 @@ mod tests {
         // Check getters return defaults
         assert_eq!(config.theme(), &AppTheme::Default);
         assert_eq!(config.tick_rate_ms(), 250);
+        assert_eq!(config.frame_rate_ms(), 250);
         assert!(!config.debug());
         assert!(!config.exclude_bpf());
         assert_eq!(config.stats_socket_path(), STATS_SOCKET_PATH);
@@ -619,6 +638,7 @@ mod tests {
         // Check that optional fields that have defaults are Some(default_value)
         assert!(config.tick_rate_ms.is_some());
         assert_eq!(config.tick_rate_ms.unwrap(), 250);
+        assert!(config.frame_rate_ms.is_some());
         assert!(config.debug.is_some());
         assert!(!config.debug.unwrap());
         assert!(config.exclude_bpf.is_some());

--- a/tools/scxtop/src/config.rs
+++ b/tools/scxtop/src/config.rs
@@ -25,7 +25,7 @@ use xdg;
 /// ```text
 /// theme = "IAmBlue"
 /// tick_rate_ms = 250
-/// frame_rate_ms =
+/// frame_rate_ms = 20
 /// debug = false
 /// exclude_bpf = false
 /// worker_threads = 4

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -417,7 +417,7 @@ fn run_tui(tui_args: &TuiArgs) -> Result<()> {
                 ]);
             };
 
-            let mut tui = Tui::new(keymap.clone(), config.tick_rate_ms())?;
+            let mut tui = Tui::new(keymap.clone(), config.tick_rate_ms(), config.frame_rate_ms())?;
             let mut event_rbb = RingBufferBuilder::new();
             let event_handler = move |data: &[u8]| {
                 let mut event = bpf_event::default();
@@ -465,7 +465,6 @@ fn run_tui(tui_args: &TuiArgs) -> Result<()> {
                     .await
                 });
             }
-
 
             loop {
                 tokio::select! {

--- a/tools/scxtop/src/tui.rs
+++ b/tools/scxtop/src/tui.rs
@@ -58,7 +58,7 @@ pub struct Tui {
     pub cancellation_token: CancellationToken,
     pub event_rx: UnboundedReceiver<Event>,
     pub event_tx: UnboundedSender<Event>,
-    pub frame_rate: f64,
+    pub frame_rate_ms: usize,
     pub tick_rate_ms: usize,
     pub mouse: bool,
     pub paste: bool,
@@ -67,8 +67,7 @@ pub struct Tui {
 
 impl Tui {
     /// Returns a new Tui.
-    pub fn new(keymap: KeyMap, tick_rate_ms: usize) -> Result<Self> {
-        let frame_rate = 60.0;
+    pub fn new(keymap: KeyMap, tick_rate_ms: usize, frame_rate_ms: usize) -> Result<Self> {
         let terminal = ratatui::Terminal::new(CrosstermBackend::new(stderr()))?;
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         let cancellation_token = CancellationToken::new();
@@ -81,18 +80,12 @@ impl Tui {
             cancellation_token,
             event_rx,
             event_tx,
-            frame_rate,
+            frame_rate_ms,
             tick_rate_ms,
             mouse,
             paste,
             keymap,
         })
-    }
-
-    /// Sets the frame rate for the Tui.
-    pub fn frame_rate(mut self, frame_rate: f64) -> Self {
-        self.frame_rate = frame_rate;
-        self
     }
 
     #[allow(dead_code)]
@@ -110,7 +103,7 @@ impl Tui {
     /// Starts the tui.
     pub fn start(&mut self) {
         let mut tick_delay = std::time::Duration::from_millis(self.tick_rate_ms as u64);
-        let render_delay = std::time::Duration::from_secs_f64(1.0 / self.frame_rate);
+        let render_delay = std::time::Duration::from_millis(self.frame_rate_ms as u64);
         self.cancel();
         self.cancellation_token = CancellationToken::new();
         let _cancellation_token = self.cancellation_token.clone();

--- a/tools/scxtop/src/tui.rs
+++ b/tools/scxtop/src/tui.rs
@@ -103,7 +103,7 @@ impl Tui {
     /// Starts the tui.
     pub fn start(&mut self) {
         let mut tick_delay = std::time::Duration::from_millis(self.tick_rate_ms as u64);
-        self.frame_rate_ms = self.frame_rate_ms.max(15);
+        self.frame_rate_ms = self.frame_rate_ms.max(15).min(5000);
         let render_delay = std::time::Duration::from_millis(self.frame_rate_ms as u64);
         self.cancel();
         self.cancellation_token = CancellationToken::new();

--- a/tools/scxtop/src/tui.rs
+++ b/tools/scxtop/src/tui.rs
@@ -103,7 +103,7 @@ impl Tui {
     /// Starts the tui.
     pub fn start(&mut self) {
         let mut tick_delay = std::time::Duration::from_millis(self.tick_rate_ms as u64);
-        self.frame_rate_ms = self.frame_rate_ms.max(15).min(5000);
+        self.frame_rate_ms = self.frame_rate_ms.clamp(15, 5000);
         let render_delay = std::time::Duration::from_millis(self.frame_rate_ms as u64);
         self.cancel();
         self.cancellation_token = CancellationToken::new();

--- a/tools/scxtop/src/tui.rs
+++ b/tools/scxtop/src/tui.rs
@@ -103,6 +103,7 @@ impl Tui {
     /// Starts the tui.
     pub fn start(&mut self) {
         let mut tick_delay = std::time::Duration::from_millis(self.tick_rate_ms as u64);
+        self.frame_rate_ms = self.frame_rate_ms.max(15);
         let render_delay = std::time::Duration::from_millis(self.frame_rate_ms as u64);
         self.cancel();
         self.cancellation_token = CancellationToken::new();


### PR DESCRIPTION
This allows the user to configure the render rate in the range `[15, 5000]` ms - `scxtop -f 200` for example. The bounds exist to ensure one cannot leave scxtop in a state where it is unresponsive.