### PR TITLE
scx_cargo: scx_utils::BpfBuilder -> scx_cargo::BpfBuilder

### DIFF
--- a/rust/scx_cargo/src/bpf_builder.rs
+++ b/rust/scx_cargo/src/bpf_builder.rs
@@ -88,16 +88,16 @@ use tracing_subscriber::{filter, layer::SubscriberExt, Layer};
 /// And then there are boilerplates to generate the bindings and make them
 /// available as modules to `main.rs`.
 ///
-/// - `Cargo.toml`: Includes `scx_utils` in the `[build-dependencies]`
+/// - `Cargo.toml`: Includes `scx_cargo` in the `[build-dependencies]`
 /// section.
 ///
-/// - `build.rs`: Uses `scx_utils::BpfBuilder` to build and generate
+/// - `build.rs`: Uses `scx_cargo::BpfBuilder` to build and generate
 /// bindings for the BPF component. For this project, it can look like the
 /// following.
 ///
 /// ```should_panic
 /// fn main() {
-///     scx_utils::BpfBuilder::new()
+///     scx_cargo::BpfBuilder::new()
 ///         .unwrap()
 ///         .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
 ///         .enable_skel("src/bpf/main.bpf.c", "bpf")


### PR DESCRIPTION
Fix failing test:
```
running 3 tests
test rust/scx_cargo/src/bpf_builder.rs - bpf_builder::BpfBuilder (line 114) ... ignored
test rust/scx_cargo/src/bpf_builder.rs - bpf_builder::BpfBuilder (line 127) ... ignored
test rust/scx_cargo/src/bpf_builder.rs - bpf_builder::BpfBuilder (line 98) ... FAILED

failures:

---- rust/scx_cargo/src/bpf_builder.rs - bpf_builder::BpfBuilder (line 98) stdout ----
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `scx_utils`
 --> rust/scx_cargo/src/bpf_builder.rs:100:5
  |
3 |     scx_utils::BpfBuilder::new()
  |     ^^^^^^^^^ use of unresolved module or unlinked crate `scx_utils`
  |
  = help: if you wanted to use a crate named `scx_utils`, use `cargo add scx_utils` to add it to your `Cargo.toml`
help: consider importing this struct
  |
2 + use scx_cargo::BpfBuilder;
  |
help: if you import `BpfBuilder`, refer to it directly
  |
3 -     scx_utils::BpfBuilder::new()
3 +     BpfBuilder::new()
  |

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0433`.
Couldn't compile the test.

failures:
    rust/scx_cargo/src/bpf_builder.rs - bpf_builder::BpfBuilder (line 98)

test result: FAILED. 0 passed; 1 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.05s

error: doctest failed, to rerun pass `-p scx_cargo --doc`
```