### PR TITLE
scx_bpf_unittests: fix build and run tests again

### DIFF
--- a/lib/scxtest/overrides.c
+++ b/lib/scxtest/overrides.c
@@ -118,3 +118,68 @@ int scx_minheap_pop(void *heap_ptr __attribute__((unused)),
 {
 	return 0;
 }
+
+__weak
+void *scx_minheap_alloc(u32 nr_elems __attribute__((unused)))
+{
+	return NULL;
+}
+
+__weak
+int scx_minheap_insert(void *heap_ptr __attribute__((unused)),
+		       u64 key __attribute__((unused)),
+		       u64 value __attribute__((unused)))
+{
+	return 0;
+}
+
+__weak
+u64 scx_atq_create_internal(int fifo __attribute__((unused)),
+			    unsigned long capacity __attribute__((unused)))
+{
+	return 0;
+}
+
+__weak
+int scx_atq_insert(void *atq_ptr __attribute__((unused)),
+		   u64 taskc_ptr __attribute__((unused)))
+{
+	return 0;
+}
+
+__weak
+int scx_atq_insert_vtime(void *atq __attribute__((unused)),
+			 u64 taskc_ptr __attribute__((unused)),
+			 u64 vtime __attribute__((unused)))
+{
+	return 0;
+}
+
+__weak
+int scx_atq_nr_queued(void *atq __attribute__((unused)))
+{
+	return 0;
+}
+
+__weak
+u64 scx_atq_pop(void *atq __attribute__((unused)))
+{
+	return 0;
+}
+
+__weak
+u64 scx_atq_peek(void *atq __attribute__((unused)))
+{
+	return 0;
+}
+
+__weak
+void *scx_task_alloc(struct task_struct *p __attribute__((unused)))
+{
+	return NULL;
+}
+
+__weak
+void scx_task_free(struct task_struct *p __attribute__((unused)))
+{
+}

--- a/lib/scxtest/overrides.h
+++ b/lib/scxtest/overrides.h
@@ -25,3 +25,34 @@
 
 /* This is a static helper for some reason, so we have to define it here. */
 #define bpf_get_prandom_u32() 0
+
+/* Arena spinlock stubs for unittest environment */
+#define arena_spin_lock(lock) 0
+#define arena_spin_unlock(lock) do { (void)(lock); } while(0)
+
+/* Define arena_spinlock_t as simple int for unittest environment */
+#define arena_spinlock_t int
+
+/* Stub out __arena for unittest environment */
+#define __arena
+
+
+
+/* Function declarations for BPF functions overridden in overrides.c */
+struct task_struct;
+void *scx_task_data(struct task_struct *p);
+void *scx_minheap_alloc(unsigned int nr_elems);
+int scx_minheap_insert(void *heap_ptr, unsigned long long key, unsigned long long value);
+struct scx_minheap_elem;
+int scx_minheap_pop(void *heap_ptr, struct scx_minheap_elem *helem);
+unsigned long long scx_atq_create_internal(int fifo, unsigned long capacity);
+int scx_atq_insert(void *atq_ptr, unsigned long long taskc_ptr);
+int scx_atq_insert_vtime(void *atq, unsigned long long taskc_ptr, unsigned long long vtime);
+int scx_atq_nr_queued(void *atq);
+unsigned long long scx_atq_pop(void *atq);
+unsigned long long scx_atq_peek(void *atq);
+void *scx_task_alloc(struct task_struct *p);
+void scx_task_free(struct task_struct *p);
+#define scx_atq_create_size(fifo, capacity) scx_atq_create_internal((fifo), (capacity))
+
+

--- a/scheds/rust/scx_p2dq/src/bpf/main.test.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.test.bpf.c
@@ -4,6 +4,9 @@
 
 #include <string.h>
 
+#include <scx/common.bpf.h>
+#include <lib/sdt_task_defs.h>
+
 #include "main.bpf.c"
 
 // per thread globals because the Rust test driver has multiple threads


### PR DESCRIPTION
These tests were disabled recently because of missing arena stubs. Add them as stubs (for now) and re-enable the tests.

I want to start using these tests in scx_chaos to test for correct behaviour without the verifier interfering, which will likely require not stubbing the arena code. But this is good enough for now.

Test plan:
- `cargo test -p scx_bpf_unittests`
- CI