### PR TITLE
scx_mitosis: Bump max cells

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -23,7 +23,7 @@ enum consts {
 	MAX_CPUS_SHIFT	      = 9,
 	MAX_CPUS	      = 1 << MAX_CPUS_SHIFT,
 	MAX_CPUS_U8	      = MAX_CPUS / 8,
-	MAX_CELLS	      = 16,
+	MAX_CELLS	      = 256,
 	USAGE_HALF_LIFE	      = 100000000, /* 100ms */
 	TIMER_INTERVAL_NS     = 100000000, /* 100 ms */
 	CLOCK_BOOTTIME	      = 7,


### PR DESCRIPTION
We see machines where we desire more cells than 16. The memory overhead of this is relatively small though there is a per-cpu, per-cell memory cost but even with this change its on the order of a megabyte or so on a pretty large machine.