### PR TITLE
scx_layered: Added --hi-fb-thread-name to give more CPU time for affinitized task

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1691,8 +1691,9 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 					hi_fb_thread_name, p->pid);
 			taskc->dsq_id = task_cpuc->hi_fb_dsq_id;
 		}
-		else
+		else {
 			taskc->dsq_id = task_cpuc->lo_fb_dsq_id;
+		}
 		/*
 		 * Start a new lo fallback queued region if the DSQ is empty.
 		 * While the following is racy, all that's needed is at least

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -66,6 +66,9 @@ const volatile bool enable_gpu_support = false;
 /* Delay permitted, in seconds, before antistall activates */
 const volatile u64 antistall_sec = 3;
 const u32 zero_u32 = 0;
+/* Move matching thread name to hi_fb */
+const volatile bool enable_hi_fb_thread_name_match = false;
+const volatile char hi_fb_thread_name[16];
 
 /*
  * XXX sched classes should be exported kernel
@@ -1679,7 +1682,17 @@ void BPF_STRUCT_OPS(layered_enqueue, struct task_struct *p, u64 enq_flags)
 	if ((!taskc->all_cpuset_allowed &&
 	     !(layer->allow_node_aligned && taskc->cpus_node_aligned)) ||
 	    !layer->nr_cpus) {
-		taskc->dsq_id = task_cpuc->lo_fb_dsq_id;
+		// Special handle for thread that has affinity set, but need more CPU time.
+		// XXX: If we need to support more than one thread (which is probably bad from
+		// deterministic performance perspective), we can change this to a map later.
+		if (enable_hi_fb_thread_name_match &&
+				bpf_strncmp(p->comm, sizeof(p->comm), (const char *)hi_fb_thread_name) == 0) {
+			trace("Put %s[%d] in hi_fb_dsq",
+					hi_fb_thread_name, p->pid);
+			taskc->dsq_id = task_cpuc->hi_fb_dsq_id;
+		}
+		else
+			taskc->dsq_id = task_cpuc->lo_fb_dsq_id;
 		/*
 		 * Start a new lo fallback queued region if the DSQ is empty.
 		 * While the following is racy, all that's needed is at least

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -2320,7 +2320,7 @@ impl<'a> Scheduler<'a> {
             rodata.task_hint_map_enabled = true;
         }
 
-        if opts.hi_fb_thread_name.is_empty() == false {
+        if !opts.hi_fb_thread_name.is_empty() {
             // let bpf_hi_fb_thread_name = &mut skel.maps.bss_data.as_mut().unwrap().hi_fb_thread_name;
             let bpf_hi_fb_thread_name = &mut rodata.hi_fb_thread_name;
             copy_into_cstr(bpf_hi_fb_thread_name, opts.hi_fb_thread_name.as_str());

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1442,7 +1442,7 @@ impl GpuTaskAffinitizer {
                         self.tasks_affinitized += 1;
                     }
                     Err(_) => {
-                        warn!(
+                        debug!(
                             "Error affinitizing gpu pid {} to node {:#?}",
                             child.as_u32(),
                             node_info

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -2321,7 +2321,6 @@ impl<'a> Scheduler<'a> {
         }
 
         if !opts.hi_fb_thread_name.is_empty() {
-            // let bpf_hi_fb_thread_name = &mut skel.maps.bss_data.as_mut().unwrap().hi_fb_thread_name;
             let bpf_hi_fb_thread_name = &mut rodata.hi_fb_thread_name;
             copy_into_cstr(bpf_hi_fb_thread_name, opts.hi_fb_thread_name.as_str());
             rodata.enable_hi_fb_thread_name_match = true;

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -716,7 +716,6 @@ struct Opts {
     /// Enable affinitized task to use hi fallback queue to get more CPU time.
     #[clap(long, default_value = "")]
     hi_fb_thread_name: String,
-
 }
 
 fn read_total_cpu(reader: &fb_procfs::ProcReader) -> Result<fb_procfs::CpuStat> {

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -712,6 +712,11 @@ struct Opts {
     /// Print the config (after template expansion) and exit.
     #[clap(long, default_value = "false")]
     print_and_exit: bool,
+
+    /// Enable affinitized task to use hi fallback queue to get more CPU time.
+    #[clap(long, default_value = "")]
+    hi_fb_thread_name: String,
+
 }
 
 fn read_total_cpu(reader: &fb_procfs::ProcReader) -> Result<fb_procfs::CpuStat> {
@@ -2314,6 +2319,13 @@ impl<'a> Scheduler<'a> {
         if layered_task_hint_map_path.is_empty() == false {
             hint_map.set_pin_path(layered_task_hint_map_path).unwrap();
             rodata.task_hint_map_enabled = true;
+        }
+
+        if opts.hi_fb_thread_name.is_empty() == false {
+            // let bpf_hi_fb_thread_name = &mut skel.maps.bss_data.as_mut().unwrap().hi_fb_thread_name;
+            let bpf_hi_fb_thread_name = &mut rodata.hi_fb_thread_name;
+            copy_into_cstr(bpf_hi_fb_thread_name, opts.hi_fb_thread_name.as_str());
+            rodata.enable_hi_fb_thread_name_match = true;
         }
 
         Self::init_layers(&mut skel, &layer_specs, &topo)?;


### PR DESCRIPTION
By default, affinitized tasks are put in lo_fb queue to guarantee a small slice of CPU time on the CPU core to avoid stalls. However, we have an important thread that has CPU affinity but we still want to give it more CPU time. Created an option to throw matching thread to hi_fb to allow it to run.