### PR TITLE
lib/arena: Fix incorrect cpumask calculation at topo_init().

### DIFF
--- a/rust/scx_arena/scx_arena/src/arenalib.rs
+++ b/rust/scx_arena/scx_arena/src/arenalib.rs
@@ -176,7 +176,7 @@ impl<'a> ArenaLib<'a> {
         }
         for (_, cpu) in topo.all_cpus {
             let mut mask = [0; Self::MAX_CPU_ARRSZ - 1];
-            mask[cpu.id.checked_shr(64).unwrap_or(0)] |= 1 << (cpu.id % 64);
+            mask[cpu.id / 64] |= 1 << (cpu.id % 64);
             self.setup_topology_node(&mask)?;
         }
 


### PR DESCRIPTION
CPU mask was incorrectly initialized at the CPU level; 'cpu.id >> 64' was used instead of 'cpu.id / 64'. When there are more than 64 CPUs, it raises an error message: "topology is too deep". So, let's fix the wrong math.