### PR TITLE
scx_utils: Add option for libbpf opts for scx_ops_open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,6 +2909,7 @@ dependencies = [
  "anyhow",
  "ctrlc",
  "libbpf-rs",
+ "libbpf-sys",
  "libc",
  "plain",
  "procfs 0.17.0",
@@ -2924,6 +2925,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "libbpf-rs",
+ "libbpf-sys",
  "libc",
  "log",
  "ordered-float",
@@ -2939,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "scx_rustland_core"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "anyhow",
  "libbpf-rs",
@@ -3030,11 +3032,12 @@ dependencies = [
 
 [[package]]
 name = "scx_utils"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "anyhow",
  "bindgen 0.72.0",
  "bitvec",
+ "clap",
  "const_format",
  "glob",
  "hex",

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland_core"
-version = "2.3.4"
+version = "2.3.5"
 edition = "2021"
 authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_utils"
-version = "1.0.19"
+version = "1.0.20"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0-only"
@@ -11,6 +11,7 @@ description = "Utilities for sched_ext schedulers"
 anyhow = "1.0.65"
 bitvec = { version = "1.0", features = ["serde"] }
 bindgen = ">=0.69"
+clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
 glob = "0.3.2"
 hex = "0.4.3"
 lazy_static = "1.5.0"

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -59,6 +59,7 @@ pub use compat::ROOT_PREFIX;
 
 mod libbpf_logger;
 pub use libbpf_logger::init_libbpf_logging;
+pub mod libbpf_clap_opts;
 
 pub mod ravg;
 

--- a/rust/scx_utils/src/libbpf_clap_opts.rs
+++ b/rust/scx_utils/src/libbpf_clap_opts.rs
@@ -1,0 +1,114 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+use clap::Parser;
+use libbpf_sys::bpf_object_open_opts;
+use libbpf_sys::size_t;
+
+use std::ffi::c_char;
+use std::ffi::CString;
+use std::mem;
+
+#[derive(Debug, Clone, Parser)]
+pub struct LibbpfOpts {
+    /// Parse map definitions non-strictly, allowing extra attributes/data.
+    #[clap(long)]
+    pub relaxed_maps: Option<bool>,
+
+    /// Maps that set the 'pinning' attribute in their definition will have their pin_path
+    /// attribute set to a file in this directory, and be auto-pinned to that path on load;
+    /// defaults to "/sys/fs/bpf".
+    #[clap(long)]
+    pub pin_root_path: Option<String>,
+
+    /// Additional kernel config content that augments and overrides system Kconfig for CONFIG_xxx
+    /// externs.
+    #[clap(long)]
+    pub kconfig: Option<String>,
+
+    /// Path to the custom BTF to be used for BPF CO-RE relocations. This custom BTF completely
+    /// replaces the use of vmlinux BTF for the purpose of CO-RE relocations. NOTE: any other BPF
+    /// feature (e.g., fentry/fexit programs, struct_ops, etc) will need actual kernel BTF at
+    /// /sys/kernel/btf/vmlinux.
+    #[clap(long)]
+    pub btf_custom_path: Option<String>,
+
+    /// Path to BPF FS mount point to derive BPF token from. Created BPF token will be used for
+    /// all bpf() syscall operations that accept BPF token (e.g., map creation, BTF and program
+    /// loads, etc) automatically within instantiated BPF object. If bpf_token_path is not
+    /// specified, libbpf will consult LIBBPF_BPF_TOKEN_PATH environment variable. If set, it will
+    /// be taken as a value of bpf_token_path option and will force libbpf to either create BPF
+    /// token from provided custom BPF FS path, or will disable implicit BPF token creation, if
+    /// envvar value is an empty string. bpf_token_path overrides LIBBPF_BPF_TOKEN_PATH, if both
+    /// are set at the same time. Setting bpf_token_path option to empty string disables libbpf's
+    /// automatic attempt to create BPF token from default BPF FS mount point (/sys/fs/bpf), in
+    /// case this default behavior is undesirable.
+    #[clap(long)]
+    pub bpf_token_path: Option<String>,
+}
+
+impl Default for LibbpfOpts {
+    fn default() -> Self {
+        Self {
+            relaxed_maps: None,
+            pin_root_path: None,
+            kconfig: None,
+            btf_custom_path: None,
+            bpf_token_path: None,
+        }
+    }
+}
+
+impl LibbpfOpts {
+    /// Helper method to convert `LibbpfOpts` into an `Option<bpf_object_open_opts>`.
+    ///
+    /// Returns `Some(bpf_object_open_opts)` if any field in `LibbpfOpts` is set,
+    /// otherwise returns `None`.
+    pub fn into_bpf_open_opts(self) -> Option<bpf_object_open_opts> {
+        if self.relaxed_maps.is_some()
+            || self.pin_root_path.is_some()
+            || self.kconfig.is_some()
+            || self.btf_custom_path.is_some()
+            || self.bpf_token_path.is_some()
+        {
+            let mut opts: bpf_object_open_opts = unsafe { mem::zeroed() };
+            opts.sz = mem::size_of::<bpf_object_open_opts>() as size_t;
+
+            if let Some(relaxed) = self.relaxed_maps {
+                opts.relaxed_maps = relaxed;
+            }
+
+            // Using CString to ensure the strings are null-terminated.
+            // The Box::into_raw() converts the CString into a raw C-style pointer.
+            if let Some(pin_path) = self.pin_root_path {
+                let c_string = CString::new(pin_path).ok()?;
+                let boxed = c_string.into_boxed_c_str();
+                opts.pin_root_path = Box::into_raw(boxed) as *const c_char;
+            }
+
+            if let Some(kconfig_str) = self.kconfig {
+                let file_data = std::fs::read_to_string(kconfig_str).ok()?;
+                let c_string = CString::new(file_data).ok()?;
+                let boxed = c_string.into_boxed_c_str();
+                opts.kconfig = Box::into_raw(boxed) as *const c_char;
+            }
+
+            if let Some(btf_path) = self.btf_custom_path {
+                let c_string = CString::new(btf_path).ok()?;
+                let boxed = c_string.into_boxed_c_str();
+                opts.btf_custom_path = Box::into_raw(boxed) as *const c_char;
+            }
+
+            if let Some(token_path) = self.bpf_token_path {
+                let c_string = CString::new(token_path).ok()?;
+                let boxed = c_string.into_boxed_c_str();
+                opts.bpf_token_path = Box::into_raw(boxed) as *const c_char;
+            }
+
+            Some(opts)
+        } else {
+            None
+        }
+    }
+}

--- a/scheds/rust/scx_bpfland/Cargo.toml
+++ b/scheds/rust/scx_bpfland/Cargo.toml
@@ -15,12 +15,12 @@ libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19", features = ["autopower"] }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -32,6 +32,7 @@ use scx_stats::prelude::*;
 use scx_utils::autopower::{fetch_power_profile, PowerProfile};
 use scx_utils::build_id;
 use scx_utils::compat;
+use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::pm::{cpu_idle_resume_latency_supported, update_cpu_idle_resume_latency};
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
@@ -252,6 +253,9 @@ struct Opts {
     /// Show descriptions for statistics.
     #[clap(long)]
     help_stats: bool,
+
+    #[clap(flatten, next_help_heading = "Libbpf Options")]
+    pub libbpf: LibbpfOpts,
 }
 
 struct Scheduler<'a> {
@@ -315,7 +319,8 @@ impl<'a> Scheduler<'a> {
         // Initialize BPF connector.
         let mut skel_builder = BpfSkelBuilder::default();
         skel_builder.obj_builder.debug(opts.verbose);
-        let mut skel = scx_ops_open!(skel_builder, open_object, bpfland_ops)?;
+        let open_opts = opts.libbpf.clone().into_bpf_open_opts();
+        let mut skel = scx_ops_open!(skel_builder, open_object, bpfland_ops, open_opts)?;
 
         skel.struct_ops.bpfland_ops_mut().exit_dump_len = opts.exit_dump_len;
 

--- a/scheds/rust/scx_chaos/Cargo.toml
+++ b/scheds/rust/scx_chaos/Cargo.toml
@@ -11,7 +11,7 @@ ci.use_clippy = true
 
 [dependencies]
 scx_userspace_arena = { path = "../../../rust/scx_userspace_arena", version = "1.0.15" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 scx_p2dq = { path = "../../../scheds/rust/scx_p2dq", version = "1.0.20" }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
@@ -28,4 +28,4 @@ serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }

--- a/scheds/rust/scx_chaos/src/lib.rs
+++ b/scheds/rust/scx_chaos/src/lib.rs
@@ -16,6 +16,7 @@ use scx_utils::build_id;
 use scx_utils::compat;
 use scx_utils::compat::tracefs_mount;
 use scx_utils::init_libbpf_logging;
+use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
@@ -424,7 +425,8 @@ impl Builder<'_> {
         skel_builder.obj_builder.debug(self.verbose > 1);
         init_libbpf_logging(None);
 
-        let mut open_skel = scx_ops_open!(skel_builder, open_object, chaos)?;
+        let open_opts = LibbpfOpts::default().into_bpf_open_opts();
+        let mut open_skel = scx_ops_open!(skel_builder, open_object, chaos, open_opts)?;
         scx_p2dq::init_open_skel!(&mut open_skel, self.p2dq_opts, self.verbose)?;
 
         let rodata = open_skel.maps.rodata_data.as_mut().unwrap();

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -15,12 +15,12 @@ libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19", features = ["autopower"] }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -32,6 +32,7 @@ use log::{debug, info, warn};
 use scx_stats::prelude::*;
 use scx_utils::build_id;
 use scx_utils::compat;
+use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
@@ -164,6 +165,9 @@ struct Opts {
     /// Show descriptions for statistics.
     #[clap(long)]
     help_stats: bool,
+
+    #[clap(flatten, next_help_heading = "Libbpf Options")]
+    pub libbpf: LibbpfOpts,
 }
 
 #[derive(PartialEq)]
@@ -310,7 +314,8 @@ impl<'a> Scheduler<'a> {
         // Initialize BPF connector.
         let mut skel_builder = BpfSkelBuilder::default();
         skel_builder.obj_builder.debug(opts.verbose);
-        let mut skel = scx_ops_open!(skel_builder, open_object, cosmos_ops)?;
+        let open_opts = opts.libbpf.clone().into_bpf_open_opts();
+        let mut skel = scx_ops_open!(skel_builder, open_object, cosmos_ops, open_opts)?;
 
         skel.struct_ops.cosmos_ops_mut().exit_dump_len = opts.exit_dump_len;
 

--- a/scheds/rust/scx_flash/Cargo.toml
+++ b/scheds/rust/scx_flash/Cargo.toml
@@ -15,12 +15,12 @@ libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19", features = ["autopower"] }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -35,6 +35,7 @@ use scx_stats::prelude::*;
 use scx_utils::autopower::{fetch_power_profile, PowerProfile};
 use scx_utils::build_id;
 use scx_utils::compat;
+use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::pm::{cpu_idle_resume_latency_supported, update_cpu_idle_resume_latency};
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
@@ -364,6 +365,9 @@ struct Opts {
     /// Show descriptions for statistics.
     #[clap(long)]
     help_stats: bool,
+
+    #[clap(flatten, next_help_heading = "Libbpf Options")]
+    pub libbpf: LibbpfOpts,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -451,7 +455,8 @@ impl<'a> Scheduler<'a> {
         // Initialize BPF connector.
         let mut skel_builder = BpfSkelBuilder::default();
         skel_builder.obj_builder.debug(opts.verbose);
-        let mut skel = scx_ops_open!(skel_builder, open_object, flash_ops)?;
+        let open_opts = opts.libbpf.clone().into_bpf_open_opts();
+        let mut skel = scx_ops_open!(skel_builder, open_object, flash_ops, open_opts)?;
 
         skel.struct_ops.flash_ops_mut().exit_dump_len = opts.exit_dump_len;
 

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4.17"
 ordered-float = "3.4.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19", features = ["autopower"] }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 static_assertions = "1.1.0"
@@ -33,7 +33,7 @@ rlimit = "0.10.2"
 nix = "0.30.1"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -47,6 +47,7 @@ use scx_stats::prelude::*;
 use scx_utils::autopower::{fetch_power_profile, PowerProfile};
 use scx_utils::build_id;
 use scx_utils::compat;
+use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
@@ -201,6 +202,9 @@ struct Opts {
     /// Show descriptions for statistics.
     #[clap(long)]
     help_stats: bool,
+
+    #[clap(flatten, next_help_heading = "Libbpf Options")]
+    pub libbpf: LibbpfOpts,
 }
 
 impl Opts {
@@ -346,7 +350,8 @@ impl<'a> Scheduler<'a> {
         skel_builder.obj_builder.debug(opts.verbose > 0);
         init_libbpf_logging(Some(PrintLevel::Debug));
 
-        let mut skel = scx_ops_open!(skel_builder, open_object, lavd_ops)?;
+        let open_opts = opts.libbpf.clone().into_bpf_open_opts();
+        let mut skel = scx_ops_open!(skel_builder, open_object, lavd_ops, open_opts)?;
 
         // Enable futex tracing using ftrace if available. If the ftrace is not
         // available, use tracepoint, which is known to be slower than ftrace.

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4.17"
 scx_bpf_compat = { path = "../../../rust/scx_bpf_compat", version = "1.0.15" }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 simplelog = "0.12"
@@ -33,11 +33,10 @@ nix = { version = "0.29", features = ["sched"] }
 sysinfo = "0.33.1"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 
 [features]
 enable_backtrace = []
 
 [package.metadata.appimage]
 auto_link = true
-

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -47,6 +47,7 @@ use scx_stats::prelude::*;
 use scx_utils::build_id;
 use scx_utils::compat;
 use scx_utils::init_libbpf_logging;
+use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::pm::{cpu_idle_resume_latency_supported, update_cpu_idle_resume_latency};
 use scx_utils::read_netdevs;
 use scx_utils::scx_enums;
@@ -716,6 +717,9 @@ struct Opts {
     /// Enable affinitized task to use hi fallback queue to get more CPU time.
     #[clap(long, default_value = "")]
     hi_fb_thread_name: String,
+
+    #[clap(flatten, next_help_heading = "Libbpf Options")]
+    pub libbpf: LibbpfOpts,
 }
 
 fn read_total_cpu(reader: &fb_procfs::ProcReader) -> Result<fb_procfs::CpuStat> {
@@ -2172,7 +2176,8 @@ impl<'a> Scheduler<'a> {
             "Running scx_layered (build ID: {})",
             build_id::full_version(env!("CARGO_PKG_VERSION"))
         );
-        let mut skel = scx_ops_open!(skel_builder, open_object, layered)?;
+        let open_opts = opts.libbpf.clone().into_bpf_open_opts();
+        let mut skel = scx_ops_open!(skel_builder, open_object, layered, open_opts)?;
 
         // enable autoloads for conditionally loaded things
         // immediately after creating skel (because this is always before loading)

--- a/scheds/rust/scx_mitosis/Cargo.toml
+++ b/scheds/rust/scx_mitosis/Cargo.toml
@@ -24,13 +24,13 @@ crossbeam = "0.8.4"
 maplit = "1.0.2"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -32,6 +32,7 @@ use scx_stats::prelude::*;
 use scx_utils::build_id;
 use scx_utils::compat;
 use scx_utils::init_libbpf_logging;
+use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::scx_enums;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
@@ -88,6 +89,9 @@ struct Opts {
     /// Print scheduler version and exit.
     #[clap(short = 'V', long, action = clap::ArgAction::SetTrue)]
     version: bool,
+
+    #[clap(flatten, next_help_heading = "Libbpf Options")]
+    pub libbpf: LibbpfOpts,
 }
 
 // The subset of cstats we care about.
@@ -166,7 +170,8 @@ impl<'a> Scheduler<'a> {
             build_id::full_version(env!("CARGO_PKG_VERSION"))
         );
 
-        let mut skel = scx_ops_open!(skel_builder, open_object, mitosis)?;
+        let open_opts = opts.libbpf.clone().into_bpf_open_opts();
+        let mut skel = scx_ops_open!(skel_builder, open_object, mitosis, open_opts)?;
 
         skel.struct_ops.mitosis_mut().exit_dump_len = opts.exit_dump_len;
 

--- a/scheds/rust/scx_p2dq/Cargo.toml
+++ b/scheds/rust/scx_p2dq/Cargo.toml
@@ -23,14 +23,14 @@ log = "0.4.17"
 ordered-float = "3.4.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -12,12 +12,13 @@ plain = "0.2.3"
 procfs = "0.17"
 ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "=0.26.0-beta.1"
+libbpf-sys = "=1.6.1"
 libc = "0.2.137"
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.4" }
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.4" }
 
 [features]

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -95,6 +95,7 @@ use std::time::SystemTime;
 use anyhow::Result;
 use bpf::*;
 use libbpf_rs::OpenObject;
+use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::UserExitInfo;
 
 // Maximum time slice (in nanoseconds) that a task can use before it is re-enqueued.
@@ -106,8 +107,10 @@ struct Scheduler<'a> {
 
 impl<'a> Scheduler<'a> {
     fn init(open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
+        let open_opts = LibbpfOpts::default();
         let bpf = BpfScheduler::init(
             open_object,
+            open_opts.clone().into_bpf_open_opts(),
             0,     // exit_dump_len (buffer size of exit info, 0 = default)
             false, // partial (false = include all tasks)
             false, // debug (false = debug mode off)

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -12,6 +12,7 @@ plain = "0.2.3"
 clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "=0.26.0-beta.1"
+libbpf-sys = "=1.6.1"
 libc = "0.2.137"
 log = "0.4.17"
 ordered-float = "3.4.0"
@@ -19,12 +20,12 @@ procfs = "0.17"
 serde = { version = "1.0.215", features = ["derive"] }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.4" }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.4" }
 
 [features]

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -25,6 +25,7 @@ use log::warn;
 use procfs::process::Process;
 use scx_stats::prelude::*;
 use scx_utils::build_id;
+use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::UserExitInfo;
 use stats::Metrics;
 
@@ -113,6 +114,9 @@ struct Opts {
     /// Print scheduler version and exit.
     #[clap(short = 'V', long, action = clap::ArgAction::SetTrue)]
     version: bool,
+
+    #[clap(flatten, next_help_heading = "Libbpf Options")]
+    pub libbpf: LibbpfOpts,
 }
 
 // Time constants.
@@ -156,6 +160,7 @@ impl<'a> Scheduler<'a> {
         // Low-level BPF connector.
         let bpf = BpfScheduler::init(
             open_object,
+            opts.libbpf.clone().into_bpf_open_opts(),
             opts.exit_dump_len,
             opts.partial,
             opts.verbose,

--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -19,14 +19,14 @@ log = "0.4.17"
 ordered-float = "3.4.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_tickless/Cargo.toml
+++ b/scheds/rust/scx_tickless/Cargo.toml
@@ -16,12 +16,12 @@ libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19", features = ["autopower"] }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20", features = ["autopower"] }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_tickless/src/main.rs
+++ b/scheds/rust/scx_tickless/src/main.rs
@@ -32,6 +32,7 @@ use log::{debug, info};
 use scx_stats::prelude::*;
 use scx_utils::build_id;
 use scx_utils::compat;
+use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
@@ -96,6 +97,9 @@ struct Opts {
     /// Show descriptions for statistics.
     #[clap(long)]
     help_stats: bool,
+
+    #[clap(flatten, next_help_heading = "Libbpf Options")]
+    pub libbpf: LibbpfOpts,
 }
 
 pub fn is_nohz_enabled() -> bool {
@@ -147,7 +151,8 @@ impl<'a> Scheduler<'a> {
         // Initialize BPF connector.
         let mut skel_builder = BpfSkelBuilder::default();
         skel_builder.obj_builder.debug(opts.verbose);
-        let mut skel = scx_ops_open!(skel_builder, open_object, tickless_ops)?;
+        let open_opts = opts.libbpf.clone().into_bpf_open_opts();
+        let mut skel = scx_ops_open!(skel_builder, open_object, tickless_ops, open_opts)?;
         skel.struct_ops.tickless_ops_mut().exit_dump_len = opts.exit_dump_len;
 
         let rodata = skel.maps.rodata_data.as_mut().unwrap();

--- a/scheds/rust/scx_wd40/Cargo.toml
+++ b/scheds/rust/scx_wd40/Cargo.toml
@@ -24,14 +24,14 @@ log = "0.4.17"
 ordered-float = "3.4.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.15" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.15" }
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 sorted-vec = "0.8.3"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.20" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_wd40/src/main.rs
+++ b/scheds/rust/scx_wd40/src/main.rs
@@ -49,6 +49,7 @@ use scx_stats::prelude::*;
 use scx_utils::build_id;
 use scx_utils::compat;
 use scx_utils::init_libbpf_logging;
+use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::scx_enums;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
@@ -230,6 +231,9 @@ struct Opts {
     /// prioritize energy efficiency. When in doubt, use 0 or 1024.
     #[clap(long, default_value = "0")]
     perf: u32,
+
+    #[clap(flatten, next_help_heading = "Libbpf Options")]
+    pub libbpf: LibbpfOpts,
 }
 
 fn read_cpu_busy_and_total(reader: &procfs::ProcReader) -> Result<(u64, u64)> {
@@ -534,7 +538,8 @@ impl<'a> Scheduler<'a> {
             "Running scx_wd40 (build ID: {})",
             build_id::full_version(env!("CARGO_PKG_VERSION"))
         );
-        let mut skel = scx_ops_open!(skel_builder, open_object, wd40).unwrap();
+        let open_opts = opts.libbpf.clone().into_bpf_open_opts();
+        let mut skel = scx_ops_open!(skel_builder, open_object, wd40, open_opts).unwrap();
 
         // Initialize skel according to @opts.
         let domains = Arc::new(DomainGroup::new(&Topology::new()?)?);


### PR DESCRIPTION
Refactor the scx_ops_open macro to accept bpf_object_open_opts for additional configuration of libbpf. Add a clap implementation LibbpfOpts for configuring libbpf options. Update the scx_utils crate with these changes. For schedulers that use arenas or __kconfig update the CLI options to support configuring libbpf with additional options. This is useful on some distributions that have kconfigs in non standard locations.