### PR TITLE
scx_central: fix sched_setaffinity() call with the set size.

### DIFF
--- a/scheds/c/scx_central.c
+++ b/scheds/c/scx_central.c
@@ -52,6 +52,7 @@ int main(int argc, char **argv)
 	__u64 seq = 0, ecode;
 	__s32 opt;
 	cpu_set_t *cpuset;
+	size_t cpuset_size;
 
 	libbpf_set_print(libbpf_print_fn);
 	signal(SIGINT, sigint_handler);
@@ -116,9 +117,10 @@ restart:
 	 */
 	cpuset = CPU_ALLOC(skel->rodata->nr_cpu_ids);
 	SCX_BUG_ON(!cpuset, "Failed to allocate cpuset");
-	CPU_ZERO_S(CPU_ALLOC_SIZE(skel->rodata->nr_cpu_ids), cpuset);
+	cpuset_size = CPU_ALLOC_SIZE(skel->rodata->nr_cpu_ids);
+	CPU_ZERO_S(cpuset_size, cpuset);
 	CPU_SET(skel->rodata->central_cpu, cpuset);
-	SCX_BUG_ON(sched_setaffinity(0, sizeof(*cpuset), cpuset),
+	SCX_BUG_ON(sched_setaffinity(0, cpuset_size, cpuset),
 		   "Failed to affinitize to central CPU %d (max %d)",
 		   skel->rodata->central_cpu, skel->rodata->nr_cpu_ids - 1);
 	CPU_FREE(cpuset);


### PR DESCRIPTION
we allocate space for a dynamic cpu set sized (nr_cpu_ids).

==399573== Syscall param sched_setaffinity(mask) points to unaddressable byte(s)
==399573==    at 0x4ACF85B: sched_setaffinity@@GLIBC_2.3.4 (sched_setaffinity.c:33)
==399573==    by 0x4004780: main (in /home/dcarlier/Contribs/scx/build/scheds/c/scx_central)
==399573==  Address 0x6e96908 is 0 bytes after a block of size 8 alloc'd
==399573==    at 0x490E858: malloc (vg_replace_malloc.c:446)
==399573==    by 0x400461B: main (in /home/dcarlier/Contribs/scx/build/scheds/c/scx_central)