### PR TITLE
scx_p2dq: Fix segfault

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -786,7 +786,6 @@ static s32 pick_idle_cpu(struct task_struct *p, task_ctx *taskc,
 		    scx_bpf_test_and_clear_cpu_idle(pref_cpu)) {
 			*is_idle = true;
 			cpu = pref_cpu;
-			trace("PREF idle %s->%d", p->comm, pref_cpu);
 			goto found_cpu;
 		}
 	}


### PR DESCRIPTION
Fix a segfault in some versions of libbpf/clang by removing some tracing code.