### PR TITLE
docs: Update dev dependencies for Ubuntu

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ $ sudo do-release-upgrade -d
 #### Setting up Dev Environment
 
 ```
-$ sudo apt install -y build-essential cmake cargo rustc clang llvm pkg-config libelf-dev protobuf-compiler libseccomp-dev
+$ sudo apt install -y build-essential cmake cargo rustc clang llvm pkg-config libelf-dev protobuf-compiler libseccomp-dev libbpf-dev
 ```
 
 #### Build the scx schedulers from source


### PR DESCRIPTION
On Ubuntu, the headers provided by libbpf-dev are also necessary to build the C schedulers. Add this package to the list of dependencies for the dev environment.