### PR TITLE
layered: bump version to 1.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "scx_layered"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_layered"
-version = "1.0.16"
+version = "1.0.17"
 authors = ["Tejun Heo <htejun@meta.com>", "Meta"]
 edition = "2021"
 description = "A highly configurable multi-layer BPF / user space hybrid scheduler used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"


### PR DESCRIPTION
Bump layered primarily to include better GPU pid matching.

Test plan:

```
$ cargo package -p scx_layered
$ cd target/package/scx_layered-1.0.17/
$ cargo build --release --locked
$ sudo target/release/scx_layered --run-example
18:49:04 [INFO] Topology awareness not specified, selecting enabled based on hardware
18:49:04 [INFO] CPUs: online/possible=96/96 nr_cores=48
18:49:04 [INFO] Running scx_layered (build ID: 1.0.17 x86_64-unknown-linux-gnu)
18:49:05 [INFO] Layered Scheduler Attached. Run `scx_layered --monitor` for metrics.
^CEXIT: unregistered from user space
18:49:11 [INFO] Unregister scx_layered scheduler
```