### PR TITLE
ci: move veristat job from ubuntu runners to python script

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -8,10 +8,11 @@ import os
 import random
 import shlex
 import shutil
+import string
 import subprocess
 import sys
 import tempfile
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 
 async def run_command(
@@ -100,6 +101,84 @@ async def run_command_in_vm(
 
         cmd += ["--", shutil.which("bash"), file.name]
         return await run_command(cmd, no_capture=no_capture)
+
+
+def parse_scheduler_kernel_requirements(
+    scheduler_metadata: dict, default_kernel: str = "sched_ext/for-next"
+) -> dict:
+    """Parse kernel requirements from scheduler metadata."""
+    kernel_config = scheduler_metadata.get("ci", {}).get("kernel", {})
+
+    return {
+        "default": kernel_config.get("default", default_kernel),
+        "allowlist": kernel_config.get("allowlist", []),
+        "blocklist": kernel_config.get("blocklist", []),
+    }
+
+
+def get_available_kernels() -> List[str]:
+    """Get list of available kernels from kernel-versions.json."""
+    with open("kernel-versions.json", "r") as f:
+        kernel_data = json.load(f)
+    return list(kernel_data.keys())
+
+
+async def generate_scheduler_kernel_matrix(
+    default_kernel: str = "sched_ext/for-next",
+) -> List[dict]:
+    schedulers = await get_scheduler_packages()
+    available_kernels = get_available_kernels()
+
+    matrix = []
+
+    for scheduler in schedulers:
+        kernel_reqs = parse_scheduler_kernel_requirements(
+            scheduler["metadata"], default_kernel
+        )
+
+        for kernel in available_kernels:
+            if kernel in kernel_reqs["blocklist"]:
+                continue
+
+            # For non-default kernels, check allowlist if it exists
+            if kernel != kernel_reqs["default"] and kernel_reqs["allowlist"]:
+                if kernel not in kernel_reqs["allowlist"]:
+                    continue
+
+            matrix.append(
+                {
+                    "scheduler": scheduler["name"],
+                    "kernel": kernel,
+                    "disable_veristat": scheduler["metadata"]
+                    .get("ci", {})
+                    .get("disable_veristat", False),
+                }
+            )
+
+    return matrix
+
+
+async def get_scheduler_packages() -> List[dict]:
+    """Get list of scheduler packages from cargo metadata."""
+    stdout = await run_command(["cargo", "metadata", "--format-version", "1"])
+    metadata = json.loads(stdout)
+
+    schedulers = []
+    for pkg in metadata.get("packages", []):
+        # Look for schedulers in scheds/ directory
+        manifest_path = pkg.get("manifest_path", "")
+        if "scheds/" in manifest_path:
+            pkg_metadata = pkg.get("metadata") or {}
+            scx_metadata = pkg_metadata.get("scx", {})
+            schedulers.append(
+                {
+                    "name": pkg["name"],
+                    "path": pkg["manifest_path"],
+                    "metadata": scx_metadata,
+                }
+            )
+
+    return schedulers
 
 
 async def get_clippy_packages() -> List[str]:
@@ -196,7 +275,309 @@ async def run_tests():
     print("✓ Tests completed successfully", flush=True)
 
 
-def run_tests_in_vm():
+async def run_veristat():
+    """Run veristat verification on all schedulers across all compatible kernels."""
+    print("Running veristat verification...", flush=True)
+
+    async def extract_bpf_objects(scheduler_name: str, output_dir: str) -> List[str]:
+        """Extract BPF objects from scheduler binary using existing script."""
+
+        # Find the scheduler binary in target/debug
+        binary_path = f"target/debug/{scheduler_name}"
+        if not os.path.exists(binary_path):
+            raise Exception(f"Warning: Scheduler binary {binary_path} not found")
+
+        result = await run_command(
+            ["./scripts/extract_bpf_objects.sh", binary_path, output_dir]
+        )
+
+        # Find extracted .bpf.o files
+        bpf_objects = []
+        for file in os.listdir(output_dir):
+            if not file.endswith(".bpf.o"):
+                raise Exception(f"unexpected file {file} in extract dir")
+            bpf_objects.append(os.path.join(output_dir, file))
+
+        if not bpf_objects:
+            raise Exception(f"No BPF objects found for {scheduler_name}")
+
+        return bpf_objects
+
+    async def get_veristat_result(kernel: str, bpf_objects: List[str]):
+        try:
+            stdout = await run_command_in_vm(
+                kernel,
+                [
+                    "veristat",
+                    "-o",
+                    "csv",
+                ]
+                + bpf_objects,
+            )
+
+            return {"success": True, "csv": stdout}
+        except subprocess.CalledProcessError as e:
+            return {
+                "success": False,
+                "return_code": e.returncode,
+                "stdout": e.stdout,
+                "stderr": e.stderr,
+            }
+
+    async def generate_readable_output(result):
+        """Generate human-readable output for a verification result using veristat -R."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv") as f:
+            f.write(result["csv_data"])
+            f.flush()
+
+            result["output"] = await run_command(["veristat", "-R", f.name])
+            return result
+
+    matrix = await generate_scheduler_kernel_matrix()
+    matrix = [x for x in matrix if not x["disable_veristat"]]
+
+    print(f"Testing {len(matrix)} scheduler-kernel combinations:")
+    for item in matrix:
+        print(f"  - {item['scheduler']} on {item['kernel']}")
+
+    # Group by kernel to reuse VMs
+    kernels_to_test = {}
+    for item in matrix:
+        kernel = item["kernel"]
+        if kernel not in kernels_to_test:
+            kernels_to_test[kernel] = []
+        kernels_to_test[kernel].append(item["scheduler"])
+
+    # Create temporary directory for BPF object extraction
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Extract BPF objects for all schedulers (parallelise over scheds)
+        schedulers = list({item["scheduler"] for item in matrix})
+        extractors = []
+        for sched in schedulers:
+            d = os.path.join(temp_dir, sched)
+            os.makedirs(d, exist_ok=True)
+            extractors.append(extract_bpf_objects(sched, d))
+
+        scheduler_bpf_objects = {
+            sched: bpf_objects
+            for sched, bpf_objects in zip(schedulers, await asyncio.gather(*extractors))
+        }
+        print(f"scheduler_bpf_objects mapping: {scheduler_bpf_objects}")
+
+        # Veristat only shows the basename of each file in the CSV output. Ensure
+        # each path name is unique before passing them to veristat so we can
+        # reverse map them later.
+        unique_bpf_object_names = set()
+        for objs in scheduler_bpf_objects.values():
+            for i, obj in enumerate(objs):
+                mod = False
+                while os.path.basename(obj) in unique_bpf_object_names:
+                    mod = True
+                    obj = obj + random.choice(string.ascii_lowercase)
+                if mod:
+                    print(f"Found duplicate BPF object, renaming {objs[i]}->{obj}")
+                    os.rename(objs[i], obj)
+                objs[i] = obj
+                unique_bpf_object_names.add(os.path.basename(obj))
+
+        bpf_object_to_scheduler = {
+            os.path.basename(path): scheduler
+            for scheduler, paths in scheduler_bpf_objects.items()
+            for path in paths
+        }
+        print(f"bpf_object_to_scheduler mapping: {bpf_object_to_scheduler}")
+
+        # Start veristat VMs (parallelise over kernels)
+        running_processes = {}
+        total_tests = len(matrix)
+
+        print(f"\n=== Starting parallel veristat VMs ===")
+
+        veristat_vms = list()
+        for kernel, schedulers in kernels_to_test.items():
+            # Collect all BPF objects for this kernel
+            all_bpf_objects = []
+            valid_schedulers = []
+
+            for scheduler in schedulers:
+                bpf_objects = scheduler_bpf_objects[scheduler]
+                all_bpf_objects.extend(bpf_objects)
+                valid_schedulers.append(scheduler)
+
+            veristat_vms.append(get_veristat_result(kernel, all_bpf_objects))
+
+        print(f"Starting {len(veristat_vms)} parallel veristat VMs")
+
+        veristat_results = {
+            kernel: result
+            for kernel, result in zip(
+                kernels_to_test.keys(), await asyncio.gather(*veristat_vms)
+            )
+        }
+
+        print(f"\n=== Processing results ===")
+
+        veristat_failures = [
+            (k, r) for k, r in veristat_results.items() if not r["success"]
+        ]
+        if veristat_failures:
+            for kernel, res in veristat_failures:
+                print(
+                    f"✗ Veristat failed for kernel {kernel} with return code {res['return_code']} and stdout:"
+                )
+                print(res["stdout"])
+                print("And stderr:")
+                print(res["stderr"])
+            raise Exception(
+                f"vmtest failed to complete on {len(veristat_failures)} kernels"
+            )
+
+        veristat_csvs = {k: r["csv"] for k, r in veristat_results.items()}
+        print(f"Raw veristat_csvs keys: {list(veristat_csvs.keys())}")
+
+        # Process CSV data for successful results
+        print(f"\n=== Processing CSV data ===")
+
+        # Create unified list of verification results: [{'scheduler': str, 'kernel': str, 'failed': bool, 'csv_data': str}, ...]
+        verification_results = []
+
+        for kernel, csv_content in veristat_csvs.items():
+            print(f"\nProcessing kernel {kernel}")
+            if not csv_content.strip():
+                print(f"  Skipping {kernel} - empty CSV content")
+                continue
+
+            # Parse CSV content line by line to group by scheduler
+            lines = csv_content.strip().split("\n")
+            if len(lines) < 2:  # Need at least header + 1 data row
+                print(f"  Skipping {kernel} - insufficient CSV data")
+                continue
+
+            header_line = lines[0]
+            print(f"  CSV header: {header_line}")
+
+            # Parse and group rows by scheduler
+            import csv
+            import io
+
+            reader = csv.DictReader(io.StringIO(csv_content.strip()))
+
+            scheduler_data = {}  # scheduler -> {'lines': [str], 'has_failure': bool}
+            row_count = 0
+
+            # Process each data row
+            for row in reader:
+                row_count += 1
+                cleaned_row = {
+                    key.strip(): value.strip() if isinstance(value, str) else value
+                    for key, value in row.items()
+                }
+
+                file_name = cleaned_row.get("file_name", "")
+                verdict = cleaned_row.get("verdict", "").lower()
+
+                scheduler = bpf_object_to_scheduler[os.path.basename(file_name)]
+
+                if scheduler not in scheduler_data:
+                    scheduler_data[scheduler] = {"lines": [], "has_failure": False}
+
+                line_values = [
+                    cleaned_row.get(field.strip(), "") for field in reader.fieldnames
+                ]
+                csv_line = ",".join(
+                    f'"{val}"' if "," in str(val) or '"' in str(val) else str(val)
+                    for val in line_values
+                )
+                scheduler_data[scheduler]["lines"].append(csv_line)
+
+                if verdict != "success":
+                    scheduler_data[scheduler]["has_failure"] = True
+
+            print(
+                f"  Processed {row_count} rows, found schedulers: {list(scheduler_data.keys())}"
+            )
+
+            # Create CSV data for each scheduler
+            for scheduler, data in scheduler_data.items():
+                if not data["lines"]:
+                    continue
+
+                # Combine header with scheduler's data lines
+                scheduler_csv = header_line + "\n" + "\n".join(data["lines"])
+
+                verification_results.append(
+                    {
+                        "scheduler": scheduler,
+                        "kernel": kernel,
+                        "failed": data["has_failure"],
+                        "csv_data": scheduler_csv,
+                    }
+                )
+
+                print(
+                    f"  Created CSV for {scheduler} on {kernel}: {len(scheduler_csv)} chars, failed={data['has_failure']}"
+                )
+
+        print(
+            f"\nCreated {len(verification_results)} scheduler-kernel verification results"
+        )
+
+        # Split into successes and failures
+        success_results = [r for r in verification_results if not r["failed"]]
+        failure_results = [r for r in verification_results if r["failed"]]
+
+        print(f"\nVerification summary:")
+        print(f"  Successes: {len(success_results)}")
+        print(f"  Failures: {len(failure_results)}")
+
+        print(f"\n=== Generating human-readable output ===")
+
+        readable_results = await asyncio.gather(
+            *[generate_readable_output(result) for result in verification_results]
+        )
+
+        readable_results.sort(key=lambda x: x["scheduler"])
+
+        readable_successes = [r for r in readable_results if not r["failed"]]
+        readable_failures = [r for r in readable_results if r["failed"]]
+
+        # Display successful results first
+        print(f"\n" + "=" * 80)
+        print(f"SUCCESSFUL VERIFICATIONS ({len(readable_successes)} results)")
+        print("=" * 80)
+
+        for result in readable_successes:
+            print(f"\n📈 {result['scheduler']} on {result['kernel']}")
+            print("-" * 60)
+            print(result["output"])
+
+        # Display failure results
+        print(f"\n" + "=" * 80)
+        print(f"FAILED VERIFICATIONS ({len(readable_failures)} results)")
+        print("=" * 80)
+
+        for result in readable_failures:
+            print(f"\n❌ {result['scheduler']} on {result['kernel']}")
+            print("-" * 60)
+            print(result["output"])
+
+        # Print final status and throw if there were failures
+        if readable_failures:
+            print(
+                f"\n✗ Veristat verification failed ({len(readable_failures)} schedulers had failures)",
+                flush=True,
+            )
+            raise Exception(
+                f"Veristat verification failed for {len(readable_failures)} scheduler-kernel combinations"
+            )
+        else:
+            print(
+                f"\n✓ Veristat verification completed successfully ({len(readable_successes)} schedulers passed)",
+                flush=True,
+            )
+
+
+async def run_tests_in_vm():
     """Run tests when already inside the VM."""
 
     subprocess.run(
@@ -221,6 +602,7 @@ async def run_all():
     await run_format()
     await run_build()
     await run_clippy()
+    await run_veristat()
     await run_tests()
 
 
@@ -238,6 +620,9 @@ async def main():
         "clippy", help="Run Clippy on crates that request it"
     )
     parser_test = subparsers.add_parser("test", help="Run Rust tests")
+    parser_veristat = subparsers.add_parser(
+        "veristat", help="Run veristat verification on all schedulers"
+    )
 
     parser_all = subparsers.add_parser("all", help="Run all commands")
 
@@ -256,6 +641,8 @@ async def main():
         await run_clippy()
     elif args.command == "test":
         await run_tests()
+    elif args.command == "veristat":
+        await run_veristat()
     elif args.command == "test-in-vm":
         run_tests_in_vm()
     elif args.command == "all":

--- a/.github/include/flake.nix
+++ b/.github/include/flake.nix
@@ -193,6 +193,8 @@
                 # fenix managed rust toolchain + nixpkgs cargo-nextest
                 cargo-nextest
                 rust-toolchain
+              ] ++ [
+                self.packages.${system}.veristat
               ];
 
               makeWrapperArgs = lib.lists.flatten ([

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -39,16 +39,18 @@ jobs:
         with:
           cachix-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-
       - name: Build
         run: nix run ./.github/include#ci -- build
 
       - name: Test
         run: nix run ./.github/include#ci -- test
 
+      - name: Veristat
+        run: nix run ./.github/include#ci -- veristat
+
   integration-test:
     uses: ./.github/workflows/integration-tests.yml
-    needs: build-kernels
+    needs: build-and-test
     secrets: inherit
 
   required-checks:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,11 +41,6 @@ jobs:
         with:
           cachix-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: Install Veristat
-        run: |
-          VERISTAT_PATH=$(nix build --no-link --print-out-paths ./.github/include#veristat)
-          nix-env -i "$VERISTAT_PATH"
-
       # prevent cache permission errors
       - run: sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
       - uses: Swatinem/rust-cache@v2
@@ -105,8 +100,6 @@ jobs:
         with:
           retries: 3
           command: meson compile -C build stress_tests_${{ matrix.scheduler['name'] }}
-      - run: meson compile -C build veristat_${{ matrix.scheduler['name'] }}
-        if: always()
       - run: sudo cat /var/log/dmesg > host-dmesg.ci.log
         if: always()
       - run: mkdir -p ./log_save/
@@ -123,7 +116,7 @@ jobs:
             KERNEL_SUFFIX="_${KERNEL_CLEAN}"
           fi
           echo "ARTIFACT_NAME=${{ matrix.scheduler['name'] }}${{ matrix.scheduler['flags'] }}${KERNEL_SUFFIX}_logs_${{ github.run_id }}_${{ github.run_attempt }}" >> $GITHUB_ENV
-      - name: upload debug logs, bpftrace, veristat, dmesg, etc.
+      - name: upload debug logs, bpftrace, dmesg, etc.
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/scheds/rust/scx_wd40/Cargo.toml
+++ b/scheds/rust/scx_wd40/Cargo.toml
@@ -8,6 +8,9 @@ license = "GPL-2.0-only"
 
 publish = false
 
+[package.metadata.scx]
+ci.disable_veristat = true  # requires some changes to vmlinux handling, see https://github.com/sched-ext/scx/pull/2246
+
 [dependencies]
 anyhow = "1.0.65"
 chrono = "0.4"

--- a/scripts/extract_bpf_objects.sh
+++ b/scripts/extract_bpf_objects.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Extract BPF objects from scheduler binaries using llvm-readobj
+#
+
+set -euo pipefail
+shopt -s lastpipe
+
+BINARY="$1"
+OUTPUT_DIR="$2"
+
+if [ -z "${BINARY}" ] || [ -z "${OUTPUT_DIR}" ]; then
+    echo "Usage: $0 <scheduler_binary> <output_dir>"
+    exit 1
+fi
+
+if [ ! -f "${BINARY}" ]; then
+    echo "Error: Binary ${BINARY} not found"
+    exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+if ! command -v llvm-readobj >/dev/null 2>&1; then
+    echo "Error: llvm-readobj not found. Please install LLVM tools."
+    exit 1
+fi
+
+EXTRACTED_COUNT=0
+
+llvm-readobj --elf-output-style=JSON --symbols "$BINARY" \
+  | jq -c '.[0].Symbols[].Symbol | select(.Section.Name == ".bpf.objs") | {name: .Name.Name, offset: .Value, size: .Size}' \
+  | while read -r line; do
+    name=$(jq -r .name <<< "$line")
+    offset=$(jq -r .offset <<< "$line")
+    size=$(jq -r .size <<< "$line")
+
+    echo "Extracting '$name.bpf.o'..."
+
+    dd if="$BINARY" of="$OUTPUT_DIR/$name.bpf.o" bs=4M iflag=skip_bytes,count_bytes skip="$offset" count="$size" status=none
+    ((EXTRACTED_COUNT++)) || true
+done
+
+echo "Successfully extracted $EXTRACTED_COUNT BPF object files to ${OUTPUT_DIR}"


### PR DESCRIPTION
Currently we run veristat when we run a full set of stress tests for a
scheduler. There are a few flaws with this approach:
- Any failures of veristat are completely ignored and still allow the PR
  to merge.
- We spin up an entire virtme-ng VM to run a single veristat invocation,
  even though veristat is very quick and the VMs are quite expensive.
- We only run veristat against the kernel(s) we have chosen for full
  stress tests, which are few because the tests are expensive.

This moves the veristat jobs from the Ubuntu runners to the ci.py Python
script. In doing that, it adds the plumbing for a job internal matrix
and many efficiency improvements. This allows us to run veristat for all
relevant kernels for all schedulers on every PR with a single quick job.

Adds a new `ci.disable_veristat` option to `package.metadata.scx` in
Cargo.toml for each scheduler, and automatically locates all Rust crates
under `scheds/`. This makes this the first opt out bit of verification
in the CI. Also places the heavy Ubuntu runner integration tests behind
this CI job, as verification failures must be dealt with and this will
save some of that limited capacity.

Test plan:
- CI