### PR TITLE
scx_qmap: Handle migration-disabled tasks in ops.enqueue()

### DIFF
--- a/scheds/c/scx_qmap.bpf.c
+++ b/scheds/c/scx_qmap.bpf.c
@@ -231,7 +231,7 @@ void BPF_STRUCT_OPS(qmap_enqueue, struct task_struct *p, u64 enq_flags)
 	}
 
 	/* if select_cpu() wasn't called, try direct dispatch */
-	if (!__COMPAT_is_enq_cpu_selected(enq_flags) &&
+	if (!__COMPAT_is_enq_cpu_selected(enq_flags) && !is_migration_disabled(p) &&
 	    (cpu = pick_direct_dispatch_cpu(p, scx_bpf_task_cpu(p))) >= 0) {
 		__sync_fetch_and_add(&nr_ddsp_from_enq, 1);
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, slice_ns, enq_flags);


### PR DESCRIPTION
When dispatching a task to a remote DSQ in ops.enqueue(), we must ensure the task is allowed to migrate.

Failing to do so can trigger errors such as:
```
  EXIT: runtime error (SCX_DSQ_LOCAL[_ON] cannot move migration disabled Xorg[341392] from CPU 5 to 0)
```
This fixes issue #2825.

Reported-by: Christian Loehle <christian.loehle@arm.com>