### PR TITLE
scx_lavd: Minor tuning of deadline calculation for heavy loads.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lat_cri.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lat_cri.bpf.c
@@ -30,6 +30,12 @@ static u64 calc_weight_factor(struct task_struct *p, task_ctx *taskc)
 		weight_boost += 2 * LAVD_LC_WEIGHT_BOOST;
 
 	/*
+	 * Further prioritize ksoftirqd.
+	 */
+	if (test_task_flag(taskc, LAVD_FLAG_KSOFTIRQD))
+		weight_boost += 4 * LAVD_LC_WEIGHT_BOOST;
+
+	/*
 	 * Further prioritize kworkers.
 	 */
 	if (is_kernel_worker(p))

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -118,6 +118,7 @@ enum consts_flags {
 	LAVD_FLAG_ON_LITTLE		= (0x1 << 7), /* can a task run on a little core? */
 	LAVD_FLAG_SLICE_BOOST		= (0x1 << 8), /* task's time slice is boosted. */
 	LAVD_FLAG_IDLE_CPU_PICKED	= (0x1 << 9), /* an idle CPU is picked at ops.select_cpu() */
+	LAVD_FLAG_KSOFTIRQD		= (0x1 << 10), /* ksoftirqd/%u thread */
 };
 
 /*

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1631,6 +1631,11 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init_task, struct task_struct *p,
 		reset_task_flag(taskc, LAVD_FLAG_IS_AFFINITIZED);
 	bpf_rcu_read_unlock();
 
+	if (is_ksoftirqd(p))
+		set_task_flag(taskc, LAVD_FLAG_KSOFTIRQD);
+	else
+		reset_task_flag(taskc, LAVD_FLAG_KSOFTIRQD);
+
 	now = scx_bpf_now();
 	taskc->last_runnable_clk = now;
 	taskc->last_running_clk = now; /* for avg_runtime */
@@ -1643,6 +1648,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init_task, struct task_struct *p,
 	taskc->cgrp_id = args->cgroup->kn->id;
 
 	set_on_core_type(taskc, p->cpus_ptr);
+
 	return 0;
 }
 

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -131,6 +131,11 @@ static bool is_kernel_worker(struct task_struct *p)
 	return !!(p->flags & (PF_WQ_WORKER | PF_IO_WORKER));
 }
 
+static bool is_ksoftirqd(struct task_struct *p)
+{
+	return is_kernel_task(p) && !__builtin_memcmp(p->comm, "ksoftirqd/", 10);
+}
+
 static bool is_pinned(const struct task_struct *p)
 {
 	return p->nr_cpus_allowed == 1;


### PR DESCRIPTION
Two changes in deadline calculation were made, especially when a system is extremely overloaded.

1) Limit the maximum waiter/wakee frequency to 100000, meaning that the shortest interval between events is 10 usec.
2) Further boost ksoftirqd since ksoftirqd runs clogged softirq when overloaded to mitigate the delay in executing softirq.

The changes should not have noticeable differences in a normal system that is not extremely overloaded.

