### PR TITLE
scx_p2dq/scx_chaos: Add cpu_release handler

### DIFF
--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -635,6 +635,7 @@ SCX_OPS_DEFINE(chaos,
 	       .tick 		    	= (void *)chaos_tick,
 
 	       .update_idle		= (void *)p2dq_update_idle,
+	       .cpu_release		= (void *)p2dq_cpu_release,
 	       .exit_task		= (void *)p2dq_exit_task,
 	       .exit			= (void *)p2dq_exit,
 	       .running			= (void *)chaos_running,

--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -1585,6 +1585,11 @@ void BPF_STRUCT_OPS(p2dq_set_cpumask, struct task_struct *p,
 		p->nr_cpus_allowed == topo_config.nr_cpus;
 }
 
+void BPF_STRUCT_OPS(p2dq_cpu_release, s32 cpu, struct scx_cpu_release_args *args)
+{
+	scx_bpf_reenqueue_local();
+}
+
 void BPF_STRUCT_OPS(p2dq_update_idle, s32 cpu, bool idle)
 {
 	struct llc_ctx *llcx;
@@ -2179,6 +2184,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(p2dq_init_task, struct task_struct *p,
 
 SCX_OPS_DEFINE(p2dq,
 	       .select_cpu		= (void *)p2dq_select_cpu,
+	       .cpu_release		= (void *)p2dq_cpu_release,
 	       .enqueue			= (void *)p2dq_enqueue,
 	       .dispatch		= (void *)p2dq_dispatch,
 	       .running			= (void *)p2dq_running,


### PR DESCRIPTION
Add handler to reenqueue tasks on the local DSQ when the CPU has been released to a higher level scheduling class.