### PR TITLE
scx_bpf_unittests: rename TEST to SCX_BPF_UNITTEST

### DIFF
--- a/lib/scxtest/scx_test.h
+++ b/lib/scxtest/scx_test.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef TEST
+#ifdef SCX_BPF_UNITTEST
 
 #ifndef __weak
 #define __weak __attribute__((weak))
@@ -32,4 +32,4 @@ void __fail_assert(const char *condition, const char *file, int line) __attribut
 	}							\
 	static __always_inline void name##_scxtest_impl(void)
 
-#endif /* TEST */
+#endif /* SCX_BPF_UNITTEST */

--- a/rust/scx_bpf_unittests/build.rs
+++ b/rust/scx_bpf_unittests/build.rs
@@ -33,7 +33,7 @@ fn main() {
         .compiler(env::var("BPF_CLANG").unwrap_or_else(|_| "clang".into()))
         .files(&[root_dir.join("scheds/rust/scx_p2dq/src/bpf/main.test.bpf.c")])
         .warnings(false)
-        .define("TEST", None)
+        .define("SCX_BPF_UNITTEST", None)
         .flags(&[
             "-Wno-attributes",
             "-Wno-unknown-pragmas",
@@ -53,7 +53,7 @@ fn main() {
             root_dir.join("lib/scxtest/scx_test_map.c"),
             root_dir.join("lib/scxtest/scx_test_cpumask.c"),
         ])
-        .define("TEST", None)
+        .define("SCX_BPF_UNITTEST", None)
         .includes(include_path)
         .compile("scxtest");
 

--- a/scheds/include/scx/bpf_arena_common.bpf.h
+++ b/scheds/include/scx/bpf_arena_common.bpf.h
@@ -86,7 +86,7 @@ void bpf_arena_free_pages(void *map, void __arena *ptr, __u32 page_cnt) __ksym _
  * Note that cond_break can only be portably used in the body of a breakable
  * construct, whereas can_loop can be used anywhere.
  */
-#ifdef TEST
+#ifdef SCX_BPF_UNITTEST
 #define can_loop true
 #define __cond_break(expr) expr
 #else
@@ -165,7 +165,7 @@ void bpf_arena_free_pages(void *map, void __arena *ptr, __u32 page_cnt) __ksym _
 	})
 #endif /* __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ */
 #endif /* __BPF_FEATURE_MAY_GOTO */
-#endif /* TEST */
+#endif /* SCX_BPF_UNITTEST */
 
 #define cond_break __cond_break(break)
 #define cond_break_label(label) __cond_break(goto label)


### PR DESCRIPTION
The scx_bpf_unittests TEST macro conflicts with the dw_dma_regs::TEST struct member. Change its name to SCX_BPF_UNITTEST.