### PR TITLE
scx_lavd: Account for time stolen from tasks from steal/irq_time

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -158,6 +158,7 @@ struct task_ctx {
 
 	/* --- cacheline 3 boundary (192 bytes) --- */
 	u64	last_quiescent_clk;	/* last time when a task became asleep */
+	u64	last_sum_exec_clk;	/* last time when sum exec time was measured */
 	u64	cgrp_id;		/* cgroup id of this task */
 	u64	resched_interval;	/* reschedule interval in ns: [last running, this running] */
 	u64	last_slice_used;	/* time(ns) used in last scheduled interval: [last running, last stopping] */
@@ -246,6 +247,11 @@ struct cpu_ctx {
 	volatile u64	cpu_release_clk; /* when the CPU is taken by higher-priority scheduler class */
 
 	/* --- cacheline 2 boundary (128 bytes) --- */
+
+	volatile u32	avg_stolen_est;	/* Average of estimated steal/irq utilization of CPU */
+	volatile u32	cur_stolen_est;	/* Estimated irq/steal utilization of the current interval */
+	volatile u64	stolen_time_est; /* Estimated time stolen by steal/irq time on CPU */
+
 	/*
 	 * Idle tracking (read-mostly)
 	 */

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -270,6 +270,15 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 		}
 
 		/*
+		 * cpuc->cur_stolen_est is only an estimate of the time stolen by
+		 * irq/steal during execution times. We extropolate that ratio to
+		 * the rest of CPU time as an approximation.
+		 */
+		cpuc->cur_stolen_est = (cpuc->stolen_time_est << LAVD_SHIFT) / compute;
+		cpuc->avg_stolen_est = calc_asym_avg(cpuc->avg_stolen_est, cpuc->cur_stolen_est);
+		cpuc->stolen_time_est = 0;
+
+		/*
 		 * Accmulate system-wide idle time.
 		 */
 		c->idle_total += cpuc->idle_total;

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -336,3 +336,8 @@ u64 get_target_dsq_id(struct task_struct *p, struct cpu_ctx *cpuc)
 		return cpu_to_dsq(cpuc->cpu_id);
 	return cpdom_to_dsq(cpuc->cpdom_id);
 }
+
+u64 task_exec_time(struct task_struct __arg_trusted *p)
+{
+	return p->se.sum_exec_runtime;
+}


### PR DESCRIPTION
In high traffic networking services, irq_time can account for up to 30% of the entire system's cpu time. The current time accounting does not take into account time stolen by IRQ or steal which can make tasks appear as though it ran longer on CPU than reality. This can skew vtime deadline calculations and other metrics.

For kernels with IRQ_TIME_ACCOUNTING and/or PARAVIRT_TIME_ACCOUNTING enabled, rq->clock_task already deducts irq/time_steal when accounting for task runtimes. p->se.sum_exec_runtime serves as a good proxy for rq->clock_task when used to determine task's runtime as it's frequently updated via update_curr_scx().