### PR TITLE
scx_lavd: Fix cpu_dsq_id typo in vtime comparison

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -402,7 +402,7 @@ static bool consume_task(u64 cpu_dsq_id, u64 cpdom_dsq_id)
 		if (p)
 			vtime = p->scx.dsq_vtime;
 
-		p = __COMPAT_scx_bpf_dsq_peek(cpu_dsq_id);
+		p = __COMPAT_scx_bpf_dsq_peek(cpdom_dsq_id);
 		if (p && p->scx.dsq_vtime < vtime) {
 			dsq_id = cpdom_dsq_id;
 			backup_dsq_id = cpu_dsq_id;


### PR DESCRIPTION
The second __COMPAT_scx_bpf_dsq_peek() call was mistakenly using cpu_dsq_id instead of cpdom_dsq_id, making the code to peek at the same dsq twice instead of comparing vtimes between the cpu dsq and the cpdom dsq as intended.