### PR TITLE
scx_lavd: Add --pinned-slice-us option for improved pinned task respo…

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -382,7 +382,11 @@ static bool consume_task(u64 cpu_dsq_id, u64 cpdom_dsq_id)
 	    try_to_steal_task(cpdomc))
 		goto x_domain_migration_out;
 
-	if (per_cpu_dsq) {
+	/*
+	 * When per_cpu_dsq or pinned_slice_ns is enabled, compare vtimes
+	 * across cpu_dsq and cpdom_dsq to select the task with the lowest vtime.
+	 */
+	if (per_cpu_dsq || pinned_slice_ns) {
 		bpf_for_each(scx_dsq, p, cpu_dsq_id, 0) {
 			vtime = p->scx.dsq_vtime;
 			break;

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -275,6 +275,7 @@ extern volatile u64		powersave_mode_ns;
 
 /* Helpers from util.bpf.c for querying CPU/task state. */
 extern const volatile bool	per_cpu_dsq;
+extern const volatile u64	pinned_slice_ns;
 
 extern volatile bool		reinit_cpumask_for_performance;
 extern volatile bool		no_preemption;


### PR DESCRIPTION
scx_lavd: Add --pinned-slice-us option for improved pinned task responsiveness

Add an option --pinned-slice-us that improves responsiveness for pinned tasks by reducing the time slice for tasks running on the contended CPU. This also allows for a longer default slice configuration while maintaining better latencies for workloads using pinning. When enabled, Per-CPU DSQs are created and pinned tasks are enqueued into their own queues.

For workloads running erlang or employ other per-cpu pinning, we observed long scheduling delays from non-pinned tasks competing with pinned tasks waiting on the same CPU. Employing a short slice time effectively allows the pinned task to pre-empt the task that's currently running on the CPU. This will allow unpinned tasks to re-enqueue on shared DSQs and find a less contended CPU while still maintaining some fairness between tasks when the system is close to saturation.

We also observed poor task placement due to congestion when using shared DSQs for pinned tasks due to:

- Having more/heavier pinned tasks increases contention on the DSQ lock, as CPUs require more time to iterate through ineligible tasks that are at the front of the queue while holding the lock

- Completely random task stealing from all CPUs will self balance to steal from more congested queues(as task stealing will more likely to succeed from longer queues)