### PR TITLE
scxtop: add tests to thread data

### DIFF
--- a/tools/scxtop/src/proc_data.rs
+++ b/tools/scxtop/src/proc_data.rs
@@ -266,7 +266,6 @@ mod tests {
         assert!(proc_data.threads.contains_key(&current_pid));
 
         // Test thread update
-        let initial_thread_count = proc_data.threads.len();
         proc_data.update_threads(100);
         // The thread count might change during the test as threads are created or destroyed
         // So we don't assert exact equality

--- a/tools/scxtop/src/thread_data.rs
+++ b/tools/scxtop/src/thread_data.rs
@@ -96,3 +96,256 @@ impl ThreadData {
         self.data.add_event_data(event, val)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use procfs::process::Process;
+
+    #[test]
+    fn test_new_thread_data() {
+        // Get the current process and its main thread
+        let current_pid = std::process::id() as i32;
+        let process = Process::new(current_pid).unwrap();
+        let tasks = process.tasks().unwrap();
+        let main_thread = tasks.flatten().next().unwrap();
+
+        // Create ThreadData from the main thread
+        let thread_data = ThreadData::new(main_thread, 10).unwrap();
+
+        // Verify basic properties
+        assert_eq!(thread_data.tgid, current_pid);
+        assert_eq!(thread_data.tid, current_pid); // Main thread has same TID as PID
+        assert!(!thread_data.thread_name.is_empty());
+        assert_eq!(thread_data.prev_cpu_time, 0);
+        // The current_cpu_time might be 0 in some environments, so we don't assert it's > 0
+        assert_eq!(thread_data.cpu_util_perc, 0.0);
+        assert_eq!(thread_data.max_data_size, 10);
+        assert!(thread_data.llc.is_none());
+        assert!(thread_data.node.is_none());
+        assert!(thread_data.dsq.is_none());
+        assert!(thread_data.layer_id.is_none());
+    }
+
+    #[test]
+    fn test_from_tgid_tid() {
+        // Get the current process ID (which is also the main thread ID)
+        let current_pid = std::process::id() as i32;
+
+        // Create ThreadData from the current process and thread ID
+        let thread_data = ThreadData::from_tgid_tid(current_pid, current_pid, 5).unwrap();
+
+        // Verify basic properties
+        assert_eq!(thread_data.tgid, current_pid);
+        assert_eq!(thread_data.tid, current_pid);
+        assert!(!thread_data.thread_name.is_empty());
+        assert_eq!(thread_data.max_data_size, 5);
+    }
+
+    #[test]
+    fn test_from_tgid_tid_invalid() {
+        // Test with invalid PID
+        let result = ThreadData::from_tgid_tid(-1, -1, 10);
+        assert!(result.is_err());
+
+        // Test with valid PID but invalid TID
+        let current_pid = std::process::id() as i32;
+        let result = ThreadData::from_tgid_tid(current_pid, -1, 10);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_update() {
+        // Get the current process ID
+        let current_pid = std::process::id() as i32;
+        let mut thread_data = ThreadData::from_tgid_tid(current_pid, current_pid, 10).unwrap();
+
+        // Store initial values
+        let initial_cpu_time = thread_data.current_cpu_time;
+
+        // Do some CPU work to ensure time changes
+        for _ in 0..1000000 {
+            let _ = 2 + 2;
+        }
+
+        // Update with a non-zero system util
+        thread_data.update(100).unwrap();
+
+        // Verify update effects
+        assert_eq!(thread_data.prev_cpu_time, initial_cpu_time);
+        assert!(thread_data.current_cpu_time >= initial_cpu_time);
+        // CPU util should be non-negative
+        assert!(thread_data.cpu_util_perc >= 0.0);
+    }
+
+    #[test]
+    fn test_update_invalid_thread() {
+        // Create a thread data with valid initial values
+        let current_pid = std::process::id() as i32;
+        let mut thread_data = ThreadData::from_tgid_tid(current_pid, current_pid, 10).unwrap();
+
+        // Change the TID to an invalid one
+        thread_data.tid = -1;
+
+        // Update should fail
+        let result = thread_data.update(100);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_set_cpu_util() {
+        // Get the current process ID
+        let current_pid = std::process::id() as i32;
+        let mut thread_data = ThreadData::from_tgid_tid(current_pid, current_pid, 10).unwrap();
+
+        // Set initial values for testing
+        thread_data.prev_cpu_time = 100;
+        thread_data.current_cpu_time = 150;
+
+        // Test with zero system_util
+        thread_data.set_cpu_util(0);
+        assert_eq!(thread_data.cpu_util_perc, 0.0);
+
+        // Test with non-zero system_util
+        thread_data.set_cpu_util(100);
+        assert_eq!(thread_data.cpu_util_perc, 50.0); // (150-100)/100 * 100 = 50%
+
+        // Test with system_util smaller than delta (should not panic)
+        thread_data.prev_cpu_time = 200;
+        thread_data.current_cpu_time = 150; // Less than prev (edge case)
+        thread_data.set_cpu_util(50);
+        assert_eq!(thread_data.cpu_util_perc, 0.0); // saturating_sub should make delta 0
+    }
+
+    #[test]
+    fn test_event_data_operations() {
+        // Get the current process ID
+        let current_pid = std::process::id() as i32;
+        let mut thread_data = ThreadData::from_tgid_tid(current_pid, current_pid, 5).unwrap();
+
+        // Test adding event data
+        thread_data.add_event_data("test_event", 42);
+        thread_data.add_event_data("test_event", 84);
+
+        // Test retrieving event data
+        let data = thread_data.event_data_immut("test_event");
+        assert!(!data.is_empty());
+        assert!(data.contains(&42));
+        assert!(data.contains(&84));
+
+        // Test retrieving non-existent event data
+        let empty_data = thread_data.event_data_immut("nonexistent_event");
+        assert!(empty_data.is_empty());
+    }
+
+    #[test]
+    fn test_event_data_max_size_respected() {
+        // Get the current process ID
+        let current_pid = std::process::id() as i32;
+        let mut thread_data = ThreadData::from_tgid_tid(current_pid, current_pid, 3).unwrap();
+
+        // Add more data than max_data_size
+        for i in 1..=5 {
+            thread_data.add_event_data("overflow_test", i * 10);
+        }
+
+        let data = thread_data.event_data_immut("overflow_test");
+        assert_eq!(data.len(), 3); // Should respect max_data_size
+        // Should contain the last 3 values: 30, 40, 50
+        assert!(data.contains(&30));
+        assert!(data.contains(&40));
+        assert!(data.contains(&50));
+        assert!(!data.contains(&10)); // First value should be dropped
+        assert!(!data.contains(&20)); // Second value should be dropped
+    }
+
+    #[test]
+    fn test_thread_data_clone() {
+        // Get the current process ID
+        let current_pid = std::process::id() as i32;
+        let mut original = ThreadData::from_tgid_tid(current_pid, current_pid, 5).unwrap();
+
+        // Add some event data
+        original.add_event_data("clone_test", 123);
+
+        // Clone the thread data
+        let cloned = original.clone();
+
+        // Verify the clone has the same data
+        assert_eq!(cloned.tid, original.tid);
+        assert_eq!(cloned.tgid, original.tgid);
+        assert_eq!(cloned.thread_name, original.thread_name);
+        assert_eq!(cloned.cpu, original.cpu);
+        assert_eq!(cloned.max_data_size, original.max_data_size);
+
+        // Verify event data is cloned
+        let original_data = original.event_data_immut("clone_test");
+        let cloned_data = cloned.event_data_immut("clone_test");
+        assert_eq!(original_data, cloned_data);
+    }
+
+    #[test]
+    fn test_thread_data_debug() {
+        // Get the current process ID
+        let current_pid = std::process::id() as i32;
+        let thread_data = ThreadData::from_tgid_tid(current_pid, current_pid, 5).unwrap();
+
+        // Verify Debug trait is implemented and doesn't panic
+        let debug_string = format!("{:?}", thread_data);
+        assert!(!debug_string.is_empty());
+        assert!(debug_string.contains("ThreadData"));
+    }
+
+    #[test]
+    fn test_multiple_events() {
+        // Get the current process ID
+        let current_pid = std::process::id() as i32;
+        let mut thread_data = ThreadData::from_tgid_tid(current_pid, current_pid, 4).unwrap();
+
+        // Add data to multiple events
+        thread_data.add_event_data("cpu_usage", 10);
+        thread_data.add_event_data("memory_usage", 20);
+        thread_data.add_event_data("cpu_usage", 15);
+        thread_data.add_event_data("io_usage", 30);
+
+        // Verify each event has correct data
+        let cpu_data = thread_data.event_data_immut("cpu_usage");
+        assert!(cpu_data.contains(&10));
+        assert!(cpu_data.contains(&15));
+
+        let memory_data = thread_data.event_data_immut("memory_usage");
+        assert!(memory_data.contains(&20));
+
+        let io_data = thread_data.event_data_immut("io_usage");
+        assert!(io_data.contains(&30));
+
+        // Verify non-existent event returns empty
+        let nonexistent_data = thread_data.event_data_immut("nonexistent");
+        assert!(nonexistent_data.is_empty());
+    }
+
+    #[test]
+    fn test_cpu_util_edge_cases() {
+        // Get the current process ID
+        let current_pid = std::process::id() as i32;
+        let mut thread_data = ThreadData::from_tgid_tid(current_pid, current_pid, 5).unwrap();
+
+        // Test with same prev and current times
+        thread_data.prev_cpu_time = 100;
+        thread_data.current_cpu_time = 100;
+        thread_data.set_cpu_util(50);
+        assert_eq!(thread_data.cpu_util_perc, 0.0);
+
+        // Test with very large numbers
+        thread_data.prev_cpu_time = u64::MAX - 100;
+        thread_data.current_cpu_time = u64::MAX;
+        thread_data.set_cpu_util(200);
+        assert_eq!(thread_data.cpu_util_perc, 50.0); // 100/200 * 100 = 50%
+
+        // Test with current time less than previous (overflow scenario)
+        thread_data.prev_cpu_time = 200;
+        thread_data.current_cpu_time = 100;
+        thread_data.set_cpu_util(100);
+        assert_eq!(thread_data.cpu_util_perc, 0.0); // saturating_sub should handle this
+    }
+}

--- a/tools/scxtop/src/thread_data.rs
+++ b/tools/scxtop/src/thread_data.rs
@@ -251,7 +251,7 @@ mod tests {
 
         let data = thread_data.event_data_immut("overflow_test");
         assert_eq!(data.len(), 3); // Should respect max_data_size
-        // Should contain the last 3 values: 30, 40, 50
+                                   // Should contain the last 3 values: 30, 40, 50
         assert!(data.contains(&30));
         assert!(data.contains(&40));
         assert!(data.contains(&50));


### PR DESCRIPTION
Add some tests to thread data. They're not necessarily amazing tests, but they'll alert one if they change behavior unknowingly.