### PR TITLE
cargo: add xtask crate for repo scripts

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4617,6 +4617,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "simplelog",
+ "toml",
+]
+
+[[package]]
 name = "zbus"
 version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [ "rust/arenalib/arenalib",
     "tools/scxctl",
     "tools/scxtop",
     "tools/vmlinux_docify",
+    "tools/xtask",
 ]
 resolver = "2"
 

--- a/rust/arenalib/arenalib/Cargo.toml
+++ b/rust/arenalib/arenalib/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.65"
 libbpf-rs = "=0.26.0-beta.1"
 libbpf-sys = "=1.6.1"
 simplelog = "0.12"
-scx_utils = { path = "../../scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../scx_utils", version = "1.0.21" }
 
 [build-dependencies]
-scx_utils = { path = "../../scx_utils", version = "1.0.19" }
+scx_utils = { path = "../../scx_utils", version = "1.0.21" }

--- a/rust/scx_raw_pmu/Cargo.toml
+++ b/rust/scx_raw_pmu/Cargo.toml
@@ -10,12 +10,12 @@ csv = "1.3.1"
 include_dir = "0.7.4"
 procfs = "0.15.1"
 regex = "1.11.2"
-scx_utils = { path = "../scx_utils", version = "1.0.19" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+scx_utils = { path = "../scx_utils", version = "1.0.21" }
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.133"
 
 [dev-dependencies]
 tempfile = "3.19.1"
 
 [build-dependencies]
-scx_utils = { path = "../scx_utils", version = "1.0.19" }
+scx_utils = { path = "../scx_utils", version = "1.0.21" }

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+
+publish = false
+
+[package.metadata.scx]
+ci.use_clippy = true
+
+[dependencies]
+anyhow = "1.0.65"
+clap = { version = "4.5.28", features = ["derive"] }
+log = "0.4.17"
+regex = "1.11.2"
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.133"
+simplelog = "0.12"
+once_cell = "1.20.2"
+toml = "0.8.19"

--- a/tools/xtask/src/bump_versions.rs
+++ b/tools/xtask/src/bump_versions.rs
@@ -1,0 +1,274 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use anyhow::Result;
+use regex::Regex;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+
+use crate::get_cargo_metadata;
+use crate::get_rust_paths;
+
+pub fn bump_versions_command(packages: Vec<String>, all: bool) -> Result<()> {
+    // Determine target crates
+    let target_crates = if all {
+        get_all_workspace_crates()?
+    } else {
+        packages
+    };
+
+    if target_crates.is_empty() {
+        log::info!("No crates to bump.");
+        return Ok(());
+    }
+
+    log::info!("Analyzing workspace dependencies...");
+
+    // Get cargo metadata
+    let metadata = get_cargo_metadata()?;
+
+    // Build map of workspace crates
+    let workspace_member_ids: HashSet<String> = metadata["workspace_members"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|id| id.as_str().unwrap().to_string())
+        .collect();
+
+    let mut workspace_members = HashSet::new();
+    let mut crate_paths = HashMap::new();
+
+    for pkg in metadata["packages"].as_array().unwrap() {
+        let pkg_id = pkg["id"].as_str().unwrap();
+        let pkg_name = pkg["name"].as_str().unwrap();
+
+        if workspace_member_ids.contains(pkg_id) {
+            workspace_members.insert(pkg_name.to_string());
+            let manifest_path = PathBuf::from(pkg["manifest_path"].as_str().unwrap());
+            crate_paths.insert(pkg_name.to_string(), manifest_path);
+        }
+    }
+
+    // Validate target crates exist
+    for crate_name in &target_crates {
+        if !workspace_members.contains(crate_name) {
+            return Err(anyhow::anyhow!(
+                "Crate '{}' not found in workspace",
+                crate_name
+            ));
+        }
+    }
+
+    // Find all crates that need to be bumped
+    let mut crates_to_bump = HashSet::new();
+    let mut version_updates = HashMap::new();
+
+    // Start with target crates
+    for target in &target_crates {
+        crates_to_bump.insert(target.clone());
+    }
+
+    // Find dependencies of target crates (what the target crates depend on)
+    for target_crate in &target_crates {
+        // Find the target crate's package in metadata
+        for pkg in metadata["packages"].as_array().unwrap() {
+            let pkg_name = pkg["name"].as_str().unwrap();
+
+            if pkg_name == target_crate && workspace_members.contains(pkg_name) {
+                // Add all workspace dependencies of this target crate (exclude dev dependencies)
+                for dep in pkg["dependencies"].as_array().unwrap() {
+                    let dep_name = dep["name"].as_str().unwrap();
+                    let is_workspace_dep = dep["source"].is_null(); // workspace dependency has null source
+                    let dep_kind = dep.get("kind").and_then(|k| k.as_str());
+
+                    // Only include regular dependencies (kind=null) and build dependencies (kind="build")
+                    // Exclude dev dependencies (kind="dev")
+                    if is_workspace_dep
+                        && workspace_members.contains(dep_name)
+                        && dep_kind != Some("dev")
+                    {
+                        crates_to_bump.insert(dep_name.to_string());
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    let sorted_crates: Vec<String> = crates_to_bump.iter().cloned().collect();
+    log::info!("Bumping versions for: {}", sorted_crates.join(", "));
+
+    // Show dependencies being bumped
+    let target_set: HashSet<String> = target_crates.iter().cloned().collect();
+    let deps: Vec<String> = crates_to_bump.difference(&target_set).cloned().collect();
+    if !deps.is_empty() {
+        log::info!("Found dependencies: {}", deps.join(", "));
+    }
+
+    // Bump all versions
+    for crate_name in &crates_to_bump {
+        if let Some(crate_path) = crate_paths.get(crate_name) {
+            let (old_version, new_version) = bump_crate_version(crate_path)?;
+            version_updates.insert(crate_name.clone(), new_version.clone());
+            log::info!("Bumping {crate_name}: {old_version} → {new_version}");
+        }
+    }
+
+    // Update dependency references in all affected files
+    update_dependent_versions(&version_updates)?;
+
+    log::info!("\nUpdated {} crates successfully.", crates_to_bump.len());
+    Ok(())
+}
+
+pub fn get_all_workspace_crates() -> Result<Vec<String>> {
+    let metadata = get_cargo_metadata()?;
+    let mut crates = Vec::new();
+
+    let workspace_member_ids: HashSet<String> = metadata["workspace_members"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|id| id.as_str().unwrap().to_string())
+        .collect();
+
+    for pkg in metadata["packages"].as_array().unwrap() {
+        let pkg_id = pkg["id"].as_str().unwrap();
+        let pkg_name = pkg["name"].as_str().unwrap();
+
+        if workspace_member_ids.contains(pkg_id) {
+            crates.push(pkg_name.to_string());
+        }
+    }
+
+    Ok(crates)
+}
+
+pub fn bump_crate_version(crate_path: &PathBuf) -> Result<(String, String)> {
+    let content = fs::read_to_string(crate_path)?;
+    let lines: Vec<&str> = content.lines().collect();
+
+    let version_re = Regex::new(r#"(^\s*version\s*=\s*")([^"]*)(".*$)"#)?;
+
+    for (line_no, line) in lines.iter().enumerate() {
+        if let Some(captures) = version_re.captures(line) {
+            let current_version = captures.get(2).unwrap().as_str();
+            let new_version = increment_patch_version(current_version)?;
+
+            // Update the file
+            let mut new_lines: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
+            new_lines[line_no] = format!(
+                "{}{}{}",
+                captures.get(1).unwrap().as_str(),
+                new_version,
+                captures.get(3).unwrap().as_str()
+            );
+
+            let new_content = new_lines.join("\n") + "\n";
+            fs::write(crate_path, new_content)?;
+
+            return Ok((current_version.to_string(), new_version));
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "Could not find version in {:?}",
+        crate_path
+    ))
+}
+
+fn increment_patch_version(version: &str) -> Result<String> {
+    let parts: Vec<&str> = version.split('.').collect();
+    if parts.len() >= 3 {
+        let major = parts[0];
+        let minor = parts[1];
+        let patch: u32 = parts[2]
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Invalid patch version: {}", parts[2]))?;
+        let new_patch = patch + 1;
+
+        // Handle any additional parts (like pre-release identifiers)
+        if parts.len() > 3 {
+            let extra: Vec<&str> = parts[3..].to_vec();
+            Ok(format!(
+                "{}.{}.{}.{}",
+                major,
+                minor,
+                new_patch,
+                extra.join(".")
+            ))
+        } else {
+            Ok(format!("{major}.{minor}.{new_patch}"))
+        }
+    } else {
+        Err(anyhow::anyhow!("Invalid version format: {}", version))
+    }
+}
+
+pub fn update_dependent_versions(updates: &HashMap<String, String>) -> Result<()> {
+    let rust_paths = get_rust_paths()?;
+    let section_re = Regex::new(r"^\s*\[([^\[\]]*)\]\s*$")?;
+
+    for path in rust_paths {
+        let content = fs::read_to_string(&path)?;
+        let lines: Vec<&str> = content.lines().collect();
+        let mut new_lines: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
+        let mut modified = false;
+
+        let mut in_dep_section = false;
+        let mut block_depth = 0;
+
+        for (line_no, line) in lines.iter().enumerate() {
+            // Check for dependency sections
+            if let Some(captures) = section_re.captures(line) {
+                if block_depth != 0 {
+                    continue;
+                }
+                let section = captures.get(1).unwrap().as_str().trim();
+                // Include all dependency sections
+                in_dep_section = section == "dependencies"
+                    || section == "build-dependencies"
+                    || section == "dev-dependencies";
+                continue;
+            }
+
+            if !in_dep_section {
+                continue;
+            }
+
+            // Track nesting depth
+            block_depth += line.matches('{').count() as i32 - line.matches('}').count() as i32;
+            block_depth += line.matches('[').count() as i32 - line.matches(']').count() as i32;
+
+            if block_depth == 0 {
+                // Look for workspace dependencies that need version updates
+                for (crate_name, new_version) in updates {
+                    let pattern = format!(
+                        r#"(^\s*{}\s*=.*version\s*=\s*")([^"]*)(".*$)"#,
+                        regex::escape(crate_name)
+                    );
+                    if let Some(captures) = Regex::new(&pattern)?.captures(line) {
+                        new_lines[line_no] = format!(
+                            "{}{}{}",
+                            captures.get(1).unwrap().as_str(),
+                            new_version,
+                            captures.get(3).unwrap().as_str()
+                        );
+                        modified = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if modified {
+            let new_content = new_lines.join("\n") + "\n";
+            fs::write(&path, new_content)?;
+        }
+    }
+
+    Ok(())
+}

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -1,0 +1,121 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use anyhow::Context;
+use anyhow::Result;
+use clap::{Args, Parser, Subcommand};
+use once_cell::sync::OnceCell;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+mod bump_versions;
+mod versions;
+
+#[derive(Parser)]
+#[command(name = "xtask")]
+#[command(about = "Sched ext repository scripts and helpers")]
+struct Cli {
+    #[arg(short = 'v', long = "verbose", help = "Verbose logging")]
+    verbose: bool,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct BumpTarget {
+    #[arg(short = 'p', long = "package", help = "Specific crates to bump")]
+    packages: Vec<String>,
+    #[arg(long, help = "Bump all workspace crates")]
+    all: bool,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Versions,
+    BumpVersions {
+        #[command(flatten)]
+        target: BumpTarget,
+    },
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    let log_level = if cli.verbose {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Warn
+    };
+
+    simplelog::TermLogger::init(
+        log_level,
+        simplelog::Config::default(),
+        simplelog::TerminalMode::Stderr,
+        simplelog::ColorChoice::Auto,
+    )
+    .unwrap();
+
+    let res = match cli.command {
+        Commands::Versions => versions::version_command(),
+        Commands::BumpVersions { target } => {
+            bump_versions::bump_versions_command(target.packages, target.all)
+        }
+    };
+
+    if let Err(e) = res {
+        eprintln!("Failed to run command: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn get_cargo_metadata() -> Result<&'static serde_json::Value> {
+    static CARGO_METADATA: OnceCell<serde_json::Value> = OnceCell::new();
+
+    CARGO_METADATA.get_or_try_init(|| {
+        let output = Command::new("cargo")
+            .args(["metadata", "--format-version", "1"])
+            .output()?;
+
+        if !output.status.success() {
+            return Err(anyhow::anyhow!("Failed to run cargo metadata"));
+        }
+
+        Ok(serde_json::from_slice(&output.stdout)?)
+    })
+}
+
+pub fn get_rust_paths() -> Result<Vec<PathBuf>> {
+    let metadata = get_cargo_metadata()?;
+
+    // Get workspace member paths only
+    let workspace_members = metadata["workspace_members"]
+        .as_array()
+        .context("no workspace_members found in cargo metadata")?;
+
+    let packages = metadata["packages"]
+        .as_array()
+        .context("no packages found in cargo metadata")?;
+
+    let mut paths = Vec::new();
+
+    // Only include packages that are workspace members
+    for package in packages {
+        if let Some(id) = package["id"].as_str() {
+            if workspace_members
+                .iter()
+                .any(|member| member.as_str() == Some(id))
+            {
+                if let Some(manifest_path) = package["manifest_path"].as_str() {
+                    paths.push(PathBuf::from(manifest_path));
+                }
+            }
+        }
+    }
+
+    Ok(paths)
+}

--- a/tools/xtask/src/versions.rs
+++ b/tools/xtask/src/versions.rs
@@ -1,0 +1,276 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use anyhow::Context;
+use anyhow::Result;
+use regex::Regex;
+use serde::Serialize;
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::get_cargo_metadata;
+use crate::get_rust_paths;
+
+pub fn version_command() -> anyhow::Result<()> {
+    #[derive(Serialize)]
+    struct Output {
+        rust_versions: HashMap<String, String>,
+        rust_dep_versions: HashMap<String, String>,
+    }
+
+    let mut output = Output {
+        rust_versions: HashMap::new(),
+        rust_dep_versions: HashMap::new(),
+    };
+
+    // Get rust paths and process versions
+    let rust_paths = get_rust_paths().context("failed to get rust paths")?;
+
+    for path in &rust_paths {
+        if let Some((name, version)) = process_rust_version(path)
+            .with_context(|| format!("failed to process rust version for {}", path.display()))?
+        {
+            output.rust_versions.insert(name, version);
+        }
+    }
+
+    // Include tree crates as deps
+    output.rust_dep_versions.extend(
+        output
+            .rust_versions
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone())),
+    );
+
+    // Process rust dependencies
+    for path in &rust_paths {
+        process_rust_deps(path, &mut output.rust_dep_versions)
+            .with_context(|| format!("failed to process rust deps for {}", path.display()))?;
+    }
+
+    // Remove tree crates from deps for output
+    for crate_name in output.rust_versions.keys() {
+        output.rust_dep_versions.remove(crate_name);
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).context("failed to serialize")?
+    );
+
+    Ok(())
+}
+
+pub fn cargo_path_to_crate(path: &Path) -> String {
+    // Get crate name from cargo metadata instead of parsing path
+    if let Ok(metadata) = get_cargo_metadata() {
+        if let Some(packages) = metadata["packages"].as_array() {
+            for package in packages {
+                if let (Some(manifest_path), Some(name)) =
+                    (package["manifest_path"].as_str(), package["name"].as_str())
+                {
+                    if PathBuf::from(manifest_path) == path {
+                        return name.to_string();
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback to path parsing if metadata lookup fails
+    path.parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn process_rust_version(path: &Path) -> Result<Option<(String, String)>> {
+    let content = fs::read_to_string(path)?;
+    let lines: Vec<&str> = content.lines().collect();
+
+    let workspace_re = Regex::new(r"^\s*\[\s*workspace\s*\]")?;
+    let name_re = Regex::new(r#"^\s*name\s*=\s*"([^"]*)".*$"#)?;
+    let version_re = Regex::new(r#"(^\s*version\s*=\s*")([^"]*)(".*$)"#)?;
+
+    let mut name = None;
+    let mut version = None;
+
+    for (line_no, line) in lines.iter().enumerate() {
+        // Skip if we hit a workspace section
+        if workspace_re.is_match(line) {
+            log::debug!(
+                "[{}:{}] SKIP: workspace section",
+                path.display(),
+                line_no + 1
+            );
+            return Ok(None);
+        }
+
+        if let Some(captures) = name_re.captures(line) {
+            name = Some(captures.get(1).unwrap().as_str().to_string());
+            log::debug!(
+                "[{}:{}] name: {}",
+                path.display(),
+                line_no + 1,
+                name.as_ref().unwrap()
+            );
+        }
+
+        if let Some(captures) = version_re.captures(line) {
+            version = Some(captures.get(2).unwrap().as_str().to_string());
+            log::debug!(
+                "[{}:{}] version: {}",
+                path.display(),
+                line_no + 1,
+                version.as_ref().unwrap()
+            );
+        }
+
+        if name.is_some() && version.is_some() {
+            break;
+        }
+    }
+
+    let crate_name = name.ok_or_else(|| anyhow::anyhow!("Failed to find crate name"))?;
+    let current_version = version.ok_or_else(|| anyhow::anyhow!("Failed to find version"))?;
+
+    // Check if name matches path
+    if crate_name != cargo_path_to_crate(path) {
+        log::warn!(
+            "[{}] name \"{}\" does not match the path",
+            path.display(),
+            crate_name
+        );
+    }
+
+    Ok(Some((crate_name, current_version)))
+}
+
+fn process_rust_deps(path: &Path, rust_deps: &mut HashMap<String, String>) -> Result<()> {
+    let content = fs::read_to_string(path)?;
+    let lines: Vec<&str> = content.lines().collect();
+
+    let sect_re = Regex::new(r"^\s*\[([^\[\]]*)\]\s*$")?;
+    let crate_re = Regex::new(r#"^\s*([^=\s]*)\s*=.*$"#)?;
+    let version_simple_re = Regex::new(r#"(^[^=].*=\s*")([^"]*)("\s*$)"#)?;
+    let version_detailed_re = Regex::new(r#"(^.*version\s*=\s*")([^"]*)(".*$)"#)?;
+
+    let mut in_dep_section = None;
+    let mut block_depth = 0;
+    let mut current_crate = None;
+
+    for (line_no, line) in lines.iter().enumerate() {
+        // Check for section headers
+        if let Some(captures) = sect_re.captures(line) {
+            if block_depth != 0 {
+                return Err(anyhow::anyhow!(
+                    "[{}:{}] Unbalanced block_depth {}",
+                    path.display(),
+                    line_no + 1,
+                    block_depth
+                ));
+            }
+
+            let section = captures.get(1).unwrap().as_str().trim();
+            if section.ends_with("dependencies") {
+                in_dep_section = Some(section.to_string());
+                log::debug!("[{}:{}] [{}]", path.display(), line_no + 1, section);
+            } else {
+                in_dep_section = None;
+            }
+            continue;
+        }
+
+        if in_dep_section.is_none() {
+            continue;
+        }
+
+        // Parse comment
+        let (body, _comment) = if let Some(comment_pos) = line.find('#') {
+            (&line[..comment_pos], &line[comment_pos..])
+        } else {
+            (&line[..], "")
+        };
+
+        if body.trim().is_empty() {
+            continue;
+        }
+
+        // Track nesting depth
+        block_depth += body.matches('{').count() as i32 - body.matches('}').count() as i32;
+        block_depth += body.matches('[').count() as i32 - body.matches(']').count() as i32;
+
+        // Determine current crate
+        if block_depth == 0 {
+            if let Some(captures) = crate_re.captures(body) {
+                current_crate = Some(captures.get(1).unwrap().as_str().to_string());
+            } else {
+                current_crate = None;
+            }
+        }
+
+        if let Some(ref crate_name) = current_crate {
+            // Try to find version
+            let version = if let Some(captures) = version_simple_re.captures(body) {
+                Some((
+                    captures.get(1).unwrap().as_str(),
+                    captures.get(2).unwrap().as_str(),
+                    captures.get(3).unwrap().as_str(),
+                ))
+            } else {
+                version_detailed_re.captures(body).map(|captures| {
+                    (
+                        captures.get(1).unwrap().as_str(),
+                        captures.get(2).unwrap().as_str(),
+                        captures.get(3).unwrap().as_str(),
+                    )
+                })
+            };
+
+            if let Some((_pre, current_version, _post)) = version {
+                log::debug!(
+                    "[{}:{}] {}: version {}",
+                    path.display(),
+                    line_no + 1,
+                    crate_name,
+                    current_version
+                );
+
+                // Check for mismatches
+                if let Some(existing_version) = rust_deps.get(crate_name) {
+                    if existing_version != current_version {
+                        log::warn!(
+                            "[{}:{}] crate \"{}\" {} mismatches existing {}",
+                            path.display(),
+                            line_no + 1,
+                            crate_name,
+                            current_version,
+                            existing_version
+                        );
+                    }
+                } else {
+                    rust_deps.insert(crate_name.clone(), current_version.to_string());
+                }
+            }
+        }
+
+        if block_depth == 0 {
+            current_crate = None;
+        }
+    }
+
+    if block_depth != 0 {
+        return Err(anyhow::anyhow!(
+            "[{}] Unbalanced block_depth {}",
+            path.display(),
+            block_depth
+        ));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
`cargo xtask` [0] is a pattern for running arbitrary commands in your Cargo workspace. You create a crate for `xtask` and add an alias for `cargo run -p xtask --` as `cargo xtask`. This means we can run "scripts" like `cargo xtask bump-versions --all` with only Cargo installed.

Add this pattern and a first couple of useful scripts to demonstrate the pattern. First we have `versions`, which emulates pretty closely the existing `version-tool.py` (with no arguments). Then we have `bump-versions`, which allows you to pass one or more crates and bumps their patch versions like we do for a full sched_ext release. Intermediate bumps are handled by the crate authors directly.

This will let us add more useful features but are a good base. After this lands I want to add more formats for `versions`, and in the future enable `bump-versions` to not bump crates that are identical to their published version (there are specific cases where this is useful).

Test plan:

- CI
- `cargo xtask bump-versions -p scx_utils` bumps scx_utils and all of its dependencies that are in the workspace. It then updates every reference to scx_utils everywhere.
- `cargo xtask bump-versions --all` bumps everything in the repo and all of its internal usages. This is what we do as part of the monthly release process.

```sh
jake@rooster:/data/users/jake/repos/scx/ > cargo xtask versions
warning: /data/users/jake/repos/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
warning: /data/users/jake/repos/scx/Cargo.toml: unused manifest key: profile.release-fast.target-cpu
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running `/home/jake/cargo_builds/scx/debug/xtask versions`
12:14:04 [WARN] [/data/users/jake/repos/scx/rust/arenalib/arenalib/Cargo.toml:16] crate "scx_utils" 1.0.19 mismatches existing 1.0.22
...
12:14:04 [WARN] [/data/users/jake/repos/scx/tools/xtask/Cargo.toml:15] crate "log" 0.4 mismatches existing 0.4.17
{
  "00-versions": {
    "meson": "1.0.16"
  },
  "01-rust-versions": {
    "arenalib": "0.1.1",
    "arenalib_selftests": "1.0.3",
    "scx_bpf_compat": "1.0.16",
...
    "scxtop": "1.0.18",
    "vmlinux_docify": "0.1.5",
    "xtask": "0.1.0"
  },
  "02-rust-deps": {
    "affinity": "0.1",
...
    "zvariant": "5.1"
  }
}
```

[0] https://github.com/matklad/cargo-xtask