### PR TITLE
scx_util: Fix up --virt-llc args

### DIFF
--- a/rust/scx_utils/src/cli.rs
+++ b/rust/scx_utils/src/cli.rs
@@ -22,13 +22,13 @@ pub struct TopologyArgs {
     /// virtual LLC partition.
     ///
     /// Examples:
-    ///   --virt-llc 2-8    (partition with 2-8 cores each)
+    ///   --virt-llc=2-8    (partition with 2-8 cores each)
     ///   --virt-llc        (use default range: 2-8 cores)
     #[clap(
         long = "virt-llc",
         value_delimiter = '-',
-        num_args = 0..=2,
-        value_names = ["MIN_CORES", "MAX_CORES"],
+        num_args = 0..=1,
+        require_equals = true,
         help = "Enable virtual LLC partitioning with optional core range (format: min-max, defaults to 2-8)"
     )]
     pub virt_llc: Option<Vec<usize>>,


### PR DESCRIPTION
Match up the intended arg parsing with the tooltips and require `=` after --virt-llc, so it doesn't inadvertently parse other args such as the spec file in scx_layered.