### PR TITLE
scx_lavd: Fix array index mismatch in test_cpu_stickable()

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -376,7 +376,7 @@ bool test_cpu_stickable(struct pick_ctx *ctx, s32 cpu, bool is_task_big)
 			ctx->i_m++;
 		}
 		else {
-			ctx->cpdoms_not_match[ctx->i_m] = cpuc->cpdom_alt_id;
+			ctx->cpdoms_not_match[ctx->i_nm] = cpuc->cpdom_alt_id;
 			ctx->cpus_not_match[ctx->i_nm] = cpu;
 			ctx->i_nm++;
 		}


### PR DESCRIPTION
This is an index typo in test_cpu_stickable(). When storing the alternate domain ID for non-matching CPUs, the code incorrectly uses ctx->i_m instead of ctx->i_nm:

ctx->cpdoms_not_match[ctx->i_m] = cpuc->cpdom_alt_id; // Typo
ctx->cpus_not_match[ctx->i_nm] = cpu;

This typo may cause array desynchronization and overwritten data. While find_sticky_cpu_and_cpdom() relies on these arrays to finalize optimal sticky domains for tasks, the bug could lead to wrong sticky domain decisions.

Fixes: e064ecfff128 ("scx_lavd: Make the idle CPU selection compute domain aware.")