### PR TITLE
scx_lavd: gate scx_bpf_dsq_nr_queued call in can_direct_dispatch

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -596,8 +596,12 @@ static bool can_direct_dispatch(u64 dsq_id, s32 cpu, bool is_idle)
 	/*
 	 * If the chosen CPU is idle and there is nothing to do
 	 * in the domain, we can safely choose the fast track.
+	 *
+	 * When per_cpu_dsq is false, we only check if the CPU is idle.
+	 * When per_cpu_dsq is true, we also need to check if the per-CPU
+	 * DSQ is empty.
 	 */
-	return is_idle && cpu >= 0 && !scx_bpf_dsq_nr_queued(dsq_id);
+	return is_idle && cpu >= 0 && (!per_cpu_dsq || !scx_bpf_dsq_nr_queued(dsq_id));
 }
 
 void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)


### PR DESCRIPTION
When checking whether a CPU should receive a direct dispatch lavd checks the contents of the per_cpu DSQ to ensure direct dispatching won't starve that queue. However, this check occurs even when that DSQ does not exist.

This is confirmed by adding printing of the `scx_bpf_dsq_nr_queued` result. It's always 4294967294, which is -ENOENT saying the queue does not exist. `!(-ENOENT)` is false, so `can_direct_dispatch` always returns false if `per_cpu_dsq` is false.

Modify the check to confirm whether `per_cpu_dsq` is enabled before checking the size of the queue.

Test plan:
- CI
- `bpf_printk` - before only the `else` branch was hit, now I get a mixture.