### PR TITLE
ci: add basic build check for aarch64

### DIFF
--- a/.github/include/flake.nix
+++ b/.github/include/flake.nix
@@ -30,7 +30,7 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, fenix, nix-develop-gha, libbpf-src, veristat-src, ... }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ]
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ]
       (system:
         let
           pkgs = import nixpkgs {

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -48,6 +48,19 @@ jobs:
       - name: Veristat
         run: nix run ./.github/include#ci -- veristat
 
+  build-and-test-aarch64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: ./.github/actions/install-nix
+        with:
+          cachix-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Build
+        run: nix run ./.github/include#ci -- build
+
   integration-test:
     uses: ./.github/workflows/integration-tests.yml
     needs: build-and-test
@@ -57,6 +70,7 @@ jobs:
     needs: [
       lint,
       build-and-test,
+      build-and-test-aarch64,
       integration-test,
     ]
     runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64", "metal:nixos" ]') || 'ubuntu-latest' }}


### PR DESCRIPTION
I recently landed a PR which broke ARM because of some different Rust types in the different architectures. Add a very basic ARM CI job that simply builds the schedulers (no kernel/verification yet) to catch things like this in future.

Test plan:
- Ran from a commit before the ARM fix, it failed: https://github.com/sched-ext/scx/actions/runs/16996832515/job/48189455830
- This PR's CI