### PR TITLE
scx_prev: fix unitialized stats counter.

### DIFF
--- a/scheds/c/scx_prev.c
+++ b/scheds/c/scx_prev.c
@@ -49,11 +49,10 @@ static void read_stats(struct scx_prev *skel, __u64 *stats)
 	__u32 idx;
 
 	memset(stats, 0, sizeof(stats[0]) * 4);
+	memset(cnts, 0, sizeof(cnts));
 
 	for (idx = 0; idx < 4; idx++) {
 		int ret, cpu;
-		for (cpu = 0; cpu < nr_cpus; cpu++)
-			cnts[idx][cpu] = 0;
 
 		ret = bpf_map_lookup_elem(bpf_map__fd(skel->maps.stats),
 					  &idx, cnts[idx]);


### PR DESCRIPTION
down the line, the general stats display these.

==5554== Conditional jump or move depends on uninitialised value(s)
==5554==    at 0x4A1C00A: __printf_buffer (vfprintf-process-arg.c:186)
==5554==    by 0x4A1D787: __vfprintf_internal (vfprintf-internal.c:1543)
==5554==    by 0x4A111F2: printf (printf.c:33)
==5554==    by 0x4004447: main (in /home/dcarlier/Contribs/scx/build/scheds/c/scx_prev)
==5554==  Uninitialised value was created by a stack allocation
==5554==    at 0x40036E4: read_stats (in /home/dcarlier/Contribs/scx/build/scheds/c/scx_prev)