### PR TITLE
percpu: Add percpu helpers for vm event states

### DIFF
--- a/scheds/include/scx/percpu.bpf.h
+++ b/scheds/include/scx/percpu.bpf.h
@@ -26,6 +26,7 @@ extern struct kernel_stat kernel_stat __ksym __weak;
 extern struct kernel_cpustat kernel_cpustat __ksym __weak;
 extern struct cpufreq_policy* cpufreq_cpu_data __ksym __weak;
 extern struct sched_domain* sd_llc __ksym __weak;
+extern struct vm_event_state vm_event_states __ksym __weak;
 
 
 #define DEFINE_PER_CPU_PTR_FUNC(func_name, type, var_name)	\
@@ -85,6 +86,7 @@ DEFINE_PER_CPU_PTR_FUNC(cpu_kernel_cpustat, struct kernel_cpustat, kernel_cpusta
 DEFINE_PER_CPU_PTR_FUNC(cpu_kernel_stat, struct kernel_stat, kernel_stat)
 DEFINE_PER_CPU_PTR_FUNC(cpu_psi_group, struct psi_group_cpu, psi_group_cpu)
 DEFINE_PER_CPU_PTR_FUNC(cpu_sugov, struct sugov_cpu, sugov_cpu)
+DEFINE_PER_CPU_PTR_FUNC(cpu_vm_event_state, struct vm_event_state, vm_event_states)
 
 DEFINE_THIS_CPU_VAL_FUNC(cpu_llc_id)
 DEFINE_THIS_CPU_VAL_FUNC(cpu_llc_size)
@@ -96,5 +98,6 @@ DEFINE_THIS_CPU_PTR_FUNC(cpu_kernel_stat)
 DEFINE_THIS_CPU_PTR_FUNC(cpu_psi_group)
 DEFINE_THIS_CPU_PTR_FUNC(cpu_llc_dom)
 DEFINE_THIS_CPU_PTR_FUNC(cpu_sugov)
+DEFINE_THIS_CPU_PTR_FUNC(cpu_vm_event_state)
 
 #endif /* BPF_PERCPU_H */


### PR DESCRIPTION
Add percpu helpers to access vm event states that reads from the percpu [`vm_event_state`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/vmstat.c#n110) struct. This will make it easier to pull out percpu stats for the use of schedulers/observability tools.

```
+       struct vm_event_state *vm_state = cpu_vm_event_state(cpu);
+       if (vm_state) {
+               trace("VM[%d] PGFAULT %llu", cpu, vm_state->event[PGFAULT]);
+               ret = vm_state->event[PGFAULT];
+       } else {
+               trace("VM[%d] vm_event_state empty", cpu);
+       }
```
output:
```
          <idle>-0       [091] dN..1 517008.155337: bpf_trace_printk: VM[91] PGFAULT 448434
          kipmi0-2210    [091] d...1 517008.155344: bpf_trace_printk: VM[91] PGFAULT 448434
          <idle>-0       [123] dN..1 517008.155347: bpf_trace_printk: VM[123] PGFAULT 246045
 systemd-machine-3755955 [085] d...1 517008.155349: bpf_trace_printk: VM[85] PGFAULT 282459
          <idle>-0       [040] dN..1 517008.155358: bpf_trace_printk: VM[40] PGFAULT 3422784
          <idle>-0       [080] dN..1 517008.155361: bpf_trace_printk: VM[80] PGFAULT 2688480
          <idle>-0       [073] dN..1 517008.155361: bpf_trace_printk: VM[73] PGFAULT 1003633
```