### PR TITLE
scxtop: Add perf top mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
 ]
 
 [[package]]
@@ -391,6 +391,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blazesym"
+version = "0.2.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a810b7e5f883ad3c711208237841f051061bf59b6ee698ac4dc1fe12a3a5db"
+dependencies = [
+ "cpp_demangle",
+ "gimli 0.32.0",
+ "libc",
+ "memmap2",
+ "miniz_oxide",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +754,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crc32fast"
@@ -1132,6 +1155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1351,17 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "gimli"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93563d740bc9ef04104f9ed6f86f1e3275c2cdafb95664e26584b9ca807a8ffe"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -1716,6 +1756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3040,6 +3081,7 @@ name = "scxtop"
 version = "1.0.16"
 dependencies = [
  "anyhow",
+ "blazesym",
  "clap",
  "clap_complete",
  "criterion",
@@ -3200,6 +3242,12 @@ checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simple_logger"

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -50,6 +50,7 @@ log-panics = { version = "2", features = ["with-backtrace"]}
 hashbrown = "0.15.2"
 smartstring = { version = "1.0.1", features = ["serde"] }
 nix = { version = "0.29", features = ["time"] }
+blazesym = "0.2.0-rc.4"
 
 [dev-dependencies]
 criterion = "0.6.0"

--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -13,15 +13,19 @@ typedef unsigned long long u64;
 #endif
 #include <stdbool.h>
 
-
 enum consts {
 	MAX_COMM	= 16,
 	/*
-	* LAYER_ID_INDEX is the current index of layer_id in the layered task_ctx struct
-	* (https://github.com/sched-ext/scx/blob/main/scheds/rust/scx_layered/src/bpf/main.bpf.c#L577).
-	* Whenever a new field is added above layer_id, LAYER_ID_INDEX must be incremented.
-	*/
+	 * LAYER_ID_INDEX is the current index of layer_id in the layered task_ctx
+	 * struct
+	 * (https://github.com/sched-ext/scx/blob/main/scheds/rust/scx_layered/src/bpf/main.bpf.c#L577).
+	 * Whenever a new field is added above layer_id, LAYER_ID_INDEX must be
+	 * incremented.
+	 */
 	LAYER_ID_INDEX	= 2,
+
+	/* Stack trace configuration */
+	MAX_STACK_DEPTH	= 127, /* Maximum number of stack frames to capture */
 };
 
 enum stat_id {
@@ -46,8 +50,10 @@ enum event_type {
 	GPU_MEM,
 	HW_PRESSURE,
 	IPI,
+	KPROBE,
+	PERF_SAMPLE,
 	SCHED_HANG,
-    	SCHED_MIGRATE,
+	SCHED_MIGRATE,
 	SCHED_REG,
 	SCHED_SWITCH,
 	SCHED_UNREG,
@@ -57,7 +63,6 @@ enum event_type {
 	TRACE_STARTED,
 	TRACE_STOPPED,
 	EVENT_MAX,
-	KPROBE,
 };
 
 struct sched_switch_event {
@@ -65,23 +70,23 @@ struct sched_switch_event {
 	bool		preempt;
 	u8		next_comm[MAX_COMM];
 	u64		next_dsq_id;
-	u64		next_dsq_lat_us;
-	u32		next_dsq_nr;
-	u64		next_dsq_vtime;
-	u64		next_slice_ns;
-	u32		next_pid;
-	u32		next_tgid;
-	int		next_prio;
-	int		next_layer_id;
+	u64 		next_dsq_lat_us;
+	u32 		next_dsq_nr;
+	u64 		next_dsq_vtime;
+	u64 		next_slice_ns;
+	u32 		next_pid;
+	u32 		next_tgid;
+	int 		next_prio;
+	int 		next_layer_id;
 	u8		prev_comm[MAX_COMM];
 	u64		prev_dsq_id;
-	u64		prev_used_slice_ns;
-	u64		prev_slice_ns;
-	u32		prev_pid;
-	u32		prev_tgid;
-	u64		prev_state;
-	int		prev_prio;
-	int		prev_layer_id;
+	u64 		prev_used_slice_ns;
+	u64 		prev_slice_ns;
+	u32 		prev_pid;
+	u32 		prev_tgid;
+	u64 		prev_state;
+	int 		prev_prio;
+	int 		prev_layer_id;
 };
 
 struct wakeup_event {
@@ -92,10 +97,10 @@ struct wakeup_event {
 };
 
 struct migrate_event {
-    u8      comm[MAX_COMM];
-    u32     pid;
-    int     prio;
-    u32     dest_cpu;
+	u32		pid;
+	int		prio;
+	u32		dest_cpu;
+	u8		comm[MAX_COMM];
 };
 
 struct set_perf_event {
@@ -106,42 +111,42 @@ struct softirq_event {
 	u64		entry_ts;
 	u64		exit_ts;
 	u32		pid;
-	int		softirq_nr;
+	int 		softirq_nr;
 };
 
 struct exit_event {
 	u32		pid;
-	u32		prio;
-	u32		tgid;
+	u32 		prio;
+	u32 		tgid;
 	u8		comm[MAX_COMM];
 };
 
 struct fork_event {
 	u32		parent_pid;
-	u32		parent_tgid;
-	u32		child_pid;
-	u32		child_tgid;
+	u32 		parent_tgid;
+	u32 		child_pid;
+	u32 		child_tgid;
+	int 		parent_layer_id;
+	int 		child_layer_id;
 	u8		parent_comm[MAX_COMM];
-	u8		child_comm[MAX_COMM];
-	int		parent_layer_id;
-	int		child_layer_id;
+	u8 		child_comm[MAX_COMM];
 };
 
 struct exec_event {
-	u32             old_pid;
-	u32             pid;
-	int             layer_id;
+	u32		old_pid;
+	u32		pid;
+	int 		layer_id;
 };
 
 struct wait_event {
-	u8              comm[MAX_COMM];
-	u32             pid;
-	int             prio;
+	u32		pid;
+	int 		prio;
+	u8		comm[MAX_COMM];
 };
 
 struct hang_event {
-	u8              comm[MAX_COMM];
-	u32             pid;
+	u32		pid;
+	u8		comm[MAX_COMM];
 };
 
 struct ipi_event {
@@ -150,39 +155,51 @@ struct ipi_event {
 };
 
 struct gpu_mem_event {
-	u64             size;
-	u32             gpu;
-	u32             pid;
+	u64		size;
+	u32 		gpu;
+	u32 		pid;
 };
 
 struct cpuhp_enter_event {
-	u32             cpu;
-	u32             pid;
-	int             target;
-	int             state;
+	u32		cpu;
+	u32 		pid;
+	int 		target;
+	int 		state;
 };
 
 struct cpuhp_exit_event {
-	u32             cpu;
-	u32             pid;
-	int             state;
-	int             idx;
-	int             ret;
+	u32		cpu;
+	u32 		pid;
+	int 		state;
+	int 		idx;
+	int 		ret;
 };
 
 struct hw_pressure_event {
-	u64             hw_pressure;
-	u32             cpu;
+	u64		hw_pressure;
+	u32 		cpu;
 };
 
 struct trace_started_event {
 	bool		start_immediately;
-	bool		stop_scheduled;
+	bool 		stop_scheduled;
 };
 
 struct kprobe_event {
-	u32             pid;
-	u64             instruction_pointer;
+	u32		pid;
+	u64 		instruction_pointer;
+};
+
+struct perf_sample_event {
+	u32		pid;
+	u64 		instruction_pointer;
+	u32 		cpu_id;
+	int 		layer_id;
+	bool		is_kernel;
+	u32		kernel_stack_size;
+	u32 		user_stack_size;
+	u64 		kernel_stack[MAX_STACK_DEPTH];
+	u64 		user_stack[MAX_STACK_DEPTH];
 };
 
 struct bpf_event {
@@ -190,34 +207,35 @@ struct bpf_event {
 	u64		ts;
 	u32		cpu;
 	union {
-		struct  exit_event exit;
-		struct  fork_event fork;
-		struct  exec_event exec;
-		struct  wait_event wait;
-		struct  hw_pressure_event hwp;
-		struct  gpu_mem_event gm;
-		struct  cpuhp_enter_event chp;
-		struct  cpuhp_exit_event cxp;
-		struct	ipi_event ipi;
-		struct	sched_switch_event sched_switch;
-		struct	set_perf_event perf;
-		struct	softirq_event softirq;
-		struct	wakeup_event wakeup;
-		struct	wakeup_event waking;
-		struct  migrate_event migrate;
-		struct  hang_event hang;
-		struct  trace_started_event trace;
-		struct  kprobe_event kprobe;
+		struct exit_event		exit;
+		struct fork_event 		fork;
+		struct exec_event 		exec;
+		struct wait_event 		wait;
+		struct hw_pressure_event	hwp;
+		struct gpu_mem_event		gm;
+		struct cpuhp_enter_event	chp;
+		struct cpuhp_exit_event		cxp;
+		struct ipi_event		ipi;
+		struct sched_switch_event	sched_switch;
+		struct set_perf_event		perf;
+		struct softirq_event		softirq;
+		struct wakeup_event		wakeup;
+		struct wakeup_event 		waking;
+		struct migrate_event		migrate;
+		struct hang_event		hang;
+		struct trace_started_event	trace;
+		struct kprobe_event		kprobe;
+		struct perf_sample_event	perf_sample;
 	} event;
 };
 
 struct task_ctx {
 	u64		wakeup_ts;
-	u64		dsq_id;
-	u64		dsq_insert_time;
-	u64		dsq_vtime;
-	u64		slice_ns;
-	u64		last_run_ns;
+	u64 		dsq_id;
+	u64 		dsq_insert_time;
+	u64 		dsq_vtime;
+	u64 		slice_ns;
+	u64 		last_run_ns;
 };
 
 struct schedule_stop_trace_args {
@@ -226,8 +244,8 @@ struct schedule_stop_trace_args {
 
 struct layered_task_ctx {
 	u32		data_a;
-	u32		data_b;
-	u32		layer_id;
+	u32 		data_b;
+	u32 		layer_id;
 };
 
 #endif /* __INTF_H */

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -41,7 +41,7 @@ u32 last_sample_rate;
 
 const int zero_int = 0;
 
-struct timer_wrapper{
+struct timer_wrapper {
 	struct bpf_timer	timer;
 	int			key;
 };
@@ -85,7 +85,6 @@ static __always_inline struct bpf_event* try_reserve_event()
 		stat_inc(STAT_DROPPED_EVENTS);
 
 	return event;
-
 }
 
 static __always_inline u32 get_random_sample(u32 n)
@@ -142,7 +141,6 @@ struct {
 	__type(value, struct __softirq_event);
 	__uint(max_entries, 1);
 } softirq_events SEC(".maps");
-
 
 static __always_inline u64 t_to_tptr(struct task_struct *p)
 {
@@ -308,7 +306,6 @@ static int on_insert(struct task_struct *p, u64 dsq)
 	return 0;
 }
 
-
 SEC("kprobe/scx_bpf_dsq_insert")
 int BPF_KPROBE(scx_insert, struct task_struct *p, u64 dsq)
 {
@@ -340,14 +337,14 @@ static int on_dsq_move(struct task_struct *p, u64 dsq)
 
 SEC("kprobe/scx_bpf_dsq_move")
 int BPF_KPROBE(scx_dsq_move, struct bpf_iter_scx_dsq *it__iter,
-	       struct task_struct *p, u64 dsq_id, u64 enq_flags)
+               struct task_struct *p, u64 dsq_id, u64 enq_flags)
 {
 	return on_dsq_move(p, dsq_id);
 }
 
 SEC("kprobe/scx_bpf_dispatch_from_dsq")
 int BPF_KPROBE(scx_dispatch_from_dsq, struct bpf_iter_scx_dsq *it__iter,
-	       struct task_struct *p, u64 dsq_id, u64 enq_flags)
+               struct task_struct *p, u64 dsq_id, u64 enq_flags)
 {
 	return on_dsq_move(p, dsq_id);
 }
@@ -371,14 +368,14 @@ static int on_dsq_move_vtime(struct task_struct *p, u64 dsq)
 
 SEC("kprobe/scx_bpf_dsq_move_vtime")
 int BPF_KPROBE(scx_dsq_move_vtime, struct bpf_iter_scx_dsq *it__iter,
-	       struct task_struct *p, u64 dsq_id, u64 enq_flags)
+               struct task_struct *p, u64 dsq_id, u64 enq_flags)
 {
 	return on_dsq_move_vtime(p, dsq_id);
 }
 
 SEC("kprobe/scx_bpf_dispatch_vtime_from_dsq")
 int BPF_KPROBE(scx_dispatch_vtime_from_dsq, struct bpf_iter_scx_dsq *it__iter,
-	       struct task_struct *p, u64 dsq_id, u64 enq_flags)
+               struct task_struct *p, u64 dsq_id, u64 enq_flags)
 {
 	return on_dsq_move_vtime(p, dsq_id);
 }
@@ -406,8 +403,8 @@ int BPF_KPROBE(scx_dsq_move_set_slice, struct bpf_iter_scx_dsq *it__iter, u64 sl
 }
 
 SEC("kprobe/scx_bpf_dispatch_from_dsq_set_slice")
-int BPF_KPROBE(scx_dispatch_from_dsq_set_slice, struct bpf_iter_scx_dsq *it__iter,
-	       u64 slice)
+int BPF_KPROBE(scx_dispatch_from_dsq_set_slice,
+               struct bpf_iter_scx_dsq *it__iter, u64 slice)
 {
 	// TODO: figure out how to return task from iterator without consuming.
 	return on_move_set_slice(NULL, slice);
@@ -429,14 +426,16 @@ static int on_move_set_vtime(struct task_struct *p, u64 vtime)
 }
 
 SEC("kprobe/scx_bpf_dsq_move_set_vtime")
-int BPF_KPROBE(scx_dsq_move_set_vtime, struct bpf_iter_scx_dsq *it__iter, u64 vtime)
+int BPF_KPROBE(scx_dsq_move_set_vtime, struct bpf_iter_scx_dsq *it__iter,
+               u64 vtime)
 {
 	// TODO: figure out how to return task from iterator without consuming.
 	return on_move_set_vtime(NULL, vtime);
 }
 
 SEC("kprobe/scx_bpf_dispatch_from_dsq_set_vtime")
-int BPF_KPROBE(scx_dispatch_from_dsq_set_vtime, struct bpf_iter_scx_dsq *it__iter, u64 vtime)
+int BPF_KPROBE(scx_dispatch_from_dsq_set_vtime,
+               struct bpf_iter_scx_dsq *it__iter, u64 vtime)
 {
 	// TODO: figure out how to return task from iterator without consuming.
 	return on_move_set_vtime(NULL, vtime);
@@ -450,8 +449,7 @@ static void record_real_comm(u8 *comm, struct task_struct *task)
 		 * stick with the measly 16 characters of the comm field to
 		 * keep things simple.
 		 */
-		struct kthread *k = bpf_core_cast(task->worker_private,
-						  struct kthread);
+		struct kthread *k = bpf_core_cast(task->worker_private, struct kthread);
 		struct worker *worker = bpf_core_cast(k->data, struct worker);
 		bpf_probe_read_kernel_str(comm, MAX_COMM, worker->desc);
 	} else {
@@ -507,11 +505,11 @@ int BPF_PROG(on_sched_waking, struct task_struct *p)
 {
 	struct bpf_event *event;
 
-        if (!enable_bpf_events || !should_sample())
-                return 0;
+	if (!enable_bpf_events || !should_sample())
+		return 0;
 
-        if (!(event = try_reserve_event()))
-                return -ENOMEM;
+	if (!(event = try_reserve_event()))
+		return -ENOMEM;
 
 	event->type = SCHED_WAKING;
 	event->ts = bpf_ktime_get_ns();
@@ -525,10 +523,9 @@ int BPF_PROG(on_sched_waking, struct task_struct *p)
 	return 0;
 }
 
-
 SEC("tp_btf/sched_switch")
 int BPF_PROG(on_sched_switch, bool preempt, struct task_struct *prev,
-	     struct task_struct *next, u64 prev_state)
+             struct task_struct *next, u64 prev_state)
 {
 	struct task_ctx *next_tctx, *prev_tctx;
 	struct bpf_event *event;
@@ -537,7 +534,6 @@ int BPF_PROG(on_sched_switch, bool preempt, struct task_struct *prev,
 
 	// We need to check if this is the tail end of a sample
 	if (prev && prev_tctx && prev_tctx->last_run_ns > 0) {
-
 		u32 *lctx;
 
 		if (!(event = try_reserve_event()))
@@ -570,13 +566,13 @@ int BPF_PROG(on_sched_switch, bool preempt, struct task_struct *prev,
 		prev_tctx->last_run_ns = 0;
 
 		/*
-		* Tracking vtime **and** the dsq a task was inserted to is kind of
-		* tricky. We could read dsq_vtime directly of the sched_ext_entity on
-		* the task_struct, but the dsq field will not be available on
-		* sched_switch as the task is not on any dsq. The current hacky
-		* solution is to record the dsq that the task was inserted to and
-		* store it in a map for the task. There still needs to be handling for
-		* when tasks are moved from iterators.
+		 * Tracking vtime **and** the dsq a task was inserted to is kind of
+		 * tricky. We could read dsq_vtime directly of the sched_ext_entity on
+		 * the task_struct, but the dsq field will not be available on
+		 * sched_switch as the task is not on any dsq. The current hacky
+		 * solution is to record the dsq that the task was inserted to and
+		 * store it in a map for the task. There still needs to be handling for
+		 * when tasks are moved from iterators.
 		*/
 		if (next) {
 			if (layered && (lctx = try_lookup_layered_task_ctx(next)))
@@ -597,10 +593,10 @@ int BPF_PROG(on_sched_switch, bool preempt, struct task_struct *prev,
 				event->event.sched_switch.next_dsq_nr =
 					scx_bpf_dsq_nr_queued(next_tctx->dsq_id);
 				/*
-				* XXX: if a task gets moved to another dsq and the vtime is updated
-				* then vtime should be read off the sched_ext_entity. To properly
-				* handle vtime any time a task is inserted to a dsq or the vtime is
-				* updated the tctx needs to be updated.
+				 * XXX: if a task gets moved to another dsq and the vtime is updated
+				 * then vtime should be read off the sched_ext_entity. To properly
+				 * handle vtime any time a task is inserted to a dsq or the vtime is
+				 * updated the tctx needs to be updated.
 				*/
 				// bpf_core_read(&event->dsq_vtime, sizeof(u64), &p->scx.dsq_vtime);
 				event->event.sched_switch.next_dsq_vtime = next_tctx->dsq_vtime;
@@ -636,24 +632,24 @@ int BPF_PROG(on_sched_switch, bool preempt, struct task_struct *prev,
 SEC("tp_btf/sched_migrate_task")
 int BPF_PROG(on_sched_migrate_task, struct task_struct *p, int dest_cpu)
 {
-    struct bpf_event *event;
+	struct bpf_event *event;
 
-    if (!enable_bpf_events || !should_sample())
-        return 0;
+	if (!enable_bpf_events || !should_sample())
+		return 0;
 
-    if (!(event = try_reserve_event()))
-        return -ENOMEM;
+	if (!(event = try_reserve_event()))
+		return -ENOMEM;
 
-    event->type = SCHED_MIGRATE;
-    event->ts = bpf_ktime_get_ns();
-    event->cpu = bpf_get_smp_processor_id();
-    event->event.migrate.pid = p->pid;
-    event->event.migrate.dest_cpu = dest_cpu;
-    event->event.migrate.prio = (int)p->prio;
+	event->type = SCHED_MIGRATE;
+	event->ts = bpf_ktime_get_ns();
+	event->cpu = bpf_get_smp_processor_id();
+	event->event.migrate.pid = p->pid;
+	event->event.migrate.dest_cpu = dest_cpu;
+	event->event.migrate.prio = (int)p->prio;
 
-    bpf_ringbuf_submit(event, 0);
+	bpf_ringbuf_submit(event, 0);
 
-    return 0;
+	return 0;
 }
 
 SEC("?tp_btf/sched_process_hang")
@@ -667,15 +663,15 @@ int BPF_PROG(on_sched_hang, struct task_struct *p)
 	if (!(event = try_reserve_event()))
 		return -ENOMEM;
 
-    event->type = SCHED_HANG;
-    event->ts = bpf_ktime_get_ns();
-    event->cpu = bpf_get_smp_processor_id();
-    record_real_comm(event->event.hang.comm, p);
-    event->event.hang.pid = p->pid;
+	event->type = SCHED_HANG;
+	event->ts = bpf_ktime_get_ns();
+	event->cpu = bpf_get_smp_processor_id();
+	record_real_comm(event->event.hang.comm, p);
+	event->event.hang.pid = p->pid;
 
-    bpf_ringbuf_submit(event, 0);
+	bpf_ringbuf_submit(event, 0);
 
-    return 0;
+	return 0;
 }
 
 SEC("tp_btf/softirq_entry")
@@ -733,7 +729,8 @@ int BPF_PROG(on_softirq_exit, unsigned int nr)
 	return 0;
 }
 
-static int stop_trace_timer_callback(void *map, int key, struct timer_wrapper *timerw)
+static int stop_trace_timer_callback(void *map, int key,
+                                     struct timer_wrapper *timerw)
 {
 	struct bpf_event *event;
 	u64 end = mode == MODE_TRACING ? bpf_ktime_get_ns() : last_trace_end_time;
@@ -760,7 +757,8 @@ static int stop_trace_timer_callback(void *map, int key, struct timer_wrapper *t
 	return 0;
 }
 
-static __always_inline int start_trace_real(bool schedule_stop, bool start_immediately)
+static __always_inline int start_trace_real(bool schedule_stop,
+                                            bool start_immediately)
 {
 	static const enum scxtop_timer_callbacks stop_trace_key = TIMER_STOP_TRACE;
 
@@ -815,7 +813,8 @@ error_no_event:
 }
 
 /*
- * Begin a trace and schedule stopping it. This is called via BPF_PROG_RUN from userspace.
+ * Begin a trace and schedule stopping it. This is called via BPF_PROG_RUN from
+ * userspace.
  */
 SEC("syscall")
 int BPF_PROG(start_trace)
@@ -846,13 +845,13 @@ int BPF_URETPROBE(long_tail_tracker_exit)
 	if (now - *entry_time < long_tail_tracing_min_latency_ns)
 		return 0;
 
-	// we can't start the trace fully from the bpf side directly here because
-	// we need to schedule the timer that terminates the trace, and:
-	//     tracing progs cannot use bpf_timer yet
+	// we can't start the trace fully from the bpf side directly here
+	// because we need to schedule the timer that terminates the trace, and:
+	//	tracing progs cannot use bpf_timer yet 
 	// instead start the trace but include in the message to userspace the
-	// fact we haven't scheduled the stop, and have userspace call back into
-	// a "syscall" type program which can schedule the stop. userspace can
-	// compute the absolute stop time to make this less racy.
+	// fact we haven't scheduled the stop, and have userspace call back
+	// into a "syscall" type program which can schedule the stop. userspace
+	// can compute the absolute stop time to make this less racy.
 	return start_trace_real(false /* schedule_stop */, true /* start_immediately */);
 }
 
@@ -923,13 +922,14 @@ int BPF_PROG(on_sched_exit, struct task_struct *task)
 }
 
 SEC("tp_btf/sched_process_fork")
-int BPF_PROG(on_sched_fork, struct task_struct *parent, struct task_struct *child)
+int BPF_PROG(on_sched_fork, struct task_struct *parent,
+             struct task_struct *child)
 {
 	struct bpf_event *event;
 	u32 *lctx;
 
 	if (!enable_bpf_events)
-		return 0;
+	return 0;
 
 	if (!(event = try_reserve_event()))
 		return -ENOMEM;
@@ -960,7 +960,8 @@ int BPF_PROG(on_sched_fork, struct task_struct *parent, struct task_struct *chil
 }
 
 SEC("tp_btf/sched_process_exec")
-int BPF_PROG(on_sched_exec, struct task_struct *p, u32 old_pid, struct linux_binprm *prm)
+int BPF_PROG(on_sched_exec,struct task_struct *p, u32 old_pid,
+	     struct linux_binprm *prm)
 {
 	struct bpf_event *event;
 	u32 *lctx;
@@ -1004,7 +1005,9 @@ int BPF_PROG(on_sched_wait, struct pid *pid)
 	event->ts = bpf_ktime_get_ns();
 	p = (struct task_struct *)bpf_get_current_task();
 	if (p) {
-		bpf_core_read_str(&event->event.wait.comm, sizeof(event->event.wait.comm), &p->comm);
+		bpf_core_read_str(&event->event.wait.comm,
+				  sizeof(event->event.wait.comm),
+				  &p->comm);
 		event->event.wait.pid = BPF_CORE_READ(p, pid);
 		event->event.wait.prio = BPF_CORE_READ(p, prio);
 	} else {
@@ -1116,6 +1119,73 @@ int BPF_PROG(on_hw_pressure_update, u32 cpu, u64 hw_pressure)
 	event->ts = bpf_ktime_get_ns();
 	event->event.hwp.hw_pressure = hw_pressure;
 	event->event.hwp.cpu = cpu;
+
+	bpf_ringbuf_submit(event, 0);
+
+	return 0;
+}
+
+SEC("perf_event")
+int perf_sample_handler(struct bpf_perf_event_data *ctx)
+{
+	struct bpf_event *event;
+	struct task_struct *task;
+	u32 *lctx;
+	int ret;
+
+	if (!enable_bpf_events || !should_sample())
+		return 0;
+
+	if (!(event = try_reserve_event()))
+		return -ENOMEM;
+
+	event->type = PERF_SAMPLE;
+	event->cpu = bpf_get_smp_processor_id();
+	event->ts = bpf_ktime_get_ns();
+	event->event.perf_sample.pid = bpf_get_current_pid_tgid() & 0xffffffff;
+	event->event.perf_sample.instruction_pointer = ctx->regs.ip;
+	event->event.perf_sample.cpu_id = bpf_get_smp_processor_id();
+
+	// Get current task for layer ID lookup
+	task = (struct task_struct *)bpf_get_current_task();
+
+	// Get layer ID if layered mode is enabled
+	if (layered && task && (lctx = try_lookup_layered_task_ctx(task)))
+		event->event.perf_sample.layer_id = lctx[LAYER_ID_INDEX];
+	else
+		event->event.perf_sample.layer_id = -1;
+
+	// Capture kernel stack trace
+	ret = bpf_get_stack(ctx, event->event.perf_sample.kernel_stack,
+			    sizeof(event->event.perf_sample.kernel_stack),
+			    0); // No flags for kernel stack
+	if (ret > 0) {
+		event->event.perf_sample.kernel_stack_size = ret / sizeof(u64);
+	} else {
+		event->event.perf_sample.kernel_stack_size = 0;
+		// Try fallback method for kernel stack - get current IP
+		if (event->event.perf_sample.is_kernel) {
+			event->event.perf_sample.kernel_stack[0] = ctx->regs.ip;
+			event->event.perf_sample.kernel_stack_size = 1;
+		}
+	}
+
+	// Capture user stack trace
+	ret = bpf_get_stack(ctx,
+			    event->event.perf_sample.user_stack,
+			    sizeof(event->event.perf_sample.user_stack),
+			    BPF_F_USER_STACK); // Only user stack flag
+	if (ret > 0) {
+		event->event.perf_sample.user_stack_size = ret / sizeof(u64);
+	} else {
+		event->event.perf_sample.user_stack_size = 0;
+		// Try fallback method for user stack - get current IP if userspace
+		if (!event->event.perf_sample.is_kernel) {
+			event->event.perf_sample.user_stack[0] = ctx->regs.ip;
+			event->event.perf_sample.user_stack_size = 1;
+		}
+	}
+	event->event.perf_sample.is_kernel = event->event.perf_sample.user_stack_size <= 1;
 
 	bpf_ringbuf_submit(event, 0);
 

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -42,8 +42,8 @@ impl Default for KeyMap {
         bindings.insert(Key::Char('e'), Action::SetState(AppState::PerfEvent));
         bindings.insert(Key::Char('K'), Action::SetState(AppState::KprobeEvent));
         bindings.insert(Key::Char('p'), Action::SetState(AppState::Process));
+        bindings.insert(Key::Char('T'), Action::SetState(AppState::PerfTop));
         bindings.insert(Key::Char('f'), Action::Filter);
-        bindings.insert(Key::Char('F'), Action::ToggleCpuFreq);
         bindings.insert(Key::Char('u'), Action::ToggleUncoreFreq);
         bindings.insert(Key::Char('L'), Action::ToggleLocalization);
         bindings.insert(Key::Char('P'), Action::ToggleHwPressure);
@@ -361,6 +361,7 @@ pub fn parse_action(action_str: &str) -> Result<Action> {
         "AppStatePause" | "SetState(Pause)" => Ok(Action::SetState(AppState::Pause)),
         "AppStatePerfEvent" | "SetState(PerfEvent)" => Ok(Action::SetState(AppState::PerfEvent)),
         "AppStateProcess" | "SetState(Process)" => Ok(Action::SetState(AppState::Process)),
+        "AppStatePerfTop" | "SetState(PerfTop)" => Ok(Action::SetState(AppState::PerfTop)),
         "AppStateKprobeEvent" | "SetState(KprobeEvent)" => {
             Ok(Action::SetState(AppState::KprobeEvent))
         }
@@ -386,6 +387,8 @@ pub fn parse_action(action_str: &str) -> Result<Action> {
         "IncTickRate" => Ok(Action::IncTickRate),
         "DecBpfSampleRate" => Ok(Action::DecBpfSampleRate),
         "IncBpfSampleRate" => Ok(Action::IncBpfSampleRate),
+        "PerfSampleRateIncrease" => Ok(Action::PerfSampleRateIncrease),
+        "PerfSampleRateDecrease" => Ok(Action::PerfSampleRateDecrease),
         "NextViewState" => Ok(Action::NextViewState),
         "Down" => Ok(Action::Down),
         "Up" => Ok(Action::Up),

--- a/tools/scxtop/src/symbol_data.rs
+++ b/tools/scxtop/src/symbol_data.rs
@@ -1,0 +1,373 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use blazesym::symbolize::source::{Kernel, Process, Source};
+use blazesym::symbolize::{Input, Sym, Symbolizer};
+use blazesym::Pid;
+use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SymbolInfo {
+    pub symbol_name: String,
+    pub module_name: String,
+    pub file_name: Option<String>,
+    pub line_number: Option<u32>,
+    pub address: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct RawStackTrace {
+    pub kernel_stack: Vec<u64>,
+    pub user_stack: Vec<u64>,
+    pub count: u64,
+    pub pid: u32,
+}
+
+#[derive(Clone, Debug)]
+pub struct SymbolizedStackTrace {
+    pub kernel_stack: Vec<SymbolInfo>,
+    pub user_stack: Vec<SymbolInfo>,
+    pub count: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct SymbolSample {
+    pub symbol_info: SymbolInfo,
+    pub count: u64,
+    pub percentage: f64,
+    pub pid: u32,
+    pub cpu_id: u32,
+    pub is_kernel: bool,
+    pub stack_traces: Vec<RawStackTrace>,
+    pub insertion_order: u64,
+    pub layer_id: Option<i32>,
+}
+
+const MAX_SYMBOLS: usize = 5000;
+
+#[derive(Debug)]
+pub struct SymbolData {
+    /// Map from address to symbol information
+    symbol_cache: HashMap<u64, SymbolInfo>,
+    /// Map from symbol name to aggregated sample count
+    symbol_samples: BTreeMap<String, SymbolSample>,
+    /// Total sample count for percentage calculation
+    total_samples: u64,
+    /// Symbolizer instance
+    symbolizer: Symbolizer,
+    /// Counter for insertion order (FIFO)
+    insertion_counter: u64,
+}
+
+impl Default for SymbolData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SymbolData {
+    pub fn new() -> Self {
+        Self {
+            symbol_cache: HashMap::new(),
+            symbol_samples: BTreeMap::new(),
+            total_samples: 0,
+            symbolizer: Symbolizer::new(),
+            insertion_counter: 0,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_sample_with_stacks_and_layer(
+        &mut self,
+        address: u64,
+        pid: u32,
+        cpu_id: u32,
+        is_kernel: bool,
+        kernel_stack: &[u64],
+        user_stack: &[u64],
+        layer_id: Option<i32>,
+    ) {
+        self.total_samples += 1;
+
+        // Try to get symbol info from cache first
+        let symbol_info = if let Some(cached_info) = self.symbol_cache.get(&address) {
+            cached_info.clone()
+        } else {
+            // Symbolize the address
+            let symbol_info = self.symbolize_address(address, pid, is_kernel);
+            self.symbol_cache.insert(address, symbol_info.clone());
+            symbol_info
+        };
+
+        // Create raw stack trace if we have stack data (don't symbolize yet)
+        let stack_trace = if !kernel_stack.is_empty() || !user_stack.is_empty() {
+            Some(RawStackTrace {
+                kernel_stack: kernel_stack
+                    .iter()
+                    .filter(|&&addr| addr != 0)
+                    .copied()
+                    .collect(),
+                user_stack: user_stack
+                    .iter()
+                    .filter(|&&addr| addr != 0)
+                    .copied()
+                    .collect(),
+                count: 1,
+                pid,
+            })
+        } else {
+            None
+        };
+
+        // Update the sample count for this symbol
+        let symbol_name = symbol_info.symbol_name.clone();
+
+        // Check if we need to enforce the limit
+        let is_new_symbol = !self.symbol_samples.contains_key(&symbol_name);
+        if is_new_symbol && self.symbol_samples.len() >= MAX_SYMBOLS {
+            // Find and remove the oldest symbol (FIFO - First In, First Out)
+            if let Some((oldest_symbol_name, _)) = self
+                .symbol_samples
+                .iter()
+                .min_by_key(|(_, sample)| sample.insertion_order)
+                .map(|(name, sample)| (name.clone(), sample.insertion_order))
+            {
+                self.symbol_samples.remove(&oldest_symbol_name);
+            }
+        }
+
+        self.symbol_samples
+            .entry(symbol_name.clone())
+            .and_modify(|sample| {
+                sample.count += 1;
+                sample.percentage = (sample.count as f64 / self.total_samples as f64) * 100.0;
+
+                // Update to the latest CPU ID and PID for this symbol
+                sample.cpu_id = cpu_id;
+                sample.pid = pid;
+
+                // Update layer_id if provided
+                if layer_id.is_some() {
+                    sample.layer_id = layer_id;
+                }
+
+                // Add stack trace if we have one
+                if let Some(new_trace) = stack_trace.clone() {
+                    // Check if we already have this exact stack trace (compare addresses)
+                    let mut found_existing = false;
+                    for existing_trace in &mut sample.stack_traces {
+                        if existing_trace.kernel_stack.len() == new_trace.kernel_stack.len()
+                            && existing_trace.user_stack.len() == new_trace.user_stack.len()
+                            && existing_trace
+                                .kernel_stack
+                                .iter()
+                                .zip(&new_trace.kernel_stack)
+                                .all(|(a, b)| a == b)
+                            && existing_trace
+                                .user_stack
+                                .iter()
+                                .zip(&new_trace.user_stack)
+                                .all(|(a, b)| a == b)
+                        {
+                            existing_trace.count += 1;
+                            found_existing = true;
+                            break;
+                        }
+                    }
+                    if !found_existing {
+                        sample.stack_traces.push(new_trace);
+                    }
+                }
+            })
+            .or_insert_with(|| {
+                self.insertion_counter += 1;
+                SymbolSample {
+                    symbol_info,
+                    count: 1,
+                    percentage: (1.0 / self.total_samples as f64) * 100.0,
+                    pid,
+                    cpu_id,
+                    is_kernel,
+                    stack_traces: if let Some(trace) = stack_trace {
+                        vec![trace]
+                    } else {
+                        Vec::new()
+                    },
+                    insertion_order: self.insertion_counter,
+                    layer_id,
+                }
+            });
+
+        // Recalculate all percentages
+        for sample in self.symbol_samples.values_mut() {
+            sample.percentage = (sample.count as f64 / self.total_samples as f64) * 100.0;
+        }
+    }
+
+    fn symbolize_address(&self, address: u64, pid: u32, is_kernel: bool) -> SymbolInfo {
+        let addrs: &[u64] = &[address];
+
+        let src = if is_kernel || pid == 0 {
+            // Use kernel source for kernel addresses with kallsyms enabled
+            let kernel = Kernel::default();
+            // The default Kernel configuration already enables kallsyms
+            Source::Kernel(kernel)
+        } else {
+            // Use process source for user space addresses
+            let process = Process::new(Pid::from(pid));
+            Source::Process(process)
+        };
+
+        let input = Input::AbsAddr(addrs);
+
+        match self.symbolizer.symbolize(&src, input) {
+            Ok(symbolized) => {
+                // Get the first result (corresponding to our single address)
+                if let Some(sym_result) = symbolized.first() {
+                    // Extract symbols from the symbolized result
+                    match sym_result {
+                        blazesym::symbolize::Symbolized::Sym(sym) => {
+                            self.extract_symbol_info(sym, address, is_kernel)
+                        }
+                        blazesym::symbolize::Symbolized::Unknown(_) => {
+                            self.unknown_symbol_info(address, is_kernel)
+                        }
+                    }
+                } else {
+                    self.unknown_symbol_info(address, is_kernel)
+                }
+            }
+            Err(_) => self.unknown_symbol_info(address, is_kernel),
+        }
+    }
+
+    fn extract_symbol_info(&self, sym: &Sym, address: u64, is_kernel: bool) -> SymbolInfo {
+        let symbol_name = sym.name.to_string();
+        let module_name = if let Some(module) = &sym.module {
+            PathBuf::from(module)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("unknown")
+                .to_string()
+        } else if is_kernel {
+            "kernel".to_string()
+        } else {
+            "unknown".to_string()
+        };
+
+        let (file_name, line_number) = if let Some(code_info) = &sym.code_info {
+            let file: Option<String> = Some(code_info.file.to_string_lossy().to_string());
+            let line = code_info.line;
+            (file, line)
+        } else {
+            (None, None)
+        };
+
+        SymbolInfo {
+            symbol_name,
+            module_name,
+            file_name,
+            line_number,
+            address,
+        }
+    }
+
+    fn unknown_symbol_info(&self, address: u64, is_kernel: bool) -> SymbolInfo {
+        SymbolInfo {
+            symbol_name: format!("0x{address:x}"),
+            module_name: if is_kernel { "kernel" } else { "unknown" }.to_string(),
+            file_name: None,
+            line_number: None,
+            address,
+        }
+    }
+
+    pub fn get_top_symbols(&self, limit: usize) -> Vec<&SymbolSample> {
+        let mut samples: Vec<&SymbolSample> = self.symbol_samples.values().collect();
+        samples.sort_by(|a, b| b.count.cmp(&a.count));
+        samples.into_iter().take(limit).collect()
+    }
+
+    pub fn clear(&mut self) {
+        self.symbol_cache.clear();
+        self.symbol_samples.clear();
+        self.total_samples = 0;
+    }
+
+    pub fn total_samples(&self) -> u64 {
+        self.total_samples
+    }
+
+    /// Update selected symbol with the latest stack trace details
+    pub fn update_selected_symbol_details(
+        &mut self,
+        address: u64,
+        kernel_stack: &[u64],
+        user_stack: &[u64],
+        pid: u32,
+    ) {
+        // Find the symbol by address and update its latest stack trace
+        for sample in self.symbol_samples.values_mut() {
+            if sample.symbol_info.address == address {
+                // Remove old stack traces and add the latest one
+                let new_trace = RawStackTrace {
+                    kernel_stack: kernel_stack
+                        .iter()
+                        .filter(|&&addr| addr != 0)
+                        .copied()
+                        .collect(),
+                    user_stack: user_stack
+                        .iter()
+                        .filter(|&&addr| addr != 0)
+                        .copied()
+                        .collect(),
+                    count: 1,
+                    pid,
+                };
+
+                // Keep only the latest stack trace for the selected symbol
+                sample.stack_traces.clear();
+                if !new_trace.kernel_stack.is_empty() || !new_trace.user_stack.is_empty() {
+                    sample.stack_traces.push(new_trace);
+                }
+                break;
+            }
+        }
+    }
+
+    /// Symbolize a raw stack trace on demand
+    pub fn symbolize_stack_trace(&self, raw_trace: &RawStackTrace) -> SymbolizedStackTrace {
+        let kernel_symbols: Vec<SymbolInfo> = raw_trace
+            .kernel_stack
+            .iter()
+            .map(|&addr| {
+                if let Some(cached_info) = self.symbol_cache.get(&addr) {
+                    cached_info.clone()
+                } else {
+                    self.symbolize_address(addr, raw_trace.pid, true)
+                }
+            })
+            .collect();
+
+        let user_symbols: Vec<SymbolInfo> = raw_trace
+            .user_stack
+            .iter()
+            .map(|&addr| {
+                if let Some(cached_info) = self.symbol_cache.get(&addr) {
+                    cached_info.clone()
+                } else {
+                    self.symbolize_address(addr, raw_trace.pid, false)
+                }
+            })
+            .collect();
+
+        SymbolizedStackTrace {
+            kernel_stack: kernel_symbols,
+            user_stack: user_symbols,
+            count: raw_trace.count,
+        }
+    }
+}

--- a/tools/scxtop/src/theme.rs
+++ b/tools/scxtop/src/theme.rs
@@ -180,6 +180,46 @@ impl AppTheme {
         }
     }
 
+    /// Returns the color for kernel space symbols in perf top view.
+    pub fn kernel_symbol_color(&self) -> Color {
+        match self {
+            AppTheme::MidnightGreen => Color::Rgb(255, 100, 100), // Light red
+            AppTheme::IAmBlue => Color::Rgb(255, 140, 0),         // Orange
+            AppTheme::SolarizedDark => Color::Rgb(220, 50, 47),   // Solarized red
+            AppTheme::Greyscale => Color::Rgb(180, 180, 180),     // Light grey
+            AppTheme::Nord => Color::Rgb(191, 97, 106),           // Nord Aurora red
+            AppTheme::Dracula => Color::Rgb(255, 85, 85),         // Dracula red
+            AppTheme::Monokai => Color::Rgb(249, 38, 114),        // Monokai magenta
+            AppTheme::Gruvbox => Color::Rgb(251, 73, 52),         // Gruvbox red
+            AppTheme::TokyoNight => Color::Rgb(247, 118, 142),    // Tokyo Night red
+            AppTheme::CatppuccinMocha => Color::Rgb(243, 139, 168), // Catppuccin red
+            AppTheme::OneDark => Color::Rgb(224, 108, 117),       // One Dark red
+            AppTheme::AyuDark => Color::Rgb(255, 160, 122),       // Ayu Dark orange
+            AppTheme::USA => Color::Rgb(187, 19, 62),             // Red for USA theme
+            AppTheme::Default => Color::Red,
+        }
+    }
+
+    /// Returns the color for userspace symbols in perf top view.
+    pub fn userspace_symbol_color(&self) -> Color {
+        match self {
+            AppTheme::MidnightGreen => Color::Rgb(100, 255, 100), // Light green
+            AppTheme::IAmBlue => Color::Rgb(100, 149, 237),       // Cornflower blue
+            AppTheme::SolarizedDark => Color::Rgb(42, 161, 152),  // Solarized cyan
+            AppTheme::Greyscale => Color::Rgb(120, 120, 120),     // Medium grey
+            AppTheme::Nord => Color::Rgb(136, 192, 208),          // Nord Frost cyan
+            AppTheme::Dracula => Color::Rgb(80, 250, 123),        // Dracula green
+            AppTheme::Monokai => Color::Rgb(166, 226, 46),        // Monokai green
+            AppTheme::Gruvbox => Color::Rgb(104, 157, 106),       // Gruvbox aqua
+            AppTheme::TokyoNight => Color::Rgb(158, 206, 106),    // Tokyo Night green
+            AppTheme::CatppuccinMocha => Color::Rgb(166, 227, 161), // Catppuccin green
+            AppTheme::OneDark => Color::Rgb(152, 195, 121),       // One Dark green
+            AppTheme::AyuDark => Color::Rgb(95, 175, 239),        // Ayu Dark blue
+            AppTheme::USA => Color::Rgb(10, 49, 97),              // Navy blue for USA theme
+            AppTheme::Default => Color::Blue,
+        }
+    }
+
     /// Returns the next theme.
     pub fn next(&self) -> Self {
         match self {


### PR DESCRIPTION
Add perf top mode to scxtop. This mode renders a view similar to `perf top` and symbolizes kernel and userspace stack traces using blazesym.

<img width="1920" height="918" alt="2025-08-10-15:46:03" src="https://github.com/user-attachments/assets/a7334e46-0012-4345-9b29-241221fd8a2a" />
<img width="1917" height="921" alt="2025-08-10-15:44:02" src="https://github.com/user-attachments/assets/d104f3ad-2e7c-43de-b687-08a128680aab" />
