### PR TITLE
lib: topology: Add topo_cpu_to_llc_id().

### DIFF
--- a/lib/topology.bpf.c
+++ b/lib/topology.bpf.c
@@ -438,3 +438,25 @@ int topo_print_by_level(void)
 
 	return 0;
 }
+
+__maybe_unused
+s64 topo_cpu_to_llc_id(u32 cpu)
+{
+	topo_ptr topo;
+	u64 llc_id;
+
+	if (cpu >= NR_CPUS) {
+		bpf_printk("invalid CPU ID");
+		return -EINVAL;
+	}
+
+	topo = (topo_ptr)topo_nodes[TOPO_CPU][cpu];
+	if (!topo) {
+		bpf_printk("cpu is offline");
+		return -EINVAL;
+	}
+
+	/* TOPO_CPU -> TOPO_CORE -> TOPO_LLC */
+	llc_id = topo->parent->parent->id;
+	return llc_id;
+}

--- a/scheds/include/lib/topology.h
+++ b/scheds/include/lib/topology.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <lib/cpumask.h>
+
 struct topology;
 typedef struct topology __arena * topo_ptr;
 
@@ -76,5 +78,7 @@ static inline int topo_iter_start(struct topo_iter *iter)
 #define TOPO_FOR_EACH_LLC(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_LLC)
 #define TOPO_FOR_EACH_CORE(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_CORE)
 #define TOPO_FOR_EACH_CPU(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_CPU)
+
+s64 topo_cpu_to_llc_id(u32 cpu);
 
 extern u64 topo_nodes[TOPO_MAX_LEVEL][NR_CPUS];


### PR DESCRIPTION
Add a utility function, topo_cpu_to_llc_id(), that returns an LLC ID from a CPU ID. When the input CPU ID is invalid or offline, topo_cpu_to_llc_id() returns -EINVAL.