### PR TITLE
scx_lavd: Increase greedy factor in deadline calculation.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lat_cri.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lat_cri.bpf.c
@@ -264,7 +264,7 @@ static u64 calc_greedy_penalty(struct task_struct *p, task_ctx *taskc)
 	/* lag = [-lag_max, lag_max] */
 
 	/*
-	 * penalty = [100%, 125%]
+	 * penalty = [100%, 200%]
 	 */
 	penalty = (((-lag + lag_max) << LAVD_SHIFT) / lag_max);
 	penalty = LAVD_SCALE + (penalty >> LAVD_LC_GREEDY_SHIFT);

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -72,9 +72,9 @@ enum consts_internal {
 	LAVD_SLICE_BOOST_BONUS		= LAVD_SLICE_MIN_NS_DFL,
 	LAVD_SLICE_BOOST_MAX		= (500ULL * NSEC_PER_MSEC),
 	LAVD_ACC_RUNTIME_MAX		= LAVD_SLICE_MAX_NS_DFL,
-	LAVD_TASK_LAG_MAX		= (10ULL * LAVD_SLICE_MAX_NS_DFL),
-	LAVD_DL_COMPETE_WINDOW		= (LAVD_SLICE_MAX_NS_DFL >> 16), /* assuming task's latency
-									    criticality is around 1000. */
+	LAVD_TASK_LAG_MAX		= (500ULL * NSEC_PER_MSEC),
+	LAVD_DL_COMPETE_WINDOW		= ((300ULL * NSEC_PER_MSEC) >> 16), /* assuming task's latency
+									       criticality is around 1000. */
 
 	LAVD_LC_FREQ_MAX                = 100000, /* shortest interval: 10usec */
 	LAVD_LC_RUNTIME_MAX		= LAVD_TIME_ONE_SEC,
@@ -82,7 +82,7 @@ enum consts_internal {
 	LAVD_LC_WEIGHT_BOOST_MEDIUM	= (2 * LAVD_LC_WEIGHT_BOOST_REGULAR),
 	LAVD_LC_WEIGHT_BOOST_HIGH	= (2 * LAVD_LC_WEIGHT_BOOST_MEDIUM),
 	LAVD_LC_WEIGHT_BOOST_HIGHEST	= (2 * LAVD_LC_WEIGHT_BOOST_HIGH),
-	LAVD_LC_GREEDY_SHIFT		= 3, /* 12.5% */
+	LAVD_LC_GREEDY_SHIFT		= 1, /* 50% */
 	LAVD_LC_WAKE_INTERVAL_MIN	= LAVD_SLICE_MIN_NS_DFL,
 	LAVD_LC_INH_RECEIVER_SHIFT	= 2, /* 25.0% of receiver's latency criticality */
 	LAVD_LC_INH_GIVER_SHIFT		= 3, /* 12.5 of giver's latency criticality */


### PR DESCRIPTION
When there are many freshly forked tasks, their deadlines tend to be similar. In this case, latency-critical tasks could be delayed for processing the bulky forked tasks. We mitigate this problem by extending the competition window and the task’s lag max. This helps to schedule underserved, latency-critical tasks against a fork bomb.