### PR TITLE
scx_lavd: remove unused cpumask

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -419,7 +419,6 @@ u64 get_target_dsq_id(struct task_struct *p, struct cpu_ctx *cpuc);
 
 extern struct bpf_cpumask __kptr *turbo_cpumask; /* CPU mask for turbo CPUs */
 extern struct bpf_cpumask __kptr *big_cpumask; /* CPU mask for big CPUs */
-extern struct bpf_cpumask __kptr *little_cpumask; /* CPU mask for little CPUs */
 extern struct bpf_cpumask __kptr *active_cpumask; /* CPU mask for active CPUs */
 extern struct bpf_cpumask __kptr *ovrflw_cpumask; /* CPU mask for overflow CPUs */
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1771,10 +1771,6 @@ static int init_cpumasks(void)
 	err = calloc_cpumask(&big_cpumask);
 	if (err)
 		goto out;
-
-	err = calloc_cpumask(&little_cpumask);
-	if (err)
-		goto out;
 out:
 	bpf_rcu_read_unlock();
 	return err;
@@ -1783,7 +1779,7 @@ out:
 static s32 init_per_cpu_ctx(u64 now)
 {
 	struct cpu_ctx *cpuc;
-	struct bpf_cpumask *turbo, *big, *little, *active, *ovrflw, *cd_cpumask;
+	struct bpf_cpumask *turbo, *big, *active, *ovrflw, *cd_cpumask;
 	const struct cpumask *online_cpumask;
 	struct cpdom_ctx *cpdomc;
 	int cpu, i, j, k, err = 0;
@@ -1798,10 +1794,9 @@ static s32 init_per_cpu_ctx(u64 now)
 	 */
 	turbo = turbo_cpumask;
 	big = big_cpumask;
-	little = little_cpumask;
 	active  = active_cpumask;
 	ovrflw  = ovrflw_cpumask;
-	if (!turbo || !big || !little || !active || !ovrflw) {
+	if (!turbo || !big || !active || !ovrflw) {
 		scx_bpf_error("Failed to prepare cpumasks.");
 		err = -ENOMEM;
 		goto unlock_out;
@@ -1873,7 +1868,6 @@ static s32 init_per_cpu_ctx(u64 now)
 			bpf_cpumask_set_cpu(cpu, big);
 		}
 		else {
-			bpf_cpumask_set_cpu(cpu, little);
 			have_little_core = true;
 		}
 

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -22,7 +22,6 @@
  */
 private(LAVD) struct bpf_cpumask __kptr *turbo_cpumask; /* CPU mask for turbo CPUs */
 private(LAVD) struct bpf_cpumask __kptr *big_cpumask; /* CPU mask for big CPUs */
-private(LAVD) struct bpf_cpumask __kptr *little_cpumask; /* CPU mask for little CPUs */
 private(LAVD) struct bpf_cpumask __kptr *active_cpumask; /* CPU mask for active CPUs */
 private(LAVD) struct bpf_cpumask __kptr *ovrflw_cpumask; /* CPU mask for overflow CPUs */
 

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.h
@@ -4,7 +4,6 @@
 
 extern struct bpf_cpumask __kptr *turbo_cpumask; /* CPU mask for turbo CPUs */
 extern struct bpf_cpumask __kptr *big_cpumask; /* CPU mask for big CPUs */
-extern struct bpf_cpumask __kptr *little_cpumask; /* CPU mask for little CPUs */
 extern struct bpf_cpumask __kptr *active_cpumask; /* CPU mask for active CPUs */
 extern struct bpf_cpumask __kptr *ovrflw_cpumask; /* CPU mask for overflow CPUs */
 


### PR DESCRIPTION
The mask tracking little cpus in big.LITTLE systems is not actually used. Remove it.