### PR TITLE
cargo: Fix target-cpu option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,5 @@ incremental = true
 
 [profile.release-fast]
 inherits = "release"
-target-cpu = "native"
 lto = false
 incremental = true


### PR DESCRIPTION
The target-cpu option doesn't work correctly in the Cargo.toml, see https://github.com/rust-lang/cargo/issues/2535 for more details. This will fix warnings in the build process:

    ```
    $ cargo build --release
    warning: /root/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
    warning: /root/scx/Cargo.toml: unused manifest key: profile.release-fast.target-cpu
    ```