### PR TITLE
scx_raw_pmu: use include_dir to embed json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,6 +1512,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,11 +2984,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "csv",
- "procfs 0.18.0",
+ "include_dir",
+ "procfs 0.15.1",
  "regex",
  "scx_utils",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/rust/scx_raw_pmu/Cargo.toml
+++ b/rust/scx_raw_pmu/Cargo.toml
@@ -7,11 +7,15 @@ publish = false
 [dependencies]
 anyhow = "1.0.65"
 csv = "1.3.1"
-procfs = "0.18"
+include_dir = "0.7.4"
+procfs = "0.15.1"
 regex = "1.11.2"
+scx_utils = { path = "../scx_utils", version = "1.0.19" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-scx_utils = { path = "../scx_utils", version = "1.0.19" }
+
+[dev-dependencies]
+tempfile = "3.19.1"
 
 [build-dependencies]
 scx_utils = { path = "../scx_utils", version = "1.0.19" }

--- a/rust/scx_raw_pmu/src/lib.rs
+++ b/rust/scx_raw_pmu/src/lib.rs
@@ -1,3 +1,4 @@
 mod json;
 pub use json::PMUManager;
 pub use json::PMUSpec;
+mod resources;

--- a/rust/scx_raw_pmu/src/resources.rs
+++ b/rust/scx_raw_pmu/src/resources.rs
@@ -1,0 +1,139 @@
+use include_dir::{include_dir, Dir};
+use std::borrow::Cow;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+static ARCH_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/arch");
+
+#[derive(Debug)]
+pub(crate) enum ResourceDir {
+    Embedded(&'static Dir<'static>),
+    Filesystem(PathBuf),
+}
+
+impl Default for ResourceDir {
+    fn default() -> Self {
+        ResourceDir::Embedded(&ARCH_DIR)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ResourceFile {
+    Embedded(&'static include_dir::File<'static>),
+    Filesystem { name: String, full_path: PathBuf },
+}
+
+impl ResourceFile {
+    pub fn path(&self) -> &str {
+        match self {
+            ResourceFile::Embedded(file) => file.path().to_str().unwrap(),
+            ResourceFile::Filesystem { name, .. } => name,
+        }
+    }
+
+    pub fn read(&self) -> io::Result<Cow<'static, [u8]>> {
+        match self {
+            ResourceFile::Embedded(file) => Ok(Cow::Borrowed(file.contents())),
+            ResourceFile::Filesystem { full_path, .. } => {
+                let contents = fs::read(full_path)?;
+                Ok(Cow::Owned(contents))
+            }
+        }
+    }
+}
+
+impl ResourceDir {
+    pub(crate) fn new_filesystem(path: PathBuf) -> Self {
+        ResourceDir::Filesystem(path)
+    }
+
+    pub(crate) fn get_file(&self, path: &str) -> io::Result<ResourceFile> {
+        match self {
+            ResourceDir::Embedded(dir) => {
+                let full_path = dir.path().join(path);
+                let file = ARCH_DIR
+                    .get_file(full_path.to_str().unwrap())
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::NotFound,
+                            "file not found in embedded resources",
+                        )
+                    })?;
+                Ok(ResourceFile::Embedded(file))
+            }
+            ResourceDir::Filesystem(base_path) => {
+                let full_path = base_path.join(path);
+                if full_path.is_file() {
+                    let name = path.to_string();
+                    Ok(ResourceFile::Filesystem { name, full_path })
+                } else {
+                    Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        format!("file not found: {}", full_path.display()),
+                    ))
+                }
+            }
+        }
+    }
+
+    pub(crate) fn get_dir(&self, path: &str) -> io::Result<ResourceDir> {
+        match self {
+            ResourceDir::Embedded(dir) => {
+                let full_path = dir.path().join(path);
+                let subdir = ARCH_DIR
+                    .get_dir(full_path.to_str().unwrap())
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::NotFound,
+                            "directory not found in embedded resources",
+                        )
+                    })?;
+                Ok(ResourceDir::Embedded(subdir))
+            }
+            ResourceDir::Filesystem(base_path) => {
+                let full_path = base_path.join(path);
+                if full_path.is_dir() {
+                    Ok(ResourceDir::Filesystem(full_path))
+                } else {
+                    Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        format!("directory not found: {}", full_path.display()),
+                    ))
+                }
+            }
+        }
+    }
+
+    pub(crate) fn files(&self) -> io::Result<Vec<ResourceFile>> {
+        match self {
+            ResourceDir::Embedded(dir) => {
+                let mut files = Vec::new();
+                for file in dir.files() {
+                    files.push(ResourceFile::Embedded(file));
+                }
+                Ok(files)
+            }
+            ResourceDir::Filesystem(base_path) => {
+                let mut files = Vec::new();
+                for entry in fs::read_dir(base_path)? {
+                    let entry = entry?;
+                    let path = entry.path();
+                    if path.is_file() {
+                        let name = path.file_name().unwrap().to_str().unwrap().to_string();
+                        files.push(ResourceFile::Filesystem {
+                            name,
+                            full_path: path,
+                        });
+                    }
+                }
+                Ok(files)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn extract_arch_resources(path: &std::path::Path) -> Result<(), std::io::Error> {
+    ARCH_DIR.extract(path)
+}

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -3526,7 +3526,7 @@ fn create_perf_fds(skel: &mut BpfSkel, event: u64) -> Result<()> {
 
 // Set up the counters
 fn setup_membw_tracking(skel: &mut OpenBpfSkel) -> Result<u64> {
-    let pmumanager = PMUManager::new(None)?;
+    let pmumanager = PMUManager::new()?;
     let codename = &pmumanager.codename as &str;
 
     let pmuspec = match codename {


### PR DESCRIPTION
scx_raw_pmu needs a bunch of JSON files. Currently these are expected to be distributed with the crate/scheduler that uses them, but this is annoying.

Use the `include_dir!` macro to package all of these resources into the crate's library, such that they can be used directly in other crates. Add an abstraction `ResourceDir` which wraps both this `include_dir::Dir` method and a regular Filesystem method for cases where the user wants to override. It's not clear this is needed, but it's less of an API break.

Test plan:
- CI
- Enabled the existing test of the filesystem based method by extracting the included files into a tempdir.
- Added a new similar test that uses the included files from memory.