### PR TITLE
kernel.config: Add CONFIG_KALLSYMS_ALL=y

### DIFF
--- a/kernel.config
+++ b/kernel.config
@@ -8,6 +8,10 @@ CONFIG_BPF_JIT_ALWAYS_ON=y
 CONFIG_BPF_JIT_DEFAULT_ON=y
 CONFIG_SCHED_CLASS_EXT=y
 
+# Required by some rust schedulers (e.g. scx_p2dq)
+#
+CONFIG_KALLSYMS_ALL=y
+
 # Required on arm64
 #
 # CONFIG_DEBUG_INFO_REDUCED is not set


### PR DESCRIPTION
This kernel config option has to be enabled in order to use scx_p2dq.

Closes issue #2923 