### PR TITLE
scx_cosmos: Avoid unnecessary CPU wakeups

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -755,7 +755,8 @@ void BPF_STRUCT_OPS(cosmos_enqueue, struct task_struct *p, u64 enq_flags)
 		cpu = pick_idle_cpu(p, prev_cpu, 0, true);
 		if (cpu >= 0) {
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, task_slice(p), enq_flags);
-			wakeup_cpu(cpu);
+			if (cpu != prev_cpu || !scx_bpf_task_running(p))
+				wakeup_cpu(cpu);
 			return;
 		}
 	}
@@ -766,7 +767,8 @@ void BPF_STRUCT_OPS(cosmos_enqueue, struct task_struct *p, u64 enq_flags)
 	 */
 	if (!is_system_busy()) {
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p), enq_flags);
-		wakeup_cpu(prev_cpu);
+		if (!__COMPAT_is_enq_cpu_selected(enq_flags) && !scx_bpf_task_running(p))
+			wakeup_cpu(prev_cpu);
 		return;
 	}
 
@@ -779,7 +781,8 @@ void BPF_STRUCT_OPS(cosmos_enqueue, struct task_struct *p, u64 enq_flags)
 		return;
 	scx_bpf_dsq_insert_vtime(p, shared_dsq(prev_cpu),
 				 task_slice(p), task_dl(p, tctx), enq_flags);
-	wakeup_cpu(prev_cpu);
+	if (!__COMPAT_is_enq_cpu_selected(enq_flags) && !scx_bpf_task_running(p))
+		wakeup_cpu(prev_cpu);
 }
 
 void BPF_STRUCT_OPS(cosmos_dispatch, s32 cpu, struct task_struct *prev)


### PR DESCRIPTION
In ops.enqueue() send CPU wakeup events only when a task is migrated to an idle CPU or when the task was previously sleeping and the wakeup wasn't already handled in ops.select_cpu().