### PR TITLE
scx_lavd: Remove an obsolete global variable, __nr_cpu_ids.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1711,6 +1711,8 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init_task, struct task_struct *p,
 		set_task_flag(taskc, LAVD_FLAG_IS_AFFINITIZED);
 	else
 		reset_task_flag(taskc, LAVD_FLAG_IS_AFFINITIZED);
+
+	set_on_core_type(taskc, p->cpus_ptr);
 	bpf_rcu_read_unlock();
 
 	if (is_ksoftirqd(p))
@@ -1728,8 +1730,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init_task, struct task_struct *p,
 	taskc->pinned_cpu_id = -ENOENT;
 	taskc->pid = p->pid;
 	taskc->cgrp_id = args->cgroup->kn->id;
-
-	set_on_core_type(taskc, p->cpus_ptr);
 
 	return 0;
 }

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -27,7 +27,6 @@ private(LAVD) struct bpf_cpumask __kptr *active_cpumask; /* CPU mask for active 
 private(LAVD) struct bpf_cpumask __kptr *ovrflw_cpumask; /* CPU mask for overflow CPUs */
 
 const volatile u64	nr_llcs;	/* number of LLC domains */
-const volatile u64	__nr_cpu_ids;	/* maximum CPU IDs */
 volatile u64		nr_cpus_onln;	/* current number of online CPUs */
 
 const volatile u32	cpu_sibling[LAVD_CPU_ID_MAX]; /* siblings for CPUs when SMT is active */
@@ -248,7 +247,13 @@ void set_on_core_type(task_ctx __arg_arena *taskc,
 	struct cpu_ctx *cpuc;
 	int cpu;
 
-	bpf_for(cpu, 0, __nr_cpu_ids) {
+	if (!cpumask)
+		return;
+
+	bpf_for(cpu, 0, nr_cpu_ids) {
+		if (cpu >= LAVD_CPU_ID_MAX)
+			break;
+
 		if (!bpf_cpumask_test_cpu(cpu, cpumask))
 			continue;
 

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.h
@@ -3,7 +3,6 @@
 #define __UTIL_H
 
 extern const volatile u64	nr_llcs;	/* number of LLC domains */
-extern const volatile u64	__nr_cpu_ids;	/* maximum CPU IDs */
 extern volatile u64		nr_cpus_onln;	/* current number of online CPUs */
 
 extern const volatile u32	cpu_sibling[LAVD_CPU_ID_MAX]; /* siblings for CPUs when SMT is active */


### PR DESCRIPTION
Also, move set_on_cpu_type() inside RCU read lock to avoid the verifier error.