### PR TITLE
scx_p2dq: Refactor dispatch to use peek API and handle affinity changes

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -28,9 +28,10 @@ struct p2dq_timer {
 };
 
 /* cpu_ctx flag bits */
-#define CPU_CTX_F_INTERACTIVE	(1 << 0)
-#define CPU_CTX_F_IS_BIG	(1 << 1)
-#define CPU_CTX_F_NICE_TASK	(1 << 2)
+#define CPU_CTX_F_INTERACTIVE		(1 << 0)
+#define CPU_CTX_F_IS_BIG		(1 << 1)
+#define CPU_CTX_F_NICE_TASK		(1 << 2)
+#define CPU_CTX_F_CLEAN_AFFN_DSQ	(1 << 3)
 
 /* Helper macros for cpu_ctx flags */
 #define cpu_ctx_set_flag(cpuc, flag)	((cpuc)->flags |= (flag))


### PR DESCRIPTION
Replace bpf_for_each loops with __COMPAT_scx_bpf_dsq_peek() for more efficient vtime comparisons during dispatch. This reduces overhead by using direct peek operations instead of iterator setup and teardown.

Key changes:

1. Affinity-aware affn_dsq handling:
   - Peek affn_dsq first and validate task affinity before dispatch
   - Handle sched_setaffinity() changes by moving misplaced tasks to the correct CPU's affn_dsq using __COMPAT_scx_bpf_dsq_move_vtime()
   - Include affn_dsq in vtime-based selection for fairness
   - Implement intelligent CPU selection for affn_dsq enqueue:
     * Priority order: prev_cpu if in affinity, CPU in last LLC if matching affinity, or random CPU from affinity mask
   - Add slice penalization for single-CPU tasks based on queue depth to prevent monopolization when many tasks pinned to one CPU
   - Tighten DSQ movement thresholds for affinitized tasks (95%/25% vs 90%/50%) to prevent monopolization

2. DSQ peek optimization:
   - Use __COMPAT_scx_bpf_dsq_peek() instead of bpf_for_each() loops for all dispatch queue types
   - LLC DSQ: peek without affinity checking (tasks can run anywhere in the LLC)
   - Migration DSQ: peek with affinity filtering (cross-LLC tasks only)
   - Affn DSQ: peek with strict affinity validation and cleanup

3. Remove redundant affn_dsq fallback:
   - Eliminate duplicate affn_dsq dispatch attempt after vtime selection
   - affn_dsq now participates in vtime ordering from the start
   - No longer direct dispatch affinitized tasks found idle in select_cpu to prevent tight wakeup loops

4. Affinity change handling:
   - Track affinity transitions in set_cpumask callback
   - Move tasks from migration DSQ to LLC DSQ when affinity narrows
   - Prevents cross-LLC livelock for tasks with restricted affinity
   - Cleanup misplaced tasks in affn_dsq during dispatch

5. Migration DSQ restrictions:
   - Only allow tasks with full CPU affinity into migration DSQs
   - Affinitized tasks stay in LLC DSQ to prevent cross-LLC livelock
   - Ensures migration logic respects affinity constraints

6. Direct dispatch changes:
   - Remove automatic direct dispatch for affinitized tasks in select_cpu
   - All affinitized tasks now queued to affn_dsq regardless of idle state
   - Only direct dispatch non-affinitized tasks to SCX_DSQ_LOCAL
   - Add affinity check before direct dispatch in enqueue path
   - Change direct dispatch from SCX_DSQ_LOCAL_ON to SCX_DSQ_LOCAL

7. Per-CPU kthread handling:
   - Simplify per-CPU kthread direct dispatch to use min_dsq_time_slice()
   - Remove unnecessary weight scaling for kthreads with single CPU affinity

8. Timeout adjustment:
   - Increase scheduler timeout from 20s to 25s to accommodate additional affn_dsq cleanup work

The refactored dispatch method maintains vtime-based fairness while correctly handling dynamic affinity changes, preventing livelock scenarios, and improving performance through efficient peek operations.