### PR TITLE
scx_p2dq: Fix BPF loading failure when sched_core_priority unavailable

### DIFF
--- a/scheds/rust/scx_p2dq/README.md
+++ b/scheds/rust/scx_p2dq/README.md
@@ -81,7 +81,12 @@ options for gaming:
    utilization of interactive tasks.
  - `--freq-control` for controling CPU frequency with certain drivers.
  - `--cpu-priority` uses a min-heap to schedule on CPUs based on a score of
-   most recently used and preferred core value.
+   most recently used and preferred core value. **Requires kernel support for
+   `sched_core_priority` symbol** - typically available on systems with hybrid
+   CPU architectures (e.g., Intel Alder Lake P/E-cores, AMD with preferred cores)
+   when using appropriate CPU frequency governors (e.g., `amd-pstate`, Intel HWP).
+   The scheduler will automatically disable this feature and warn if kernel support
+   is unavailable.
  - `--sched-mode` can use the performance mode to schedule on Big cores.
  - `--idle-resume-us` how long a CPU stays idle before dropping to a lower C-state.
 
@@ -105,6 +110,23 @@ known in advance. `scxtop` can be used to get an understanding of time slice
 utilization so that DSQs can be properly configured. For desktop systems keeping
 the interactive ratio small (ex: <5) and using a small number of queues will
 give a general performance with autoslice enabled.
+
+### Kernel Requirements
+
+Some features require specific kernel support:
+
+- **`--cpu-priority`**: Requires kernel with `sched_core_priority` symbol, typically
+  available on:
+  - Kernels with hybrid CPU support (`CONFIG_SCHED_MC`)
+  - Systems with Intel HWP (Hardware P-states) or AMD P-state support
+  - Appropriate CPU frequency governor loaded (e.g., `amd-pstate`)
+  - Recent kernel versions (check with: `grep sched_core_priority /proc/kallsyms`)
+
+  Not available on: older kernels, virtual machines, or systems without hybrid CPU
+  support. The scheduler will automatically detect and disable this feature with a
+  warning if unavailable.
+
+- **`--atq-enabled`**: Requires BPF arena support (kernel 6.12+)
 
 ## Things you probably shouldn't use `p2dq` for
 


### PR DESCRIPTION
Add conditional kernel symbol checking for the --cpu-priority feature to prevent BPF loading failures on kernels that don't export the sched_core_priority symbol.

Problem:
When --cpu-priority is enabled, the p2dq_update_idle BPF program unconditionally references the sched_core_priority kernel symbol via the cpu_priority() helper. The BPF verifier must resolve all __ksym references at load time, even when runtime checks exist. If the kernel doesn't export this symbol (older kernels, VMs, non-x86 architectures, or kernels without hybrid CPU support), BPF loading fails with:

  libbpf: prog 'p2dq_update_idle': BPF program load failed: -ENOENT
  ldimm64 failed to find the address for kernel symbol 'sched_core_priority'.

Solution:
- Check for sched_core_priority symbol availability using compat::ksym_exists() before enabling the feature
- Only enable cpu_priority if both user requests it AND kernel supports it
- Add clear warning messages when feature is unavailable, explaining requirements (hybrid CPU support, appropriate CPU governor like amd-pstate)
- Follow the existing pattern used for atq_enabled in the same file

This allows the scheduler to load successfully and run without cpu_priority on unsupported kernels, providing graceful degradation instead of failure.

Documentation:
- Update README Gaming section to document kernel requirements for --cpu-priority
- Add new "Kernel Requirements" section explaining:
  - What hardware/kernel configurations support the feature
  - How to check support (grep sched_core_priority /proc/kallsyms)
  - Scenarios where it's unavailable (VMs, older kernels)
  - Automatic detection and graceful fallback behavior
- Document --atq-enabled requirements for consistency

The sched_core_priority symbol is typically available on:
- Kernels with hybrid CPU support (CONFIG_SCHED_MC)
- Systems with Intel HWP (Hardware P-states) or AMD P-state
- Recent kernel versions with appropriate CPU frequency governors

Fixes #2923