### PR TITLE
layered: fix GPU matching when member_expire_ms=0

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2608,9 +2608,12 @@ static __noinline bool match_one(struct layer *layer, struct layer_match *match,
 			/*
 			 * If the last kprobe fire was more than member_expire_ms ago, timestamp is stale.
 			 * Mark us as expired to trigger a rematch if we fire off any GPU kprobes.
+			 *
+			 * NOTE: member_expire_ms=0 means "never expire", so skip the expiration check.
 			 */
 			recently_used = true;
-			if (taskc && taskc->recheck_layer_membership != MEMBER_NOEXPIRE &&
+			if (layer->member_expire_ms > 0 && taskc &&
+				taskc->recheck_layer_membership != MEMBER_NOEXPIRE &&
 				taskc->recheck_layer_membership != MEMBER_CANTMATCH &&
 				(*last_used) + layer->member_expire_ms * 1000 * 1000 < now) {
 


### PR DESCRIPTION
Recently, we introduced the TTL changes, which allow GPU matcher to "expire" a task to force a rematch. By default, member_expire_ms=0, which means a task should never expire, or fail the expieration check.

We noticed after the TTL change, we lost the matching ability when member_expire_ms=0. After debugging, we see that member_expire_ms=0 was treated as a valid timestamp for expieration check.

This diff makes sure we only compare valid member_expire_ms.