### PR TITLE
scx_utils, scx_lavd: Harden the futex tracing.

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -455,6 +455,11 @@ impl<'a> Scheduler<'a> {
             ("futex_unlock_pi", &skel.progs.fexit_futex_unlock_pi),
         ];
 
+        if compat::tracer_available("function_graph")? == false {
+            info!("Ftrace is not enabled in the kernel.");
+            return Ok(false);
+        }
+
         compat::cond_kprobes_enable(ftraces)
     }
 


### PR DESCRIPTION
When neither tracepoint nor ftrace is enabled by the kernel, the existing futex tracing code raises runtime errors. This PR is to handle such error cases gracefully. It first add a missing error condition check (compat::tracepoint_exists), and check if ftraced is available before attaching ftrace points (compat::tracer_available). 

This should resolve the problem reported at https://github.com/Frogging-Family/linux-tkg/issues/1156
Once this is merged, https://github.com/sched-ext/scx/pull/2914 should be closed. 