### PR TITLE
lib/arena.h: Fix __arena macro redefinition warnings

### DIFF
--- a/scheds/include/lib/arena.h
+++ b/scheds/include/lib/arena.h
@@ -2,11 +2,6 @@
 
 #define NR_CPU_IDS_UNINIT (~(u32)0)
 
-/* For userspace programs, __arena is a no-op. */
-#ifndef __arena
-#define __arena
-#endif
-
 struct arena_init_args {
 	u64 static_pages;
 	u64 task_ctx_size;


### PR DESCRIPTION
```rust
warning: scx_arena@0.1.3: In file included from src/bpf/lib/bitmap.bpf.c:4:
warning: scx_arena@0.1.3: In file included from /home/underdog/underdog/scx/target/release/build/scx_arena-c5f62fbd0b3ebee6/out/scx_utils-bpf_h/lib/cpumask.h:4:
warning: scx_arena@0.1.3: In file included from /home/underdog/underdog/scx/target/release/build/scx_arena-c5f62fbd0b3ebee6/out/scx_utils-bpf_h/lib/sdt_task.h:11:
warning: scx_arena@0.1.3: /home/underdog/underdog/scx/target/release/build/scx_arena-c5f62fbd0b3ebee6/out/scx_utils-bpf_h/scx/bpf_arena_common.bpf.h:18:9: warning: '__arena' macro redefined [-Wmacro-redefined]
warning: scx_arena@0.1.3:    18 | #define __arena __attribute__((address_space(1)))
warning: scx_arena@0.1.3:       |         ^
warning: scx_arena@0.1.3: /home/underdog/underdog/scx/target/release/build/scx_arena-c5f62fbd0b3ebee6/out/scx_utils-bpf_h/lib/arena.h:7:9: note: previous definition is here
warning: scx_arena@0.1.3:     7 | #define __arena
warning: scx_arena@0.1.3:       |         ^
warning: scx_arena@0.1.3: 1 warning generated.
```