### PR TITLE
scx_layered: remove task_layer_id

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -204,7 +204,6 @@ struct cpu_ctx {
 	u64			lo_fb_dsq_id;
 	bool			in_open_layers;
 	u32			layer_id;
-	u32			task_layer_id;
 	u32			llc_id;
 	u32			node_id;
 	u32			perf;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2976,7 +2976,6 @@ void BPF_STRUCT_OPS(layered_running, struct task_struct *p)
 
 	cpuc->current_preempt = layer->preempt ||
 		(is_percpu_kthread(p) && is_percpu_kthread_preempting(p));
-	cpuc->task_layer_id = taskc->layer_id;
 	cpuc->used_at = now;
 	taskc->running_at = now;
 	cpuc->is_protected = layer->is_protected;
@@ -3090,7 +3089,6 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 
 	cpuc->running_fallback = false;
 	cpuc->current_preempt = false;
-	cpuc->task_layer_id = MAX_LAYERS;
 
 	if (nr_excl_layers) {
 		cpuc->prev_excl = cpuc->current_excl;
@@ -3849,7 +3847,6 @@ static s32 init_cpu(s32 cpu, int *nr_online_cpus,
 	if (!(cpuc = lookup_cpu_ctx(cpu))) {
 		return -ENOMEM;
 	}
-	cpuc->task_layer_id = MAX_LAYERS;
 
 
 	/*

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -2079,7 +2079,6 @@ impl<'a> Scheduler<'a> {
             let is_big = topo_cpu.core_type == CoreType::Big { turbo: true };
             cpu_ctxs[cpu].cpu = cpu as i32;
             cpu_ctxs[cpu].layer_id = MAX_LAYERS as u32;
-            cpu_ctxs[cpu].task_layer_id = MAX_LAYERS as u32;
             cpu_ctxs[cpu].is_big = is_big;
 
             fastrand::seed(cpu as u64);


### PR DESCRIPTION
The task_layer_id variable is only set, never used. Remove it.