### PR TITLE
arenas: Make sure arena is visible to the verifier for sdt_alloc

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -148,6 +148,8 @@ int scx_alloc_attempt(struct scx_alloc_stack __arena *stack)
 {
 	int i;
 
+	scx_arena_subprog_init();
+
 	/*
 	 * Use can_loop to help with verification. The can_loop macro was
 	 * introduced in kernel commit ba39486 and wraps around the may_goto


### PR DESCRIPTION
When trying to alloc on the arena make it is initialized from the verifiers perspective.

@arighi I think this might fix the verifier errors you saw on the ubuntu kernels.