### PR TITLE
Update service README

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -4,11 +4,29 @@ This guide provides instructions for running the SCX schedulers as a systemd ser
 
 ## Getting Started
 
-At the very beginning, configure the /etc/default/scx file:
+To start, create the scx_loader configuration directory:
+```bash
+sudo mkdir /etc/scx_loader
+```
+then copy the default configuration into said directory
+```bash
+sudo cp /usr/share/scx_loader/config.toml /etc/scx_loader/config.toml
+```
+now you can edit the copied file
+```bash
+sudo nano /etc/scx_loader/config.toml
+```
+- First uncomment `#default_sched = "scx_cosmos"` and `#default_mode = "Auto"` as both of these variables are required to set your preferred scheduler.
+- From here you can change the default_sched to your preferred scheduler. You can get more information on the available schedulers at [scheds](https://github.com/sched-ext/scx/tree/main/scheds).
+- The default_mode variable corresponds to the mode scx_loader will launch in by default, and by extension, the scheduler flags listed therein. (Be sure to uncomment this line as well).
 
-- in the SCX_SCHEDULER variable, select the scheduler you are interested in
+For example if you set  
+`default_sched = "scx_rusty"`  
+`default_mode = "Auto"`  
+`auto_mode = ["--perf"]`  
+Then scx_loader would launch `scx_rusty --perf` as the default scheduler.
 
-- in the SCX_FLAGS variable, specify the flags you want to add. To do this, execute and read what flags you can add.
+- To see what flags you can add to any given scheduler:
 
 ```
 scx_SCHEDNAME --help
@@ -20,46 +38,25 @@ To start the SCX scheduler at boot, you need to run the systemd service as root.
 - Enable the service:
 
 ```
-systemctl enable scx.service
+systemctl enable scx_loader.service
 ```
 
 - Start the service:
 
 ```
-systemctl start scx.service
+systemctl start scx_loader.service
 ```
 
 Alternatively, you can use a shortened version of these commands:
 
 ```
-systemctl enable --now scx.service
+systemctl enable --now scx_loader.service
 ```
 
 - To check the status of the service, use the following command:
 
 ```
-systemctl status scx.service
-```
-
-## Override global configuration
-
-It is possible to override the global scx settings using systemd environment
-variables `SCX_SCHEDULER_OVERRIDE` and `SCX_FLAGS_OVERRIDE`.
-
-Example:
-
-```
-systemctl set-environment SCX_SCHEDULER_OVERRIDE=scx_rustland
-systemctl set-environment SCX_FLAGS_OVERRIDE="-s 10000"
-systemctl restart scx
-```
-
-If you want to restore the default value from the `/etc/default/scx` file execute:
-
-```
-systemctl unset-environment SCX_SCHEDULER_OVERRIDE
-systemctl unset-environment SCX_FLAGS_OVERRIDE
-systemctl restart scx
+systemctl status scx_loader.service
 ```
 
 ## Checking journald Logs
@@ -68,12 +65,12 @@ systemctl restart scx
 - To view the logs, use the following command:
 
 ```
-journalctl -u scx.service
+journalctl -u scx_loader.service
 ```
 
 - To view the logs of the current session use the command
 
 ```
-journalctl -u scx.service -b 0
+journalctl -u scx_loader.service -b 0
 ```
 


### PR DESCRIPTION
Updated the service folder README to the most recent instructions and configuration settings for the system service. Some of these instructions are behavior I have observed whilst using the service, other of these were posted in (the now gone) scx/services/systemd/MIGRATION_GUIDE.md provided by commit 22fe5e758587e70b10dadc1a94541d3fa8663f59. This is not fully fleshed out but it is a start; and the current services README contains deprecated information.