### PR TITLE
scx_raw_pmu: remove flaky tests

### DIFF
--- a/rust/scx_raw_pmu/src/json.rs
+++ b/rust/scx_raw_pmu/src/json.rs
@@ -260,28 +260,3 @@ impl PMUManager {
         Self::new_with_resource_dir(resource_dir, dataroot.into())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_with_resources() {
-        let manager = PMUManager::new().expect("could not create PMU manager");
-
-        manager.list_metadata();
-        manager.list_counters().expect("could not list counters");
-    }
-
-    #[test]
-    fn test_with_dir() {
-        let td = tempfile::tempdir().unwrap();
-        crate::resources::extract_arch_resources(td.path()).expect("could not extract resources");
-
-        let manager =
-            PMUManager::new_with_dataroot(Some(td.path())).expect("could not create PMU manager");
-
-        manager.list_metadata();
-        manager.list_counters().expect("could not list counters");
-    }
-}

--- a/rust/scx_raw_pmu/src/resources.rs
+++ b/rust/scx_raw_pmu/src/resources.rs
@@ -132,8 +132,3 @@ impl ResourceDir {
         }
     }
 }
-
-#[cfg(test)]
-pub(crate) fn extract_arch_resources(path: &std::path::Path) -> Result<(), std::io::Error> {
-    ARCH_DIR.extract(path)
-}


### PR DESCRIPTION
The scx_raw_pmu tests have proven to be more trouble than they're worth. The tests exercise the main code paths of the module, but their correctness is heavily platform-dependent. This causes them to fail, e.g., when run in QEMU. There is no straightforward way of adjusting their behavior without introducing the possibility of false positives, so remove the tests for now until we come up with a better version.