### PR TITLE
scx_lavd: Reintroduce using Per-Cpu DSQs for pinned tasks

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -9,7 +9,7 @@
 /*
  * common macros
  */
-#define U64_MAX		((u64)~0U)
+#define U64_MAX		((u64)~0ULL)
 #define S64_MAX		((s64)(U64_MAX >> 1))
 #define U32_MAX		((u32)~0U)
 #define S32_MAX		((s32)(U32_MAX >> 1))


### PR DESCRIPTION
Use Per-Cpu DSQs when pinned_slice_ns is enabled, this also fixes a bug where U64_MAX was not defined correctly causing out of order dispatches when comparing DSQs to select tasks to run.

In workloads using erlang that relies on running "real-time" tasks on Per-CPU erlang scheduling threads, scheduling latencies that exceed 5ms results in poor service behavior at higher loads. Further increase the overall responsiveness of the system by keeping the pinned task counter until the pinned task becomes quiescent and aggressively kick out unpinned tasks during tick to avoid high p99 scheduling latencies for pinned tasks.