### PR TITLE
scx_mitosis: Add debug event recording

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -19,17 +19,44 @@ typedef _Bool bool;
 #endif
 
 enum consts {
-	CACHELINE_SIZE	  = 64,
-	MAX_CPUS_SHIFT	  = 9,
-	MAX_CPUS	  = 1 << MAX_CPUS_SHIFT,
-	MAX_CPUS_U8	  = MAX_CPUS / 8,
-	MAX_CELLS	  = 16,
-	USAGE_HALF_LIFE	  = 100000000, /* 100ms */
-	TIMER_INTERVAL_NS = 100000000, /* 100 ms */
-	CLOCK_BOOTTIME	  = 7,
+	CACHELINE_SIZE	      = 64,
+	MAX_CPUS_SHIFT	      = 9,
+	MAX_CPUS	      = 1 << MAX_CPUS_SHIFT,
+	MAX_CPUS_U8	      = MAX_CPUS / 8,
+	MAX_CELLS	      = 16,
+	USAGE_HALF_LIFE	      = 100000000, /* 100ms */
+	TIMER_INTERVAL_NS     = 100000000, /* 100 ms */
+	CLOCK_BOOTTIME	      = 7,
 
-	PCPU_BASE	  = 0x80000000,
-	MAX_CG_DEPTH	  = 256,
+	PCPU_BASE	      = 0x80000000,
+	MAX_CG_DEPTH	      = 256,
+
+	DEBUG_EVENTS_BUF_SIZE = 256,
+};
+
+/* Debug event types */
+enum debug_event_type {
+	DEBUG_EVENT_CGROUP_INIT,
+	DEBUG_EVENT_INIT_TASK,
+	DEBUG_EVENT_CGROUP_EXIT,
+};
+
+/* Debug event record - discriminated union */
+struct debug_event {
+	u64 timestamp;
+	u32 event_type;
+	union {
+		struct {
+			u64 cgid;
+		} cgroup_init;
+		struct {
+			u64 cgid;
+			u32 pid;
+		} init_task;
+		struct {
+			u64 cgid;
+		} cgroup_exit;
+	};
 };
 
 /* Statistics */

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -90,6 +90,11 @@ struct Opts {
     #[clap(short = 'V', long, action = clap::ArgAction::SetTrue)]
     version: bool,
 
+    /// Enable debug event tracking for cgroup_init, init_task, and cgroup_exit.
+    /// Events are recorded in a ring buffer and output in dump().
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    debug_events: bool,
+
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
 }
@@ -176,6 +181,7 @@ impl<'a> Scheduler<'a> {
         skel.struct_ops.mitosis_mut().exit_dump_len = opts.exit_dump_len;
 
         skel.maps.rodata_data.as_mut().unwrap().slice_ns = scx_enums.SCX_SLICE_DFL;
+        skel.maps.rodata_data.as_mut().unwrap().debug_events_enabled = opts.debug_events;
 
         skel.maps.rodata_data.as_mut().unwrap().nr_possible_cpus = *NR_CPUS_POSSIBLE as u32;
         for cpu in topology.all_cpus.keys() {


### PR DESCRIPTION
We've seen incidents which indicate cgroup_init and init_task not following the expected ordering. This commit adds a flag that enables recording of such events to be output at dump time. This should make it easier to track down the issue.