### PR TITLE
scx: Make kconfig symbols weak

### DIFF
--- a/scheds/include/scx/bpf_arena_spin_lock.h
+++ b/scheds/include/scx/bpf_arena_spin_lock.h
@@ -16,7 +16,7 @@
 #define EOPNOTSUPP 95
 #define ETIMEDOUT 110
 
-extern unsigned long CONFIG_NR_CPUS __kconfig;
+extern unsigned long CONFIG_NR_CPUS __kconfig __weak;
 
 /*
  * Typically, we'd just rely on the definition in vmlinux.h for qspinlock, but

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -44,7 +44,7 @@
 #define	NUMA_NO_NODE	(-1)
 #endif
 
-extern int LINUX_KERNEL_VERSION __kconfig;
+extern int LINUX_KERNEL_VERSION __kconfig __weak;
 extern const char CONFIG_CC_VERSION_TEXT[64] __kconfig __weak;
 extern const char CONFIG_LOCALVERSION[64] __kconfig __weak;
 


### PR DESCRIPTION
See the docs for __kconfig[1], on some systems if __weak is not used it can cause libbpf to error out on loading.

  [1] https://docs.ebpf.io/ebpf-library/libbpf/ebpf/__kconfig/