### PR TITLE
scx_rustland, scx_tickless: Remove redundant 'static lifetime

### DIFF
--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -29,7 +29,7 @@ use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::UserExitInfo;
 use stats::Metrics;
 
-const SCHEDULER_NAME: &'static str = "RustLand";
+const SCHEDULER_NAME: &str = "RustLand";
 
 /// scx_rustland: user-space scheduler written in Rust
 ///

--- a/scheds/rust/scx_tickless/src/main.rs
+++ b/scheds/rust/scx_tickless/src/main.rs
@@ -45,7 +45,7 @@ use scx_utils::UserExitInfo;
 use scx_utils::NR_CPU_IDS;
 use stats::Metrics;
 
-const SCHEDULER_NAME: &'static str = "scx_tickless";
+const SCHEDULER_NAME: &str = "scx_tickless";
 
 #[derive(Debug, Parser)]
 struct Opts {


### PR DESCRIPTION
String literals in const have implicit 'static lifetime, so the annotation is unnecessary. Also updated for consistency.