### PR TITLE
scx_lavd: Don't use Per-CPU DSQ for pinned tasks

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -386,7 +386,7 @@ static bool consume_task(u64 cpu_dsq_id, u64 cpdom_dsq_id)
 	 * When per_cpu_dsq or pinned_slice_ns is enabled, compare vtimes
 	 * across cpu_dsq and cpdom_dsq to select the task with the lowest vtime.
 	 */
-	if (per_cpu_dsq || pinned_slice_ns) {
+	if (per_cpu_dsq) {
 		bpf_for_each(scx_dsq, p, cpu_dsq_id, 0) {
 			vtime = p->scx.dsq_vtime;
 			break;

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -680,7 +680,7 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 	if (can_direct_dispatch(cpu_to_dsq(cpu), cpu, is_idle)) {
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, p->scx.slice,
 				   enq_flags);
-	} else if (per_cpu_dsq || (pinned_slice_ns && is_pinned(p))) {
+	} else if (per_cpu_dsq) {
 		scx_bpf_dsq_insert_vtime(p, cpu_to_dsq(cpu), p->scx.slice,
 					 p->scx.dsq_vtime, enq_flags);
 	} else {
@@ -1813,7 +1813,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init)
 	 * Per-CPU DSQs are created when per_cpu_dsq is enabled OR when
 	 * pinned_slice_ns is enabled (for pinned task handling).
 	 */
-	if (per_cpu_dsq || pinned_slice_ns) {
+	if (per_cpu_dsq) {
 		err = init_per_cpu_dsqs();
 		if (err)
 			return err;


### PR DESCRIPTION
Using separate Per-CPU DSQs for pinned tasks is causing issues for workloads don't don't rely on pinned tasks.

Let's revert to using Shared DSQ for pinned tasks until we have a better understanding of the issue at hand.