### PR TITLE
scx_lavd: Disable ops.cgroup_set_bandwidth() when no kernel support.

### DIFF
--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -52,6 +52,7 @@ pub use user_exit_info::UEI_DUMP_PTR_MUTEX;
 
 pub mod build_id;
 pub mod compat;
+pub use compat::ksym_exists;
 pub use compat::ROOT_PREFIX;
 
 mod libbpf_logger;


### PR DESCRIPTION
The old kernels (e.g., 6.11 and 6.12) fail to attach the BPF program with the following error:

  > libbpf: struct_ops init_kern lavd_ops: Cannot find member cgroup_set_bandwidth in kernel BTF
  > libbpf: failed to load BPF skeleton 'bpf_bpf': -EOPNOTSUPP

If the kernel does not support ops.cgroup_set_bandwidth(), so scx_group_set_bandwidth() does not exist in the kernel symbols, we set lavd_ops.cgroup_set_bandwidth to NULL before attaching the BPF program.