### PR TITLE
scx_p2dq: Fix verifier on newer kernels with bpf_rcu_read_lock

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -1683,6 +1683,8 @@ static void p2dq_dispatch_impl(s32 cpu, struct task_struct *prev)
 
 	u64 min_vtime = 0;
 
+	bpf_rcu_read_lock();
+
 	// start with affn_dsq (local cpu dsq)
 	p = __COMPAT_scx_bpf_dsq_peek(cpuc->affn_dsq);
 	if (p) {
@@ -1764,6 +1766,8 @@ static void p2dq_dispatch_impl(s32 cpu, struct task_struct *prev)
 			}
 		}
 	}
+
+	bpf_rcu_read_unlock();
 
 	if (dsq_id != 0)
 		trace("DISPATCH cpu[%d] min_vtime %llu dsq_id %llu atq %llu",


### PR DESCRIPTION
Add bpf_rcu_read_lock when accessing cpus_ptr to fix verification failures on newer kernels.