### PR TITLE
scx_lavd: Optimize CPU mask iteration with __builtin_ctzll

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -263,6 +263,31 @@ extern const volatile u8	verbose;
 u64 calc_avg(u64 old_val, u64 new_val);
 u64 calc_asym_avg(u64 old_val, u64 new_val);
 
+/* Bitmask helpers. */
+static __always_inline int cpumask_next_set_bit(u64 *cpumask)
+{
+	/*
+	 * Check the cpumask is not empty. __builtin_ctzll(x) is only
+	 * well-defined for nonzero x; that's why we check for zero earlier to
+	 * avoid undefined behavior.
+	 */
+	if (!*cpumask)
+		return -ENOENT;
+
+	/* Find the next set bit. */
+	int bit = __builtin_ctzll(*cpumask);
+
+	/*
+	 * This is equivalent to finding and clearing the least significant set
+	 * bit.  The statement works because subtracting one from a nonzero bit
+	 * flips all bits from the lowest set bit (inclusive) to the rightmost
+	 * position; Then, The logic here ANDing it with the original value
+	 * clears the lowest set bit.
+	 */
+	*cpumask &= *cpumask - 1;
+	return bit;
+}
+
 /* System statistics module .*/
 extern struct sys_stat		sys_stat;
 

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -93,7 +93,7 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 	 * Collect statistics for each compute domain.
 	 */
 	bpf_for(cpdom_id, 0, nr_cpdoms) {
-		int i, j;
+		int i, j, k;
 		if (cpdom_id >= LAVD_CPDOM_MAX_NR)
 			break;
 
@@ -104,13 +104,14 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 		if (per_cpu_dsq) {
 			bpf_for(i, 0, LAVD_CPU_ID_MAX/64) {
 				u64 cpumask = cpdomc->__cpumask[i];
-				bpf_for(j, 0, 64) {
-					if (cpumask & 0x1LLU << j) {
-						cpu = (i * 64) + j;
-						if (cpu >= __nr_cpu_ids)
-							break;
-						cpdomc->nr_queued_task += scx_bpf_dsq_nr_queued(cpu_to_dsq(cpu));
-					}
+				bpf_for(k, 0, 64) {
+					j = cpumask_next_set_bit(&cpumask);
+					if (j < 0)
+						break;
+					cpu = (i * 64) + j;
+					if (cpu >= __nr_cpu_ids)
+						break;
+					cpdomc->nr_queued_task += scx_bpf_dsq_nr_queued(cpu_to_dsq(cpu));
 				}
 			}
 		}


### PR DESCRIPTION
scx_lavd: Optimize CPU mask iteration with __builtin_ctzll

Replace bit-by-bit iteration through CPU masks with __builtin_ctzll()
intrinsic across three critical paths: pick_most_loaded_cpu(),
init_per_cpu_ctx(), and collect_sys_stat().

The optimization uses count-trailing-zeros to jump directly to set bits
instead of checking all 64 bits sequentially, particularly beneficial
for sparse CPU masks common in scheduling scenarios.

Measurement:

i). bpf_for(j, 0, 64) measurement

Ther are three loops inside collect_sys_stat:

1. number of domains (3 domains on my system: big, medium, little)
2. 8 cpumask chunks (# cpu mask = LAVD_CPU_ID_MAX/64 = 512/64)
3. bpf_for(j, 0, 64)

The first measurement is around the inner bpf_for by taking timestamps
with bpf_ktime_get_ns() before the bpf_for loop and print the delta
after the loop via, for example:
```c
+       if (cnt < 10000ULL)
+               before = bpf_ktime_get_ns();
+       bpf_for(k, 0, 64) {
+               if (!cpumask)
+                       break;
+               j = __builtin_ctzll(cpumask);
+               cpu = (i * 64) + j;
+               cpumask &= cpumask - 1;
+               if (cpu >= __nr_cpu_ids)
+                       break;
+               cpdomc->nr_queued_task += scx_bpf_dsq_nr_queued(cpu_to_dsq(cpu));
+       }
+       if (cnt++ < 10000ULL)
+               bpf_printk("collect_sys_stat_lat: %llu", time_delta(bpf_ktime_get_ns(), before));
```
Then, the following table is generated by the two 10k data samples
captured before and after the optimization:

Performance improvement (10k samples) [1]:
|               | Before   | After    | Change (%)  |
|---------------|----------|----------|-------------|
| Mean (ns)     | 375.59   | 80.72    | -78.51%     |
| Median (ns)   | 333.00   | 38.00    | -88.59%     |
| Min (ns)      | 74       | 11       | -85.14%     |
| Max (ns)      | 10837    | 8130     | -24.98%     |
| Std Dev       | 316.12   | 192.71   | -39.04%     |
| P25 (ns)      | 232.00   | 16.00    | -93.10%     |
| P75 (ns)      | 386.00   | 53.00    | -86.27%     |
| P95 (ns)      | 989.15   | 382.10   | -61.37%     |
| P99 (ns)      | 1610.00  | 885.00   | -45.03%     |

ii). Timer callback function comparison

To analyze the broader impact of the optimization, measurements were
taken at a larger scope around update_sys_stat(), which is the main
function called by the timer every 10ms. This provides insight into the
overall performance improvement at the system level. It provides an
observation which is not just the CPU mask calculation but the entire
statistics update operation.
```c
@@ -474,8 +472,13 @@ int update_sys_stat(void)
  static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
  {
        int err;
+       static u64 cnt = 0, before;

+       if (cnt < 10000ULL)
+               before = bpf_ktime_get_ns();
        update_sys_stat();
+       if (cnt++ < 10000ULL)
+               bpf_printk("update_timer_cb: %llu ns\n", time_delta(bpf_ktime_get_ns(), before));

        err = bpf_timer_start(timer, LAVD_SYS_STAT_INTERVAL_NS, 0);
        if (err)
```
Timer callback update_sys_stat performance improvement (10k samples) [2]:
|              | Before    | After     | Change (%) |
|--------------|-----------|-----------|------------|
| Mean (ns)    | 37500.51  | 27289.40  | -27.23%    |
| Median (ns)  | 35542.00  | 25326.50  | -28.74%    |
| Min (ns)     | 7850      | 6989      | -10.97%    |
| Max (ns)     | 488695    | 115608    | -76.34%    |
| Std Dev (ns) | 12070.89  | 10964.63  |  -9.16%    |
| P25 (ns)     | 29740.00  | 19486.75  | -34.48%    |
| P75 (ns)     | 42976.00  | 32791.75  | -23.70%    |
| P95 (ns)     | 58490.05  | 48083.40  | -17.79%    |
| P99 (ns)     | 72651.25  | 61630.88  | -15.17%    |

Algorithm time complexity improvement:
Before: O(64) - iterate all bits with (cpumask & 0x1LLU << j)
After:  O(set_bits) - use __builtin_ctzll() + (cpumask &= cpumask - 1)

The intrinsic typically compiles to a single CPU instruction (BSF/TZCNT
on x86, CLZ on ARM), providing substantial latency reduction.

Link: https://gavinguo.cc/scx/ctz_performance_report.html [1]
Link: https://gavinguo.cc/scx/ctz_performance_timer_report.html [2]