### PR TITLE
scx_p2dq: Fix ARM build

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -3637,7 +3637,7 @@ void BPF_STRUCT_OPS(p2dq_exit, struct scx_exit_info *ei)
  *
  * Note: This tracepoint only exists on ARM/ARM64 architectures
  */
-#if defined(__aarch64__) || defined(__arm__)
+#if defined(__TARGET_ARCH_arm64) || defined(__aarch64__)
 __weak __hidden SEC("tp_btf/hw_pressure_update?")
 int BPF_PROG(on_thermal_pressure, u32 cpu, u64 hw_pressure)
 {


### PR DESCRIPTION
```rust
   Compiling scx_p2dq v1.0.24 (/home/underdog/underdog/scx/scheds/rust/scx_p2dq)
   Compiling scx_chaos v1.0.22 (/home/underdog/underdog/scx/scheds/rust/scx_chaos)
error[E0609]: no field `on_thermal_pressure` on type `OpenBpfProgs<'_>`
   --> scheds/rust/scx_p2dq/src/main.rs:165:25
    |
165 |         open_skel.progs.on_thermal_pressure.set_autoload(false);
    |                         ^^^^^^^^^^^^^^^^^^^ unknown field
    |
    = note: available fields are: `arena_init`, `arena_alloc_mask`, `arena_topology_node_init`, `arena_topology_print`, `scx_userspace_arena_alloc_pages` ... and 13 others

error[E0609]: no field `on_thermal_pressure` on type `OpenBpfProgs<'_>`
   --> scheds/rust/scx_p2dq/src/main.rs:198:33
    |
198 |                 open_skel.progs.on_thermal_pressure.set_autoload(true);
    |                                 ^^^^^^^^^^^^^^^^^^^ unknown field
    |
    = note: available fields are: `arena_init`, `arena_alloc_mask`, `arena_topology_node_init`, `arena_topology_print`, `scx_userspace_arena_alloc_pages` ... and 13 others

For more information about this error, try `rustc --explain E0609`.
error: could not compile `scx_p2dq` (bin "scx_p2dq") due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```