### PR TITLE
scx_bpfland: Use nr_cpu_ids as the actual CPU limit

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -336,7 +336,9 @@ static inline const struct cpumask *get_idle_smtmask(s32 cpu)
  */
 static inline bool is_cpu_valid(s32 cpu)
 {
-	if (cpu < 0 || cpu >= MAX_CPUS) {
+	u64 max_cpu = MIN(nr_cpu_ids, MAX_CPUS);
+
+	if (cpu < 0 || cpu >= max_cpu) {
 		scx_bpf_error("invalid CPU id: %d", cpu);
 		return false;
 	}


### PR DESCRIPTION
The kernel uses nr_cpu_ids to indicate the real upper bound of possible CPUs. Any CPU >= nr_cpu_ids is guaranteed to be invalid, therefore, rely on nr_cpu_ids (clamped to MAX_CPUS) when checking CPU validity.

This also prevents potential BPF verifier errors.