### PR TITLE
scx_p2dq: Refactor enqueue for unselected tasks

### DIFF
--- a/scheds/rust/scx_chaos/src/lib.rs
+++ b/scheds/rust/scx_chaos/src/lib.rs
@@ -431,10 +431,6 @@ impl Builder<'_> {
 
         let rodata = open_skel.maps.rodata_data.as_mut().unwrap();
 
-        // TODO: figure out how to abstract waking a CPU in enqueue properly, but for now disable
-        // this codepath
-        rodata.p2dq_config.select_idle_in_enqueue = MaybeUninit::new(false);
-
         if self.p2dq_opts.queued_wakeup {
             open_skel.struct_ops.chaos_mut().flags |= *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP;
         }

--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -122,7 +122,6 @@ const volatile struct {
 	bool interactive_sticky;
 	bool keep_running_enabled;
 	bool kthreads_local;
-	bool select_idle_in_enqueue;
 } p2dq_config = {
 	.sched_mode = MODE_DEFAULT,
 	.nr_dsqs_per_llc = 3,
@@ -138,7 +137,6 @@ const volatile struct {
 	.interactive_sticky = false,
 	.keep_running_enabled = true,
 	.kthreads_local = true,
-	.select_idle_in_enqueue = true,
 };
 
 const volatile u32 debug = 2;
@@ -992,8 +990,7 @@ static void async_p2dq_enqueue(struct enqueue_promise *ret,
 	}
 
 	// If an idle CPU hasn't been found in select_cpu find one now
-	if (p2dq_config.select_idle_in_enqueue &&
-	    !__COMPAT_is_enq_cpu_selected(enq_flags)) {
+	if (!__COMPAT_is_enq_cpu_selected(enq_flags)) {
 		cpu = pick_idle_cpu(p,
 				    taskc,
 				    cpu,

--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -141,7 +141,7 @@ pub struct SchedulerOpts {
     #[clap(long, action = clap::ArgAction::SetTrue)]
     pub wakeup_llc_migrations: bool,
 
-    /// Allow selecting idle in enqueue path.
+    /// **DEPRECATED*** Allow selecting idle in enqueue path.
     #[clap(long, action = clap::ArgAction::SetTrue)]
     pub select_idle_in_enqueue: bool,
 
@@ -314,8 +314,6 @@ macro_rules! init_open_skel {
             rodata.p2dq_config.freq_control = MaybeUninit::new(opts.freq_control);
             rodata.p2dq_config.interactive_sticky = MaybeUninit::new(opts.interactive_sticky);
             rodata.p2dq_config.keep_running_enabled = MaybeUninit::new(opts.keep_running);
-            rodata.p2dq_config.select_idle_in_enqueue =
-                MaybeUninit::new(opts.select_idle_in_enqueue);
 
             rodata.debug = verbose as u32;
             rodata.nr_cpu_ids = *NR_CPU_IDS as u32;


### PR DESCRIPTION
Update enqueue so CPU selection is always run in enqueue if a task has not been selected. This is needed because p2dq always reenqueues on cpu_release.