### PR TITLE
scxtop: Bind both 'q' and 'Q' to Quit action

### DIFF
--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -63,6 +63,7 @@ impl Default for KeyMap {
         bindings.insert(Key::Char('j'), Action::PrevEvent);
         bindings.insert(Key::Char('k'), Action::NextEvent);
         bindings.insert(Key::Char('q'), Action::Quit);
+        bindings.insert(Key::Char('Q'), Action::Quit);
         bindings.insert(Key::Char('t'), Action::ChangeTheme);
         bindings.insert(Key::Char('-'), Action::DecTickRate);
         bindings.insert(Key::Char('+'), Action::IncTickRate);


### PR DESCRIPTION
Since [btop](https://github.com/aristocratos/btop) allows the same, I think it makes sense to provide this consistency.