### PR TITLE
scx_lavd: --per-cpu-dsq shares DSQ between SMT siblings

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -20,7 +20,6 @@
 #define s2p(scale)			(((scale) * 100) >> LAVD_SHIFT)
 
 #define cpdom_to_dsq(cpdom_id)		((cpdom_id) | LAVD_DSQ_TYPE_CPDOM << LAVD_DSQ_TYPE_SHFT)
-#define cpu_to_dsq(cpu_id)		((cpu_id) | LAVD_DSQ_TYPE_CPU << LAVD_DSQ_TYPE_SHFT)
 #define dsq_to_cpdom(dsq_id)		((dsq_id) & LAVD_DSQ_ID_MASK)
 #define dsq_to_cpu(dsq_id)		((dsq_id) & LAVD_DSQ_ID_MASK)
 #define dsq_type(dsq_id)		(((dsq_id) & LAVD_DSQ_TYPE_MASK) >> LAVD_DSQ_TYPE_SHFT)
@@ -292,6 +291,7 @@ bool have_pending_tasks(struct cpu_ctx *cpuc);
 bool can_boost_slice(void);
 bool is_lat_cri(struct task_ctx *taskc);
 u16 get_nice_prio(struct task_struct *p);
+u32 cpu_to_dsq(u32 cpu);
 
 void set_task_flag(struct task_ctx *taskc, u64 flag);
 void reset_task_flag(struct task_ctx *taskc, u64 flag);

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1727,6 +1727,9 @@ static int init_per_cpu_dsqs(void)
 			return -ESRCH;
 		}
 
+		if (is_smt_active && (cpu != get_primary_cpu(cpu)))
+			continue;
+
 		err = scx_bpf_create_dsq(cpu_to_dsq(cpu), cpdomc->numa_id);
 		if (err) {
 			scx_bpf_error("Failed to create a DSQ for cpu %d on NUMA node %d",

--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -20,7 +20,6 @@ bool			have_turbo_core;
 bool			have_little_core;
 const volatile bool	is_smt_active;
 
-
 /*
  * CPU properties
  */

--- a/scheds/rust/scx_lavd/src/cpu_order.rs
+++ b/scheds/rust/scx_lavd/src/cpu_order.rs
@@ -47,6 +47,7 @@ pub struct CpuId {
     pub cpu_cap: usize,
     pub big_core: bool,
     pub turbo_core: bool,
+    pub cpu_sibling: usize,
 }
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
@@ -155,6 +156,7 @@ impl CpuOrderCtx {
     /// Build a CPU preference order based on its optimization target
     fn build_topo_order(&self, prefer_powersave: bool) -> Option<Vec<CpuId>> {
         let mut cpu_ids = Vec::new();
+        let smt_siblings = self.topo.sibling_cpus();
 
         // Build a vector of cpu ids.
         for (&numa_adx, node) in self.topo.nodes.iter() {
@@ -176,6 +178,7 @@ impl CpuOrderCtx {
                             cpu_cap: cpu.cpu_capacity,
                             big_core: cpu.core_type != CoreType::Little,
                             turbo_core: cpu.core_type == CoreType::Big { turbo: true },
+                            cpu_sibling: smt_siblings[cpu_adx] as usize,
                         };
                         cpu_ids.push(RefCell::new(cpu_id));
                     }

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -436,11 +436,13 @@ impl<'a> Scheduler<'a> {
     fn init_cpus(skel: &mut OpenBpfSkel, order: &CpuOrder) {
         debug!("{:#?}", order);
 
-        // Initialize CPU capacity.
+        // Initialize CPU capacity and sibling
         for cpu in order.cpuids.iter() {
             skel.maps.rodata_data.as_mut().unwrap().cpu_capacity[cpu.cpu_adx] = cpu.cpu_cap as u16;
             skel.maps.rodata_data.as_mut().unwrap().cpu_big[cpu.cpu_adx] = cpu.big_core as u8;
             skel.maps.rodata_data.as_mut().unwrap().cpu_turbo[cpu.cpu_adx] = cpu.turbo_core as u8;
+            skel.maps.rodata_data.as_mut().unwrap().cpu_sibling[cpu.cpu_adx] =
+                cpu.cpu_sibling as u32;
         }
 
         // Initialize performance vs. CPU order table.


### PR DESCRIPTION
When SMT is enabled, map each SMT sibling to share the same CPU DSQ. This should help with preserving better vtime ordering correctness while still maintaining l1/l2 cache locality.