### PR TITLE
ci: add test for arighi's patched 6.12

### DIFF
--- a/.github/workflows/arighi_6_12.yml
+++ b/.github/workflows/arighi_6_12.yml
@@ -1,0 +1,18 @@
+name: arighi-6_12-test
+
+on:
+  # only runs on main, every 6 hours. specify hours explicitly so scheduled runs can be offset and use a random minute.
+  schedule:
+    - cron: "42 3,9,15,21 * * *"
+
+jobs:
+  build-kernels:
+    uses: ./.github/workflows/build-kernels.yml
+    secrets: inherit
+
+  integration-test:
+    uses: ./.github/workflows/integration-tests.yml
+    needs: build-kernels
+    secrets: inherit
+    with:
+      repo-name: arighi/6_12

--- a/kernel-versions.json
+++ b/kernel-versions.json
@@ -23,6 +23,14 @@
     "narHash": "sha256-KIUrzpGMDSsYjFlWaluZ5LA1MpunLiF+KHEq/4W9y3s=",
     "kernelVersion": "6.12.41"
   },
+  "arighi/6_12": {
+    "repo": "https://git.kernel.org/pub/scm/linux/kernel/git/arighi/linux.git",
+    "branch": "scx-6.12",
+    "commitHash": "b51409746fbc4d9269bba1eef415b93596a82763",
+    "lastModified": 1754560679,
+    "narHash": "sha256-XlWDG/Qb/kUuaGtyrz3AbVIlvQg9V/mgOlyjn6pds/8=",
+    "kernelVersion": "6.12.41"
+  },
   "stable/linux-rolling-stable": {
     "repo": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
     "branch": "linux-rolling-stable",


### PR DESCRIPTION
Rustland needs a 6.12 LTS backport to be able to call `scx_bpf_pick_idle_cpu` from a BPF timer. Add a branch with this backport to our CI temporarily to confirm it fixes the issue. This will run 6 hourly and once it's applied to stable we can remove this additional testing.

Test plan:
- CI for job runs succeeding
- Inspection to confirm the scheduled job runs the same kernel as the trailer

CI-Test-Kernel: arighi/6_12