### PR TITLE
scx_lavd: Revise the time slice calculation when pinned_slice_ns is on.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -384,8 +384,7 @@ const volatile u16 *get_cpu_order(void);
 int plan_x_cpdom_migration(void);
 
 /* Preemption management helpers. */
-
-int shrink_boosted_slice_remote(struct cpu_ctx *cpuc, u64 now);
+void shrink_slice_at_tick(struct task_struct *p, struct cpu_ctx *cpuc, u64 now);
 
 /* Futex lock-related helpers. */
 


### PR DESCRIPTION
This PR made three changes:
- When the system is heavily loaded, the system-wide time slice could be smaller than the pinned_slice_ns. In this case, choose the system-wide time slice.
- At `ops.tick()`, the task's time slice was set to 0 when its accumulated time slice is greater than pinned_slice_ns (`taskc->acc_runtime`). However, `taskc->acc_runtime` is the total execution time accumulated once the task becomes runnable. Instead, calculate the real execution from `cpuc->running_clk`.
- Merge the time slice shrink logic into `shrink_boosted_slice_remote()` for readability.

