### PR TITLE
scx_mitosis: Increase debug events buffer size

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -31,7 +31,7 @@ enum consts {
 	PCPU_BASE	      = 0x80000000,
 	MAX_CG_DEPTH	      = 256,
 
-	DEBUG_EVENTS_BUF_SIZE = 256,
+	DEBUG_EVENTS_BUF_SIZE = 4096,
 };
 
 /* Debug event types */


### PR DESCRIPTION
When debugging initialization failures, we're often seeing not enough history. This is still only ~100kb of memory so not too concerned with increasing it a lot.