### PR TITLE
p2dq/chaos: remove sources from p2dq lib and symlink into chaos

### DIFF
--- a/scheds/rust/scx_chaos/Cargo.toml
+++ b/scheds/rust/scx_chaos/Cargo.toml
@@ -29,4 +29,3 @@ simplelog = "0.12"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
-scx_p2dq = { path = "../../../scheds/rust/scx_p2dq", version = "1.0.20" }

--- a/scheds/rust/scx_chaos/build.rs
+++ b/scheds/rust/scx_chaos/build.rs
@@ -2,32 +2,7 @@
 //
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
-use std::io::Write;
-
 fn main() {
-    let include_path = std::env::var("OUT_DIR").unwrap() + "/include";
-
-    std::fs::create_dir_all(include_path.clone() + "/scx_p2dq").unwrap();
-    let mut file = std::fs::File::create(include_path.clone() + "/scx_p2dq/main.bpf.c").unwrap();
-    file.write_all(scx_p2dq::bpf_srcs::main_bpf_c()).unwrap();
-    let mut file = std::fs::File::create(include_path.clone() + "/scx_p2dq/intf.h").unwrap();
-    file.write_all(scx_p2dq::bpf_srcs::intf_h()).unwrap();
-    let mut file = std::fs::File::create(include_path.clone() + "/scx_p2dq/types.h").unwrap();
-    file.write_all(scx_p2dq::bpf_srcs::types_h()).unwrap();
-
-    // TODO: this is a massive hack. BpfBuilder should be rewritten to have an explicit change of
-    // state between "builder" mode (where options are set) and "actualised" mode where they are
-    // turned into the useful arguments. As it is cflags is generated too early, and refactoring it
-    // is a pain and will require a change of interface.
-    let mut extra_flags = vec!["-I".to_string() + &include_path];
-    if let Ok(e) = std::env::var("BPF_EXTRA_CFLAGS_POST_INCL") {
-        extra_flags.push(e);
-    }
-
-    unsafe {
-        std::env::set_var("BPF_EXTRA_CFLAGS_POST_INCL", extra_flags.join(" "));
-    }
-
     scx_utils::BpfBuilder::new()
         .unwrap()
         .enable_intf("src/bpf/intf.h", "bpf_intf.rs")

--- a/scheds/rust/scx_chaos/src/bpf/scx_p2dq
+++ b/scheds/rust/scx_chaos/src/bpf/scx_p2dq
@@ -1,0 +1,1 @@
+../../../scx_p2dq/src/bpf

--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -317,27 +317,3 @@ macro_rules! init_skel {
         }
     };
 }
-
-pub mod bpf_srcs {
-
-    pub fn intf_h() -> &'static [u8] {
-        const INTF_H: &[u8] =
-            include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/intf.h"));
-
-        INTF_H
-    }
-
-    pub fn main_bpf_c() -> &'static [u8] {
-        const MAIN_BPF_C: &[u8] =
-            include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/main.bpf.c"));
-
-        MAIN_BPF_C
-    }
-
-    pub fn types_h() -> &'static [u8] {
-        const TYPES_H: &[u8] =
-            include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/bpf/types.h"));
-
-        TYPES_H
-    }
-}


### PR DESCRIPTION
chaos currently builds by using p2dq in build.rs and getting the source from the library. This sounds like a neat idea, providing the source code that others can depend on as part of the library interface. Unfortunately it sucks.

Switch to using symlinks to access the p2dq source in chaos, like with `lib/` and other cross-directory includes. We know this works for publishing. The reason depending on scx_p2dq in build_dependencies is so bad is that Cargo builds it with `cfg(build)`, creating an entirely different dependency tree and duplicating a bunch of work.

Also remove this, breaking the p2dq API. I think this is fine, it's such a bad idea to use it in this way that we should remove it to stop anyone else using it.

Test plan:
- CI

Perf before:
```
jake@rooster:/data/users/jake/repos/scx/ > cargo clean && time cargo build --release
     Removed 16227 files, 11.1GiB total
...
    Finished `release` profile [optimized] target(s) in 2m 07s
cargo build --release  2345.34s user 367.26s system 2127% cpu 2:07.50 total

jake@rooster:/data/users/jake/repos/scx/ > cargo clean && time cargo build --release -p scx_chaos
     Removed 2620 files, 1.4GiB total
...
    Finished `release` profile [optimized] target(s) in 2m 00s
cargo build --release -p scx_chaos  404.64s user 88.32s system 408% cpu 2:00.61 total

jake@rooster:/data/users/jake/repos/scx/ > echo '// invalidate cache' >> scheds/rust/scx_p2dq/src/bpf/main.bpf.c && time cargo build --release -p scx_chaos
...
    Finished `release` profile [optimized] target(s) in 1m 34s
cargo build --release -p scx_chaos  161.14s user 43.14s system 215% cpu 1:34.71 total
```

Perf after:
```
jake@rooster:/data/users/jake/repos/scx/ > cargo clean && time cargo build --release
     Removed 6013 files, 4.3GiB total
...
    Finished `release` profile [optimized] target(s) in 2m 01s
cargo build --release  2312.50s user 353.85s system 2195% cpu 2:01.45 total

jake@rooster:/data/users/jake/repos/scx/ > cargo clean && time cargo build --release -p scx_chaos
     Removed 5816 files, 4.2GiB total
...
    Finished `release` profile [optimized] target(s) in 1m 48s
cargo build --release -p scx_chaos  363.84s user 78.10s system 406% cpu 1:48.74 total
jake@rooster:/data/users/jake/repos/scx/ > echo '// invalidate cache' >> scheds/rust/scx_p2dq/src/bpf/main.bpf.c && time cargo build --release -p scx_chaos

jake@rooster:/data/users/jake/repos/scx/ > cargo build --release -p scx_chaos
...
    Finished `release` profile [optimized] target(s) in 1m 22s
cargo build --release -p scx_chaos  121.73s user 31.95s system 186% cpu 1:22.51 total
```

The wall time doesn't decrease a huge amount on a multicore machine, but the CPU time goes down a fair bit.