### PR TITLE
scx_layered: add TTL for layer membership

### DIFF
--- a/scheds/rust/scx_layered/examples/ttl.json
+++ b/scheds/rust/scx_layered/examples/ttl.json
@@ -1,0 +1,46 @@
+[
+	{
+		"name": "first",
+		"matches": [
+			[{ "PcommPrefix": "htop" }],
+			[{ "PcommPrefix": "scxtop" }],
+			[{ "PcommPrefix": "bash" }],
+			[{ "PcommPrefix": "yes" }]
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range":  [5, 5],
+				"util_range": [0.4, 0.85],
+				"growth_algo": "RandomTopo",
+				"disallow_preempt_after_us": 0,
+				"protected": true
+			}
+		}
+	},
+	{
+		"name": "second",
+		"matches": [
+			[{ "PcommPrefix": "stress-ng" }]
+		],
+		"kind": {
+			"Grouped": {
+				"cpus_range":  [5, 5],
+				"util_range": [0.4, 0.85],
+				"growth_algo": "RandomTopo",
+				"protected": false,
+				"member_expire_ms": 1000
+			}
+		}
+	},
+	{
+		"name": "third",
+		"matches": [
+			[]
+		],
+		"kind": {
+			"Open": {
+				"growth_algo": "RandomTopo"
+			}
+		}
+	}
+]

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -68,7 +68,12 @@ enum consts {
 	SCXCMD_COMLEN		= 13,
 	MAX_GPU_PIDS 		= 100000,
 
-	MEMBER_NOEXPIRE		= (u32)-1,
+};
+
+enum layer_membership {
+	MEMBER_NOEXPIRE		= (u64)-1,
+	MEMBER_EXPIRED		= (u64)-2,
+	MEMBER_CANTMATCH	= (u64)-3,
 };
 
 static inline void ___consts_sanity_check___(void) {

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -68,7 +68,7 @@ enum consts {
 	SCXCMD_COMLEN		= 13,
 	MAX_GPU_PIDS 		= 100000,
 
-	MEMBER_NOEXPIRE		= 0,
+	MEMBER_NOEXPIRE		= (u32)-1,
 };
 
 static inline void ___consts_sanity_check___(void) {

--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -67,6 +67,8 @@ enum consts {
 	SCXCMD_PREFIX		= 0x5C10,
 	SCXCMD_COMLEN		= 13,
 	MAX_GPU_PIDS 		= 100000,
+
+	MEMBER_NOEXPIRE		= 0,
 };
 
 static inline void ___consts_sanity_check___(void) {
@@ -364,6 +366,7 @@ struct layer {
 	bool			is_protected;
 	bool			periodically_refresh;
 	u8			cpuset[MAX_CPUS_U8];
+	u64			member_expire_ms;
 };
 
 struct scx_cmd {

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -698,7 +698,7 @@ int save_gpu_tgid_pid(void) {
 	if (!enable_gpu_support)
 		return 0;
 	struct task_struct *p = NULL;
-	struct task_ctx *taskc;
+	struct task_ctx *taskc, *parent;
 	u64 pid_tgid;
 	u32 pid, tid;
 	u64 timestamp = 0;
@@ -713,6 +713,13 @@ int save_gpu_tgid_pid(void) {
 			if(!bpf_map_lookup_elem(&gpu_tid, &tid)) {
 				trace("New GPU tid: %d, force to refresh layer", tid);
 				taskc->refresh_layer = true;
+			}
+
+			if(!bpf_map_lookup_elem(&gpu_tgid, &pid) && 
+				(parent = lookup_task_ctx_may_fail(p->parent)) && parent) {
+
+				trace("New GPU pid: %d, force to refresh layer", pid);
+				parent->refresh_layer = true;
 			}
 
 			timestamp = taskc->running_at;

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -144,6 +144,8 @@ pub struct LayerCommon {
     pub llcs: Vec<usize>,
     #[serde(default)]
     pub placement: LayerPlacement,
+    #[serde(default)]
+    pub member_expire_ms: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -150,6 +150,7 @@ lazy_static! {
                         perf: 1024,
                         nodes: vec![],
                         llcs: vec![],
+                        member_expire_ms: 0,
                         placement: LayerPlacement::Standard,
                     },
                 },
@@ -185,6 +186,7 @@ lazy_static! {
                         idle_resume_us: None,
                         nodes: vec![],
                         llcs: vec![],
+                        member_expire_ms: 0,
                         placement: LayerPlacement::Standard,
                     },
                 },
@@ -225,6 +227,7 @@ lazy_static! {
                         idle_resume_us: None,
                         nodes: vec![],
                         llcs: vec![],
+                        member_expire_ms: 0,
                         placement: LayerPlacement::Standard,
                     },
                 },
@@ -263,6 +266,7 @@ lazy_static! {
                         idle_resume_us: None,
                         nodes: vec![],
                         llcs: vec![],
+                        member_expire_ms: 0,
                         placement: LayerPlacement::Standard,
                     },
                 },
@@ -1747,6 +1751,7 @@ impl<'a> Scheduler<'a> {
                     disallow_preempt_after_us,
                     xllc_mig_min_us,
                     placement,
+                    member_expire_ms,
                     ..
                 } = spec.kind.common();
 
@@ -1771,6 +1776,7 @@ impl<'a> Scheduler<'a> {
                 layer.prev_over_idle_core.write(*prev_over_idle_core);
                 layer.growth_algo = growth_algo.as_bpf_enum();
                 layer.weight = *weight;
+                layer.member_expire_ms = *member_expire_ms;
                 layer.disallow_open_after_ns = match disallow_open_after_us.unwrap() {
                     v if v == u64::MAX => v,
                     v => v * 1000,


### PR DESCRIPTION
Layer membership for scx_layered is based on rules that are checked during tCertain layer membership conditions may change over the course of the scheduler's runtime. For example, the GPU matcher marks tasks that use NVIDIA API calls as "GPU tasks", but there are workloads that use GPUs once and never again. We want to mark some layers as having a Time-To-Live for its members, where layer membership is re-evaluated after a user-defined number of schedules. Add this per-layer TTL and check it during the .stopping() call to periodically trigger match_layer() for those tasks.