### PR TITLE
meson: deprecate harder

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,7 +82,7 @@ jobs:
         run: cargo install virtiofsd && sudo cp -a ~/.cargo/bin/virtiofsd /usr/lib/
 
       # The actual build:
-      - run: meson setup build -Dkernel=$KERNEL_STORE_PATH/bzImage -Dkernel_headers=$KERNEL_HEADERS_STORE_PATH -Denable_stress=true -Dvng_rw_mount=true -Dextra_sched_args=" ${{ matrix.scheduler['flags'] }}"
+      - run: meson setup build -Dforce_meson=true -Dkernel=$KERNEL_STORE_PATH/bzImage -Dkernel_headers=$KERNEL_HEADERS_STORE_PATH -Denable_stress=true -Dvng_rw_mount=true -Dextra_sched_args=" ${{ matrix.scheduler['flags'] }}"
       - run: meson compile -C build ${{ matrix.scheduler['name'] }}
 
       # Print CPU model before running the tests (this can be useful for

--- a/meson.build
+++ b/meson.build
@@ -4,10 +4,15 @@ project('sched_ext schedulers', 'c',
         license: 'GPL-2.0',
         meson_version : '>= 1.2.0',)
 
-warning('Meson builds are deprecated. Please switch to `cargo build` for Rust'
-        + ' schedulers and `make` for C schedulers. Meson will be removed in an'
-        + ' upcoming release. Please report any issues packaing for distributions'
-        + ' at https://github.com/sched-ext/scx/discussions/2731')
+force_meson = get_option('force_meson')
+if not force_meson
+  error('Meson builds are deprecated. Please switch to `cargo build` for Rust'
+          + ' schedulers and `make` for C schedulers. Meson will be removed in an'
+          + ' upcoming release. Please report any issues packaging for distributions'
+          + ' at https://github.com/sched-ext/scx/discussions/2731. If you need'
+          + ' Meson to unblock yourself temporarily, add `-Dforce_meson=true` when'
+          + ' configuring.')
+endif
 
 fs = import('fs')
 

--- a/meson.options
+++ b/meson.options
@@ -56,3 +56,9 @@ option(
   value: '',
   description: 'extra sched args for stress tests',
 )
+option(
+  'force_meson',
+  type: 'boolean',
+  value: false,
+  description: 'force use of deprecated meson build system',
+)


### PR DESCRIPTION
Now we've had the warning about Meson for a while and everyone we know about has migrated to pure Cargo, increase the level of the deprecation. The next step is to hard error the build unless a flag is specified to override this. This new flag to hide this error is documented and will force anyone who was taking updates automatically to notice the change.

Test plan:
- CI
- CI with the first version of this commit (no flag). It failed with the expected error.