### PR TITLE
scx_utils: Update libbpf-rs version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,9 +1544,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.26.0-beta.0"
+version = "0.26.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf0f7ff3792d69d11e5a1a8a96343fa604adcc1737b5946e7ae2186d512b907"
+checksum = "8f67e781e4af482d9fb558bcf9fe601c8f1188614d08694ceb4c2f0b35b5fd3f"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
@@ -1563,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.26.0-beta.0"
+version = "0.26.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bacc8ccbc646056b3d290f68db80fff5842188e7ba3b479f91800de59e7c58ba"
+checksum = "7129813a2bcf27f1751fa7bf88bee2e2e2cd81a41c0b9cf6a5aab16ab150ab2f"
 dependencies = [
  "bitflags 2.9.1",
  "libbpf-sys",
@@ -1575,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-sys"
-version = "1.5.1+v1.5.1"
+version = "1.6.1+v1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912fae30b08bcbdb861d4b85bd09c05352c0ac9d7b93765ced5ca23709e7e590"
+checksum = "e351855cbd724ac341b2a1c163568808e72acd930c491a921331c2e5347390d3"
 dependencies = [
  "cc",
  "nix 0.30.1",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "scx_utils"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "anyhow",
  "bindgen 0.72.0",

--- a/rust/scx_bpf_compat/Cargo.toml
+++ b/rust/scx_bpf_compat/Cargo.toml
@@ -12,12 +12,12 @@ homepage = "https://github.com/sched-ext/scx"
 ci.use_clippy = true
 
 [dependencies]
-scx_utils = { path = "../scx_utils", version = "1.0.17" }
+scx_utils = { path = "../scx_utils", version = "1.0.18" }
 
 anyhow = "1.0.65"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
 once_cell = "1.20.2"
 
 [build-dependencies]
-scx_utils = { path = "../scx_utils", version = "1.0.17" }
+scx_utils = { path = "../scx_utils", version = "1.0.18" }

--- a/rust/scx_bpf_unittests/Cargo.toml
+++ b/rust/scx_bpf_unittests/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 publish = false
 
 [dependencies]
-libbpf-sys = "=1.5.1"  # has to be in `dependencies` to provide the include path
+libbpf-sys = "=1.6.1"  # has to be in `dependencies` to provide the include path
 
 [dev-dependencies]
-libbpf-sys = "=1.5.1"
+libbpf-sys = "=1.6.1"
 
 [build-dependencies]
 cc = "1.2.29"
 indoc = "2.0.5"
-libbpf-sys = "=1.5.1"
+libbpf-sys = "=1.6.1"
 object = "0.36.7"

--- a/rust/scx_lib_selftests/Cargo.toml
+++ b/rust/scx_lib_selftests/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.65"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 simplelog = "0.12"
-scx_utils = { path = "../scx_utils", version = "1.0.17" }
+scx_utils = { path = "../scx_utils", version = "1.0.18" }
 
 [build-dependencies]
-scx_utils = { path = "../scx_utils", version = "1.0.17" }
+scx_utils = { path = "../scx_utils", version = "1.0.18" }

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -10,10 +10,10 @@ description = "Framework to implement sched_ext schedulers running in user space
 [dependencies]
 anyhow = "1.0.65"
 plain = "0.2.3"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 seccomp = "0.1"
-scx_utils = { path = "../scx_utils", version = "1.0.17" }
+scx_utils = { path = "../scx_utils", version = "1.0.18" }
 
 
 [lib]

--- a/rust/scx_userspace_arena/Cargo.toml
+++ b/rust/scx_userspace_arena/Cargo.toml
@@ -11,11 +11,11 @@ description = "Utilities for interacting with BPF arenas from userspace in sched
 ci.use_clippy = true
 
 [dependencies]
-scx_utils = { path = "../scx_utils", version = "1.0.17" }
+scx_utils = { path = "../scx_utils", version = "1.0.18" }
 
 anyhow = "1.0.65"
 buddy_system_allocator = { version = "0.11.0", default-features = false }
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 
 [build-dependencies]
-scx_utils = { path = "../scx_utils", version = "1.0.17" }
+scx_utils = { path = "../scx_utils", version = "1.0.18" }

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_utils"
-version = "1.0.17"
+version = "1.0.18"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0-only"
@@ -14,9 +14,9 @@ bindgen = ">=0.69"
 glob = "0.3.2"
 hex = "0.4.3"
 lazy_static = "1.5.0"
-libbpf-sys = "=1.5.1"
-libbpf-cargo = "=0.26.0-beta.0"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-sys = "=1.6.1"
+libbpf-cargo = "=0.26.0-beta.1"
+libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
 nvml-wrapper = { version = "0.11.0", optional = true }
 nvml-wrapper-sys = { version = "0.9.0", optional = true }
@@ -43,7 +43,7 @@ anyhow = "1.0.65"
 bindgen = ">=0.69"
 glob = "0.3.2"
 lazy_static = "1.5.0"
-libbpf-cargo = "=0.26.0-beta.0"
+libbpf-cargo = "=0.26.0-beta.1"
 sscanf = "0.4"
 tar = "0.4"
 vergen = { version = "8.0.0", features = ["cargo", "git", "gitcl"] }

--- a/scheds/rust/scx_bpfland/Cargo.toml
+++ b/scheds/rust/scx_bpfland/Cargo.toml
@@ -11,16 +11,16 @@ anyhow = "1.0.65"
 ctrlc = { version = "3.1", features = ["termination"] }
 clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17", features = ["autopower"] }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_chaos/Cargo.toml
+++ b/scheds/rust/scx_chaos/Cargo.toml
@@ -11,7 +11,7 @@ ci.use_clippy = true
 
 [dependencies]
 scx_userspace_arena = { path = "../../../rust/scx_userspace_arena", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 scx_p2dq = { path = "../../../scheds/rust/scx_p2dq", version = "1.0.19" }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
@@ -20,7 +20,7 @@ anyhow = "1.0.65"
 clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
 ctrlc = { version = "3.1", features = ["termination"] }
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 nix = { version = "0.29", features = ["process"] }
@@ -28,5 +28,5 @@ serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 scx_p2dq = { path = "../../../scheds/rust/scx_p2dq", version = "1.0.19" }

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -11,16 +11,16 @@ anyhow = "1.0.65"
 ctrlc = { version = "3.1", features = ["termination"] }
 clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17", features = ["autopower"] }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_flash/Cargo.toml
+++ b/scheds/rust/scx_flash/Cargo.toml
@@ -11,16 +11,16 @@ anyhow = "1.0.65"
 ctrlc = { version = "3.1", features = ["termination"] }
 clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17", features = ["autopower"] }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -16,13 +16,13 @@ ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7"
 hex = "0.4.3"
 itertools = "0.13.0"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17", features = ["autopower"] }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 static_assertions = "1.1.0"
@@ -31,7 +31,7 @@ gpoint = "0.2"
 combinations = "0.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -16,13 +16,13 @@ ctrlc = { version = "3.1", features = ["termination"] }
 fastrand = "2.1.1"
 fb_procfs = "0.7"
 lazy_static = "1.5.0"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 scx_bpf_compat = { path = "../../../rust/scx_bpf_compat", version = "1.0.14" }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 simplelog = "0.12"
@@ -33,7 +33,7 @@ nix = { version = "0.29", features = ["sched"] }
 sysinfo = "0.33.1"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_mitosis/Cargo.toml
+++ b/scheds/rust/scx_mitosis/Cargo.toml
@@ -17,20 +17,20 @@ ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7"
 itertools = "0.13.0"
 lazy_static = "1.5.0"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 crossbeam = "0.8.4"
 maplit = "1.0.2"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_p2dq/Cargo.toml
+++ b/scheds/rust/scx_p2dq/Cargo.toml
@@ -14,20 +14,20 @@ crossbeam = "0.8.4"
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7"
 lazy_static = "1.5.0"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -11,13 +11,13 @@ anyhow = "1.0.65"
 plain = "0.2.3"
 procfs = "0.17"
 ctrlc = { version = "3.1", features = ["termination"] }
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.3" }
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.3" }
 
 [features]

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.65"
 plain = "0.2.3"
 clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3.1", features = ["termination"] }
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
@@ -19,12 +19,12 @@ procfs = "0.17"
 serde = { version = "1.0.215", features = ["derive"] }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.3" }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.3" }
 
 [features]

--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -13,20 +13,20 @@ clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"
 crossbeam = "0.8.4"
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_tickless/Cargo.toml
+++ b/scheds/rust/scx_tickless/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = "1.0.65"
 ctrlc = { version = "3.1", features = ["termination"] }
 clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17", features = ["autopower"] }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_wd40/Cargo.toml
+++ b/scheds/rust/scx_wd40/Cargo.toml
@@ -18,20 +18,20 @@ clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"
 crossbeam = "0.8.4"
 ctrlc = { version = "3.1", features = ["termination"] }
 fb_procfs = "0.7"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 nix = { features = ["process", "time"], default-features = false, version = "0.29" }
 log = "0.4.17"
 ordered-float = "3.4.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
 
 [features]
 enable_backtrace = []

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -24,7 +24,7 @@ clap_complete = "4.5.45"
 crossterm = { version = "0.28.1", features = ["serde", "event-stream"] }
 futures = "0.3.31"
 glob = "0.3.2"
-libbpf-rs = "=0.26.0-beta.0"
+libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 num-format = { version = "0.4.3", features = ["with-serde", "with-system-locale"] }
@@ -36,7 +36,7 @@ rand = "0.8.5"
 ratatui = { version = "0.29.0", features = ["serde", "macros"] }
 regex = "1.11.1"
 scx_stats = { path = "../../rust/scx_stats", version = "1.0.14" }
-scx_utils = { path = "../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../rust/scx_utils", version = "1.0.18" }
 simplelog = "0.12"
 serde_json = "1.0.133"
 serde = { version = "1.0.215", features = ["derive"] }
@@ -61,4 +61,4 @@ harness = false
 
 [build-dependencies]
 scx_stats = { path = "../../rust/scx_stats", version = "1.0.14" }
-scx_utils = { path = "../../rust/scx_utils", version = "1.0.17" }
+scx_utils = { path = "../../rust/scx_utils", version = "1.0.18" }


### PR DESCRIPTION
Update libbpf-rs version for scx_utils and all uses of scx_utils to use the latest libbpf-rs version. This version contains this [patch]( https://lore.kernel.org/all/20250718001009.610955-1-andrii@kernel.org/) which seems to remediate random segfault issues when using arenas.