### PR TITLE
scx_bpfland: Print command line options

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -302,6 +302,12 @@ impl<'a> Scheduler<'a> {
             if smt_enabled { "SMT on" } else { "SMT off" }
         );
 
+        // Print command line.
+        info!(
+            "scheduler options: {}",
+            std::env::args().collect::<Vec<_>>().join(" ")
+        );
+
         if opts.idle_resume_us >= 0 {
             if !cpu_idle_resume_latency_supported() {
                 warn!("idle resume latency not supported");


### PR DESCRIPTION
Commit https://github.com/sched-ext/scx/commit/23ffc2b8fbf39b49d06b0e4fa69e747cda5567b7 introduced a similar option to scx_flash. Let's do the same for scx_bpfland. 

**- before**

```
❯ systemctl status scx_loader.service
● scx_loader.service - DBUS on-demand loader of sched-ext schedulers
     Loaded: loaded (/usr/lib/systemd/system/scx_loader.service; disabled; preset: disabled)
     Active: active (running) since Fri 2025-09-26 13:20:46 CEST; 11min ago
 Invocation: 1d3af529dc61443bb69c1d286f8caf1c
   Main PID: 73490 (scx_loader)
      Tasks: 22 (limit: 37395)
     Memory: 11.6M (peak: 13.3M)
        CPU: 350ms
     CGroup: /system.slice/scx_loader.service
             ├─73490 /usr/bin/scx_loader
             └─92703 scx_bpfland -m performance

wrz 26 13:32:38 cachyos scx_loader[87984]: 13:32:38 [INFO] Unregister scx_bpfland scheduler
wrz 26 13:32:38 cachyos scx_loader[73490]: [INFO]: starting scx_bpfland command
wrz 26 13:32:38 cachyos scx_loader[92703]: 13:32:38 [INFO] NUMA nodes: 1
wrz 26 13:32:38 cachyos scx_loader[92703]: 13:32:38 [INFO] Disabling NUMA optimizations
wrz 26 13:32:38 cachyos scx_loader[92703]: 13:32:38 [INFO] scx_bpfland 1.0.16-g95087879-dirty x86_64-unknown-linux-gnu SMT on
wrz 26 13:32:38 cachyos scx_loader[92703]: 13:32:38 [INFO] scheduler flags: 0x36
wrz 26 13:32:38 cachyos scx_loader[92703]: 13:32:38 [INFO] primary CPU domain = 0xffff
wrz 26 13:32:38 cachyos scx_loader[92703]: 13:32:38 [INFO] cpufreq performance level: max
wrz 26 13:32:38 cachyos scx_loader[92703]: 13:32:38 [INFO] SMT sibling CPUs: [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7]
wrz 26 13:32:38 cachyos scx_loader[92703]: 13:32:38 [INFO] L3 cache ID 0: sibling CPUs: [0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15]
```

**- after**

```
❯ systemctl status scx_loader.service
● scx_loader.service - DBUS on-demand loader of sched-ext schedulers
     Loaded: loaded (/usr/lib/systemd/system/scx_loader.service; disabled; preset: disabled)
     Active: active (running) since Fri 2025-09-26 13:20:46 CEST; 15min ago
 Invocation: 1d3af529dc61443bb69c1d286f8caf1c
   Main PID: 73490 (scx_loader)
      Tasks: 22 (limit: 37395)
     Memory: 10.9M (peak: 13.3M)
        CPU: 417ms
     CGroup: /system.slice/scx_loader.service
             ├─ 73490 /usr/bin/scx_loader
             └─107694 scx_bpfland -m performance

wrz 26 13:35:59 cachyos scx_loader[73490]: [INFO]: starting scx_bpfland command
wrz 26 13:35:59 cachyos scx_loader[107694]: 13:35:59 [INFO] NUMA nodes: 1
wrz 26 13:35:59 cachyos scx_loader[107694]: 13:35:59 [INFO] Disabling NUMA optimizations
wrz 26 13:35:59 cachyos scx_loader[107694]: 13:35:59 [INFO] scx_bpfland 1.0.16-g95087879-dirty x86_64-unknown-linux-gnu SMT on
wrz 26 13:35:59 cachyos scx_loader[107694]: 13:35:59 [INFO] scheduler options: scx_bpfland -m performance
wrz 26 13:35:59 cachyos scx_loader[107694]: 13:35:59 [INFO] scheduler flags: 0x36
wrz 26 13:35:59 cachyos scx_loader[107694]: 13:35:59 [INFO] primary CPU domain = 0xffff
wrz 26 13:35:59 cachyos scx_loader[107694]: 13:35:59 [INFO] cpufreq performance level: max
wrz 26 13:35:59 cachyos scx_loader[107694]: 13:35:59 [INFO] SMT sibling CPUs: [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7]
wrz 26 13:35:59 cachyos scx_loader[107694]: 13:35:59 [INFO] L3 cache ID 0: sibling CPUs: [0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15]
```