### PR TITLE
INSTALL.md: Update ubuntu instructions.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,7 +38,7 @@ $ sudo reboot
 #### Setting up Dev Environment
 
 ```
-$ sudo apt install -y build-essential meson cmake cargo rustc clang llvm pkg-config libelf-dev
+$ sudo apt install -y build-essential meson cmake cargo rustc clang llvm pkg-config libelf-dev protobuf-compiler libseccomp-dev
 ```
 
 #### Build the scx schedulers from source


### PR DESCRIPTION
Two necessary packages are missing in the setup of the development environment step. So, let's add them: protobuf-compiler libseccomp-dev