### PR TITLE
chaos: generate random numbers with less bias

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -762,6 +762,14 @@ static inline u64 scale_by_task_weight_inverse(const struct task_struct *p, u64 
 	return value * 100 / p->scx.weight;
 }
 
+/*
+ * Get a random u64 from the kernel's pseudo-random generator.
+ */
+static inline u64 get_prandom_u64()
+{
+	return ((u64)bpf_get_prandom_u32() << 32) | bpf_get_prandom_u32();
+}
+
 
 #include "compat.bpf.h"
 #include "enums.bpf.h"

--- a/scheds/rust/scx_chaos/src/bpf/intf.h
+++ b/scheds/rust/scx_chaos/src/bpf/intf.h
@@ -14,6 +14,8 @@ enum chaos_consts {
 	CHAOS_DSQ_BASE		= 1 << CHAOS_DSQ_BASE_SHIFT,
 
 	CHAOS_NUM_PPIDS_CHECK	= 1 << 20,
+
+	CHAOS_MAX_RAND_ATTEMPTS	= 512,
 };
 
 enum chaos_match {


### PR DESCRIPTION
chaos currently uses a mod to move the uniform random number from the kfunc into the requested range. This has a potential bias which increases as you move towards larger numbers.

Any solution to this requires a loop which means it's impossible to completely remove bias within BPF's termination guarantees, but we can get a lot closer. This approach uses Lemire's Algorithm 5 which avoids a mod in all cases by using 128 bit arithmetic. Unfortunately, BPF doesn't support 128 bit arithmetic, so we roll it by hand.

Test plan:
- CI
- `cargo build --release && sudo target/release/scx_chaos --random-delay-frequency 0.5 --random-delay-min-us 1000 --random-delay-max-us 10000`

[0] https://arxiv.org/pdf/1805.10941v2