### PR TITLE
scx_lavd: Fix the required tracer name for futex tracing.

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -455,7 +455,7 @@ impl<'a> Scheduler<'a> {
             ("futex_unlock_pi", &skel.progs.fexit_futex_unlock_pi),
         ];
 
-        if compat::tracer_available("function_graph")? == false {
+        if compat::tracer_available("function")? == false {
             info!("Ftrace is not enabled in the kernel.");
             return Ok(false);
         }


### PR DESCRIPTION
'fexit', which is used for futex tracing, requires a "function" tracer, not a "function_graph" tracer. So, let's fix it.

Fixes: 8f20db19336b ("scx_utils, scx_lavd: Check if ftrace is enabled before tracing futex.")