### PR TITLE
scheds/rust: Suppress unused Result warnings

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -266,7 +266,7 @@ struct Scheduler<'a> {
 
 impl<'a> Scheduler<'a> {
     fn init(opts: &'a Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
-        set_rlimit_infinity();
+        let _ = set_rlimit_infinity();
 
         // Validate command line arguments.
         assert!(opts.slice_us >= opts.slice_us_min);

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -286,7 +286,7 @@ struct Scheduler<'a> {
 
 impl<'a> Scheduler<'a> {
     fn init(opts: &'a Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
-        set_rlimit_infinity();
+        let _ = set_rlimit_infinity();
 
         // Initialize CPU topology.
         let topo = Topology::new().unwrap();

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -385,7 +385,7 @@ struct Scheduler<'a> {
 
 impl<'a> Scheduler<'a> {
     fn init(opts: &'a Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
-        set_rlimit_infinity();
+        let _ = set_rlimit_infinity();
 
         // Validate command line arguments.
         assert!(opts.slice_us >= opts.slice_us_min);

--- a/scheds/rust/scx_tickless/src/main.rs
+++ b/scheds/rust/scx_tickless/src/main.rs
@@ -114,7 +114,7 @@ struct Scheduler<'a> {
 
 impl<'a> Scheduler<'a> {
     fn init(opts: &'a Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
-        set_rlimit_infinity();
+        let _ = set_rlimit_infinity();
 
         // Initialize CPU topology.
         let topo = Topology::new().unwrap();


### PR DESCRIPTION
Explicitly ignore with `let _ = ...` to avoid build noise.

```c
warning: unused `Result` that must be used
   --> scheds/rust/scx_tickless/src/main.rs:117:9
    |
117 |         set_rlimit_infinity();
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
    = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
    |
117 |         let _ = set_rlimit_infinity();
    |         +++++++
```