### PR TITLE
scx_lavd: Don't try to migrate a task from non-migratable DSQs.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -208,7 +208,12 @@ u64 __attribute__((noinline)) pick_most_loaded_dsq(struct cpdom_ctx *cpdomc)
 		highest_queued = scx_bpf_dsq_nr_queued(pick_dsq_id);
 	}
 
-	if (use_per_cpu_dsq()) {
+	/*
+	 * When tasks on a per-CPU DSQ are not migratable
+	 * (e.g., pinned_slice_ns is on but per_cpu_dsq is not),
+	 * there is no need to check per-CPU DSQs.
+	 */
+	if (is_per_cpu_dsq_migratable()) {
 		int pick_cpu = -ENOENT, cpu, i, j, k;
 
 		bpf_for(i, 0, LAVD_CPU_ID_MAX/64) {

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -433,6 +433,18 @@ static __always_inline bool use_per_cpu_dsq(void)
 	return per_cpu_dsq || pinned_slice_ns;
 }
 
+static __always_inline  bool is_per_cpu_dsq_migratable(void)
+{
+	/*
+	 * When per_cpu-dsq is on, all tasks go to the per-CPU DSQ.
+	 * So a task on a per-CPU DSQ can be migrated to another CPU.
+	 * However, when pinned_slice_ns is on but per_cpu-dsq is not,
+	 * only pinned tasks go to the per-CPU DSQ.
+	 * Hence, tasks in a per-CPU DSQ are not migratable.
+	 */
+	return per_cpu_dsq;
+}
+
 static __always_inline bool use_cpdom_dsq(void)
 {
 	return !per_cpu_dsq;


### PR DESCRIPTION
When pinned_slice_ns is on but per_cpu_dsq is not, per-CPU DSQ is used only for pinned tasks, which cannot be migrated to another CPU. In this case, we don't need to check the load of per-CPU DSQs of a domain.

To express the intention of the code more explicitly, add a utility function, is_per_cpu_dsq_migratable(), and use it in pick_most_loaded_dsq().