### PR TITLE
scx_lavd: Move task_ctx to lavd.bpf.h from intf.h

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/intf.h
+++ b/scheds/rust/scx_lavd/src/bpf/intf.h
@@ -21,28 +21,11 @@ typedef signed long s64;
 
 typedef int pid_t;
 
-#define U64_MAX ((u64)~0ULL)
-
 enum {
 	TASK_COMM_LEN = 16,
-	SCX_SLICE_INF = U64_MAX,
 };
 
-#define __kptr
 #endif
-
-#ifdef __VMLINUX_H__
-#define MAX_NICE	19
-#define MIN_NICE	-20
-#define NICE_WIDTH	(MAX_NICE - MIN_NICE + 1)
-#define MAX_RT_PRIO	100
-
-struct bpf_iter_task;
-extern int bpf_iter_task_new(struct bpf_iter_task *it,
-		struct task_struct *task, unsigned int flags) __weak __ksym;
-extern struct task_struct *bpf_iter_task_next(struct bpf_iter_task *it) __weak __ksym;
-extern void bpf_iter_task_destroy(struct bpf_iter_task *it) __weak __ksym;
-#endif /* __KERNEL__ */
 
 /*
  * common constants
@@ -59,28 +42,6 @@ enum {
 						 {HI: performance-Hungry, performance-Insensitive}
 						 {BT: Big, liTtle}
 						 {EG: Eligible, Greedy} */
-};
-
-/*
- *  DSQ (dispatch queue) IDs are 64bit of the format:
- *  Lower 63 bits are reserved by users
- *
- *   Bits: [63] [62 .. 14] [13 .. 12] [11 .. 0]
- *         [ B] [    R   ] [    T   ] [   ID  ]
- *
- *    B: Sched_ext built-in ID bit, see include/linux/sched/ext.h
- *    R: Reserved
- *    T: Type of LAVD DSQ
- *   ID: DSQ ID
- */
-enum {
-	LAVD_DSQ_TYPE_SHFT		= 12,
-	LAVD_DSQ_TYPE_MASK		= 0x3 << LAVD_DSQ_TYPE_SHFT,
-	LAVD_DSQ_ID_SHFT		= 0,
-	LAVD_DSQ_ID_MASK		= 0xfff << LAVD_DSQ_ID_SHFT,
-	LAVD_DSQ_NR_TYPES		= 2,
-	LAVD_DSQ_TYPE_CPDOM		= 1,
-	LAVD_DSQ_TYPE_CPU		= 0,
 };
 
 /*
@@ -120,93 +81,36 @@ struct sys_stat {
 };
 
 /*
- * Task context
- */
-struct atq_ctx {
-	u64	dummy[8];
-};
-
-struct task_ctx {
-	/*
-	 * Do NOT change the position of atq. It should be at the beginning
-	 * of the task_ctx. 
-	 *
-	 * TODO: The type of atq should be scx_task_common. However, to
-	 * workaround the complex header dependencies, a large enough space
-	 * that can hold scx_task_common is allocated for now. This will be
-	 * fixed later after some more refactoring.
-	 */
-	struct atq_ctx atq;
-
-	/*
-	 * Clocks when a task state transition happens for task statistics calculation
-	 */
-	u64	last_runnable_clk;	/* last time when a task became runnable */
-	u64	last_running_clk;	/* last time when scheduled in */
-	u64	last_measured_clk;	/* last time when running time was measured */
-	u64	last_stopping_clk;	/* last time when scheduled out */
-	u64	last_quiescent_clk;	/* last time when a task became asleep */
-
-	/*
-	 * Task running statistics for latency criticality calculation
-	 */
-	u64	acc_runtime;		/* accmulated runtime from runnable to quiescent state */
-	u64	avg_runtime;		/* average runtime per schedule */
-	u64	run_freq;		/* scheduling frequency in a second */
-	u64	wait_freq;		/* waiting frequency in a second */
-	u64	wake_freq;		/* waking-up frequency in a second */
-	u64	svc_time;		/* total CPU time consumed for this task scaled by task's weight */
-
-	/*
-	 * Task deadline and time slice
-	 */
-	u64	slice;			/* time slice */
-	u32	lat_cri;		/* final context-aware latency criticality */
-	u32	lat_cri_waker;		/* waker's latency criticality */
-	u32	perf_cri;		/* performance criticality of a task */
-
-	/*
-	 * IDs
-	 */
-	u32	prev_cpu_id;		/* where a task ran last time */
-	s32	pinned_cpu_id;		/* pinned CPU id. -ENOENT if not pinned or not runnable. */
-	pid_t	pid;			/* pid for this task */
-	u64	cgrp_id;		/* cgroup id of this task */
-
-	/*
-	 * Task status
-	 */
-	volatile u64	flags;		/* LAVD_FLAG_* */
-	u32	cpdom_id;		/* chosen compute domain id at ops.enqueue() */
-	u32	suggested_cpu_id;	/* suggested CPU ID at ops.enqueue() and ops.select_cpu() */
-
-	/*
-	 * Additional information when the scheduler is monitored,
-	 * so it is updated only when is_monitored is true.
-	 */
-	u64	resched_interval;	/* reschedule interval in ns: [last running, this running] */
-	u32	cpu_id;			/* where a task is running now */
-	u64	last_slice_used;	/* time(ns) used in last scheduled interval: [last running, last stopping] */
-	pid_t	waker_pid;		/* last waker's PID */
-	char	waker_comm[TASK_COMM_LEN + 1]; /* last waker's comm */
-};
-
-/*
- * Task's extra context for report
+ * Task information for report
  */
 struct task_ctx_x {
+	pid_t	pid;			/* pid for this task */
 	char	comm[TASK_COMM_LEN + 1];
 	char	stat[LAVD_STATUS_STR_LEN + 1];
+	u32	cpu_id;			/* where a task is running now */
+	u32	prev_cpu_id;		/* where a task ran last time */
+	u32	suggested_cpu_id;	/* suggested CPU ID at ops.enqueue() and ops.select_cpu() */
+	pid_t	waker_pid;		/* last waker's PID */
+	char	waker_comm[TASK_COMM_LEN + 1]; /* last waker's comm */
+	u64	slice;		/* base time slice */
+	u32	lat_cri;		/* final context-aware latency criticality */
+	u32	avg_lat_cri;	/* average latency criticality */
 	u16	static_prio;	/* nice priority */
+	u64	rerunnable_interval;	/* rerunnable interval in ns: [last quiescent, last runnable] */
+	u64	resched_interval;	/* reschedule interval in ns: [last running, this running] */
+	u64	run_freq;		/* scheduling frequency in a second */
+	u64	avg_runtime;		/* average runtime per schedule */
+	u64	wait_freq;		/* waiting frequency in a second */
+	u64	wake_freq;		/* waking-up frequency in a second */
+	u32	perf_cri;		/* performance criticality of a task */
+	u32	thr_perf_cri;	/* performance criticality threshold */
+	u32	cpuperf_cur;	/* CPU's current performance target */
 	u64	cpu_util;	/* cpu utilization in [0..100] */
 	u64	cpu_sutil;	/* scaled cpu utilization in [0..100] */
-	u64	rerunnable_interval;	/* rerunnable interval in ns: [last quiescent, last runnable] */
-	u32	thr_perf_cri;	/* performance criticality threshold */
-	u32	avg_lat_cri;	/* average latency criticality */
 	u32	nr_active;	/* number of active cores */
-	u32	cpuperf_cur;	/* CPU's current performance target */
 	u64	dsq_id;		/* CPU's associated DSQ */
 	u64	dsq_consume_lat; /* DSQ's consume latency */
+	u64	last_slice_used;	/* time(ns) used in last scheduled interval: [last running, last stopping] */
 };
 
 
@@ -233,7 +137,6 @@ struct msg_hdr {
 
 struct msg_task_ctx {
 	struct msg_hdr		hdr;
-	struct task_ctx		taskc;
 	struct task_ctx_x	taskc_x;
 };
 

--- a/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/introspec.bpf.c
@@ -50,27 +50,38 @@ int submit_task_ctx(struct task_struct *p, task_ctx __arg_arena *taskc, u32 cpu_
 		return -ENOMEM;
 
 	m->hdr.kind = LAVD_MSG_TASKC;
+	m->taskc_x.pid = taskc->pid;
 	__builtin_memcpy_inline(m->taskc_x.comm, p->comm, TASK_COMM_LEN);
-	m->taskc_x.static_prio = get_nice_prio(p);
-	m->taskc_x.cpu_util = s2p(cpuc->avg_util);
-	m->taskc_x.cpu_sutil = s2p(cpuc->avg_sc_util);
-	m->taskc_x.rerunnable_interval = time_delta(taskc->last_quiescent_clk, taskc->last_runnable_clk);
-	m->taskc_x.avg_lat_cri = sys_stat.avg_lat_cri;
-	m->taskc_x.thr_perf_cri = sys_stat.thr_perf_cri;
-	m->taskc_x.nr_active = sys_stat.nr_active;
-	m->taskc_x.cpuperf_cur = cpuc->cpuperf_cur;
-	/* Refactor this when per-cpu DSQs are added */
-	m->taskc_x.dsq_id = cpdomc->id;
-	m->taskc_x.dsq_consume_lat = cpdomc->dsq_consume_lat;
-
 	m->taskc_x.stat[0] = is_lat_cri(taskc) ? 'L' : 'R';
 	m->taskc_x.stat[1] = is_perf_cri(taskc) ? 'H' : 'I';
 	m->taskc_x.stat[2] = cpuc->big_core ? 'B' : 'T';
 	m->taskc_x.stat[3] = test_task_flag(taskc, LAVD_FLAG_IS_GREEDY)? 'G' : 'E';
 	m->taskc_x.stat[4] = '\0';
-
-	for (i = 0; i < sizeof(m->taskc) && can_loop; i++)
-		((char *) &m->taskc)[i] = ((char __arena *) taskc)[i];
+	m->taskc_x.cpu_id = taskc->cpu_id;
+	m->taskc_x.prev_cpu_id = taskc->prev_cpu_id;
+	m->taskc_x.suggested_cpu_id = taskc->suggested_cpu_id;
+	m->taskc_x.waker_pid = taskc->waker_pid;
+	for (i = 0; i < sizeof(m->taskc_x.waker_comm) && can_loop; i++)
+		((char *)m->taskc_x.waker_comm)[i] = ((char __arena *)taskc->waker_comm)[i];
+	m->taskc_x.slice = taskc->slice;
+	m->taskc_x.lat_cri = taskc->lat_cri;
+	m->taskc_x.avg_lat_cri = sys_stat.avg_lat_cri;
+	m->taskc_x.static_prio = get_nice_prio(p);
+	m->taskc_x.rerunnable_interval = time_delta(taskc->last_quiescent_clk, taskc->last_runnable_clk);
+	m->taskc_x.resched_interval = taskc->resched_interval;
+	m->taskc_x.run_freq = taskc->run_freq;
+	m->taskc_x.avg_runtime = taskc->avg_runtime;
+	m->taskc_x.wait_freq = taskc->wait_freq;
+	m->taskc_x.wake_freq = taskc->wake_freq;
+	m->taskc_x.perf_cri = taskc->perf_cri;
+	m->taskc_x.thr_perf_cri = sys_stat.thr_perf_cri;
+	m->taskc_x.cpuperf_cur = cpuc->cpuperf_cur;
+	m->taskc_x.cpu_util = s2p(cpuc->avg_util);
+	m->taskc_x.cpu_sutil = s2p(cpuc->avg_sc_util);
+	m->taskc_x.nr_active = sys_stat.nr_active;
+	m->taskc_x.dsq_id = cpdomc->id;
+	m->taskc_x.dsq_consume_lat = cpdomc->dsq_consume_lat;
+	m->taskc_x.last_slice_used = taskc->last_slice_used;
 
 	bpf_ringbuf_submit(m, 0);
 

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -8,6 +8,8 @@
 
 #include <scx/common.bpf.h>
 #include <scx/bpf_arena_common.bpf.h>
+#include <lib/sdt_task.h>
+#include <lib/atq.h>
 
 /*
  * common macros
@@ -16,6 +18,8 @@
 #define S64_MAX		((s64)(U64_MAX >> 1))
 #define U32_MAX		((u32)~0U)
 #define S32_MAX		((s32)(U32_MAX >> 1))
+
+#define MAX_RT_PRIO	100
 
 #define LAVD_SHIFT			10
 #define LAVD_SCALE			(1L << LAVD_SHIFT)
@@ -26,6 +30,28 @@
 #define dsq_to_cpdom(dsq_id)		((dsq_id) & LAVD_DSQ_ID_MASK)
 #define dsq_to_cpu(dsq_id)		((dsq_id) & LAVD_DSQ_ID_MASK)
 #define dsq_type(dsq_id)		(((dsq_id) & LAVD_DSQ_TYPE_MASK) >> LAVD_DSQ_TYPE_SHFT)
+
+/*
+ *  DSQ (dispatch queue) IDs are 64bit of the format:
+ *  Lower 63 bits are reserved by users
+ *
+ *   Bits: [63] [62 .. 14] [13 .. 12] [11 .. 0]
+ *         [ B] [    R   ] [    T   ] [   ID  ]
+ *
+ *    B: Sched_ext built-in ID bit, see include/linux/sched/ext.h
+ *    R: Reserved
+ *    T: Type of LAVD DSQ
+ *   ID: DSQ ID
+ */
+enum {
+	LAVD_DSQ_TYPE_SHFT		= 12,
+	LAVD_DSQ_TYPE_MASK		= 0x3 << LAVD_DSQ_TYPE_SHFT,
+	LAVD_DSQ_ID_SHFT		= 0,
+	LAVD_DSQ_ID_MASK		= 0xfff << LAVD_DSQ_ID_SHFT,
+	LAVD_DSQ_NR_TYPES		= 2,
+	LAVD_DSQ_TYPE_CPDOM		= 1,
+	LAVD_DSQ_TYPE_CPU		= 0,
+};
 
 /*
  * common constants
@@ -92,6 +118,74 @@ enum consts_flags {
 	LAVD_FLAG_ON_LITTLE		= (0x1 << 7), /* can a task run on a little core? */
 	LAVD_FLAG_SLICE_BOOST		= (0x1 << 8), /* task's time slice is boosted. */
 	LAVD_FLAG_IDLE_CPU_PICKED	= (0x1 << 9), /* an idle CPU is picked at ops.select_cpu() */
+};
+
+/*
+ * Task context
+ */
+struct task_ctx {
+	/*
+	 * Do NOT change the position of atq. It should be at the beginning
+	 * of the task_ctx. 
+	 *
+	 * TODO: The type of atq should be scx_task_common. However, to
+	 * workaround the complex header dependencies, a large enough space
+	 * that can hold scx_task_common is allocated for now. This will be
+	 * fixed later after some more refactoring.
+	 */
+	struct scx_task_common atq;
+
+	/*
+	 * Clocks when a task state transition happens for task statistics calculation
+	 */
+	u64	last_runnable_clk;	/* last time when a task became runnable */
+	u64	last_running_clk;	/* last time when scheduled in */
+	u64	last_measured_clk;	/* last time when running time was measured */
+	u64	last_stopping_clk;	/* last time when scheduled out */
+	u64	last_quiescent_clk;	/* last time when a task became asleep */
+
+	/*
+	 * Task running statistics for latency criticality calculation
+	 */
+	u64	acc_runtime;		/* accmulated runtime from runnable to quiescent state */
+	u64	avg_runtime;		/* average runtime per schedule */
+	u64	run_freq;		/* scheduling frequency in a second */
+	u64	wait_freq;		/* waiting frequency in a second */
+	u64	wake_freq;		/* waking-up frequency in a second */
+	u64	svc_time;		/* total CPU time consumed for this task scaled by task's weight */
+
+	/*
+	 * Task deadline and time slice
+	 */
+	u64	slice;			/* time slice */
+	u32	lat_cri;		/* final context-aware latency criticality */
+	u32	lat_cri_waker;		/* waker's latency criticality */
+	u32	perf_cri;		/* performance criticality of a task */
+
+	/*
+	 * IDs
+	 */
+	u32	prev_cpu_id;		/* where a task ran last time */
+	s32	pinned_cpu_id;		/* pinned CPU id. -ENOENT if not pinned or not runnable. */
+	pid_t	pid;			/* pid for this task */
+	u64	cgrp_id;		/* cgroup id of this task */
+
+	/*
+	 * Task status
+	 */
+	volatile u64	flags;		/* LAVD_FLAG_* */
+	u32	cpdom_id;		/* chosen compute domain id at ops.enqueue() */
+	u32	suggested_cpu_id;	/* suggested CPU ID at ops.enqueue() and ops.select_cpu() */
+
+	/*
+	 * Additional information when the scheduler is monitored,
+	 * so it is updated only when is_monitored is true.
+	 */
+	u64	resched_interval;	/* reschedule interval in ns: [last running, this running] */
+	u32	cpu_id;			/* where a task is running now */
+	u64	last_slice_used;	/* time(ns) used in last scheduled interval: [last running, last stopping] */
+	pid_t	waker_pid;		/* last waker's PID */
+	char	waker_comm[TASK_COMM_LEN + 1]; /* last waker's comm */
 };
 
 /*

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -190,8 +190,6 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <lib/cgroup.h>
-#include <lib/sdt_task.h>
-#include <lib/atq.h>
 
 char _license[] SEC("license") = "GPL";
 
@@ -2038,10 +2036,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init)
 {
 	u64 now = scx_bpf_now();
 	int err;
-
-	_Static_assert(
-		sizeof(struct atq_ctx) >= sizeof(struct scx_task_common),
-		"atq_ctx should be equal or larger than scx_task_common");
 
 	/*
 	 * Create compute domains.

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -642,7 +642,6 @@ impl<'a> Scheduler<'a> {
     fn relay_introspec(data: &[u8], intrspc_tx: &Sender<SchedSample>) -> i32 {
         let mt = msg_task_ctx::from_bytes(data);
         let tx = mt.taskc_x;
-        let tc = mt.taskc;
 
         // No idea how to print other types than LAVD_MSG_TASKC
         if mt.hdr.kind != LAVD_MSG_TASKC {
@@ -655,7 +654,7 @@ impl<'a> Scheduler<'a> {
         let c_tx_cm_str: &CStr = unsafe { CStr::from_ptr(c_tx_cm) };
         let tx_comm: &str = c_tx_cm_str.to_str().unwrap();
 
-        let c_waker_cm: *const c_char = (&tc.waker_comm as *const [c_char; 17]) as *const c_char;
+        let c_waker_cm: *const c_char = (&tx.waker_comm as *const [c_char; 17]) as *const c_char;
         let c_waker_cm_str: &CStr = unsafe { CStr::from_ptr(c_waker_cm) };
         let waker_comm: &str = c_waker_cm_str.to_str().unwrap();
 
@@ -665,25 +664,25 @@ impl<'a> Scheduler<'a> {
 
         match intrspc_tx.try_send(SchedSample {
             mseq,
-            pid: tc.pid,
+            pid: tx.pid,
             comm: tx_comm.into(),
             stat: tx_stat.into(),
-            cpu_id: tc.cpu_id,
-            prev_cpu_id: tc.prev_cpu_id,
-            suggested_cpu_id: tc.suggested_cpu_id,
-            waker_pid: tc.waker_pid,
+            cpu_id: tx.cpu_id,
+            prev_cpu_id: tx.prev_cpu_id,
+            suggested_cpu_id: tx.suggested_cpu_id,
+            waker_pid: tx.waker_pid,
             waker_comm: waker_comm.into(),
-            slice: tc.slice,
-            lat_cri: tc.lat_cri,
+            slice: tx.slice,
+            lat_cri: tx.lat_cri,
             avg_lat_cri: tx.avg_lat_cri,
             static_prio: tx.static_prio,
             rerunnable_interval: tx.rerunnable_interval,
-            resched_interval: tc.resched_interval,
-            run_freq: tc.run_freq,
-            avg_runtime: tc.avg_runtime,
-            wait_freq: tc.wait_freq,
-            wake_freq: tc.wake_freq,
-            perf_cri: tc.perf_cri,
+            resched_interval: tx.resched_interval,
+            run_freq: tx.run_freq,
+            avg_runtime: tx.avg_runtime,
+            wait_freq: tx.wait_freq,
+            wake_freq: tx.wake_freq,
+            perf_cri: tx.perf_cri,
             thr_perf_cri: tx.thr_perf_cri,
             cpuperf_cur: tx.cpuperf_cur,
             cpu_util: tx.cpu_util,
@@ -691,7 +690,7 @@ impl<'a> Scheduler<'a> {
             nr_active: tx.nr_active,
             dsq_id: tx.dsq_id,
             dsq_consume_lat: tx.dsq_consume_lat,
-            slice_used: tc.last_slice_used,
+            slice_used: tx.last_slice_used,
         }) {
             Ok(()) | Err(TrySendError::Full(_)) => 0,
             Err(e) => panic!("failed to send on intrspc_tx ({})", e),


### PR DESCRIPTION
Previously, struct task_ctx was defined in intf.h because struct task_ctx information was passed over the ring buffer for introspection (--monitor-sched-samples). However, intf.h is shared between BPF code and userspace code, so adding a new field of a struct type can complicate things due to header file dependencies.

To remove such a header file dependency, we made the following changes:
- Move struct task_ctx to lavd.bpf.h, which is included only in the BPF code.
- Extend struct task_ctx_x to contain all the necessary information for introspection.
- Change the type of atq in task_ctx from a dummy type (struct atq_ctx) to a real type (struct scx_task_common).

There is no functional change intended.