### PR TITLE
meson: extend deprecation warning with link to gh discussion

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,8 @@ project('sched_ext schedulers', 'c',
 
 warning('Meson builds are deprecated. Please switch to `cargo build` for Rust'
         + ' schedulers and `make` for C schedulers. Meson will be removed in an'
-        + ' upcoming release.')
+        + ' upcoming release. Please report any issues packaing for distributions'
+        + ' at https://github.com/sched-ext/scx/discussions/2731')
 
 fs = import('fs')
 


### PR DESCRIPTION
Add a link to the Meson deprecation warning so distro packagers know where to report issues.

Test plan:
```
jake@rooster:/data/users/jake/repos/scx/ > meson setup build
The Meson build system
Version: 1.7.2
Source dir: /data/users/jake/repos/scx
Build dir: /data/users/jake/repos/scx/build
Build type: native build
Project name: sched_ext schedulers
Project version: 1.0.15
C compiler for the host machine: gcc (gcc 14.3.0 "gcc (GCC) 14.3.0")
C linker for the host machine: gcc ld.bfd 2.44
Host machine cpu family: x86_64
Host machine cpu: x86_64
meson.build:7: WARNING: Meson builds are deprecated. Please switch to `cargo build` for Rust schedulers and `make` for C schedulers. Meson will be removed in an upcoming release. Please report any issues packaing for distributions at https://github.com/sched-ext/scx/discussions/2731
Program clang found: YES
(/nix/store/3awwcrqv9lpcq553zs2zb7y0mr5niswd-clang-wrapper-19.1.7/bin/clang)
```