### PR TITLE
nix: support aarch64-linux in flake

### DIFF
--- a/.nix/flake.nix
+++ b/.nix/flake.nix
@@ -30,7 +30,7 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, fenix, nix-develop-gha, libbpf-src, veristat-src, ... }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ]
+    flake-utils.lib.eachSystem [ "aarch64-linux" "x86_64-linux" ]
       (system:
         let
           pkgs = import nixpkgs {


### PR DESCRIPTION
This makes my dev environment work on ARM. Don't apply in the CI yet given last time it didn't work, but it should be enabled at some point to populate the cache.

Test plan:
- Loaded the dev environment on an aarch64 NixOS machine. Can then run `cargo build`.