### PR TITLE
nix: build scx_chaos with nix

### DIFF
--- a/.nix/crane.nix
+++ b/.nix/crane.nix
@@ -1,0 +1,86 @@
+{ lib
+, pkgs
+, crane
+, rust-toolchain
+, bpf-clang
+, pkg-config
+, clang
+, libclang
+, elfutils
+, libbpf-git
+, libseccomp
+, protobuf
+, zlib
+, zstd
+}:
+
+let
+  craneLib = (crane.mkLib pkgs).overrideToolchain rust-toolchain;
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      (craneLib.fileset.commonCargoSources ../.)
+      (lib.fileset.fileFilter (file: file.hasExt "h") ../.)
+      (lib.fileset.fileFilter (file: file.hasExt "c") ../.)
+      (lib.fileset.fileFilter (file: file.hasExt "zst") ../.)
+      (lib.fileset.fileFilter (file: file.type == "symlink") ../.)
+    ];
+  };
+
+  # Common crane arguments
+  commonArgs = {
+    inherit src;
+    strictDeps = true;
+
+    nativeBuildInputs = [
+      pkg-config
+      clang
+      libclang
+    ];
+
+    buildInputs = [
+      elfutils
+      libbpf-git
+      libseccomp
+      protobuf
+      zlib
+      zstd
+    ];
+
+    env = {
+      BPF_CLANG = lib.getExe bpf-clang;
+      LIBCLANG_PATH = "${lib.getLib libclang}/lib";
+      RUSTFLAGS = "-C relocation-model=pic -C link-args=-lelf -C link-args=-lz -C link-args=-lzstd -C link-args=-Wl,-rpath,${lib.makeLibraryPath [
+          elfutils
+          zlib
+        ]}";
+    };
+  };
+
+  cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
+    pname = "scx-workspace";
+    version = "git";
+  });
+
+  individualCrateArgs = commonArgs // {
+    inherit cargoArtifacts;
+    doCheck = false;
+  };
+in
+{
+  makeCargoSchedulerPackage = name:
+    craneLib.buildPackage (individualCrateArgs // {
+      pname = name;
+      version = "git";
+      cargoExtraArgs = "-p ${name}";
+
+      meta = with lib; {
+        description = "sched_ext scheduler: ${name}";
+        homepage = "https://github.com/sched-ext/scx";
+        license = licenses.gpl2Only;
+        maintainers = [ ];
+        platforms = platforms.linux;
+      };
+    });
+}

--- a/.nix/flake.lock
+++ b/.nix/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1759893430,
+        "narHash": "sha256-yAy4otLYm9iZ+NtQwTMEbqHwswSFUbhn7x826RR6djw=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "1979a2524cb8c801520bd94c38bb3d5692419d93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -93,6 +108,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "fenix": "fenix",
         "flake-utils": "flake-utils",
         "libbpf-src": "libbpf-src",

--- a/.nix/flake.nix
+++ b/.nix/flake.nix
@@ -14,6 +14,7 @@
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    crane.url = "github:ipetkov/crane";
 
     nix-develop-gha.url = "github:nicknovitski/nix-develop";
     nix-develop-gha.inputs.nixpkgs.follows = "nixpkgs";
@@ -29,261 +30,280 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, fenix, nix-develop-gha, libbpf-src, veristat-src, ... }:
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , fenix
+    , crane
+    , nix-develop-gha
+    , libbpf-src
+    , veristat-src
+    , ...
+    }:
     flake-utils.lib.eachSystem [ "aarch64-linux" "x86_64-linux" ]
       (system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [
-              (final: prev: {
-                libbpf-git = prev.libbpf.overrideAttrs (oldAttrs: {
-                  src = libbpf-src;
-                  version = "git";
-                  patches = [ ];
-                });
-                virtme-ng = prev.callPackage ./pkgs/virtme-ng.nix { };
-              })
-            ];
-          };
-          lib = pkgs.lib;
-
-          rust-toolchain = fenix.packages.${system}.stable.withComponents [
-            "cargo"
-            "clippy"
-            "rust-src"
-            "rustc"
-            "rustfmt"
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (final: prev: {
+              libbpf-git = prev.libbpf.overrideAttrs (oldAttrs: {
+                src = libbpf-src;
+                version = "git";
+                patches = [ ];
+              });
+              virtme-ng = prev.callPackage ./pkgs/virtme-ng.nix { };
+            })
           ];
+        };
+        lib = pkgs.lib;
 
-          makeBpfClang = llvmPackages: kernel: pkgs.stdenv.mkDerivation {
-            pname = "bpf-clang";
-            version = llvmPackages.clang.version;
-            meta.mainProgram = "clang";
+        rust-toolchain = fenix.packages.${system}.stable.withComponents [
+          "cargo"
+          "clippy"
+          "rust-src"
+          "rustc"
+          "rustfmt"
+        ];
 
-            dontUnpack = true;
-            dontConfigure = true;
-            dontBuild = true;
+        makeBpfClang = llvmPackages: kernel: pkgs.stdenv.mkDerivation {
+          pname = "bpf-clang";
+          version = llvmPackages.clang.version;
+          meta.mainProgram = "clang";
 
-            nativeBuildInputs = [ pkgs.makeWrapper ];
+          dontUnpack = true;
+          dontConfigure = true;
+          dontBuild = true;
 
-            installPhase = ''
-              mkdir -p $out/bin
-              makeWrapper ${pkgs.llvmPackages.clang-unwrapped}/bin/clang \
-                $out/bin/clang \
-                --add-flags "-I${llvmPackages.clang-unwrapped.lib}/lib/clang/${lib.versions.major llvmPackages.clang-unwrapped.version}/include" \
-                --add-flags "-I${kernel.headers}/usr/include" \
-                --add-flags "-I${pkgs.glibc.dev}/include" \
-                --prefix PATH : ${llvmPackages.clang-unwrapped}/bin
-            '';
-          };
+          nativeBuildInputs = [ pkgs.makeWrapper ];
 
-          build-env-vars = {
-            BPF_CLANG = lib.getExe self.packages.${system}.bpf-clang;
-            LIBCLANG_PATH = "${lib.getLib pkgs.llvmPackages.libclang}/lib";
-            RUSTFLAGS = "-C relocation-model=pic -C link-args=-lelf -C link-args=-lz -C link-args=-lzstd -C link-args=-Wl,-rpath,${lib.makeLibraryPath (with pkgs; [
+          installPhase = ''
+            mkdir -p $out/bin
+            makeWrapper ${pkgs.llvmPackages.clang-unwrapped}/bin/clang \
+              $out/bin/clang \
+              --add-flags "-I${llvmPackages.clang-unwrapped.lib}/lib/clang/${lib.versions.major llvmPackages.clang-unwrapped.version}/include" \
+              --add-flags "-I${kernel.headers}/usr/include" \
+              --add-flags "-I${pkgs.glibc.dev}/include" \
+              --prefix PATH : ${llvmPackages.clang-unwrapped}/bin
+          '';
+        };
+
+        cranePackages = pkgs.callPackage ./crane.nix {
+          inherit crane rust-toolchain;
+          bpf-clang = self.packages.${system}.bpf-clang;
+          libclang = pkgs.llvmPackages.libclang;
+        };
+
+        build-env-vars = {
+          BPF_CLANG = lib.getExe self.packages.${system}.bpf-clang;
+          LIBCLANG_PATH = "${lib.getLib pkgs.llvmPackages.libclang}/lib";
+          RUSTFLAGS = "-C relocation-model=pic -C link-args=-lelf -C link-args=-lz -C link-args=-lzstd -C link-args=-Wl,-rpath,${lib.makeLibraryPath (with pkgs; [
               elfutils
               zlib
             ])}";
-          };
+        };
 
-          gha-common-pkgs = with pkgs; [
-            cachix
-            git
-            gnutar
-            zstd
-          ];
-        in
-        {
-          devShells = {
-            default = pkgs.mkShell ({
-              buildInputs = with pkgs; [
-                bash
-                binutils
-                bpftools
-                clang
-                coreutils
-                elfutils
-                gcc
-                git
-                glibc
-                gnumake
-                jq
-                libbpf-git
-                libseccomp
-                pkg-config
-                protobuf
-                zlib
-                zstd
-
-                llvmPackages.libclang
-                llvmPackages.libllvm
-
-                # fenix managed rust toolchain
-                rust-toolchain
-              ];
-            } // build-env-vars);
-
-            gha-common = pkgs.mkShellNoCC {
-              buildInputs = gha-common-pkgs;
-            };
-
-            gha-build-kernels = pkgs.mkShellNoCC {
-              buildInputs = with pkgs; gha-common-pkgs ++ [
-                gawk
-                jq
-              ];
-            };
-
-            gha-update-kernels = pkgs.mkShellNoCC {
-              buildInputs = with pkgs; gha-common-pkgs ++ [
-                gh
-                jq
-              ];
-            };
-          };
-
-          packages = {
-            nix-develop-gha = nix-develop-gha.packages.${system}.default;
-            bpf-clang = makeBpfClang pkgs.llvmPackages self.packages.${system}."kernel_sched_ext/for-next";
-
-            veristat = pkgs.callPackage ./pkgs/veristat.nix {
-              version = "git";
-              src = veristat-src;
-              libbpf = pkgs.libbpf-git;
-            };
-
-            virtme-ng = pkgs.virtme-ng;
-
-            list-integration-tests = pkgs.python3Packages.buildPythonApplication rec {
-              pname = "list-integration-tests";
-              version = "git";
-
-              pyproject = false;
-              dontUnpack = true;
-
-              propagatedBuildInputs = [
-                rust-toolchain # requires cargo, use the toolchain to match version exactly
-              ];
-
-              installPhase = "install -Dm755 ${../.github/include/list-integration-tests.py} $out/bin/list-integration-tests";
-            };
-
-            ci = pkgs.python3Packages.buildPythonApplication rec {
-              pname = "ci";
-              version = "git";
-
-              pyproject = false;
-              dontUnpack = true;
-
-              propagatedBuildInputs = with pkgs; [
-                bash
-                binutils
-                black
-                bpftools
-                clang
-                coreutils
-                diffutils
-                gcc
-                git
-                gnugrep
-                gnumake
-                gnused
-                gnutar
-                isort
-                jq
-                libbpf-git
-                libseccomp.lib
-                llvmPackages.libclang
-                llvmPackages.libllvm
-                pkg-config
-                protobuf
-                virtme-ng
-
-                elfutils.dev
-                zlib.dev
-                zstd.dev
-
-                # fenix managed rust toolchain + nixpkgs cargo-nextest
-                cargo-nextest
-                rust-toolchain
-              ] ++ [
-                self.packages.${system}.veristat
-              ];
-
-              makeWrapperArgs = lib.lists.flatten ([
-                [ "--set" "CC" "gcc" ]
-                [ "--set" "LD" "ld" ]
-
-                [ "--set" "PKG_CONFIG_PATH" "${lib.makeSearchPath "lib/pkgconfig" propagatedBuildInputs}" ]
-
-
-                [ "--set" "NIX_BINTOOLS" pkgs.binutils ]
-                [ "--set" "NIX_CC" pkgs.gcc ]
-
-                (
-                  let system = builtins.replaceStrings [ "-" ] [ "_" ] pkgs.stdenv.hostPlatform.config; in [
-                    [ "--set" "NIX_BINTOOLS_WRAPPER_TARGET_HOST_${system}" "1" ]
-                    [ "--set" "NIX_CC_WRAPPER_TARGET_HOST_${system}" "1" ]
-                    [ "--set" "NIX_PKG_CONFIG_WRAPPER_TARGET_HOST_${system}" "1" ]
-                  ]
-                )
-
-                [
-                  "--set"
-                  "NIX_LDFLAGS"
-                  ("'" + (lib.concatStringsSep " " (builtins.map (drv: "-L${drv}/lib") (with pkgs; [
-                    elfutils.out
-                    zlib
-                    zstd.out
-                    libseccomp.lib
-                  ]))) + "'")
-                ]
-              ] ++ (lib.mapAttrsToList (key: val: "--set ${key} \"${val}\"") build-env-vars));
-
-              installPhase = "install -Dm755 ${../.github/include/ci.py} $out/bin/ci";
-            };
-          } // (with lib.attrsets; mapAttrs'
-            (name: details: nameValuePair "kernel_${name}" (pkgs.callPackage ./pkgs/build-kernel.nix {
-              inherit name;
-              inherit (details) repo branch commitHash narHash;
-              version = details.kernelVersion;
-              patches = map (patchName: ./kernel-patches + ("/" + patchName)) (details.patches or [ ]);
-            }))
-            (builtins.fromJSON (builtins.readFile ./../kernel-versions.json)));
-        }) // flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
+        gha-common-pkgs = with pkgs; [
+          cachix
+          git
+          gnutar
+          zstd
+        ];
       in
       {
-        formatter = pkgs.nixpkgs-fmt;
+        devShells = {
+          default = pkgs.mkShell ({
+            buildInputs = with pkgs; [
+              bash
+              binutils
+              bpftools
+              clang
+              coreutils
+              elfutils
+              gcc
+              git
+              glibc
+              gnumake
+              jq
+              libbpf-git
+              libseccomp
+              pkg-config
+              protobuf
+              zlib
+              zstd
 
-        apps = {
-          update-kernels =
-            let
-              script = pkgs.python3Packages.buildPythonApplication {
-                pname = "update-kernels";
-                version = "git";
+              llvmPackages.libclang
+              llvmPackages.libllvm
 
-                pyproject = false;
-                dontUnpack = true;
+              # fenix managed rust toolchain
+              rust-toolchain
+            ];
+          } // build-env-vars);
 
-                dependencies = with pkgs; [
-                  bash
-                  coreutils
-                  git
-                  gnumake
-                  gnused
-                  nix
-                ];
+          gha-common = pkgs.mkShellNoCC {
+            buildInputs = gha-common-pkgs;
+          };
 
-                installPhase = "install -Dm755 ${../.github/include/update-kernels.py} $out/bin/update-kernels";
-              };
-            in
-            {
-              type = "app";
-              program = "${script}/bin/update-kernels";
-            };
+          gha-build-kernels = pkgs.mkShellNoCC {
+            buildInputs = with pkgs; gha-common-pkgs ++ [
+              gawk
+              jq
+            ];
+          };
+
+          gha-update-kernels = pkgs.mkShellNoCC {
+            buildInputs = with pkgs; gha-common-pkgs ++ [
+              gh
+              jq
+            ];
+          };
         };
-      });
+
+        packages = {
+          nix-develop-gha = nix-develop-gha.packages.${system}.default;
+          bpf-clang = makeBpfClang pkgs.llvmPackages self.packages.${system}."kernel_sched_ext/for-next";
+
+          veristat = pkgs.callPackage ./pkgs/veristat.nix {
+            version = "git";
+            src = veristat-src;
+            libbpf = pkgs.libbpf-git;
+          };
+
+          virtme-ng = pkgs.virtme-ng;
+
+          list-integration-tests = pkgs.python3Packages.buildPythonApplication rec {
+            pname = "list-integration-tests";
+            version = "git";
+
+            pyproject = false;
+            dontUnpack = true;
+
+            propagatedBuildInputs = [
+              rust-toolchain # requires cargo, use the toolchain to match version exactly
+            ];
+
+            installPhase = "install -Dm755 ${../.github/include/list-integration-tests.py} $out/bin/list-integration-tests";
+          };
+
+          ci = pkgs.python3Packages.buildPythonApplication rec {
+            pname = "ci";
+            version = "git";
+
+            pyproject = false;
+            dontUnpack = true;
+
+            propagatedBuildInputs = with pkgs; [
+              bash
+              binutils
+              black
+              bpftools
+              clang
+              coreutils
+              diffutils
+              gcc
+              git
+              gnugrep
+              gnumake
+              gnused
+              gnutar
+              isort
+              jq
+              libbpf-git
+              libseccomp.lib
+              llvmPackages.libclang
+              llvmPackages.libllvm
+              pkg-config
+              protobuf
+              virtme-ng
+
+              elfutils.dev
+              zlib.dev
+              zstd.dev
+
+              # fenix managed rust toolchain + nixpkgs cargo-nextest
+              cargo-nextest
+              rust-toolchain
+            ] ++ [
+              self.packages.${system}.veristat
+            ];
+
+            makeWrapperArgs = lib.lists.flatten ([
+              [ "--set" "CC" "gcc" ]
+              [ "--set" "LD" "ld" ]
+
+              [ "--set" "PKG_CONFIG_PATH" "${lib.makeSearchPath "lib/pkgconfig" propagatedBuildInputs}" ]
+
+
+              [ "--set" "NIX_BINTOOLS" pkgs.binutils ]
+              [ "--set" "NIX_CC" pkgs.gcc ]
+
+              (
+                let system = builtins.replaceStrings [ "-" ] [ "_" ] pkgs.stdenv.hostPlatform.config; in [
+                  [ "--set" "NIX_BINTOOLS_WRAPPER_TARGET_HOST_${system}" "1" ]
+                  [ "--set" "NIX_CC_WRAPPER_TARGET_HOST_${system}" "1" ]
+                  [ "--set" "NIX_PKG_CONFIG_WRAPPER_TARGET_HOST_${system}" "1" ]
+                ]
+              )
+
+              [
+                "--set"
+                "NIX_LDFLAGS"
+                ("'" + (lib.concatStringsSep " " (builtins.map (drv: "-L${drv}/lib") (with pkgs; [
+                  elfutils.out
+                  zlib
+                  zstd.out
+                  libseccomp.lib
+                ]))) + "'")
+              ]
+            ] ++ (lib.mapAttrsToList (key: val: "--set ${key} \"${val}\"") build-env-vars));
+
+            installPhase = "install -Dm755 ${../.github/include/ci.py} $out/bin/ci";
+          };
+
+          # scx_chaos scheduler built with Nix
+          scx_chaos = cranePackages.makeCargoSchedulerPackage "scx_chaos";
+        } // (with lib.attrsets; mapAttrs'
+          (name: details: nameValuePair "kernel_${name}" (pkgs.callPackage ./pkgs/build-kernel.nix {
+            inherit name;
+            inherit (details) repo branch commitHash narHash;
+            version = details.kernelVersion;
+            patches = map (patchName: ./kernel-patches + ("/" + patchName)) (details.patches or [ ]);
+          }))
+          (builtins.fromJSON (builtins.readFile ./../kernel-versions.json)));
+      }) // flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      formatter = pkgs.nixpkgs-fmt;
+
+      apps = {
+        update-kernels =
+          let
+            script = pkgs.python3Packages.buildPythonApplication {
+              pname = "update-kernels";
+              version = "git";
+
+              pyproject = false;
+              dontUnpack = true;
+
+              dependencies = with pkgs; [
+                bash
+                coreutils
+                git
+                gnumake
+                gnused
+                nix
+              ];
+
+              installPhase = "install -Dm755 ${../.github/include/update-kernels.py} $out/bin/update-kernels";
+            };
+          in
+          {
+            type = "app";
+            program = "${script}/bin/update-kernels";
+          };
+      };
+    });
 }


### PR DESCRIPTION
Nix offers reproducible builds which are very handy for testing, and with our cachix cache this makes passing builds around easier too. Add the initial infrastructure for scheduler Nix builds with the aspiration of removing a lot of the special handling in ci.py and also further splitting the steps in GitHub Actions.

Start with scx_chaos to annoy only me first (it won't break without code changes). Use in the CI as well as building chaos with Cargo & as the place to extract objects for veristat.

Test plan:
- CI
- `nix run .nix#ci build`
- `nix run .nix#ci veristat`

```
jake@merlin:/data/users/jake/repos/scx/ > sudo $(nix build --no-link --print-out-paths .nix#scx_chaos)/bin/scx_chaos --stats 10
warning: Git tree '/data/users/jake/repos/scx' is dirty
14:36:37 [INFO] Running scx_chaos (build ID: 1.0.20 x86_64-unknown-linux-gnu)
14:36:37 [INFO] Builder { traits: [], verbose: 0, kprobe_random_delays: None, p2dq_opts: SchedulerOpts { disable_kthreads_local: false, autoslice: false, interactive_ratio: 10, deadline: false, eager_load_balance: false, freq_control: false, greedy_idle_disable: true, interactive_sticky: false, interactive_fifo: false, dispatch_pick2_disable: false, dispatch_lb_busy: 75, dispatch_lb_interactive: true, keep_running: false, atq_enabled: false, cpu_priority: false, interactive_dsq: true, wakeup_lb_busy: 0, wakeup_llc_migrations: false, select_idle_in_enqueue: false, queued_wakeup: false, idle_resume_us: None, max_dsq_pick2: false, task_slice: false, min_slice_us: 100, lb_mode: Load, sched_mode: Default, lb_slack_factor: 5, min_llc_runs_pick2: 1, saturated_percent: 5, dsq_time_slices: [], dsq_shift: 4, llc_shards: 5, min_nr_queued_pick2: 0, dumb_queues: 3, init_dsq_index: 0, virt_llc_enabled: false, topo: TopologyArgs { virt_llc: None } }, requires_ppid: None }
14:36:37 [INFO] DSQ[0] slice_ns 100000
14:36:37 [INFO] DSQ[1] slice_ns 3200000
14:36:37 [INFO] DSQ[2] slice_ns 6400000
14:36:37 [WARN] libbpf: map 'chaos': BPF map skeleton link is uninitialized

chaos traits: random_delays/cpu_freq/degradation 0/0/0
        chaos excluded/skipped 0/0
        kprobe_random_delays 0
        timer kicks: 0
chaos traits: random_delays/cpu_freq/degradation 0/0/0
        chaos excluded/skipped 0/0
        kprobe_random_delays 0
        timer kicks: 0
^C14:36:50 [INFO] Unregister scx_chaos scheduler
```