### PR TITLE
scx_lavd: Increase the maximum number of domains to 24.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -50,7 +50,7 @@ extern void bpf_iter_task_destroy(struct bpf_iter_task *it) __weak __ksym;
 enum {
 	LAVD_CPU_ID_MAX			= 512,
 
-	LAVD_CPDOM_MAX_NR		= 16, /* maximum number of compute domain */
+	LAVD_CPDOM_MAX_NR		= 24, /* maximum number of compute domain */
 	LAVD_CPDOM_MAX_DIST		= 3,  /* maximum distance from one compute domain to another */
 
 	LAVD_PCO_STATE_MAX		= 11, /* maximum number of performance vs. CPU order states */


### PR DESCRIPTION
AMD processors could have many LLC domains (e.g., 12 LLCs per socket). So, let's increase LAVD_CPDOM_MAX_NR to 24.