### PR TITLE
nix: bump virtme-ng 1.36->1.40

### DIFF
--- a/.nix/flake.nix
+++ b/.nix/flake.nix
@@ -130,6 +130,7 @@
               libseccomp
               pkg-config
               protobuf
+              virtme-ng
               zlib
               zstd
 

--- a/.nix/pkgs/virtme-ng.nix
+++ b/.nix/pkgs/virtme-ng.nix
@@ -13,13 +13,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "virtme-ng";
-  version = "1.36";
+  version = "1.40";
 
   src = fetchFromGitHub {
     owner = "arighi";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-/dO7BAWLsmL/EVO/9Ja8h7MuYTwOxBav3iHQkegyyoY=";
+    sha256 = "sha256-5vJ+wyCA0XKXtEzEGim1OoTBDFTS2BjJSIzkLvTYHn8=";
   };
 
   pyproject = true;


### PR DESCRIPTION
Mostly to pull in the new MCP features. Also add it to the devshell.

Test plan:
- CI