### PR TITLE
scx_raw_pmu: Set edition to 2021

### DIFF
--- a/rust/scx_raw_pmu/Cargo.toml
+++ b/rust/scx_raw_pmu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scx_raw_pmu"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Use the 2021 edition to avoid breaking the build in those distro that are not shipping a recent Rust toolchain (e.g., Ubuntu).