### PR TITLE
scxtop: add process appstate

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -365,7 +365,6 @@ impl<'a> App<'a> {
             || self.state == AppState::Default
             || self.state == AppState::Llc
             || self.state == AppState::Node
-            || self.state == AppState::Memory
             || self.state == AppState::Process
         {
             self.filtered_state.lock().unwrap().reset();

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -41,6 +41,7 @@ impl Default for KeyMap {
         bindings.insert(Key::Char(' '), Action::SetState(AppState::Pause));
         bindings.insert(Key::Char('e'), Action::SetState(AppState::PerfEvent));
         bindings.insert(Key::Char('K'), Action::SetState(AppState::KprobeEvent));
+        bindings.insert(Key::Char('p'), Action::SetState(AppState::Process));
         bindings.insert(Key::Char('f'), Action::Filter);
         bindings.insert(Key::Char('F'), Action::ToggleCpuFreq);
         bindings.insert(Key::Char('u'), Action::ToggleUncoreFreq);
@@ -359,6 +360,7 @@ pub fn parse_action(action_str: &str) -> Result<Action> {
         "AppStateDefault" | "SetState(Default)" => Ok(Action::SetState(AppState::Default)),
         "AppStatePause" | "SetState(Pause)" => Ok(Action::SetState(AppState::Pause)),
         "AppStatePerfEvent" | "SetState(PerfEvent)" => Ok(Action::SetState(AppState::PerfEvent)),
+        "AppStateProcess" | "SetState(Process)" => Ok(Action::SetState(AppState::Process)),
         "AppStateKprobeEvent" | "SetState(KprobeEvent)" => {
             Ok(Action::SetState(AppState::KprobeEvent))
         }

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -94,6 +94,8 @@ pub enum AppState {
     Pause,
     /// Application is in the PerfEvent list state.
     PerfEvent,
+    /// Application is in the Process state.
+    Process,
     /// Application is in the scheduler state.
     Scheduler,
     /// Application is in the tracing  state.
@@ -715,6 +717,7 @@ impl std::fmt::Display for Action {
             Action::SetState(AppState::Default) => write!(f, "AppStateDefault"),
             Action::SetState(AppState::Pause) => write!(f, "AppStatePause"),
             Action::SetState(AppState::PerfEvent) => write!(f, "AppStatePerfEvent"),
+            Action::SetState(AppState::Process) => write!(f, "AppStateProcess"),
             Action::SetState(AppState::KprobeEvent) => write!(f, "AppStateKprobeEvent"),
             Action::SetState(AppState::MangoApp) => write!(f, "AppStateMangoApp"),
             Action::Filter => write!(f, "Filter"),

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -77,7 +77,7 @@ fn handle_key_event(app: &App, keymap: &KeyMap, key: KeyEvent) -> Action {
 fn handle_input_entry(app: &App, s: String) -> Option<Action> {
     match app.state() {
         AppState::PerfEvent | AppState::KprobeEvent => Some(Action::InputEntry(s)),
-        AppState::Default | AppState::Llc | AppState::Node => {
+        AppState::Default | AppState::Llc | AppState::Node | AppState::Process => {
             if app.filtering() {
                 Some(Action::InputEntry(s))
             } else {


### PR DESCRIPTION
This adds a detailed process view and sets the stage to enable additional columns on the wider screen and column toggling. Also removes unnecessary `AppState::Memory` checks.

<img width="2560" height="1489" alt="Screenshot 2025-08-08 at 1 11 55 PM" src="https://github.com/user-attachments/assets/7cb48af9-8d47-4aa7-a57e-c57e7d70d59f" />


Testing:
* Played around with it. Went Default -> Process -> Scheduler and Default -> Process -> Thread -> Process -> Default, behavior was as expected.