### PR TITLE
meson: add deprecation warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,10 @@ project('sched_ext schedulers', 'c',
         license: 'GPL-2.0',
         meson_version : '>= 1.2.0',)
 
+warning('Meson builds are deprecated. Please switch to `cargo build` for Rust'
+        + ' schedulers and `make` for C schedulers. Meson will be removed in an'
+        + ' upcoming release.')
+
 fs = import('fs')
 
 cc = meson.get_compiler('c')


### PR DESCRIPTION
Meson as a build system is being replaced by a split between Cargo/gnumake for Rust/C schedulers. Add a warning before the next release to ask packagers to switch over to the replacements.

In a future release we'll add an error that can be overridden with a configuration option, and in the release after that we'll remove the Meson build entirely.

Test plan:
- CI - the new warning shows up.