### PR TITLE
scx_lavd: Check Per-CPU dsq on select cpu path

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -550,7 +550,10 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 			goto out;
 		}
 
-		dsq_id = cpdom_to_dsq(cpuc->cpdom_id);
+		if (per_cpu_dsq)
+			dsq_id = cpu_to_dsq(cpu_id);
+		else
+			dsq_id = cpdom_to_dsq(cpuc->cpdom_id);
 
 		if (!scx_bpf_dsq_nr_queued(dsq_id)) {
 			p->scx.dsq_vtime = calc_when_to_run(p, taskc);


### PR DESCRIPTION
When Per-CPU DSQ option is enabled, the check on the number of queued tasks on Per-LLC DSQ will always return 0. We should check the CPU specific DSQ instead.