### PR TITLE
lib: cgroup_bw: Fix a BPF verifier error on 6.18-rc6/clang-19/ARM64.

### DIFF
--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -956,12 +956,13 @@ struct tree_levels *get_clean_tree_levels(void)
 static
 int cbw_update_runtime_total_sloppy(struct cgroup *cgrp)
 {
-	struct cgroup *cur_cgrp;
-	struct scx_cgroup_ctx *cur_cgx = NULL;
+	u32 cur_level, prev_level = CBW_CGRP_TREE_HEIGHT_MAX;
 	struct cgroup_subsys_state *subroot_css, *pos;
+	struct scx_cgroup_ctx *cur_cgx = NULL;
 	struct tree_levels *tree;
+	struct cgroup *cur_cgrp;
 	s64 rt_llcx;
-	int cur_level, prev_level = -EINVAL, ret = 0;
+	int ret = 0;
 
 
 	tree = get_clean_tree_levels();
@@ -1006,17 +1007,11 @@ int cbw_update_runtime_total_sloppy(struct cgroup *cgrp)
 		cur_level = cur_cgrp->level;
 		if (cur_level == 0 && can_loop) /* cgroup_root */
 			break;
-		if (cur_level >= CBW_CGRP_TREE_HEIGHT_MAX || ret == -E2BIG) {
-			/*
-			 * Note that to make the verifier happy, the 'break'
-			 * was replaced with 'continue' and necessary changes
-			 * were made.
-			 */
-			cbw_err("The cgroup tree is too tall: %d", cur_level);
+		if (cur_level >= CBW_CGRP_TREE_HEIGHT_MAX) {
 			ret = -E2BIG;
-			continue;
+			break;
 		}
-		if (prev_level == -EINVAL)
+		if (prev_level == CBW_CGRP_TREE_HEIGHT_MAX)
 			prev_level = cur_level;
 
 		cur_cgx = cbw_get_cgroup_ctx(cur_cgrp);


### PR DESCRIPTION
On a system with 6.18-rc6/clang-19/ARM64, the BPF verifier confused signed integer handling and reported an error as follows on innocent code:

```
; tree->levels[cur_level] += cur_cgx->runtime_total_sloppy; @ cgroup_bw.bpf.c:1082
2798: (bf) r2 = r5                    ; frame1: R2=scalar(id=2383,smin=umin=umin32=0x80000000,smax=umax=0xffffffff,smax32=-1,var_off=(0x80000000; 0x7fffffff)) R5=scalar(id=2383,smin=umin=umin32=0x80000000,smax=umax=0xffffffff,smax32=-1,var_off=(0x80000000; 0x7fffffff)) refs=2218
2799: (67) r2 <<= 32                  ; frame1: R2=scalar(smax=0xffffffff00000000,umin=0x8000000000000000,umax=0xffffffff00000000,smin32=0,smax32=umax32=0,var_off=(0x8000000000000000; 0x7fffffff00000000)) refs=2218
2800: (c7) r2 s>>= 32                 ; frame1: R2=scalar(smin=0xffffffff80000000,smax=smax32=-1,umin=0xffffffff80000000,umin32=0x80000000,var_off=(0xffffffff80000000; 0x7fffffff)) refs=2218
2801: (67) r2 <<= 3                   ; frame1: R2=scalar(smin=0xfffffffc00000000,smax=-8,umin=0xfffffffc00000000,umax=0xfffffffffffffff8,smax32=0x7ffffff8,umax32=0xfffffff8,var_off=(0xfffffffc00000000; 0x3fffffff8)) refs=2218
2802: (bf) r3 = r6                    ; frame1: R3=map_value(map=tree_levels_map,ks=4,vs=128) R6=map_value(map=tree_levels_map,ks=4,vs=128) refs=2218
2803: (0f) r3 += r2
value -17179869184 makes map_value pointer be out of bounds
```

Let's change cur_level and prev_level from int to u32 to reduce the verifier's burden.