### PR TITLE
chore(spelling): fix typos across schedulers, libs, and tools

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,6 +1,6 @@
 # Breaking Changes
 
-[`sched_ext`](https://github.com/sched-ext/scx) is still experimental and while we're trying to reduce the number of breaking changes, sometimes they're neccessary to fix bugs or improve the usability.
+[`sched_ext`](https://github.com/sched-ext/scx) is still experimental and while we're trying to reduce the number of breaking changes, sometimes they're necessary to fix bugs or improve the usability.
 
 Below are the changes in both the `sched_ext` kernel tree and the associated commits in this repo.
 

--- a/lib/ravg.bpf.c
+++ b/lib/ravg.bpf.c
@@ -163,7 +163,7 @@ u64 u64_x_u32_rshift(u64 a, u32 b, u32 rshift)
 /**
  * ravg_scale - Scale a running avg
  * @rd: ravg_data to scale
- * @mult: multipler
+ * @mult: multiplier
  * @rshift: right shift amount
  *
  * Scale @rd by multiplying the tracked values by @mult and shifting right by
@@ -215,7 +215,7 @@ u64 ravg_read(struct ravg_data *rd, u64 now, u64 half_life)
 	/*
 	 * At the beginning of a new half_life period, the running avg is the
 	 * same as @rd->old. At the beginning of the next, it'd be old load / 2
-	 * + current load / 2. Inbetween, we blend the two linearly.
+	 * + current load / 2. In between, we blend the two linearly.
 	 */
 	if (elapsed) {
 		u32 progress = ravg_normalize_dur(elapsed, half_life);

--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -151,7 +151,7 @@ int scx_alloc_attempt(struct scx_alloc_stack __arena *stack)
 	/*
 	 * Use can_loop to help with verification. The can_loop macro was
 	 * introduced in kernel commit ba39486 and wraps around the may_goto
-	 * instruction that helps with verifiying for loops. Using may_goto
+	 * instruction that helps with verifying for loops. Using may_goto
 	 * embeds a switch into the loop that ensures it is considered
 	 * terminable by the verifier by adding a hidden switch to the loop
 	 * and counting down with every iteration.

--- a/lib/topology.bpf.c
+++ b/lib/topology.bpf.c
@@ -10,7 +10,7 @@ volatile topo_ptr topo_all;
 /*
  * XXXETSAL: This is a (hopefully) temporary measure that
  * makes it easier to integrate with existing schedulers that
- * use arbitraty IDs to index CPUs/LLCs/nodes. In the future we 
+ * use arbitrary IDs to index CPUs/LLCs/nodes. In the future we
  * will just keep a CPU id to CPU topology node array, but for
  * now we will have an array for each level.
  */

--- a/rust/scx_arena/scx_arena/src/arenalib.rs
+++ b/rust/scx_arena/scx_arena/src/arenalib.rs
@@ -24,7 +24,7 @@ use libbpf_rs::Object;
 use libbpf_rs::ProgramInput;
 use libbpf_rs::ProgramMut;
 
-// MAX_CPU_ARRSZ has to be big enough to accomodate all present CPUs.
+// MAX_CPU_ARRSZ has to be big enough to accommodate all present CPUs.
 // Even if it's larger than the size of cpumask_t, we truncate any
 // invalid data when passing it to the kernel's topology init functions.
 /// Maximum length of CPU mask supported by the library in bits.

--- a/rust/scx_bpf_unittests/build.rs
+++ b/rust/scx_bpf_unittests/build.rs
@@ -23,7 +23,7 @@ fn main() {
         root_dir.join("scheds/vmlinux/arch/x86/"),
         root_dir.join("scheds/include/bpf-compat/"),
         env::var("DEP_BPF_INCLUDE")
-            .expect("libbpf-sys include must be avaiable")
+            .expect("libbpf-sys include must be available")
             .into(),
     ];
 

--- a/rust/scx_cargo/src/bpf_builder.rs
+++ b/rust/scx_cargo/src/bpf_builder.rs
@@ -79,7 +79,7 @@ use tracing_subscriber::{filter, layer::SubscriberExt, Layer};
 /// - `src/main.rs`: Rust userspace component which loads the BPF blob and
 /// interacts it using the generated bindings.
 ///
-/// - `src/bpf/intf.h`: C header file definining constants and structs
+/// - `src/bpf/intf.h`: C header file defining constants and structs
 /// that will be used by both the BPF and userspace components.
 ///
 /// - `src/bpf/main.c`: C source code implementing the BPF component -
@@ -155,11 +155,11 @@ use tracing_subscriber::{filter, layer::SubscriberExt, Layer};
 ///
 /// - `BPF_BASE_CFLAGS`: Override the non-include part of cflags.
 ///
-/// - `BPF_EXTRA_CFLAGS_PRE_INCL`: Add cflags before the automic include
+/// - `BPF_EXTRA_CFLAGS_PRE_INCL`: Add cflags before the automatic include
 ///   search path options. Header files in the search paths added by this
-///   variable will supercede the automatic ones.
+///   variable will supersede the automatic ones.
 ///
-/// - `BPF_EXTRA_CFLAGS_POST_INCL`: Add cflags after the automic include
+/// - `BPF_EXTRA_CFLAGS_POST_INCL`: Add cflags after the automatic include
 ///   search path options. Header paths added by this variable will be
 ///   searched only if the target header file can't be found in the
 ///   automatic header paths.

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -579,7 +579,7 @@ s32 BPF_STRUCT_OPS(rustland_select_cpu, struct task_struct *p, s32 prev_cpu,
 
 	/*
 	 * If built-in idle CPU policy is not enabled, completely delegate
-	 * the idle selection policy to user-space and keep re-using the
+	 * the idle selection policy to user-space and keep reusing the
 	 * same CPU here.
 	 */
 	if (!builtin_idle)

--- a/rust/scx_rustland_core/src/alloc.rs
+++ b/rust/scx_rustland_core/src/alloc.rs
@@ -227,7 +227,7 @@ impl BuddyAlloc {
             let leaf2base = log2(leaf_size);
             base_addr = roundup(base_addr, leaf2base);
             // we use (k + 1)-th entry's split flag to test existence of k-th entry's blocks;
-            // to accoding this convention, we make a dummy (entries_size - 1)-th entry.
+            // according to this convention, we make a dummy (entries_size - 1)-th entry.
             // so we plus 2 on entries_size.
             let entries_size = log2((end_addr - base_addr) >> leaf2base) + 2;
 

--- a/rust/scx_stats/examples/server.rs
+++ b/rust/scx_stats/examples/server.rs
@@ -57,7 +57,7 @@ fn main() {
                 let res = tx.send(id);
                 debug!("Sendt {:?} {:?}", id, res);
                 let res = rx.recv();
-                debug!("Recevied {:?}", res);
+                debug!("Received {:?}", res);
                 stats.to_json()
             }),
         );

--- a/rust/scx_stats/src/server.rs
+++ b/rust/scx_stats/src/server.rs
@@ -276,7 +276,7 @@ where
             return Ok(());
         }
 
-        // Null visit checks all nested stats are reacheable without loops.
+        // Null visit checks all nested stats are reachable without loops.
         self.visit_meta(self.top.as_ref().unwrap(), &mut |_| Ok(()))
     }
 

--- a/rust/scx_utils/src/perf.rs
+++ b/rust/scx_utils/src/perf.rs
@@ -13,7 +13,7 @@ use std::os::raw::{c_int, c_ulong};
 /// `std::io::Error::last_os_error`) is set to indicate the error.
 ///
 /// Note: The `attrs` argument needs to be a `*mut` because if the `size` field
-/// is too small or too large, the kernel writes the size it was expecing back
+/// is too small or too large, the kernel writes the size it was expecting back
 /// into that field. It might do other things as well.
 ///
 /// # Safety

--- a/scheds/c/scx_nest.bpf.c
+++ b/scheds/c/scx_nest.bpf.c
@@ -6,7 +6,7 @@
  * [0]: https://hal.inria.fr/hal-03612592/file/paper.pdf
  *
  * It operates as a global weighted vtime scheduler (similarly to CFS), while
- * using the Nest algorithm to choose idle cores at wakup time.
+ * using the Nest algorithm to choose idle cores at wakeup time.
  *
  * It also demonstrates the following niceties.
  *
@@ -650,4 +650,3 @@ SCX_OPS_DEFINE(nest_ops,
 	       .exit			= (void *)nest_exit,
 	       .flags			= 0,
 	       .name			= "nest");
-

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -173,7 +173,7 @@ static inline long scx_hotplug_seq(void)
 /*
  * New versions of bpftool now emit additional link placeholders for BPF maps,
  * and set up BPF skeleton in such a way that libbpf will auto-attach BPF maps
- * automatically, assumming libbpf is recent enough (v1.5+). Old libbpf will do
+ * automatically, assuming libbpf is recent enough (v1.5+). Old libbpf will do
  * nothing with those links and won't attempt to auto-attach maps.
  *
  * To maintain compatibility with older libbpf while avoiding trying to attach

--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -79,7 +79,7 @@ const volatile u64 preferred_cpus[MAX_CPUS];
 const volatile bool cpufreq_enabled = true;
 
 /*
- * Enable NUMA optimizatons.
+ * Enable NUMA optimizations.
  */
 const volatile bool numa_enabled;
 

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -1024,7 +1024,7 @@ static s32 pick_idle_cpu(struct task_struct *p, struct task_ctx *tctx,
 
 	/*
 	 * If a full-idle core can't be found (or if this is not an SMT system)
-	 * try to re-use the same CPU, even if it's not in a full-idle core.
+	 * try to reuse the same CPU, even if it's not in a full-idle core.
 	 */
 	if (is_prev_allowed &&
 	    scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
@@ -1627,7 +1627,7 @@ static void update_cpu_load(struct task_struct *p, struct task_ctx *tctx)
 	perf_lvl = MIN(delta_runtime * SCX_CPUPERF_ONE / delta_t, SCX_CPUPERF_ONE);
 
 	/*
-	 * Use a moving average to evalute the target performance level,
+	 * Use a moving average to evaluate the target performance level,
 	 * giving more priority to the current average, so that we can
 	 * react faster at CPU load variations and at the same time smooth
 	 * the short spikes.

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -199,7 +199,7 @@ struct Opts {
 
     /// Utilization percentage to consider a CPU as busy (-1 = auto).
     ///
-    /// A value close to 0 forces tasks to migrate quickier, increasing work conservation and
+    /// A value close to 0 forces tasks to migrate quicker, increasing work conservation and
     /// potentially system responsiveness.
     ///
     /// A value close to 100 makes tasks more sticky to their CPU, increasing cache-sensivite and

--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -127,7 +127,7 @@ bool init_idle_ato_masks(struct pick_ctx *ctx, const struct cpumask *idle_mask)
 	ctx->ia_mask = ctx->cpuc_cur->tmp_t_mask;
 	ctx->io_mask = ctx->cpuc_cur->tmp_t2_mask;
 	ctx->iat_mask = ctx->cpuc_cur->tmp_t3_mask;
-	ctx->temp_mask = ctx->cpuc_cur->tmp_l_mask; /* l_mask is no longer used, recyle it. */
+	ctx->temp_mask = ctx->cpuc_cur->tmp_l_mask; /* l_mask is no longer used, recycle it. */
 	if (!ctx->ia_mask || !ctx->io_mask || !ctx->iat_mask || !ctx->temp_mask)
 		return false;
 
@@ -395,7 +395,7 @@ bool is_sync_wakeup(struct pick_ctx *ctx)
 	return true;
 }
 
-static 
+static
 s32 find_sticky_cpu_and_cpdom(struct pick_ctx *ctx, s64 *sticky_cpdom)
 {
 	struct cpu_ctx *p0, *p1, *cpuc;
@@ -560,19 +560,19 @@ s32 __attribute__ ((noinline)) pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle
 	/*
 	 * At the high level, the idle CPU selection policy considers the
 	 * following factors:
-	 * 
+	 *
 	 * 1) Current active and overflow set: Stay on the current active and
 	 *    overflow sets if a task can run on them.
-	 * 
+	 *
 	 * 2) CPU preference order: If a task cannot run on the current active
 	 *    or overflow set, extend the overflow set following the CPU
 	 *    preference order (performance mode vs. power-save mode).
-	 * 
+	 *
 	 * 3) CPU type vs. task type: If possible, try to run a task on the
 	 *    matching CPU type (i.e., a big task on a big core vs. a little
 	 *    task on a little core). If the matching CPUs are not active,
 	 *    stay on the previous CPU.
-	 * 
+	 *
 	 * 4) Fully idle CPU vs. partially idle CPU: Choose a fully idle CPU
 	 *    over a partially idle CPU within the previous CPU's domain.
 	 *
@@ -581,7 +581,7 @@ s32 __attribute__ ((noinline)) pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle
 	 *    good for cache locality because the waker task hands over the CPU
 	 *    to the wakee task for the further processing after finishing
 	 *    its job.
-	 * 
+	 *
 	 * 6) Minimize cross-domain migration: Before migrating to a neighbor
 	 *    domain, try to find an (any) idle CPU on the current domain.
 	 *    Migrate a task to another domain only when the current sticky

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -128,7 +128,7 @@ struct task_ctx {
 	/* --- cacheline 0 boundary (0 bytes) --- */
 	/*
 	 * Do NOT change the position of atq. It should be at the beginning
-	 * of the task_ctx. 
+	 * of the task_ctx.
 	 */
 	struct scx_task_common atq __attribute__((aligned(CACHELINE_SIZE)));
 
@@ -185,7 +185,7 @@ struct cpdom_ctx {
 
 	/* --- cacheline 8 boundary (512 bytes): read-write, read-mostly --- */
 	u8	is_stealer __attribute__((aligned(CACHELINE_SIZE))); /* this domain should steal tasks from others */
-	u8	is_stealee;			    /* stealer doamin should steal tasks from this domain */
+	u8	is_stealee;			    /* stealer domain should steal tasks from this domain */
 	u16	nr_active_cpus;			    /* the number of active CPUs in this compute domain */
 	u16	nr_acpus_temp;			    /* temp for nr_active_cpus */
 	u32	sc_load;			    /* scaled load considering DSQ length and CPU utilization */
@@ -229,7 +229,7 @@ struct cpu_ctx {
 	volatile u64	sum_perf_cri;	/* sum of performance criticality */
 
 	/* --- cacheline 1 boundary (64 bytes) --- */
-	volatile u32	min_perf_cri;	/* mininum performance criticality */
+	volatile u32	min_perf_cri;	/* minimum performance criticality */
 	volatile u32	max_perf_cri;	/* maximum performance criticality */
 	volatile u32	nr_sched;	/* number of schedules */
 	volatile u32	nr_preempt;

--- a/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
@@ -77,7 +77,7 @@ void reset_lock_futex_boost(task_ctx *taskc, struct cpu_ctx *cpuc)
  * Trace futex_wait() and futex_wake() variants similar as in-kernel lock
  * and unlock. However, in the case of futex, the user-level implementation,
  * like NTPL, can skip futex_wait() and futex_wake() for performance
- * optimization to reduce syscall overhead. Hence, tracing only the 
+ * optimization to reduce syscall overhead. Hence, tracing only the
  * kernel-side futex calls reveals incomplete user-level lock status. Also,
  * futex's spurious wake-up further complicates the problem; a lock holder
  * can call futex_wait() more than once for a single lock acquisition.
@@ -115,7 +115,7 @@ void reset_lock_futex_boost(task_ctx *taskc, struct cpu_ctx *cpuc)
  */
 
 /*
- * We trace the folloing futex calls:
+ * We trace the following futex calls:
  * - int __futex_wait(u32 *uaddr, unsigned int flags, u32 val, struct hrtimer_sleeper *to, u32 bitset)
  * - int futex_wait_multiple(struct futex_vector *vs, unsigned int count, struct hrtimer_sleeper *to)
  * - int futex_wait_requeue_pi(u32 *uaddr, unsigned int flags, u32 val, ktime_t *abs_time, u32 bitset, u32 *uaddr2)
@@ -149,9 +149,9 @@ int BPF_PROG(fexit_futex_wait_multiple, struct futex_vector *vs, unsigned int co
 		 * All of futexes are acquired.
 		 *
 		 * We don't want to traverse futex_vector here since that's
-		 * a userspace address. Hence we just pass an invalid adderess
+		 * a userspace address. Hence we just pass an invalid address
 		 * to consider all futex_waitv() calls are for the same address.
-		 * Thit is a conservative approximation boosting less.
+		 * This is a conservative approximation boosting less.
 		 */
 		inc_futex_boost();
 	}
@@ -221,7 +221,7 @@ int BPF_PROG(fexit_futex_unlock_pi, u32 *uaddr, unsigned int flags, int ret)
 
 
 /*
- * We trace the folloing futex tracepoints:
+ * We trace the following futex tracepoints:
  * - sys_exit_futex
  * - sys_exit_futex_wait
  * - sys_exit_futex_waitv

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -721,7 +721,7 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 	 * Under the CPU bandwidth control with cpu.max, check if the cgroup
 	 * is throttled before executing the task.
 	 *
-	 * Note that we calculate the task's deadline before checking the 
+	 * Note that we calculate the task's deadline before checking the
 	 * cgroup, as we need the deadline to put aside the task when the
 	 * cgroup is throttled.
 	 *
@@ -1487,7 +1487,7 @@ void BPF_STRUCT_OPS(lavd_update_idle, s32 cpu, bool idle)
 			 * timer already took the idle_time duration. However,
 			 * instead of dropping out, the logic here still needs
 			 * to retry to ensure the cpuc->idle_start_clk is
-			 * updated to 0 or the timer will continute accumulating
+			 * updated to 0 or the timer will continue accumulating
 			 * the idle_time for an already activated CPU.
 			 */
 			bool ret = __sync_bool_compare_and_swap(
@@ -1619,7 +1619,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init_task, struct task_struct *p,
 	 * When @p becomes under the SCX control (e.g., being forked), @p's
 	 * context data is initialized. We can sleep in this function and the
 	 * following will automatically use GFP_KERNEL.
-	 * 
+	 *
 	 * Return 0 on success.
 	 * Return -ESRCH if @p is invalid.
 	 * Return -ENOMEM if context allocation fails.
@@ -1628,7 +1628,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init_task, struct task_struct *p,
 		scx_bpf_error("NULL task_struct pointer received");
 		return -ESRCH;
 	}
-	
+
 	taskc = scx_task_alloc(p);
 	if (!taskc) {
 		scx_bpf_error("task_ctx_stor first lookup failed");
@@ -1801,7 +1801,7 @@ static s32 init_per_cpu_ctx(u64 now)
 	}
 
 	/*
-	 * Initilize CPU info
+	 * Initialize CPU info
 	 */
 	one_little_capacity = LAVD_SCALE;
 	bpf_for(cpu, 0, nr_cpu_ids) {
@@ -1925,7 +1925,7 @@ static s32 init_per_cpu_ctx(u64 now)
 	}
 
 	/*
-	 * Print some useful informatin for debugging.
+	 * Print some useful information for debugging.
 	 */
 	bpf_for(cpu, 0, nr_cpu_ids) {
 		cpuc = get_cpu_ctx_id(cpu);
@@ -2108,7 +2108,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init)
 	init_autopilot_caps();
 
 	/*
-	 * Initilize the current logical clock and service time.
+	 * Initialize the current logical clock and service time.
 	 */
 	WRITE_ONCE(cur_logical_clk, 0);
 	WRITE_ONCE(cur_svc_time, 0);
@@ -2163,4 +2163,3 @@ SCX_OPS_DEFINE(lavd_ops,
 	       .exit			= (void *)lavd_exit,
 	       .timeout_ms		= 30000U,
 	       .name			= "lavd");
-

--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -52,7 +52,7 @@ private(LAVD) struct bpf_cpumask cpdom_cpumask[LAVD_CPDOM_MAX_NR];
 /* Do not use energy model in making CPU preference order decisions. */
 const volatile u8	no_use_em;
 
-/* The numbr of PCO states populated */
+/* The number of PCO states populated */
 const volatile u8	nr_pco_states;
 
 /* The upper bounds of performance capacity for each PCO state. */
@@ -406,7 +406,7 @@ int update_power_mode_time(void)
 		__sync_fetch_and_add(&powersave_mode_ns, delta);
 		break;
 	}
-	
+
 	return 0;
 }
 
@@ -832,5 +832,3 @@ int set_power_profile(struct power_arg *input)
 {
 	return do_set_power_profile(input->power_mode);
 }
-
-

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -167,7 +167,7 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 
 		/*
 		 * Accumulate cpus' scaled loads,
-		 * whcih is capacity and frequency invariant.
+		 * which is capacity and frequency invariant.
 		 */
 		c->tot_sc_time += cpuc_tot_sc_time;
 
@@ -238,7 +238,7 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 
 		/*
 		 * If the CPU is in an idle state (i.e., idle_start_clk is
-		 * non-zero), accumulate the current idle peirod so far.
+		 * non-zero), accumulate the current idle period so far.
 		 */
 		for (int i = 0; i < LAVD_MAX_RETRY; i++) {
 			u64 old_clk = cpuc->idle_start_clk;
@@ -256,7 +256,7 @@ static void collect_sys_stat(struct sys_stat_ctx *c)
 		}
 
 		/*
-		 * Calculcate per-CPU utilization.
+		 * Calculate per-CPU utilization.
 		 */
 		compute = time_delta(c->duration, cpuc->idle_total);
 
@@ -535,5 +535,3 @@ s32 init_sys_stat(u64 now)
 
 	return 0;
 }
-
-

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -100,7 +100,7 @@ u64 __attribute__ ((noinline)) calc_avg(u64 old_val, u64 new_val)
 u64 __attribute__ ((noinline)) calc_asym_avg(u64 old_val, u64 new_val)
 {
 	/*
-	 * Increase fast but descrease slowly.
+	 * Increase fast but decrease slowly.
 	 */
 	if (old_val < new_val)
 		return __calc_avg(new_val, old_val, 2);

--- a/scheds/rust/scx_lavd/src/cpu_order.rs
+++ b/scheds/rust/scx_lavd/src/cpu_order.rs
@@ -209,7 +209,7 @@ impl CpuOrderCtx {
             //     * prefer more capable CPU with higher capacity
             //       and larger cache
             //         - ^cpu_cap (chip binning), ^cache_size,
-            //     * prefere the SMT core within the same performance domain
+            //     * prefer the SMT core within the same performance domain
             //         - pd_adx, core_rdx, ^smt_level, cpu_rdx
             (true, false) => {
                 cpu_ids.sort_by(|a, b| {
@@ -230,7 +230,7 @@ impl CpuOrderCtx {
             //         - numa_adx, llc_rdx,
             //     * prefer energy-efficient LITTLE CPU with a larger cache
             //         - cpu_cap (big/little), ^cache_size,
-            //     * prefere the SMT core within the same performance domain
+            //     * prefer the SMT core within the same performance domain
             //         - pd_adx, core_rdx, ^smt_level, cpu_rdx
             (true, true) => {
                 cpu_ids.sort_by(|a, b| {
@@ -1027,7 +1027,7 @@ impl<'a> EnergyModelOptimizer<'a> {
         }
         pds_set.append(&mut xset);
 
-        // Sort the pds_set for easy comparision.
+        // Sort the pds_set for easy comparison.
         pds_set.sort();
     }
 }
@@ -1083,7 +1083,7 @@ impl<'a> PDSetInfo<'_> {
             pd_id_set.insert(pds.pd.id);
         }
 
-        // Create a pdcpu_set, so first gather the same PDS entires.
+        // Create a pdcpu_set, so first gather the same PDS entries.
         let mut pds_map: BTreeMap<PDS<'a>, RefCell<Vec<PDS<'a>>>> = BTreeMap::new();
 
         for pds in pds_set.iter() {

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -75,7 +75,7 @@ const SCHEDULER_NAME: &str = "scx_lavd";
 /// See the more detailed overview of the LAVD design at main.bpf.c.
 #[derive(Debug, Parser)]
 struct Opts {
-    /// Depricated, noop, use RUST_LOG or --log-level instead.
+    /// Deprecated, noop, use RUST_LOG or --log-level instead.
     #[clap(short = 'v', long, action = clap::ArgAction::Count)]
     verbose: u8,
 
@@ -965,7 +965,7 @@ fn main(mut opts: Opts) -> Result<()> {
     init_log(&opts);
 
     if opts.verbose > 0 {
-        warn!("Setting verbose via -v is depricated and will be an error in future releases.");
+        warn!("Setting verbose via -v is deprecated and will be an error in future releases.");
     }
 
     if let Some(run_id) = opts.run_id {

--- a/scheds/rust/scx_layered/README.md
+++ b/scheds/rust/scx_layered/README.md
@@ -54,7 +54,7 @@ and turbo is enabled.
 
 Layer affinities can be defined using the `nodes` or `llcs` layer configs. This
 allows for restricting a layer to a NUMA node or LLC. Layers will by default
-attempt to grow within the same NUMA node, however this may change to suppport
+attempt to grow within the same NUMA node, however this may change to support
 different layer growth strategies in the future. When tuning the `util_range`
 for a layer there should be some consideration for how the layer should grow.
 For example, if the `util_range` lower bound is too high, it may lead to the

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2076,7 +2076,7 @@ bool antistall_consume(struct cpu_ctx *cpuc)
 	antistall_dsq = bpf_map_lookup_elem(&antistall_cpu_dsq, &zero_u32);
 
 	if (!antistall_dsq) {
-		scx_bpf_error("cant happen");
+		scx_bpf_error("can't happen");
 		return false;
 	}
 
@@ -2183,7 +2183,7 @@ static __always_inline bool try_consume_layer(u32 layer_id, struct cpu_ctx *cpuc
 		return false;
 
 	/*
-	 * If a layer is confined, and the CPU doens't belong to it, we shouldn't
+	 * If a layer is confined, and the CPU doesn't belong to it, we shouldn't
 	 * consume from it.
 	 */
 	if (layer->kind == LAYER_KIND_CONFINED && cpuc->layer_id != layer_id)
@@ -3463,8 +3463,8 @@ s32 BPF_STRUCT_OPS(layered_init_task, struct task_struct *p,
 	taskc->qrt_layer_id = MAX_LLCS;
 	taskc->qrt_llc_id = MAX_LLCS;
 
-	/* 
-	 * Necessary for GPU membership logic. The field is overwritten during 
+	/*
+	 * Necessary for GPU membership logic. The field is overwritten during
 	 * .running() and read during .stopping(), so this value is only visible
 	 * from the GPU membership kprobes.
 	 */
@@ -3592,7 +3592,7 @@ void BPF_STRUCT_OPS(layered_dump, struct scx_dump_ctx *dctx)
 	bpf_for(i, 0, nr_layers) {
 		layer = lookup_layer(i);
 		if (!layer) {
-			scx_bpf_error("unabled to lookup layer %d", i);
+			scx_bpf_error("unable to lookup layer %d", i);
 			return;
 		}
 
@@ -3690,7 +3690,7 @@ u64 antistall_set(u64 dsq_id, u64 jiffies_now)
 			delay = bpf_map_lookup_percpu_elem(&antistall_cpu_max_delay, &zero_u32, cpu);
 
 			if (!antistall_dsq || !delay) {
-				scx_bpf_error("cant happen");
+				scx_bpf_error("can't happen");
 				goto unlock;
 			}
 
@@ -3745,7 +3745,7 @@ static u64 antistall_scan(void)
 
 /*
  * Timer callback that runs all registered timers. If a timer returns a non
- * zero value it is rerun after the return value (in nanosecods).
+ * zero value it is rerun after the return value (in nanoseconds).
  */
 u64 run_timer_cb(int key)
 {
@@ -3948,7 +3948,7 @@ static s32 init_layer(int layer_id)
 	}
 
 	if ((ret = init_layer_cpumasks(layer_id))) {
-		scx_bpf_error("could not initalize cpumasks");
+		scx_bpf_error("could not initialize cpumasks");
 		return ret;
 	}
 

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -570,7 +570,7 @@ lazy_static! {
 #[derive(Debug, Parser)]
 #[command(verbatim_doc_comment)]
 struct Opts {
-    /// Depricated, noop, use RUST_LOG or --log-level instead.
+    /// Deprecated, noop, use RUST_LOG or --log-level instead.
     #[clap(short = 'v', long, action = clap::ArgAction::Count)]
     verbose: u8,
 
@@ -654,7 +654,7 @@ struct Opts {
     /// Low priority fallback DSQs are used to execute tasks with custom CPU
     /// affinities. These DSQs are immediately executed iff a CPU is
     /// otherwise idle. However, after the specified wait, they are
-    /// guranteed upto --lo-fb-share fraction of each CPU.
+    /// guaranteed upto --lo-fb-share fraction of each CPU.
     #[clap(long, default_value = "10000")]
     lo_fb_wait_us: u64,
 
@@ -692,7 +692,7 @@ struct Opts {
     enable_gpu_support: bool,
 
     /// Gpu Kprobe Level
-    /// The value set here determines how agressive
+    /// The value set here determines how aggressive
     /// the kprobes enabled on gpu driver functions are.
     /// Higher values are more aggressive, incurring more system overhead
     /// and more accurately identifying PIDs using GPUs in a more timely manner.
@@ -1505,7 +1505,7 @@ struct NodeInfo {
 
 #[derive(Debug)]
 struct GpuTaskAffinitizer {
-    // This struct tracks information neccessary to numa affinitize
+    // This struct tracks information necessary to numa affinitize
     // gpu tasks periodically when needed.
     gpu_devs_to_node_info: HashMap<u32, NodeInfo>,
     gpu_pids_to_devs: HashMap<Pid, u32>,
@@ -2274,7 +2274,7 @@ impl<'a> Scheduler<'a> {
             sys_order.retain(|id| !node_order.contains(id));
             node_order.retain(|&id| id != llc_id);
 
-            // Shufle so that different LLCs follow different orders. See
+            // Shuffle so that different LLCs follow different orders. See
             // init_cpu_prox_map().
             fastrand::seed(llc_id as u64);
             fastrand::shuffle(&mut sys_order);
@@ -3361,7 +3361,7 @@ impl<'a> Scheduler<'a> {
 
         // Grow layers. Do so in the ascending target number of CPUs order
         // so that we're always more generous to smaller layers. This avoids
-        // starving small layers and shouldn't make noticable difference for
+        // starving small layers and shouldn't make noticeable difference for
         // bigger layers as work conservation should still be achieved
         // through open execution.
         for &(idx, target) in &ascending {
@@ -4312,7 +4312,7 @@ fn main(opts: Opts) -> Result<()> {
     }
 
     if opts.verbose > 0 {
-        warn!("Setting verbose via -v is depricated and will be an error in future releases.");
+        warn!("Setting verbose via -v is deprecated and will be an error in future releases.");
     }
 
     if opts.no_load_frac_limit {

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -58,7 +58,7 @@ const NR_CSTATS: usize = bpf_intf::cell_stat_idx_NR_CSTATS as usize;
 /// split and which CPUs they should be assigned to.
 #[derive(Debug, Parser)]
 struct Opts {
-    /// Depricated, noop, use RUST_LOG or --log-level instead.
+    /// Deprecated, noop, use RUST_LOG or --log-level instead.
     #[clap(short = 'v', long, action = clap::ArgAction::Count)]
     verbose: u8,
 
@@ -597,7 +597,7 @@ fn main(opts: Opts) -> Result<()> {
     }
 
     if opts.verbose > 0 {
-        warn!("Setting verbose via -v is depricated and will be an error in future releases.");
+        warn!("Setting verbose via -v is deprecated and will be an error in future releases.");
     }
 
     debug!("opts={:?}", &opts);

--- a/scheds/rust/scx_p2dq/README.md
+++ b/scheds/rust/scx_p2dq/README.md
@@ -79,7 +79,7 @@ options for gaming:
    Overrides other slice scaling methods.
  - `--autoslice` auto scaling of interactive slice duration based on
    utilization of interactive tasks.
- - `--freq-control` for controling CPU frequency with certain drivers.
+ - `--freq-control` for controlling CPU frequency with certain drivers.
  - `--cpu-priority` uses a min-heap to schedule on CPUs based on a score of
    most recently used and preferred core value. **Requires kernel support for
    `sched_core_priority` symbol** - typically available on systems with hybrid

--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -1726,7 +1726,7 @@ skip_preempt:
  * immediately in `enqueue` or later in `dispatch`. This returns a tagged union
  * with three states:
  * - P2DQ_ENQUEUE_PROMISE_COMPLETE: The enqueue has been completed. Note that
- *     this case _must_ be determinstic, or else scx_chaos will stall. That is,
+ *     this case _must_ be deterministic, or else scx_chaos will stall. That is,
  *     if the same task and enq_flags arrive twice, it must have returned
  *     _COMPLETE the first time to return it again.
  * - P2DQ_ENQUEUE_PROMISE_FIFO: The completer should enqueue this task on a fifo dsq.

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -80,7 +80,7 @@ const SCHEDULER_NAME: &str = "scx_p2dq";
 ///
 #[derive(Debug, Parser)]
 struct CliOpts {
-    /// Depricated, noop, use RUST_LOG or --log-level instead.
+    /// Deprecated, noop, use RUST_LOG or --log-level instead.
     #[clap(short = 'v', long, action = clap::ArgAction::Count)]
     verbose: u8,
 
@@ -377,7 +377,7 @@ fn main(opts: CliOpts) -> Result<()> {
     }
 
     if opts.verbose > 0 {
-        warn!("Setting verbose via -v is depricated and will be an error in future releases.");
+        warn!("Setting verbose via -v is deprecated and will be an error in future releases.");
     }
 
     if let Some(run_id) = opts.run_id {

--- a/scheds/rust/scx_p2dq/src/stats.rs
+++ b/scheds/rust/scx_p2dq/src/stats.rs
@@ -55,9 +55,9 @@ pub struct Metrics {
     pub enq_intr: u64,
     #[stat(desc = "Number of times a task was enqueued to migration DSQ")]
     pub enq_mig: u64,
-    #[stat(desc = "Number of times a select_cpu pick 2 load balancing occured")]
+    #[stat(desc = "Number of times a select_cpu pick 2 load balancing occurred")]
     pub select_pick2: u64,
-    #[stat(desc = "Number of times a dispatch pick 2 load balancing occured")]
+    #[stat(desc = "Number of times a dispatch pick 2 load balancing occurred")]
     pub dispatch_pick2: u64,
     #[stat(desc = "Number of times a task migrated LLCs")]
     pub llc_migrations: u64,

--- a/scheds/rust/scx_rusty/src/bpf/ravg_impl.bpf.h
+++ b/scheds/rust/scx_rusty/src/bpf/ravg_impl.bpf.h
@@ -230,7 +230,7 @@ static __always_inline u64 u64_x_u32_rshift(u64 a, u32 b, u32 rshift)
 /**
  * ravg_scale - Scale a running avg
  * @rd: ravg_data to scale
- * @mult: multipler
+ * @mult: multiplier
  * @rshift: right shift amount
  *
  * Scale @rd by multiplying the tracked values by @mult and shifting right by
@@ -278,7 +278,7 @@ static RAVG_FN_ATTRS u64 ravg_read(struct ravg_data *rd, u64 now, u64 half_life)
 	/*
 	 * At the beginning of a new half_life period, the running avg is the
 	 * same as @rd->old. At the beginning of the next, it'd be old load / 2
-	 * + current load / 2. Inbetween, we blend the two linearly.
+	 * + current load / 2. In between, we blend the two linearly.
 	 */
 	if (elapsed) {
 		u32 progress = ravg_normalize_dur(elapsed, half_life);

--- a/scheds/rust/scx_rusty/src/bpf/sdt_alloc.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/sdt_alloc.bpf.c
@@ -192,7 +192,7 @@ int sdt_alloc_attempt(struct sdt_alloc_stack __arena *stack)
 	/*
 	 * Use can_loop to help with verification. The can_loop macro was
 	 * introduced in kernel commit ba39486 and wraps around the may_goto
-	 * instruction that helps with verifiying for loops. Using may_goto
+	 * instruction that helps with verifying for loops. Using may_goto
 	 * embeds a switch into the loop that ensures it is considered
 	 * terminable by the verifier by adding a hidden switch to the loop
 	 * and counting down with every iteration.

--- a/scripts/slicesnoop.bt
+++ b/scripts/slicesnoop.bt
@@ -8,7 +8,7 @@
 /*
  * slicesnoop - Explore the slice distribution of DSQs
  *
- * This script is used to explore the distrubtion of slice intervals for
+ * This script is used to explore the distribution of slice intervals for
  * schedulers aggregated by DSQ id.
  *
  * Processes can be filtered by passing a pid as the first parameter (0 for

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -188,7 +188,7 @@ pub struct App<'a> {
     power_snapshot: crate::PowerSnapshot,
     power_collector: crate::PowerDataCollector,
 
-    // layout releated
+    // layout related
     events_list_size: u16,
 
     // trace related
@@ -219,7 +219,7 @@ pub struct App<'a> {
 }
 
 impl<'a> App<'a> {
-    /// Creates a new appliation.
+    /// Creates a new application.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Config,

--- a/tools/scxtop/src/tracer.rs
+++ b/tools/scxtop/src/tracer.rs
@@ -16,7 +16,7 @@ pub struct Tracer<'a> {
 }
 
 impl<'a> Tracer<'a> {
-    /// Creates a new appliation.
+    /// Creates a new application.
     pub fn new(skel: BpfSkel<'a>) -> Self {
         let trace_links = vec![];
         Self { skel, trace_links }


### PR DESCRIPTION
Fix a batch of codespell findings across the tree, limited to comments, docstrings, and user-facing log/error strings (no behavioral changes).

Notable fixes include:
- scheds: wakeup/deprecated wording and various comment typos across scx_{mitosis,flash,layered,lavd,p2dq,cosmos}
- bpf/lib: “multiplier”, “verifying”, “arbitrary”, “distribution”, and other small spelling corrections
- rust tools/libs: typo fixes in scx_cargo docs, scxtop UI docs, scx_stats example logs, and misc helpers

These changes were validated by grepping for the reported misspellings and by confirming the final remaining codespell hits:
- scx_cosmos: “optimizatons” -> “optimizations”
- scx_rustland_core assets: “re-using” -> “reusing”

Author: rezky_nightky <with dot rezky at gmail dot com>
Repository: scx
Branch: main
Signing: GPG (4B65AAC2)
HashAlgo: BLAKE3

[ Block Metadata ]
BlockHash: 14469cf72fe54f73e1e0b893ff41abb01bd1cdcfcc394acf0885b6d0f52b76ee PrevHash: 72f7e008d57c0be6d17b9ca0affa4a8b9661df8a3bb3f293a9e4745fa1c99434 PatchHash: 5eba23897451a056ea3654aed56283d9c7c131e720142d8dca3ac2d49adfcb56

FilesChanged: 39
Lines: +87 / -93

Timestamp: 2025-12-22T16:11:05Z
Signature1: 0b82d619b2b5bab3630068f12b9740b370ea8d58d98b1060996dcc1cf5c38c73
Signature2: 464a03c44fb6258a7393bf4158e80250f8bc56854620ca71b6a028cffaad8104