### PR TITLE
scx_lavd: Reduce the BPF program size.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -556,7 +556,7 @@ bool is_sync_waker_idle(struct pick_ctx * ctx, s64 *cpdom_id)
 }
 
 static
-s32 pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle)
+s32 __attribute__ ((noinline)) pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle)
 {
 	const struct cpumask *idle_cpumask = NULL, *idle_smtmask = NULL;
 	struct cpdom_ctx *cpdc, *mig_cpdc;
@@ -758,13 +758,14 @@ s32 pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle)
 
 	nuance = bpf_get_prandom_u32();
 	mig_cpdom = sticky_cpdom;
-	for (i = 0; i < LAVD_CPDOM_MAX_DIST && cpdc; i++) {
+	bpf_for(i, 0, LAVD_CPDOM_MAX_DIST) {
 		nr_nbr = min(cpdc->nr_neighbors[i], LAVD_CPDOM_MAX_NR);
 		if (nr_nbr == 0)
 			break;
-		for (j = 0; j < LAVD_CPDOM_MAX_NR; j++, nuance = mig_cpdom + 1) {
+		bpf_for(j, 0, LAVD_CPDOM_MAX_NR) {
 			if (j >= nr_nbr)
 				break;
+			nuance = mig_cpdom + 1;
 			mig_cpdom  = pick_any_bit(cpdc->neighbor_bits[i], nuance);
 			if (mig_cpdom < 0)
 				continue;

--- a/scheds/rust/scx_lavd/src/bpf/lat_cri.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lat_cri.bpf.c
@@ -92,6 +92,11 @@ static u64 calc_sum_runtime_factor(struct task_struct *p, struct task_ctx *taskc
 	return (sum >> LAVD_SHIFT) * p->scx.weight;
 }
 
+u32 __attribute__ ((noinline)) log2x(u64 v)
+{
+	return log2_u64(v);
+}
+
 static void calc_lat_cri(struct task_struct *p, struct task_ctx *taskc)
 {
 	u64 weight_ft, wait_ft, wake_ft, runtime_ft, sum_runtime_ft;
@@ -118,8 +123,8 @@ static void calc_lat_cri(struct task_struct *p, struct task_ctx *taskc)
 	 * task is in the middle of a task chain. The ratio tends to follow an
 	 * exponentially skewed distribution, so we linearize it using sqrt.
 	 */
-	log_wwf = log2_u64(wait_ft * wake_ft);
-	lat_cri = log_wwf + log2_u64(runtime_ft * weight_ft);
+	log_wwf = log2x(wait_ft * wake_ft);
+	lat_cri = log_wwf + log2x(runtime_ft * weight_ft);
 
 	/*
 	 * Amplify the task's latency criticality to better differentiate
@@ -161,7 +166,7 @@ static void calc_lat_cri(struct task_struct *p, struct task_ctx *taskc)
 	 */
 	if (have_little_core) {
 		sum_runtime_ft = calc_sum_runtime_factor(p, taskc);
-		perf_cri = log_wwf + log2_u64(sum_runtime_ft);
+		perf_cri = log_wwf + log2x(sum_runtime_ft);
 	}
 	taskc->perf_cri = perf_cri;
 }

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -229,6 +229,7 @@ s64 __attribute__ ((noinline)) pick_any_bit(u64 bitmap, u64 nuance)
 {
 	u64 i, pos;
 
+	#pragma clang loop unroll(disable)
 	bpf_for(i, 0, 64) {
 		pos = (i + nuance) % 64;
 		if (bitmap & (1LLU << pos))


### PR DESCRIPTION
To avoid an --E2BIG error, tweak the code to reduce the BPF program size.