### PR TITLE
scx_cosmos: Bump up version to 1.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "scx_cosmos"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_cosmos"
-version = "1.0.5"
+version = "1.0.6"
 authors = ["Andrea Righi <arighi@nvidia.com>"]
 edition = "2021"
 description = "Lightweight scheduler optimized for preserving task-to-CPU locality. https://github.com/sched-ext/scx/tree/main"


### PR DESCRIPTION
The current implementation of scx_cosmos has passed extensive production testing with positive results.

Therefore, bump up the version so that we can publish a new pre-release version on crates.io as a stable build and continue with the next development cycle.