### PR TITLE
lib/topology: Add two utility functions: topo_cpu_to_llc_id() and TOPO_NR(type).

### DIFF
--- a/lib/topology.bpf.c
+++ b/lib/topology.bpf.c
@@ -16,6 +16,8 @@ volatile topo_ptr topo_all;
  */
 u64 topo_nodes[TOPO_MAX_LEVEL][NR_CPUS];
 
+int nr_topo_nodes[TOPO_MAX_LEVEL];
+
 __hidden
 int topo_contains(topo_ptr topo, u32 cpu)
 {
@@ -131,6 +133,7 @@ int topo_init(scx_bitmap_t __arg_arena mask, u64 data_size, u64 id)
 		 */
 		if (j == topo->nr_children) {
 			topo_add(topo, mask, id);
+			nr_topo_nodes[i]++;
 			return 0;
 		}
 

--- a/scheds/include/lib/topology.h
+++ b/scheds/include/lib/topology.h
@@ -81,3 +81,6 @@ static inline int topo_iter_start(struct topo_iter *iter)
 #define TOPO_FOR_EACH_CPU(_iter, _topo) TOPO_FOR_EACH_LEVEL((_iter), (_topo), TOPO_CPU)
 
 extern u64 topo_nodes[TOPO_MAX_LEVEL][NR_CPUS];
+extern int nr_topo_nodes[TOPO_MAX_LEVEL];
+
+#define TOPO_NR(type) nr_topo_nodes[TOPO_##type - 1]


### PR DESCRIPTION
The topology library already has complete information about the system's topology. Let's expose two of them by adding utility functions: topo_cpu_to_llc_id() that returns which LLC a CPU belongs to, and TOPO_NR(type) that returns the number of NODE/LLC/CORE/CPUs. 