### PR TITLE
mitosis: add version info

### DIFF
--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -29,6 +29,7 @@ use log::info;
 use log::trace;
 use log::warn;
 use scx_stats::prelude::*;
+use scx_utils::build_id;
 use scx_utils::compat;
 use scx_utils::init_libbpf_logging;
 use scx_utils::scx_enums;
@@ -82,6 +83,10 @@ struct Opts {
     /// is not launched.
     #[clap(long)]
     monitor: Option<f64>,
+
+    /// Print scheduler version and exit.
+    #[clap(short = 'V', long, action = clap::ArgAction::SetTrue)]
+    version: bool,
 }
 
 // The subset of cstats we care about.
@@ -154,6 +159,11 @@ impl<'a> Scheduler<'a> {
         let mut skel_builder = BpfSkelBuilder::default();
         skel_builder.obj_builder.debug(opts.verbose > 1);
         init_libbpf_logging(None);
+        info!(
+            "Running scx_mitosis (build ID: {})",
+            build_id::full_version(env!("CARGO_PKG_VERSION"))
+        );
+
         let mut skel = scx_ops_open!(skel_builder, open_object, mitosis)?;
 
         skel.struct_ops.mitosis_mut().exit_dump_len = opts.exit_dump_len;
@@ -472,6 +482,14 @@ fn read_cpu_ctxs(skel: &BpfSkel) -> Result<Vec<bpf_intf::cpu_ctx>> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if opts.version {
+        println!(
+            "scx_mitosis {}",
+            build_id::full_version(env!("CARGO_PKG_VERSION"))
+        );
+        return Ok(());
+    }
 
     let llv = match opts.verbose {
         0 => simplelog::LevelFilter::Info,


### PR DESCRIPTION
add version info to mitosis printed at startup before verification.

also add a `-V/--version` flag to print this info and exit:

```
❯ ./target/release/scx_mitosis -V
scx_mitosis 0.0.11-g8bf6ab4d-dirty x86_64-unknown-linux-gnu
```

key detail about this is it does it exactly like layered does.