### PR TITLE
scxtop: Do not use is_multiple_of() to avoid an E0658 error.

### DIFF
--- a/tools/scxtop/src/mcp/perf_profiling.rs
+++ b/tools/scxtop/src/mcp/perf_profiling.rs
@@ -470,7 +470,8 @@ impl PerfProfiler {
         self.samples.push(sample);
         self.samples_collected += 1;
 
-        if self.samples_collected.is_multiple_of(100) {
+        #[allow(clippy::manual_is_multiple_of)]
+        if self.samples_collected % 100 == 0 {
             log::debug!("Collected {} samples so far", self.samples_collected);
         }
 


### PR DESCRIPTION
`is_multiple_of()` is recently introduced, so it could cause an unstable feature error (E0658) in not-so-up-to-date toolchains. So let's replace `X.is_multiple_of(Y)` to `X % Y == 0` to avoid the compilation error.