### PR TITLE
rust/scx_lib_selftest: add BPF Streams support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,6 +2829,7 @@ version = "1.0.2"
 dependencies = [
  "anyhow",
  "libbpf-rs",
+ "libbpf-sys",
  "scx_utils",
  "simplelog",
 ]

--- a/rust/scx_lib_selftests/Cargo.toml
+++ b/rust/scx_lib_selftests/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.65"
 libbpf-rs = "=0.26.0-beta.1"
+libbpf-sys = "=1.6.1"
 simplelog = "0.12"
 scx_utils = { path = "../scx_utils", version = "1.0.19" }
 


### PR DESCRIPTION
Add support for the BPF streams error reporting interfaces when testing the arena library.