### PR TITLE
scx_lavd: Fix lost cpu assignment when reusing prev_cpu

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -814,6 +814,7 @@ skip_fully_idle_neighbor:
 	if (can_run_on_cpu(ctx, ctx->prev_cpu)) {
 		cpu = ctx->prev_cpu;
 		sticky_cpdom = -ENOENT;
+		goto unlock_out;
 	}
 
 	/*


### PR DESCRIPTION
When `can_run_on_cpu(ctx, ctx->prev_cpu)` returns true, cpu is assigned to `ctx->prev_cpu`. 
However, the code path does not jump to `unlock_out` afterward.
As a result, execution falls through to `err_out`, where cpu is overwritten with `-ENOENT`. 
Later, this leads to `pick_random_cpu(ctx)` being invoked, effectively discarding the earlier `cpu = ctx->prev_cpu` assignment.
Fix this by adding a `goto unlock_out` after setting `cpu = ctx->prev_cpu`, ensuring the selected CPU is
retained as intended.