### PR TITLE
utils: Update cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,12 +1929,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2160,12 +2159,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owning_ref"
@@ -3929,9 +3922,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "chrono",
  "nu-ansi-term",

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -33,7 +33,7 @@ zbus = { version = "5.3.1", optional = true }
 num = "0.4.3"
 tempfile = "3.19.1"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = "0.3.20"
 libc = "0.2.175"
 nix = { version = "0.30.1", features = ["resource"] }
 


### PR DESCRIPTION
Running `cargo audit` reveals there are some dependencies with vulnerabilities:

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 822 security advisories (from /home/hodgesd/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (473 crate dependencies)
Crate:     owning_ref
Version:   0.4.1
Title:     Multiple soundness issues in `owning_ref`
Date:      2022-01-26
ID:        RUSTSEC-2022-0040
URL:       https://rustsec.org/advisories/RUSTSEC-2022-0040
Solution:  No fixed upgrade is available!
Dependency tree:
owning_ref 0.4.1
└── cursive_core 0.3.7
    └── cursive 0.20.0
        └── below-common 0.9.0
            └── cgroupfs 0.9.0
                └── scx_mitosis 0.0.14
Crate:     tracing-subscriber
Version:   0.3.19
Title:     Logging user input may result in poisoning logs with ANSI escape sequences
Date:      2025-08-29
ID:        RUSTSEC-2025-0055
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0055
Solution:  Upgrade to >=0.3.20
Dependency tree:
tracing-subscriber 0.3.19
├── scx_utils 1.0.22
│   ├── scxtop 1.0.19
│   ├── scxcash 0.1.2
│   ├── scx_wd40 1.0.17
│   ├── scx_userspace_arena 1.0.17
│   │   └── scx_chaos 1.0.20
│   ├── scx_tickless 1.0.8
│   ├── scx_rusty 1.0.17
│   ├── scx_rustland_core 2.4.7
│   │   ├── scx_rustland 1.0.17
│   │   └── scx_rlfifo 1.0.17
│   ├── scx_rustland 1.0.17
│   ├── scx_rlfifo 1.0.17
│   ├── scx_raw_pmu 0.1.1
│   │   └── scx_layered 1.0.19
│   ├── scx_p2dq 1.0.22
│   │   └── scx_chaos 1.0.20
│   ├── scx_mitosis 0.0.14
│   ├── scx_layered 1.0.19
│   ├── scx_lavd 1.0.17
│   ├── scx_flash 1.0.15
│   ├── scx_cosmos 1.0.3
│   ├── scx_chaos 1.0.20
│   ├── scx_cargo 1.0.22
│   │   ├── scxtop 1.0.19
│   │   ├── scxcash 0.1.2
│   │   ├── scx_wd40 1.0.17
│   │   ├── scx_userspace_arena 1.0.17
│   │   ├── scx_tickless 1.0.8
│   │   ├── scx_rusty 1.0.17
│   │   ├── scx_rustland 1.0.17
│   │   ├── scx_rlfifo 1.0.17
│   │   ├── scx_p2dq 1.0.22
│   │   ├── scx_mitosis 0.0.14
│   │   ├── scx_layered 1.0.19
│   │   ├── scx_lavd 1.0.17
│   │   ├── scx_flash 1.0.15
│   │   ├── scx_cosmos 1.0.3
│   │   ├── scx_chaos 1.0.20
│   │   ├── scx_bpfland 1.0.17
│   │   ├── scx_bpf_compat 1.0.17
│   │   │   └── scx_layered 1.0.19
│   │   └── scx_arena_selftests 1.0.4
│   ├── scx_bpfland 1.0.17
│   ├── scx_bpf_compat 1.0.17
│   ├── scx_arena_selftests 1.0.4
│   └── scx_arena 0.1.1
│       ├── scx_wd40 1.0.17
│       ├── scx_p2dq 1.0.22
│       └── scx_chaos 1.0.20
└── libbpf-cargo 0.26.0-beta.1
    └── scx_utils 1.0.22
Crate:     paste
Version:   1.0.15
Warning:   unmaintained
Title:     paste - no longer maintained
Date:      2024-10-07
ID:        RUSTSEC-2024-0436
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0436
Dependency tree:
paste 1.0.15
├── scx_utils 1.0.22
│   ├── scxtop 1.0.19
│   ├── scxcash 0.1.2
│   ├── scx_wd40 1.0.17
│   ├── scx_userspace_arena 1.0.17
│   │   └── scx_chaos 1.0.20
│   ├── scx_tickless 1.0.8
│   ├── scx_rusty 1.0.17
│   ├── scx_rustland_core 2.4.7
│   │   ├── scx_rustland 1.0.17
│   │   └── scx_rlfifo 1.0.17
│   ├── scx_rustland 1.0.17
│   ├── scx_rlfifo 1.0.17
│   ├── scx_raw_pmu 0.1.1
│   │   └── scx_layered 1.0.19
│   ├── scx_p2dq 1.0.22
│   │   └── scx_chaos 1.0.20
│   ├── scx_mitosis 0.0.14
│   ├── scx_layered 1.0.19
│   ├── scx_lavd 1.0.17
│   ├── scx_flash 1.0.15
│   ├── scx_cosmos 1.0.3
│   ├── scx_chaos 1.0.20
│   ├── scx_cargo 1.0.22
│   │   ├── scxtop 1.0.19
│   │   ├── scxcash 0.1.2
│   │   ├── scx_wd40 1.0.17
│   │   ├── scx_userspace_arena 1.0.17
│   │   ├── scx_tickless 1.0.8
│   │   ├── scx_rusty 1.0.17
│   │   ├── scx_rustland 1.0.17
│   │   ├── scx_rlfifo 1.0.17
│   │   ├── scx_p2dq 1.0.22
│   │   ├── scx_mitosis 0.0.14
│   │   ├── scx_layered 1.0.19
│   │   ├── scx_lavd 1.0.17
│   │   ├── scx_flash 1.0.15
│   │   ├── scx_cosmos 1.0.3
│   │   ├── scx_chaos 1.0.20
│   │   ├── scx_bpfland 1.0.17
│   │   ├── scx_bpf_compat 1.0.17
│   │   │   └── scx_layered 1.0.19
│   │   └── scx_arena_selftests 1.0.4
│   ├── scx_bpfland 1.0.17
│   ├── scx_bpf_compat 1.0.17
│   ├── scx_arena_selftests 1.0.4
│   └── scx_arena 0.1.1
│       ├── scx_wd40 1.0.17
│       ├── scx_p2dq 1.0.22
│       └── scx_chaos 1.0.20
└── ratatui 0.29.0
    └── scxtop 1.0.19
error: 2 vulnerabilities found!
warning: 1 allowed warning found
```
Update scx_utils to use a vetted version of the tracing-subscriber crate.