### PR TITLE
docs: Fix broken links

### DIFF
--- a/rust/scx_utils/src/bpf_builder.rs
+++ b/rust/scx_utils/src/bpf_builder.rs
@@ -30,7 +30,7 @@ use tracing_subscriber::{filter, layer::SubscriberExt, Layer};
 ///
 /// All sched_ext BPF implementations require `vmlinux.h` and many make use
 /// of common constructs such as
-/// [`user_exit_info`](https://github.com/sched-ext/scx/blob/main/scheds/include/common/user_exit_info.h).
+/// [`user_exit_info`](https://github.com/sched-ext/scx/blob/main/scheds/include/scx/user_exit_info.h).
 /// `BpfBuilder` makes these headers available when compiling BPF source
 /// code and generating bindings for it. The included headers can be browsed
 /// at <https://github.com/sched-ext/scx/tree/main/scheds/include>.

--- a/rust/scx_utils/src/ravg.rs
+++ b/rust/scx_utils/src/ravg.rs
@@ -7,9 +7,9 @@
 //!
 //! Rust userland utilities to access running averages tracked by BPF
 //! ravg_data. See
-//! [ravg.bpf.h](https://github.com/sched-ext/scx/blob/main/scheds/include/common/ravg.bpf.h)
+//! [ravg.bpf.h](https://github.com/sched-ext/scx/blob/main/scheds/include/scx/ravg.bpf.h)
 //! and
-//! [ravg_impl.bpf.h](https://github.com/sched-ext/scx/blob/main/scheds/include/common/ravg_impl.bpf.h)
+//! [ravg_impl.bpf.h](https://github.com/sched-ext/scx/blob/main/scheds/include/scx/ravg_impl.bpf.h)
 //! for details.
 
 /// Read the current running average


### PR DESCRIPTION
Some links in comments became invalid due to a directory rename. This commit updates those links according to the current locations of the files under scheds/include.