### PR TITLE
ci: bump vng memory for cargo-nextest to 16GB

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -332,7 +332,7 @@ async def run_tests():
             sys.argv[0],
             "test-in-vm",
         ],
-        memory=10 * 1024 * 1024 * 1024,
+        memory=16 * 1024 * 1024 * 1024,
         cpus=cpu_count,
         no_capture=True,
     )


### PR DESCRIPTION
vng mounts a /tmp as a fresh tmpfs. This defaults to half of available RAM. The `cargo nextest` job unpacks a bunch of binaries/test executables into /tmp, and this is now running out of space reliably.

Increase the RAM of the CI test machine to 12GB. Ideally we would also be able to bump the tmpfs to 100% of RAM instead of the default 50, but I can't find an option for this.

This appears to have been caused by the recent scxtop refactoring generating several massive test binaries in this tarball. Fix by adding more memory for now then we can debug that later - the machine this runs on has 256GB and something like 6 runners.

Test plan:
- CI