### PR TITLE
scx_rustland_core: Keep return style consistent

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -1168,7 +1168,7 @@ static int usersched_timer_fn(void *map, int *key, struct bpf_timer *timer)
 	if (err)
 		scx_bpf_error("Failed to arm stats timer");
 
-	return 0;
+	return err;
 }
 
 /*


### PR DESCRIPTION
Return the actual error code in usersched_timer_fn for consistency, though scx_bpf_error() already forces scheduler exit.