### PR TITLE
services: show options instead of setting any

### DIFF
--- a/services/scx_loader.toml
+++ b/services/scx_loader.toml
@@ -1,2 +1,13 @@
 # This field specifies the scheduler that will be started automatically when scx_loader starts (e.g., on boot).
-default_sched = "scx_flash"
+#default_sched = "scx_flash"
+
+# This field specifies the mode which will be used when scx_loader starts (e.g., on boot).
+#default_mode = "Auto"
+
+# This "structure" allows configuring flags for each scheduler mode of particular scx scheduler
+#[scheds.'scheduler']
+#auto_mode = []
+#gaming_mode = []
+#lowlatency_mode = []
+#powersave_mode = []
+#server_mode = []


### PR DESCRIPTION
don't set default scheduler and instead show possible options that user can set in the configuration file