### PR TITLE
Revert "scx_rustland_core: Re-enqueue tasks in cpu_release"

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -828,7 +828,7 @@ void BPF_STRUCT_OPS(rustland_enqueue, struct task_struct *p, u64 enq_flags)
 	 */
 	if ((is_kthread(p) && p->nr_cpus_allowed == 1) || is_kswapd(p) || is_khugepaged(p)) {
 		cpu = scx_bpf_task_cpu(p);
-		scx_bpf_dsq_insert_vtime(p, cpu_to_dsq(cpu),
+                scx_bpf_dsq_insert_vtime(p, cpu_to_dsq(cpu),
 					 SCX_SLICE_DFL, p->scx.dsq_vtime, enq_flags);
 		__sync_fetch_and_add(&nr_kernel_dispatches, 1);
 		return;
@@ -836,10 +836,9 @@ void BPF_STRUCT_OPS(rustland_enqueue, struct task_struct *p, u64 enq_flags)
 
 	/*
 	 * Give the task a chance to be directly dispatched if
-	 * ops.select_cpu() was skipped or if it has been re-enqueued due
-	 * to a higher scheduling class stealing the CPU.
+	 * ops.select_cpu() was skipped.
 	 */
-	if (builtin_idle && (is_queued_wakeup(p, enq_flags) || (enq_flags & SCX_ENQ_REENQ))) {
+	if (builtin_idle && is_queued_wakeup(p, enq_flags)) {
 		bool dispatched = false;
 
 		cpu = try_direct_dispatch(p, scx_bpf_task_cpu(p), enq_flags, &dispatched);
@@ -1067,13 +1066,6 @@ void BPF_STRUCT_OPS(rustland_cpu_release, s32 cpu,
 	dbg_msg("cpu preemption: pid=%d (%s)", p->pid, p->comm);
 	if (is_usersched_task(p))
 		set_usersched_needed();
-
-	/*
-	 * A higher scheduler class stole the CPU, re-enqueue all the tasks
-	 * that are waiting on this CPU and give them a chance to pick
-	 * another idle CPU.
-	 */
-	scx_bpf_reenqueue_local();
 }
 
 /*


### PR DESCRIPTION
Commit 04033ecf ("scx_rustland_core: Re-enqueue tasks in cpu_release") seems to introduce pretty bad regressions with certain gaming workloads (i.e., Elden Ring becomes very stuttery).

Using scx_bpf_reenqueue_local() in ops.cpu_release() is quite pointless, since rustland-core never uses SCX_DSQ_LOCAL[_ON] directly, so this only adds unnecessary overhead and increases locking contention on the local DSQs.

Without this commit performance in Elden Ring and other games are restored to normal.