### PR TITLE
scx_mitosis: Fix runnable task stall

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -1164,7 +1164,12 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)))
 		return;
 
-	cidx = tctx->cell;
+	/*
+	 * Use CPU's cell (not task's cell) to match dispatch() logic.
+	 * Prevents starvation when a task is pinned outside its cell.
+	 * E.g. a cell 0 kworker pinned to a cell 1 CPU.
+	 */
+	cidx = cctx->cell;
 	if (!(cell = lookup_cell(cidx)))
 		return;
 


### PR DESCRIPTION
This fixes an error I created in PR #2978, which lead to mitosis getting kicked out due to runnable task stalls.

When we update cell dsq vtime in stopping(), we need to update the cell dsq that corresponds to the CPU, not the task.

These are often the same thing, but there are special cases where a task belonging to one cell is pinned to a CPU that belongs to another cell, e.g. a pinned kworker thread.