### PR TITLE
scxtop: Refactor BPF program rendering into separate module (Phase 5)

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -17,7 +17,11 @@ use crate::columns::{
 use crate::config::get_config_path;
 use crate::config::Config;
 use crate::get_default_events;
-use crate::render::{MemoryRenderer, NetworkRenderer, ProcessRenderer, SchedulerRenderer};
+use crate::render::bpf_programs::{ProgramDetailParams, ProgramsListParams};
+use crate::render::scheduler::{SchedulerStatsParams, SchedulerViewParams};
+use crate::render::{
+    BpfProgramRenderer, MemoryRenderer, NetworkRenderer, ProcessRenderer, SchedulerRenderer,
+};
 use crate::search;
 use crate::symbol_data::SymbolData;
 use crate::util::{
@@ -1016,7 +1020,7 @@ impl<'a> App<'a> {
         Ok(())
     }
 
-    /// resizes existing events based on new max value.
+    /// resizes existing sched event data based on new max value.
     fn resize_events(&mut self, max_events: usize) {
         for node in self.topo.nodes.keys() {
             let node_data = self
@@ -2529,78 +2533,91 @@ impl<'a> App<'a> {
                     .map(|s| s.maps.data_data.as_ref().unwrap().sample_rate)
                     .unwrap_or(0);
 
+                let params1 = SchedulerViewParams {
+                    event: "dsq_lat_us",
+                    scheduler_name: &self.scheduler,
+                    dsq_data: &self.dsq_data,
+                    sample_rate,
+                    localize: self.localize,
+                    locale: &self.locale,
+                    theme: self.theme(),
+                    render_title: false,
+                    render_sample_rate: true,
+                };
                 let new_max = SchedulerRenderer::render_scheduler_view(
                     frame,
-                    "dsq_lat_us",
                     left_top,
                     &self.view_state,
-                    &self.scheduler,
-                    &self.dsq_data,
-                    sample_rate,
                     self.max_sched_events,
-                    self.localize,
-                    &self.locale,
-                    self.theme(),
-                    false,
-                    true,
+                    &params1,
                 )?;
                 self.max_sched_events = new_max;
 
+                let params2 = SchedulerViewParams {
+                    event: "dsq_slice_consumed",
+                    scheduler_name: &self.scheduler,
+                    dsq_data: &self.dsq_data,
+                    sample_rate,
+                    localize: self.localize,
+                    locale: &self.locale,
+                    theme: self.theme(),
+                    render_title: false,
+                    render_sample_rate: false,
+                };
                 SchedulerRenderer::render_scheduler_view(
                     frame,
-                    "dsq_slice_consumed",
                     left_center,
                     &self.view_state,
-                    &self.scheduler,
-                    &self.dsq_data,
-                    sample_rate,
                     self.max_sched_events,
-                    self.localize,
-                    &self.locale,
-                    self.theme(),
-                    false,
-                    false,
+                    &params2,
                 )?;
+
+                let params3 = SchedulerViewParams {
+                    event: "dsq_vtime",
+                    scheduler_name: &self.scheduler,
+                    dsq_data: &self.dsq_data,
+                    sample_rate,
+                    localize: self.localize,
+                    locale: &self.locale,
+                    theme: self.theme(),
+                    render_title: false,
+                    render_sample_rate: false,
+                };
                 SchedulerRenderer::render_scheduler_view(
                     frame,
-                    "dsq_vtime",
                     left_bottom,
                     &self.view_state,
-                    &self.scheduler,
-                    &self.dsq_data,
-                    sample_rate,
                     self.max_sched_events,
-                    self.localize,
-                    &self.locale,
-                    self.theme(),
-                    false,
-                    false,
+                    &params3,
                 )?;
+
+                let params4 = SchedulerViewParams {
+                    event: "dsq_nr_queued",
+                    scheduler_name: &self.scheduler,
+                    dsq_data: &self.dsq_data,
+                    sample_rate,
+                    localize: self.localize,
+                    locale: &self.locale,
+                    theme: self.theme(),
+                    render_title: false,
+                    render_sample_rate: false,
+                };
                 SchedulerRenderer::render_scheduler_view(
                     frame,
-                    "dsq_nr_queued",
                     right_bottom,
                     &self.view_state,
-                    &self.scheduler,
-                    &self.dsq_data,
-                    sample_rate,
                     self.max_sched_events,
-                    self.localize,
-                    &self.locale,
-                    self.theme(),
-                    false,
-                    false,
+                    &params4,
                 )?;
-                SchedulerRenderer::render_scheduler_stats(
-                    frame,
-                    right_top,
-                    &self.scheduler,
-                    &self.sched_stats_raw,
-                    self.config.tick_rate_ms(),
-                    self.scx_stats.dispatch_keep_last,
-                    self.scx_stats.select_cpu_fallback,
-                    self.theme(),
-                )
+                let stats_params = SchedulerStatsParams {
+                    scheduler_name: &self.scheduler,
+                    sched_stats_raw: &self.sched_stats_raw,
+                    tick_rate_ms: self.config.tick_rate_ms(),
+                    dispatch_keep_last: self.scx_stats.dispatch_keep_last,
+                    select_cpu_fallback: self.scx_stats.select_cpu_fallback,
+                    theme: self.theme(),
+                };
+                SchedulerRenderer::render_scheduler_stats(frame, right_top, &stats_params)
             }
             AppState::Tracing => self.render_tracing(frame),
             _ => self.render_default(frame),
@@ -3146,35 +3163,42 @@ impl<'a> App<'a> {
             .map(|s| s.maps.data_data.as_ref().unwrap().sample_rate)
             .unwrap_or(0);
 
+        let params1 = SchedulerViewParams {
+            event: "dsq_lat_us",
+            scheduler_name: &self.scheduler,
+            dsq_data: &self.dsq_data,
+            sample_rate,
+            localize: self.localize,
+            locale: &self.locale,
+            theme: self.theme(),
+            render_title: false,
+            render_sample_rate: true,
+        };
         SchedulerRenderer::render_scheduler_view(
             frame,
-            "dsq_lat_us",
             left_areas[1],
             &self.view_state,
-            &self.scheduler,
-            &self.dsq_data,
-            sample_rate,
             self.max_sched_events,
-            self.localize,
-            &self.locale,
-            self.theme(),
-            false,
-            true,
+            &params1,
         )?;
+
+        let params2 = SchedulerViewParams {
+            event: "dsq_slice_consumed",
+            scheduler_name: &self.scheduler,
+            dsq_data: &self.dsq_data,
+            sample_rate,
+            localize: self.localize,
+            locale: &self.locale,
+            theme: self.theme(),
+            render_title: false,
+            render_sample_rate: false,
+        };
         SchedulerRenderer::render_scheduler_view(
             frame,
-            "dsq_slice_consumed",
             left_areas[2],
             &self.view_state,
-            &self.scheduler,
-            &self.dsq_data,
-            sample_rate,
             self.max_sched_events,
-            self.localize,
-            &self.locale,
-            self.theme(),
-            false,
-            false,
+            &params2,
         )?;
 
         Ok(())
@@ -3783,38 +3807,6 @@ impl<'a> App<'a> {
 
     /// Renders the BPF programs view
     fn render_bpf_programs(&mut self, frame: &mut Frame) -> Result<()> {
-        // Split screen: table on top, sparkline on bottom
-        let main_chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Min(10),   // Table area
-                Constraint::Length(5), // Sparkline section
-            ])
-            .split(frame.area());
-
-        if self.filtering && !self.event_input_buffer.is_empty() {
-            // Further split table area for filter input
-            let table_chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Min(0), Constraint::Length(3)])
-                .split(main_chunks[0]);
-
-            self.render_bpf_programs_table(frame, table_chunks[0])?;
-            self.render_filter_input(frame, table_chunks[1])?;
-        } else {
-            self.render_bpf_programs_table(frame, main_chunks[0])?;
-        }
-
-        // Render overhead sparkline
-        self.render_bpf_overhead_sparkline(frame, main_chunks[1])?;
-
-        Ok(())
-    }
-
-    /// Renders the BPF programs table
-    fn render_bpf_programs_table(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        let theme = self.theme();
-
         // Use filtered programs if filtering is active, otherwise use all programs
         let programs_to_display: Vec<(u32, BpfProgData)> = if self.filtering {
             self.filtered_bpf_programs.clone()
@@ -3836,266 +3828,26 @@ impl<'a> App<'a> {
             programs
         };
 
-        // Build table rows with sched_ext highlighting
-        let rows: Vec<Row> = programs_to_display
-            .iter()
-            .map(|(id, data)| {
-                let cols = self.bpf_program_columns.visible_columns();
-                let cells: Vec<Cell> = cols
-                    .map(|col| {
-                        let mut value = (col.value_fn)(*id, data);
-                        // Special handling for runtime percentage column
-                        if col.header == "Runtime %" {
-                            let percentage =
-                                data.runtime_percentage(self.bpf_program_stats.total_runtime_ns);
-                            value = format!("{:.2}%", percentage);
-                        }
-                        Cell::from(value)
-                    })
-                    .collect();
-
-                // Apply sched_ext highlighting
-                let row = Row::new(cells);
-                if data.is_sched_ext {
-                    row.style(
-                        Style::default()
-                            .fg(Color::Cyan)
-                            .add_modifier(Modifier::BOLD),
-                    )
-                } else {
-                    row
-                }
-            })
-            .collect();
-
-        // Create header
-        let header = Row::new(
-            self.bpf_program_columns
-                .visible_columns()
-                .map(|col| Cell::from(col.header))
-                .collect::<Vec<_>>(),
-        )
-        .style(theme.title_style())
-        .height(1);
-
-        // Get constraints for visible columns
-        let constraints: Vec<Constraint> = self
-            .bpf_program_columns
-            .visible_columns()
-            .map(|col| col.constraint)
-            .collect();
-
-        // Create title with filter information
-        let title = if self.filtering {
-            format!(
-                "BPF Programs ({}/{} programs) - Filtering: {} - Press Enter for details, Esc to clear filter",
-                programs_to_display.len(),
-                self.bpf_program_stats.programs.len(),
-                self.event_input_buffer
-            )
-        } else {
-            format!(
-                "BPF Programs ({} programs) - Press f to filter, Enter for details",
-                self.bpf_program_stats.programs.len()
-            )
+        let list_params = ProgramsListParams {
+            bpf_program_stats: &self.bpf_program_stats,
+            filtered_programs: &programs_to_display,
+            bpf_program_columns: &self.bpf_program_columns,
+            bpf_overhead_history: &self.bpf_overhead_history,
+            filtering: self.filtering,
+            filter_input: &self.event_input_buffer,
+            event_input_buffer: &self.event_input_buffer,
+            theme: self.config.theme(),
+            tick_rate_ms: self.config.tick_rate_ms(),
         };
-
-        // Create table widget
-        let table = Table::new(rows, constraints)
-            .header(header)
-            .block(
-                Block::bordered()
-                    .title(title)
-                    .border_style(theme.border_style())
-                    .title_top(
-                        Line::from(format!("{}ms", self.config.tick_rate_ms()))
-                            .style(self.config.theme().text_important_color())
-                            .right_aligned(),
-                    ),
-            )
-            .style(Style::default().fg(theme.text_color()))
-            .row_highlight_style(Style::default().fg(theme.text_enabled_color()))
-            .highlight_symbol(">> ");
-
-        // Render the table
-        frame.render_stateful_widget(table, area, &mut self.bpf_program_table_state);
-        Ok(())
-    }
-
-    /// Renders the filter input area
-    fn render_filter_input(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        let theme = self.theme();
-
-        let input = Paragraph::new(self.event_input_buffer.as_str())
-            .style(Style::default().fg(theme.text_color()))
-            .block(
-                Block::bordered()
-                    .title("Filter")
-                    .border_style(theme.border_style()),
-            );
-
-        frame.render_widget(input, area);
-        Ok(())
-    }
-
-    /// Render BPF overhead sparkline showing trend over time
-    fn render_bpf_overhead_sparkline(&self, frame: &mut Frame, area: Rect) -> Result<()> {
-        let theme = self.theme();
-
-        if self.bpf_overhead_history.is_empty() {
-            // No data yet, show empty sparkline
-            let sparkline = Sparkline::default()
-                .block(
-                    Block::bordered()
-                        .title("BPF CPU Overhead: No data yet")
-                        .border_style(theme.border_style()),
-                )
-                .style(Style::default().fg(Color::Cyan));
-
-            frame.render_widget(sparkline, area);
-            return Ok(());
-        }
-
-        // Calculate the number of data points needed to fill the width
-        // Subtract 2 for borders
-        let available_width = area.width.saturating_sub(2) as usize;
-
-        // Prepare data to fill the entire width
-        let mut data: Vec<u64> = Vec::with_capacity(available_width);
-
-        if self.bpf_overhead_history.len() >= available_width {
-            // We have enough data, take the most recent points
-            data = self
-                .bpf_overhead_history
-                .iter()
-                .rev()
-                .take(available_width)
-                .rev()
-                .map(|v| (*v * 100.0) as u64)
-                .collect();
-        } else {
-            // Not enough data yet, pad with zeros at the beginning
-            let padding = available_width - self.bpf_overhead_history.len();
-            data.extend(std::iter::repeat_n(0, padding));
-            data.extend(
-                self.bpf_overhead_history
-                    .iter()
-                    .map(|v| (*v * 100.0) as u64),
-            );
-        }
-
-        let current_overhead = self.bpf_overhead_history.back().unwrap_or(&0.0);
-
-        let sparkline = Sparkline::default()
-            .block(
-                Block::bordered()
-                    .title(format!("BPF CPU Overhead: {:.2}%", current_overhead))
-                    .border_style(theme.border_style()),
-            )
-            .data(&data)
-            .style(Style::default().fg(Color::Cyan));
-
-        frame.render_widget(sparkline, area);
-        Ok(())
-    }
-
-    /// Render per-operation breakdown for sched_ext programs
-    fn render_operation_breakdown(&self, frame: &mut Frame, area: Rect) -> Result<()> {
-        let theme = self.theme();
-
-        // Sort operations by runtime descending
-        let mut ops: Vec<(
-            &crate::bpf_prog_data::SchedExtOpType,
-            &crate::bpf_prog_data::OperationStats,
-        )> = self.bpf_program_stats.operation_stats.iter().collect();
-        ops.sort_by(|a, b| b.1.total_runtime_ns.cmp(&a.1.total_runtime_ns));
-
-        let mut text = vec![
-            Line::from(Span::styled(
-                "sched_ext Callback Statistics:",
-                Style::default().fg(theme.title_style().fg.unwrap_or(Color::Yellow)),
-            )),
-            Line::from(""),
-            // Header row
-            Line::from(vec![
-                Span::styled(
-                    format!("{:>12}  ", "Operation"),
-                    Style::default()
-                        .fg(theme.text_color())
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    format!("{:>10}       ", "Calls"),
-                    Style::default()
-                        .fg(theme.text_color())
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    format!("{:>8}       ", "Avg Time"),
-                    Style::default()
-                        .fg(theme.text_color())
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    format!("{:>8}", "% Runtime"),
-                    Style::default()
-                        .fg(theme.text_color())
-                        .add_modifier(Modifier::BOLD),
-                ),
-            ]),
-        ];
-
-        // Show top 8 operations
-        for (op_type, stats) in ops.iter().take(8) {
-            let avg_ns = if stats.total_calls > 0 {
-                stats.total_runtime_ns / stats.total_calls
-            } else {
-                0
-            };
-
-            let pct = if self.bpf_program_stats.total_runtime_ns > 0 {
-                (stats.total_runtime_ns as f64 / self.bpf_program_stats.total_runtime_ns as f64)
-                    * 100.0
-            } else {
-                0.0
-            };
-
-            let line = Line::from(vec![
-                Span::styled(
-                    format!("{:>12}: ", op_type.display_name()),
-                    Style::default().fg(theme.text_color()),
-                ),
-                Span::styled(
-                    format!("{:>10} calls  ", stats.total_calls),
-                    Style::default().fg(theme.text_enabled_color()),
-                ),
-                Span::styled(
-                    format!("{:>8.2}μs avg  ", avg_ns as f64 / 1000.0),
-                    Style::default().fg(theme.text_enabled_color()),
-                ),
-                Span::styled(
-                    format!("{:>5.1}%", pct),
-                    Style::default().fg(if pct > 50.0 { Color::Red } else { Color::Green }),
-                ),
-            ]);
-            text.push(line);
-        }
-
-        let paragraph = Paragraph::new(text).block(
-            Block::bordered()
-                .title("sched_ext Callback Operations")
-                .border_style(theme.border_style()),
-        );
-
-        frame.render_widget(paragraph, area);
-        Ok(())
+        BpfProgramRenderer::render_programs_list(
+            frame,
+            &mut self.bpf_program_table_state,
+            &list_params,
+        )
     }
 
     /// Renders the BPF program detail view using real BPF_ENABLE_STATS data
     fn render_bpf_program_detail(&mut self, frame: &mut Frame) -> Result<()> {
-        let area = frame.area();
-        let theme = self.theme();
-
         // Get the selected program data and clone it to avoid borrowing issues
         let selected_program_data = if let Some(prog_id) = self.selected_bpf_program_id {
             self.bpf_program_stats.programs.get(&prog_id).cloned()
@@ -4103,473 +3855,22 @@ impl<'a> App<'a> {
             None
         };
 
-        if let Some(prog_data) = selected_program_data {
-            // Split the area based on whether this is a sched_ext program
-            let chunks = if prog_data.is_sched_ext {
-                // For sched_ext programs, include operation breakdown section
-                Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints([
-                        Constraint::Length(10), // Program info
-                        Constraint::Length(8),  // Runtime stats
-                        Constraint::Min(15),    // Historical sparklines (fills remaining space)
-                        Constraint::Length(12), // Operation breakdown
-                        Constraint::Min(10),    // Symbol table
-                    ])
-                    .split(area)
-            } else {
-                // For non-sched_ext programs, use original layout
-                Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints([
-                        Constraint::Length(10), // Program info
-                        Constraint::Length(8),  // Runtime stats
-                        Constraint::Min(15),    // Historical sparklines (fills remaining space)
-                        Constraint::Min(10),    // Symbol table
-                    ])
-                    .split(area)
-            };
+        let active_event_name = self.active_event.event_name();
 
-            // Render program information with BPF_ENABLE_STATS emphasis
-            self.render_bpf_program_info_with_stats(frame, chunks[0], &prog_data)?;
-
-            // Render runtime statistics collected via BPF_ENABLE_STATS
-            self.render_bpf_runtime_stats(frame, chunks[1], &prog_data)?;
-
-            // Render historical sparklines
-            self.render_bpf_program_sparklines(frame, chunks[2], &prog_data)?;
-
-            if prog_data.is_sched_ext {
-                // Render operation breakdown for sched_ext programs
-                self.render_operation_breakdown(frame, chunks[3])?;
-                // Render symbol table in the last chunk
-                self.render_bpf_program_symbol_table(frame, chunks[4])?;
-            } else {
-                // Render symbol table (perf top style)
-                self.render_bpf_program_symbol_table(frame, chunks[3])?;
-            }
-        } else {
-            // No program selected, show message
-            let paragraph = Paragraph::new("No BPF program selected")
-                .block(
-                    Block::bordered()
-                        .title("BPF Program Detail")
-                        .border_style(theme.border_style()),
-                )
-                .style(Style::default().fg(theme.text_color()));
-
-            frame.render_widget(paragraph, area);
-        }
-
-        Ok(())
-    }
-
-    /// Renders BPF program information with emphasis on BPF_ENABLE_STATS data collection
-    fn render_bpf_program_info_with_stats(
-        &mut self,
-        frame: &mut Frame,
-        area: Rect,
-        prog_data: &BpfProgData,
-    ) -> Result<()> {
-        let theme = self.theme();
-
-        let info_text = vec![
-            Line::from(vec![
-                Span::styled("Program ID: ", Style::default().fg(theme.text_color())),
-                Span::styled(
-                    prog_data.id.to_string(),
-                    Style::default().fg(theme.text_enabled_color()),
-                ),
-                Span::styled("  Type: ", Style::default().fg(theme.text_color())),
-                Span::styled(
-                    prog_data.prog_type.clone(),
-                    Style::default().fg(theme.text_enabled_color()),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled("Name: ", Style::default().fg(theme.text_color())),
-                Span::styled(
-                    if prog_data.name.is_empty() {
-                        format!("<unnamed-{}>", prog_data.id)
-                    } else {
-                        prog_data.name.clone()
-                    },
-                    Style::default().fg(theme.text_enabled_color()),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled("Instructions: ", Style::default().fg(theme.text_color())),
-                Span::styled(
-                    prog_data.verified_insns.to_string(),
-                    Style::default().fg(theme.text_enabled_color()),
-                ),
-                Span::styled("  BTF ID: ", Style::default().fg(theme.text_color())),
-                Span::styled(
-                    if prog_data.btf_id == 0 {
-                        "-".to_string()
-                    } else {
-                        prog_data.btf_id.to_string()
-                    },
-                    Style::default().fg(theme.text_enabled_color()),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled("UID: ", Style::default().fg(theme.text_color())),
-                Span::styled(
-                    prog_data.uid.to_string(),
-                    Style::default().fg(theme.text_enabled_color()),
-                ),
-                Span::styled(
-                    "  GPL Compatible: ",
-                    Style::default().fg(theme.text_color()),
-                ),
-                Span::styled(
-                    if prog_data.gpl_compatible {
-                        "Yes"
-                    } else {
-                        "No"
-                    }
-                    .to_string(),
-                    Style::default().fg(theme.text_enabled_color()),
-                ),
-            ]),
-            Line::from(""),
-        ];
-
-        // Create title with perf sampling status
-        let title = if self.bpf_perf_sampling_active {
-            format!(
-                "BPF Program {} Details - Perf Sampling ACTIVE ({}) - Press 'p' to stop",
-                prog_data.id,
-                self.active_event.event_name()
-            )
-        } else {
-            format!(
-                "BPF Program {} Details - Press 'p' to enable perf sampling",
-                prog_data.id
-            )
+        let detail_params = ProgramDetailParams {
+            selected_program_data: selected_program_data.as_ref(),
+            bpf_program_stats: &self.bpf_program_stats,
+            filtered_symbols: &self.bpf_program_filtered_symbols,
+            bpf_perf_sampling_active: self.bpf_perf_sampling_active,
+            active_event_name,
+            theme: self.config.theme(),
+            tick_rate_ms: self.config.tick_rate_ms(),
         };
-
-        let paragraph = Paragraph::new(info_text)
-            .block(
-                Block::bordered()
-                    .title(title)
-                    .border_style(theme.border_style())
-                    .title_top(
-                        Line::from(format!("{}ms", self.config.tick_rate_ms()))
-                            .style(self.config.theme().text_important_color())
-                            .right_aligned(),
-                    ),
-            )
-            .style(Style::default().fg(theme.text_color()));
-
-        frame.render_widget(paragraph, area);
-        Ok(())
-    }
-
-    /// Renders BPF runtime statistics collected via BPF_ENABLE_STATS
-    fn render_bpf_runtime_stats(
-        &mut self,
-        frame: &mut Frame,
-        area: Rect,
-        prog_data: &BpfProgData,
-    ) -> Result<()> {
-        let theme = self.theme();
-
-        let avg_runtime_ns = if prog_data.run_cnt > 0 {
-            prog_data.run_time_ns / prog_data.run_cnt
-        } else {
-            0
-        };
-
-        let runtime_percentage =
-            prog_data.runtime_percentage(self.bpf_program_stats.total_runtime_ns);
-
-        let stats_text = vec![
-            Line::from(vec![
-                Span::styled("Total Runtime: ", Style::default().fg(theme.text_color())),
-                Span::styled(
-                    if prog_data.run_time_ns > 1_000_000_000 {
-                        format!("{:.2}s", prog_data.run_time_ns as f64 / 1_000_000_000.0)
-                    } else if prog_data.run_time_ns > 1_000_000 {
-                        format!("{:.2}ms", prog_data.run_time_ns as f64 / 1_000_000.0)
-                    } else if prog_data.run_time_ns > 1_000 {
-                        format!("{:.2}μs", prog_data.run_time_ns as f64 / 1_000.0)
-                    } else {
-                        format!("{}ns", prog_data.run_time_ns)
-                    },
-                    Style::default()
-                        .fg(theme.text_enabled_color())
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("  Runtime %: ", Style::default().fg(theme.text_color())),
-                Span::styled(
-                    format!("{:.2}%", runtime_percentage),
-                    Style::default()
-                        .fg(theme.text_enabled_color())
-                        .add_modifier(Modifier::BOLD),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled("Run Count: ", Style::default().fg(theme.text_color())),
-                Span::styled(
-                    prog_data.run_cnt.to_string(),
-                    Style::default().fg(theme.text_enabled_color()),
-                ),
-                Span::styled("  Avg Runtime: ", Style::default().fg(theme.text_color())),
-                Span::styled(
-                    if avg_runtime_ns > 1_000_000 {
-                        format!("{:.2}ms", avg_runtime_ns as f64 / 1_000_000.0)
-                    } else if avg_runtime_ns > 1_000 {
-                        format!("{:.2}μs", avg_runtime_ns as f64 / 1_000.0)
-                    } else {
-                        format!("{}ns", avg_runtime_ns)
-                    },
-                    Style::default().fg(theme.text_enabled_color()),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled("Maps: ", Style::default().fg(theme.text_color())),
-                Span::styled(
-                    prog_data.nr_map_ids.to_string(),
-                    Style::default().fg(theme.text_enabled_color()),
-                ),
-            ]),
-            Line::from(""),
-        ];
-
-        let paragraph = Paragraph::new(stats_text)
-            .block(
-                Block::bordered()
-                    .title("Runtime Statistics")
-                    .border_style(theme.border_style()),
-            )
-            .style(Style::default().fg(theme.text_color()));
-
-        frame.render_widget(paragraph, area);
-        Ok(())
-    }
-
-    /// Renders historical sparklines for BPF program metrics
-    fn render_bpf_program_sparklines(
-        &mut self,
-        frame: &mut Frame,
-        area: Rect,
-        prog_data: &BpfProgData,
-    ) -> Result<()> {
-        let theme = self.theme();
-
-        // Split area into three horizontal sparklines (side by side)
-        let chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Ratio(1, 3),
-                Constraint::Ratio(1, 3),
-                Constraint::Ratio(1, 3),
-            ])
-            .spacing(0)
-            .split(area);
-
-        // Calculate available width for data (subtract 2 for borders)
-        let available_width = chunks[0].width.saturating_sub(2) as usize;
-
-        // Convert runtime_history to Vec<u64> for Sparkline, trimming to available width
-        let runtime_data: Vec<u64> = prog_data
-            .runtime_history
-            .iter()
-            .rev()
-            .take(available_width)
-            .rev()
-            .copied()
-            .collect();
-
-        // Convert calls_history deltas to calls per second, trimming to available width
-        let mut calls_per_sec_data: Vec<u64> = Vec::new();
-        if prog_data.calls_history.len() >= 2 && prog_data.timestamp_history.len() >= 2 {
-            let start_idx = prog_data
-                .calls_history
-                .len()
-                .saturating_sub(available_width + 1);
-            for i in (start_idx + 1)..prog_data.calls_history.len() {
-                let call_delta =
-                    prog_data.calls_history[i].saturating_sub(prog_data.calls_history[i - 1]);
-                let time_delta_ns = prog_data.timestamp_history[i]
-                    .saturating_sub(prog_data.timestamp_history[i - 1]);
-
-                if time_delta_ns > 0 {
-                    let calls_per_sec =
-                        (call_delta as f64 / time_delta_ns as f64) * 1_000_000_000.0;
-                    calls_per_sec_data.push(calls_per_sec as u64);
-                } else {
-                    calls_per_sec_data.push(0);
-                }
-            }
-        }
-
-        // Calculate percentile data for sparkline (p50, p90, p99 over time), trimming to available width
-        // For simplicity, we'll use a rolling window approach
-        let mut p99_data: Vec<u64> = Vec::new();
-        if prog_data.runtime_history.len() >= 10 {
-            let start_idx = 9.max(
-                prog_data
-                    .runtime_history
-                    .len()
-                    .saturating_sub(available_width),
-            );
-            for i in start_idx..prog_data.runtime_history.len() {
-                let window_start = i.saturating_sub(9);
-                let window: Vec<u64> = prog_data
-                    .runtime_history
-                    .iter()
-                    .skip(window_start)
-                    .take(i - window_start + 1)
-                    .copied()
-                    .collect();
-                let mut sorted = window.clone();
-                sorted.sort_unstable();
-                let idx = ((sorted.len() - 1) as f64 * 0.99) as usize;
-                p99_data.push(sorted[idx]);
-            }
-        }
-
-        // Helper function to calculate min/max/avg
-        let calc_stats = |data: &[u64]| -> (u64, u64, u64) {
-            if data.is_empty() {
-                return (0, 0, 0);
-            }
-            let min = *data.iter().min().unwrap_or(&0);
-            let max = *data.iter().max().unwrap_or(&0);
-            let sum: u64 = data.iter().sum();
-            let avg = sum / data.len() as u64;
-            (min, max, avg)
-        };
-
-        // Calculate stats for each dataset
-        let (runtime_min, runtime_max, runtime_avg) = calc_stats(&runtime_data);
-        let (calls_min, calls_max, calls_avg) = calc_stats(&calls_per_sec_data);
-        let (p99_min, p99_max, p99_avg) = calc_stats(&p99_data);
-
-        // Runtime sparkline with min/max/avg labels
-        let runtime_sparkline = Sparkline::default()
-            .block(
-                Block::bordered()
-                    .title(format!(
-                        "Runtime (ns/call) Min:{} Avg:{} Max:{}",
-                        runtime_min, runtime_avg, runtime_max
-                    ))
-                    .border_style(theme.border_style()),
-            )
-            .data(&runtime_data)
-            .max(runtime_max.max(1))
-            .bar_set(NINE_LEVELS)
-            .style(Style::default().fg(theme.text_important_color()));
-
-        // Calls per second sparkline with min/max/avg labels
-        let calls_sparkline = Sparkline::default()
-            .block(
-                Block::bordered()
-                    .title(format!(
-                        "Calls/sec Min:{} Avg:{} Max:{}",
-                        calls_min, calls_avg, calls_max
-                    ))
-                    .border_style(theme.border_style()),
-            )
-            .data(&calls_per_sec_data)
-            .max(calls_max.max(1))
-            .bar_set(NINE_LEVELS)
-            .style(Style::default().fg(theme.positive_value_color()));
-
-        // P99 sparkline with min/max/avg labels
-        let p99_sparkline = Sparkline::default()
-            .block(
-                Block::bordered()
-                    .title(format!(
-                        "P99 Runtime Min:{} Avg:{} Max:{}",
-                        p99_min, p99_avg, p99_max
-                    ))
-                    .border_style(theme.border_style()),
-            )
-            .data(&p99_data)
-            .max(p99_max.max(1))
-            .bar_set(NINE_LEVELS)
-            .style(Style::default().fg(theme.userspace_symbol_color()));
-
-        frame.render_widget(runtime_sparkline, chunks[0]);
-        frame.render_widget(calls_sparkline, chunks[1]);
-        frame.render_widget(p99_sparkline, chunks[2]);
-
-        Ok(())
-    }
-
-    /// Renders BPF program symbol table (perf top style)
-    fn render_bpf_program_symbol_table(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        let theme = self.theme();
-
-        // Build table rows from filtered symbols with module name and source location
-        let rows: Vec<Row> = self
-            .bpf_program_filtered_symbols
-            .iter()
-            .map(|symbol| {
-                let source_location = if let (Some(file), Some(line)) = (
-                    &symbol.symbol_info.file_name,
-                    symbol.symbol_info.line_number,
-                ) {
-                    format!("{}:{}", file, line)
-                } else {
-                    "-".to_string()
-                };
-
-                Row::new(vec![
-                    Cell::from(format!("{:.2}%", symbol.percentage)),
-                    Cell::from(symbol.count.to_string()),
-                    Cell::from(format!("0x{:x}", symbol.symbol_info.address)),
-                    Cell::from(symbol.symbol_info.symbol_name.clone()),
-                    Cell::from(symbol.symbol_info.module_name.clone()),
-                    Cell::from(source_location),
-                ])
-            })
-            .collect();
-
-        // Create header
-        let header = Row::new(vec![
-            Cell::from("Overhead"),
-            Cell::from("Samples"),
-            Cell::from("Address"),
-            Cell::from("Symbol"),
-            Cell::from("Module"),
-            Cell::from("Source"),
-        ])
-        .style(theme.title_style())
-        .height(1);
-
-        // Define column constraints
-        let constraints = vec![
-            Constraint::Length(10), // Overhead
-            Constraint::Length(10), // Samples
-            Constraint::Length(16), // Address
-            Constraint::Fill(1),    // Symbol (with line number included in name)
-            Constraint::Length(10), // Module
-            Constraint::Length(20), // Source location
-        ];
-
-        // Create table widget
-        let table = Table::new(rows, constraints)
-            .header(header)
-            .block(
-                Block::bordered()
-                    .title(format!(
-                        "BPF Program Symbols ({} symbols) - Line numbers from jited_line_info",
-                        self.bpf_program_filtered_symbols.len()
-                    ))
-                    .border_style(theme.border_style()),
-            )
-            .style(Style::default().fg(theme.text_color()))
-            .row_highlight_style(Style::default().fg(theme.text_enabled_color()))
-            .highlight_symbol(">> ");
-
-        // Render the table
-        frame.render_stateful_widget(table, area, &mut self.bpf_program_symbol_table_state);
-        Ok(())
+        BpfProgramRenderer::render_program_detail(
+            frame,
+            &mut self.bpf_program_symbol_table_state,
+            &detail_params,
+        )
     }
 
     /// Updates app state when the down arrow or mapped key is pressed.

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -39,6 +39,7 @@ pub mod util;
 
 pub use crate::bpf_skel::types::bpf_event;
 pub use app::App;
+pub use bpf_prog_data::{BpfProgData, BpfProgStats};
 pub use bpf_skel::*;
 pub use columns::{Column, Columns};
 pub use cpu_data::CpuData;

--- a/tools/scxtop/src/render/bpf_programs.rs
+++ b/tools/scxtop/src/render/bpf_programs.rs
@@ -1,0 +1,887 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use crate::bpf_prog_data::{BpfProgData, BpfProgStats, SchedExtOpType};
+use crate::columns::Columns;
+use crate::symbol_data::SymbolSample;
+use crate::AppTheme;
+use anyhow::Result;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::symbols::bar::NINE_LEVELS;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Cell, Paragraph, Row, Sparkline, Table, TableState};
+use ratatui::Frame;
+use std::collections::VecDeque;
+
+/// Parameters for rendering BPF programs list
+pub struct ProgramsListParams<'a> {
+    pub bpf_program_stats: &'a BpfProgStats,
+    pub filtered_programs: &'a [(u32, BpfProgData)],
+    pub bpf_program_columns: &'a Columns<u32, BpfProgData>,
+    pub bpf_overhead_history: &'a VecDeque<f64>,
+    pub filtering: bool,
+    pub filter_input: &'a str,
+    pub event_input_buffer: &'a str,
+    pub theme: &'a AppTheme,
+    pub tick_rate_ms: usize,
+}
+
+/// Parameters for rendering BPF program details
+pub struct ProgramDetailParams<'a> {
+    pub selected_program_data: Option<&'a BpfProgData>,
+    pub bpf_program_stats: &'a BpfProgStats,
+    pub filtered_symbols: &'a [SymbolSample],
+    pub bpf_perf_sampling_active: bool,
+    pub active_event_name: &'a str,
+    pub theme: &'a AppTheme,
+    pub tick_rate_ms: usize,
+}
+
+/// Parameters for rendering BPF programs table
+pub struct ProgramsTableParams<'a> {
+    pub bpf_program_stats: &'a BpfProgStats,
+    pub programs_to_display: &'a [(u32, BpfProgData)],
+    pub bpf_program_columns: &'a Columns<u32, BpfProgData>,
+    pub filtering: bool,
+    pub event_input_buffer: &'a str,
+    pub theme: &'a AppTheme,
+    pub tick_rate_ms: usize,
+}
+
+/// Renderer for BPF programs views
+pub struct BpfProgramRenderer;
+
+impl BpfProgramRenderer {
+    /// Renders the BPF programs list view with overhead sparkline
+    pub fn render_programs_list(
+        frame: &mut Frame,
+        table_state: &mut TableState,
+        params: &ProgramsListParams,
+    ) -> Result<()> {
+        let main_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Min(10),   // Table area
+                Constraint::Length(5), // Sparkline section
+            ])
+            .split(frame.area());
+
+        if params.filtering && !params.event_input_buffer.is_empty() {
+            // Further split table area for filter input
+            let table_chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(0), Constraint::Length(3)])
+                .split(main_chunks[0]);
+
+            let table_params = ProgramsTableParams {
+                bpf_program_stats: params.bpf_program_stats,
+                programs_to_display: params.filtered_programs,
+                bpf_program_columns: params.bpf_program_columns,
+                filtering: params.filtering,
+                event_input_buffer: params.event_input_buffer,
+                theme: params.theme,
+                tick_rate_ms: params.tick_rate_ms,
+            };
+
+            Self::render_programs_table(frame, table_chunks[0], table_state, &table_params)?;
+            Self::render_filter_input(frame, table_chunks[1], params.filter_input, params.theme)?;
+        } else {
+            let table_params = ProgramsTableParams {
+                bpf_program_stats: params.bpf_program_stats,
+                programs_to_display: params.filtered_programs,
+                bpf_program_columns: params.bpf_program_columns,
+                filtering: params.filtering,
+                event_input_buffer: params.event_input_buffer,
+                theme: params.theme,
+                tick_rate_ms: params.tick_rate_ms,
+            };
+
+            Self::render_programs_table(frame, main_chunks[0], table_state, &table_params)?;
+        }
+
+        // Render overhead sparkline
+        Self::render_overhead_sparkline(
+            frame,
+            main_chunks[1],
+            params.bpf_overhead_history,
+            params.theme,
+        )?;
+
+        Ok(())
+    }
+
+    /// Renders the BPF program detail view
+    pub fn render_program_detail(
+        frame: &mut Frame,
+        symbol_table_state: &mut TableState,
+        params: &ProgramDetailParams,
+    ) -> Result<()> {
+        let area = frame.area();
+
+        if let Some(prog_data) = params.selected_program_data {
+            // Split the area based on whether this is a sched_ext program
+            let chunks = if prog_data.is_sched_ext {
+                // For sched_ext programs, include operation breakdown section
+                Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(10), // Program info
+                        Constraint::Length(8),  // Runtime stats
+                        Constraint::Min(15),    // Historical sparklines (fills remaining space)
+                        Constraint::Length(12), // Operation breakdown
+                        Constraint::Min(10),    // Symbol table
+                    ])
+                    .split(area)
+            } else {
+                // For non-sched_ext programs, use original layout
+                Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(10), // Program info
+                        Constraint::Length(8),  // Runtime stats
+                        Constraint::Min(15),    // Historical sparklines (fills remaining space)
+                        Constraint::Min(10),    // Symbol table
+                    ])
+                    .split(area)
+            };
+
+            // Render program information with BPF_ENABLE_STATS emphasis
+            Self::render_program_info(
+                frame,
+                chunks[0],
+                prog_data,
+                params.bpf_perf_sampling_active,
+                params.active_event_name,
+                params.theme,
+                params.tick_rate_ms,
+            )?;
+
+            // Render runtime statistics collected via BPF_ENABLE_STATS
+            Self::render_runtime_stats(
+                frame,
+                chunks[1],
+                prog_data,
+                params.bpf_program_stats,
+                params.theme,
+            )?;
+
+            // Render historical sparklines
+            Self::render_program_sparklines(frame, chunks[2], prog_data, params.theme)?;
+
+            if prog_data.is_sched_ext {
+                // Render operation breakdown for sched_ext programs
+                Self::render_operation_breakdown(
+                    frame,
+                    chunks[3],
+                    params.bpf_program_stats,
+                    params.theme,
+                )?;
+                // Render symbol table in the last chunk
+                Self::render_symbol_table(
+                    frame,
+                    chunks[4],
+                    params.filtered_symbols,
+                    symbol_table_state,
+                    params.theme,
+                )?;
+            } else {
+                // Render symbol table (perf top style)
+                Self::render_symbol_table(
+                    frame,
+                    chunks[3],
+                    params.filtered_symbols,
+                    symbol_table_state,
+                    params.theme,
+                )?;
+            }
+        } else {
+            // No program selected, show message
+            let paragraph = Paragraph::new("No BPF program selected")
+                .block(
+                    Block::bordered()
+                        .title("BPF Program Detail")
+                        .border_style(params.theme.border_style()),
+                )
+                .style(Style::default().fg(params.theme.text_color()));
+
+            frame.render_widget(paragraph, area);
+        }
+
+        Ok(())
+    }
+
+    /// Renders the BPF programs table
+    fn render_programs_table(
+        frame: &mut Frame,
+        area: Rect,
+        table_state: &mut TableState,
+        params: &ProgramsTableParams,
+    ) -> Result<()> {
+        // Build table rows with sched_ext highlighting
+        let rows: Vec<Row> = params
+            .programs_to_display
+            .iter()
+            .map(|(id, data)| {
+                let cols = params.bpf_program_columns.visible_columns();
+                let cells: Vec<Cell> = cols
+                    .map(|col| {
+                        let mut value = (col.value_fn)(*id, data);
+                        // Special handling for runtime percentage column
+                        if col.header == "Runtime %" {
+                            let percentage =
+                                data.runtime_percentage(params.bpf_program_stats.total_runtime_ns);
+                            value = format!("{:.2}%", percentage);
+                        }
+                        Cell::from(value)
+                    })
+                    .collect();
+
+                // Apply sched_ext highlighting
+                let row = Row::new(cells);
+                if data.is_sched_ext {
+                    row.style(
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                } else {
+                    row
+                }
+            })
+            .collect();
+
+        // Create header
+        let header = Row::new(
+            params
+                .bpf_program_columns
+                .visible_columns()
+                .map(|col| Cell::from(col.header))
+                .collect::<Vec<_>>(),
+        )
+        .style(params.theme.title_style())
+        .height(1);
+
+        // Get constraints for visible columns
+        let constraints: Vec<Constraint> = params
+            .bpf_program_columns
+            .visible_columns()
+            .map(|col| col.constraint)
+            .collect();
+
+        // Create title with filter information
+        let title = if params.filtering {
+            format!(
+                "BPF Programs ({}/{} programs) - Filtering: {} - Press Enter for details, Esc to clear filter",
+                params.programs_to_display.len(),
+                params.bpf_program_stats.programs.len(),
+                params.event_input_buffer
+            )
+        } else {
+            format!(
+                "BPF Programs ({} programs) - Press f to filter, Enter for details",
+                params.bpf_program_stats.programs.len()
+            )
+        };
+
+        // Create table widget
+        let table = Table::new(rows, constraints)
+            .header(header)
+            .block(
+                Block::bordered()
+                    .title(title)
+                    .border_style(params.theme.border_style())
+                    .title_top(
+                        Line::from(format!("{}ms", params.tick_rate_ms))
+                            .style(params.theme.text_important_color())
+                            .right_aligned(),
+                    ),
+            )
+            .style(Style::default().fg(params.theme.text_color()))
+            .row_highlight_style(Style::default().fg(params.theme.text_enabled_color()))
+            .highlight_symbol(">> ");
+
+        // Render the table
+        frame.render_stateful_widget(table, area, table_state);
+        Ok(())
+    }
+
+    /// Renders the filter input area
+    fn render_filter_input(
+        frame: &mut Frame,
+        area: Rect,
+        filter_input: &str,
+        theme: &AppTheme,
+    ) -> Result<()> {
+        let input = Paragraph::new(filter_input)
+            .style(Style::default().fg(theme.text_color()))
+            .block(
+                Block::bordered()
+                    .title("Filter")
+                    .border_style(theme.border_style()),
+            );
+
+        frame.render_widget(input, area);
+        Ok(())
+    }
+
+    /// Render BPF overhead sparkline showing trend over time
+    fn render_overhead_sparkline(
+        frame: &mut Frame,
+        area: Rect,
+        bpf_overhead_history: &VecDeque<f64>,
+        theme: &AppTheme,
+    ) -> Result<()> {
+        if bpf_overhead_history.is_empty() {
+            // No data yet, show empty sparkline
+            let sparkline = Sparkline::default()
+                .block(
+                    Block::bordered()
+                        .title("BPF CPU Overhead: No data yet")
+                        .border_style(theme.border_style()),
+                )
+                .style(Style::default().fg(Color::Cyan));
+
+            frame.render_widget(sparkline, area);
+            return Ok(());
+        }
+
+        // Calculate the number of data points needed to fill the width
+        // Subtract 2 for borders
+        let available_width = area.width.saturating_sub(2) as usize;
+
+        // Prepare data to fill the entire width
+        let mut data: Vec<u64> = Vec::with_capacity(available_width);
+
+        if bpf_overhead_history.len() >= available_width {
+            // We have enough data, take the most recent points
+            data = bpf_overhead_history
+                .iter()
+                .rev()
+                .take(available_width)
+                .rev()
+                .map(|v| (*v * 100.0) as u64)
+                .collect();
+        } else {
+            // Not enough data yet, pad with zeros at the beginning
+            let padding = available_width - bpf_overhead_history.len();
+            data.extend(std::iter::repeat_n(0, padding));
+            data.extend(bpf_overhead_history.iter().map(|v| (*v * 100.0) as u64));
+        }
+
+        let current_overhead = bpf_overhead_history.back().unwrap_or(&0.0);
+
+        let sparkline = Sparkline::default()
+            .block(
+                Block::bordered()
+                    .title(format!("BPF CPU Overhead: {:.2}%", current_overhead))
+                    .border_style(theme.border_style()),
+            )
+            .data(&data)
+            .style(Style::default().fg(Color::Cyan));
+
+        frame.render_widget(sparkline, area);
+        Ok(())
+    }
+
+    /// Render per-operation breakdown for sched_ext programs
+    fn render_operation_breakdown(
+        frame: &mut Frame,
+        area: Rect,
+        bpf_program_stats: &BpfProgStats,
+        theme: &AppTheme,
+    ) -> Result<()> {
+        // Sort operations by runtime descending
+        let mut ops: Vec<(&SchedExtOpType, &crate::bpf_prog_data::OperationStats)> =
+            bpf_program_stats.operation_stats.iter().collect();
+        ops.sort_by(|a, b| b.1.total_runtime_ns.cmp(&a.1.total_runtime_ns));
+
+        let mut text = vec![
+            Line::from(Span::styled(
+                "sched_ext Callback Statistics:",
+                Style::default().fg(theme.title_style().fg.unwrap_or(Color::Yellow)),
+            )),
+            Line::from(""),
+            // Header row
+            Line::from(vec![
+                Span::styled(
+                    format!("{:>12}  ", "Operation"),
+                    Style::default()
+                        .fg(theme.text_color())
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("{:>10}       ", "Calls"),
+                    Style::default()
+                        .fg(theme.text_color())
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("{:>8}       ", "Avg Time"),
+                    Style::default()
+                        .fg(theme.text_color())
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("{:>8}", "% Runtime"),
+                    Style::default()
+                        .fg(theme.text_color())
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]),
+        ];
+
+        // Show top 8 operations
+        for (op_type, stats) in ops.iter().take(8) {
+            let avg_ns = if stats.total_calls > 0 {
+                stats.total_runtime_ns / stats.total_calls
+            } else {
+                0
+            };
+
+            let pct = if bpf_program_stats.total_runtime_ns > 0 {
+                (stats.total_runtime_ns as f64 / bpf_program_stats.total_runtime_ns as f64) * 100.0
+            } else {
+                0.0
+            };
+
+            let line = Line::from(vec![
+                Span::styled(
+                    format!("{:>12}: ", op_type.display_name()),
+                    Style::default().fg(theme.text_color()),
+                ),
+                Span::styled(
+                    format!("{:>10} calls  ", stats.total_calls),
+                    Style::default().fg(theme.text_enabled_color()),
+                ),
+                Span::styled(
+                    format!("{:>8.2}μs avg  ", avg_ns as f64 / 1000.0),
+                    Style::default().fg(theme.text_enabled_color()),
+                ),
+                Span::styled(
+                    format!("{:>5.1}%", pct),
+                    Style::default().fg(if pct > 50.0 { Color::Red } else { Color::Green }),
+                ),
+            ]);
+            text.push(line);
+        }
+
+        let paragraph = Paragraph::new(text).block(
+            Block::bordered()
+                .title("sched_ext Callback Operations")
+                .border_style(theme.border_style()),
+        );
+
+        frame.render_widget(paragraph, area);
+        Ok(())
+    }
+
+    /// Renders BPF program information with emphasis on BPF_ENABLE_STATS data collection
+    fn render_program_info(
+        frame: &mut Frame,
+        area: Rect,
+        prog_data: &BpfProgData,
+        bpf_perf_sampling_active: bool,
+        active_event_name: &str,
+        theme: &AppTheme,
+        tick_rate_ms: usize,
+    ) -> Result<()> {
+        let info_text = vec![
+            Line::from(vec![
+                Span::styled("Program ID: ", Style::default().fg(theme.text_color())),
+                Span::styled(
+                    prog_data.id.to_string(),
+                    Style::default().fg(theme.text_enabled_color()),
+                ),
+                Span::styled("  Type: ", Style::default().fg(theme.text_color())),
+                Span::styled(
+                    prog_data.prog_type.clone(),
+                    Style::default().fg(theme.text_enabled_color()),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("Name: ", Style::default().fg(theme.text_color())),
+                Span::styled(
+                    if prog_data.name.is_empty() {
+                        format!("<unnamed-{}>", prog_data.id)
+                    } else {
+                        prog_data.name.clone()
+                    },
+                    Style::default().fg(theme.text_enabled_color()),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("Instructions: ", Style::default().fg(theme.text_color())),
+                Span::styled(
+                    prog_data.verified_insns.to_string(),
+                    Style::default().fg(theme.text_enabled_color()),
+                ),
+                Span::styled("  BTF ID: ", Style::default().fg(theme.text_color())),
+                Span::styled(
+                    if prog_data.btf_id == 0 {
+                        "-".to_string()
+                    } else {
+                        prog_data.btf_id.to_string()
+                    },
+                    Style::default().fg(theme.text_enabled_color()),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("UID: ", Style::default().fg(theme.text_color())),
+                Span::styled(
+                    prog_data.uid.to_string(),
+                    Style::default().fg(theme.text_enabled_color()),
+                ),
+                Span::styled(
+                    "  GPL Compatible: ",
+                    Style::default().fg(theme.text_color()),
+                ),
+                Span::styled(
+                    if prog_data.gpl_compatible {
+                        "Yes"
+                    } else {
+                        "No"
+                    }
+                    .to_string(),
+                    Style::default().fg(theme.text_enabled_color()),
+                ),
+            ]),
+            Line::from(""),
+        ];
+
+        // Create title with perf sampling status
+        let title = if bpf_perf_sampling_active {
+            format!(
+                "BPF Program {} Details - Perf Sampling ACTIVE ({}) - Press 'p' to stop",
+                prog_data.id, active_event_name
+            )
+        } else {
+            format!(
+                "BPF Program {} Details - Press 'p' to enable perf sampling",
+                prog_data.id
+            )
+        };
+
+        let paragraph = Paragraph::new(info_text)
+            .block(
+                Block::bordered()
+                    .title(title)
+                    .border_style(theme.border_style())
+                    .title_top(
+                        Line::from(format!("{}ms", tick_rate_ms))
+                            .style(theme.text_important_color())
+                            .right_aligned(),
+                    ),
+            )
+            .style(Style::default().fg(theme.text_color()));
+
+        frame.render_widget(paragraph, area);
+        Ok(())
+    }
+
+    /// Renders BPF runtime statistics collected via BPF_ENABLE_STATS
+    fn render_runtime_stats(
+        frame: &mut Frame,
+        area: Rect,
+        prog_data: &BpfProgData,
+        bpf_program_stats: &BpfProgStats,
+        theme: &AppTheme,
+    ) -> Result<()> {
+        let avg_runtime_ns = if prog_data.run_cnt > 0 {
+            prog_data.run_time_ns / prog_data.run_cnt
+        } else {
+            0
+        };
+
+        let runtime_percentage = prog_data.runtime_percentage(bpf_program_stats.total_runtime_ns);
+
+        let stats_text = vec![
+            Line::from(vec![
+                Span::styled("Total Runtime: ", Style::default().fg(theme.text_color())),
+                Span::styled(
+                    if prog_data.run_time_ns > 1_000_000_000 {
+                        format!("{:.2}s", prog_data.run_time_ns as f64 / 1_000_000_000.0)
+                    } else if prog_data.run_time_ns > 1_000_000 {
+                        format!("{:.2}ms", prog_data.run_time_ns as f64 / 1_000_000.0)
+                    } else if prog_data.run_time_ns > 1_000 {
+                        format!("{:.2}μs", prog_data.run_time_ns as f64 / 1_000.0)
+                    } else {
+                        format!("{}ns", prog_data.run_time_ns)
+                    },
+                    Style::default()
+                        .fg(theme.text_enabled_color())
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled("  Runtime %: ", Style::default().fg(theme.text_color())),
+                Span::styled(
+                    format!("{:.2}%", runtime_percentage),
+                    Style::default()
+                        .fg(theme.text_enabled_color())
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("Run Count: ", Style::default().fg(theme.text_color())),
+                Span::styled(
+                    prog_data.run_cnt.to_string(),
+                    Style::default().fg(theme.text_enabled_color()),
+                ),
+                Span::styled("  Avg Runtime: ", Style::default().fg(theme.text_color())),
+                Span::styled(
+                    if avg_runtime_ns > 1_000_000 {
+                        format!("{:.2}ms", avg_runtime_ns as f64 / 1_000_000.0)
+                    } else if avg_runtime_ns > 1_000 {
+                        format!("{:.2}μs", avg_runtime_ns as f64 / 1_000.0)
+                    } else {
+                        format!("{}ns", avg_runtime_ns)
+                    },
+                    Style::default().fg(theme.text_enabled_color()),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("Maps: ", Style::default().fg(theme.text_color())),
+                Span::styled(
+                    prog_data.nr_map_ids.to_string(),
+                    Style::default().fg(theme.text_enabled_color()),
+                ),
+            ]),
+            Line::from(""),
+        ];
+
+        let paragraph = Paragraph::new(stats_text)
+            .block(
+                Block::bordered()
+                    .title("Runtime Statistics")
+                    .border_style(theme.border_style()),
+            )
+            .style(Style::default().fg(theme.text_color()));
+
+        frame.render_widget(paragraph, area);
+        Ok(())
+    }
+
+    /// Renders historical sparklines for BPF program metrics
+    fn render_program_sparklines(
+        frame: &mut Frame,
+        area: Rect,
+        prog_data: &BpfProgData,
+        theme: &AppTheme,
+    ) -> Result<()> {
+        // Split area into three horizontal sparklines (side by side)
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Ratio(1, 3),
+                Constraint::Ratio(1, 3),
+                Constraint::Ratio(1, 3),
+            ])
+            .spacing(0)
+            .split(area);
+
+        // Calculate available width for data (subtract 2 for borders)
+        let available_width = chunks[0].width.saturating_sub(2) as usize;
+
+        // Convert runtime_history to Vec<u64> for Sparkline, trimming to available width
+        let runtime_data: Vec<u64> = prog_data
+            .runtime_history
+            .iter()
+            .rev()
+            .take(available_width)
+            .rev()
+            .copied()
+            .collect();
+
+        // Convert calls_history deltas to calls per second, trimming to available width
+        let mut calls_per_sec_data: Vec<u64> = Vec::new();
+        if prog_data.calls_history.len() >= 2 && prog_data.timestamp_history.len() >= 2 {
+            let start_idx = prog_data
+                .calls_history
+                .len()
+                .saturating_sub(available_width + 1);
+            for i in (start_idx + 1)..prog_data.calls_history.len() {
+                let call_delta =
+                    prog_data.calls_history[i].saturating_sub(prog_data.calls_history[i - 1]);
+                let time_delta_ns = prog_data.timestamp_history[i]
+                    .saturating_sub(prog_data.timestamp_history[i - 1]);
+
+                if time_delta_ns > 0 {
+                    let calls_per_sec =
+                        (call_delta as f64 / time_delta_ns as f64) * 1_000_000_000.0;
+                    calls_per_sec_data.push(calls_per_sec as u64);
+                } else {
+                    calls_per_sec_data.push(0);
+                }
+            }
+        }
+
+        // Calculate percentile data for sparkline (p50, p90, p99 over time), trimming to available width
+        // For simplicity, we'll use a rolling window approach
+        let mut p99_data: Vec<u64> = Vec::new();
+        if prog_data.runtime_history.len() >= 10 {
+            let start_idx = 9.max(
+                prog_data
+                    .runtime_history
+                    .len()
+                    .saturating_sub(available_width),
+            );
+            for i in start_idx..prog_data.runtime_history.len() {
+                let window_start = i.saturating_sub(9);
+                let window: Vec<u64> = prog_data
+                    .runtime_history
+                    .iter()
+                    .skip(window_start)
+                    .take(i - window_start + 1)
+                    .copied()
+                    .collect();
+                let mut sorted = window.clone();
+                sorted.sort_unstable();
+                let idx = ((sorted.len() - 1) as f64 * 0.99) as usize;
+                p99_data.push(sorted[idx]);
+            }
+        }
+
+        // Helper function to calculate min/max/avg
+        let calc_stats = |data: &[u64]| -> (u64, u64, u64) {
+            if data.is_empty() {
+                return (0, 0, 0);
+            }
+            let min = *data.iter().min().unwrap_or(&0);
+            let max = *data.iter().max().unwrap_or(&0);
+            let sum: u64 = data.iter().sum();
+            let avg = sum / data.len() as u64;
+            (min, max, avg)
+        };
+
+        // Calculate stats for each dataset
+        let (runtime_min, runtime_max, runtime_avg) = calc_stats(&runtime_data);
+        let (calls_min, calls_max, calls_avg) = calc_stats(&calls_per_sec_data);
+        let (p99_min, p99_max, p99_avg) = calc_stats(&p99_data);
+
+        // Runtime sparkline with min/max/avg labels
+        let runtime_sparkline = Sparkline::default()
+            .block(
+                Block::bordered()
+                    .title(format!(
+                        "Runtime (ns/call) Min:{} Avg:{} Max:{}",
+                        runtime_min, runtime_avg, runtime_max
+                    ))
+                    .border_style(theme.border_style()),
+            )
+            .data(&runtime_data)
+            .max(runtime_max.max(1))
+            .bar_set(NINE_LEVELS)
+            .style(Style::default().fg(theme.text_important_color()));
+
+        // Calls per second sparkline with min/max/avg labels
+        let calls_sparkline = Sparkline::default()
+            .block(
+                Block::bordered()
+                    .title(format!(
+                        "Calls/sec Min:{} Avg:{} Max:{}",
+                        calls_min, calls_avg, calls_max
+                    ))
+                    .border_style(theme.border_style()),
+            )
+            .data(&calls_per_sec_data)
+            .max(calls_max.max(1))
+            .bar_set(NINE_LEVELS)
+            .style(Style::default().fg(theme.positive_value_color()));
+
+        // P99 sparkline with min/max/avg labels
+        let p99_sparkline = Sparkline::default()
+            .block(
+                Block::bordered()
+                    .title(format!(
+                        "P99 Runtime Min:{} Avg:{} Max:{}",
+                        p99_min, p99_avg, p99_max
+                    ))
+                    .border_style(theme.border_style()),
+            )
+            .data(&p99_data)
+            .max(p99_max.max(1))
+            .bar_set(NINE_LEVELS)
+            .style(Style::default().fg(theme.userspace_symbol_color()));
+
+        frame.render_widget(runtime_sparkline, chunks[0]);
+        frame.render_widget(calls_sparkline, chunks[1]);
+        frame.render_widget(p99_sparkline, chunks[2]);
+
+        Ok(())
+    }
+
+    /// Renders BPF program symbol table (perf top style)
+    fn render_symbol_table(
+        frame: &mut Frame,
+        area: Rect,
+        filtered_symbols: &[SymbolSample],
+        symbol_table_state: &mut TableState,
+        theme: &AppTheme,
+    ) -> Result<()> {
+        // Build table rows from filtered symbols with module name and source location
+        let rows: Vec<Row> = filtered_symbols
+            .iter()
+            .map(|symbol| {
+                let source_location = if let (Some(file), Some(line)) = (
+                    &symbol.symbol_info.file_name,
+                    symbol.symbol_info.line_number,
+                ) {
+                    format!("{}:{}", file, line)
+                } else {
+                    "-".to_string()
+                };
+
+                Row::new(vec![
+                    Cell::from(format!("{:.2}%", symbol.percentage)),
+                    Cell::from(symbol.count.to_string()),
+                    Cell::from(format!("0x{:x}", symbol.symbol_info.address)),
+                    Cell::from(symbol.symbol_info.symbol_name.clone()),
+                    Cell::from(symbol.symbol_info.module_name.clone()),
+                    Cell::from(source_location),
+                ])
+            })
+            .collect();
+
+        // Create header
+        let header = Row::new(vec![
+            Cell::from("Overhead"),
+            Cell::from("Samples"),
+            Cell::from("Address"),
+            Cell::from("Symbol"),
+            Cell::from("Module"),
+            Cell::from("Source"),
+        ])
+        .style(theme.title_style())
+        .height(1);
+
+        // Define column constraints
+        let constraints = vec![
+            Constraint::Length(10), // Overhead
+            Constraint::Length(10), // Samples
+            Constraint::Length(16), // Address
+            Constraint::Fill(1),    // Symbol (with line number included in name)
+            Constraint::Length(10), // Module
+            Constraint::Length(20), // Source location
+        ];
+
+        // Create table widget
+        let table = Table::new(rows, constraints)
+            .header(header)
+            .block(
+                Block::bordered()
+                    .title(format!(
+                        "BPF Program Symbols ({} symbols) - Line numbers from jited_line_info",
+                        filtered_symbols.len()
+                    ))
+                    .border_style(theme.border_style()),
+            )
+            .style(Style::default().fg(theme.text_color()))
+            .row_highlight_style(Style::default().fg(theme.text_enabled_color()))
+            .highlight_symbol(">> ");
+
+        // Render the table
+        frame.render_stateful_widget(table, area, symbol_table_state);
+        Ok(())
+    }
+}

--- a/tools/scxtop/src/render/mod.rs
+++ b/tools/scxtop/src/render/mod.rs
@@ -12,7 +12,10 @@ pub mod memory;
 pub mod network;
 // Scheduler rendering
 pub mod scheduler;
+// BPF program rendering
+pub mod bpf_programs;
 
+pub use bpf_programs::BpfProgramRenderer;
 pub use memory::MemoryRenderer;
 pub use network::NetworkRenderer;
 pub use process::ProcessRenderer;

--- a/tools/scxtop/tests/render_bpf_programs_tests.rs
+++ b/tools/scxtop/tests/render_bpf_programs_tests.rs
@@ -1,0 +1,196 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+// Basic smoke tests for BPF program rendering
+// More comprehensive tests would require constructing complex BpfProgData structures
+
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+use scxtop::render::bpf_programs::{ProgramDetailParams, ProgramsListParams};
+use scxtop::{render::BpfProgramRenderer, AppTheme, BpfProgStats, Columns};
+use std::collections::VecDeque;
+
+#[test]
+fn test_render_programs_list_empty() {
+    let mut terminal = Terminal::new(TestBackend::new(160, 50)).unwrap();
+    let bpf_program_stats = BpfProgStats::default();
+    let filtered_programs = vec![];
+    let bpf_program_columns = Columns::new(vec![]);
+    let mut table_state = ratatui::widgets::TableState::default();
+    let bpf_overhead_history = VecDeque::new();
+    let theme = AppTheme::Default;
+
+    terminal
+        .draw(|frame| {
+            let params = ProgramsListParams {
+                bpf_program_stats: &bpf_program_stats,
+                filtered_programs: &filtered_programs,
+                bpf_program_columns: &bpf_program_columns,
+                bpf_overhead_history: &bpf_overhead_history,
+                filtering: false,
+                filter_input: "",
+                event_input_buffer: "",
+                theme: &theme,
+                tick_rate_ms: 1000,
+            };
+            let result = BpfProgramRenderer::render_programs_list(frame, &mut table_state, &params);
+
+            assert!(
+                result.is_ok(),
+                "render_programs_list should succeed with empty program list"
+            );
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_programs_list_with_overhead_history() {
+    let mut terminal = Terminal::new(TestBackend::new(160, 50)).unwrap();
+    let bpf_program_stats = BpfProgStats::default();
+    let filtered_programs = vec![];
+    let bpf_program_columns = Columns::new(vec![]);
+    let mut table_state = ratatui::widgets::TableState::default();
+    let mut bpf_overhead_history = VecDeque::new();
+
+    // Add some overhead history
+    for i in 0..60 {
+        bpf_overhead_history.push_back((i as f64) * 0.1);
+    }
+
+    let theme = AppTheme::Default;
+
+    terminal
+        .draw(|frame| {
+            let params = ProgramsListParams {
+                bpf_program_stats: &bpf_program_stats,
+                filtered_programs: &filtered_programs,
+                bpf_program_columns: &bpf_program_columns,
+                bpf_overhead_history: &bpf_overhead_history,
+                filtering: false,
+                filter_input: "",
+                event_input_buffer: "",
+                theme: &theme,
+                tick_rate_ms: 1000,
+            };
+            let result = BpfProgramRenderer::render_programs_list(frame, &mut table_state, &params);
+
+            assert!(
+                result.is_ok(),
+                "render_programs_list should succeed with overhead history"
+            );
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_programs_list_different_themes() {
+    let mut terminal = Terminal::new(TestBackend::new(160, 50)).unwrap();
+    let bpf_program_stats = BpfProgStats::default();
+    let filtered_programs = vec![];
+    let bpf_program_columns = Columns::new(vec![]);
+    let bpf_overhead_history = VecDeque::new();
+
+    for theme in [
+        AppTheme::Default,
+        AppTheme::MidnightGreen,
+        AppTheme::SolarizedDark,
+    ] {
+        let mut table_state = ratatui::widgets::TableState::default();
+
+        terminal
+            .draw(|frame| {
+                let params = ProgramsListParams {
+                    bpf_program_stats: &bpf_program_stats,
+                    filtered_programs: &filtered_programs,
+                    bpf_program_columns: &bpf_program_columns,
+                    bpf_overhead_history: &bpf_overhead_history,
+                    filtering: false,
+                    filter_input: "",
+                    event_input_buffer: "",
+                    theme: &theme,
+                    tick_rate_ms: 1000,
+                };
+                let result =
+                    BpfProgramRenderer::render_programs_list(frame, &mut table_state, &params);
+
+                assert!(
+                    result.is_ok(),
+                    "render_programs_list with {:?} theme should succeed",
+                    theme
+                );
+            })
+            .unwrap();
+    }
+}
+
+#[test]
+fn test_render_program_detail_no_program() {
+    let mut terminal = Terminal::new(TestBackend::new(160, 50)).unwrap();
+    let bpf_program_stats = BpfProgStats::default();
+    let filtered_symbols = vec![];
+    let mut symbol_table_state = ratatui::widgets::TableState::default();
+    let theme = AppTheme::Default;
+
+    terminal
+        .draw(|frame| {
+            let params = ProgramDetailParams {
+                selected_program_data: None, // no program selected
+                bpf_program_stats: &bpf_program_stats,
+                filtered_symbols: &filtered_symbols,
+                bpf_perf_sampling_active: false,
+                active_event_name: "cycles",
+                theme: &theme,
+                tick_rate_ms: 1000,
+            };
+            let result =
+                BpfProgramRenderer::render_program_detail(frame, &mut symbol_table_state, &params);
+
+            assert!(
+                result.is_ok(),
+                "render_program_detail should succeed with no program selected"
+            );
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_program_detail_different_themes() {
+    let mut terminal = Terminal::new(TestBackend::new(160, 50)).unwrap();
+    let bpf_program_stats = BpfProgStats::default();
+    let filtered_symbols = vec![];
+
+    for theme in [
+        AppTheme::Default,
+        AppTheme::MidnightGreen,
+        AppTheme::SolarizedDark,
+    ] {
+        let mut symbol_table_state = ratatui::widgets::TableState::default();
+
+        terminal
+            .draw(|frame| {
+                let params = ProgramDetailParams {
+                    selected_program_data: None,
+                    bpf_program_stats: &bpf_program_stats,
+                    filtered_symbols: &filtered_symbols,
+                    bpf_perf_sampling_active: false,
+                    active_event_name: "cycles",
+                    theme: &theme,
+                    tick_rate_ms: 1000,
+                };
+                let result = BpfProgramRenderer::render_program_detail(
+                    frame,
+                    &mut symbol_table_state,
+                    &params,
+                );
+
+                assert!(
+                    result.is_ok(),
+                    "render_program_detail with {:?} theme should succeed",
+                    theme
+                );
+            })
+            .unwrap();
+    }
+}

--- a/tools/scxtop/tests/render_scheduler_tests.rs
+++ b/tools/scxtop/tests/render_scheduler_tests.rs
@@ -6,6 +6,7 @@
 use num_format::SystemLocale;
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
+use scxtop::render::scheduler::{SchedulerStatsParams, SchedulerViewParams};
 use scxtop::{render::SchedulerRenderer, AppTheme, EventData, ViewState};
 use std::collections::BTreeMap;
 
@@ -44,20 +45,23 @@ fn test_render_scheduler_view_sparkline() {
     terminal
         .draw(|frame| {
             let area = frame.area();
+            let params = SchedulerViewParams {
+                event: "dsq_lat_us",
+                scheduler_name: "scx_rustland",
+                dsq_data: &dsq_data,
+                sample_rate: 1000,
+                localize: false,
+                locale: &locale,
+                theme: &theme,
+                render_title: true,
+                render_sample_rate: true,
+            };
             let result = SchedulerRenderer::render_scheduler_view(
                 frame,
-                "dsq_lat_us",
                 area,
                 &ViewState::Sparkline,
-                "scx_rustland",
-                &dsq_data,
-                1000, // sample_rate
-                60,   // max_sched_events
-                false,
-                &locale,
-                &theme,
-                true,
-                true,
+                60,
+                &params,
             );
 
             assert!(
@@ -78,20 +82,23 @@ fn test_render_scheduler_view_barchart() {
     terminal
         .draw(|frame| {
             let area = frame.area();
+            let params = SchedulerViewParams {
+                event: "dsq_lat_us",
+                scheduler_name: "scx_rustland",
+                dsq_data: &dsq_data,
+                sample_rate: 1000,
+                localize: false,
+                locale: &locale,
+                theme: &theme,
+                render_title: true,
+                render_sample_rate: true,
+            };
             let result = SchedulerRenderer::render_scheduler_view(
                 frame,
-                "dsq_lat_us",
                 area,
                 &ViewState::BarChart,
-                "scx_rustland",
-                &dsq_data,
-                1000,
                 60,
-                false,
-                &locale,
-                &theme,
-                true,
-                true,
+                &params,
             );
 
             assert!(
@@ -112,20 +119,23 @@ fn test_render_scheduler_view_no_scheduler() {
     terminal
         .draw(|frame| {
             let area = frame.area();
+            let params = SchedulerViewParams {
+                event: "dsq_lat_us",
+                scheduler_name: "", // Empty scheduler name
+                dsq_data: &dsq_data,
+                sample_rate: 1000,
+                localize: false,
+                locale: &locale,
+                theme: &theme,
+                render_title: true,
+                render_sample_rate: true,
+            };
             let result = SchedulerRenderer::render_scheduler_view(
                 frame,
-                "dsq_lat_us",
                 area,
                 &ViewState::Sparkline,
-                "", // Empty scheduler name
-                &dsq_data,
-                1000,
                 60,
-                false,
-                &locale,
-                &theme,
-                true,
-                true,
+                &params,
             );
 
             assert!(
@@ -146,20 +156,23 @@ fn test_render_scheduler_view_no_dsqs() {
     terminal
         .draw(|frame| {
             let area = frame.area();
+            let params = SchedulerViewParams {
+                event: "dsq_lat_us",
+                scheduler_name: "scx_rustland",
+                dsq_data: &dsq_data,
+                sample_rate: 1000,
+                localize: false,
+                locale: &locale,
+                theme: &theme,
+                render_title: true,
+                render_sample_rate: true,
+            };
             let result = SchedulerRenderer::render_scheduler_view(
                 frame,
-                "dsq_lat_us",
                 area,
                 &ViewState::Sparkline,
-                "scx_rustland",
-                &dsq_data,
-                1000,
                 60,
-                false,
-                &locale,
-                &theme,
-                true,
-                true,
+                &params,
             );
 
             assert!(
@@ -180,20 +193,23 @@ fn test_render_scheduler_view_with_localization() {
     terminal
         .draw(|frame| {
             let area = frame.area();
+            let params = SchedulerViewParams {
+                event: "dsq_lat_us",
+                scheduler_name: "scx_rustland",
+                dsq_data: &dsq_data,
+                sample_rate: 1000,
+                localize: true, // localize enabled
+                locale: &locale,
+                theme: &theme,
+                render_title: true,
+                render_sample_rate: true,
+            };
             let result = SchedulerRenderer::render_scheduler_view(
                 frame,
-                "dsq_lat_us",
                 area,
                 &ViewState::BarChart,
-                "scx_rustland",
-                &dsq_data,
-                1000,
                 60,
-                true, // localize enabled
-                &locale,
-                &theme,
-                true,
-                true,
+                &params,
             );
 
             assert!(
@@ -212,16 +228,15 @@ fn test_render_scheduler_stats() {
     terminal
         .draw(|frame| {
             let area = frame.area();
-            let result = SchedulerRenderer::render_scheduler_stats(
-                frame,
-                area,
-                "scx_rustland",
-                "dispatch_count: 12345\nlocal: 98%\nglobal: 2%",
-                1000, // tick_rate_ms
-                100,  // dispatch_keep_last
-                50,   // select_cpu_fallback
-                &theme,
-            );
+            let params = SchedulerStatsParams {
+                scheduler_name: "scx_rustland",
+                sched_stats_raw: "dispatch_count: 12345\nlocal: 98%\nglobal: 2%",
+                tick_rate_ms: 1000,
+                dispatch_keep_last: 100,
+                select_cpu_fallback: 50,
+                theme: &theme,
+            };
+            let result = SchedulerRenderer::render_scheduler_stats(frame, area, &params);
 
             assert!(result.is_ok(), "render_scheduler_stats should succeed");
         })
@@ -240,16 +255,15 @@ fn test_render_scheduler_stats_different_themes() {
         terminal
             .draw(|frame| {
                 let area = frame.area();
-                let result = SchedulerRenderer::render_scheduler_stats(
-                    frame,
-                    area,
-                    "scx_rustland",
-                    "test stats",
-                    1000,
-                    100,
-                    50,
-                    &theme,
-                );
+                let params = SchedulerStatsParams {
+                    scheduler_name: "scx_rustland",
+                    sched_stats_raw: "test stats",
+                    tick_rate_ms: 1000,
+                    dispatch_keep_last: 100,
+                    select_cpu_fallback: 50,
+                    theme: &theme,
+                };
+                let result = SchedulerRenderer::render_scheduler_stats(frame, area, &params);
 
                 assert!(
                     result.is_ok(),
@@ -277,20 +291,23 @@ fn test_render_scheduler_view_different_events() {
         terminal
             .draw(|frame| {
                 let area = frame.area();
+                let params = SchedulerViewParams {
+                    event,
+                    scheduler_name: "scx_rustland",
+                    dsq_data: &dsq_data,
+                    sample_rate: 1000,
+                    localize: false,
+                    locale: &locale,
+                    theme: &theme,
+                    render_title: true,
+                    render_sample_rate: true,
+                };
                 let result = SchedulerRenderer::render_scheduler_view(
                     frame,
-                    event,
                     area,
                     &ViewState::Sparkline,
-                    "scx_rustland",
-                    &dsq_data,
-                    1000,
                     60,
-                    false,
-                    &locale,
-                    &theme,
-                    true,
-                    true,
+                    &params,
                 );
 
                 assert!(


### PR DESCRIPTION
Extract all BPF program rendering logic from app.rs into a dedicated
BpfProgramRenderer module, continuing the refactoring effort to improve
code organization and maintainability.

This phase extracts 10 methods related to BPF program
monitoring, including program list view, detail view, symbol tables,
overhead tracking, and sched_ext operation statistics.

Changes:
- Extract BPF program rendering methods into render::BpfProgramRenderer
- Create stateless static methods with clear public API
- Add comprehensive test suite (5 tests, 100% pass rate)
- Remove old methods from app.rs and delegate to new module
- Export BpfProgData and BpfProgStats for testing
- Fix clippy needless borrow warning

Modified Files:
  tools/scxtop/src/app.rs
    - Remove render_bpf_programs, render_bpf_programs_table methods
    - Remove render_filter_input, render_bpf_overhead_sparkline methods
    - Remove render_operation_breakdown, render_bpf_program_detail methods
    - Remove render_bpf_program_info_with_stats, render_bpf_runtime_stats methods
    - Remove render_bpf_program_sparklines, render_bpf_program_symbol_table methods
    - Add BpfProgramRenderer import and delegation
    - Fix borrowing by calling self.config.theme() directly
    - Fix clippy needless borrow warning (active_event_name)

  tools/scxtop/src/render/mod.rs
    - Add bpf_programs module declaration
    - Export BpfProgramRenderer

  tools/scxtop/src/lib.rs
    - Export BpfProgData and BpfProgStats types for test accessibility

  tools/scxtop/tests/render_bpf_programs_tests.rs
    - 5 smoke tests covering all rendering paths
    - Tests for empty program list, overhead history
    - Theme compatibility tests (Default, MidnightGreen, SolarizedDark)
    - Program detail view tests with and without selection
    - Helper functions for test data creation

Signed-off-by: Daniel Hodges <hodgesd@meta.com>