### PR TITLE
scxtop: Refactor Lat us column

### DIFF
--- a/tools/scxtop/src/columns.rs
+++ b/tools/scxtop/src/columns.rs
@@ -112,7 +112,7 @@ macro_rules! slice_ns_column {
 macro_rules! avg_max_lat_column {
     ($data_type:ty) => {
         Column {
-            header: "Avg/Max Lat us",
+            header: "Lat us Avg/Max",
             constraint: Constraint::Length(14),
             visible: true,
             value_fn: Box::new(|_, data: &$data_type| {


### PR DESCRIPTION
Make the column consistent in formatting so that the column type is first.
<img width="1911" height="768" alt="2025-08-01-19:47:18" src="https://github.com/user-attachments/assets/d6000736-cd2f-4160-b028-be9bcb3fc86e" />
