### PR TITLE
scx_rustland_core: Log user ringbuf drain return value

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -947,7 +947,10 @@ void BPF_STRUCT_OPS(rustland_dispatch, s32 cpu, struct task_struct *prev)
 	 * dispatch them on the target CPU decided by the user-space
 	 * scheduler.
 	 */
-	bpf_user_ringbuf_drain(&dispatched, handle_dispatched_task, NULL, BPF_RB_NO_WAKEUP);
+	s32 ret = bpf_user_ringbuf_drain(&dispatched,
+					 handle_dispatched_task, NULL, BPF_RB_NO_WAKEUP);
+	if (ret)
+		dbg_msg("User ringbuf drain error: %d", ret);
 
 	/*
 	 * Consume a task from the per-CPU DSQ.


### PR DESCRIPTION
~Check the return value of bpf_user_ringbuf_drain() in rustland_dispatch(). If draining fails, log the error and bail out early.~

Record the return value of bpf_user_ringbuf_drain() in rustland_dispatch() to help debug and validate ringbuf behavior.
Edit: Since these return values carry [useful information](https://docs.ebpf.io/linux/helper-function/bpf_user_ringbuf_drain/), I think it would be better to log them out as well.
