### PR TITLE
percpu: Properly handle missing percpu symbols

### DIFF
--- a/scheds/include/scx/percpu.bpf.h
+++ b/scheds/include/scx/percpu.bpf.h
@@ -59,6 +59,8 @@ static __always_inline type func_name(s32 cpu)					\
 type func_name(s32 cpu) {					\
 	type *ptr;						\
 								\
+	if (!&var_name)						\
+		return -ENOENT;					\
 	ptr = bpf_per_cpu_ptr(&var_name, cpu);			\
 	if (!ptr)						\
 		return -EINVAL;					\


### PR DESCRIPTION
Accessing an undefined percpu symbol through bpf_per_cpu_ptr() causes the BPF verifier to complain, for example:
```
 36: (85) call bpf_per_cpu_ptr#153
 R1 type=scalar expected=percpu_ptr_, percpu_rcu_ptr_, percpu_trusted_ptr_
```
Fix this by checking whether the symbol is defined (non-NULL) before dereferencing it via bpf_per_cpu_ptr(), ensuring the verifier accepts the access.