### PR TITLE
lib/atq: Don't print an error message when -ENOENT at scx_atq_pop().

### DIFF
--- a/lib/atq.bpf.c
+++ b/lib/atq.bpf.c
@@ -143,7 +143,8 @@ u64 scx_atq_pop(scx_atq_t *atq)
 	arena_spin_unlock(&atq->lock);
 
 	if (ret) {
-		bpf_printk("%s: error %d", __func__, ret);
+		if (ret != -ENOENT)
+			bpf_printk("%s: error %d", __func__, ret);
 		return (u64)NULL;
 	}
 


### PR DESCRIPTION
When there is no entry in an ATQ, its rbtree returns -ENOENT so the ATQ prints out an error message. However, it is an expected behavior, so the error message is only confusing. Let's not print the error message when there is no entry.