### PR TITLE
versions: bump versions for 1.0.15 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,7 +2663,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scx_bpf_compat"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "libbpf-rs",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "scx_bpf_unittests"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cc",
  "indoc",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "scx_bpfland"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "scx_chaos"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "scx_cosmos"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "scx_flash"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "scx_lavd"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "scx_layered"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "scx_lib_selftests"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "libbpf-rs",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "scx_loader"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -2843,7 +2843,7 @@ dependencies = [
 
 [[package]]
 name = "scx_mitosis"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "scx_p2dq"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "scx_rlfifo"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "scx_rustland"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "scx_rustland_core"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "anyhow",
  "libbpf-rs",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "scx_rusty"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "scx_stats"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "scx_stats_derive"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "scx_tickless"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "affinity",
  "anyhow",
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "scx_userspace_arena"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "buddy_system_allocator",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "scx_utils"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "anyhow",
  "bindgen 0.72.0",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "scx_wd40"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "scxctl"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "clap",
  "colored 3.0.0",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "scxtop"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "anyhow",
  "blazesym",
@@ -3877,7 +3877,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmlinux_docify"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap",
  "walkdir",

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('sched_ext schedulers', 'c',
         default_options : ['c_std=gnu11'], # Use gnu11 as the C standard to compile vmlinux.h without errors.
-        version: '1.0.14',
+        version: '1.0.15',
         license: 'GPL-2.0',
         meson_version : '>= 1.2.0',)
 

--- a/rust/scx_bpf_compat/Cargo.toml
+++ b/rust/scx_bpf_compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_bpf_compat"
-version = "1.0.14"
+version = "1.0.15"
 edition = "2021"
 description = "BPF compatibility testing utilities for sched_ext"
 license = "GPL-2.0-only"
@@ -12,7 +12,7 @@ homepage = "https://github.com/sched-ext/scx"
 ci.use_clippy = true
 
 [dependencies]
-scx_utils = { path = "../scx_utils", version = "1.0.18" }
+scx_utils = { path = "../scx_utils", version = "1.0.19" }
 
 anyhow = "1.0.65"
 libbpf-rs = "=0.26.0-beta.1"
@@ -20,4 +20,4 @@ log = "0.4.17"
 once_cell = "1.20.2"
 
 [build-dependencies]
-scx_utils = { path = "../scx_utils", version = "1.0.18" }
+scx_utils = { path = "../scx_utils", version = "1.0.19" }

--- a/rust/scx_bpf_unittests/Cargo.toml
+++ b/rust/scx_bpf_unittests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_bpf_unittests"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 publish = false

--- a/rust/scx_lib_selftests/Cargo.toml
+++ b/rust/scx_lib_selftests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_lib_selftests"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 publish = false
@@ -9,7 +9,7 @@ publish = false
 anyhow = "1.0.65"
 libbpf-rs = "=0.26.0-beta.1"
 simplelog = "0.12"
-scx_utils = { path = "../scx_utils", version = "1.0.18" }
+scx_utils = { path = "../scx_utils", version = "1.0.19" }
 
 [build-dependencies]
-scx_utils = { path = "../scx_utils", version = "1.0.18" }
+scx_utils = { path = "../scx_utils", version = "1.0.19" }

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland_core"
-version = "2.3.3"
+version = "2.3.4"
 edition = "2021"
 authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"
@@ -13,7 +13,7 @@ plain = "0.2.3"
 libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 seccomp = "0.1"
-scx_utils = { path = "../scx_utils", version = "1.0.18" }
+scx_utils = { path = "../scx_utils", version = "1.0.19" }
 
 
 [lib]

--- a/rust/scx_stats/Cargo.toml
+++ b/rust/scx_stats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_stats"
-version = "1.0.14"
+version = "1.0.15"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0-only"

--- a/rust/scx_stats/scx_stats_derive/Cargo.toml
+++ b/rust/scx_stats/scx_stats_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_stats_derive"
-version = "1.0.14"
+version = "1.0.15"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0-only"
@@ -13,7 +13,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-scx_stats = { path = "..", version = "1.0.14" }
+scx_stats = { path = "..", version = "1.0.15" }
 serde_json = "1.0.133"
 syn = { version = "2.0", features = ["extra-traits", "full"] }
 

--- a/rust/scx_userspace_arena/Cargo.toml
+++ b/rust/scx_userspace_arena/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_userspace_arena"
-version = "1.0.14"
+version = "1.0.15"
 edition = "2021"
 authors = ["Jake Hillion <jake@hillion.co.uk>"]
 license = "GPL-2.0-only"
@@ -11,11 +11,11 @@ description = "Utilities for interacting with BPF arenas from userspace in sched
 ci.use_clippy = true
 
 [dependencies]
-scx_utils = { path = "../scx_utils", version = "1.0.18" }
+scx_utils = { path = "../scx_utils", version = "1.0.19" }
 
 anyhow = "1.0.65"
 buddy_system_allocator = { version = "0.11.0", default-features = false }
 libbpf-rs = "=0.26.0-beta.1"
 
 [build-dependencies]
-scx_utils = { path = "../scx_utils", version = "1.0.18" }
+scx_utils = { path = "../scx_utils", version = "1.0.19" }

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_utils"
-version = "1.0.18"
+version = "1.0.19"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0-only"
@@ -22,7 +22,7 @@ nvml-wrapper = { version = "0.11.0", optional = true }
 nvml-wrapper-sys = { version = "0.9.0", optional = true }
 paste = "1.0"
 regex = "1.11.1"
-scx_stats = { path = "../scx_stats", version = "1.0.14" }
+scx_stats = { path = "../scx_stats", version = "1.0.15" }
 serde = { version = "1.0.215", features = ["derive"] }
 sscanf = "0.4"
 tar = "0.4"

--- a/scheds/rust/scx_bpfland/Cargo.toml
+++ b/scheds/rust/scx_bpfland/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_bpfland"
-version = "1.0.14"
+version = "1.0.15"
 authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 edition = "2021"
 description = "A vruntime-based sched_ext scheduler that prioritizes interactive workloads. https://github.com/sched-ext/scx/tree/main"
@@ -13,14 +13,14 @@ clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"
 crossbeam = "0.8.4"
 libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
-scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
-scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18", features = ["autopower"] }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_chaos/Cargo.toml
+++ b/scheds/rust/scx_chaos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_chaos"
-version = "1.0.17"
+version = "1.0.18"
 edition = "2021"
 authors = ["Jake Hillion <jake@hillion.co.uk>"]
 description = "scx_chaos A general purpose sched_ext scheduler designed to amplify race conditions"
@@ -10,11 +10,11 @@ license = "GPL-2.0-only"
 ci.use_clippy = true
 
 [dependencies]
-scx_userspace_arena = { path = "../../../rust/scx_userspace_arena", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
-scx_p2dq = { path = "../../../scheds/rust/scx_p2dq", version = "1.0.19" }
-scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
-scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
+scx_userspace_arena = { path = "../../../rust/scx_userspace_arena", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_p2dq = { path = "../../../scheds/rust/scx_p2dq", version = "1.0.20" }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
 
 anyhow = "1.0.65"
 clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
@@ -28,5 +28,5 @@ serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
-scx_p2dq = { path = "../../../scheds/rust/scx_p2dq", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_p2dq = { path = "../../../scheds/rust/scx_p2dq", version = "1.0.20" }

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_cosmos"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Andrea Righi <arighi@nvidia.com>"]
 edition = "2021"
 description = "Lightweight scheduler optimized for preserving task-to-CPU locality. https://github.com/sched-ext/scx/tree/main"
@@ -13,14 +13,14 @@ clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"
 crossbeam = "0.8.4"
 libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
-scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
-scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18", features = ["autopower"] }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_flash/Cargo.toml
+++ b/scheds/rust/scx_flash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_flash"
-version = "1.0.12"
+version = "1.0.13"
 authors = ["Andrea Righi <arighi@nvidia.com>"]
 edition = "2021"
 description = "A scheduler designed for multimedia and real-time audio processing workloads. https://github.com/sched-ext/scx/tree/main"
@@ -13,14 +13,14 @@ clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"
 crossbeam = "0.8.4"
 libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
-scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
-scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18", features = ["autopower"] }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_lavd"
-version = "1.0.14"
+version = "1.0.15"
 authors = ["Changwoo Min <changwoo@igalia.com>", "Igalia"]
 edition = "2021"
 description = "A Latency-criticality Aware Virtual Deadline (LAVD) scheduler based on sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
@@ -20,9 +20,9 @@ libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
-scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
-scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18", features = ["autopower"] }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 static_assertions = "1.1.0"
@@ -31,7 +31,7 @@ gpoint = "0.2"
 combinations = "0.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_layered"
-version = "1.0.15"
+version = "1.0.16"
 authors = ["Tejun Heo <htejun@meta.com>", "Meta"]
 edition = "2021"
 description = "A highly configurable multi-layer BPF / user space hybrid scheduler used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
@@ -19,10 +19,10 @@ lazy_static = "1.5.0"
 libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
-scx_bpf_compat = { path = "../../../rust/scx_bpf_compat", version = "1.0.14" }
-scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
-scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_bpf_compat = { path = "../../../rust/scx_bpf_compat", version = "1.0.15" }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 simplelog = "0.12"
@@ -33,7 +33,7 @@ nix = { version = "0.29", features = ["sched"] }
 sysinfo = "0.33.1"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_mitosis/Cargo.toml
+++ b/scheds/rust/scx_mitosis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_mitosis"
-version = "0.0.11"
+version = "0.0.12"
 authors = ["Dan Schatzberg <dschatzberg@meta.com>", "Meta"]
 edition = "2021"
 description = "A dynamic affinity scheduler used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
@@ -22,15 +22,15 @@ libc = "0.2.137"
 log = "0.4.17"
 crossbeam = "0.8.4"
 maplit = "1.0.2"
-scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
-scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_p2dq/Cargo.toml
+++ b/scheds/rust/scx_p2dq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_p2dq"
-version = "1.0.19"
+version = "1.0.20"
 authors = ["Daniel Hodges <hodges.daniel.scott@gmail.com>"]
 edition = "2021"
 description = "scx_p2dq A simple pick two load balancing scheduler in BPF"
@@ -18,16 +18,16 @@ libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
-scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
-scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rlfifo"
-version = "1.0.14"
+version = "1.0.15"
 authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 edition = "2021"
 description = "A simple FIFO scheduler in Rust that runs in user-space"
@@ -13,12 +13,12 @@ procfs = "0.17"
 ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.3" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.4" }
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.3" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.4" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland"
-version = "1.0.14"
+version = "1.0.15"
 authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 edition = "2021"
 description = "A BPF component (dispatcher) that implements the low level sched-ext functionalities and a user-space counterpart (scheduler), written in Rust, that implements the actual scheduling policy. This is used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
@@ -17,15 +17,15 @@ log = "0.4.17"
 ordered-float = "3.4.0"
 procfs = "0.17"
 serde = { version = "1.0.215", features = ["derive"] }
-scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
-scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.3" }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.4" }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.3" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.4" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rusty"
-version = "1.0.14"
+version = "1.0.15"
 authors = ["Dan Schatzberg <dschatzberg@meta.com>", "Meta"]
 edition = "2021"
 description = "A multi-domain, BPF / user space hybrid scheduler used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
@@ -17,16 +17,16 @@ libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
-scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
-scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_tickless/Cargo.toml
+++ b/scheds/rust/scx_tickless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_tickless"
-version = "1.0.5"
+version = "1.0.6"
 authors = ["Andrea Righi <arighi@nvidia.com>", "NVIDIA"]
 edition = "2021"
 description = "A server-oriented scheduler designed to minimize OS noise and maximize performance isolation. https://github.com/sched-ext/scx/tree/main"
@@ -14,14 +14,14 @@ clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"
 crossbeam = "0.8.4"
 libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
-scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
-scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18", features = ["autopower"] }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_wd40/Cargo.toml
+++ b/scheds/rust/scx_wd40/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_wd40"
-version = "1.0.14"
+version = "1.0.15"
 authors = ["Emil Tsalapatis <etsal@meta.com>", "Dan Schatzberg <dschatzberg@meta.com>", "Meta"]
 edition = "2021"
 description = "An experimental fork of the scx_rusty scheduler that uses BPF arenas to simplify scheduler development. Found in: https://github.com/sched-ext/scx/tree/main"
@@ -22,16 +22,16 @@ libbpf-rs = "=0.26.0-beta.1"
 nix = { features = ["process", "time"], default-features = false, version = "0.29" }
 log = "0.4.17"
 ordered-float = "3.4.0"
-scx_stats = { path = "../../../rust/scx_stats", version = "1.0.14" }
-scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.14" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.18" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
 
 [features]
 enable_backtrace = []

--- a/tools/scx_loader/Cargo.toml
+++ b/tools/scx_loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_loader"
-version = "1.0.14"
+version = "1.0.15"
 authors = ["Vladislav Nepogodin <vnepogodin@cachyos.org>"]
 edition = "2021"
 description = "DBUS on-demand loader of sched-ext schedulers"

--- a/tools/scxctl/Cargo.toml
+++ b/tools/scxctl/Cargo.toml
@@ -3,7 +3,7 @@ name = "scxctl"
 
 [package]
 name = "scxctl"
-version = "1.0.14"
+version = "1.0.15"
 edition = "2021"
 description = "A cli dbus client for scx_loader"
 authors = ["Joe Maples <joe@maples.dev>"]
@@ -17,4 +17,4 @@ license = "GPL-2.0-only"
 clap = { version = "4.5.28", features = ["derive"] }
 colored = "3.0.0"
 zbus = "5.3.1"
-scx_loader = { path = "../../tools/scx_loader", version="1.0.14" }
+scx_loader = { path = "../../tools/scx_loader", version="1.0.15" }

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scxtop"
-version = "1.0.16"
+version = "1.0.17"
 edition = "2021"
 authors = ["Daniel Hodges <hodges.daniel.scott@gmail.com>", "Yaakov Stein <ymstein14@gmail.com>"]
 license = "GPL-2.0-only"
@@ -35,8 +35,8 @@ protobuf = "3.7.2"
 rand = "0.8.5"
 ratatui = { version = "0.29.0", features = ["serde", "macros"] }
 regex = "1.11.1"
-scx_stats = { path = "../../rust/scx_stats", version = "1.0.14" }
-scx_utils = { path = "../../rust/scx_utils", version = "1.0.18" }
+scx_stats = { path = "../../rust/scx_stats", version = "1.0.15" }
+scx_utils = { path = "../../rust/scx_utils", version = "1.0.19" }
 simplelog = "0.12"
 serde_json = "1.0.133"
 serde = { version = "1.0.215", features = ["derive"] }
@@ -54,12 +54,12 @@ blazesym = "0.2.0-rc.4"
 
 [dev-dependencies]
 criterion = "0.6.0"
-tempfile = "3.20.0"
+tempfile = "3.19.1"
 
 [[bench]]
 name = "search_benchmark"
 harness = false
 
 [build-dependencies]
-scx_stats = { path = "../../rust/scx_stats", version = "1.0.14" }
-scx_utils = { path = "../../rust/scx_utils", version = "1.0.18" }
+scx_stats = { path = "../../rust/scx_stats", version = "1.0.15" }
+scx_utils = { path = "../../rust/scx_utils", version = "1.0.19" }

--- a/tools/vmlinux_docify/Cargo.toml
+++ b/tools/vmlinux_docify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmlinux_docify"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Pat S <patso@likewhatevs.io>"]
 description = "A tool to annotate vmlinux.h with documentation from kernel sources"


### PR DESCRIPTION
Downgraded tempfile in scxtop so all crates use the same dependency but left sysinfo and procfs as they cause build failures if unified.