### PR TITLE
scx_p2dq: Add conservative wakeup preemption for latency-critical tasks

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/types.h
+++ b/scheds/rust/scx_p2dq/src/bpf/types.h
@@ -53,6 +53,7 @@ struct cpu_ctx {
 	u64				mig_dsq;
 	u64				llc_dsq;
 	u64				max_load_dsq;
+	u32				running_weight;  /* Weight of currently running task */
 
 	scx_atq_t			*mig_atq;
 	scx_dhq_t			*mig_dhq;

--- a/scheds/rust/scx_p2dq/src/lib.rs
+++ b/scheds/rust/scx_p2dq/src/lib.rs
@@ -321,6 +321,14 @@ pub struct SchedulerOpts {
     #[clap(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub enable_pelt: bool,
 
+    /// Enable latency priority system (uses task nice value)
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub latency_priority: bool,
+
+    /// Enable wakeup preemption for latency-critical tasks
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub wakeup_preemption: bool,
+
     #[clap(flatten, next_help_heading = "Topology Options")]
     pub topo: TopologyArgs,
 }
@@ -448,6 +456,10 @@ macro_rules! init_open_skel {
             rodata.p2dq_config.interactive_sticky = MaybeUninit::new(opts.interactive_sticky);
             rodata.p2dq_config.keep_running_enabled = MaybeUninit::new(opts.keep_running);
             rodata.p2dq_config.pelt_enabled = MaybeUninit::new(opts.enable_pelt);
+
+            // Latency priority config
+            rodata.latency_config.latency_priority_enabled = MaybeUninit::new(opts.latency_priority);
+            rodata.latency_config.wakeup_preemption_enabled = MaybeUninit::new(opts.wakeup_preemption);
 
             rodata.debug = verbose as u32;
             rodata.nr_cpu_ids = *NR_CPU_IDS as u32;


### PR DESCRIPTION
Implement optional wakeup preemption to reduce latency for high-priority tasks when no idle CPU is available.

Core changes:
- Add running_weight field to cpu_ctx to track current task's priority
- Update p2dq_running_impl() to store task weight when task starts running
- Implement wakeup preemption in p2dq_select_cpu_impl() with strict criteria

Preemption conditions (all must be satisfied):
1. Waking task has very high priority (scx.weight >= 2847, nice <= -15)
2. No idle CPU was found during idle CPU search
3. Task can run on prev_cpu (affinity check)
4. prev_cpu is NOT running an interactive task
5. Waking task has HIGHER priority than task running on prev_cpu

The preemption mechanism doesn't bypass normal queueing - it only provides a CPU target hint (prev_cpu) for cache affinity while letting vtime ordering handle priority scheduling.

Configuration flags:
- --latency-priority: Enable latency priority system (unused currently)
- --wakeup-preemption: Enable wakeup preemption feature

This conservative approach ensures we only interrupt lower-priority work and never disrupt interactive or equally important tasks, minimizing impact on tail latency.