### PR TITLE
scx_rustland_core: Allow to define a default time slice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "scx_rustland_core"
-version = "2.3.7"
+version = "2.4.7"
 dependencies = [
  "anyhow",
  "libbpf-rs",

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_rustland_core"
-version = "2.3.7"
+version = "2.4.7"
 edition = "2021"
 authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"

--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -213,6 +213,7 @@ impl<'cb> BpfScheduler<'cb> {
         partial: bool,
         debug: bool,
         builtin_idle: bool,
+        slice_ns: u64,
         name: &str,
     ) -> Result<Self> {
         let shutdown = Arc::new(AtomicBool::new(false));
@@ -263,6 +264,7 @@ impl<'cb> BpfScheduler<'cb> {
         skel.maps.rodata_data.as_mut().unwrap().usersched_pid = std::process::id();
         skel.maps.rodata_data.as_mut().unwrap().khugepaged_pid = Self::khugepaged_pid();
         skel.maps.rodata_data.as_mut().unwrap().builtin_idle = builtin_idle;
+        skel.maps.rodata_data.as_mut().unwrap().slice_ns = slice_ns;
         skel.maps.rodata_data.as_mut().unwrap().debug = debug;
         let _ = Self::set_scx_ops_name(&mut skel.struct_ops.rustland_mut().name, name);
 

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -14,11 +14,11 @@ ctrlc = { version = "3.1", features = ["termination"] }
 libbpf-rs = "=0.26.0-beta.1"
 libc = "0.2.175"
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.22" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.7" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.4.7" }
 
 [build-dependencies]
 scx_cargo = { path = "../../../rust/scx_cargo", version = "1.0.22" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.7" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.4.7" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -116,6 +116,7 @@ impl<'a> Scheduler<'a> {
             false,    // partial (false = include all tasks)
             false,    // debug (false = debug mode off)
             true,     // builtin_idle (true = allow BPF to use idle CPUs if available)
+            SLICE_NS, // default time slice (for tasks automatically dispatched by the backend)
             "rlfifo", // name of the scx ops
         )?;
         Ok(Self { bpf })

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -20,12 +20,12 @@ serde = { version = "1.0.215", features = ["derive"] }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.17" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.17" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.22" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.7" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.4.7" }
 simplelog = "0.12"
 
 [build-dependencies]
 scx_cargo = { path = "../../../rust/scx_cargo", version = "1.0.22" }
-scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.3.7" }
+scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.4.7" }
 
 [features]
 enable_backtrace = []

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -163,6 +163,9 @@ impl<'a> Scheduler<'a> {
     fn init(opts: &'a Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
         let stats_server = StatsServer::new(stats::server_data()).launch()?;
 
+        let slice_ns = opts.slice_us * NSEC_PER_USEC;
+        let slice_ns_min = opts.slice_us_min * NSEC_PER_USEC;
+
         // Low-level BPF connector.
         let bpf = BpfScheduler::init(
             open_object,
@@ -171,6 +174,7 @@ impl<'a> Scheduler<'a> {
             opts.partial,
             opts.verbose,
             true, // Enable built-in idle CPU selection policy
+            slice_ns_min,
             "rustland",
         )?;
 
@@ -189,8 +193,8 @@ impl<'a> Scheduler<'a> {
             tasks: BTreeSet::new(),
             vruntime_now: 0,
             init_page_faults: 0,
-            slice_ns: opts.slice_us * NSEC_PER_USEC,
-            slice_ns_min: opts.slice_us_min * NSEC_PER_USEC,
+            slice_ns,
+            slice_ns_min,
         })
     }
 


### PR DESCRIPTION
When initializing the BpfScheduler, allow specifying a default time slice for tasks automatically dispatched by the scx_rustland_core backend (for example, when the built-in idle CPU selection policy is enabled and a task is automatically dispatched on an idle CPU).

This helps improve responsiveness for schedulers with latency-sensitive requirements, ensuring that tasks never receive a time slice larger than the value defined by the user-space scheduler.

Also bump up scx_rustland_core major version, as this change breaks backward compatibility due to the new slice_ns argument added to BpfScheduler.