### PR TITLE
scxtop: Add softirq analyzer with selective BPF program attachment

### DIFF
--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -848,7 +848,7 @@ int BPF_PROG(on_softirq_exit, unsigned int nr)
 	struct bpf_event       *event;
 	struct __softirq_event *softirq_event;
 
-	if (!enable_bpf_events || !should_sample())
+	if (!enable_bpf_events)
 		return 0;
 
 	u64 exit_ts   = bpf_ktime_get_ns();

--- a/tools/scxtop/src/mcp/mod.rs
+++ b/tools/scxtop/src/mcp/mod.rs
@@ -36,7 +36,8 @@ pub use event_control::{
 };
 pub use event_filter::EventFilter;
 pub use extended_analyzers::{
-    DsqMonitor, DsqMonitorStats, EventRateMonitor, ProcessEventHistory, RateAnomaly,
+    CpuSoftirqStats, DsqMonitor, DsqMonitorStats, EventRateMonitor, ProcessEventHistory,
+    ProcessSoftirqStats, RateAnomaly, SoftirqAnalyzer, SoftirqStats, SoftirqSummary,
     SystemSnapshot, WakeupChainTracker,
 };
 pub use perf_profiling::{


### PR DESCRIPTION
Add a comprehensive softirq (software interrupt) analyzer to the scxtop MCP server for tracking and analyzing software interrupt processing performance. This enables users to identify softirq bottlenecks, high- latency handlers, and CPU hotspots related to interrupt processing.

Key features of the softirq analyzer:
- Track all 10 softirq types (HI, TIMER, NET_TX, NET_RX, BLOCK, etc.)
- Measure processing duration and system impact per softirq type
- Provide per-CPU breakdown and per-process analysis
- Support multiple analysis modes: summary, by_type, by_cpu, by_process
- Time-windowed statistics with configurable window size

Architecture improvements:
- Refactor BPF program attachment to support selective loading
- Introduce attach_progs_selective() to attach only required programs
- Each analyzer now declares its BPF program dependencies
- Automatically attach/detach programs based on active analyzers
- Reduce system overhead by only loading necessary tracepoints

Implementation details:
- Add get_required_bpf_programs() to map analyzers to BPF programs
- Extend EventControl to accept program filter lists
- Remove sampling from softirq_exit to ensure complete data collection
- Integrate softirq analyzer into unified analyzer control system
- Add softirq event processing to main event handler loop