### PR TITLE
build: Reduce the binary size for the release-tiny profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ inherits = "release"
 lto = "thin"
 strip = true
 incremental = true
+codegen-units = 1
 
 [profile.release-fast]
 inherits = "release"


### PR DESCRIPTION
Let's add `codegen-units = 1` to the release-tiny profile, for cross-crate optimizations and for smaller binary sizes.

Here is the binary size comparison before and after adding `codegen-units = 1`.

|        Binary       |  before  |   after  | Reduction % |
|:-------------------:|:--------:|:--------:|:-----------:|
| scx_arena_selftests | 25564528 | 25253704 |        1.22 |
| scx_beerland        |  4536488 |  4019976 |       11.39 |
| scx_bpfland         |  6802936 |  5850128 |       14.01 |
| scxcash             |  1588888 |  1449392 |        8.78 |
| scx_chaos           | 15728656 | 15215760 |        3.26 |
| scx_cosmos          |  4499104 |  3988432 |       11.35 |
| scx_flash           |  6853968 |  5906680 |       13.82 |
| scx_lavd            | 25058808 | 24009088 |        4.19 |
| scx_layered         | 30433864 | 29740616 |        2.28 |
| scx_mitosis         |  4853328 |  4286400 |       11.68 |
| scx_p2dq            | 16902944 | 16344088 |        3.31 |
| scx_rlfifo          |  3327504 |  2957512 |       11.12 |
| scx_rustland        |  4679400 |  4083032 |       12.74 |
| scx_rusty           |  4979936 |  4444904 |       10.74 |
| scx_tickless        |  4464496 |  3945824 |       11.62 |
| scxtop              | 15375112 | 12206024 |       20.61 |
| scx_wd40            | 18755512 | 18213848 |        2.89 |
| vmlinux_docify      |   981496 |   877352 |       10.61 |
| xtask               |  3500752 |  3052256 |       12.81 |