### PR TITLE
Update kernel.config with LAVD specific info

### DIFF
--- a/kernel.config
+++ b/kernel.config
@@ -12,6 +12,10 @@ CONFIG_SCHED_CLASS_EXT=y
 #
 # CONFIG_DEBUG_INFO_REDUCED is not set
 
+# LAVD tracks futex to give an additional time slice for futex holder (i.e., avoiding lock holder preemption) for better system-wide progress.
+# LAVD first tries to use ftrace to trace futex function calls. If that is not available, it tries to use a tracepoint.
+CONFIG_FUNCTION_TRACER=y
+
 # Enable scheduling debugging
 #
 CONFIG_SCHED_DEBUG=y
@@ -46,7 +50,6 @@ CONFIG_BPF_JIT=y
 CONFIG_HAVE_EBPF_JIT=y
 CONFIG_BPF_EVENTS=y
 CONFIG_FTRACE_SYSCALLS=y
-CONFIG_FUNCTION_TRACER=y
 CONFIG_HAVE_DYNAMIC_FTRACE=y
 CONFIG_DYNAMIC_FTRACE=y
 CONFIG_HAVE_KPROBES=y


### PR DESCRIPTION
Moved FUNCTION_TRACER up, because LAVD uses it for its internals

Is there specific kernel config things for other schedulers ?