### PR TITLE
scx_lavd: Fix stale migration roles in load balancer, remove redundant condition, and optimize the stealing loop

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -133,8 +133,16 @@ int plan_x_cpdom_migration(void)
 		}
 		return 0;
 	}
-	if ((stealee_threshold <= max_sc_load || overflow_running) &&
-	    (stealer_threshold < min_sc_load)) {
+
+	/*
+	 * At this point, there is at least one overloaded domain (stealee),
+	 * indicated by the following condition:
+	 *    stealee_threshold <= max_sc_load || overflow_running
+	 *
+	 * Adjust the stealer threshold to minimum scaled load to ensure that
+	 * there exists at least one stealer.
+	 */
+	if (stealer_threshold < min_sc_load) {
 		/*
 		 * If there is a overloaded domain, always try to steal.
 		 *  <~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~>


### PR DESCRIPTION
This series fixes a bug where cross-domain migration decisions were based on
stale stealer/stealee roles.

plan_x_cpdom_migration() returned early when no domain was overloaded, which
skips the classification loop that updates is_stealer/is_stealee roles. The
stale roles from previous rounds caused consume_task() and pick_idle_cpu() to
continue migrating tasks even when the system loading is neutral and the load
balancer determined no migration was needed.

The fix replaces the early return with a goto to ensure the classification loop
runs, guarantees roles are refreshed and sys_stat.nr_stealee accurately
reflects the current state.

With correct sys_stat.nr_stealee, we add an early exit in try_to_steal_task()
when nr_stealee is zero. This avoids the nested neighbor traversal when there is
nothing to steal. The enhancement converts a previously unused counter into an
optimization.

PATCH [1/3]: Fix stale roles by always running the classification loop
PATCH [2/3]: Remove a redundant condition 
PATCH [3/3]: Skip try_to_steal_task() iteration when nr_stealee is zero