### PR TITLE
scx_rustland_core: Fix char type on arm64

### DIFF
--- a/rust/scx_rustland_core/README.md
+++ b/rust/scx_rustland_core/README.md
@@ -86,7 +86,7 @@ struct QueuedTask {
     pub exec_runtime: u64,     // Total cpu time since last sleep (in ns)
     pub weight: u64,           // Task priority in the range [1..10000] (default is 100)
     pub vtime: u64,            // Current task vruntime / deadline (set by the scheduler)
-    pub comm: [i8; TASK_COMM_LEN], // Task's executable name
+    pub comm: [c_char; TASK_COMM_LEN], // Task's executable name
 }
 ```
 

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -30,7 +30,7 @@ use libbpf_rs::libbpf_sys::bpf_object_open_opts;
 use libbpf_rs::OpenObject;
 use libbpf_rs::ProgramInput;
 
-use libc::{pthread_self, pthread_setschedparam, sched_param};
+use libc::{pthread_self, pthread_setschedparam, sched_param, c_char};
 
 #[cfg(target_env = "musl")]
 use libc::timespec;
@@ -87,7 +87,7 @@ pub struct QueuedTask {
     pub exec_runtime: u64,         // Total cpu time since last sleep (in ns)
     pub weight: u64,               // Task priority in the range [1..10000] (default is 100)
     pub vtime: u64,                // Current task vruntime / deadline (set by the scheduler)
-    pub comm: [i8; TASK_COMM_LEN], // Task's executable name
+    pub comm: [c_char; TASK_COMM_LEN], // Task's executable name
 }
 
 impl QueuedTask {

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -55,7 +55,7 @@
 //!     pub exec_runtime: u64,     // Total cpu time since last sleep (in ns)
 //!     pub weight: u64,           // Task priority in the range [1..10000] (default is 100)
 //!     pub vtime: u64,            // Current task vruntime / deadline (set by the scheduler)
-//!     pub comm: [i8; TASK_COMM_LEN], // Task's executable name
+//!     pub comm: [c_char; TASK_COMM_LEN], // Task's executable name
 //! }
 //!
 //! Each task dispatched using dispatch_task() contains the following:


### PR DESCRIPTION
Commit beab2f38 ("scx_rustland_core: Introduce QueuedTask:comm_str()") introduced the following build error on arm64:
```
error[E0308]: mismatched types
   --> scheds/rust/scx_rustland/src/bpf.rs:167:19
    |
167 |             comm: self.inner.comm,
    |                   ^^^^^^^^^^^^^^^ expected `[i8; 16]`, found `[u8; 16]`
    |
    = note: expected array `[i8; 16]`
               found array `[u8; 16]`
```
Fix by declaring comm as an array of c_char elements, instead of i8, ensuring portability across different architectures.

Fixes: beab2f38 ("scx_rustland_core: Introduce QueuedTask:comm_str()")