### PR TITLE
scxtop: Add scx_collect_stats helper

### DIFF
--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -10,6 +10,8 @@
 typedef unsigned char	   u8;
 typedef unsigned int	   u32;
 typedef unsigned long long u64;
+typedef long long	   s64;
+struct scx_event_stats;
 #endif
 #include <stdbool.h>
 
@@ -244,6 +246,21 @@ struct task_ctx {
 
 struct schedule_stop_trace_args {
 	u64 stop_timestamp;
+};
+
+// Simplified sched_ext stats
+struct scxtop_sched_ext_stats {
+	s64 select_cpu_fallback;
+	s64 dispatch_local_dsq_offline;
+	s64 dispatch_keep_last;
+	s64 enq_skip_exiting;
+	s64 enq_skip_migration_disabled;
+	s64 timestamp_ns; // When these stats were collected
+};
+
+// Syscall args for collecting sched_ext stats
+struct collect_scx_stats_args {
+	struct scxtop_sched_ext_stats stats;
 };
 
 struct layered_task_ctx {

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -936,6 +936,26 @@ int schedule_stop_trace(struct schedule_stop_trace_args *args)
 	return 0;
 }
 
+SEC("syscall")
+int collect_scx_stats(struct collect_scx_stats_args *args)
+{
+	struct scx_event_stats kernel_stats = {};
+
+	scx_bpf_events(&kernel_stats, sizeof(kernel_stats));
+
+	args->stats.select_cpu_fallback =
+		kernel_stats.SCX_EV_SELECT_CPU_FALLBACK;
+	args->stats.dispatch_local_dsq_offline =
+		kernel_stats.SCX_EV_DISPATCH_LOCAL_DSQ_OFFLINE;
+	args->stats.dispatch_keep_last = kernel_stats.SCX_EV_DISPATCH_KEEP_LAST;
+	args->stats.enq_skip_exiting   = kernel_stats.SCX_EV_ENQ_SKIP_EXITING;
+	args->stats.enq_skip_migration_disabled =
+		kernel_stats.SCX_EV_ENQ_SKIP_MIGRATION_DISABLED;
+	args->stats.timestamp_ns = bpf_ktime_get_ns();
+
+	return 0;
+}
+
 SEC("tp_btf/ipi_send_cpu")
 int BPF_PROG(on_ipi_send_cpu, u32 cpu, void *callsite, void *callback)
 {

--- a/tools/scxtop/src/util.rs
+++ b/tools/scxtop/src/util.rs
@@ -3,6 +3,7 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
+use crate::bpf_intf;
 use anyhow::Result;
 use nix::time::{clock_gettime, ClockId};
 use nix::unistd::{getuid, Uid};
@@ -210,6 +211,17 @@ pub fn get_capability_warning_message() -> Vec<String> {
     }
 
     messages
+}
+
+pub fn default_scxtop_sched_ext_stats() -> bpf_intf::scxtop_sched_ext_stats {
+    bpf_intf::scxtop_sched_ext_stats {
+        select_cpu_fallback: 0,
+        dispatch_local_dsq_offline: 0,
+        dispatch_keep_last: 0,
+        enq_skip_exiting: 0,
+        enq_skip_migration_disabled: 0,
+        timestamp_ns: 0,
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add helper to use scx_collect_stats to render scheduler stats in the scheduler TUI view.

<img width="960" height="761" alt="2025-09-09-06:51:42" src="https://github.com/user-attachments/assets/7a0f3649-b66b-46e7-85b7-893d2be223c6" />
