### PR TITLE
README.md: update systemd howto

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ $ scx_rustland --monitor 5
 
 ## systemd services
 
-See: [services](services/README.md)
+See: [scx_loader](tools/scx_loader/README.md) and [scxctl](tools/scxctl/README.md)
 
 ## Kernel Feature Status
 


### PR DESCRIPTION
PR #2769 removed support for scx.service.


Let README.md indicate the current solutions. 