### PR TITLE
lib/btree: add free bnode cache

### DIFF
--- a/scheds/include/lib/btree.h
+++ b/scheds/include/lib/btree.h
@@ -23,6 +23,7 @@ struct bt_node {
 
 struct btree {
 	bt_node *root;
+	bt_node *freelist;
 	/* XXXETSAL Locking */
 };
 


### PR DESCRIPTION
Add a linked list of freed btree nodes to each tree. This lets us implement free without switching off of the static allocator.