### PR TITLE
scxtop: Add last waker to thread view

### DIFF
--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -15,54 +15,54 @@ typedef unsigned long long u64;
 
 enum consts {
 	MAX_COMM	= 16,
-	/*
-	 * LAYER_ID_INDEX is the current index of layer_id in the layered task_ctx
-	 * struct
-	 * (https://github.com/sched-ext/scx/blob/main/scheds/rust/scx_layered/src/bpf/main.bpf.c#L577).
-	 * Whenever a new field is added above layer_id, LAYER_ID_INDEX must be
-	 * incremented.
-	 */
+  /*
+   * LAYER_ID_INDEX is the current index of layer_id in the layered task_ctx
+   * struct
+   * (https://github.com/sched-ext/scx/blob/main/scheds/rust/scx_layered/src/bpf/main.bpf.c#L577).
+   * Whenever a new field is added above layer_id, LAYER_ID_INDEX must be
+   * incremented.
+   */
 	LAYER_ID_INDEX	= 2,
 
-	/* Stack trace configuration */
+  /* Stack trace configuration */
 	MAX_STACK_DEPTH	= 127, /* Maximum number of stack frames to capture */
 };
 
 enum stat_id {
-	STAT_DROPPED_EVENTS,
-	NR_SCXTOP_STATS,
+  STAT_DROPPED_EVENTS,
+  NR_SCXTOP_STATS,
 };
 
 enum mode {
-	MODE_NORMAL,
-	MODE_TRACING,
-	MODE_TRACE_STOPPING,
+  MODE_NORMAL,
+  MODE_TRACING,
+  MODE_TRACE_STOPPING,
 };
 
 enum event_type {
-	CPU_HP_ENTER,
-	CPU_HP_EXIT,
-	CPU_PERF_SET,
-	EXEC,
-	EXIT,
-	FORK,
-	WAIT,
-	GPU_MEM,
-	HW_PRESSURE,
-	IPI,
-	KPROBE,
-	PERF_SAMPLE,
-	SCHED_HANG,
-	SCHED_MIGRATE,
-	SCHED_REG,
-	SCHED_SWITCH,
-	SCHED_UNREG,
-	SCHED_WAKEUP,
-	SCHED_WAKING,
-	SOFTIRQ,
-	TRACE_STARTED,
-	TRACE_STOPPED,
-	EVENT_MAX,
+  CPU_HP_ENTER,
+  CPU_HP_EXIT,
+  CPU_PERF_SET,
+  EXEC,
+  EXIT,
+  FORK,
+  WAIT,
+  GPU_MEM,
+  HW_PRESSURE,
+  IPI,
+  KPROBE,
+  PERF_SAMPLE,
+  SCHED_HANG,
+  SCHED_MIGRATE,
+  SCHED_REG,
+  SCHED_SWITCH,
+  SCHED_UNREG,
+  SCHED_WAKEUP,
+  SCHED_WAKING,
+  SOFTIRQ,
+  TRACE_STARTED,
+  TRACE_STOPPED,
+  EVENT_MAX,
 };
 
 struct sched_switch_event {
@@ -93,7 +93,9 @@ struct wakeup_event {
 	u32		pid;
 	u32		tgid;
 	int		prio;
+  u32   waker_pid;
 	u8		comm[MAX_COMM];
+  u8    waker_comm[MAX_COMM];
 };
 
 struct migrate_event {
@@ -206,7 +208,7 @@ struct bpf_event {
 	int		type;
 	u64		ts;
 	u32		cpu;
-	union {
+  union {
 		struct exit_event		exit;
 		struct fork_event 		fork;
 		struct exec_event 		exec;
@@ -226,7 +228,7 @@ struct bpf_event {
 		struct trace_started_event	trace;
 		struct kprobe_event		kprobe;
 		struct perf_sample_event	perf_sample;
-	} event;
+  } event;
 };
 
 struct task_ctx {
@@ -236,6 +238,8 @@ struct task_ctx {
 	u64 		dsq_vtime;
 	u64 		slice_ns;
 	u64 		last_run_ns;
+  u32     last_waker_pid;
+  u8      last_waker_comm[MAX_COMM];
 };
 
 struct schedule_stop_trace_args {

--- a/tools/scxtop/src/columns.rs
+++ b/tools/scxtop/src/columns.rs
@@ -303,14 +303,32 @@ pub fn get_thread_columns() -> Vec<Column<i32, ThreadData>> {
     vec![
         id_column!("TID"),
         name_column!(ThreadData, thread_name),
-        state_column!(ThreadData),
-        layer_id_column!(ThreadData),
-        last_dsq_column!(ThreadData),
-        slice_ns_column!(ThreadData),
-        avg_max_lat_column!(ThreadData),
         cpu_column!(ThreadData),
         llc_column!(ThreadData),
         numa_column!(ThreadData),
+        state_column!(ThreadData),
+        layer_id_column!(ThreadData),
+        last_dsq_column!(ThreadData),
+        Column {
+            header: "Waker PID",
+            constraint: Constraint::Length(9),
+            visible: true,
+            value_fn: Box::new(|_, data: &ThreadData| {
+                data.last_waker_pid
+                    .map(|pid| pid.to_string())
+                    .unwrap_or_default()
+            }),
+        },
+        Column {
+            header: "Waker Comm",
+            constraint: Constraint::Length(15),
+            visible: true,
+            value_fn: Box::new(|_, data: &ThreadData| {
+                data.last_waker_comm.clone().unwrap_or_default()
+            }),
+        },
+        slice_ns_column!(ThreadData),
+        avg_max_lat_column!(ThreadData),
         cpu_util_column!(ThreadData),
     ]
 }

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -291,6 +291,8 @@ pub struct SchedWakeActionCtx {
     pub tgid: u32,
     pub prio: i32,
     pub comm: SsoString,
+    pub waker_pid: u32,
+    pub waker_comm: SsoString,
 }
 
 pub type SchedWakeupNewAction = SchedWakeActionCtx;
@@ -571,6 +573,7 @@ impl TryFrom<&bpf_event> for Action {
                 let wakeup = unsafe { event.event.wakeup };
 
                 let comm = String::from_utf8_lossy(&wakeup.comm);
+                let waker_comm = String::from_utf8_lossy(&wakeup.waker_comm);
 
                 Ok(Action::SchedWakeup(SchedWakeupAction {
                     ts: event.ts,
@@ -579,6 +582,8 @@ impl TryFrom<&bpf_event> for Action {
                     tgid: wakeup.tgid,
                     prio: wakeup.prio,
                     comm: comm.into(),
+                    waker_pid: wakeup.waker_pid,
+                    waker_comm: waker_comm.into(),
                 }))
             }
             #[allow(non_upper_case_globals)]
@@ -586,6 +591,7 @@ impl TryFrom<&bpf_event> for Action {
                 let waking = unsafe { &event.event.waking };
 
                 let comm = String::from_utf8_lossy(&waking.comm);
+                let waker_comm = String::from_utf8_lossy(&waking.waker_comm);
 
                 Ok(Action::SchedWaking(SchedWakingAction {
                     ts: event.ts,
@@ -594,6 +600,8 @@ impl TryFrom<&bpf_event> for Action {
                     tgid: waking.tgid,
                     prio: waking.prio,
                     comm: comm.into(),
+                    waker_pid: waking.waker_pid,
+                    waker_comm: waker_comm.into(),
                 }))
             }
             #[allow(non_upper_case_globals)]

--- a/tools/scxtop/src/thread_data.rs
+++ b/tools/scxtop/src/thread_data.rs
@@ -25,6 +25,8 @@ pub struct ThreadData {
     pub state: ProcState,
     pub data: EventData,
     pub max_data_size: usize,
+    pub last_waker_pid: Option<u32>,
+    pub last_waker_comm: Option<String>,
 }
 
 impl ThreadData {
@@ -52,6 +54,8 @@ impl ThreadData {
             state: thread_stats.state()?,
             data: EventData::new(max_data_size),
             max_data_size,
+            last_waker_pid: None,
+            last_waker_comm: None,
         };
 
         Ok(thread_data)


### PR DESCRIPTION
In the TUI thread view add the last waker to the thread view. This is useful for understanding waker/wakee relationships.

Example output:
<img width="1920" height="1138" alt="2025-08-15-17:44:58" src="https://github.com/user-attachments/assets/61161d68-185d-43c5-a6cb-5e5cfac94a36" />
