### PR TITLE
lib: introduce red-black tree

### DIFF
--- a/lib/rbtree.bpf.c
+++ b/lib/rbtree.bpf.c
@@ -1,0 +1,803 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2025 Emil Tsalapatis <etsal@meta.com>
+ */
+
+#include <scx/common.bpf.h>
+
+#include <lib/sdt_task.h>
+#include <lib/rbtree.h>
+
+int rb_integrity_check(rbtree_t __arg_arena *rbtree);
+void rbnode_print(size_t depth, rbnode_t *rbn);
+
+#define INTEGRITY_CHECK(rbtree) do {						\
+	int ret = rb_integrity_check(rbtree);					\
+	if (ret) {								\
+		bpf_printk("%s:%d integrity failure", __func__, __LINE__);	\
+		rb_print(rbtree);						\
+		return -EINVAL;							\
+	}									\
+} while (0)
+
+__weak
+u64 rb_create_internal()
+{
+	rbtree_t *rbtree;
+
+	rbtree = (rbtree_t *)scx_static_alloc(sizeof(*rbtree), 1);
+	if (!rbtree)
+		return (u64)NULL;
+
+	rbtree->root = NULL;
+
+	return (u64)rbtree;
+}
+
+__weak
+int rb_destroy(rbtree_t *rbtree)
+{
+	int ret;
+
+	while (rbtree->root && can_loop) {
+		ret = rb_remove(rbtree, rbtree->root->key);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+static inline int rbnode_dir(rbnode_t *node)
+{
+	/* Arbitrarily choose a direction for the root. */
+	if (unlikely(!node->parent))
+		return 0;
+
+	return (node->parent->left == node) ? 0 : 1;
+}
+
+int rbnode_rotate(rbtree_t __arg_arena *rbtree, rbnode_t __arg_arena *node, int dir)
+{
+	rbnode_t *tmp, *parent;
+	int parentdir;
+
+	parent = node->parent;
+	if (parent)
+		parentdir = rbnode_dir(node);
+
+	/* If we're doing a root change, are we the root? */
+	if (unlikely(!parent && rbtree->root != node))
+		return -EINVAL;
+
+	/*
+	 * Does the node we're turning into the root into exist?
+	 * Note that the new root is on the opposite side of the
+	 * rotation's direction.
+	 */
+	tmp = node->child[1 - dir];
+	if (unlikely(!tmp))
+		return -EINVAL;
+
+	/* Steal the closest child of the new root. */
+	node->child[1 - dir] = tmp->child[dir];
+	if (node->child[1 - dir])
+		node->child[1 - dir]->parent = node;
+
+	/* Put the node below the new root.*/
+	tmp->child[dir] = node;
+	node->parent = tmp;
+
+	tmp->parent = parent;
+	if (parent)
+		parent->child[parentdir] = tmp;
+	else
+		rbtree->root = tmp;
+
+	return 0;
+}
+
+static
+rbnode_t *rbnode_find(rbnode_t *subtree, uint64_t key)
+{
+	rbnode_t *node = subtree;
+	int dir;
+
+	if (!subtree)
+		return NULL;
+
+	while (can_loop) {
+		if (node->key == key)
+			break;
+
+		dir = (key < node->key) ? 0 : 1;
+
+		if (!node->child[dir])
+			break;
+
+		node = node->child[dir];
+	}
+
+	return node;
+}
+
+__weak
+int rb_find(rbtree_t __arg_arena *rbtree, u64 key, u64 *value)
+{
+	rbnode_t *node = rbnode_find(rbtree->root, key);
+
+	if (unlikely(!rbtree))
+		return -EINVAL;
+
+	if (unlikely(!value))
+		return -EINVAL;
+
+	if (!node || node->key != key)
+		return -EINVAL;
+
+	*value = node->value;
+
+	return 0;
+}
+
+static inline
+rbnode_t *rbnode_alloc(rbtree_t *rbtree, u64 key, u64 value)
+{
+	rbnode_t *rbnode;
+	volatile rbnode_t *node;
+
+	do  {
+		rbnode = rbtree->freelist;
+		if (!rbnode)
+			break;
+
+	} while (cmpxchg(&rbtree->freelist, rbnode, rbnode->parent) != rbnode && can_loop);
+
+	if (!rbnode)
+		rbnode = (rbnode_t *)scx_static_alloc(sizeof(*rbnode), 1);
+	if (!rbnode)
+		return NULL;
+
+	/* 
+	 * XXXETSAL:  Use a second volatile variable because the verifier demotes
+	 * the rbnode variable to a scalar during cmpxchg.
+	 */
+
+	node = (rbnode_t *)rbnode;
+
+	node->left = NULL;
+	node->right = NULL;
+	node->parent = NULL;
+
+	node->key = key;
+	node->value = value;
+	node->is_red = true;
+
+	return rbnode;
+}
+
+static inline
+void rbnode_free(rbtree_t *rbtree, rbnode_t *rbnode)
+{
+	rbnode_t *old;
+
+	do {
+		old = rbtree->freelist;
+		rbnode->parent = old;
+	} while (cmpxchg(&rbtree->freelist, old, rbnode) != old && can_loop);
+}
+__weak
+int rb_insert(rbtree_t __arg_arena *rbtree, uint64_t key, uint64_t value, bool update)
+{
+	rbnode_t *grandparent, *parent = rbtree->root;
+	rbnode_t *node, *uncle;
+	int dir;
+
+	if (unlikely(!rbtree))
+		return -EINVAL;
+
+	node = rbnode_alloc(rbtree, key, value);
+	if (!node)
+		return -ENOMEM;
+
+	if (!parent) {
+		rbtree->root = node;
+		return 0;
+	}
+
+	parent = rbnode_find(parent, key);
+
+	if (key == parent->key) {
+		if (!update)
+			return -EALREADY;
+		parent->value = value;
+		return 0;
+	}
+
+	node->parent = parent;
+	if (key < parent->key)
+		parent->left = node;
+	else
+		parent->right = node;
+
+	while (can_loop) {
+		parent = node->parent;
+		if (!parent)
+			return 0;
+
+		if (!parent->is_red)
+			return 0;
+
+		grandparent = parent->parent;
+		if (!grandparent) {
+			parent->is_red = false;
+			return 0;
+		}
+
+		dir = rbnode_dir(parent);
+		uncle = grandparent->child[1 - dir];
+
+		if (!uncle || !uncle->is_red) {
+			if (node == parent->child[1 - dir]) {
+				rbnode_rotate(rbtree, parent, dir);
+				node = parent;
+				parent = grandparent->child[dir];
+			}
+
+			rbnode_rotate(rbtree, grandparent, 1 - dir);
+			parent->is_red = false;
+			grandparent->is_red = true;
+
+			return 0;
+		}
+
+		/* Uncle is red. */
+
+		parent->is_red = false;
+		uncle->is_red = false;
+		grandparent->is_red = true;
+
+		node = grandparent;
+	}
+
+	return 0;
+}
+
+static rbnode_t *rbnode_least(rbnode_t *subtree)
+{
+	while (subtree->left && can_loop)
+		subtree = subtree->left;
+
+	return subtree;
+}
+
+
+/* 
+ * If we are referencing ourselves, a and b have a parent-child relation,
+ * and we should be pointing at the other node instead.
+ */
+static inline void rbnode_fixup_pointers(rbnode_t *a, rbnode_t *b)
+{
+#define fixup(n1, n2, member) do { if (n1->member == n1) n1->member = n2; } while (0)
+	fixup(a, b, left);
+	fixup(a, b, right);
+	fixup(a, b, parent);
+#undef fixup
+}
+
+static inline void rbnode_swap_values(rbnode_t *a, rbnode_t *b)
+{
+#define swap(n1, n2, tmp) do { (tmp) = (n1); (n1) = (n2); (n2) = (tmp); } while (0)
+	rbnode_t *tmpnode;
+	u64 tmp;
+
+	/* Swap the pointers. */
+	swap(a->is_red, b->is_red, tmp);
+
+	swap(a->left, b->left, tmpnode);
+	swap(a->right, b->right, tmpnode);
+	swap(a->parent, b->parent, tmpnode);
+#undef swap
+
+	/* Account for the nodes being parent and child. */
+	rbnode_fixup_pointers(b, a);
+	rbnode_fixup_pointers(a, b);
+}
+
+static inline void rbnode_adjust_neighbors(rbtree_t *rbtree, rbnode_t *node, int dir)
+{
+	if (node->left)
+		node->left->parent = node;
+	if (node->right)
+		node->right->parent = node;
+
+	if (node->parent) {
+		node->parent->child[dir] = node;
+		return;
+	}
+
+	rbtree->root = node;
+}
+
+/*
+ * Switch two nodes in the tree in place. This is useful during node deletion.
+ * This is more involved than switching the values of the two nodes because we
+ * must update all tree pointers.
+ */
+static void rbnode_switch(rbtree_t *rbtree, rbnode_t *a, rbnode_t *b)
+{
+	int adir = 0, bdir = 0;
+
+	/* 
+	 * Store the direction in the parent because we will not 
+	 * be able to recompute it once we start swapping values.
+	 */
+	if (a->parent)
+		adir = rbnode_dir(a);
+
+	if (b->parent)
+		bdir = rbnode_dir(b);
+
+	rbnode_swap_values(a, b);
+
+	/*
+	 * Fix up the pointers from the children/parent to the
+	 * new nodes.
+	 */
+	rbnode_adjust_neighbors(rbtree, a, bdir);
+	rbnode_adjust_neighbors(rbtree, b, adir);
+}
+
+static inline int rbnode_remove_node_single_child(rbtree_t *rbtree, rbnode_t *node)
+{
+	rbnode_t *child;
+	int dir;
+
+	if (unlikely(node->is_red)) {
+		bpf_printk("Node unexpectedly red");
+		return -EINVAL;
+	}
+
+	child = node->left ? node->left : node->right;
+	if (unlikely(!child->is_red)) {
+		bpf_printk("Only child is black");
+		return -EINVAL;
+	}
+
+	/*
+	 * Since it's the immediate child, we can just
+	 * remove the parent.
+	 */
+	child->parent = node->parent;
+
+	if (node->parent) {
+		dir = rbnode_dir(node);
+		node->parent->child[dir] = child;
+	} else {
+		rbtree->root = child;
+	}
+
+	/* Color the child black. */
+	child->is_red = false;
+
+	rbnode_free(rbtree, node);
+
+	return 0;
+}
+
+static inline bool rbnode_has_red_children(rbnode_t *node)
+{
+	if (node->left && node->left->is_red)
+		return true;
+
+	return node->right && node->right->is_red;
+}
+
+__weak
+int rb_remove(rbtree_t __arg_arena *rbtree, u64 key)
+{
+	rbnode_t *parent, *sibling, *close_nephew, *distant_nephew, *node;
+	rbnode_t *replace, *initial;
+	bool is_red;
+	int dir;
+
+	if (unlikely(!rbtree))
+		return -EINVAL;
+
+	node = rbnode_find(rbtree->root, key);
+	if (!node || node->key != key)
+		return -ENOENT;
+
+	/* Both children present, replace with next largest key. */
+	if (node->left && node->right) {
+		/*
+		 * Swap the node itself instead of just the
+		 * key/value pair to account for nodes embedded
+		 * in other structs.
+		 */
+
+		replace = rbnode_least(node->right);
+		rbnode_switch(rbtree, replace, node);
+
+		/*
+		 * FALLTHROUGH: We moved the node we are removing to
+		 * the leftmost position of the subtree. We can now
+		 * remove it as if it was always where we moved it to.
+		 */
+	}
+
+	initial = node;
+
+	/* Only one child present, replace with child and paint it black. */
+	if (!node->left != !node->right)
+		return rbnode_remove_node_single_child(rbtree, node);
+
+	/* (!node->left && !node->right) */
+
+	parent = node->parent;
+	if (!parent) {
+		rbtree->root = NULL;
+		rbnode_free(rbtree, node);
+		return 0;
+	}
+
+	dir = rbnode_dir(node);
+	parent->child[dir] = NULL;
+	is_red = node->is_red;
+
+	rbnode_free(rbtree, node);
+
+	/* If we removed a red node, we did not unbalance the tree.*/
+	if (is_red)
+		return 0;
+
+	sibling = parent->child[1 - dir];
+	if (unlikely(!sibling)) {
+		bpf_printk("rbtree: removed black node has no sibling");
+		rb_print(rbtree);
+		return -EINVAL;
+	}
+
+	/*
+	 * We removed a black node, causing a change in path
+	 * weight. Start rebalancing. The invariant is that
+	 * all paths going through the node are shortened
+	 * by one, and the current node is black.
+	 */
+	while (can_loop) {
+
+		/* Balancing reached the root, there can be no imbalance. */
+		if (!parent)
+			return 0;
+
+		/*
+		 * We already determined the dir, either above or
+		 * at the end of the loop.
+		 */
+
+		/*
+		 * If we have no sibling, the tree was
+		 * already unbalanced.
+		 */
+		sibling = parent->child[1 - dir];
+		if (unlikely(!sibling)) {
+			bpf_printk("rbtree: removed black node has no sibling");
+			return -EINVAL;
+		}
+
+		/* Sibling is red, turn it into the grandparent. */
+		if (sibling->is_red) {
+			/*
+			 * Sibling is red. Transform the tree to turn
+			 * the sibling into the parent's position, and
+			 * repaint them. This does not balance the tree
+			 * but makes it so we know the sibling is black
+			 * and so can use the transformations to balance.
+			 */
+			rbnode_rotate(rbtree, parent, dir);
+			parent->is_red = true;
+			sibling->is_red = false;
+
+			/* Our new sibling is now the close nephew. */
+			sibling = parent->child[1 - dir];
+			/* If sibling has any red siblings, break out. */
+			if (rbnode_has_red_children(sibling))
+				break;
+
+			/* We can repaint the sibling and parent, we're done. */
+			sibling->is_red = true;
+			parent->is_red = false;
+
+			return 0;
+		} 
+
+		/* Sibling guaranteed to be black. If it has red children, break out. */
+		if (rbnode_has_red_children(sibling))
+			break;
+
+		/*
+		 * Both sibling and children are black. If parent is red, swap
+		 * colors with the sibling. Otherwise
+		 */
+		if (parent->is_red) {
+			parent->is_red = false;
+			sibling->is_red = true;
+			return 0;
+		}
+
+		/*
+		 * Parent, sibling, and all its children are black. Repaint the sibling.
+		 * This shortens the paths through it, so pop up a level in the
+		 * tree and repeat the balancing.
+		 */
+		sibling->is_red = true;
+		node = parent;
+		parent = node->parent;
+		dir = rbnode_dir(node);
+	}
+
+	if (node != initial) {
+		dir = rbnode_dir(node);
+		parent = node->parent;
+		sibling = parent->child[1-dir];
+	}
+	/*
+	 * Almost there. We know between the parent, sibling,
+	 * and nephews only one or two of the nephews are red. If
+	 * it is the close one, rotate it to the sibling position,
+	 * paint it black, and paint the previous sibling red.
+	 */
+
+	close_nephew = sibling->child[dir];
+	distant_nephew = sibling->child[1 - dir];
+
+	/*
+	 * If the distant red nephew is not red, rotate
+	 * and repaint. We need the distant nephew
+	 * to be red. We know the close nephew is red
+	 * because at least one of them are, so the
+	 */
+	if (!distant_nephew || !distant_nephew->is_red) {
+		rbnode_rotate(rbtree, sibling, 1 - dir);
+		sibling->is_red = true;
+		close_nephew->is_red = false;
+		distant_nephew = sibling;
+		sibling = close_nephew;
+	} 
+
+	/*
+	 * We now know it's the close nephew that's red.
+	 * Rotate the sibling into our parent's position and paint
+	 * both black.
+	 */
+
+	rbnode_rotate(rbtree, parent, dir);
+	sibling->is_red = parent->is_red;
+	parent->is_red = false;
+	distant_nephew->is_red = false;
+
+	return 0;
+}
+
+inline void rbnode_print(size_t depth, rbnode_t *rbn)
+{
+	bpf_printk("[DEPTH %d] %p (%s) PARENT %p", depth, rbn, rbn->is_red ? "red" : "black", rbn->parent);
+	bpf_printk("\tKV (%ld, %ld) LEFT %p RIGHT %p]\n", rbn->key, rbn->value, rbn->left, rbn->right);
+}
+
+enum rb_print_state {
+	RB_NONE_VISITED,
+	RB_LEFT_VISITED,
+	RB_RIGHT_VISITED,
+};
+
+__weak
+enum rb_print_state rb_print_next_state(rbnode_t __arg_arena *rbnode, enum rb_print_state state, rbnode_t **next)
+{
+	if (unlikely(!next))
+		return RB_NONE_VISITED;
+
+	switch (state) {
+	case RB_NONE_VISITED:
+		if (rbnode->left) {
+			*next = rbnode->left;
+			state = RB_LEFT_VISITED;
+			break;
+		}
+
+		/* FALLTHROUGH */
+
+	case RB_LEFT_VISITED:
+		if (rbnode->right) {
+			*next = rbnode->right;
+			state = RB_RIGHT_VISITED;
+			break;
+		}
+
+		/* FALLTHROUGH */
+
+	default:
+		*next = NULL;
+		state = RB_RIGHT_VISITED;
+	}
+
+	return state;
+}
+
+/*
+ * Pass everything by reference. This is to avoid arcane verification failures
+ * caused by embedding this code in the main rb_print call.
+ */
+__weak
+int rb_print_pop_up(rbnode_t **rbnode, u8 *depthp, enum rb_print_state (*stack)[RB_MAXLVL_PRINT], enum rb_print_state *state)
+{
+	/*
+	 * XXXETSAL If we do marked as volatile, the compiler reorders
+	 * the assignment to depth to be after the comparison by reusing
+	 * *depthp. This in turn relaxes the range of depth's values
+	 * enough to fail verification.
+	 */
+	volatile u8 depth;
+	int j;
+
+	if (unlikely(!rbnode || !depthp || !stack || !state))
+		return -EINVAL;
+
+	depth = *depthp;
+
+	bpf_for (j, 0, RB_MAXLVL_PRINT) {
+		if (*state != RB_RIGHT_VISITED)
+			break;
+
+		depth -= 1;
+		if (depth < 0 || depth >= RB_MAXLVL_PRINT)
+			break;
+
+		*state = (*stack)[depth % RB_MAXLVL_PRINT];
+		*rbnode = (*rbnode)->parent;
+	}
+
+	*depthp = depth;
+
+	return 0;
+}
+
+__weak
+int rb_print(rbtree_t __arg_arena *rbtree)
+{
+	enum rb_print_state stack[RB_MAXLVL_PRINT];
+	rbnode_t *rbnode = rbtree->root;
+	enum rb_print_state state;
+	rbnode_t *next;
+	u8 depth;
+	int ret;
+
+	if (unlikely(!rbtree))
+		return -EINVAL;
+
+	depth = 0;
+	state = RB_NONE_VISITED;
+
+	bpf_printk("=== BPF PRINTK START ===");
+
+	/* Even with can_loop, the verifier doesn't like infinite loops. */
+	while (can_loop) {
+		if (state == RB_NONE_VISITED)
+			rbnode_print(depth, rbnode);
+
+		/* Find which child to traverse next. */
+		state = rb_print_next_state(rbnode, state, &next);
+
+		/* Child found. Store the node state and go on. */
+		if (next) {
+			if (depth < 0 || depth >= RB_MAXLVL_PRINT)
+				return 0;
+
+			stack[depth++] = state;
+
+			rbnode = next;
+			state = RB_NONE_VISITED;
+
+			continue;
+		}
+
+		/* Otherwise, go as far up as possible. */
+		ret = rb_print_pop_up(&rbnode, &depth, &stack, &state);
+		if (ret)
+			return -EINVAL;
+
+		if (depth < 0 || depth >= RB_MAXLVL_PRINT) {
+			bpf_printk("=== BPF PRINTK END (depth %d)===", depth);
+			return 0;
+		}
+
+	}
+
+	bpf_printk("=== BPF PRINTK END ===");
+
+	return 0;
+}
+
+__weak
+int rb_integrity_check(rbtree_t __arg_arena *rbtree)
+{
+	enum rb_print_state stack[RB_MAXLVL_PRINT];
+	rbnode_t *rbnode = rbtree->root;
+	enum rb_print_state state;
+	rbnode_t *next;
+	u8 depth;
+	int ret;
+
+	if (unlikely(!rbtree))
+		return -EINVAL;
+
+	depth = 0;
+	state = RB_NONE_VISITED;
+
+	/* Even with can_loop, the verifier doesn't like infinite loops. */
+	while (can_loop) {
+		if (rbnode->parent && rbnode->parent->left != rbnode
+			&& rbnode->parent->right != rbnode) {
+			bpf_printk("WARNING: Inconsistent tree. Parent %p has no child %p", rbnode->parent, rbnode);
+			return -EINVAL;
+		}
+
+		if (rbnode->parent == rbnode) {
+			bpf_printk("WARNING: Inconsistent tree, node %p is its own parent", rbnode);
+			return -EINVAL;
+		}
+
+		if (rbnode->left == rbnode) {
+			bpf_printk("WARNING: Inconsistent tree, node %p is its own left child", rbnode);
+			return -EINVAL;
+		}
+
+		if (rbnode->right == rbnode) {
+			bpf_printk("WARNING: Inconsistent tree, node %p is its own right child", rbnode);
+			return -EINVAL;
+		}
+
+		if (rbnode->is_red) {
+			if (rbnode->left && rbnode->left->is_red) {
+				bpf_printk("WARNING: Inconsistent tree. Parent has %p has red child %p", rbnode, rbnode->left);
+				return -EINVAL;
+			}
+			if (rbnode->right && rbnode->left->is_red) {
+				bpf_printk("WARNING: Inconsistent tree. Parent has %p has red child %p", rbnode, rbnode->right);
+				return -EINVAL;
+			}
+		} else if (rbnode->parent && rbnode->parent->child[1 - rbnode_dir(rbnode)] == NULL) {
+			bpf_printk("WARNING: Inconsistent tree. Black node %p has no sibling", rbnode);
+			return -EINVAL;
+		}
+
+		/* Find which child to traverse next. */
+		state = rb_print_next_state(rbnode, state, &next);
+
+		/* Child found. Store the node state and go on. */
+		if (next) {
+			if (depth < 0 || depth >= RB_MAXLVL_PRINT)
+				return 0;
+
+			stack[depth++] = state;
+
+			rbnode = next;
+			state = RB_NONE_VISITED;
+
+			continue;
+		}
+
+		/* Otherwise, go as far up as possible. */
+		ret = rb_print_pop_up(&rbnode, &depth, &stack, &state);
+		if (ret)
+			return -EINVAL;
+
+		if (depth < 0 || depth >= RB_MAXLVL_PRINT) {
+			return 0;
+		}
+
+	}
+
+	return 0;
+}

--- a/lib/selftests/selftest.bpf.c
+++ b/lib/selftests/selftest.bpf.c
@@ -35,6 +35,13 @@ int arena_selftest(void)
 		return ret;
 	}
 
+	ret = scx_selftest_rbtree();
+	if (ret) {
+		bpf_printk("scx_selftest_rbtree failed with %d", ret);
+		return ret;
+	}
+
+
 	ret = scx_selftest_topology();
 	if (ret) {
 		bpf_printk("scx_selftest_topology failed with %d", ret);

--- a/lib/selftests/selftest.h
+++ b/lib/selftests/selftest.h
@@ -15,3 +15,4 @@ int scx_selftest_lvqueue(void);
 int scx_selftest_minheap(void);
 int scx_selftest_topology(void);
 int scx_selftest_btree(void);
+int scx_selftest_rbtree(void);

--- a/lib/selftests/st_rbtree.bpf.c
+++ b/lib/selftests/st_rbtree.bpf.c
@@ -1,0 +1,567 @@
+#include <scx/common.bpf.h>
+#include <lib/sdt_task.h>
+
+#include <lib/rbtree.h>
+
+#include "selftest.h"
+
+static const u64 keys[] = { 51, 43,  37, 3, 301,  46, 383, 990, 776, 729, 871, 96, 189, 213,
+	376, 167, 131, 939, 626, 119, 374, 700, 772, 154, 883, 620, 641, 5,
+	428, 516, 105, 622, 988, 811, 931, 973, 246, 690, 934, 744, 210, 311,
+	32, 255, 960, 830, 523, 429, 541, 738, 705, 774, 715, 446, 98, 578,
+	777, 191, 279, 91, 767 };
+
+static const u64 morekeys[] = { 173, 636, 1201, 8642, 5957, 3617, 4586, 8053, 6551, 7592, 1748, 1589, 8644, 9918, 6977,
+	4448, 5852, 4640, 9717, 2303, 7424, 7695, 2334, 8876, 8618, 5745, 7134, 2178, 5280, 2140, 1138,
+	5083, 8922, 1516, 2437, 2488, 4307, 4329, 5088, 8456, 5938, 1441, 1684, 5750, 721, 1107, 2089,
+	9737, 4687, 5016, 4849, 8193, 9603, 9147, 5992, 166, 6721, 812, 4144, 6237, 6509, 3466, 9255,
+	7767, 3960, 6759, 2968, 6046, 9784, 8395, 2619, 1711, 528, 6424, 9084, 3179, 1342, 5676, 9445,
+	5691, 6678, 8487, 1627, 998, 6178, 2229, 1987, 3319, 572, 169, 2161, 3018, 5439, 7287, 7265, 5995,
+	5003, 5857, 2836, 5634, 4735, 9261, 8287, 5359, 533, 1406, 9573, 4026, 714, 3956, 1722, 6395,
+	9648, 3887, 7185, 470, 4482, 4997, 841, 8913, 9946, 3999, 9357, 9847, 277, 8184, 8704, 6766, 3323,
+	5468, 8638, 7905, 8858, 6142, 3685, 3452, 4689, 8878, 8836, 158, 831, 7914, 3031, 8374, 4921,
+	4207, 3460, 5547, 3358, 1083, 4619, 7818, 2962, 4879, 4583, 2172, 8819, 9830, 1194, 2666, 9812,
+	5704, 8432, 5916, 6007, 6609, 4791, 1985, 3226, 2478, 9605, 5236, 8079, 3042, 1965, 3539, 9704,
+	4267, 6416, 760, 9968, 2983, 1190, 1964, 3211, 2870, 3106, 2794, 1542, 6916, 5986, 9096, 441,
+	5894, 8353, 7765, 3757, 5732, 88, 3091, 5637, 6042, 8447, 4073, 6923, 5491, 7010, 3663, 5029,
+	6162, 822, 4874, 7491, 5100, 3461, 6983, 2170, 1458, 1856, 648, 6272, 4887, 976, 2369, 5909, 4274,
+	3324, 6968, 2312, 2271, 8891, 6268, 6581, 1610, 8880, 6194, 6144, 9764, 6915, 829, 3774, 2265,
+	1752, 1314, 6377, 8760, 8004, 501, 4912, 9278, 1425, 9578, 7337, 307, 1885, 3151, 9617, 1647,
+	2458, 3702, 6091, 8902, 5663, 9378, 7640, 3336, 557, 1644, 6848, 1559, 8821, 266, 4330, 9790,
+	5920, 4222, 1143, 6248, 5792, 4847, 9726, 6303, 821, 6839, 6062, 7133, 3649, 9888, 2528, 1966,
+	5456, 4914, 3615, 1543, 3206, 3353, 6097, 2800, 1424, 9094, 7920, 7243, 1394, 5464, 1707, 576,
+	6524, 4261, 4187, 7889, 5336, 3377, 2921, 7244, 2766, 6584, 5514, 1387, 2957, 2258, 1077, 9979,
+	1128, 876, 4056, 4668, 4532, 1982, 7093, 4184, 5460, 7588, 4704, 6717, 61, 3959, 1826, 2294, 18,
+	8170, 9394, 8796, 7288, 7285, 7143, 148, 6676, 6603, 1051, 8225, 4169, 3230, 7697, 6971, 3454,
+	7501, 9514, 394, 2339, 4993, 5606, 6060, 1297, 8273, 3012, 157, 8181, 6765, 7207, 1005, 8833, 1914,
+	7456, 1846, 8375, 2741, 2074, 1712, 5286 };
+
+__weak int scx_selftest_rbtree_find_nonexistent(rbtree_t __arg_arena *rbtree)
+{
+	u64 key = 0xdeadbeef;
+	u64 value = 0;
+	int ret;
+
+	if (!rbtree)
+		return 1;
+
+	/* Should return -EINVAL */
+	ret = rb_find(rbtree, key, &value);
+	if (!ret)
+		return 2;
+
+	return 0;
+}
+
+__weak int scx_selftest_rbtree_insert_existing(rbtree_t __arg_arena *rbtree)
+{
+	u64 key = 525252;
+	u64 value = 24;
+	int ret;
+
+	if (!rbtree)
+		return 1;
+
+	/* Should return -EINVAL. */
+	ret = rb_insert(rbtree, key, value, false);
+	if (ret)
+		return 2;
+
+	/* Should return -EALREADY. */
+	ret = rb_insert(rbtree, key, value, false);
+	if (ret != -EALREADY) {
+		return 3;
+	}
+
+	return 0;
+}
+
+__weak int scx_selftest_rbtree_update_existing(rbtree_t __arg_arena *rbtree)
+{
+	u64 key = 33333;
+	u64 value;
+	int ret;
+
+	if (!rbtree)
+		return 1;
+
+	/* Should return -EINVAL. */
+	value = 52;
+	ret = rb_insert(rbtree, key, value, true);
+	if (ret)
+		return 2;
+
+	ret = rb_find(rbtree, key, &value);
+	if (ret)
+		return 3;
+
+	if (value != 52)
+		return 4;
+
+	value = 65;
+
+	/* Should succeed. */
+	ret = rb_insert(rbtree, key, value, true);
+	if (ret)
+		return 5;
+
+	/* Should be updated. */
+	ret = rb_find(rbtree, key, &value);
+	if (ret)
+		return 6;
+
+	if (value != 65)
+		return 7;
+
+	return 0;
+}
+
+
+__weak int scx_selftest_rbtree_insert_one(rbtree_t __arg_arena *rbtree)
+{
+	u64 key = 202020;
+	u64 value = 0xbadcafe;
+	int ret;
+
+	ret = rb_insert(rbtree, key, value, true);
+	if (ret)
+		return 1;
+
+	ret = rb_find(rbtree, key, &value);
+	if (ret)
+		return 2;
+
+	if (value != 0xbadcafe)
+		return 3;
+
+	return 0;
+}
+
+__weak int scx_selftest_rbtree_insert_ten(rbtree_t __arg_arena *rbtree)
+{
+	u64 key, value;
+	int ret, i;
+
+	if (!rbtree)
+		return 1;
+
+	for (i = 0; i < 10 && can_loop; i++) {
+		key = keys[i];
+		ret = rb_insert(rbtree, key, 2 * key, true);
+		if (ret)
+			return 2 + 3 * i;
+
+		/* Read it back. */
+		ret = rb_find(rbtree, key, &value);
+		if (ret)
+			return 2 + 3 * i + 1;
+
+		if (value != 2 * key)
+			return 2 + 3 * i + 2;
+	}
+
+	/* Go find all inserted pairs. */
+	for (i = 0; i < 10 && can_loop; i++) {
+		key = keys[i];
+
+		ret = rb_find(rbtree, key, &value);
+		if (ret)
+			return 35 + 2 * i;
+
+		if (value != 2 * key)
+			return 35 + 2 * i + 1;
+	}
+
+	return 0;
+}
+
+__weak int scx_selftest_rbtree_insert_many(rbtree_t __arg_arena *rbtree)
+{
+	const size_t numkeys = sizeof(keys) / sizeof(keys[0]);
+	u64 key, value;
+	int ret;
+	int i;
+
+	if (!rbtree)
+		return 1;
+
+	for (i = 0; i < numkeys && can_loop; i++) {
+		key = keys[i];
+		ret = rb_insert(rbtree, key, 2 * key, true);
+		if (ret)
+			return 2 + 3 * i;
+
+		/* Read it back. */
+		ret = rb_find(rbtree, key, &value);
+		if (ret)
+			return 2 + 3 * i + 1;
+
+		if (value != 2 * key)
+			return 2 + 3 * i + 2;
+	}
+
+	/* Go find all inserted pairs. */
+	for (i = 0; i < numkeys && can_loop; i++) {
+		key = keys[i];
+
+		ret = rb_find(rbtree, key, &value);
+		if (ret)
+			return 302 + 2 * i;
+
+		if (value != 2 * key)
+			return 302 + 2 * i + 1;
+	}
+
+	return 0;
+}
+
+__weak int scx_selftest_rbtree_remove_one(rbtree_t __arg_arena *rbtree)
+{
+	u64 key = 20, value = 5, newvalue;
+	int ret;
+
+	if (!rbtree)
+		return 1;
+
+	ret = rb_find(rbtree, key, &newvalue);
+	if (!ret)
+		return 2;
+
+	ret = rb_insert(rbtree, key, value, false);
+	if (ret)
+		return 3;
+
+	ret = rb_find(rbtree, key, &newvalue);
+	if (ret || value != newvalue)
+		return 4;
+
+	ret = rb_remove(rbtree, key);
+	if (ret)
+		return 5;
+
+	ret = rb_find(rbtree, key, &newvalue);
+	if (!ret)
+		return 6;
+
+
+
+	return 0;
+}
+
+__weak int scx_selftest_rbtree_remove_many(rbtree_t __arg_arena *rbtree)
+{
+	const size_t numkeys = sizeof(morekeys) / sizeof(morekeys[0]);
+	u64 key, value;
+	int errval = 1;
+	int ret;
+	int i;
+
+	if (!rbtree)
+		return 1;
+
+	bpf_for(i, 0, numkeys) {
+		key = morekeys[i];
+		ret = rb_insert(rbtree, key, 2 * key, true);
+		if (ret)
+			return errval;
+
+		errval += 1;
+
+		/* Read it back. */
+		ret = rb_find(rbtree, key, &value);
+		if (ret)
+			return errval;
+
+		errval += 1;
+
+		if (value != 2 * key)
+			return errval;
+
+		errval += 1;
+	}
+
+	/* Go find all inserted pairs. */
+	bpf_for(i, 0, numkeys) {
+		key = morekeys[i];
+
+		ret = rb_find(rbtree, key, &value);
+		if (ret)
+			return errval;
+
+		errval += 1;
+
+		if (value != 2 * key)
+			return errval;
+
+		errval += 1;
+	}
+
+	errval = 10000;
+
+	/* Remove half of them. */
+	for (i = 0; i < numkeys && can_loop; i += 2) {
+		key = morekeys[i];
+		ret = rb_remove(rbtree, key);
+		if (ret) {
+			bpf_printk("Failed to remove %ld", key);
+			return errval;
+		}
+
+		errval += 1;
+
+		/* Read it back. */
+		ret = rb_find(rbtree, key, &value);
+		if (!ret)
+			return errval;
+
+		errval += 1;
+	}
+
+
+	/* Ensure removed pairs are missing and added pairs are present. */
+	for (i = 0; i < numkeys && can_loop; i += 2) {
+		/* Even keys should be missing */
+		key = morekeys[i];
+		ret = rb_find(rbtree, key, &value);
+		if (!ret)
+			return errval;
+
+		if (i + 1 >= numkeys)
+			break;
+
+		key = morekeys[i + 1];
+
+		ret = rb_find(rbtree, key, &value);
+		if (ret)
+			return errval;
+
+		errval += 1;
+
+		if (value != 2 * key)
+			return errval;
+
+		errval += 1;
+
+	}
+
+	/* Odd keys should still be present. */
+	for (i = 1; i < numkeys && can_loop; i += 2) {
+		key = morekeys[i];
+		ret = rb_find(rbtree, key, &value);
+		if (ret)
+			return errval;
+
+		if (value != 2 * key)
+			return errval;
+	}
+
+	return 0;
+}
+
+__weak int scx_selftest_rbtree_add_remove_circular(rbtree_t __arg_arena *rbtree)
+{
+	const size_t iters = 60;
+	const size_t prefill = 10;
+	const size_t numkeys = 50;
+	const size_t prefix = 400000;
+	u64 value, rmval;
+	int errval = 1;
+	u64 key;
+	int ret;
+	int i;
+
+	if (!rbtree)
+		return 1;
+
+	bpf_for(i, 0, prefill) {
+		ret = rb_insert(rbtree, prefix + (i % numkeys), i, true);
+		if (ret)
+			return errval;
+
+		errval += 1;
+	}
+
+	errval = 2 * 1000 * 1000;
+
+	bpf_for(i, 0, prefill) {
+		/* Read it back. */
+		ret = rb_find(rbtree, prefix + (i % numkeys), &value);
+		if (ret)
+			return errval;
+
+		if (value != i)
+			return errval;
+	}
+
+	errval = 3 * 1000 * 1000;
+
+	bpf_for(i, prefill, iters) {
+		key = prefix + (i % numkeys);
+
+		ret = rb_find(rbtree, key, &value);
+		if (!ret) {
+			bpf_printk("Key %d already present", key);
+			return errval;
+		}
+
+		errval += 1;
+
+		ret = rb_insert(rbtree, key, i, true);
+		if (ret) {
+			bpf_printk("ITERATION %d", i);
+			rb_print(rbtree);
+			return errval;
+		}
+
+		rmval = i - prefill;
+
+		errval += 1;
+
+		ret = rb_find(rbtree, prefix + (rmval % numkeys), &value);
+		if (ret)
+			return errval;
+
+		errval += 1;
+
+		if (value != rmval)
+			return errval;
+
+		errval += 1;
+
+		ret = rb_remove(rbtree, prefix + (rmval % numkeys));
+		if (ret) {
+			bpf_printk("ITERATION %d", i);
+			return errval;
+		}
+
+		errval += 1;
+	}
+
+	bpf_for(i, 0, numkeys) {
+		rb_remove(rbtree, prefix + i);
+	}
+
+	return 0;
+}
+
+__weak int scx_selftest_rbtree_add_remove_circular_reverse(rbtree_t __arg_arena *rbtree)
+{
+	const size_t iters = 110;
+	const size_t prefill = 10;
+	const size_t numkeys = 50;
+	const size_t prefix = 500000;
+	u64 value, rmval;
+	int errval = 1;
+	u64 key;
+	int ret;
+	int i;
+
+	if (!rbtree)
+		return 1;
+
+	bpf_for(i, 0, prefill) {
+		ret = rb_insert(rbtree, prefix - (i % numkeys), i, true);
+		if (ret)
+			return errval;
+
+		errval += 1;
+	}
+
+	errval = 2 * 1000 * 1000;
+
+	bpf_for(i, 0, prefill) {
+		/* Read it back. */
+		ret = rb_find(rbtree, prefix - (i % numkeys), &value);
+		if (ret)
+			return errval;
+
+		if (value != i)
+			return errval;
+	}
+
+	errval = 3 * 1000 * 1000;
+
+	bpf_for(i, prefill, iters) {
+		key = prefix - (i % numkeys);
+
+		ret = rb_find(rbtree, key, &value);
+		if (!ret) {
+			bpf_printk("Key %d already present", key);
+			return errval;
+		}
+
+		errval += 1;
+
+		ret = rb_insert(rbtree, key, i, true);
+		if (ret) {
+			bpf_printk("error %d on insert", ret);
+			rb_print(rbtree);
+			return errval;
+		}
+
+		rmval = i - prefill;
+
+		errval += 1;
+
+		ret = rb_find(rbtree, prefix - (rmval % numkeys), &value);
+		if (ret)
+			return errval;
+
+		errval += 1;
+
+		if (value != rmval)
+			return errval;
+
+		errval += 1;
+
+		ret = rb_remove(rbtree, prefix - (rmval % numkeys));
+		if (ret)
+			return errval;
+
+		errval += 1;
+	}
+
+
+	errval = 4 * 1000 * 1000;
+	bpf_for(i, 0, prefill) {
+		ret = rb_remove(rbtree, prefix - i);
+		if (ret) {
+			bpf_printk("Did not remove %d, error %d", prefix - i, ret);
+			return errval + i;
+		}
+	}
+
+	return 0;
+}
+
+__weak int scx_selftest_rbtree_print(rbtree_t __arg_arena *rbtree)
+{
+	rb_print(rbtree);
+	return 0;
+}
+
+#define SCX_RBTREE_SELFTEST(suffix) SCX_SELFTEST(scx_selftest_rbtree_ ## suffix, rbtree)
+
+__weak
+int scx_selftest_rbtree(void)
+{
+	rbtree_t __arg_arena *rbtree;
+
+	rbtree = rb_create();
+	if (!rbtree)
+		return -ENOMEM;
+
+	SCX_RBTREE_SELFTEST(find_nonexistent);
+	SCX_RBTREE_SELFTEST(insert_one);
+	SCX_RBTREE_SELFTEST(print);
+	SCX_RBTREE_SELFTEST(insert_existing);
+	SCX_RBTREE_SELFTEST(update_existing);
+	SCX_RBTREE_SELFTEST(insert_ten);
+	SCX_RBTREE_SELFTEST(insert_many);
+	SCX_RBTREE_SELFTEST(remove_one);
+	SCX_RBTREE_SELFTEST(remove_many);
+	SCX_RBTREE_SELFTEST(add_remove_circular_reverse);
+	SCX_RBTREE_SELFTEST(add_remove_circular);
+
+	return 0;
+}

--- a/rust/scx_lib_selftests/build.rs
+++ b/rust/scx_lib_selftests/build.rs
@@ -13,6 +13,7 @@ fn main() {
         .add_source("../../lib/btree.bpf.c")
         .add_source("../../lib/lvqueue.bpf.c")
         .add_source("../../lib/minheap.bpf.c")
+        .add_source("../../lib/rbtree.bpf.c")
         .add_source("../../lib/sdt_alloc.bpf.c")
         .add_source("../../lib/sdt_task.bpf.c")
         .add_source("../../lib/topology.bpf.c")
@@ -22,6 +23,7 @@ fn main() {
         .add_source("../../lib/selftests/st_btree.bpf.c")
         .add_source("../../lib/selftests/st_lvqueue.bpf.c")
         .add_source("../../lib/selftests/st_minheap.bpf.c")
+        .add_source("../../lib/selftests/st_rbtree.bpf.c")
         .add_source("../../lib/selftests/st_topology.bpf.c")
         .compile_link_gen()
         .unwrap();

--- a/scheds/include/lib/rbtree.h
+++ b/scheds/include/lib/rbtree.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <scx/common.bpf.h>
+#include <scx/bpf_arena_common.bpf.h>
+#include <scx/bpf_arena_spin_lock.h>
+
+#define RB_MAXLVL_PRINT (16)
+
+struct rbnode;
+
+typedef struct rbnode __arena rbnode_t;
+
+struct rbnode {
+	rbnode_t *parent;
+	union {
+		struct {
+			rbnode_t *left;
+			rbnode_t *right;
+		};
+
+		rbnode_t *child[2];
+	};
+	uint64_t key;
+	/* Used as a linked list or to store KV pairs. */
+	union {
+		rbnode_t *next;
+		uint64_t value;
+	};
+	bool is_red;
+};
+
+struct rbtree {
+	rbnode_t *root;
+	rbnode_t *freelist;
+};
+
+typedef struct rbtree __arena rbtree_t;
+
+u64 rb_create_internal(void);
+#define rb_create() ((rbtree_t *)(rb_create_internal()))
+
+int rb_destroy(rbtree_t *rbtree);
+int rb_insert(rbtree_t *rbtree, u64 key, u64 value, bool update);
+int rb_remove(rbtree_t *rbtree, u64 key);
+int rb_find(rbtree_t *rbtree, u64 key, u64 *value);
+int rb_print(rbtree_t *rbtree);


### PR DESCRIPTION
Add a red-black tree data structure with nodes that are embeddable into other structs. This tree type can be used to back ATQs and the fact it is embeddable allows us to add it to task_ctx structs directly.