### PR TITLE
scxcash: Bump edition to 2021

### DIFF
--- a/tools/scxcash/Cargo.toml
+++ b/tools/scxcash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scxcash"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 authors = ["Kumar Kartikeya Dwivedi <memxor@gmail.com>"]
 license = "GPL-2.0-only"
 repository = "https://github.com/sched-ext/scx"

--- a/tools/scxcash/src/monitors.rs
+++ b/tools/scxcash/src/monitors.rs
@@ -1,10 +1,10 @@
 // Cache monitor trait definitions and implementations.
 
 use anyhow::{Context, Result};
-use libbpf_rs::AsRawLibbpf;
 use libbpf_rs::libbpf_sys;
 use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::SkelBuilder;
+use libbpf_rs::AsRawLibbpf;
 use libbpf_rs::{PerfBuffer, PerfBufferBuilder};
 use libbpf_rs::{RingBuffer, RingBufferBuilder};
 use log::trace;
@@ -88,7 +88,11 @@ impl<'a> SoftDirtyCacheMonitor<'a> {
                     unsafe { &*(data.as_ptr() as *const _) };
                 trace!(
                     "soft-dirty fault timestamp={} pid={} tid={} cpu={} addr=0x{:x}",
-                    ev.timestamp, ev.pid, ev.tid, ev.cpu, ev.address
+                    ev.timestamp,
+                    ev.pid,
+                    ev.tid,
+                    ev.cpu,
+                    ev.address
                 );
                 events_cb
                     .borrow_mut()
@@ -269,7 +273,11 @@ impl<'a> PerfSampleMonitor<'a> {
                         unsafe { &*(data.as_ptr() as *const _) };
                     trace!(
                         "perf sample timestamp={} pid={} tid={} cpu={} addr=0x{:x}",
-                        ev.timestamp, ev.pid, ev.tid, ev.cpu, ev.address
+                        ev.timestamp,
+                        ev.pid,
+                        ev.tid,
+                        ev.cpu,
+                        ev.address
                     );
                     events_cb
                         .borrow_mut()


### PR DESCRIPTION
```rust
eric@eric-hp:~/dev/scx$ cargo build --release 
error: failed to load manifest for workspace member `/home/eric/dev/scx/tools/scxcash`
referenced by workspace at `/home/eric/dev/scx/Cargo.toml`

Caused by:
  failed to parse manifest at `/home/eric/dev/scx/tools/scxcash/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.84.1 (66221abde 2024-11-19)).
  Consider adding `cargo-features = ["edition2024"]` to the top of Cargo.toml (above the [package] table) to tell Cargo you are opting in to use this unstable feature.
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
eric@eric-hp:~/dev/scx$ 
```