### PR TITLE
scx_p2dq: Add scheduler mode configuration

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/intf.h
+++ b/scheds/rust/scx_p2dq/src/bpf/intf.h
@@ -82,7 +82,9 @@ enum stat_idx {
 };
 
 enum scheduler_mode {
-	MODE_PERFORMANCE,
+	MODE_DEFAULT,
+	MODE_GAMING,
+	MODE_EFFICIENCY,
 };
 
 #endif /* __P2DQ_INTF_H */

--- a/scheds/rust/scx_p2dq/src/bpf/intf.h
+++ b/scheds/rust/scx_p2dq/src/bpf/intf.h
@@ -83,7 +83,7 @@ enum stat_idx {
 
 enum scheduler_mode {
 	MODE_DEFAULT,
-	MODE_GAMING,
+	MODE_PERF,
 	MODE_EFFICIENCY,
 };
 

--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -750,7 +750,7 @@ static s32 pick_idle_cpu(struct task_struct *p, task_ctx *taskc,
 		goto found_cpu;
 	}
 
-	if (p2dq_config.sched_mode == MODE_GAMING &&
+	if (p2dq_config.sched_mode == MODE_PERF &&
 	    topo_config.has_little_cores &&
 	    llcx->big_cpumask) {
 		cpu = __pick_idle_cpu(llcx->big_cpumask,

--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -44,6 +44,26 @@ impl LbMode {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum SchedMode {
+    /// default mode
+    Default,
+    /// Gaming mode tries to schedule on Big cores.
+    Gaming,
+    /// Efficiency mode tries to schedule on little cores.
+    Efficiency,
+}
+
+impl SchedMode {
+    pub fn as_i32(&self) -> i32 {
+        match self {
+            SchedMode::Default => bpf_intf::scheduler_mode_MODE_DEFAULT as i32,
+            SchedMode::Gaming => bpf_intf::scheduler_mode_MODE_GAMING as i32,
+            SchedMode::Efficiency => bpf_intf::scheduler_mode_MODE_EFFICIENCY as i32,
+        }
+    }
+}
+
 #[derive(Debug, Parser)]
 pub struct SchedulerOpts {
     /// Disables per-cpu kthreads directly dispatched into local dsqs.
@@ -149,6 +169,10 @@ pub struct SchedulerOpts {
     /// ***DEPRECATED*** Load balance mode
     #[arg(value_enum, long, default_value_t = LbMode::Load)]
     pub lb_mode: LbMode,
+
+    /// Scheduler mode
+    #[arg(value_enum, long, default_value_t = SchedMode::Default)]
+    pub sched_mode: SchedMode,
 
     /// Slack factor for load balancing, load balancing is not performed if load is within slack
     /// factor percent.
@@ -280,6 +304,7 @@ macro_rules! init_open_skel {
             rodata.p2dq_config.nr_dsqs_per_llc = opts.dumb_queues as u32;
             rodata.p2dq_config.init_dsq_index = opts.init_dsq_index as i32;
             rodata.p2dq_config.saturated_percent = opts.saturated_percent;
+            rodata.p2dq_config.sched_mode = opts.sched_mode.clone() as u32;
 
             rodata.p2dq_config.atq_enabled = MaybeUninit::new(
                 opts.atq_enabled && compat::ksym_exists("bpf_spin_unlock").unwrap_or(false),

--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -46,11 +46,11 @@ impl LbMode {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum SchedMode {
-    /// default mode
+    /// Default mode for most workloads.
     Default,
-    /// Gaming mode tries to schedule on Big cores.
-    Gaming,
-    /// Efficiency mode tries to schedule on little cores.
+    /// Performance mode prioritizes scheduling on Big cores.
+    Performance,
+    /// Efficiency mode prioritizes scheduling on little cores.
     Efficiency,
 }
 
@@ -58,7 +58,7 @@ impl SchedMode {
     pub fn as_i32(&self) -> i32 {
         match self {
             SchedMode::Default => bpf_intf::scheduler_mode_MODE_DEFAULT as i32,
-            SchedMode::Gaming => bpf_intf::scheduler_mode_MODE_GAMING as i32,
+            SchedMode::Performance => bpf_intf::scheduler_mode_MODE_PERF as i32,
             SchedMode::Efficiency => bpf_intf::scheduler_mode_MODE_EFFICIENCY as i32,
         }
     }

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -154,7 +154,6 @@ impl<'a> Scheduler<'a> {
             atq_reenq: stats[stat_idx_P2DQ_STAT_ATQ_REENQ as usize],
             direct: stats[stat_idx_P2DQ_STAT_DIRECT as usize],
             idle: stats[stat_idx_P2DQ_STAT_IDLE as usize],
-            sched_mode: self.skel.maps.bss_data.as_ref().unwrap().sched_mode,
             dsq_change: stats[stat_idx_P2DQ_STAT_DSQ_CHANGE as usize],
             same_dsq: stats[stat_idx_P2DQ_STAT_DSQ_SAME as usize],
             keep: stats[stat_idx_P2DQ_STAT_KEEP as usize],

--- a/scheds/rust/scx_p2dq/src/stats.rs
+++ b/scheds/rust/scx_p2dq/src/stats.rs
@@ -15,8 +15,6 @@ use serde::Serialize;
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(top)]
 pub struct Metrics {
-    #[stat(desc = "Scheduler mode")]
-    pub sched_mode: u32,
     #[stat(desc = "Number of times a task was enqueued to a ATQ")]
     pub atq_enq: u64,
     #[stat(desc = "Number of times a task was re-enqueued to a ATQ")]
@@ -106,7 +104,6 @@ impl Metrics {
             wake_prev: self.wake_prev - rhs.wake_prev,
             wake_llc: self.wake_llc - rhs.wake_llc,
             wake_mig: self.wake_mig - rhs.wake_mig,
-            ..self.clone()
         }
     }
 }


### PR DESCRIPTION
Add different modes for gaming, efficiency and default scheduler performance. For the the implementation is rather simple and only effects the select path.