### PR TITLE
scx_rustland_core: Return prev_cpu if no idle CPU

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -539,14 +539,15 @@ static s32 pick_idle_cpu(const struct task_struct *p, s32 prev_cpu)
 	if (cpu >= 0)
 		goto out_put_cpumask;
 
-	/*
-	 * If all the previous attempts have failed, dispatch the task to the
-	 * first CPU that will become available.
-	 */
-	cpu = -EBUSY;
-
 out_put_cpumask:
 	scx_bpf_put_cpumask(idle_smtmask);
+
+	/*
+	 * If we couldn't find any CPU, or in case of error, return the
+	 * previously used CPU.
+	 */
+	if(cpu < 0)
+		cpu = prev_cpu;
 
 	return cpu;
 }


### PR DESCRIPTION
If no idle CPU is available, fall back to prev_cpu to ensure a valid execution target and prevent errors.

Ref: scx/scheds/rust/scx_bpfland/src/bpf/main.bpf.c