### PR TITLE
scxcash: Add task hint backend

### DIFF
--- a/tools/scxcash/build.rs
+++ b/tools/scxcash/build.rs
@@ -5,6 +5,7 @@ fn main() {
         .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
         .enable_skel("src/bpf/soft_dirty.bpf.c", "bpf")
         .enable_skel("src/bpf/perf_sample.bpf.c", "perf_bpf")
+        .enable_skel("src/bpf/hints_tls.bpf.c", "hints_bpf")
         .compile_link_gen()
         .unwrap();
 }

--- a/tools/scxcash/src/bpf/hints_tls.bpf.c
+++ b/tools/scxcash/src/bpf/hints_tls.bpf.c
@@ -1,0 +1,49 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. */
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "intf.h"
+
+char _license[] SEC("license") = "GPL";
+
+struct task_hint {
+    __u64 hint;
+    __u64 __reserved[3];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_TASK_STORAGE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__type(key, int);
+	__type(value, struct task_hint);
+} scx_layered_task_hint_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 4 * 1024 * 1024);
+} hints_events SEC(".maps");
+
+/* Trace on kfunc map_update path; use fentry to see updates before copy. */
+SEC("fentry/bpf_pid_task_storage_update_elem")
+int BPF_PROG(handle_map_update, struct bpf_map *map, void *key, void *value, u64 flags)
+{
+	struct task_struct *current = bpf_get_current_task_btf();
+	struct hints_event *e;
+	u64 hint_value = 0;
+
+	if (map != (void *)&scx_layered_task_hint_map)
+		return 0;
+	bpf_probe_read_kernel(&hint_value, sizeof(hint_value), value);
+
+	e = bpf_ringbuf_reserve(&hints_events, sizeof(*e), 0);
+	if (!e)
+		return 0;
+	e->timestamp = bpf_ktime_get_ns();
+	e->pid = current->tgid;
+	e->tid = current->pid;
+	e->cpu = bpf_get_smp_processor_id();
+	e->hint_value = hint_value;
+	bpf_ringbuf_submit(e, 0);
+	return 0;
+}

--- a/tools/scxcash/src/bpf/intf.h
+++ b/tools/scxcash/src/bpf/intf.h
@@ -27,4 +27,13 @@ struct perf_sample_event {
     u64 address; /* placeholder */
 };
 
+/* Emitted on task local storage map update; reports first 8 bytes of value. */
+struct hints_event {
+    u64 timestamp;
+    u32 pid;
+    u32 tid;
+    u32 cpu;
+    u64 hint_value;
+};
+
 #endif /* __INTF_H */


### PR DESCRIPTION
Add a backend for emitting events for updates to scx_layered's task hint map, so that we can track precisely the updates to the hint values happening across the system with the monotonic clock timestamps since system boot and correlate with other events in user space.