### PR TITLE
scx_rustland_core: Use dbg_msg instead of scx_bpf_error in cpu_to_dsq()

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -372,7 +372,7 @@ static bool usersched_has_pending_tasks(void)
 static u64 cpu_to_dsq(s32 cpu)
 {
 	if (cpu < 0 || cpu >= MAX_CPUS) {
-		scx_bpf_error("Invalid cpu: %d", cpu);
+		dbg_msg("Invalid cpu: %d", cpu);
 		return SHARED_DSQ;
 	}
 	return (u64)cpu;


### PR DESCRIPTION
Since cpu_to_dsq() should return SHARED_DSQ on invalid CPUs, using scx_bpf_error() would abort the scheduler. Switch to dbg_msg() to warn without exiting.