### PR TITLE
scx_wd40: Fix warning on ARM64

### DIFF
--- a/scheds/rust/scx_wd40/src/bpf/placement.bpf.c
+++ b/scheds/rust/scx_wd40/src/bpf/placement.bpf.c
@@ -26,6 +26,8 @@
 
 const volatile bool mempolicy_affinity;
 
+#ifndef __TARGET_ARCH_arm64
+
 /*
  * Returns the dom mask for a node.
  */
@@ -43,8 +45,6 @@ static u64 node_dom_mask(u32 node_id)
 
 	return mask;
 }
-
-#ifndef __TARGET_ARCH_arm64
 
 /*
  * Sets the preferred domain mask according to the mempolicy. See man(2)


### PR DESCRIPTION
```c
Compiling scx_wd40 v1.0.15 (/home/underdog/eric/scx/scheds/rust/scx_wd40)
warning: scx_wd40@1.0.15: src/bpf/placement.bpf.c:32:12: warning: unused function 'node_dom_mask' [-Wunused-function]
warning: scx_wd40@1.0.15:    32 | static u64 node_dom_mask(u32 node_id)
warning: scx_wd40@1.0.15:       |            ^~~~~~~~~~~~~
warning: scx_wd40@1.0.15: 1 warning generated.
```

follow up: #2610