### PR TITLE
scx_utils: refactor version appending to make it work on aarch64

### DIFF
--- a/rust/scx_utils/src/build_id.rs
+++ b/rust/scx_utils/src/build_id.rs
@@ -40,9 +40,8 @@ pub fn full_version(semver: &str) -> String {
     ver
 }
 
-pub fn ops_version(sched_name: &str, semver: &str) -> String {
-    let mut ver = sched_name.to_string();
-    ver.push('_');
+pub fn ops_version_suffix(semver: &str) -> String {
+    let mut ver = String::from("_");
     ver.push_str(semver);
     if !GIT_VERSION.is_empty() {
         write!(ver, "_{}", &*GIT_VERSION).unwrap();


### PR DESCRIPTION
https://github.com/sched-ext/scx/pull/2599 broke aarch64 builds because they have a different type for the pointer of a CStr. Fix that, and take the opportunity to refactor this loop so it doesn't copy a string just to overwrite it in place with the same value.

Test plan:
- CI

```
jake@rooster:/data/users/jake/repos/scx/ > cargo build
jake@rooster:/data/users/jake/repos/scx/ > sudo target/debug/scx_lavd &
jake@rooster:/data/users/jake/repos/scx/ > cat /sys/kernel/sched_ext/root/ops
lavd_1.0.15_g608d859d_x86_64_unknown_linux_gnu_debug
```

```
root@ubuntu-16gb-hel1-1:~/scx# cargo build # failed before
root@ubuntu-16gb-hel1-1:~/scx# sudo target/debug/scx_lavd &
root@ubuntu-16gb-hel1-1:~/scx# cat /sys/kernel/sched_ext/root/ops
lavd_1.0.15_g608d859d_dirty_aarch64_unknown_linux_gnu_debug
```