### PR TITLE
load_balance: Remove duplicate node count check

### DIFF
--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -869,7 +869,7 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
         //              with a positive load imbalance):
         //                      For each "pull domain" (i.e. each domain in
         //                      "pull node" with a negative load imbalance):
-        //                              load = try_move_load(push_dom -> pull-dom)
+        //                              load = try_move_load(push_dom -> pull_dom)
         //                              if load > 0
         //                                      goto restart_pushext_pull
         //

--- a/scheds/rust/scx_rusty/src/load_balance.rs
+++ b/scheds/rust/scx_rusty/src/load_balance.rs
@@ -853,10 +853,6 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
     }
 
     fn balance_between_nodes(&mut self) -> Result<()> {
-        if self.nodes.len() < 2 {
-            return Ok(());
-        }
-
         debug!("Node <-> Node LB started");
 
         // Keep track of the nodes we're pushing load from, and pulling load to,

--- a/scheds/rust/scx_wd40/src/load_balance.rs
+++ b/scheds/rust/scx_wd40/src/load_balance.rs
@@ -868,7 +868,7 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
         //              with a positive load imbalance):
         //                      For each "pull domain" (i.e. each domain in
         //                      "pull node" with a negative load imbalance):
-        //                              load = try_move_load(push_dom -> pull-dom)
+        //                              load = try_move_load(push_dom -> pull_dom)
         //                              if load > 0
         //                                      goto restart_pushext_pull
         //

--- a/scheds/rust/scx_wd40/src/load_balance.rs
+++ b/scheds/rust/scx_wd40/src/load_balance.rs
@@ -852,10 +852,6 @@ impl<'a, 'b> LoadBalancer<'a, 'b> {
     }
 
     fn balance_between_nodes(&mut self) -> Result<()> {
-        if self.nodes.len() < 2 {
-            return Ok(());
-        }
-
         debug!("Node <-> Node LB started");
 
         // Keep track of the nodes we're pushing load from, and pulling load to,


### PR DESCRIPTION
In `perform_balancing`, we already check `self.dom_group.nr_nodes() > 1`
before calling `balance_between_nodes`. Inside `balance_between_nodes`,
there is another check on `self.nodes.len() < 2`.

However, as seen in `create_domain_hierarchy`, the length of
`self.nodes` is directly determined by `self.dom_group.nr_nodes()`.
This makes the second check redundant.

This commit removes the check in `balance_between_nodes`, while keeping
the one in `perform_balancing` to avoid unnecessary function calls.