### PR TITLE
scxcash: Add perf sampling backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,6 +3096,7 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "log",
+ "num_cpus",
  "scx_utils",
  "serde",
  "serde_json",

--- a/tools/scxcash/Cargo.toml
+++ b/tools/scxcash/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 simplelog = "0.12"
 ctrlc = "3.4"
+num_cpus = "1.16"
 
 [build-dependencies]
 scx_utils = { path = "../../rust/scx_utils", version = "1.0.19" }

--- a/tools/scxcash/build.rs
+++ b/tools/scxcash/build.rs
@@ -4,6 +4,7 @@ fn main() {
         .unwrap()
         .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
         .enable_skel("src/bpf/soft_dirty.bpf.c", "bpf")
+        .enable_skel("src/bpf/perf_sample.bpf.c", "perf_bpf")
         .compile_link_gen()
         .unwrap();
 }

--- a/tools/scxcash/src/bpf/intf.h
+++ b/tools/scxcash/src/bpf/intf.h
@@ -16,4 +16,11 @@ struct soft_dirty_fault_event {
     u64 address;
 };
 
+struct perf_sample_event {
+    u32 pid;
+    u32 tid;
+    u32 cpu;
+    u64 address; /* placeholder */
+};
+
 #endif /* __INTF_H */

--- a/tools/scxcash/src/bpf/intf.h
+++ b/tools/scxcash/src/bpf/intf.h
@@ -12,11 +12,15 @@ typedef unsigned long long u64;
 #endif
 
 struct soft_dirty_fault_event {
+    u64 timestamp;
+    u32 pid;
     u32 tid;
-    u64 address;
+    u32 cpu;
+    u64 address; /* faulting address */
 };
 
 struct perf_sample_event {
+    u64 timestamp;
     u32 pid;
     u32 tid;
     u32 cpu;

--- a/tools/scxcash/src/bpf/perf_sample.bpf.c
+++ b/tools/scxcash/src/bpf/perf_sample.bpf.c
@@ -23,6 +23,7 @@ int handle_perf(struct bpf_perf_event_data *ctx)
 	if (!current->pid || !ctx->addr)
 		return 0;
 
+	ev.timestamp = bpf_ktime_get_ns();
 	ev.pid = current->tgid;
 	ev.tid = current->pid;
 	ev.cpu = bpf_get_smp_processor_id();

--- a/tools/scxcash/src/bpf/perf_sample.bpf.c
+++ b/tools/scxcash/src/bpf/perf_sample.bpf.c
@@ -20,13 +20,13 @@ int handle_perf(struct bpf_perf_event_data *ctx)
 	struct task_struct *current;
 
 	current = bpf_get_current_task_btf();
-	if (!current->pid)
+	if (!current->pid || !ctx->addr)
 		return 0;
 
 	ev.pid = current->tgid;
 	ev.tid = current->pid;
 	ev.cpu = bpf_get_smp_processor_id();
-	ev.address = 0; /* placeholder */
+	ev.address = (unsigned long)ctx->addr;
 	bpf_perf_event_output(ctx, &perf_sample_events, BPF_F_CURRENT_CPU, &ev, sizeof(ev));
 	return 0;
 }

--- a/tools/scxcash/src/bpf/perf_sample.bpf.c
+++ b/tools/scxcash/src/bpf/perf_sample.bpf.c
@@ -1,0 +1,32 @@
+/* Prototype perf sampling BPF program for scxcash. */
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "intf.h"
+
+char _license[] SEC("license") = "GPL";
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__type(key, u32);
+	__type(value, u32);
+	__uint(max_entries, 0);
+} perf_sample_events SEC(".maps");
+
+SEC("perf_event")
+int handle_perf(struct bpf_perf_event_data *ctx)
+{
+	struct perf_sample_event ev = {};
+	struct task_struct *current;
+
+	current = bpf_get_current_task_btf();
+	if (!current->pid)
+		return 0;
+
+	ev.pid = current->tgid;
+	ev.tid = current->pid;
+	ev.cpu = bpf_get_smp_processor_id();
+	ev.address = 0; /* placeholder */
+	bpf_perf_event_output(ctx, &perf_sample_events, BPF_F_CURRENT_CPU, &ev, sizeof(ev));
+	return 0;
+}

--- a/tools/scxcash/src/bpf/soft_dirty.bpf.c
+++ b/tools/scxcash/src/bpf/soft_dirty.bpf.c
@@ -29,7 +29,10 @@ int BPF_PROG(handle_do_fault, struct vm_fault *vmf)
 	e = bpf_ringbuf_reserve(&soft_dirty_events, sizeof(*e), 0);
 	if (!e)
 		return 0;
+	e->timestamp = bpf_ktime_get_ns();
+	e->pid = current->tgid;
 	e->tid = current->pid;
+	e->cpu = bpf_get_smp_processor_id();
 	e->address = (unsigned long)vmf->address;
 	bpf_ringbuf_submit(e, 0);
 	return 0;

--- a/tools/scxcash/src/monitors.rs
+++ b/tools/scxcash/src/monitors.rs
@@ -5,8 +5,10 @@ use libbpf_rs::AsRawLibbpf;
 use libbpf_rs::libbpf_sys;
 use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::SkelBuilder;
+use libbpf_rs::{PerfBuffer, PerfBufferBuilder};
 use libbpf_rs::{RingBuffer, RingBufferBuilder};
 use log::trace;
+use scx_utils::perf;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::fs::OpenOptions;
@@ -21,6 +23,13 @@ use std::time::Duration;
 pub enum CacheMonitorValue {
     /// A soft-dirty page fault event (tid and faulting address).
     SoftDirtyFault { tid: u32, address: u64 },
+    /// A perf sampling event (placeholder address / metadata).
+    PerfSample {
+        pid: u32,
+        tid: u32,
+        cpu: u32,
+        address: u64,
+    },
 }
 
 /// Trait representing a cache monitor instance.
@@ -142,6 +151,137 @@ impl<'a> CacheMonitor<'a> for SoftDirtyCacheMonitor<'a> {
             while let Some(ev) = q.pop_front() {
                 cb(ev);
             }
+        }
+        Ok(())
+    }
+}
+
+// Perf sampling monitor.
+pub struct PerfSampleMonitor<'a> {
+    _skel: crate::bpf::BpfSkel<'a>,
+    perf_buf: PerfBuffer<'a>,
+    _links: Vec<libbpf_rs::Link>,
+    events: Rc<RefCell<VecDeque<CacheMonitorValue>>>,
+}
+
+impl<'a> PerfSampleMonitor<'a> {
+    pub fn new(
+        open_storage: &'a mut std::mem::MaybeUninit<libbpf_rs::OpenObject>,
+        pid: Option<u32>,
+        period: u64,
+    ) -> Result<Self> {
+        let open = crate::bpf::BpfSkelBuilder::default().open(open_storage)?;
+        let skel = open.load()?;
+
+        let mut links = Vec::new();
+        let mut failures = 0u32;
+        let mut attr = perf::bindings::perf_event_attr::default();
+        attr.size = std::mem::size_of::<perf::bindings::perf_event_attr>() as u32;
+        attr.type_ = perf::bindings::PERF_TYPE_HARDWARE;
+        attr.config = perf::bindings::PERF_COUNT_HW_CPU_CYCLES as u64;
+        attr.__bindgen_anon_1.sample_freq = period as u64;
+        attr.set_freq(1); // frequency mode
+        attr.sample_type = perf::bindings::PERF_SAMPLE_RAW as u64;
+        attr.read_format = (perf::bindings::PERF_FORMAT_TOTAL_TIME_ENABLED
+            | perf::bindings::PERF_FORMAT_TOTAL_TIME_RUNNING) as u64;
+        attr.set_inherit(if pid.is_some() { 1 } else { 0 });
+        attr.set_disabled(1);
+        attr.set_enable_on_exec(1);
+        attr.__bindgen_anon_2.wakeup_events = 1;
+
+        let events = Rc::new(RefCell::new(VecDeque::new()));
+        let events_cb = Rc::clone(&events);
+        let perf_events_map = &skel.maps.perf_sample_events;
+
+        let cpus: Vec<u32> = (0..num_cpus::get() as u32).collect();
+        let target_pid: i32 = pid.map(|p| p as i32).unwrap_or(-1); // -1 all processes
+        for cpu in cpus {
+            let fd = unsafe {
+                perf::perf_event_open(&mut attr as *mut _, target_pid, cpu as i32, -1, 0)
+            };
+            if fd < 0 {
+                failures += 1;
+                trace!(
+                    "perf_event_open failed cpu={cpu} pid={target_pid} errno={} period={period}",
+                    std::io::Error::last_os_error()
+                );
+                continue;
+            }
+            match skel.progs.handle_perf.attach_perf_event(fd) {
+                Ok(link) => {
+                    // attach_perf_event does event enablement
+                    trace!("attached perf sample prog cpu={cpu} fd={fd}");
+                    links.push(link);
+                }
+                Err(e) => {
+                    trace!("attach_perf_event failed cpu={cpu} fd={fd} err={:?}", e);
+                    unsafe {
+                        libc::close(fd);
+                    }
+                    failures += 1;
+                }
+            }
+
+            let map_fd =
+                unsafe { libbpf_sys::bpf_map__fd(perf_events_map.as_libbpf_object().as_ptr()) };
+            let key = cpu as u32;
+            let val = fd as u32;
+            let ret = unsafe {
+                libbpf_sys::bpf_map_update_elem(
+                    map_fd,
+                    &key as *const _ as *const _,
+                    &val as *const _ as *const _,
+                    0,
+                )
+            };
+            if ret != 0 {
+                trace!("bpf_map_update_elem failed cpu={cpu} fd={fd} ret={ret}");
+            } else {
+                trace!("mapped cpu={cpu} -> fd={fd}");
+            }
+        }
+        if links.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Failed to attach perf events to any CPU ({} failures)",
+                failures
+            ));
+        }
+
+        let perf_buf = PerfBufferBuilder::new(perf_events_map)
+            .sample_cb(move |_cpu, data: &[u8]| {
+                let expect = std::mem::size_of::<crate::bpf_intf::perf_sample_event>();
+                if data.len() == expect + 4 {
+                    let ev: &crate::bpf_intf::perf_sample_event =
+                        unsafe { &*(data.as_ptr() as *const _) };
+                    events_cb
+                        .borrow_mut()
+                        .push_back(CacheMonitorValue::PerfSample {
+                            pid: ev.pid,
+                            tid: ev.tid,
+                            cpu: ev.cpu,
+                            address: ev.address,
+                        });
+                }
+            })
+            .build()?;
+        Ok(Self {
+            _skel: skel,
+            perf_buf,
+            _links: links,
+            events,
+        })
+    }
+}
+
+impl<'a> CacheMonitor<'a> for PerfSampleMonitor<'a> {
+    fn poll(&mut self) -> Result<()> {
+        let _ = self.perf_buf.poll(Duration::from_millis(0));
+        Ok(())
+    }
+    fn consume(&mut self, cb: &mut dyn FnMut(CacheMonitorValue)) -> Result<()> {
+        let mut q = self.events.borrow_mut();
+        while let Some(ev) = q.pop_front() {
+            cb(ev);
         }
         Ok(())
     }


### PR DESCRIPTION
A perf sampling backend support that enables firing of the program and capture of events and addresses.

This can now be combined with --soft-dirty flag to combine various monitoring backends together.

Output:
```
$ scxcash --pid 3050 --perf-sample --perf-freq 1000 --soft-dirty --json
...
{"type":"soft_dirty_fault","timestamp":487340764605663,"pid":3050,"tid":3050,"cpu":174,"address":130279465189376}
{"type":"soft_dirty_fault","timestamp":487340825410580,"pid":3050,"tid":3050,"cpu":35,"address":130279465193472} 
{"type":"soft_dirty_fault","timestamp":487340879684148,"pid":3050,"tid":3050,"cpu":40,"address":130279465197568} 
{"type":"soft_dirty_fault","timestamp":487340938595960,"pid":3050,"tid":3050,"cpu":10,"address":130279465201664} 
{"type":"soft_dirty_fault","timestamp":487340994974266,"pid":3050,"tid":3050,"cpu":224,"address":130279465205760}
{"type":"soft_dirty_fault","timestamp":487341056328583,"pid":3050,"tid":3050,"cpu":186,"address":130279465209856}
{"type":"soft_dirty_fault","timestamp":487341112745160,"pid":3050,"tid":3050,"cpu":35,"address":130279465213952} 
{"type":"soft_dirty_fault","timestamp":487341168058456,"pid":3050,"tid":3050,"cpu":26,"address":130279465218048}
{"type":"soft_dirty_fault","timestamp":487341226095373,"pid":3050,"tid":3050,"cpu":26,"address":130279465222144} 
{"type":"soft_dirty_fault","timestamp":487341286496942,"pid":3050,"tid":3050,"cpu":6,"address":130279465226240}  
{"type":"soft_dirty_fault","timestamp":487341352725458,"pid":3050,"tid":3050,"cpu":191,"address":130279465230336}
{"type":"soft_dirty_fault","timestamp":487341404219815,"pid":3050,"tid":3050,"cpu":16,"address":130279465234432} 
{"type":"soft_dirty_fault","timestamp":487341463915552,"pid":3050,"tid":3050,"cpu":3,"address":130279465238528}  
{"type":"soft_dirty_fault","timestamp":487341518933893,"pid":3050,"tid":3050,"cpu":184,"address":130279465242624}
{"type":"perf_sample","timestamp":487340575324048,"pid":3050,"tid":3050,"cpu":186,"address":18446696425730374144}
{"type":"perf_sample","timestamp":487340661174770,"pid":3050,"tid":3050,"cpu":186,"address":18446696425730374488}
{"type":"perf_sample","timestamp":487340892488061,"pid":3050,"tid":3050,"cpu":186,"address":18446696425730374712}
{"type":"perf_sample","timestamp":487340669211967,"pid":3050,"tid":3050,"cpu":54,"address":18446744072526371704} 
{"type":"perf_sample","timestamp":487341108272318,"pid":3050,"tid":3050,"cpu":57,"address":18446617445006554192} 
{"type":"perf_sample","timestamp":487340796310360,"pid":3050,"tid":3050,"cpu":111,"address":140727605567200}    
{"type":"perf_sample","timestamp":487340531323227,"pid":3050,"tid":3050,"cpu":94,"address":18446617565704847368} 
{"type":"perf_sample","timestamp":487340579840150,"pid":3050,"tid":3050,"cpu":136,"address":18446696425730375208}
{"type":"perf_sample","timestamp":487340603648713,"pid":3050,"tid":3050,"cpu":142,"address":18446617393912446984}
{"type":"perf_sample","timestamp":487340603668974,"pid":3050,"tid":3050,"cpu":142,"address":18446696425730374272}
{"type":"perf_sample","timestamp":487340853701455,"pid":3050,"tid":3050,"cpu":142,"address":18446696425730374064}
{"type":"perf_sample","timestamp":487340634972623,"pid":3050,"tid":3050,"cpu":184,"address":18446617496978030616}
{"type":"perf_sample","timestamp":487340802080095,"pid":3050,"tid":3050,"cpu":184,"address":18446696425730375104}
{"type":"perf_sample","timestamp":487341099067631,"pid":3050,"tid":3050,"cpu":184,"address":18446617429730727560}
...
```