### PR TITLE
scx_layered: Add per-layer LLC stickiness control

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -148,6 +148,7 @@ enum layer_stat_id {
 	LSTAT_XNUMA_MIGRATION,
 	LSTAT_XLLC_MIGRATION,
 	LSTAT_XLLC_MIGRATION_SKIP,
+	LSTAT_LLC_STICKY_SKIP,
 	LSTAT_XLAYER_WAKE,
 	LSTAT_XLAYER_REWAKE,
 	LSTAT_LLC_DRAIN_TRY,
@@ -348,6 +349,7 @@ struct layer {
 	u64			disallow_open_after_ns;
 	u64			disallow_preempt_after_ns;
 	u64			xllc_mig_min_ns;
+	u32			llc_sticky_runs;
 
 	int			kind;
 	bool			preempt;

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -132,6 +132,8 @@ pub struct LayerCommon {
     pub disallow_preempt_after_us: Option<u64>,
     #[serde(default)]
     pub xllc_mig_min_us: f64,
+    #[serde(default)]
+    pub llc_sticky_runs: u32,
     #[serde(default, skip_serializing)]
     pub idle_smt: Option<bool>,
     #[serde(default)]

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -152,6 +152,7 @@ lazy_static! {
                         disallow_open_after_us: None,
                         disallow_preempt_after_us: None,
                         xllc_mig_min_us: 1000.0,
+                        llc_sticky_runs: 0,
                         growth_algo: LayerGrowthAlgo::Sticky,
                         idle_resume_us: None,
                         perf: 1024,
@@ -188,6 +189,7 @@ lazy_static! {
                         disallow_open_after_us: None,
                         disallow_preempt_after_us: None,
                         xllc_mig_min_us: 0.0,
+                        llc_sticky_runs: 0,
                         growth_algo: LayerGrowthAlgo::Sticky,
                         perf: 1024,
                         idle_resume_us: None,
@@ -229,6 +231,7 @@ lazy_static! {
                         disallow_open_after_us: None,
                         disallow_preempt_after_us: None,
                         xllc_mig_min_us: 0.0,
+                        llc_sticky_runs: 2,
                         growth_algo: LayerGrowthAlgo::Topo,
                         perf: 1024,
                         idle_resume_us: None,
@@ -268,6 +271,7 @@ lazy_static! {
                         disallow_open_after_us: None,
                         disallow_preempt_after_us: None,
                         xllc_mig_min_us: 100.0,
+                        llc_sticky_runs: 0,
                         growth_algo: LayerGrowthAlgo::Linear,
                         perf: 1024,
                         idle_resume_us: None,
@@ -1908,6 +1912,7 @@ impl<'a> Scheduler<'a> {
                     disallow_open_after_us,
                     disallow_preempt_after_us,
                     xllc_mig_min_us,
+                    llc_sticky_runs,
                     placement,
                     member_expire_ms,
                     ..
@@ -1944,6 +1949,7 @@ impl<'a> Scheduler<'a> {
                     v => v * 1000,
                 };
                 layer.xllc_mig_min_ns = (xllc_mig_min_us * 1000.0) as u64;
+                layer.llc_sticky_runs = *llc_sticky_runs;
                 layer_weights.push(layer.weight.try_into().unwrap());
                 layer.perf = u32::try_from(*perf)?;
                 layer.node_mask = nodemask_from_nodes(nodes) as u64;

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -71,6 +71,7 @@ const LSTAT_MIGRATION: usize = bpf_intf::layer_stat_id_LSTAT_MIGRATION as usize;
 const LSTAT_XNUMA_MIGRATION: usize = bpf_intf::layer_stat_id_LSTAT_XNUMA_MIGRATION as usize;
 const LSTAT_XLLC_MIGRATION: usize = bpf_intf::layer_stat_id_LSTAT_XLLC_MIGRATION as usize;
 const LSTAT_XLLC_MIGRATION_SKIP: usize = bpf_intf::layer_stat_id_LSTAT_XLLC_MIGRATION_SKIP as usize;
+const LSTAT_LLC_STICKY_SKIP: usize = bpf_intf::layer_stat_id_LSTAT_LLC_STICKY_SKIP as usize;
 const LSTAT_XLAYER_WAKE: usize = bpf_intf::layer_stat_id_LSTAT_XLAYER_WAKE as usize;
 const LSTAT_XLAYER_REWAKE: usize = bpf_intf::layer_stat_id_LSTAT_XLAYER_REWAKE as usize;
 const LSTAT_LLC_DRAIN_TRY: usize = bpf_intf::layer_stat_id_LSTAT_LLC_DRAIN_TRY as usize;
@@ -184,6 +185,8 @@ pub struct LayerStats {
     pub xllc_migration: f64,
     #[stat(desc = "% migration skipped across LLCs due to xllc_mig_min_us")]
     pub xllc_migration_skip: f64,
+    #[stat(desc = "% migration skipped across LLCs due to llc_sticky_runs")]
+    pub llc_sticky_skip: f64,
     #[stat(desc = "% wakers across layers")]
     pub xlayer_wake: f64,
     #[stat(desc = "% rewakers across layers where waker has waken the task previously")]
@@ -306,6 +309,7 @@ impl LayerStats {
             xlayer_rewake: lstat_pct(LSTAT_XLAYER_REWAKE),
             xllc_migration: lstat_pct(LSTAT_XLLC_MIGRATION),
             xllc_migration_skip: lstat_pct(LSTAT_XLLC_MIGRATION_SKIP),
+            llc_sticky_skip: lstat_pct(LSTAT_LLC_STICKY_SKIP),
             llc_drain_try: lstat_pct(LSTAT_LLC_DRAIN_TRY),
             llc_drain: lstat_pct(LSTAT_LLC_DRAIN),
             skip_remote_node: lstat_pct(LSTAT_SKIP_REMOTE_NODE),
@@ -378,13 +382,14 @@ impl LayerStats {
 
         writeln!(
             w,
-            "  {:<width$}  open_idle={} mig={} xnuma_mig={} xllc_mig/skip={}/{} affn_viol={}",
+            "  {:<width$}  open_idle={} mig={} xnuma_mig={} xllc_mig/skip/sticky_skip={}/{}/{} affn_viol={}",
             "",
             fmt_pct(self.open_idle),
             fmt_pct(self.migration),
             fmt_pct(self.xnuma_migration),
             fmt_pct(self.xllc_migration),
             fmt_pct(self.xllc_migration_skip),
+            fmt_pct(self.llc_sticky_skip),
             fmt_pct(self.affn_viol),
             width = header_width,
         )?;


### PR DESCRIPTION
Add a new configuration option `llc_sticky_runs` that controls how many times a task must run on its current LLC before being allowed to migrate to a different LLC. This provides finer-grained control over LLC locality and complements the existing `xllc_mig_min_us` option.

The implementation tracks the number of consecutive runs on the current LLC in the task context (`taskc->llc_runs`). When the scheduler attempts to find an idle CPU and no idle CPUs are available on the current LLC, it checks if the task has run fewer times than the configured threshold. If so, cross-LLC migration is prevented, keeping the task sticky to its current LLC to preserve cache locality.

Key changes:

- Add `llc_runs` counter to `task_ctx` to track consecutive runs on current LLC
- Add `llc_sticky_runs` configuration field to `layer` struct and `LayerConfig` in config.rs
- Increment `llc_runs` in `layered_running()` when stickiness is enabled
- Reset `llc_runs` to 0 in `maybe_update_task_llc()` on LLC migration
- Add stickiness check in `pick_idle_cpu()` to prevent cross-LLC migration when task hasn't run enough times on current LLC
- Add `LSTAT_LLC_STICKY_SKIP` statistic to track prevented migrations
- Initialize `llc_runs` to 0 in `layered_init_task()`

The feature is disabled by default (llc_sticky_runs = 0) and can be configured per-layer. Example configuration:

  {
    "name": "batch",
    "kind": {
      "Confined": {
        "llc_sticky_runs": 20,
      }
    }
  }

This would keep tasks on their current LLC for 20 runs before allowing cross-LLC migration, providing stronger LLC affinity for workloads that benefit from cache locality.

The new statistic appears in the output as:
  xllc_mig/skip/sticky_skip={xllc_migration%}/{xllc_skip%}/{llc_sticky_skip%}