### PR TITLE
scx_rustland_core: Introduce QueuedTask:comm_str()

### DIFF
--- a/rust/scx_rustland_core/README.md
+++ b/rust/scx_rustland_core/README.md
@@ -86,6 +86,7 @@ struct QueuedTask {
     pub exec_runtime: u64,     // Total cpu time since last sleep (in ns)
     pub weight: u64,           // Task priority in the range [1..10000] (default is 100)
     pub vtime: u64,            // Current task vruntime / deadline (set by the scheduler)
+    pub comm: [i8; TASK_COMM_LEN], // Task's executable name
 }
 ```
 

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -45,6 +45,10 @@ typedef int pid_t;
  */
 #define MAX_CPUS 1024
 
+#ifndef TASK_COMM_LEN
+#define TASK_COMM_LEN	16
+#endif
+
 /* Special dispatch flags */
 enum {
 	/*
@@ -89,6 +93,7 @@ struct queued_task_ctx {
 	u64 exec_runtime; /* Total cpu time since last sleep */
 	u64 weight; /* Task static priority */
 	u64 vtime; /* Current task's vruntime */
+	char comm[TASK_COMM_LEN]; /* Task's executable name */
 };
 
 /*

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -782,6 +782,8 @@ static void get_task_info(struct queued_task_ctx *task,
 	task->exec_runtime = tctx ? tctx->exec_runtime : 0;
 	task->weight = p->scx.weight;
 	task->vtime = p->scx.dsq_vtime;
+
+	bpf_core_read(&task->comm, sizeof(task->comm), &p->comm);
 }
 
 /*

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -55,6 +55,7 @@
 //!     pub exec_runtime: u64,     // Total cpu time since last sleep (in ns)
 //!     pub weight: u64,           // Task priority in the range [1..10000] (default is 100)
 //!     pub vtime: u64,            // Current task vruntime / deadline (set by the scheduler)
+//!     pub comm: [i8; TASK_COMM_LEN], // Task's executable name
 //! }
 //!
 //! Each task dispatched using dispatch_task() contains the following:


### PR DESCRIPTION
Add a helper to QueuedTask to retrieve the task's command name.

Having direct access to the executable name from user space can be useful for classifying workloads based on the application or task name.t