### PR TITLE
scx: Mark smp_mb variable as volatile

### DIFF
--- a/scheds/include/scx/bpf_atomic.h
+++ b/scheds/include/scx/bpf_atomic.h
@@ -28,7 +28,7 @@ extern bool CONFIG_X86_64 __kconfig __weak;
 
 #define smp_mb()                                 \
 	({                                       \
-		unsigned long __val;             \
+		volatile unsigned long __val;	 \
 		__sync_fetch_and_add(&__val, 0); \
 	})
 


### PR DESCRIPTION
Cherry-pick of upstream fix [0] to prevent the barrier from being optimized out.

 [0]: https://lore.kernel.org/bpf/20250710175434.18829-2-puranjay@kernel.org