### PR TITLE
Cargo: update dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,9 +426,9 @@ checksum = "a1a0108968a3a2dab95b089c0fc3f1afa7759aa5ebe6f1d86d206d6f7ba726eb"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -444,9 +444,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "camino"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
  "serde_core",
 ]
@@ -1755,13 +1755,13 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.6.0",
 ]
 
 [[package]]
@@ -2253,7 +2253,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2398,7 +2398,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.9",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -2662,6 +2662,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -3921,9 +3930,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.4+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "fe3cea6b2aa3b910092f6abd4053ea464fab5f9c170ba5e9a6aead16ec4af2b6"
 dependencies = [
  "serde_core",
 ]
@@ -3944,21 +3953,21 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.9"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime 0.7.3",
+ "toml_datetime 0.7.4+spec-1.0.0",
  "toml_parser",
  "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.5+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "4c03bee5ce3696f31250db0bbaff18bc43301ce0e8db2ed1f07cbb2acf89984c"
 dependencies = [
  "winnow",
 ]

--- a/rust/scx_arena/scx_arena/Cargo.toml
+++ b/rust/scx_arena/scx_arena/Cargo.toml
@@ -6,7 +6,7 @@ description = "Crate for setting up the BPF arena library for sched-ext schedule
 license = "GPL-2.0-only"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 libbpf-rs = "=0.26.0-beta.1"
 libbpf-sys = "=1.6.1"
 simplelog = "0.12"

--- a/rust/scx_arena/selftests/Cargo.toml
+++ b/rust/scx_arena/selftests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 libbpf-rs = "=0.26.0-beta.1"
 simplelog = "0.12"
 scx_utils = { path = "../../scx_utils", version = "1.0.25" }

--- a/rust/scx_bpf_compat/Cargo.toml
+++ b/rust/scx_bpf_compat/Cargo.toml
@@ -14,10 +14,10 @@ ci.use_clippy = true
 [dependencies]
 scx_utils = { path = "../scx_utils", version = "1.0.25" }
 
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 libbpf-rs = "=0.26.0-beta.1"
-log = "0.4.17"
-once_cell = "1.20.2"
+log = "0.4.29"
+once_cell = "1.21.3"
 
 [build-dependencies]
 scx_cargo = { path = "../scx_cargo", version = "1.0.25" }

--- a/rust/scx_bpf_unittests/Cargo.toml
+++ b/rust/scx_bpf_unittests/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 libbpf-sys = "=1.6.1"  # need the includes and can't use libbpf_rs instead
 
 [build-dependencies]
-cc = "1.2.29"
-indoc = "2.0.5"
+cc = "1.2.49"
+indoc = "2.0.7"
 object = "0.36.7"

--- a/rust/scx_cargo/Cargo.toml
+++ b/rust/scx_cargo/Cargo.toml
@@ -8,24 +8,24 @@ repository = "https://github.com/sched-ext/scx"
 description = "Build time utilities for sched_ext schedulers"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 lazy_static = "1.5.0"
 sscanf = "0.4"
 version-compare = "0.1"
-glob = "0.3.2"
+glob = "0.3.3"
 tracing = "0.1"
-tracing-subscriber = "0.3.20"
+tracing-subscriber = "0.3.22"
 libbpf-cargo = "=0.26.0-beta.1"
 tar = "0.4"
 libbpf-rs = "=0.26.0-beta.1"
 bindgen = ">=0.69"
 
 [build-dependencies]
-ruzstd = "0.8.1"
+ruzstd = "0.8.2"
 tar = "0.4"
 walkdir = "2.5"
-tempfile = "3.19.1"
+tempfile = "3.23.0"
 
 [dev-dependencies]
-regex = "1.11.2"
-tempfile = "3.19.1"
+regex = "1.12.2"
+tempfile = "3.23.0"

--- a/rust/scx_raw_pmu/Cargo.toml
+++ b/rust/scx_raw_pmu/Cargo.toml
@@ -6,17 +6,17 @@ description = "Utilities to handle raw PMU counters in sched_ext schedulers"
 license = "GPL-2.0-only"
 
 [dependencies]
-anyhow = "1.0.65"
-csv = "1.3.1"
+anyhow = "1.0.100"
+csv = "1.4.0"
 include_dir = "0.7.4"
 procfs = "0.15.1"
-regex = "1.11.2"
+regex = "1.12.2"
 scx_utils = { path = "../scx_utils", version = "1.0.25" }
-serde = { version = "1.0.215", features = ["derive"] }
-serde_json = "1.0.133"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 
 [dev-dependencies]
-tempfile = "3.19.1"
+tempfile = "3.23.0"
 
 [build-dependencies]
 scx_utils = { path = "../scx_utils", version = "1.0.25" }

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/sched-ext/scx"
 description = "Framework to implement sched_ext schedulers running in user space"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 plain = "0.2.3"
 libbpf-rs = "=0.26.0-beta.1"
-libc = "0.2.175"
+libc = "0.2.178"
 seccomp = "0.1"
 scx_cargo = { path = "../scx_cargo", version = "1.0.25" }
 

--- a/rust/scx_stats/Cargo.toml
+++ b/rust/scx_stats/Cargo.toml
@@ -8,19 +8,19 @@ repository = "https://github.com/sched-ext/scx"
 description = "Statistics transport library for sched_ext schedulers"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 crossbeam = "0.8.4"
-libc = "0.2.175"
-log = "0.4.17"
+libc = "0.2.178"
+log = "0.4.29"
 proc-macro2 = "1.0"
 quote = "1.0"
-serde = { version = "1.0.215", features = ["derive"] }
-serde_json = "1.0.133"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 syn = { version = "2.0", features = ["extra-traits", "full"] }
 
 [dev-dependencies]
 scx_stats_derive = { path = "scx_stats_derive" }
-simple_logger = "5.0"
+simple_logger = "5.1"
 
 [lints.clippy]
 not_unsafe_ptr_arg_deref = "allow"

--- a/rust/scx_stats/scx_stats_derive/Cargo.toml
+++ b/rust/scx_stats/scx_stats_derive/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 scx_stats = { path = "..", version = "1.0.20" }
-serde_json = "1.0.133"
+serde_json = "1.0.145"
 syn = { version = "2.0", features = ["extra-traits", "full"] }
 
 [lints.clippy]

--- a/rust/scx_userspace_arena/Cargo.toml
+++ b/rust/scx_userspace_arena/Cargo.toml
@@ -13,7 +13,7 @@ ci.use_clippy = true
 [dependencies]
 scx_utils = { path = "../scx_utils", version = "1.0.25" }
 
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 buddy_system_allocator = { version = "0.11.0", default-features = false }
 libbpf-rs = "=0.26.0-beta.1"
 

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -8,49 +8,49 @@ repository = "https://github.com/sched-ext/scx"
 description = "Utilities for sched_ext schedulers"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 bitvec = { version = "1.0", features = ["serde"] }
 bindgen = ">=0.69"
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
-glob = "0.3.2"
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
+glob = "0.3.3"
 hex = "0.4.3"
 lazy_static = "1.5.0"
 libbpf-cargo = "=0.26.0-beta.1"
 libbpf-rs = "=0.26.0-beta.1"
-log = "0.4.17"
+log = "0.4.29"
 nvml-wrapper = { version = "0.11.0", optional = true }
 nvml-wrapper-sys = { version = "0.9.0", optional = true }
 paste = "1.0"
-regex = "1.11.2"
-ruzstd = "0.8.1"
+regex = "1.12.2"
+ruzstd = "0.8.2"
 scx_stats = { path = "../scx_stats", version = "1.0.20" }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 sscanf = "0.4"
 tar = "0.4"
 walkdir = "2.5"
 version-compare = "0.1"
-zbus = { version = "5.3.1", optional = true }
+zbus = { version = "5.12.0", optional = true }
 num = "0.4.3"
-tempfile = "3.19.1"
+tempfile = "3.23.0"
 tracing = "0.1"
-tracing-subscriber = "0.3.20"
-libc = "0.2.175"
+tracing-subscriber = "0.3.22"
+libc = "0.2.178"
 nix = { version = "0.30.1", features = ["resource"] }
 
 scx_cargo = { path = "../scx_cargo", version = "1.0.25", optional = true }
 
 [build-dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 bindgen = ">=0.69"
-glob = "0.3.2"
+glob = "0.3.3"
 lazy_static = "1.5.0"
 libbpf-cargo = "=0.26.0-beta.1"
-ruzstd = "0.8.1"
+ruzstd = "0.8.2"
 scx_cargo = { path = "../scx_cargo", version = "1.0.25" }
 sscanf = "0.4"
 tar = "0.4"
-tempfile = "3.19.1"
-vergen = { version = "8.0.0", features = ["cargo", "git", "gitcl"] }
+tempfile = "3.23.0"
+vergen = { version = "8.3.2", features = ["cargo", "git", "gitcl"] }
 version-compare = "0.1"
 walkdir = "2.5"
 

--- a/scheds/rust/scx_beerland/Cargo.toml
+++ b/scheds/rust/scx_beerland/Cargo.toml
@@ -7,16 +7,16 @@ description = "Scheduler designed to prioritize locality and scalability. https:
 license = "GPL-2.0-only"
 
 [dependencies]
-anyhow = "1.0.65"
-ctrlc = { version = "3.1", features = ["termination"] }
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+anyhow = "1.0.100"
+ctrlc = { version = "3.5", features = ["termination"] }
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
 libbpf-rs = "=0.26.0-beta.1"
-log = "0.4.17"
+log = "0.4.29"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25", features = ["autopower"] }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]

--- a/scheds/rust/scx_bpfland/Cargo.toml
+++ b/scheds/rust/scx_bpfland/Cargo.toml
@@ -7,16 +7,16 @@ description = "A vruntime-based sched_ext scheduler that prioritizes interactive
 license = "GPL-2.0-only"
 
 [dependencies]
-anyhow = "1.0.65"
-ctrlc = { version = "3.1", features = ["termination"] }
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+anyhow = "1.0.100"
+ctrlc = { version = "3.5", features = ["termination"] }
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
 libbpf-rs = "=0.26.0-beta.1"
-log = "0.4.17"
+log = "0.4.29"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25", features = ["autopower"] }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]

--- a/scheds/rust/scx_chaos/Cargo.toml
+++ b/scheds/rust/scx_chaos/Cargo.toml
@@ -17,15 +17,15 @@ scx_p2dq = { path = "../../../scheds/rust/scx_p2dq", version = "1.0.24" }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 
-anyhow = "1.0.65"
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+anyhow = "1.0.100"
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
-ctrlc = { version = "3.1", features = ["termination"] }
+ctrlc = { version = "3.5", features = ["termination"] }
 libbpf-rs = "=0.26.0-beta.1"
-libc = "0.2.175"
-log = "0.4.17"
+libc = "0.2.178"
+log = "0.4.29"
 nix = { version = "0.30.1", features = ["process"] }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -7,17 +7,17 @@ description = "Lightweight scheduler optimized for preserving task-to-CPU locali
 license = "GPL-2.0-only"
 
 [dependencies]
-anyhow = "1.0.65"
-ctrlc = { version = "3.1", features = ["termination"] }
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+anyhow = "1.0.100"
+ctrlc = { version = "3.5", features = ["termination"] }
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
 libbpf-rs = "=0.26.0-beta.1"
-log = "0.4.17"
+log = "0.4.29"
 perf-event-open-sys = "5.0"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25", features = ["autopower"] }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]

--- a/scheds/rust/scx_flash/Cargo.toml
+++ b/scheds/rust/scx_flash/Cargo.toml
@@ -7,16 +7,16 @@ description = "A scheduler designed for multimedia and real-time audio processin
 license = "GPL-2.0-only"
 
 [dependencies]
-anyhow = "1.0.65"
-ctrlc = { version = "3.1", features = ["termination"] }
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+anyhow = "1.0.100"
+ctrlc = { version = "3.5", features = ["termination"] }
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
 libbpf-rs = "=0.26.0-beta.1"
-log = "0.4.17"
+log = "0.4.29"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25", features = ["autopower"] }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -13,22 +13,22 @@ blocklist = [
 
 [dependencies]
 scx_arena = { path = "../../../rust/scx_arena/scx_arena", version = "0.1.3" }
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 bitvec = { version = "1.0", features = ["serde"] }
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_main = "0.2.9"
 clap-num = { version = "1.2.0" }
 crossbeam = "0.8.4"
-ctrlc = { version = "3.1", features = ["termination"] }
+ctrlc = { version = "3.5", features = ["termination"] }
 hex = "0.4.3"
 itertools = "0.13.0"
 libbpf-rs = "=0.26.0-beta.1"
-libc = "0.2.175"
-ordered-float = "3.4.0"
+libc = "0.2.178"
+ordered-float = "3.9.2"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25", features = ["autopower"] }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "parking_lot", "tracing-log"] }
 static_assertions = "1.1.0"

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -7,30 +7,30 @@ description = "A highly configurable multi-layer BPF / user space hybrid schedul
 license = "GPL-2.0-only"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 bitvec = "1.0"
 chrono = "0.4"
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_main = "0.2.9"
 crossbeam = "0.8.4"
-ctrlc = { version = "3.1", features = ["termination"] }
-fastrand = "2.1.1"
+ctrlc = { version = "3.5", features = ["termination"] }
+fastrand = "2.3.0"
 fb_procfs = "0.7"
 inotify = "0.11"
 lazy_static = "1.5.0"
 libbpf-rs = "=0.26.0-beta.1"
-libc = "0.2.175"
-regex = "1.11.2"
+libc = "0.2.178"
+regex = "1.12.2"
 scx_bpf_compat = { path = "../../../rust/scx_bpf_compat", version = "1.0.19" }
 scx_raw_pmu = { path = "../../../rust/scx_raw_pmu", version = "0.1.3" }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25" }
-serde = { version = "1.0.215", features = ["derive"] }
-serde_json = "1.0.133"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "parking_lot", "tracing-log"] }
-once_cell = "1.20.2"
+once_cell = "1.21.3"
 walkdir = "2.5"
 nvml-wrapper = "0.11.0"
 nix = { version = "0.30.1", features = ["sched"] }

--- a/scheds/rust/scx_mitosis/Cargo.toml
+++ b/scheds/rust/scx_mitosis/Cargo.toml
@@ -9,23 +9,23 @@ license = "GPL-2.0-only"
 publish = false
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 bitvec = "1.0"
 cgroupfs = "0.9.0"
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_main = "0.2.9"
-ctrlc = { version = "3.1", features = ["termination"] }
+ctrlc = { version = "3.5", features = ["termination"] }
 itertools = "0.13.0"
 lazy_static = "1.5.0"
 libbpf-rs = "=0.26.0-beta.1"
-libc = "0.2.175"
+libc = "0.2.178"
 crossbeam = "0.8.4"
 maplit = "1.0.2"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25" }
-serde = { version = "1.0.215", features = ["derive"] }
-serde_json = "1.0.133"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "parking_lot", "tracing-log"] }
 

--- a/scheds/rust/scx_p2dq/Cargo.toml
+++ b/scheds/rust/scx_p2dq/Cargo.toml
@@ -16,23 +16,23 @@ blocklist = [
 
 [dependencies]
 scx_arena = { path = "../../../rust/scx_arena/scx_arena", version = "0.1.3" }
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 chrono = "0.4"
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_main = "0.2.9"
 crossbeam = "0.8.4"
-ctrlc = { version = "3.1", features = ["termination"] }
+ctrlc = { version = "3.5", features = ["termination"] }
 lazy_static = "1.5.0"
 libbpf-rs = "=0.26.0-beta.1"
-libc = "0.2.175"
-ordered-float = "3.4.0"
+libc = "0.2.178"
+ordered-float = "3.9.2"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25" }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "parking_lot", "tracing-log"] }
-sorted-vec = "0.8.3"
+sorted-vec = "0.8.10"
 static_assertions = "1.1.0"
 
 [build-dependencies]

--- a/scheds/rust/scx_rlfifo/Cargo.toml
+++ b/scheds/rust/scx_rlfifo/Cargo.toml
@@ -7,12 +7,12 @@ description = "A simple FIFO scheduler in Rust that runs in user-space"
 license = "GPL-2.0-only"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 plain = "0.2.3"
 procfs = "0.18"
-ctrlc = { version = "3.1", features = ["termination"] }
+ctrlc = { version = "3.5", features = ["termination"] }
 libbpf-rs = "=0.26.0-beta.1"
-libc = "0.2.175"
+libc = "0.2.178"
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.4.9" }
 

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -7,16 +7,16 @@ description = "A BPF component (dispatcher) that implements the low level sched-
 license = "GPL-2.0-only"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 plain = "0.2.3"
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
-ctrlc = { version = "3.1", features = ["termination"] }
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
+ctrlc = { version = "3.5", features = ["termination"] }
 libbpf-rs = "=0.26.0-beta.1"
-libc = "0.2.175"
-log = "0.4.17"
-ordered-float = "3.4.0"
+libc = "0.2.178"
+log = "0.4.29"
+ordered-float = "3.9.2"
 procfs = "0.18"
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25" }

--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -7,22 +7,22 @@ description = "A multi-domain, BPF / user space hybrid scheduler used within sch
 license = "GPL-2.0-only"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 chrono = "0.4"
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
-ctrlc = { version = "3.1", features = ["termination"] }
+ctrlc = { version = "3.5", features = ["termination"] }
 fb_procfs = "0.7"
 libbpf-rs = "=0.26.0-beta.1"
-libc = "0.2.175"
-log = "0.4.17"
-ordered-float = "3.4.0"
+libc = "0.2.178"
+log = "0.4.29"
+ordered-float = "3.9.2"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25" }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 simplelog = "0.12"
-sorted-vec = "0.8.3"
+sorted-vec = "0.8.10"
 static_assertions = "1.1.0"
 
 [build-dependencies]

--- a/scheds/rust/scx_tickless/Cargo.toml
+++ b/scheds/rust/scx_tickless/Cargo.toml
@@ -8,16 +8,16 @@ license = "GPL-2.0-only"
 
 [dependencies]
 affinity = "0.1"
-anyhow = "1.0.65"
-ctrlc = { version = "3.1", features = ["termination"] }
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+anyhow = "1.0.100"
+ctrlc = { version = "3.5", features = ["termination"] }
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
 libbpf-rs = "=0.26.0-beta.1"
-log = "0.4.17"
+log = "0.4.29"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25", features = ["autopower"] }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]

--- a/scheds/rust/scx_wd40/Cargo.toml
+++ b/scheds/rust/scx_wd40/Cargo.toml
@@ -12,23 +12,23 @@ publish = false
 ci.disable_veristat = true  # requires some changes to vmlinux handling, see https://github.com/sched-ext/scx/pull/2246
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 scx_arena = { path = "../../../rust/scx_arena/scx_arena", version = "0.1.3" }
 chrono = "0.4"
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8.4"
-ctrlc = { version = "3.1", features = ["termination"] }
+ctrlc = { version = "3.5", features = ["termination"] }
 fb_procfs = "0.7"
 libbpf-rs = "=0.26.0-beta.1"
 nix = { features = ["process", "time"], default-features = false, version = "0.30.1" }
-log = "0.4.17"
-ordered-float = "3.4.0"
+log = "0.4.29"
+ordered-float = "3.9.2"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.0.20" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.0.20" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25" }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 simplelog = "0.12"
-sorted-vec = "0.8.3"
+sorted-vec = "0.8.10"
 static_assertions = "1.1.0"
 
 [build-dependencies]

--- a/tools/scxcash/Cargo.toml
+++ b/tools/scxcash/Cargo.toml
@@ -9,17 +9,17 @@ description = "Cache Usage Analyzer for sched_ext Schedulers"
 build = "build.rs"
 
 [dependencies]
-anyhow = "1.0.65"
-clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
-log = "0.4.17"
-libc = "0.2.175"
+anyhow = "1.0.100"
+clap = { version = "4.5.53", features = ["derive", "env", "unicode", "wrap_help"] }
+log = "0.4.29"
+libc = "0.2.178"
 libbpf-rs = "=0.26.0-beta.1"
 scx_utils = { path = "../../rust/scx_utils", version = "1.0.25" }
-serde = { version = "1.0.215", features = ["derive"] }
-serde_json = "1.0.133"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 simplelog = "0.12"
-ctrlc = "3.1"
-num_cpus = "1.16"
+ctrlc = "3.5"
+num_cpus = "1.17"
 
 [build-dependencies]
 scx_cargo = { path = "../../rust/scx_cargo", version = "1.0.25" }

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -11,8 +11,8 @@ description = "sched_ext scheduler tool for observability"
 ci.use_clippy = true
 
 [dependencies]
-anyhow = "1.0.65"
-clap = { version = "4.5.28", features = [
+anyhow = "1.0.100"
+clap = { version = "4.5.53", features = [
     "derive",
     "cargo",
     "wrap_help",
@@ -20,42 +20,42 @@ clap = { version = "4.5.28", features = [
     "string",
     "unstable-styles",
 ] }
-clap_complete = "4.5.45"
+clap_complete = "4.5.61"
 crossterm = { version = "0.28.1", features = ["serde", "event-stream"] }
 futures = "0.3.31"
-glob = "0.3.2"
+glob = "0.3.3"
 libbpf-rs = "=0.26.0-beta.1"
-libc = "0.2.175"
-log = "0.4.17"
-num-format = { version = "0.4.3", features = ["with-serde", "with-system-locale"] }
+libc = "0.2.178"
+log = "0.4.29"
+num-format = { version = "0.4.4", features = ["with-serde", "with-system-locale"] }
 perfetto_protos = "0.51.1"
 plain = "0.2.3"
 procfs = "0.15.1"
 protobuf = "3.7.2"
 rand = "0.8.5"
 ratatui = { version = "0.29.0", features = ["serde", "macros"] }
-regex = "1.11.2"
+regex = "1.12.2"
 scx_stats = { path = "../../rust/scx_stats", version = "1.0.20" }
 scx_utils = { path = "../../rust/scx_utils", version = "1.0.25" }
 simplelog = "0.12"
-serde_json = "1.0.133"
-serde = { version = "1.0.215", features = ["derive"] }
-signal-hook = "0.3.17"
+serde_json = "1.0.145"
+serde = { version = "1.0.228", features = ["derive"] }
+signal-hook = "0.3.18"
 sysinfo = "0.35.2"
-tokio-util = "0.7.13"
-tokio = { version = "1.42.0", features = ["full"] }
-toml = "0.8.19"
+tokio-util = "0.7.17"
+tokio = { version = "1.48.0", features = ["full"] }
+toml = "0.8.23"
 xdg = "2.5.2"
 log-panics = { version = "2", features = ["with-backtrace"]}
-hashbrown = "0.15.2"
+hashbrown = "0.15.5"
 smartstring = { version = "1.0.1", features = ["serde"] }
 nix = { version = "0.30.1", features = ["time", "user"] }
-blazesym = "0.2.0-rc.4"
-rayon = "1.10"
+blazesym = "0.2.1"
+rayon = "1.11"
 
 [dev-dependencies]
 criterion = "0.6.0"
-tempfile = "3.19.1"
+tempfile = "3.23.0"
 
 [[bench]]
 name = "search_benchmark"

--- a/tools/vmlinux_docify/Cargo.toml
+++ b/tools/vmlinux_docify/Cargo.toml
@@ -8,5 +8,5 @@ description = "A tool to annotate vmlinux.h with documentation from kernel sourc
 publish = false
 
 [dependencies]
-clap = { version = "4.5.28", features = ["derive"] }
+clap = { version = "4.5.53", features = ["derive"] }
 walkdir = "2.5"

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 ci.use_clippy = true
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.100"
 cargo_metadata = "0.23"
-clap = { version = "4.5.28", features = ["derive"] }
-log = "0.4.17"
-regex = "1.11.2"
-serde = { version = "1.0.215", features = ["derive"] }
-serde_json = "1.0.133"
+clap = { version = "4.5.53", features = ["derive"] }
+log = "0.4.29"
+regex = "1.12.2"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 simplelog = "0.12"
-once_cell = "1.20.2"
-toml = "0.8.19"
+once_cell = "1.21.3"
+toml = "0.8.23"


### PR DESCRIPTION
Before releasing the next version, it would be a good idea to bump the crates versions in the .toml files.

`cargo-edit` seems to be a good tool for this—it skips incompatible and pinned versions, updating only what should have no real impact on potential bugs. 

```❯ cargo upgrade --verbose
    Checking virtual workspace's dependencies
    Checking scx_arena's dependencies
name       old req compatible latest  new req note
====       ======= ========== ======  ======= ====
anyhow     1.0.65  1.0.100    1.0.100 1.0.100
libbpf-sys =1.6.1  1.6.1      1.6.2   =1.6.1  pinned
    Checking scx_arena_selftests's dependencies
name   old req compatible latest  new req
====   ======= ========== ======  =======
anyhow 1.0.65  1.0.100    1.0.100 1.0.100
    Checking scx_beerland's dependencies
name   old req compatible latest  new req
====   ======= ========== ======  =======
anyhow 1.0.65  1.0.100    1.0.100 1.0.100
ctrlc  3.1     3.5.1      3.5.1   3.5
clap   4.5.28  4.5.53     4.5.53  4.5.53
log    0.4.17  0.4.29     0.4.29  0.4.29
serde  1.0.215 1.0.228    1.0.228 1.0.228
    Checking scx_bpf_compat's dependencies
name      old req compatible latest  new req
====      ======= ========== ======  =======
anyhow    1.0.65  1.0.100    1.0.100 1.0.100
log       0.4.17  0.4.29     0.4.29  0.4.29
once_cell 1.20.2  1.21.3     1.21.3  1.21.3
    Checking scx_bpf_unittests's dependencies
name       old req compatible latest new req note
====       ======= ========== ====== ======= ====
libbpf-sys =1.6.1  1.6.1      1.6.2  =1.6.1  pinned
cc         1.2.29  1.2.49     1.2.49 1.2.49
indoc      2.0.5   2.0.7      2.0.7  2.0.7
object     0.36.7  0.36.7     0.38.0 0.36.7  incompatible
    Checking scx_bpfland's dependencies
name   old req compatible latest  new req
====   ======= ========== ======  =======
anyhow 1.0.65  1.0.100    1.0.100 1.0.100
ctrlc  3.1     3.5.1      3.5.1   3.5
clap   4.5.28  4.5.53     4.5.53  4.5.53
log    0.4.17  0.4.29     0.4.29  0.4.29
serde  1.0.215 1.0.228    1.0.228 1.0.228
    Checking scx_cargo's dependencies
name               old req compatible latest  new req note
====               ======= ========== ======  ======= ====
anyhow             1.0.65  1.0.100    1.0.100 1.0.100
version-compare    0.1     0.1.1      0.2.1   0.1     incompatible
glob               0.3.2   0.3.3      0.3.3   0.3.3
tracing-subscriber 0.3.20  0.3.22     0.3.22  0.3.22
ruzstd             0.8.1   0.8.2      0.8.2   0.8.2
tempfile           3.19.1  3.23.0     3.23.0  3.23.0
regex              1.11.2  1.12.2     1.12.2  1.12.2
tempfile           3.19.1  3.23.0     3.23.0  3.23.0
    Checking scx_chaos's dependencies
name   old req compatible latest  new req
====   ======= ========== ======  =======
anyhow 1.0.65  1.0.100    1.0.100 1.0.100
clap   4.5.28  4.5.53     4.5.53  4.5.53
ctrlc  3.1     3.5.1      3.5.1   3.5
libc   0.2.175 0.2.178    0.2.178 0.2.178
log    0.4.17  0.4.29     0.4.29  0.4.29
serde  1.0.215 1.0.228    1.0.228 1.0.228
    Checking scx_cosmos's dependencies
name   old req compatible latest  new req
====   ======= ========== ======  =======
anyhow 1.0.65  1.0.100    1.0.100 1.0.100
ctrlc  3.1     3.5.1      3.5.1   3.5
clap   4.5.28  4.5.53     4.5.53  4.5.53
log    0.4.17  0.4.29     0.4.29  0.4.29
serde  1.0.215 1.0.228    1.0.228 1.0.228
    Checking scx_flash's dependencies
name   old req compatible latest  new req
====   ======= ========== ======  =======
anyhow 1.0.65  1.0.100    1.0.100 1.0.100
ctrlc  3.1     3.5.1      3.5.1   3.5
clap   4.5.28  4.5.53     4.5.53  4.5.53
log    0.4.17  0.4.29     0.4.29  0.4.29
serde  1.0.215 1.0.228    1.0.228 1.0.228
    Checking scx_lavd's dependencies
name          old req compatible latest  new req note
====          ======= ========== ======  ======= ====
anyhow        1.0.65  1.0.100    1.0.100 1.0.100
clap          4.5.28  4.5.53     4.5.53  4.5.53
ctrlc         3.1     3.5.1      3.5.1   3.5
itertools     0.13.0  0.13.0     0.14.0  0.13.0  incompatible
libc          0.2.175 0.2.178    0.2.178 0.2.178
ordered-float 3.4.0   3.9.2      5.1.0   3.9.2   incompatible
serde         1.0.215 1.0.228    1.0.228 1.0.228
    Checking scx_layered's dependencies
name       old req compatible latest  new req note
====       ======= ========== ======  ======= ====
anyhow     1.0.65  1.0.100    1.0.100 1.0.100
clap       4.5.28  4.5.53     4.5.53  4.5.53
ctrlc      3.1     3.5.1      3.5.1   3.5
fastrand   2.1.1   2.3.0      2.3.0   2.3.0
fb_procfs  0.7     0.7.1      0.9.0   0.7     incompatible
libc       0.2.175 0.2.178    0.2.178 0.2.178
regex      1.11.2  1.12.2     1.12.2  1.12.2
serde      1.0.215 1.0.228    1.0.228 1.0.228
serde_json 1.0.133 1.0.145    1.0.145 1.0.145
once_cell  1.20.2  1.21.3     1.21.3  1.21.3
sysinfo    0.35.2  0.35.2     0.37.2  0.35.2  incompatible
    Checking scx_mitosis's dependencies
name       old req compatible latest  new req note
====       ======= ========== ======  ======= ====
anyhow     1.0.65  1.0.100    1.0.100 1.0.100
clap       4.5.28  4.5.53     4.5.53  4.5.53
ctrlc      3.1     3.5.1      3.5.1   3.5
itertools  0.13.0  0.13.0     0.14.0  0.13.0  incompatible
libc       0.2.175 0.2.178    0.2.178 0.2.178
serde      1.0.215 1.0.228    1.0.228 1.0.228
serde_json 1.0.133 1.0.145    1.0.145 1.0.145
    Checking scx_p2dq's dependencies
name          old req compatible latest  new req note
====          ======= ========== ======  ======= ====
anyhow        1.0.65  1.0.100    1.0.100 1.0.100
clap          4.5.28  4.5.53     4.5.53  4.5.53
ctrlc         3.1     3.5.1      3.5.1   3.5
libc          0.2.175 0.2.178    0.2.178 0.2.178
ordered-float 3.4.0   3.9.2      5.1.0   3.9.2   incompatible
serde         1.0.215 1.0.228    1.0.228 1.0.228
sorted-vec    0.8.3   0.8.10     0.8.10  0.8.10
    Checking scx_raw_pmu's dependencies
name       old req compatible latest  new req note
====       ======= ========== ======  ======= ====
anyhow     1.0.65  1.0.100    1.0.100 1.0.100
csv        1.3.1   1.4.0      1.4.0   1.4.0
procfs     0.15.1  0.15.1     0.18.0  0.15.1  incompatible
regex      1.11.2  1.12.2     1.12.2  1.12.2
serde      1.0.215 1.0.228    1.0.228 1.0.228
serde_json 1.0.133 1.0.145    1.0.145 1.0.145
tempfile   3.19.1  3.23.0     3.23.0  3.23.0
    Checking scx_rlfifo's dependencies
name   old req compatible latest  new req
====   ======= ========== ======  =======
anyhow 1.0.65  1.0.100    1.0.100 1.0.100
ctrlc  3.1     3.5.1      3.5.1   3.5
libc   0.2.175 0.2.178    0.2.178 0.2.178
    Checking scx_rustland's dependencies
name          old req compatible latest  new req note
====          ======= ========== ======  ======= ====
anyhow        1.0.65  1.0.100    1.0.100 1.0.100
clap          4.5.28  4.5.53     4.5.53  4.5.53
ctrlc         3.1     3.5.1      3.5.1   3.5
libc          0.2.175 0.2.178    0.2.178 0.2.178
log           0.4.17  0.4.29     0.4.29  0.4.29
ordered-float 3.4.0   3.9.2      5.1.0   3.9.2   incompatible
serde         1.0.215 1.0.228    1.0.228 1.0.228
    Checking scx_rustland_core's dependencies
name   old req compatible latest  new req
====   ======= ========== ======  =======
anyhow 1.0.65  1.0.100    1.0.100 1.0.100
libc   0.2.175 0.2.178    0.2.178 0.2.178
    Checking scx_rusty's dependencies
name          old req compatible latest  new req note
====          ======= ========== ======  ======= ====
anyhow        1.0.65  1.0.100    1.0.100 1.0.100
clap          4.5.28  4.5.53     4.5.53  4.5.53
ctrlc         3.1     3.5.1      3.5.1   3.5
fb_procfs     0.7     0.7.1      0.9.0   0.7     incompatible
libc          0.2.175 0.2.178    0.2.178 0.2.178
log           0.4.17  0.4.29     0.4.29  0.4.29
ordered-float 3.4.0   3.9.2      5.1.0   3.9.2   incompatible
serde         1.0.215 1.0.228    1.0.228 1.0.228
sorted-vec    0.8.3   0.8.10     0.8.10  0.8.10
    Checking scx_stats's dependencies
name          old req compatible latest  new req
====          ======= ========== ======  =======
anyhow        1.0.65  1.0.100    1.0.100 1.0.100
libc          0.2.175 0.2.178    0.2.178 0.2.178
log           0.4.17  0.4.29     0.4.29  0.4.29
serde         1.0.215 1.0.228    1.0.228 1.0.228
serde_json    1.0.133 1.0.145    1.0.145 1.0.145
simple_logger 5.0     5.1.0      5.1.0   5.1
    Checking scx_stats_derive's dependencies
name       old req compatible latest  new req
====       ======= ========== ======  =======
serde_json 1.0.133 1.0.145    1.0.145 1.0.145
    Checking scx_tickless's dependencies
name   old req compatible latest  new req
====   ======= ========== ======  =======
anyhow 1.0.65  1.0.100    1.0.100 1.0.100
ctrlc  3.1     3.5.1      3.5.1   3.5
clap   4.5.28  4.5.53     4.5.53  4.5.53
log    0.4.17  0.4.29     0.4.29  0.4.29
serde  1.0.215 1.0.228    1.0.228 1.0.228
    Checking scx_userspace_arena's dependencies
name   old req compatible latest  new req
====   ======= ========== ======  =======
anyhow 1.0.65  1.0.100    1.0.100 1.0.100
    Checking scx_utils's dependencies
name               old req compatible latest  new req note
====               ======= ========== ======  ======= ====
anyhow             1.0.65  1.0.100    1.0.100 1.0.100
clap               4.5.28  4.5.53     4.5.53  4.5.53
glob               0.3.2   0.3.3      0.3.3   0.3.3
log                0.4.17  0.4.29     0.4.29  0.4.29
regex              1.11.2  1.12.2     1.12.2  1.12.2
ruzstd             0.8.1   0.8.2      0.8.2   0.8.2
serde              1.0.215 1.0.228    1.0.228 1.0.228
version-compare    0.1     0.1.1      0.2.1   0.1     incompatible
zbus               5.3.1   5.12.0     5.12.0  5.12.0
tempfile           3.19.1  3.23.0     3.23.0  3.23.0
tracing-subscriber 0.3.20  0.3.22     0.3.22  0.3.22
libc               0.2.175 0.2.178    0.2.178 0.2.178
anyhow             1.0.65  1.0.100    1.0.100 1.0.100
glob               0.3.2   0.3.3      0.3.3   0.3.3
ruzstd             0.8.1   0.8.2      0.8.2   0.8.2
tempfile           3.19.1  3.23.0     3.23.0  3.23.0
vergen             8.0.0   8.3.2      9.0.6   8.3.2   incompatible
version-compare    0.1     0.1.1      0.2.1   0.1     incompatible
    Checking scx_wd40's dependencies
name          old req compatible latest  new req note
====          ======= ========== ======  ======= ====
anyhow        1.0.65  1.0.100    1.0.100 1.0.100
clap          4.5.28  4.5.53     4.5.53  4.5.53
ctrlc         3.1     3.5.1      3.5.1   3.5
fb_procfs     0.7     0.7.1      0.9.0   0.7     incompatible
log           0.4.17  0.4.29     0.4.29  0.4.29
ordered-float 3.4.0   3.9.2      5.1.0   3.9.2   incompatible
serde         1.0.215 1.0.228    1.0.228 1.0.228
sorted-vec    0.8.3   0.8.10     0.8.10  0.8.10
    Checking scxcash's dependencies
name       old req compatible latest  new req
====       ======= ========== ======  =======
anyhow     1.0.65  1.0.100    1.0.100 1.0.100
clap       4.5.28  4.5.53     4.5.53  4.5.53
log        0.4.17  0.4.29     0.4.29  0.4.29
libc       0.2.175 0.2.178    0.2.178 0.2.178
serde      1.0.215 1.0.228    1.0.228 1.0.228
serde_json 1.0.133 1.0.145    1.0.145 1.0.145
ctrlc      3.1     3.5.1      3.5.1   3.5
num_cpus   1.16    1.17.0     1.17.0  1.17
    Checking scxtop's dependencies
name          old req    compatible latest  new req note
====          =======    ========== ======  ======= ====
anyhow        1.0.65     1.0.100    1.0.100 1.0.100
clap          4.5.28     4.5.53     4.5.53  4.5.53
clap_complete 4.5.45     4.5.61     4.5.61  4.5.61
crossterm     0.28.1     0.28.1     0.29.0  0.28.1  incompatible
glob          0.3.2      0.3.3      0.3.3   0.3.3
libc          0.2.175    0.2.178    0.2.178 0.2.178
log           0.4.17     0.4.29     0.4.29  0.4.29
num-format    0.4.3      0.4.4      0.4.4   0.4.4
procfs        0.15.1     0.15.1     0.18.0  0.15.1  incompatible
rand          0.8.5      0.8.5      0.9.2   0.8.5   incompatible
regex         1.11.2     1.12.2     1.12.2  1.12.2
serde_json    1.0.133    1.0.145    1.0.145 1.0.145
serde         1.0.215    1.0.228    1.0.228 1.0.228
signal-hook   0.3.17     0.3.18     0.3.18  0.3.18
sysinfo       0.35.2     0.35.2     0.37.2  0.35.2  incompatible
tokio-util    0.7.13     0.7.17     0.7.17  0.7.17
tokio         1.42.0     1.48.0     1.48.0  1.48.0
toml          0.8.19     0.8.23     0.9.9   0.8.23  incompatible
xdg           2.5.2      2.5.2      3.0.0   2.5.2   incompatible
hashbrown     0.15.2     0.15.5     0.16.1  0.15.5  incompatible
blazesym      0.2.0-rc.4 0.2.1      0.2.1   0.2.1
rayon         1.10       1.11.0     1.11.0  1.11
criterion     0.6.0      0.6.0      0.8.1   0.6.0   incompatible
tempfile      3.19.1     3.23.0     3.23.0  3.23.0
    Checking vmlinux_docify's dependencies
name old req compatible latest new req
==== ======= ========== ====== =======
clap 4.5.28  4.5.53     4.5.53 4.5.53
    Checking xtask's dependencies
name       old req compatible latest  new req note
====       ======= ========== ======  ======= ====
anyhow     1.0.65  1.0.100    1.0.100 1.0.100
clap       4.5.28  4.5.53     4.5.53  4.5.53
log        0.4.17  0.4.29     0.4.29  0.4.29
regex      1.11.2  1.12.2     1.12.2  1.12.2
serde      1.0.215 1.0.228    1.0.228 1.0.228
serde_json 1.0.133 1.0.145    1.0.145 1.0.145
once_cell  1.20.2  1.21.3     1.21.3  1.21.3
toml       0.8.19  0.8.23     0.9.9   0.8.23  incompatible
   Upgrading recursive dependencies
     Locking 5 packages to latest compatible versions
    Updating bumpalo v3.19.0 -> v3.19.1
    Updating camino v1.2.1 -> v1.2.2
    Updating toml_datetime v0.7.3 -> v0.7.4+spec-1.0.0
    Updating toml_edit v0.23.9 -> v0.23.10+spec-1.0.0
    Updating toml_parser v1.0.4 -> v1.0.5+spec-1.0.0
    Removing windows-core v0.62.2
    Removing windows-result v0.4.1
    Removing windows-strings v0.5.1
note: pass `--verbose` to see 10 unchanged dependencies behind latest
note: Re-run with `--pinned` to upgrade pinned version requirements
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  latest: 55 packages
  local: scx_stats_derive
❯ cargo update --verbose
    Updating crates.io index
     Locking 5 packages to latest compatible versions
   Unchanged criterion v0.6.0 (available: v0.8.1)
   Unchanged crossterm v0.28.1 (available: v0.29.0)
   Unchanged fb_procfs v0.7.1 (available: v0.9.0)
   Unchanged hashbrown v0.15.5 (available: v0.16.1)
   Unchanged itertools v0.13.0 (available: v0.14.0)
   Unchanged libbpf-sys v1.6.1+v1.6.1 (available: v1.6.2+v1.6.2)
    Updating libredox v0.1.10 -> v0.1.11
   Unchanged object v0.36.7 (available: v0.38.0)
   Unchanged ordered-float v3.9.2 (available: v5.1.0)
   Unchanged procfs v0.15.1 (available: v0.18.0)
   Unchanged rand v0.8.5 (available: v0.9.2)
      Adding redox_syscall v0.6.0
   Unchanged sysinfo v0.35.2 (available: v0.37.2)
   Unchanged toml v0.8.23 (available: v0.9.9+spec-1.0.0)
   Unchanged unicode-width v0.2.0 (available: v0.2.2)
   Unchanged vergen v8.3.2 (available: v9.0.6)
   Unchanged version-compare v0.1.1 (available: v0.2.1)
      Adding windows-core v0.62.2
      Adding windows-result v0.4.1
      Adding windows-strings v0.5.1
   Unchanged xdg v2.5.2 (available: v3.0.0)
note: to see how you depend on a package, run `cargo tree --invert <dep>@<ver>`
```