### PR TITLE
lib/rbtree: add rb_least() and rb_pop() API methods

### DIFF
--- a/lib/selftests/st_rbtree.bpf.c
+++ b/lib/selftests/st_rbtree.bpf.c
@@ -534,6 +534,63 @@ __weak int scx_selftest_rbtree_add_remove_circular_reverse(rbtree_t __arg_arena 
 	return 0;
 }
 
+__weak int scx_selftest_rbtree_least_pop(rbtree_t __arg_arena *rbtree)
+{
+	const size_t keys = 10;
+	u64 key, value;
+	int errval = 1;
+	int ret, i;
+
+	bpf_for(i, 0, keys / 2) {
+		ret = rb_insert(rbtree, i, i, true);
+		if (ret)
+			return errval;
+
+		errval += 1;
+
+		ret = rb_insert(rbtree, keys - 1 - i, keys - 1 - i, true);
+		if (ret)
+			return errval;
+
+		errval += 1;
+
+		ret = rb_least(rbtree, &key, &value);
+		if (ret)
+			return errval;
+
+		errval += 1;
+
+		if (key != 0 || value != 0)
+			return errval;
+
+		errval += 1;
+	}
+
+	errval = 1000;
+
+	bpf_for(i, 0, keys) {
+		ret = rb_least(rbtree, &key, &value);
+		if (ret)
+			return errval;
+
+		errval += 1;
+
+		if (key != i || value != i)
+			return errval;
+
+		ret = rb_pop(rbtree, &key, &value);
+		if (ret)
+			return errval;
+
+		errval += 1;
+
+		if (key != i || value != i)
+			return errval;
+	}
+
+	return 0;
+}
+
 __weak int scx_selftest_rbtree_print(rbtree_t __arg_arena *rbtree)
 {
 	rb_print(rbtree);

--- a/scheds/include/lib/rbtree.h
+++ b/scheds/include/lib/rbtree.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#ifdef __BPF__
 #include <scx/common.bpf.h>
 #include <scx/bpf_arena_common.bpf.h>
 #include <scx/bpf_arena_spin_lock.h>
+#endif /* __BPF__ */
 
 #define RB_MAXLVL_PRINT (16)
 
@@ -36,6 +38,7 @@ struct rbtree {
 
 typedef struct rbtree __arena rbtree_t;
 
+#ifdef __BPF__
 u64 rb_create_internal(void);
 #define rb_create() ((rbtree_t *)(rb_create_internal()))
 
@@ -44,3 +47,6 @@ int rb_insert(rbtree_t *rbtree, u64 key, u64 value, bool update);
 int rb_remove(rbtree_t *rbtree, u64 key);
 int rb_find(rbtree_t *rbtree, u64 key, u64 *value);
 int rb_print(rbtree_t *rbtree);
+int rb_least(rbtree_t *rbtree, u64 *key, u64 *value);
+int rb_pop(rbtree_t *rbtree, u64 *key, u64 *value);
+#endif /* __BPF__ */


### PR DESCRIPTION
Our red black trees currently lack a pop() method, which is necessary for any data structure that backs ATQs. Add pop(), and while we're at it peek().