### PR TITLE
scxtop: Reduce redundant if-else

### DIFF
--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -88,19 +88,11 @@ fn handle_input_entry(app: &App, s: String) -> Option<Action> {
         | AppState::Llc
         | AppState::Node
         | AppState::Process
-        | AppState::Memory => {
-            if app.filtering() {
-                Some(Action::InputEntry(s))
-            } else {
-                None
-            }
-        }
-        AppState::PerfTop => {
-            if app.filtering() {
-                Some(Action::InputEntry(s))
-            } else {
-                None
-            }
+        | AppState::Memory
+        | AppState::PerfTop
+            if app.filtering() =>
+        {
+            Some(Action::InputEntry(s))
         }
         _ => None,
     }


### PR DESCRIPTION
Simplify the logic in handle_input_entry by merging identical branches for AppState::Memory and AppState::PerfTop into a single match arm with a guard condition.