### PR TITLE
veristat: hack to increase buffer size

### DIFF
--- a/.nix/patches/veristat-increase-log-buf.patch
+++ b/.nix/patches/veristat-increase-log-buf.patch
@@ -1,0 +1,13 @@
+diff --git a/src/veristat.c b/src/veristat.c
+index d532dd8..d2240c5 100644
+--- a/src/veristat.c
++++ b/src/veristat.c
+@@ -970,7 +970,7 @@ static void free_verif_stats(struct verif_stats *stats, size_t stat_cnt)
+ 	free(stats);
+ }
+ 
+-static char verif_log_buf[64 * 1024];
++static char verif_log_buf[1024  * 1024];
+ 
+ #define MAX_PARSED_LOG_LINES 100
+ 

--- a/.nix/pkgs/veristat.nix
+++ b/.nix/pkgs/veristat.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation {
   pname = "veristat";
   inherit version src;
 
+  patches = [ ../patches/veristat-increase-log-buf.patch ];
+
   buildInputs = [
     elfutils
     zlib


### PR DESCRIPTION
CI is failing on lavd_dispatch because veristat needs a bigger buffer. The buffer size is hardcoded so this is not ideal. Until veristat adds a feature to increase this buffer size, patch the source to have a bigger buffer.

Test plan:

This only partially fixes the CI. Previously we'd get:

```
================================================================================
REPRODUCTION COMMANDS FOR FAILED SYMBOLS
================================================================================
Run these commands to debug specific symbol failures locally:
  $ nix run ".nix#ci" veristat bpf/bpf-next scx_lavd lavd_dispatch
  $ nix run ".nix#ci" veristat sched_ext/for-next scx_lavd lavd_dispatch
  $ nix run ".nix#ci" veristat stable/6_12 scx_lavd lavd_cgroup_set_bandwidth
  $ nix run ".nix#ci" veristat stable/6_12 scx_lavd lavd_dequeue
  $ nix run ".nix#ci" veristat stable/6_12 scx_lavd lavd_dispatch
  $ nix run ".nix#ci" veristat stable/6_12 scx_p2dq p2dq_dequeue
  $ nix run ".nix#ci" veristat stable/linux-rolling-stable scx_lavd lavd_dispatch
```

Now we get:
```
================================================================================
REPRODUCTION COMMANDS FOR FAILED SYMBOLS
================================================================================
Run these commands to debug specific symbol failures locally:

  $ nix run ".nix#ci" veristat stable/6_12 scx_lavd lavd_cgroup_set_bandwidth
  $ nix run ".nix#ci" veristat stable/6_12 scx_lavd lavd_dequeue
  $ nix run ".nix#ci" veristat stable/6_12 scx_p2dq p2dq_dequeue
```

This resolves all the symbols on modern kernels but lavd keeps failing on 6.12, which will need to be addressed separately.