### PR TITLE
CARGO_BUILD: extend information about fetch, test and cross compilation

### DIFF
--- a/CARGO_BUILD.md
+++ b/CARGO_BUILD.md
@@ -154,12 +154,87 @@ To make a scheduler or tool available system-wide, you can either:
 
 ---
 
-## 6. Summary
+## 6. Running tests
+
+To verify the correctness of the build, you can run tests:
+
+- For the entire workspace:
+  ```bash
+  cargo test
+  ```
+
+- For a specific scheduler:
+  ```bash
+  cargo test -p scx_flash
+  ```
+
+---
+
+## 7. Dependency management
+
+The workspace uses a shared `Cargo.lock` file.
+
+- To prefetch dependencies for offline builds:
+  ```bash
+  cargo fetch --locked
+  ```
+
+- To update dependencies:
+  ```bash
+  cargo update
+  ```
+
+---
+
+## 8. Cross-compilation
+
+You can build for different targets, for example **musl**:
+
+```bash
+cargo build --release --target x86_64-unknown-linux-musl
+```
+
+Make sure the target is installed first:
+
+```bash
+rustup target add x86_64-unknown-linux-musl
+```
+
+---
+
+## 9. Debugging
+
+
+- Enable backtraces:
+  ```bash
+  sudo env RUST_BACKTRACE=1 ./target/debug/scx_flash
+  ```
+
+- Enable debug logging:
+  ```bash
+  sudo env RUST_LOG=debug ./target/debug/scx_flash
+  ```
+
+---
+
+## 10. Cleaning up
+
+To remove build artifacts and start fresh:
+
+```bash
+cargo clean
+```
+
+---
+
+## 11. Summary
 
 - **Build everything**: `cargo build --release`
 - **Build one scheduler**: `cargo build --profile=<profile> -p <name>`
 - **Install from crates.io**: `cargo install <crate_name>`
 - **Make available system-wide**: copy binary to `/usr/local/bin` or add `~/.cargo/bin` to `PATH`
+- **Run tests**: `cargo test`
+- **Cross-compile**: `cargo build --target=<target>`
 - **Profiles available**: `release`, `release-tiny`, `release-fast`
 
 This approach allows you to build and test either the whole project at once or focus on a single scheduler or tool.


### PR DESCRIPTION
PR #2772 introduced a basic how-to guide for cargo. It is now being expanded to include, among other things:

- downloading dependencies for cargo

- testing and debugging

- cross-compilation for musl 