### PR TITLE
scx_lavd: Add configurable migration threshold with avg utilization

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -110,6 +110,7 @@ struct cpdom_ctx {
 	u32	sc_load;			    /* scaled load considering DSQ length and CPU utilization */
 	u32	nr_queued_task;			    /* the number of queued tasks in this domain */
 	u32	cur_util_sum;			    /* the sum of CPU utilization in the current interval */
+	u32	avg_util_sum;			    /* the sum of average CPU utilization */
 	u32	cap_sum_active_cpus;		    /* the sum of capacities of active CPUs in this domain */
 	u32	cap_sum_temp;			    /* temp for cap_sum_active_cpus */
 	u32	dsq_consume_lat;		    /* latency to consume from dsq, shows how contended the dsq is */

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -208,6 +208,11 @@ static u64		cur_svc_time;
 const volatile u64	slice_min_ns = LAVD_SLICE_MIN_NS_DFL;
 const volatile u64	slice_max_ns = LAVD_SLICE_MAX_NS_DFL;
 
+/*
+ * Migration delta threshold percentage (0-100)
+ */
+const volatile u8	mig_delta_pct = 0;
+
 static volatile u64	nr_cpus_big;
 
 /*

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -99,6 +99,7 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 
 		cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpdom_id]);
 		cpdomc->cur_util_sum = 0;
+		cpdomc->avg_util_sum = 0;
 		cpdomc->nr_queued_task = scx_bpf_dsq_nr_queued(cpdom_to_dsq(cpdom_id));
 		if (per_cpu_dsq) {
 			bpf_for(i, 0, LAVD_CPU_ID_MAX/64) {
@@ -255,8 +256,10 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 		cpuc->avg_util = calc_asym_avg(cpuc->avg_util, cpuc->cur_util);
 
 		cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpuc->cpdom_id]);
-		if (cpdomc)
+		if (cpdomc) {
 			cpdomc->cur_util_sum += cpuc->cur_util;
+			cpdomc->avg_util_sum += cpuc->avg_util;
+		}
 
 		/*
 		 * Accmulate system-wide idle time.


### PR DESCRIPTION
The current utilization based migration scheme look back period is too short and results in overly aggressive load balancing. For example, in certain workloads on a machine that has an average utilization at ~90%, sampling load deltas between compute domains still showed > 50% differences in load.

Allow users to define some threshold for task stealing using sum of util_avg of CPUs on a compute domain instead to smooth out load tracking and reduce overall task migrations.

These are sampled on a ~90% workload to measure the cost of cross CCX/LLC domain migrations.

bpftop sample:
+-----------------+--------------+---------------+
| lavd_dispatch   | forced_steal | no_task_steal |
+-----------------+--------------+---------------+
| avg_runtime(ns) | 3593         | 762           |
| cputime(%)      | 250.99       | 40.87         |
| events/s        | 704720       | 746275        |
+-----------------+--------------+---------------+

latencies(ns):
+-----+---------------+--------------------+----------------------+
|     | dispatch(avg) | consume(local_llc) | consume(remote_llc)  |
+-----+---------------+--------------------+----------------------+
| avg | 3884          | 595.9              | 2216.6               |
| p90 | 7721          | 1952.3             | 5709.0               |
| p99 | 14715         | 6900.0             | 13023.5              |
+-----+---------------+--------------------+----------------------+

In general, cross CCX/LLC domain migrations are expensive at high utilization and results in lower IPC due to cache locality. Disabling forced task stealing allows us to trade off some work conservation for better cache characteristics and scheduler overhead.