### PR TITLE
scx_rustland_core: Remove redundant 'static lifetime

### DIFF
--- a/rust/scx_rustland_core/src/lib.rs
+++ b/rust/scx_rustland_core/src/lib.rs
@@ -1,4 +1,4 @@
-pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 mod alloc;
 pub use alloc::ALLOCATOR;


### PR DESCRIPTION
String literals in const have implicit 'static lifetime, so the annotation is unnecessary.