### PR TITLE
Bump slab to 0.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slog"


### PR DESCRIPTION
Current slab 0.4.10 is affected by CVE-2025-55159/RUSTSEC-2025-0047/GHSA-qx2v-8332-m4fv, use 0.4.11 which has the corresponding fix instead.