### PR TITLE
scx: Introduce scx_bpf_dsq_peek()

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -75,6 +75,7 @@ u32 scx_bpf_reenqueue_local(void) __ksym;
 void scx_bpf_kick_cpu(s32 cpu, u64 flags) __ksym;
 s32 scx_bpf_dsq_nr_queued(u64 dsq_id) __ksym;
 void scx_bpf_destroy_dsq(u64 dsq_id) __ksym;
+struct task_struct *scx_bpf_dsq_peek(u64 dsq_id) __ksym __weak;
 int bpf_iter_scx_dsq_new(struct bpf_iter_scx_dsq *it, u64 dsq_id, u64 flags) __ksym __weak;
 struct task_struct *bpf_iter_scx_dsq_next(struct bpf_iter_scx_dsq *it) __ksym __weak;
 void bpf_iter_scx_dsq_destroy(struct bpf_iter_scx_dsq *it) __ksym __weak;

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -911,29 +911,6 @@ static bool keep_running(const struct task_struct *p, s32 cpu)
 }
 
 /*
- * NOTE: drop this when a proper scx_bpf_dsq_peek() helper is added.
- */
-struct task_struct *scx_bpf_dsq_peek(u64 dsq_id) __ksym __weak;
-
-/*
- * NOTE: drop this when a proper scx_bpf_dsq_peek() helper is added.
- */
-static inline struct task_struct *dsq_first_task(u64 dsq_id)
-{
-	struct task_struct *p = NULL;
-	struct bpf_iter_scx_dsq it;
-
-	if (bpf_ksym_exists(scx_bpf_dsq_peek))
-		return scx_bpf_dsq_peek(dsq_id);
-
-	if (!bpf_iter_scx_dsq_new(&it, dsq_id, 0))
-		p = bpf_iter_scx_dsq_next(&it);
-	bpf_iter_scx_dsq_destroy(&it);
-
-	return p;
-}
-
-/*
  * Consume and dispatch the first task from @dsq_id. If the first task can't be
  * dispatched on the corresponding DSQ, redirect the task to a proper CPU.
  */
@@ -947,8 +924,8 @@ static bool consume_first_task(u64 dsq_id, struct task_struct *p)
 
 void BPF_STRUCT_OPS(bpfland_dispatch, s32 cpu, struct task_struct *prev)
 {
-	struct task_struct *p = dsq_first_task(cpu_dsq(cpu));
-	struct task_struct *q = dsq_first_task(node_dsq(cpu));
+	struct task_struct *p = __COMPAT_scx_bpf_dsq_peek(cpu_dsq(cpu));
+	struct task_struct *q = __COMPAT_scx_bpf_dsq_peek(node_dsq(cpu));
 
 	/*
 	 * Let the CPU go idle if the system is throttled.


### PR DESCRIPTION
Since we have the lockless peek API in the development kernel branch, add it also to the common/compat headers, so that scx schedulers can start using it in a consistent way.