### PR TITLE
docs: update Ubuntu install steps after 25.10 release

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,17 +2,14 @@
 
 ## Ubuntu
 
-`sched_ext` support for Ubuntu is currently provided by the linux-unstable
-kernel, available at
-[ppa:canonical-kernel-team/unstable](https://launchpad.net/~canonical-kernel-team/+archive/ubuntu/unstable).
-
-#### Upgrading to 25.04 (Plucky Puffin) - recommended
+#### Upgrading to 25.10 (Questing Quokka) - recommended
 
 Currently, only release 25.04 and newer are supported. If you're using an
-earlier release, upgrade using the command below:
+earlier release, upgrade to the latest release (25.10) using the command
+below:
 
 ```
-$ sudo do-release-upgrade -d
+$ sudo do-release-upgrade
 ```
 
 #### Setting up Dev Environment


### PR DESCRIPTION
Ubuntu 25.10 (Questing Quokka) released recently, based on kernel 6.17, therefore the following updates can be made to the instructions:

- remove the instructions to get the linux-unstable kernel from the unstable PPA. The generic distro already contains all the upstream parts (up to 6.17).
- with the 25.10 release it's recommended to move to this release, although 25.04 will still be supported for a couple of months.
- it's not necessary anymore to install the latest development release, therefore remove the '-d' flag from the 'do-release-upgrade' step.