### PR TITLE
scxtop: add layered thread support

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -3272,6 +3272,7 @@ impl<'a> App<'a> {
 
         match table.as_str() {
             "Process" => self.process_columns.update_visibility(col, *visible),
+            "Thread" => self.thread_columns.update_visibility(col, *visible),
             _ => bail!("Invalid table name"),
         };
 

--- a/tools/scxtop/src/columns.rs
+++ b/tools/scxtop/src/columns.rs
@@ -230,6 +230,7 @@ pub fn get_thread_columns() -> Vec<Column<i32, ThreadData>> {
         id_column!("TID"),
         name_column!(ThreadData, thread_name),
         state_column!(ThreadData),
+        layer_id_column!(ThreadData),
         last_dsq_column!(ThreadData),
         slice_ns_column!(ThreadData),
         avg_max_lat_column!(ThreadData),

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -367,6 +367,11 @@ fn run_tui(tui_args: &TuiArgs) -> Result<()> {
                     col: "Layer ID".to_string(),
                     visible: true,
                 }))?;
+                action_tx.send(Action::UpdateColVisibility(UpdateColVisibilityAction {
+                    table: "Thread".to_string(),
+                    col: "Layer ID".to_string(),
+                    visible: true,
+                }))?;
                 Some(layered_util::attach_to_existing_map("task_ctxs", &mut skel.maps.task_ctxs)?)
             } else {
                 None


### PR DESCRIPTION
This adds layer_id to the thread view as well, making it easier to understand which layers individual threads are located in. Example:
<img width="1279" height="164" alt="Screenshot 2025-08-05 at 10 27 09 AM" src="https://github.com/user-attachments/assets/7cef0bb3-e8eb-4e42-9c7b-50fa2146aaaf" />
