### PR TITLE
mitosis: replace layered with mitosis

### DIFF
--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -187,7 +187,7 @@ impl<'a> Scheduler<'a> {
     fn run(&mut self, shutdown: Arc<AtomicBool>) -> Result<UserExitInfo> {
         let struct_ops = scx_ops_attach!(self.skel, mitosis)?;
 
-        info!("Layered Scheduler Attached. Run `scx_mitosis --monitor` for metrics.");
+        info!("Mitosis Scheduler Attached. Run `scx_mitosis --monitor` for metrics.");
 
         let (res_ch, req_ch) = self.stats_server.channels();
 


### PR DESCRIPTION
Commit https://github.com/sched-ext/scx/commit/57065c0947ec59375b4f722a7544dece9957e73c introduced an incorrect description of the “layered” scheduler, when it should be mitosis. Let's fix it.

Before:

```
lucjan at cachyos ~ 10:37:34    
❯ scxctl start -s mitosis            
started Mitosis in Auto mode
lucjan at cachyos ~ 10:37:39    
❯ systemctl status scx_loader.service
● scx_loader.service - DBUS on-demand loader of sched-ext schedulers
     Loaded: loaded (/usr/lib/systemd/system/scx_loader.service; disabled; preset: disabled)
     Active: active (running) since Wed 2025-08-27 10:37:39 CEST; 4s ago
 Invocation: 9132e01691c74d69874e74d12f58c4c4
   Main PID: 113952 (scx_loader)
      Tasks: 23 (limit: 37402)
     Memory: 20M (peak: 20.3M)
        CPU: 72ms
     CGroup: /system.slice/scx_loader.service
             ├─113952 /usr/bin/scx_loader
             └─113971 scx_mitosis

sie 27 10:37:39 cachyos systemd[1]: Starting DBUS on-demand loader of sched-ext schedulers...
sie 27 10:37:39 cachyos scx_loader[113952]: [INFO]: Starting as dbus interface
sie 27 10:37:39 cachyos systemd[1]: Started DBUS on-demand loader of sched-ext schedulers.
sie 27 10:37:39 cachyos scx_loader[113952]: [INFO]: starting Mitosis with mode Auto..
sie 27 10:37:39 cachyos scx_loader[113952]: [INFO]: Got event to start scheduler!
sie 27 10:37:39 cachyos scx_loader[113952]: [INFO]: called "scx_mitosis"
sie 27 10:37:39 cachyos scx_loader[113952]: [INFO]: starting scx_mitosis command
sie 27 10:37:39 cachyos scx_loader[113971]: 10:37:39 [INFO] Running scx_mitosis (build ID: 0.0.12-g059ce35c-dirty x86_64-unknown-linux-gnu)
sie 27 10:37:39 cachyos scx_loader[113971]: 10:37:39 [WARN] libbpf: map 'mitosis': BPF map skeleton link is uninitialized
sie 27 10:37:39 cachyos scx_loader[113971]: 10:37:39 [INFO] Layered Scheduler Attached. Run `scx_mitosis --monitor` for metrics.
```
After:

```
lucjan at cachyos ~ 10:38:37    
❯ scxctl restart                                                   
restarted
lucjan at cachyos ~ 10:38:44    
❯ systemctl status scx_loader.service
● scx_loader.service - DBUS on-demand loader of sched-ext schedulers
     Loaded: loaded (/usr/lib/systemd/system/scx_loader.service; disabled; preset: disabled)
     Active: active (running) since Wed 2025-08-27 10:37:39 CEST; 1min 6s ago
 Invocation: 9132e01691c74d69874e74d12f58c4c4
   Main PID: 113952 (scx_loader)
      Tasks: 22 (limit: 37402)
     Memory: 14.8M (peak: 20.3M)
        CPU: 144ms
     CGroup: /system.slice/scx_loader.service
             ├─113952 /usr/bin/scx_loader
             └─115963 scx_mitosis

sie 27 10:37:39 cachyos scx_loader[113971]: 10:37:39 [INFO] Layered Scheduler Attached. Run `scx_mitosis --monitor` for metrics.
sie 27 10:38:44 cachyos scx_loader[113952]: [INFO]: restarting "scx_mitosis"..
sie 27 10:38:44 cachyos scx_loader[113952]: [INFO]: Got event to restart scheduler!
sie 27 10:38:44 cachyos scx_loader[113952]: [INFO]: Got event to restart scheduler!
sie 27 10:38:44 cachyos scx_loader[113971]: 10:38:44 [INFO] Unregister scx_mitosis scheduler
sie 27 10:38:44 cachyos scx_loader[113971]: EXIT: unregistered from user space
sie 27 10:38:44 cachyos scx_loader[113952]: [INFO]: starting scx_mitosis command
sie 27 10:38:44 cachyos scx_loader[115963]: 10:38:44 [INFO] Running scx_mitosis (build ID: 0.0.12-g059ce35c-dirty x86_64-unknown-linux-gnu)
sie 27 10:38:44 cachyos scx_loader[115963]: 10:38:44 [WARN] libbpf: map 'mitosis': BPF map skeleton link is uninitialized
sie 27 10:38:44 cachyos scx_loader[115963]: 10:38:44 [INFO] Mitosis Scheduler Attached. Run `scx_mitosis --monitor` for metrics.
```