### PR TITLE
scx_utils, scx_lavd: Handle an error in set_rlimit_infinity() gracefully.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,6 +2568,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2772,8 +2781,10 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "log",
+ "nix 0.30.1",
  "ordered-float",
  "plain",
+ "rlimit",
  "scx_stats",
  "scx_stats_derive",
  "scx_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -3032,6 +3032,7 @@ dependencies = [
  "libbpf-sys",
  "libc",
  "log",
+ "nix 0.30.1",
  "num",
  "nvml-wrapper",
  "nvml-wrapper-sys",

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -28,12 +28,13 @@ sscanf = "0.4"
 tar = "0.4"
 walkdir = "2.5"
 version-compare = "0.1"
-libc = "0.2.137"
 zbus = { version = "5.3.1", optional = true }
 const_format = "0.2.34"
 num = "0.4.3"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+libc = "0.2.175"
+nix = { version = "0.30.1", features = ["resource"] }
 
 [dev-dependencies]
 tempfile = "3.19.1"

--- a/rust/scx_utils/src/misc.rs
+++ b/rust/scx_utils/src/misc.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use anyhow::{anyhow, bail};
-use libc;
 use log::{info, warn};
+use nix::sys::resource::{setrlimit, Resource, RLIM_INFINITY};
 use scx_stats::prelude::*;
 use serde::Deserialize;
 use std::path::Path;
@@ -65,18 +65,9 @@ where
     Ok(())
 }
 
-pub fn set_rlimit_infinity() {
-    unsafe {
-        // Call setrlimit to set the locked-in-memory limit to unlimited.
-        let new_rlimit = libc::rlimit {
-            rlim_cur: libc::RLIM_INFINITY,
-            rlim_max: libc::RLIM_INFINITY,
-        };
-        let res = libc::setrlimit(libc::RLIMIT_MEMLOCK, &new_rlimit);
-        if res != 0 {
-            panic!("setrlimit failed with error code: {res}");
-        }
-    };
+pub fn set_rlimit_infinity() -> Result<()> {
+    setrlimit(Resource::RLIMIT_MEMLOCK, RLIM_INFINITY, RLIM_INFINITY)?;
+    Ok(())
 }
 
 /// Read a file and parse its content into the specified type.

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -29,6 +29,8 @@ static_assertions = "1.1.0"
 plain = "0.2.3"
 gpoint = "0.2"
 combinations = "0.1.0"
+rlimit = "0.10.2"
+nix = "0.30.1"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }


### PR DESCRIPTION
Setting rlimit for MEMLOCK to infinity would fail with -ENOPERM.
However, it does not necessarily mean catastrophic failure. Especially
when rlimits are already set to a large enough value, it is okay to
ignore the error.
    
So let's ignore the error and print the current rlimits. If the current
rlimits are insufficient, the program will fail anyway later in the
initialization, allocating BPF objects.
