### PR TITLE
ci: drop vm for cargo test

### DIFF
--- a/tools/scxtop/src/profiling_events/mod.rs
+++ b/tools/scxtop/src/profiling_events/mod.rs
@@ -128,15 +128,6 @@ mod tests {
     }
 
     #[test]
-    fn test_kprobe_event_parsing() {
-        let result = ProfilingEvent::from_str_args("kprobe:vfs_read", None).unwrap();
-
-        let expected = ProfilingEvent::Kprobe(KprobeEvent::new("vfs_read".to_string(), 0));
-
-        assert_eq!(result, expected);
-    }
-
-    #[test]
     fn test_invalid_format_missing_colon() {
         let tracker = dummy_tracker();
         let err = ProfilingEvent::from_str_args("invalid_format", None);


### PR DESCRIPTION
Currently we run the equivalent of `cargo test`, `cargo nextest`, in a VM as root. This was not a good idea as it allows people to write tests that rely on this, and some distros when they package want to run the cargo tests and don't have the ability to run them in a VM. This means we should constrain our `cargo test` to run without root.

Also, this VM is causing problems. This is partially because the CI runner setup is a bit weird at the minute, but given it's also not a good idea let's drop it again and run the tests directly on the host as the unprivileged user. If we want VMs in Cargo tests we need to adjust the test to launch a VM somehow.

Test plan:
- CI