### PR TITLE
chore: Add .codespellrc for future-proof typo checking

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,13 @@
+[codespell]
+# Keep this file in sync with the repository layout. The goal is to spellcheck
+# only maintained sources and documentation, and skip generated/imported files.
+
+# Comma-separated list of paths/globs to skip.
+skip =
+    ./scheds/vmlinux,
+    ./rust/scx_raw_pmu,
+    ./**/*.autogen.*,
+    ./rust/scx_utils/src/enums.rs
+
+# Regex of lines to ignore (project-specific terms / proper nouns).
+ignore-regex = .*(ratatui|Affinitized|affinitized).*


### PR DESCRIPTION
- Skip generated headers under scheds/vmlinux/
- Skip imported PMU data under rust/scx_raw_pmu/
- Skip autogenerated *.autogen.* files and rust/scx_utils/src/enums.rs
- Preserve project-specific ignore-regex for ratatui/Affinitized/affinitized

This ensures  only checks maintainable source/docs and avoids wasting effort on files that are regenerated or imported.

Author: rezky_nightky <with dot rezky at gmail dot com>
Repository: scx
Branch: main
Signing: GPG (4B65AAC2)
HashAlgo: BLAKE3

[ Block Metadata ]
BlockHash: e0ed845ea1e6fc45b7d8acd51bf63a8b20370ced0f9756b75ff0ca3bad804595 PrevHash: 86536e53d6c8364e14e1fa1bd1669abb6b9c7bd52bfe755671f0c1cd9cc631e2 PatchHash: 79534685bfff3bcdbfe8b391b5ce4345d350b19966dad94707aaa916acf3033d

FilesChanged: 1
Lines: +13 / -0

Timestamp: 2025-12-27T14:38:15Z
Signature1: ce32cefc25ebfa5c0fa63104507d37acbc89b9684113997ddf5ee40ceafd5ad7
Signature2: 379c9b50cdeb06c488f5fbbf9959492a0774e24f7ec644cced0fd5f8e49fbe1f