### PR TITLE
scx_loader: set scx_cosmos as suggested scheduler

### DIFF
--- a/services/scx_loader.toml
+++ b/services/scx_loader.toml
@@ -1,5 +1,5 @@
 # This field specifies the scheduler that will be started automatically when scx_loader starts (e.g., on boot).
-#default_sched = "scx_flash"
+#default_sched = "scx_cosmos"
 
 # This field specifies the mode which will be used when scx_loader starts (e.g., on boot).
 #default_mode = "Auto"


### PR DESCRIPTION
CachyOS users have repeatedly suggested that scx_cosmos is currently the most efficient scheduler and should be the one suggested in the scx_loader configuration. 