### PR TITLE
scx_utils: few helpers simplifications.

### DIFF
--- a/rust/scx_utils/src/energy_model.rs
+++ b/rust/scx_utils/src/energy_model.rs
@@ -73,12 +73,10 @@ impl EnergyModel {
     }
 
     pub fn get_pd_by_cpu_id(&self, cpu_id: usize) -> Option<&PerfDomain> {
-        for (_, pd) in self.perf_doms.iter() {
-            if pd.span.test_cpu(cpu_id) {
-                return Some(pd);
-            }
-        }
-        None
+        self.perf_doms
+            .values()
+            .find(|&pd| pd.span.test_cpu(cpu_id))
+            .map(|c| c as _)
     }
 
     pub fn perf_total(&self) -> usize {

--- a/rust/scx_utils/src/misc.rs
+++ b/rust/scx_utils/src/misc.rs
@@ -68,7 +68,7 @@ where
 pub fn try_set_rlimit_infinity() {
     // Increase MEMLOCK size since the BPF scheduler might use
     // more than the current limit
-    if let Err(_) = setrlimit(Resource::RLIMIT_MEMLOCK, RLIM_INFINITY, RLIM_INFINITY) {
+    if setrlimit(Resource::RLIMIT_MEMLOCK, RLIM_INFINITY, RLIM_INFINITY).is_err() {
         // If there is an error in expanding rlimit to infinity,
         // show the current rlimits then proceed.
         if let Ok((soft, hard)) = getrlimit(Resource::RLIMIT_MEMLOCK) {


### PR DESCRIPTION
- get_pd_by_cpu_id() using map iterator find instead of manual lookup.
- try_set_rlimit_infinity() using a little more rust-y idiom for error checks.