### PR TITLE
scx_layered: userspace logic for memory-bandwidth based layer growth

### DIFF
--- a/scheds/rust/scx_layered/examples/membw.json
+++ b/scheds/rust/scx_layered/examples/membw.json
@@ -1,0 +1,47 @@
+[
+	{
+		"name": "first",
+		"matches": [
+			[{ "PcommPrefix": "htop" }],
+			[{ "PcommPrefix": "scxtop" }],
+			[{ "PcommPrefix": "bash" }],
+			[{ "PcommPrefix": "yes" }]
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range":  [5, 5],
+				"util_range": [0.4, 0.85],
+				"growth_algo": "RandomTopo",
+				"disallow_preempt_after_us": 0,
+				"protected": true,
+				"membw_gb": 25
+			}
+		}
+	},
+	{
+		"name": "second",
+		"matches": [
+			[{ "PcommPrefix": "stress-ng" }]
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range":  [5, 5],
+				"util_range": [0.4, 0.85],
+				"growth_algo": "RandomTopo",
+				"protected": false,
+				"membw_gb": 40
+			}
+		}
+	},
+	{
+		"name": "third",
+		"matches": [
+			[]
+		],
+		"kind": {
+			"Open": {
+				"growth_algo": "RandomTopo"
+			}
+		}
+	}
+]

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -182,6 +182,7 @@ struct cpu_ctx {
 	bool			is_protected;
 
 	u64			layer_usages[MAX_LAYERS][NR_LAYER_USAGES];
+	u64			layer_membw_agg[MAX_LAYERS][NR_LAYER_USAGES];
 	u64			gstats[NR_GSTATS];
 	u64			lstats[MAX_LAYERS][NR_LSTATS];
 	u64			ran_current_for;

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -160,6 +160,9 @@ pub enum LayerKind {
 
         #[serde(flatten)]
         common: LayerCommon,
+
+        #[serde(default)]
+        membw_gb: Option<u64>,
     },
     Grouped {
         util_range: (f64, f64),
@@ -170,6 +173,9 @@ pub enum LayerKind {
 
         #[serde(default)]
         cpus_range_frac: Option<(f64, f64)>,
+
+        #[serde(default)]
+        membw_gb: Option<u64>,
 
         #[serde(default)]
         protected: bool,

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -156,13 +156,13 @@ pub enum LayerKind {
         cpus_range_frac: Option<(f64, f64)>,
 
         #[serde(default)]
+        membw_gb: Option<u64>,
+
+        #[serde(default)]
         protected: bool,
 
         #[serde(flatten)]
         common: LayerCommon,
-
-        #[serde(default)]
-        membw_gb: Option<u64>,
     },
     Grouped {
         util_range: (f64, f64),

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -122,6 +122,7 @@ lazy_static! {
                     cpus_range: Some((0, 16)),
                     cpus_range_frac: None,
                     protected: false,
+                    membw_gb: None,
                     common: LayerCommon {
                         min_exec_us: 1000,
                         yield_ignore: 0.0,
@@ -196,6 +197,7 @@ lazy_static! {
                     util_range: (0.2, 0.8),
                     protected: false,
                     cpus_range_frac: None,
+                    membw_gb: None,
                     common: LayerCommon {
                         min_exec_us: 800,
                         yield_ignore: 0.0,
@@ -233,6 +235,7 @@ lazy_static! {
                     util_includes_open_cputime: true,
                     protected: false,
                     cpus_range_frac: None,
+                    membw_gb: None,
                     common: LayerCommon {
                         min_exec_us: 200,
                         yield_ignore: 0.0,

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -929,6 +929,9 @@ struct Stats {
     layer_utils: Vec<Vec<f64>>,
     prev_layer_usages: Vec<Vec<u64>>,
 
+    layer_membws: Vec<Vec<f64>>, // Estimated memory bandsidth consumption
+    prev_layer_membw_agg: Vec<Vec<u64>>, // Estimated aggregate membw consumption
+
     cpu_busy: f64, // Read from /proc, maybe higher than total_util
     prev_total_cpu: fb_procfs::CpuStat,
 
@@ -959,6 +962,21 @@ impl Stats {
         layer_usages
     }
 
+    // Same as above, but for aggregate memory bandwidth consumption.
+    fn read_layer_membw_agg(cpu_ctxs: &[bpf_intf::cpu_ctx], nr_layers: usize) -> Vec<Vec<u64>> {
+        let mut layer_membw_agg = vec![vec![0u64; NR_LAYER_USAGES]; nr_layers];
+
+        for cpu in 0..*NR_CPUS_POSSIBLE {
+            for layer in 0..nr_layers {
+                for usage in 0..NR_LAYER_USAGES {
+                    layer_membw_agg[layer][usage] += cpu_ctxs[cpu].layer_membw_agg[layer][usage];
+                }
+            }
+        }
+
+        layer_membw_agg
+    }
+
     fn new(
         skel: &mut BpfSkel,
         proc_reader: &fb_procfs::ProcReader,
@@ -978,7 +996,9 @@ impl Stats {
 
             total_util: 0.0,
             layer_utils: vec![vec![0.0; NR_LAYER_USAGES]; nr_layers],
+            layer_membws: vec![vec![0.0; NR_LAYER_USAGES]; nr_layers],
             prev_layer_usages: Self::read_layer_usages(&cpu_ctxs, nr_layers),
+            prev_layer_membw_agg: Self::read_layer_membw_agg(&cpu_ctxs, nr_layers),
 
             cpu_busy: 0.0,
             prev_total_cpu: read_total_cpu(proc_reader)?,
@@ -1029,9 +1049,11 @@ impl Stats {
             .collect();
 
         let cur_layer_usages = Self::read_layer_usages(&cpu_ctxs, self.nr_layers);
-        let cur_layer_utils: Vec<Vec<f64>> = cur_layer_usages
+        let cur_layer_membw_agg = Self::read_layer_membw_agg(&cpu_ctxs, self.nr_layers);
+
+        let compute_diff = | cur_agg: &Vec<Vec<u64>>, prev_agg: &Vec<Vec<u64>> | cur_agg
             .iter()
-            .zip(self.prev_layer_usages.iter())
+            .zip(prev_agg.iter())
             .map(|(cur, prev)| {
                 cur.iter()
                     .zip(prev.iter())
@@ -1039,9 +1061,13 @@ impl Stats {
                     .collect()
             })
             .collect();
-        let layer_utils: Vec<Vec<f64>> = cur_layer_utils
+
+        let cur_layer_utils: Vec<Vec<f64>> = compute_diff(&cur_layer_usages, &self.prev_layer_usages);
+        let cur_layer_membw: Vec<Vec<f64>> = compute_diff(&cur_layer_membw_agg, &self.prev_layer_membw_agg);
+
+        let metric_decay = | cur_metric: Vec<Vec<f64>>, prev_metric: &Vec<Vec<f64>>| cur_metric
             .iter()
-            .zip(self.layer_utils.iter())
+            .zip(prev_metric.iter())
             .map(|(cur, prev)| {
                 cur.iter()
                     .zip(prev.iter())
@@ -1052,6 +1078,9 @@ impl Stats {
                     .collect()
             })
             .collect();
+
+        let layer_utils: Vec<Vec<f64>> = metric_decay(cur_layer_utils, &self.layer_utils);
+        let layer_membws: Vec<Vec<f64>> = metric_decay(cur_layer_membw, &self.layer_membws);
 
         let cur_total_cpu = read_total_cpu(proc_reader)?;
         let cpu_busy = calc_util(&cur_total_cpu, &self.prev_total_cpu)?;
@@ -1075,7 +1104,9 @@ impl Stats {
                 .map(|x| x.iter().take(LAYER_USAGE_SUM_UPTO + 1).sum::<f64>())
                 .sum(),
             layer_utils,
+            layer_membws,
             prev_layer_usages: cur_layer_usages,
+            prev_layer_membw_agg: cur_layer_membw_agg,
 
             cpu_busy,
             prev_total_cpu: cur_total_cpu,
@@ -2492,6 +2523,25 @@ impl<'a> Scheduler<'a> {
         Ok(())
     }
 
+    fn clamp_target_by_membw(&self, layer: &Layer, membw_limit: usize, last_membw: usize, low: usize, high: usize) -> usize {
+            let last_membw_percpu = last_membw / layer.cpus.weight();
+
+            // If there's no way we're hitting the limit, we're good.
+            if last_membw_percpu * high < membw_limit {
+                return high;
+            }
+
+            // If there's no way to drop our memory usage down enough,
+            // pin the target CPUs to low and drop a warning.
+            if last_membw_percpu * low > membw_limit {
+                warn!("cannot satisfy memory bw limit for layer {}", layer.name);
+                return low;
+            }
+
+            // Clamped membw is between low and high, clamp high.
+            return membw_limit / last_membw_percpu;
+    }
+
     /// Calculate how many CPUs each layer would like to have if there were
     /// no competition. The CPU range is determined by applying the inverse
     /// of util_range and then capping by cpus_range. If the current
@@ -2510,12 +2560,14 @@ impl<'a> Scheduler<'a> {
                     util_range,
                     cpus_range,
                     cpus_range_frac,
+                    membw_gb,
                     ..
                 }
                 | LayerKind::Grouped {
                     util_range,
                     cpus_range,
                     cpus_range_frac,
+                    membw_gb,
                     ..
                 } => {
                     // A grouped layer can choose to include open cputime
@@ -2532,7 +2584,14 @@ impl<'a> Scheduler<'a> {
 
                     let util = if util < 0.01 { 0.0 } else { util };
                     let low = (util / util_range.1).ceil() as usize;
-                    let high = ((util / util_range.0).floor() as usize).max(low);
+                    let mut high = ((util / util_range.0).floor() as usize).max(low);
+
+                    if let Some(membw_limit) = membw_gb {
+                        let membw_cpus = &self.sched_stats.layer_membws[idx];
+                        let last_membw = membw_cpus.into_iter().map(|x: &f64| *x as usize).sum();
+                        high = self.clamp_target_by_membw(&layer, (*membw_limit * 1024_u64.pow(3)) as usize, last_membw, low, high);
+                    }
+
                     let target = layer.cpus.weight().clamp(low, high);
                     let cpus_range =
                         resolve_cpus_pct_range(cpus_range, cpus_range_frac, nr_cpus).unwrap();

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -25,6 +25,7 @@ use crate::bpf_intf;
 use crate::BpfStats;
 use crate::Layer;
 use crate::Stats;
+use crate::LayerKind;
 use crate::LAYER_USAGE_OPEN;
 use crate::LAYER_USAGE_PROTECTED;
 use crate::LAYER_USAGE_PROTECTED_PREEMPT;
@@ -209,6 +210,8 @@ pub struct LayerStats {
     pub llc_fracs: Vec<f64>,
     #[stat(desc = "Per-LLC average latency")]
     pub llc_lats: Vec<f64>,
+    #[stat(desc = "Layer memory bandwidth as a % of total allowed (0 for \"no limit\"")]
+    pub membw_pct: f64,
 }
 
 impl LayerStats {
@@ -238,6 +241,23 @@ impl LayerStats {
             .iter()
             .take(LAYER_USAGE_SUM_UPTO + 1)
             .sum::<f64>();
+
+        let membw_frac = match &layer.kind {
+            // Open layer's can't have a memory BW limit.
+            LayerKind::Open { .. } => 0.0,
+            LayerKind::Confined { membw_gb, ..} |
+            LayerKind::Grouped { membw_gb, ..} => {
+                // Check if we have set a memory BW limit.
+                if let Some(membw_limit_gb) = membw_gb {
+                    stats.layer_membws[lidx]
+                            .iter()
+                            .take(LAYER_USAGE_SUM_UPTO + 1)
+                            .sum::<f64>() / ((*membw_limit_gb * 1024_u64.pow(3))as f64)
+                } else {
+                    0.0
+                }
+            }
+        };
 
         Self {
             index: lidx,
@@ -308,6 +328,7 @@ impl LayerStats {
                 .iter()
                 .map(|lstats| lstats[LLC_LSTAT_LAT] as f64 / 1_000_000_000.0)
                 .collect(),
+            membw_pct: membw_frac * 100.0,
         }
     }
 


### PR DESCRIPTION
Add a new config option and related logic for throttling CPU growth based on its memory bandwidth consumption. The new logic uses the size of memory traffic reported by the kernel to prevent the growth or even shrink layers that are consuming memory bus bandwidth above a user-defined limit.


This code is currently a no-op, as the BPF side does not do the necessary tracking. The code for tracking memory memory bandwidth consumption on the BPF side will be added as a separate patch.