### PR TITLE
scx_utils: Add lifetime to cpumask iterator

### DIFF
--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -269,7 +269,7 @@ impl Cpumask {
     ///     info!("cpu {} was set", cpu);
     /// }
     /// ```
-    pub fn iter(&self) -> CpumaskIterator {
+    pub fn iter(&self) -> CpumaskIterator<'_> {
         CpumaskIterator {
             mask: self,
             index: 0,


### PR DESCRIPTION
Fix lint issue to add lifetime to cpumask iterator.