### PR TITLE
ci: update description when modifying an update-kernels pr

### DIFF
--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -74,6 +74,7 @@ jobs:
           if echo $PR_IDS | jq -e '. == []'; then
             gh pr create --fill
           else
-            echo "PR already exists, skipping creation."
+            echo "PR already exists, updating description..."
+            gh pr edit --title "$(git log -1 --pretty=%s)" --body "$(git log -1 --pretty=%b)"
           fi
           gh pr merge --auto


### PR DESCRIPTION
Update kernels commits/PRs include a link to the kernel changelog
automatically. This changes in the commit whenever a PR is updated (when
the PR failed to merge previously), but isn't updated in the PR body.

Add a `gh pr edit` command to ensure the PR body always matches the sole
commit.

Test plan:
- Ran the workflow from this branch
  (https://github.com/sched-ext/scx/actions/runs/18684425487/job/53273179379) on #2889.
  The PR message was updated correctly to match the commit.
