### PR TITLE
scx_rustland: avoid dispatch when task pool is empty

### DIFF
--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -342,8 +342,10 @@ impl<'a> Scheduler<'a> {
             }
         }
 
-        // Dispatch the first task from the task pool.
-        self.dispatch_task();
+        // Dispatch the first task from the task pool only if there are tasks available.
+        if !self.tasks.is_empty() {
+            self.dispatch_task();
+        }
     }
 
     // Main scheduling function (called in a loop to periodically drain tasks from the queued list


### PR DESCRIPTION
Avoid calling dispatch_task() with an empty task pool to skip redundant dispatch attempts.

Previously, drain_queued_tasks() always invoked dispatch_task() even when no tasks were available. Since dispatch_task() would immediately return in that case, the call was redundant. 

Update the logic to only dispatch when the task pool is non-empty. This avoids unnecessary function calls while keeping the scheduling semantics unchanged.