### PR TITLE
scx_rusty: Initialize bpf wrapper var

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -1649,7 +1649,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rusty_init_task, struct task_struct *p,
 {
 	u64 now = scx_bpf_now();
 	struct task_struct *p_map;
-	struct bpfmask_wrapper wrapper;
+	struct bpfmask_wrapper wrapper = {};
 	struct bpfmask_wrapper *mask_map_value;
 	struct task_ctx *taskc;
 	long ret;


### PR DESCRIPTION
Building scx_rusty with cargo emits the following warning:

```
warning: scx_rusty@1.0.16: src/bpf/main.bpf.c:1680:50: warning: variable 'wrapper' is uninitialized when passed as a const pointer argument here [-Wuninitialized-const-pointer]
warning: scx_rusty@1.0.16:  1680 |         ret = bpf_map_update_elem(&task_masks, &p_map, &wrapper, 0 /*BPF NOEXIST*/);
warning: scx_rusty@1.0.16:       |                                                         ^~~~~~~
warning: scx_rusty@1.0.16: 1 warning generated.
```

This commit initializes 'wrapper' to an empty struct to remove the warning.

Signed-off-by: Fredrik Lönnegren <fredrik@frelon.se>
