### PR TITLE
Revert "ci: add basic build check for aarch64"

### DIFF
--- a/.github/include/flake.nix
+++ b/.github/include/flake.nix
@@ -30,7 +30,7 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, fenix, nix-develop-gha, libbpf-src, veristat-src, ... }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ]
+    flake-utils.lib.eachSystem [ "x86_64-linux" ]
       (system:
         let
           pkgs = import nixpkgs {

--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -48,19 +48,6 @@ jobs:
       - name: Veristat
         run: nix run ./.github/include#ci -- veristat
 
-  build-and-test-aarch64:
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Nix
-        uses: ./.github/actions/install-nix
-        with:
-          cachix-auth-token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-      - name: Build
-        run: nix run ./.github/include#ci -- build
-
   integration-test:
     uses: ./.github/workflows/integration-tests.yml
     needs: build-and-test
@@ -70,7 +57,6 @@ jobs:
     needs: [
       lint,
       build-and-test,
-      build-and-test-aarch64,
       integration-test,
     ]
     runs-on: ${{ github.repository_owner == 'sched-ext' && fromJSON('[ "self-hosted", "linux", "x64", "metal:nixos" ]') || 'ubuntu-latest' }}


### PR DESCRIPTION
This reverts commit 25ca9892569530373b1cbdd5dd6551d5ee943952.

GitHub's aarch64 runners are even more unreliable than their x86_64, and they drop all logging regularly. We'll have to come back to this with a different approach.