### PR TITLE
scx_layered: fix warning

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1172,7 +1172,7 @@ impl Stats {
                 .map(|(cur, prev)| {
                     cur.iter()
                         .zip(prev.iter())
-                        .map(|(c, p)| ((*c as i64 - *p as i64) as f64 / (1024 as f64).powf(3.0)))
+                        .map(|(c, p)| (*c as i64 - *p as i64) as f64 / (1024 as f64).powf(3.0))
                         .collect()
                 })
                 .collect()


### PR DESCRIPTION
Fix warining.

**- before:**

```
lucjan at cachyos ~/Pobrane/b/scx 19:25:24 41c30ffb main    
❯ cargo build -p scx_layered
warning: /home/lucjan/Pobrane/b/scx/Cargo.toml: unused manifest key: profile.release-fast.target-cpu
warning: /home/lucjan/Pobrane/b/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
   Compiling proc-macro2 v1.0.95
   Compiling unicode-ident v1.0.18
   Compiling libc v0.2.175
   Compiling cfg-if v1.0.1
   Compiling autocfg v1.5.0
   Compiling bitflags v2.9.1
   Compiling itoa v1.0.15
   Compiling memchr v2.7.5
   Compiling serde_core v1.0.228
   Compiling cfg_aliases v0.2.1
   Compiling serde v1.0.228
   Compiling serde_json v1.0.145
   Compiling shlex v1.3.0
   Compiling ryu v1.0.20
   Compiling log v0.4.27
   Compiling rustix v1.0.8
   Compiling regex-syntax v0.8.5
   Compiling linux-raw-sys v0.9.4
   Compiling camino v1.1.10
   Compiling cc v1.2.29
   Compiling lazy_static v1.5.0
   Compiling semver v1.0.26
   Compiling strsim v0.11.1
   Compiling nix v0.30.1
   Compiling once_cell v1.21.3
   Compiling anyhow v1.0.98
   Compiling crossbeam-utils v0.8.21
   Compiling iana-time-zone v0.1.63
   Compiling tracing-core v0.1.34
   Compiling thiserror v1.0.69
   Compiling num-traits v0.2.19
   Compiling utf8parse v0.2.2
   Compiling pkg-config v0.3.32
   Compiling minimal-lexical v0.2.1
   Compiling thiserror v2.0.12
   Compiling glob v0.3.2
   Compiling quote v1.0.40
   Compiling anstyle-parse v0.2.7
   Compiling aho-corasick v1.1.3
   Compiling syn v2.0.104
   Compiling libloading v0.8.8
   Compiling is_terminal_polyfill v1.70.1
   Compiling time-core v0.1.4
   Compiling powerfmt v0.2.0
   Compiling rustversion v1.0.21
   Compiling overload v0.1.1
   Compiling anstyle v1.0.11
   Compiling getrandom v0.3.3
   Compiling clang-sys v1.8.1
   Compiling pin-project-lite v0.2.16
   Compiling colorchoice v1.0.4
   Compiling num-conv v0.1.0
   Compiling prettyplease v0.2.35
   Compiling anstyle-query v1.1.3
   Compiling deranged v0.4.0
   Compiling anstream v0.6.19
   Compiling nu-ansi-term v0.46.0
   Compiling tracing-log v0.2.0
   Compiling sharded-slab v0.1.7
   Compiling thread_local v1.1.9
   Compiling heck v0.5.0
   Compiling unicase v2.8.1
   Compiling unicode-xid v0.2.6
   Compiling unicode-width v0.2.0
   Compiling clap_lex v0.7.5
   Compiling unicode-segmentation v1.12.0
   Compiling smallvec v1.15.1
   Compiling num_threads v0.1.7
   Compiling vsprintf v2.0.0
   Compiling const_format_proc_macros v0.2.34
   Compiling crossbeam-epoch v0.9.18
   Compiling regex-syntax v0.6.29
   Compiling bindgen v0.72.0
   Compiling regex-automata v0.4.9
   Compiling convert_case v0.6.0
   Compiling unicode-width v0.1.14
   Compiling either v1.15.0
   Compiling strsim v0.10.0
   Compiling fastrand v2.3.0
   Compiling itertools v0.13.0
   Compiling vergen v8.3.2
   Compiling crossbeam-deque v0.8.6
   Compiling memmap2 v0.9.7
   Compiling num-integer v0.1.46
   Compiling const_format v0.2.34
   Compiling terminal_size v0.4.2
   Compiling tempfile v3.20.0
   Compiling clap_builder v4.5.41
   Compiling chrono v0.4.41
   Compiling crossbeam-channel v0.5.15
   Compiling crossbeam-queue v0.3.12
   Compiling nom v7.1.3
   Compiling radium v0.7.0
   Compiling rustc-hash v2.1.1
   Compiling libbpf-sys v1.6.1+v1.6.1
   Compiling crossbeam v0.8.4
   Compiling xattr v1.5.1
   Compiling time v0.3.41
   Compiling filetime v0.2.25
   Compiling tap v1.0.1
   Compiling same-file v1.0.6
   Compiling twox-hash v2.1.2
   Compiling walkdir v2.5.0
   Compiling tar v0.4.44
   Compiling ruzstd v0.8.1
   Compiling wyz v0.5.1
   Compiling tracing-subscriber v0.3.19
   Compiling num-bigint v0.4.6
   Compiling funty v2.0.0
   Compiling version-compare v0.1.1
   Compiling regex v1.11.2
   Compiling paste v1.0.15
   Compiling num-iter v0.1.45
   Compiling num-complex v0.4.6
   Compiling hex v0.4.3
   Compiling cexpr v0.6.0
   Compiling libbpf-rs v0.26.0-beta.1
   Compiling num-rational v0.4.2
   Compiling fnv v1.0.7
   Compiling ident_case v1.0.1
   Compiling bitflags v1.3.2
   Compiling num v0.4.3
   Compiling io-lifetimes v1.0.11
   Compiling crc32fast v1.5.0
   Compiling darling_core v0.20.11
   Compiling memoffset v0.6.5
   Compiling adler2 v2.0.1
   Compiling rustix v0.36.17
   Compiling miniz_oxide v0.8.9
   Compiling linux-raw-sys v0.1.4
   Compiling procfs v0.15.1
   Compiling flate2 v1.1.2
   Compiling num_cpus v1.17.0
   Compiling mio v1.0.4
   Compiling socket2 v0.5.10
   Compiling time-macros v0.2.22
   Compiling include_dir_macros v0.7.4
   Compiling csv-core v0.1.12
   Compiling pin-utils v0.1.0
   Compiling byteorder v1.5.0
   Compiling nix v0.25.1
   Compiling tokio v1.46.1
   Compiling serde_derive v1.0.228
   Compiling thiserror-impl v2.0.12
   Compiling thiserror-impl v1.0.69
   Compiling clap_derive v4.5.41
   Compiling tracing-attributes v0.1.30
   Compiling sscanf_macro v0.4.1
   Compiling include_dir v0.7.4
   Compiling threadpool v1.8.1
   Compiling inotify-sys v0.1.5
   Compiling openat v0.1.21
   Compiling nvml-wrapper-sys v0.9.0
   Compiling darling_macro v0.20.11
   Compiling termcolor v1.4.1
   Compiling darling v0.20.11
   Compiling wrapcenum-derive v0.4.1
   Compiling futures-core v0.3.31
   Compiling static_assertions v1.1.0
   Compiling tracing v0.1.41
   Compiling inotify v0.11.0
   Compiling ctrlc v3.4.7
   Compiling sysinfo v0.35.2
   Compiling clap v4.5.41
   Compiling sscanf v0.4.1
   Compiling simplelog v0.12.2
   Compiling nvml-wrapper v0.11.0
   Compiling cargo-platform v0.1.9
   Compiling scx_stats v1.0.17 (/home/lucjan/Pobrane/b/scx/rust/scx_stats)
   Compiling bitvec v1.0.1
   Compiling csv v1.3.1
   Compiling fb_procfs v0.7.1
   Compiling cargo_metadata v0.19.2
   Compiling cargo_metadata v0.18.1
   Compiling scx_stats_derive v1.0.17 (/home/lucjan/Pobrane/b/scx/rust/scx_stats/scx_stats_derive)
   Compiling libbpf-cargo v0.26.0-beta.1
   Compiling scx_utils v1.0.22 (/home/lucjan/Pobrane/b/scx/rust/scx_utils)
   Compiling scx_cargo v1.0.22 (/home/lucjan/Pobrane/b/scx/rust/scx_cargo)
   Compiling scx_raw_pmu v0.1.1 (/home/lucjan/Pobrane/b/scx/rust/scx_raw_pmu)
   Compiling scx_bpf_compat v1.0.17 (/home/lucjan/Pobrane/b/scx/rust/scx_bpf_compat)
   Compiling scx_layered v1.0.19 (/home/lucjan/Pobrane/b/scx/scheds/rust/scx_layered)
warning: unnecessary parentheses around closure body
    --> scheds/rust/scx_layered/src/main.rs:1175:39
     |
1175 |                         .map(|(c, p)| ((*c as i64 - *p as i64) as f64 / (1024 as f64).powf(3.0)))
     |                                       ^                                                        ^
     |
     = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
     |
1175 -                         .map(|(c, p)| ((*c as i64 - *p as i64) as f64 / (1024 as f64).powf(3.0)))
1175 +                         .map(|(c, p)| (*c as i64 - *p as i64) as f64 / (1024 as f64).powf(3.0))
     |

warning: `scx_layered` (bin "scx_layered") generated 1 warning (run `cargo fix --bin "scx_layered"` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 29.19s
```

**- after:**

```
lucjan at cachyos ~/Pobrane/scx/scheds/rust/scx_layered/src 19:24:52 d9edaa21 layered-fix    
❯ cargo build -p scx_layered                  
warning: /home/lucjan/Pobrane/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
warning: /home/lucjan/Pobrane/scx/Cargo.toml: unused manifest key: profile.release-fast.target-cpu
   Compiling proc-macro2 v1.0.95
   Compiling unicode-ident v1.0.18
   Compiling libc v0.2.175
   Compiling cfg-if v1.0.1
   Compiling autocfg v1.5.0
   Compiling bitflags v2.9.1
   Compiling itoa v1.0.15
   Compiling serde_core v1.0.228
   Compiling memchr v2.7.5
   Compiling cfg_aliases v0.2.1
   Compiling ryu v1.0.20
   Compiling serde_json v1.0.145
   Compiling serde v1.0.228
   Compiling shlex v1.3.0
   Compiling log v0.4.27
   Compiling rustix v1.0.8
   Compiling camino v1.1.10
   Compiling semver v1.0.26
   Compiling lazy_static v1.5.0
   Compiling strsim v0.11.1
   Compiling linux-raw-sys v0.9.4
   Compiling regex-syntax v0.8.5
   Compiling cc v1.2.29
   Compiling nix v0.30.1
   Compiling anyhow v1.0.98
   Compiling crossbeam-utils v0.8.21
   Compiling once_cell v1.21.3
   Compiling iana-time-zone v0.1.63
   Compiling minimal-lexical v0.2.1
   Compiling num-traits v0.2.19
   Compiling tracing-core v0.1.34
   Compiling glob v0.3.2
   Compiling thiserror v2.0.12
   Compiling utf8parse v0.2.2
   Compiling thiserror v1.0.69
   Compiling pkg-config v0.3.32
   Compiling quote v1.0.40
   Compiling anstyle-parse v0.2.7
   Compiling aho-corasick v1.1.3
   Compiling syn v2.0.104
   Compiling libloading v0.8.8
   Compiling anstyle v1.0.11
   Compiling overload v0.1.1
   Compiling clang-sys v1.8.1
   Compiling getrandom v0.3.3
   Compiling powerfmt v0.2.0
   Compiling pin-project-lite v0.2.16
   Compiling colorchoice v1.0.4
   Compiling rustversion v1.0.21
   Compiling anstyle-query v1.1.3
   Compiling num-conv v0.1.0
   Compiling time-core v0.1.4
   Compiling prettyplease v0.2.35
   Compiling is_terminal_polyfill v1.70.1
   Compiling deranged v0.4.0
   Compiling nu-ansi-term v0.46.0
   Compiling anstream v0.6.19
   Compiling tracing-log v0.2.0
   Compiling sharded-slab v0.1.7
   Compiling thread_local v1.1.9
   Compiling num_threads v0.1.7
   Compiling clap_lex v0.7.5
   Compiling heck v0.5.0
   Compiling smallvec v1.15.1
   Compiling unicode-width v0.2.0
   Compiling unicode-segmentation v1.12.0
   Compiling unicase v2.8.1
   Compiling unicode-xid v0.2.6
   Compiling const_format_proc_macros v0.2.34
   Compiling crossbeam-epoch v0.9.18
   Compiling vsprintf v2.0.0
   Compiling strsim v0.10.0
   Compiling convert_case v0.6.0
   Compiling regex-syntax v0.6.29
   Compiling either v1.15.0
   Compiling unicode-width v0.1.14
   Compiling fastrand v2.3.0
   Compiling bindgen v0.72.0
   Compiling regex-automata v0.4.9
   Compiling vergen v8.3.2
   Compiling itertools v0.13.0
   Compiling crossbeam-deque v0.8.6
   Compiling memmap2 v0.9.7
   Compiling chrono v0.4.41
   Compiling num-integer v0.1.46
   Compiling crossbeam-channel v0.5.15
   Compiling crossbeam-queue v0.3.12
   Compiling const_format v0.2.34
   Compiling nom v7.1.3
   Compiling rustc-hash v2.1.1
   Compiling terminal_size v0.4.2
   Compiling tempfile v3.20.0
   Compiling clap_builder v4.5.41
   Compiling radium v0.7.0
   Compiling crossbeam v0.8.4
   Compiling xattr v1.5.1
   Compiling libbpf-sys v1.6.1+v1.6.1
   Compiling time v0.3.41
   Compiling filetime v0.2.25
   Compiling same-file v1.0.6
   Compiling twox-hash v2.1.2
   Compiling tap v1.0.1
   Compiling tar v0.4.44
   Compiling tracing-subscriber v0.3.19
   Compiling wyz v0.5.1
   Compiling ruzstd v0.8.1
   Compiling walkdir v2.5.0
   Compiling num-bigint v0.4.6
   Compiling funty v2.0.0
   Compiling paste v1.0.15
   Compiling version-compare v0.1.1
   Compiling num-iter v0.1.45
   Compiling num-complex v0.4.6
   Compiling cexpr v0.6.0
   Compiling regex v1.11.2
   Compiling hex v0.4.3
   Compiling libbpf-rs v0.26.0-beta.1
   Compiling crc32fast v1.5.0
   Compiling fnv v1.0.7
   Compiling num-rational v0.4.2
   Compiling ident_case v1.0.1
   Compiling io-lifetimes v1.0.11
   Compiling bitflags v1.3.2
   Compiling darling_core v0.20.11
   Compiling num v0.4.3
   Compiling memoffset v0.6.5
   Compiling rustix v0.36.17
   Compiling adler2 v2.0.1
   Compiling miniz_oxide v0.8.9
   Compiling linux-raw-sys v0.1.4
   Compiling procfs v0.15.1
   Compiling mio v1.0.4
   Compiling flate2 v1.1.2
   Compiling socket2 v0.5.10
   Compiling num_cpus v1.17.0
   Compiling time-macros v0.2.22
   Compiling include_dir_macros v0.7.4
   Compiling csv-core v0.1.12
   Compiling byteorder v1.5.0
   Compiling pin-utils v0.1.0
   Compiling nix v0.25.1
   Compiling include_dir v0.7.4
   Compiling threadpool v1.8.1
   Compiling tokio v1.46.1
   Compiling openat v0.1.21
   Compiling inotify-sys v0.1.5
   Compiling nvml-wrapper-sys v0.9.0
   Compiling futures-core v0.3.31
   Compiling serde_derive v1.0.228
   Compiling thiserror-impl v1.0.69
   Compiling thiserror-impl v2.0.12
   Compiling clap_derive v4.5.41
   Compiling tracing-attributes v0.1.30
   Compiling sscanf_macro v0.4.1
   Compiling static_assertions v1.1.0
   Compiling termcolor v1.4.1
   Compiling darling_macro v0.20.11
   Compiling darling v0.20.11
   Compiling wrapcenum-derive v0.4.1
   Compiling inotify v0.11.0
   Compiling nvml-wrapper v0.11.0
   Compiling ctrlc v3.4.7
   Compiling sysinfo v0.35.2
   Compiling tracing v0.1.41
   Compiling simplelog v0.12.2
   Compiling clap v4.5.41
   Compiling sscanf v0.4.1
   Compiling cargo-platform v0.1.9
   Compiling bitvec v1.0.1
   Compiling scx_stats v1.0.17 (/home/lucjan/Pobrane/scx/rust/scx_stats)
   Compiling csv v1.3.1
   Compiling cargo_metadata v0.19.2
   Compiling cargo_metadata v0.18.1
   Compiling fb_procfs v0.7.1
   Compiling scx_stats_derive v1.0.17 (/home/lucjan/Pobrane/scx/rust/scx_stats/scx_stats_derive)
   Compiling libbpf-cargo v0.26.0-beta.1
   Compiling scx_utils v1.0.22 (/home/lucjan/Pobrane/scx/rust/scx_utils)
   Compiling scx_cargo v1.0.22 (/home/lucjan/Pobrane/scx/rust/scx_cargo)
   Compiling scx_raw_pmu v0.1.1 (/home/lucjan/Pobrane/scx/rust/scx_raw_pmu)
   Compiling scx_bpf_compat v1.0.17 (/home/lucjan/Pobrane/scx/rust/scx_bpf_compat)
   Compiling scx_layered v1.0.19 (/home/lucjan/Pobrane/scx/scheds/rust/scx_layered)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 36.29s
```