### PR TITLE
scxtop: add process scrollbar

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -2350,7 +2350,7 @@ impl<'a> App<'a> {
                 .begin_symbol(Some("↑"))
                 .end_symbol(Some("↓")),
             scroll_area,
-            &mut ScrollbarState::new(filtered_processes.len().into()).position(selected as usize),
+            &mut ScrollbarState::new(filtered_processes.len().into()).position(selected),
         );
 
         if let Some((tgid, _)) = filtered_processes.get(selected) {

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -2350,7 +2350,7 @@ impl<'a> App<'a> {
                 .begin_symbol(Some("↑"))
                 .end_symbol(Some("↓")),
             scroll_area,
-            &mut ScrollbarState::new(filtered_processes.len().into()).position(selected),
+            &mut ScrollbarState::new(filtered_processes.len()).position(selected),
         );
 
         if let Some((tgid, _)) = filtered_processes.get(selected) {

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -2270,7 +2270,9 @@ impl<'a> App<'a> {
 
     /// Render the process view.
     fn render_process_table(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        self.update_events_list_size(area);
+        let [scroll_area, data_area] =
+            Layout::horizontal(vec![Constraint::Min(1), Constraint::Percentage(100)]).areas(area);
+        self.update_events_list_size(data_area);
 
         let visible_columns: Vec<_> = self.process_columns.visible_columns().collect();
         let (header, constraints) = self.create_table_header_and_constraints(&visible_columns);
@@ -2337,7 +2339,19 @@ impl<'a> App<'a> {
 
         let table = Table::new(rows, constraints).header(header).block(block);
 
-        frame.render_stateful_widget(table, area, &mut TableState::new().with_offset(selected));
+        frame.render_stateful_widget(
+            table,
+            data_area,
+            &mut TableState::new().with_offset(selected),
+        );
+
+        frame.render_stateful_widget(
+            Scrollbar::new(ScrollbarOrientation::VerticalLeft)
+                .begin_symbol(Some("↑"))
+                .end_symbol(Some("↓")),
+            scroll_area,
+            &mut ScrollbarState::new(filtered_processes.len().into()).position(selected as usize),
+        );
 
         if let Some((tgid, _)) = filtered_processes.get(selected) {
             self.selected_process = Some(*tgid);


### PR DESCRIPTION
This adds a scrollbar on the left-hand side of the process view to help the user see the current state of the view. Example:

<img width="1917" height="547" alt="Screenshot 2025-08-01 at 4 33 42 PM" src="https://github.com/user-attachments/assets/d623298c-0dfe-4d69-a6de-2d446afd64a5" />
