### PR TITLE
test_sched: ignore RETBleed lines

### DIFF
--- a/meson-scripts/test_sched
+++ b/meson-scripts/test_sched
@@ -78,7 +78,10 @@ for sched in ${!SCHEDS[@]}; do
         vng --user root -m 10G --cpu 8 $VNG_RW -v -r ${kernel} -- \
             "timeout --foreground --preserve-status ${TEST_TIMEOUT} ${sched_path} ${args}" \
                 2> >(tee /tmp/output) </dev/null
-        grep -v " Speculative Return Stack Overflow" /tmp/output | \
+        grep -v \
+            -e " Speculative Return Stack Overflow" \
+            -e " RETBleed: " \
+            /tmp/output | \
             sed -n -e '/\bBUG:/q1' \
                    -e '/\bWARNING:/q1' \
                    -e '/\berror\b/Iq1' \


### PR DESCRIPTION
New kernels have brought annoying lines like:
```
[    0.695894] RETBleed: WARNING: Spectre v2 mitigation leaves CPU vulnerable to RETBleed attacks, data leaks possible!
[    0.695894] RETBleed: Vulnerable
```

To the output on certain machines. This makes the CI fail spuriously when it lands on machines with this vulnerability.

Test plan:
- CI, added a load of extra kernels to create more instances and confirm it doesn't hit this error anymore.

CI-Test-Kernel: bpf/bpf-next
CI-Test-Kernel: sched_ext/for-next