### PR TITLE
Revert "chaos: generate random numbers with less bias"

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -763,14 +763,6 @@ static inline u64 scale_by_task_weight_inverse(const struct task_struct *p, u64 
 	return value * 100 / p->scx.weight;
 }
 
-/*
- * Get a random u64 from the kernel's pseudo-random generator.
- */
-static inline u64 get_prandom_u64()
-{
-	return ((u64)bpf_get_prandom_u32() << 32) | bpf_get_prandom_u32();
-}
-
 
 #include "compat.bpf.h"
 #include "enums.bpf.h"

--- a/scheds/rust/scx_chaos/src/bpf/intf.h
+++ b/scheds/rust/scx_chaos/src/bpf/intf.h
@@ -14,8 +14,6 @@ enum chaos_consts {
 	CHAOS_DSQ_BASE		= 1 << CHAOS_DSQ_BASE_SHIFT,
 
 	CHAOS_NUM_PPIDS_CHECK	= 1 << 20,
-
-	CHAOS_MAX_RAND_ATTEMPTS	= 512,
 };
 
 enum chaos_match {

--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -88,46 +88,6 @@ struct chaos_task_ctx *lookup_create_chaos_task_ctx(struct task_struct *p)
 	return bpf_task_storage_get(&chaos_task_ctxs, p, NULL, BPF_LOCAL_STORAGE_GET_F_CREATE);
 }
 
-static __always_inline u64 chaos_get_prandom_u64_limit(u64 s)
-{
-	// Implementation of Lemire's algorithm 5 without 128-bit arithmetic.
-	// See https://arxiv.org/pdf/1805.10941v2 for details.
-	// Uses a bounded loop given this is BPF, but given the loop should
-	// rarely be entered this is fine.
-	u64 x, m_low, m_high;
-	u64 t;
-
-	x = get_prandom_u64();
-
-	// Compute 64-bit multiplication high and low parts
-	// m = x * s, split into m_high and m_low
-	m_high = ((x >> 32) * (s >> 32)) +
-		 (((x & 0xFFFFFFFF) * (s >> 32)) >> 32) +
-		 (((x >> 32) * (s & 0xFFFFFFFF)) >> 32);
-	m_low = x * s;
-
-	if (m_low < s) {
-		t = ((u64)(-s)) % s;
-		bpf_repeat(CHAOS_MAX_RAND_ATTEMPTS) {
-			if (m_low >= t)
-				break;
-
-			x = get_prandom_u64();
-			m_high = ((x >> 32) * (s >> 32)) +
-				 (((x & 0xFFFFFFFF) * (s >> 32)) >> 32) +
-				 (((x >> 32) * (s & 0xFFFFFFFF)) >> 32);
-			m_low = x * s;
-		}
-	}
-
-	return m_high;
-}
-
-static __always_inline u64 chaos_get_uniform_u64(u64 min, u64 max)
-{
-	return min + chaos_get_prandom_u64_limit(max - min + 1);
-}
-
 static __always_inline void chaos_stat_inc(enum chaos_stat_idx stat)
 {
 	u64 *cnt_p = bpf_map_lookup_elem(&chaos_stats, &stat);
@@ -296,8 +256,15 @@ out:
 __weak s32 enqueue_random_delay(struct task_struct *p __arg_trusted, u64 enq_flags,
 				struct chaos_task_ctx *taskc __arg_nonnull, u64 min_ns, u64 max_ns)
 {
-	u64 vtime = chaos_get_uniform_u64(min_ns, max_ns);
+	u64 rand64 = ((u64)bpf_get_prandom_u32() << 32) | bpf_get_prandom_u32();
+
+	u64 vtime = bpf_ktime_get_ns() + min_ns;
+	if (min_ns != max_ns) {
+		vtime += rand64 % (max_ns - min_ns);
+	}
+
 	scx_bpf_dsq_insert_vtime(p, get_cpu_delay_dsq(-1), 0, vtime, enq_flags);
+
 	return true;
 }
 


### PR DESCRIPTION
This reverts commit c576237ad0393027247d7e1b08cf84119fc4246b.

This commit doesn't work. I bisected and the reason chaos isn't working anymore is this is producing random numbers that always fail. D'oh.

I have a decent test for the failure though, will figure out where to run it and see if it can be made part of the CI. For now, revert this change and come back to it once it has proper test coverage.

Test plan:
- CI

Manual testing: clear regression now, this didn't work before.
```
$ sudo ./target/release/scx_chaos &
$ sudo ./target/release/schtest --benchmarks --filter sleep_wakeup_histogram  # not upstreamed

running 1 test
test sleep_wakeup_histogram ... Gnuplot not found, using plotters backend
measure: sleep_wakeup_histogram/wakeup_latency
Benchmarking sleep_wakeup_histogram/wakeup_latency
Benchmarking sleep_wakeup_histogram/wakeup_latency: Warming up for 3.0000 s
61.754µs |▁▄▅▆▆▆▆▆▇▇▇▇▇▇▇███ 100.258µs ███████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▃▃| 249.711µs
84.31µs |▁▄▅▅▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇█████████████ 140.245µs ███▇▇▇▇▆▆▆▆▅▅▅▅▅▄▄▄▄▄▃| 158.111µs
64.695µs |▁▄▄▅▅▆▆▆▆▆▆▇▇▇▇▇▇▇████ 104.2µs ██████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▄▃| 226.307µs
59.403µs |▁▄▄▅▅▆▆▆▇▇▇▇██ 81.472µs ███████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▄▃▁| 199.074µs
28.278µs |▁▂▂▃▃▄▄▅▅▆▆▆▇▇█ 95.847µs ██████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▄▄▁| 427.278µs
60.876µs |▁▂▃▄▅▆▆▆▆▆▆▇▇▇▇▇▇███ 157.618µs █████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▄▄▃▃▂▂▁| 475.634µs
53.59µs |▁▃▄▄▅▅▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇████ 172.317µs ████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▄▄▃▁| 446.864µs
32.536µs |▁▁▂▂▂▃▃▄▄▅▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇████ 182.629µs ███████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▄▄▃▁| 453.103µs
39.434µs |▁▂▂▃▃▄▄▅▆▆▆▆▇▇▇▇▇██ 130.788µs ████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▄▄▃▃▂▂▁▁| 459.099µs
Benchmarking sleep_wakeup_histogram/wakeup_latency: Collecting 10 samples in estimated 5.0287 s (490 iterations)
38.41µs |▁▂▂▃▄▄▅▆▆▇▇▇█ 109.533µs ███████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▄▄▄▃▃▃▃▃▃▃▂▂▂▂▂▂▂▁▁▁▁| 511.275µs
67.09µs |▁▃▄▅▅▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇████ 172.267µs ████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▄▄▄▁| 454.607µs
56.325µs |▁▂▃▄▄▅▆▆▆▆▆▇▇▇▇▇██ 140.593µs ██████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▄▃▂▁| 451.093µs
37.316µs |▁▁▂▂▂▃▃▄▅▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇█████ 187.986µs ███████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▄▁| 445.825µs
61.863µs |▁▄▅▆▆▆▆▆▇▇▇▇▇██ 130.726µs ███████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▄▁| 455.447µs
56.139µs |▁▂▃▄▅▆▆▆▆▇▇▇▇▇██ 128.397µs ██████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▄▄▄▁| 455.88µs
48.837µs | 93.419µs ▁▇▅▄▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁| 7.862632ms
6.642µs |▁▂▂▃▃▄▄▄▅▅▅▇ 57.807µs ████▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▁▁▁▁▁| 388.653µs
16.156µs |▁▁▁▂▂▂▂▂▃▃▃▃▃▃▃▃▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▆▆▆▆▆▇ 53.479µs ██▇▇▇▆▆▅▅▄▄▃▃▂▂▁| 60.998µs
9.881µs |▁▂▃▃▄▄▄▄▄▄▄▅▅▅▅▅▅▆▆ 53.834µs ███▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▃▃▃▃▃▂▂▁| 217.669µs
Benchmarking sleep_wakeup_histogram/wakeup_latency: Analyzing
sleep_wakeup_histogram/wakeup_latency
                        time:   [84.675 µs 112.80 µs 141.38 µs]
                        change: [-20.749% +7.1431% +36.090%] (p = 0.65 > 0.05)
                        No change in performance detected.

$ sudo target/release/scx_chaos --random-delay-frequency 1.0 --random-delay-min-us 100000 --random-delay-max-us 200000 &
$ sudo ./target/release/schtest --benchmarks --filter sleep_wakeup_histogram

running 1 test
test sleep_wakeup_histogram ... Gnuplot not found, using plotters backend
measure: sleep_wakeup_histogram/wakeup_latency
Benchmarking sleep_wakeup_histogram/wakeup_latency
Benchmarking sleep_wakeup_histogram/wakeup_latency: Warming up for 3.0000 s
74.961µs |▁▅▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇██████████ 109.859µs ████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▃| 135.4µs
76.071µs |▁▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇█████████ 94.594139ms █████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▃| 183.824112ms
80.637µs |▁▆▆▆▆▆▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇████████ 88.509378ms ███████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅▄▄▄▄▄▄▃| 193.656955ms
73.371µs |▁▆▆▆▆▆▆▆▆▆▆▆▇▇▇▇▇▇▇▇▇▇▇▇▇▇███████ 77.400335ms █████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▅▄▄▄▄▄▁| 197.307031ms
Benchmarking sleep_wakeup_histogram/wakeup_latency: Collecting 10 samples in estimated 6.3545 s (30 iterations)
97.18µs | 125.504µs ▁█████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▃▃| 200.208333ms
69.525µs | 109.713µs ▁██████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅▅▄▄▄▄▄▄▄▃▃| 200.42639ms
72.36µs | 156.009µs ▁█████████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▄▃| 163.175967ms
70.242µs | 144.491µs ▁█████████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▄▃| 201.438072ms
70.547µs | 124.178µs ▁█████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▄▃▃| 198.71247ms
86.004µs | 127.628µs ▁██████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▅▅▅▅▅▅▄▄▄▄▄▄▄▄▄▃▃| 186.4796ms
71.957µs | 159.607µs ▁████████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▅▄▄▃| 192.443885ms
72.55µs | 119.991µs ▁█████████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▄▄▃| 193.710755ms
76.801µs | 136.949µs ▁█████████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▃| 200.150291ms
94.175µs | 131.706µs ▁█████████████████▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▅▄▃| 197.324104ms
Benchmarking sleep_wakeup_histogram/wakeup_latency: Analyzing
sleep_wakeup_histogram/wakeup_latency
                        time:   [124.58 µs 133.58 µs 143.08 µs]
                        change: [-6.2000% +18.416% +59.406%] (p = 0.21 > 0.05)
                        No change in performance detected.
```