### PR TITLE
scx_bpfland: Classify sticky tasks based on their average runtime

### DIFF
--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -359,19 +359,6 @@ impl<'a> Scheduler<'a> {
         // (it's never a good idea to throttle per-CPU kthreads).
         rodata.local_kthreads = opts.local_kthreads || opts.throttle_us > 0;
 
-        // Enable conditional kprobes to classify sticky tasks.
-        if opts.sticky_tasks {
-            if let Err(err) =
-                compat::cond_kprobe_enable("do_nanosleep", &skel.progs.kprobe_do_nanosleep)
-            {
-                warn!("failed to enable kprobe/do_nanosleep{}", err);
-            }
-            if let Err(err) = compat::cond_kprobe_enable("ksys_read", &skel.progs.kprobe_ksys_read)
-            {
-                warn!("failed to enable kprobe/ksys_read{}", err);
-            }
-        }
-
         // Set scheduler flags.
         skel.struct_ops.bpfland_ops_mut().flags = *compat::SCX_OPS_ENQ_EXITING
             | *compat::SCX_OPS_ENQ_LAST


### PR DESCRIPTION
Tasks that generate a massive volume of scheduling events (such as `stress-ng --sleep 0`) can create excessive locking pressure on the per-node and per-CPU DSQs, potentially rendering the system unresponsive.

To mitigate this issue, the "sticky tasks" classification feature (option --sticky-tasks / -S) was introduced: when a task is classified as "scheduling intensive" it is dispatched for @slice_lag ns to the same CPU (SCX_DSQ_LOCAL). This allows reducing the locking contention on the per-CPU and per-node DSQs and it also prioritizes frequent sleepers that typically release the CPU quickly.

However, the classification logic relies on intercepting specific syscalls, such as sys_read() and sys_nanosleep(), which proved to be a fragile approach and insufficiently generic.

The new implementation takes a more robust approach by tracking the average runtime of each task: tasks with an average runtime below a defined threshold (10 us) are classified as "scheduling intensive" and dispatched directly to the local DSQ (SCX_DSQ_LOCAL).

This runtime-based classification is considerably more generic and enables more robust handling of diverse workloads.