### PR TITLE
scx_mitosis: Fix tasks getting vtime too far ahead

### DIFF
--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -101,6 +101,12 @@ struct Opts {
     #[clap(long, default_value = "true", action = clap::ArgAction::Set)]
     exiting_task_workaround: bool,
 
+    /// Split vtime updates between running() and stopping() instead of unifying them in stopping().
+    /// Enabling this flag restores the legacy behavior of vtime updates, which we've observed to
+    /// cause "vtime too far ahead" errors.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    split_vtime_updates: bool,
+
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
 }
@@ -197,6 +203,7 @@ impl<'a> Scheduler<'a> {
             .as_mut()
             .unwrap()
             .exiting_task_workaround_enabled = opts.exiting_task_workaround;
+        skel.maps.rodata_data.as_mut().unwrap().split_vtime_updates = opts.split_vtime_updates;
 
         skel.maps.rodata_data.as_mut().unwrap().nr_possible_cpus = *NR_CPUS_POSSIBLE as u32;
         for cpu in topology.all_cpus.keys() {


### PR DESCRIPTION
We've observed "vtime too far ahead" errors with scx_mitosis that occur when task vtimes run far ahead of cell/CPU dsq clocks. In a single call to `mitosis_stopping()`, we've observed tasks accumulating hundreds of seconds of vtime. This happened when a task with a large nice value (minimum weight) ran on a cpu for over 1.5 seconds without a scheduling event.

The error "vtime too far ahead" happens in the `enqueue()` callback. The vtime gap is detected because the task vtime has already been updated in `stopping()`, but the cell/CPU dsq vtimes have not yet been updated in `running()`.

This commit eliminates that vtime gap by unifying the three vtime updates (cell, CPU, and task) to all occur in `stopping()`.

This is done by changing the default behavior to unify vtime updates and adding a --split-vtime-updates flag to restore the legacy behavior.