### PR TITLE
lavd/p2dq: disable 6.12 CI testing

### DIFF
--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2021"
 description = "A Latency-criticality Aware Virtual Deadline (LAVD) scheduler based on sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
 license = "GPL-2.0-only"
 
+[package.metadata.scx.ci.kernel]
+blocklist = [
+  "stable/6_12" # https://github.com/sched-ext/scx/issues/3046
+]
+
 [dependencies]
 scx_arena = { path = "../../../rust/scx_arena/scx_arena", version = "0.1.1" }
 anyhow = "1.0.65"

--- a/scheds/rust/scx_p2dq/Cargo.toml
+++ b/scheds/rust/scx_p2dq/Cargo.toml
@@ -9,6 +9,11 @@ license = "GPL-2.0-only"
 [package.metadata.scx]
 ci.use_clippy = true
 
+[package.metadata.scx.ci.kernel]
+blocklist = [
+  "stable/6_12" # https://github.com/sched-ext/scx/issues/3047
+]
+
 [dependencies]
 scx_arena = { path = "../../../rust/scx_arena/scx_arena", version = "0.1.2" }
 anyhow = "1.0.65"


### PR DESCRIPTION
lavd and p2dq are both currently broken on 6.12. Created #3046 and #3047 to track this, but in the meantime we need to disable their CI on 6.12 to get things working again.

Test plan:
- CI - this gets the Nix build-and-test passing, but naturally the Ubuntu runners are failing. Will follow up.