### PR TITLE
scx_chaos: Log unregister on drop

### DIFF
--- a/scheds/rust/scx_chaos/src/lib.rs
+++ b/scheds/rust/scx_chaos/src/lib.rs
@@ -66,6 +66,7 @@ use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
+const SCHEDULER_NAME: &str = "scx_chaos";
 struct ArenaAllocator(Pin<Rc<SkelWithObject>>);
 
 unsafe impl Allocator for ArenaAllocator {
@@ -243,6 +244,12 @@ impl Scheduler {
         }
 
         Ok(())
+    }
+}
+
+impl Drop for Scheduler {
+    fn drop(&mut self) {
+        info!("Unregister {SCHEDULER_NAME} scheduler");
     }
 }
 


### PR DESCRIPTION
Before:
```rust
~/l/scx/ta/release  main *1 !1  sudo ./scx_chaos                                    ok  1m 18s  base py  eric-wcnlab@eric-wcnlab  21:42:35 
21:42:49 [INFO] Running scx_chaos (build ID: 1.0.18-g71cd0960-dirty x86_64-unknown-linux-gnu)
21:42:49 [INFO] Builder { traits: [], verbose: 0, kprobe_random_delays: None, p2dq_opts: SchedulerOpts { disable_kthreads_local: false, autoslice: false, interactive_ratio: 10, deadline: false, eager_load_balance: false, freq_control: false, greedy_idle_disable: false, interactive_sticky: false, interactive_fifo: false, dispatch_pick2_disable: false, dispatch_lb_busy: 75, dispatch_lb_interactive: true, keep_running: false, atq_enabled: false, cpu_priority: false, interactive_dsq: true, wakeup_lb_busy: 0, wakeup_llc_migrations: false, select_idle_in_enqueue: false, queued_wakeup: false, idle_resume_us: None, max_dsq_pick2: false, task_slice: false, min_slice_us: 100, lb_mode: Load, sched_mode: Default, lb_slack_factor: 5, min_llc_runs_pick2: 0, saturated_percent: 5, dsq_time_slices: [], dsq_shift: 4, min_nr_queued_pick2: 0, dumb_queues: 3, init_dsq_index: 0 }, requires_ppid: None }
21:42:49 [INFO] DSQ[0] slice_ns 100000
21:42:49 [INFO] DSQ[1] slice_ns 3200000
21:42:49 [INFO] DSQ[2] slice_ns 6400000
21:42:49 [INFO] libbpf: struct_ops chaos: member priv not found in kernel, skipping it as it's set to zero

21:42:49 [WARN] libbpf: map 'chaos': BPF map skeleton link is uninitialized

^C%                       
```

After:
```rust
 ~/l/scx/ta/release  chaos-add-drop *1 !1  sudo ./scx_chaos                                  ok  base py  eric-wcnlab@eric-wcnlab  21:40:04 
21:40:15 [INFO] Running scx_chaos (build ID: 1.0.18-g71cd0960-dirty x86_64-unknown-linux-gnu)
21:40:15 [INFO] Builder { traits: [], verbose: 0, kprobe_random_delays: None, p2dq_opts: SchedulerOpts { disable_kthreads_local: false, autoslice: false, interactive_ratio: 10, deadline: false, eager_load_balance: false, freq_control: false, greedy_idle_disable: false, interactive_sticky: false, interactive_fifo: false, dispatch_pick2_disable: false, dispatch_lb_busy: 75, dispatch_lb_interactive: true, keep_running: false, atq_enabled: false, cpu_priority: false, interactive_dsq: true, wakeup_lb_busy: 0, wakeup_llc_migrations: false, select_idle_in_enqueue: false, queued_wakeup: false, idle_resume_us: None, max_dsq_pick2: false, task_slice: false, min_slice_us: 100, lb_mode: Load, sched_mode: Default, lb_slack_factor: 5, min_llc_runs_pick2: 0, saturated_percent: 5, dsq_time_slices: [], dsq_shift: 4, min_nr_queued_pick2: 0, dumb_queues: 3, init_dsq_index: 0 }, requires_ppid: None }
21:40:15 [INFO] DSQ[0] slice_ns 100000
21:40:15 [INFO] DSQ[1] slice_ns 3200000
21:40:15 [INFO] DSQ[2] slice_ns 6400000
21:40:15 [INFO] libbpf: struct_ops chaos: member priv not found in kernel, skipping it as it's set to zero

21:40:15 [WARN] libbpf: map 'chaos': BPF map skeleton link is uninitialized

^C21:40:16 [INFO] Unregister scx_chaos scheduler
```