### PR TITLE
scxtop: fix various bugs + add tests

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -764,7 +764,7 @@ impl<'a> App<'a> {
             ProfilingEvent::CpuUtil(_) => llc_data.num_cpus,
             _ => 1,
         };
-        let data = llc_data
+        let data: Vec<u64> = llc_data
             .event_data_immut(self.active_event.event_name())
             .iter()
             .map(|x| x / divisor as u64)
@@ -817,7 +817,7 @@ impl<'a> App<'a> {
             ProfilingEvent::CpuUtil(_) => node_data.num_cpus,
             _ => 1,
         };
-        let data = node_data
+        let data: Vec<u64> = node_data
             .event_data_immut(self.active_event.event_name())
             .iter()
             .map(|x| x / divisor as u64)

--- a/tools/scxtop/src/cpu_data.rs
+++ b/tools/scxtop/src/cpu_data.rs
@@ -46,7 +46,7 @@ impl CpuData {
         self.data.event_data(event)
     }
 
-    /// Returns the data for an event and updates if no entry is present.
+    /// Returns the data for an event. Returns empty Vec if event doesn't exist.
     pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
         self.data.event_data_immut(event)
     }

--- a/tools/scxtop/src/event_data.rs
+++ b/tools/scxtop/src/event_data.rs
@@ -86,17 +86,12 @@ impl EventData {
         self.data.clear();
     }
 
-    /// Returns the data for an event and updates if no entry is present.
+    /// Returns the data for an event. Returns empty Vec if event doesn't exist.
     pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
         if let Some(vs) = self.data.get(event) {
             vs.iter().copied().collect()
         } else {
-            vec![
-                0,
-                self.max_data_size
-                    .try_into()
-                    .expect("invalid max data size"),
-            ]
+            Vec::new()
         }
     }
 
@@ -108,5 +103,264 @@ impl EventData {
             data.pop_front();
         }
         data.push_back(val);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let event_data = EventData::new(10);
+        assert_eq!(event_data.max_data_size, 10);
+        assert!(event_data.data.is_empty());
+    }
+
+    #[test]
+    fn test_initialize_events() {
+        let mut event_data = EventData::new(5);
+        let events = vec!["event1", "event2", "event3"];
+
+        event_data.initialize_events(&events);
+
+        assert_eq!(event_data.data.len(), 3);
+        for event in &events {
+            assert!(event_data.data.contains_key(*event));
+            let data = event_data.data.get(*event).unwrap();
+            assert_eq!(data.len(), 5);
+            // All values should be initialized to 0
+            for &val in data {
+                assert_eq!(val, 0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_event_data_mut_creates_new_entry() {
+        let mut event_data = EventData::new(3);
+
+        let data = event_data.event_data_mut("new_event");
+        assert_eq!(data.len(), 3);
+        for &val in data.iter() {
+            assert_eq!(val, 0);
+        }
+
+        assert!(event_data.data.contains_key("new_event"));
+    }
+
+    #[test]
+    fn test_event_data_mut_returns_existing_entry() {
+        let mut event_data = EventData::new(3);
+
+        // Create initial entry
+        let data1 = event_data.event_data_mut("existing_event");
+        data1[0] = 42;
+
+        // Get the same entry again
+        let data2 = event_data.event_data_mut("existing_event");
+        assert_eq!(data2[0], 42);
+    }
+
+    #[test]
+    fn test_event_data() {
+        let mut event_data = EventData::new(3);
+
+        let data = event_data.event_data("test_event");
+        assert_eq!(data.len(), 3);
+        for &val in data {
+            assert_eq!(val, 0);
+        }
+    }
+
+    #[test]
+    fn test_zero_event() {
+        let mut event_data = EventData::new(3);
+
+        // Add some data
+        event_data.add_event_data("test_event", 10);
+        event_data.add_event_data("test_event", 20);
+        event_data.add_event_data("test_event", 30);
+
+        // Verify data is not zero
+        let data = event_data.event_data("test_event");
+        assert!(data.iter().any(|&x| x != 0));
+
+        // Zero out the event
+        event_data.zero_event("test_event");
+
+        // Verify all values are zero
+        let data = event_data.event_data("test_event");
+        for &val in data {
+            assert_eq!(val, 0);
+        }
+    }
+
+    #[test]
+    fn test_set_max_size_increase() {
+        let mut event_data = EventData::new(3);
+        event_data.add_event_data("test_event", 10);
+        event_data.add_event_data("test_event", 20);
+        event_data.add_event_data("test_event", 30);
+
+        // Increase max size
+        event_data.set_max_size(5);
+
+        assert_eq!(event_data.max_data_size, 5);
+        let data = event_data.event_data("test_event");
+        assert_eq!(data.len(), 5);
+
+        // The original data should be preserved, with zeros added at the front
+        let vec_data: Vec<u64> = data.iter().copied().collect();
+        assert_eq!(vec_data[vec_data.len() - 3..], [10, 20, 30]);
+    }
+
+    #[test]
+    fn test_set_max_size_decrease() {
+        let mut event_data = EventData::new(5);
+        for i in 1..=5 {
+            event_data.add_event_data("test_event", i * 10);
+        }
+
+        // Decrease max size
+        event_data.set_max_size(3);
+
+        assert_eq!(event_data.max_data_size, 3);
+        let data = event_data.event_data("test_event");
+        assert_eq!(data.len(), 3);
+    }
+
+    #[test]
+    fn test_clear_event() {
+        let mut event_data = EventData::new(3);
+        event_data.add_event_data("event1", 10);
+        event_data.add_event_data("event2", 20);
+
+        assert!(event_data.data.contains_key("event1"));
+        assert!(event_data.data.contains_key("event2"));
+
+        event_data.clear_event("event1");
+
+        assert!(!event_data.data.contains_key("event1"));
+        assert!(event_data.data.contains_key("event2"));
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut event_data = EventData::new(3);
+        event_data.add_event_data("event1", 10);
+        event_data.add_event_data("event2", 20);
+
+        assert_eq!(event_data.data.len(), 2);
+
+        event_data.clear();
+
+        assert!(event_data.data.is_empty());
+    }
+
+    #[test]
+    fn test_event_data_immut_existing_event() {
+        let mut event_data = EventData::new(3);
+        event_data.add_event_data("test_event", 10);
+        event_data.add_event_data("test_event", 20);
+        event_data.add_event_data("test_event", 30);
+
+        let data = event_data.event_data_immut("test_event");
+        assert_eq!(data.len(), 3);
+        assert_eq!(data[data.len() - 3..], [10, 20, 30]);
+    }
+
+    #[test]
+    fn test_event_data_immut_nonexistent_event() {
+        let event_data = EventData::new(5);
+
+        let data = event_data.event_data_immut("nonexistent");
+        // Returns empty Vec for non-existent events
+        assert_eq!(data, Vec::<u64>::new());
+    }
+
+    #[test]
+    fn test_add_event_data_basic() {
+        let mut event_data = EventData::new(3);
+
+        event_data.add_event_data("test_event", 10);
+        let data = event_data.event_data("test_event");
+        assert_eq!(data.back(), Some(&10));
+
+        event_data.add_event_data("test_event", 20);
+        let data = event_data.event_data("test_event");
+        assert_eq!(data.back(), Some(&20));
+    }
+
+    #[test]
+    fn test_add_event_data_overflow() {
+        let mut event_data = EventData::new(3);
+
+        // Fill up the deque
+        for i in 1..=3 {
+            event_data.add_event_data("test_event", i * 10);
+        }
+
+        let data = event_data.event_data("test_event");
+        assert_eq!(data.len(), 3);
+
+        // Add one more item, should cause the first item to be removed
+        event_data.add_event_data("test_event", 40);
+
+        let data = event_data.event_data("test_event");
+        assert_eq!(data.len(), 3);
+        let vec_data: Vec<u64> = data.iter().copied().collect();
+        assert_eq!(vec_data[vec_data.len() - 3..], [20, 30, 40]);
+    }
+
+    #[test]
+    fn test_add_event_data_multiple_events() {
+        let mut event_data = EventData::new(2);
+
+        event_data.add_event_data("event1", 10);
+        event_data.add_event_data("event2", 20);
+        event_data.add_event_data("event1", 30);
+
+        let data1 = event_data.event_data_immut("event1");
+        let data2 = event_data.event_data_immut("event2");
+
+        assert_eq!(data1[data1.len() - 2..], [10, 30]);
+        assert_eq!(data2[data2.len() - 1..], [20]);
+    }
+
+    #[test]
+    fn test_complex_workflow() {
+        let mut event_data = EventData::new(4);
+
+        // Initialize multiple events
+        event_data.initialize_events(&["cpu_usage", "memory_usage", "disk_io"]);
+
+        // Add data to different events
+        for i in 1..=5 {
+            event_data.add_event_data("cpu_usage", i * 10);
+            event_data.add_event_data("memory_usage", i * 20);
+        }
+
+        // Verify cpu_usage data (should have overflow behavior)
+        let cpu_data = event_data.event_data_immut("cpu_usage");
+        assert_eq!(cpu_data.len(), 4);
+        // First value (10) should be dropped due to overflow, remaining: [20, 30, 40, 50]
+        assert_eq!(cpu_data[cpu_data.len() - 4..], [20, 30, 40, 50]);
+
+        // Verify memory_usage data
+        let mem_data = event_data.event_data_immut("memory_usage");
+        assert_eq!(mem_data.len(), 4);
+        // First value (20) should be dropped due to overflow, remaining: [40, 60, 80, 100]
+        assert_eq!(mem_data[mem_data.len() - 4..], [40, 60, 80, 100]);
+
+        // Verify disk_io has only zeros (no data added)
+        let disk_data = event_data.event_data_immut("disk_io");
+        assert_eq!(disk_data.len(), 4);
+        assert_eq!(disk_data, vec![0, 0, 0, 0]);
+
+        // Clear one event and verify
+        event_data.clear_event("memory_usage");
+        let cleared_data = event_data.event_data_immut("memory_usage");
+        assert_eq!(cleared_data, Vec::<u64>::new()); // Returns empty Vec for cleared event
     }
 }

--- a/tools/scxtop/src/llc_data.rs
+++ b/tools/scxtop/src/llc_data.rs
@@ -45,7 +45,7 @@ impl LlcData {
         self.data.event_data(event)
     }
 
-    /// Returns the data for an event and updates if no entry is present.
+    /// Returns the data for an event. Returns empty Vec if event doesn't exist.
     pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
         self.data.event_data_immut(event)
     }

--- a/tools/scxtop/src/node_data.rs
+++ b/tools/scxtop/src/node_data.rs
@@ -42,7 +42,7 @@ impl NodeData {
         self.data.event_data(event)
     }
 
-    /// Returns the data for an event and updates if no entry is present.
+    /// Returns the data for an event. Returns empty Vec if event doesn't exist.
     pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
         self.data.event_data_immut(event)
     }

--- a/tools/scxtop/src/proc_data.rs
+++ b/tools/scxtop/src/proc_data.rs
@@ -140,7 +140,7 @@ impl ProcData {
         self.threads.clear();
     }
 
-    /// Returns the data for an event and updates if no entry is present.
+    /// Returns the data for an event. Returns empty Vec if event doesn't exist.
     pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
         self.data.event_data_immut(event)
     }

--- a/tools/scxtop/src/stats.rs
+++ b/tools/scxtop/src/stats.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 use std::collections::HashSet;
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum StatAggregation {
     P999,
     P99,
@@ -67,7 +67,7 @@ impl VecStats {
     pub fn new(vec: &Vec<u64>, percentiles: Option<HashSet<StatAggregation>>) -> Self {
         let mut min: u64 = u64::MAX;
         let mut max: u64 = 0;
-        let mut sum: u64 = 0;
+        let mut sum: u128 = 0;
         for &val in vec {
             if val < min {
                 min = val;
@@ -75,7 +75,7 @@ impl VecStats {
             if val > max {
                 max = val;
             }
-            sum += val;
+            sum += val as u128;
         }
         match percentiles {
             Some(ref hashset) => {
@@ -103,7 +103,7 @@ impl VecStats {
                 }
                 Self {
                     avg: if !vec.is_empty() {
-                        sum / vec.len() as u64
+                        (sum / (vec.len() as u128)) as u64
                     } else {
                         0
                     },
@@ -114,7 +114,7 @@ impl VecStats {
             }
             None => Self {
                 avg: if !vec.is_empty() {
-                    sum / vec.len() as u64
+                    (sum / (vec.len() as u128)) as u64
                 } else {
                     0
                 },
@@ -123,5 +123,298 @@ impl VecStats {
                 percentiles: None,
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vec_stats_empty_data() {
+        let data: Vec<u64> = Vec::new();
+        let stats = VecStats::new(&data, None);
+
+        assert_eq!(stats.min, u64::MAX);
+        assert_eq!(stats.max, 0);
+        assert_eq!(stats.avg, 0);
+        assert!(stats.percentiles.is_none());
+    }
+
+    #[test]
+    fn test_vec_stats_single_value() {
+        let data = vec![42];
+        let stats = VecStats::new(&data, None);
+
+        assert_eq!(stats.min, 42);
+        assert_eq!(stats.max, 42);
+        assert_eq!(stats.avg, 42);
+        assert!(stats.percentiles.is_none());
+    }
+
+    #[test]
+    fn test_vec_stats_basic_calculations() {
+        let data = vec![10, 20, 30, 40, 50];
+        let stats = VecStats::new(&data, None);
+
+        assert_eq!(stats.min, 10);
+        assert_eq!(stats.max, 50);
+        assert_eq!(stats.avg, 30); // (10+20+30+40+50)/5 = 30
+        assert!(stats.percentiles.is_none());
+    }
+
+    #[test]
+    fn test_vec_stats_all_zeros() {
+        let data = vec![0, 0, 0, 0, 0];
+        let stats = VecStats::new(&data, None);
+
+        assert_eq!(stats.min, 0);
+        assert_eq!(stats.max, 0);
+        assert_eq!(stats.avg, 0);
+    }
+
+    #[test]
+    fn test_vec_stats_same_values() {
+        let data = vec![25, 25, 25, 25];
+        let stats = VecStats::new(&data, None);
+
+        assert_eq!(stats.min, 25);
+        assert_eq!(stats.max, 25);
+        assert_eq!(stats.avg, 25);
+    }
+
+    #[test]
+    fn test_vec_stats_unsorted_data() {
+        let data = vec![50, 10, 30, 20, 40];
+        let stats = VecStats::new(&data, None);
+
+        assert_eq!(stats.min, 10);
+        assert_eq!(stats.max, 50);
+        assert_eq!(stats.avg, 30); // (50+10+30+20+40)/5 = 30
+    }
+
+    #[test]
+    fn test_vec_stats_with_percentiles() {
+        let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let mut percentiles = HashSet::new();
+        percentiles.insert(StatAggregation::P50);
+        percentiles.insert(StatAggregation::P90);
+        percentiles.insert(StatAggregation::P99);
+
+        let stats = VecStats::new(&data, Some(percentiles));
+
+        assert_eq!(stats.min, 1);
+        assert_eq!(stats.max, 10);
+        assert_eq!(stats.avg, 5); // (1+2+...+10)/10 = 5.5, truncated to 5
+
+        let percentile_map = stats.percentiles.unwrap();
+        assert!(percentile_map.contains_key(&StatAggregation::P50));
+        assert!(percentile_map.contains_key(&StatAggregation::P90));
+        assert!(percentile_map.contains_key(&StatAggregation::P99));
+
+        // P50 of [1,2,3,4,5,6,7,8,9,10] should be around 5-6
+        let p50 = *percentile_map.get(&StatAggregation::P50).unwrap();
+        assert!(p50 >= 5 && p50 <= 6);
+
+        // P90 should be around 9-10
+        let p90 = *percentile_map.get(&StatAggregation::P90).unwrap();
+        assert!(p90 >= 9);
+
+        // P99 should be close to 10
+        let p99 = *percentile_map.get(&StatAggregation::P99).unwrap();
+        assert!(p99 >= 9);
+    }
+
+    #[test]
+    fn test_vec_stats_percentiles_single_value() {
+        let data = vec![42];
+        let mut percentiles = HashSet::new();
+        percentiles.insert(StatAggregation::P50);
+        percentiles.insert(StatAggregation::P90);
+
+        let stats = VecStats::new(&data, Some(percentiles));
+
+        let percentile_map = stats.percentiles.unwrap();
+        assert_eq!(*percentile_map.get(&StatAggregation::P50).unwrap(), 42);
+        assert_eq!(*percentile_map.get(&StatAggregation::P90).unwrap(), 42);
+    }
+
+    #[test]
+    fn test_vec_stats_percentiles_empty_data() {
+        let data: Vec<u64> = Vec::new();
+        let mut percentiles = HashSet::new();
+        percentiles.insert(StatAggregation::P50);
+
+        let stats = VecStats::new(&data, Some(percentiles));
+
+        assert_eq!(stats.min, u64::MAX);
+        assert_eq!(stats.max, 0);
+        assert_eq!(stats.avg, 0);
+
+        let percentile_map = stats.percentiles.unwrap();
+        assert!(percentile_map.is_empty()); // Should be empty for empty data
+    }
+
+    #[test]
+    fn test_vec_stats_percentiles_empty_set() {
+        let data = vec![1, 2, 3, 4, 5];
+        let percentiles = HashSet::new(); // Empty set
+
+        let stats = VecStats::new(&data, Some(percentiles));
+
+        assert_eq!(stats.min, 1);
+        assert_eq!(stats.max, 5);
+        assert_eq!(stats.avg, 3);
+
+        let percentile_map = stats.percentiles.unwrap();
+        assert!(percentile_map.is_empty()); // Should be empty for empty percentile set
+    }
+
+    #[test]
+    fn test_vec_stats_all_percentiles() {
+        let data = vec![
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        ];
+        let mut percentiles = HashSet::new();
+        percentiles.insert(StatAggregation::P1);
+        percentiles.insert(StatAggregation::P5);
+        percentiles.insert(StatAggregation::P10);
+        percentiles.insert(StatAggregation::P25);
+        percentiles.insert(StatAggregation::P50);
+        percentiles.insert(StatAggregation::P75);
+        percentiles.insert(StatAggregation::P90);
+        percentiles.insert(StatAggregation::P95);
+        percentiles.insert(StatAggregation::P99);
+        percentiles.insert(StatAggregation::P999);
+
+        let stats = VecStats::new(&data, Some(percentiles));
+
+        let percentile_map = stats.percentiles.unwrap();
+
+        // Verify all percentiles are calculated
+        assert!(percentile_map.contains_key(&StatAggregation::P1));
+        assert!(percentile_map.contains_key(&StatAggregation::P5));
+        assert!(percentile_map.contains_key(&StatAggregation::P10));
+        assert!(percentile_map.contains_key(&StatAggregation::P25));
+        assert!(percentile_map.contains_key(&StatAggregation::P50));
+        assert!(percentile_map.contains_key(&StatAggregation::P75));
+        assert!(percentile_map.contains_key(&StatAggregation::P90));
+        assert!(percentile_map.contains_key(&StatAggregation::P95));
+        assert!(percentile_map.contains_key(&StatAggregation::P99));
+        assert!(percentile_map.contains_key(&StatAggregation::P999));
+
+        // Verify percentiles are in ascending order
+        let p1 = *percentile_map.get(&StatAggregation::P1).unwrap();
+        let p50 = *percentile_map.get(&StatAggregation::P50).unwrap();
+        let p99 = *percentile_map.get(&StatAggregation::P99).unwrap();
+
+        assert!(p1 <= p50);
+        assert!(p50 <= p99);
+    }
+
+    #[test]
+    fn test_vec_stats_large_values() {
+        let data = vec![u64::MAX / 4, u64::MAX / 3, u64::MAX / 2];
+        let stats = VecStats::new(&data, None);
+
+        assert_eq!(stats.min, u64::MAX / 4);
+        assert_eq!(stats.max, u64::MAX / 2);
+        // Average calculation should handle large numbers without overflow
+        assert!(stats.avg > u64::MAX / 4);
+        assert!(stats.avg < u64::MAX);
+    }
+
+    #[test]
+    fn test_vec_stats_duplicate_values() {
+        let data = vec![5, 5, 10, 10, 15, 15];
+        let mut percentiles = HashSet::new();
+        percentiles.insert(StatAggregation::P50);
+
+        let stats = VecStats::new(&data, Some(percentiles));
+
+        assert_eq!(stats.min, 5);
+        assert_eq!(stats.max, 15);
+        assert_eq!(stats.avg, 10); // (5+5+10+10+15+15)/6 = 60/6 = 10
+
+        let percentile_map = stats.percentiles.unwrap();
+        let p50 = *percentile_map.get(&StatAggregation::P50).unwrap();
+        assert_eq!(p50, 10);
+    }
+
+    #[test]
+    fn test_vec_stats_integer_division_behavior() {
+        // Test cases where integer division affects results
+        let data = vec![1, 2, 3];
+        let stats = VecStats::new(&data, None);
+
+        // Sum = 6, length = 3, so 6/3 = 2
+        assert_eq!(stats.avg, 2);
+
+        let data2 = vec![1, 2, 3, 4];
+        let stats2 = VecStats::new(&data2, None);
+
+        // Sum = 10, length = 4, so 10/4 = 2 (integer division truncates)
+        assert_eq!(stats2.avg, 2);
+    }
+
+    #[test]
+    fn test_vec_stats_percentile_interpolation() {
+        // Test data where percentiles require interpolation
+        let data = vec![1, 2, 3, 4];
+        let mut percentiles = HashSet::new();
+        percentiles.insert(StatAggregation::P50);
+
+        let stats = VecStats::new(&data, Some(percentiles));
+
+        let percentile_map = stats.percentiles.unwrap();
+        let p50 = *percentile_map.get(&StatAggregation::P50).unwrap();
+
+        // For 4 elements [1,2,3,4], P50 should be between 2 and 3
+        assert!(p50 >= 2 && p50 <= 3);
+    }
+
+    #[test]
+    fn test_stat_aggregation_to_f64() {
+        assert_eq!(StatAggregation::P1.to_f64(), 1.0);
+        assert_eq!(StatAggregation::P5.to_f64(), 5.0);
+        assert_eq!(StatAggregation::P10.to_f64(), 10.0);
+        assert_eq!(StatAggregation::P25.to_f64(), 25.0);
+        assert_eq!(StatAggregation::P50.to_f64(), 50.0);
+        assert_eq!(StatAggregation::P75.to_f64(), 75.0);
+        assert_eq!(StatAggregation::P90.to_f64(), 90.0);
+        assert_eq!(StatAggregation::P95.to_f64(), 95.0);
+        assert_eq!(StatAggregation::P99.to_f64(), 99.0);
+        assert_eq!(StatAggregation::P999.to_f64(), 99.9);
+    }
+
+    #[test]
+    fn test_stat_aggregation_display() {
+        assert_eq!(format!("{}", StatAggregation::P1), "p1");
+        assert_eq!(format!("{}", StatAggregation::P5), "p5");
+        assert_eq!(format!("{}", StatAggregation::P10), "p10");
+        assert_eq!(format!("{}", StatAggregation::P25), "p25");
+        assert_eq!(format!("{}", StatAggregation::P50), "p50");
+        assert_eq!(format!("{}", StatAggregation::P75), "p75");
+        assert_eq!(format!("{}", StatAggregation::P90), "p90");
+        assert_eq!(format!("{}", StatAggregation::P95), "p95");
+        assert_eq!(format!("{}", StatAggregation::P99), "p99");
+        assert_eq!(format!("{}", StatAggregation::P999), "p99.9");
+    }
+
+    #[test]
+    fn test_vec_stats_edge_case_two_values() {
+        let data = vec![10, 20];
+        let mut percentiles = HashSet::new();
+        percentiles.insert(StatAggregation::P50);
+
+        let stats = VecStats::new(&data, Some(percentiles));
+
+        assert_eq!(stats.min, 10);
+        assert_eq!(stats.max, 20);
+        assert_eq!(stats.avg, 15); // (10+20)/2 = 15
+
+        let percentile_map = stats.percentiles.unwrap();
+        let p50 = *percentile_map.get(&StatAggregation::P50).unwrap();
+        assert!(p50 >= 10 && p50 <= 20);
     }
 }

--- a/tools/scxtop/src/thread_data.rs
+++ b/tools/scxtop/src/thread_data.rs
@@ -86,7 +86,7 @@ impl ThreadData {
         };
     }
 
-    /// Returns the data for an event and updates if no entry is present.
+    /// Returns the data for an event. Returns empty Vec if event doesn't exist.
     pub fn event_data_immut(&self, event: &str) -> Vec<u64> {
         self.data.event_data_immut(event)
     }


### PR DESCRIPTION
Previously, avg/max data was showing up as 50/100 whenever there wasn't any data. Ex. (see the threads that don't have NUMA/LLC):
<img width="1916" height="684" alt="Screenshot 2025-08-01 at 11 08 17 AM" src="https://github.com/user-attachments/assets/dca1e6fb-f72c-4b41-96c1-1f9333ca6aff" />

This was due to the `EventData::event_data_immut` returning a vec of `[0, max_data_size]` whenever an entry didn't exist. Instead, we should just return an empty vec. Now, the data is correct:

<img width="867" height="180" alt="Screenshot 2025-08-03 at 6 21 15 PM" src="https://github.com/user-attachments/assets/e9e2aeef-c5e9-4d24-9e95-189d485bf1a3" />

To hopefully prevent these issues from coming up in the future, test suites were added to `EventData` and `VecStats`. These tests already caught an possible overflow bug in `VecStats` where we were adding u64's into a single u64.
