### PR TITLE
scx_rustland_core: Add API to set scheduler name

### DIFF
--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -111,10 +111,11 @@ impl<'a> Scheduler<'a> {
         let bpf = BpfScheduler::init(
             open_object,
             open_opts.clone().into_bpf_open_opts(),
-            0,     // exit_dump_len (buffer size of exit info, 0 = default)
-            false, // partial (false = include all tasks)
-            false, // debug (false = debug mode off)
-            true,  // builtin_idle (true = allow BPF to use idle CPUs if available)
+            0,        // exit_dump_len (buffer size of exit info, 0 = default)
+            false,    // partial (false = include all tasks)
+            false,    // debug (false = debug mode off)
+            true,     // builtin_idle (true = allow BPF to use idle CPUs if available)
+            "rlfifo", // name of the scx ops
         )?;
         Ok(Self { bpf })
     }

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -165,6 +165,7 @@ impl<'a> Scheduler<'a> {
             opts.partial,
             opts.verbose,
             true, // Enable built-in idle CPU selection policy
+            "rustland",
         )?;
 
         info!(


### PR DESCRIPTION
Expose a `name: &str` parameter in `BpfScheduler::init` and write it into `struct_ops.rustland.name` before `scx_ops_load!()`.

Still wondering if we should also append the build version to the name, or just keep the exact string?

<img width="1848" height="326" alt="image" src="https://github.com/user-attachments/assets/8c1fc0cd-d160-4497-809b-f2743237c042" />
