### PR TITLE
tools/xtask: Downgrade cargo_metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,22 +460,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-platform"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122ec45a44b270afd1402f351b782c676b173e3c3fb28d86ff7ebfb4d86a4ee4"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "cargo_metadata"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
- "cargo-platform 0.1.9",
+ "cargo-platform",
  "semver",
  "serde",
  "serde_json",
@@ -489,21 +480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform 0.1.9",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981a6f317983eec002839b90fae7411a85621410ae591a9cab2ecf5cb5744873"
-dependencies = [
- "camino",
- "cargo-platform 0.3.1",
+ "cargo-platform",
  "semver",
  "serde",
  "serde_json",
@@ -4678,7 +4655,7 @@ name = "xtask"
 version = "0.1.1"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.23.0",
+ "cargo_metadata 0.19.2",
  "clap",
  "log",
  "once_cell",

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -10,7 +10,7 @@ ci.use_clippy = true
 
 [dependencies]
 anyhow = "1.0.65"
-cargo_metadata = "0.23"
+cargo_metadata = "0.19"
 clap = { version = "4.5.28", features = ["derive"] }
 log = "0.4.17"
 regex = "1.11.2"


### PR DESCRIPTION
The cargo_metadata 0.23 dependency breaks `cargo vendor` on Ubuntu 24.04, due to the usual error:
```
  feature `edition2024` is required
```
This prevents including all required crates in the source package.

Downgrade to cargo_metadata 0.19 in xtask to avoid maintaining a custom patch for Ubuntu Noble.

All the `cargo xtask` commands seem to be still functional after downgrading the dependency.