### PR TITLE
scx_cargo: Bump up version to 1.0.26 for scx_cosmos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "scx_cargo"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "anyhow",
  "bindgen 0.72.0",

--- a/rust/scx_cargo/Cargo.toml
+++ b/rust/scx_cargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_cargo"
-version = "1.0.25"
+version = "1.0.26"
 edition = "2021"
 authors = ["Tejun Heo <tj@kernel.org>"]
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.215", features = ["derive"] }
 simplelog = "0.12"
 
 [build-dependencies]
-scx_cargo = { path = "../../../rust/scx_cargo", version = "1.0.25" }
+scx_cargo = { path = "../../../rust/scx_cargo", version = "1.0.26" }
 
 [features]
 enable_backtrace = []


### PR DESCRIPTION
In order to publish a new crate for scx_cosmos we need to update scx_cargo as well, because the current version is missing __COMPAT_scx_bpf_cpu_curr().

Fixes: b5ad176c ("scx_cosmos: Bump up version to 1.0.6")