### PR TITLE
scx/bpf_arena_spin_lock: Make arena_spin_lock_slowpath static inline

### DIFF
--- a/scheds/include/scx/bpf_arena_spin_lock.h
+++ b/scheds/include/scx/bpf_arena_spin_lock.h
@@ -243,7 +243,7 @@ static __always_inline int arena_spin_trylock(arena_spinlock_t __arena *lock)
 	return likely(atomic_try_cmpxchg_acquire(&lock->val, &val, _Q_LOCKED_VAL));
 }
 
-__noinline __weak
+static __always_inline
 int arena_spin_lock_slowpath(arena_spinlock_t __arena __arg_arena *lock, u32 val)
 {
 	struct arena_mcs_spinlock __arena *prev, *next, *node0, *node;


### PR DESCRIPTION
The slowpath was previously marked as `__noinline __weak`, which forces it to be compiled as a global subprog. When invoked under bpf_preempt_disable(), the verifier rejects the program with:

    global function calls are not allowed with preemption disabled

Convert the function to `static __always_inline` so that it becomes a local helper (or is inlined entirely). This avoids generating a global subprog and satisfies the verifier's restriction, while keeping the locking semantics unchanged.

Test plan:
- Verified program loads successfully on both x86 ~and ARM~.

Edit: Works on x86, fails on ARM — will double check.

---

<details>
<summary> Error msg </summary>

```rs
$ sudo ./scx_wd40                                                
21:15:34 [INFO] Running scx_wd40 (build ID: 1.0.15-g66abe7b2 x86_64-unknown-linux-gnu)
21:15:34 [INFO] libbpf: struct_ops wd40: member priv not found in kernel, skipping it as it's set to zero

21:15:35 [WARN] libbpf: prog 'wd40_setup': BPF program load failed: -EINVAL

21:15:35 [WARN] libbpf: prog 'wd40_setup': -- BEGIN PROG LOAD LOG --
Func#9 ('scx_static_alloc_internal') is safe for any args that match its prototype
Validating scx_stk_alloc() func#11...
1182: R1=mem_or_null(id=2877,sz=80) R10=fp0
; if (!stack) { @ sdt_alloc.bpf.c:966
1182: (55) if r1 != 0x0 goto pc+6 1189: R1=mem(sz=80) R10=fp0
; return 0ULL; @ sdt_alloc.bpf.c:973
1189: (b4) w3 = -95                   ; R3_w=0xffffffa1
; if (CONFIG_NR_CPUS > _Q_MAX_CPUS) @ bpf_arena_spin_lock.h:500
1190: (18) r2 = 0xffffbd8fc09ac000    ; R2_w=map_value(map=bpf_bpf.kconfig,ks=4,vs=9)
1192: (79) r2 = *(u64 *)(r2 +0)       ; R2_w=8192
1193: (25) if r2 > 0x4000 goto pc+20          ; R2_w=8192
1194: (bf) r9 = r1                    ; R1=mem(sz=80) R9_w=mem(sz=80)
; if ((ret = arena_spin_lock(stack->lock))) { @ sdt_alloc.bpf.c:971
1195: (79) r6 = *(u64 *)(r1 +0)       ; R1=mem(sz=80) R6_w=scalar()
1196: (bf) r7 = addr_space_cast(r6, 0, 1)     ; R6_w=scalar() R7_w=arena
; bpf_preempt_disable(); @ bpf_arena_spin_lock.h:503
1197: (85) call bpf_preempt_disable#86672     ;
1198: (b7) r1 = 0                     ; R1_w=0
1199: (0f) r7 += r1                   ; R1_w=0 R7_w=arena
1200: (b4) w1 = 1                     ; R1_w=1
; if (likely(atomic_try_cmpxchg_acquire(&lock->val, &val, _Q_LOCKED_VAL))) @ bpf_arena_spin_lock.h:504
1201: (b4) w0 = 0                     ; R0_w=0
1202: (c3) r0 = atomic_cmpxchg((u32 *)(r7 +0), r0, r1)        ; R0_w=scalar(smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) R1_w=1 R7_w=arena
1203: (16) if w0 == 0x0 goto pc+1     ; R0_w=scalar(smin=umin=umin32=1,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff))
1204: (b4) w1 = 0                     ; R1_w=0
1205: (54) w1 &= 1                    ; R1_w=0
1206: (56) if w1 != 0x0 goto pc+13    ; R1_w=0
; val = arena_spin_lock_slowpath(lock, val); @ bpf_arena_spin_lock.h:507
1207: (bf) r1 = r6                    ; R1_w=scalar(id=2878) R6=scalar(id=2878)
1208: (bc) w2 = w0                    ; R0=scalar(id=2879,smin=umin=umin32=1,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) R2=scalar(id=2879,smin=umin=umin32=1,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff))
1209: (85) call pc+285
global function calls are not allowed with preemption disabled,
use static function instead
processed 30574 insns (limit 1000000) max_states_per_insn 31 total_states 1775 peak_states 288 mark_read 46
-- END PROG LOAD LOG --

21:15:35 [WARN] libbpf: prog 'wd40_setup': failed to load: -EINVAL

21:15:35 [WARN] libbpf: failed to load object 'bpf_bpf'

21:15:35 [WARN] libbpf: failed to load BPF skeleton 'bpf_bpf': -EINVAL

Error: Failed to load BPF program

Caused by:
    Invalid argument (os error 22)
```
</details>