### PR TITLE
scx_lavd: Optimize task migration for execve.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -128,7 +128,10 @@ enum consts_flags {
 	LAVD_FLAG_WOKEN_BY_RT_DL	= (0x1 << 11), /* woken by a RT/DL task */
 	LAVD_FLAG_WOKEN_BY_HARDIRQ	= (0x1 << 12), /* woken by a hardware interrupt */
 	LAVD_FLAG_WOKEN_BY_SOFTIRQ	= (0x1 << 13), /* woken by a softirq */
+	LAVD_FLAG_MIGRATION_AGGRESSIVE  = (0x1 << 14), /* immediate task migration is necessary. */
 };
+
+#define LAVD_MASK_MIGRATION		(LAVD_FLAG_MIGRATION_AGGRESSIVE)
 
 /*
  * Task context
@@ -395,6 +398,7 @@ u32 cpu_to_dsq(u32 cpu);
 void set_task_flag(task_ctx *taskc, u64 flag);
 void reset_task_flag(task_ctx *taskc, u64 flag);
 bool test_task_flag(task_ctx *taskc, u64 flag);
+bool test_task_flag_mask(task_ctx __arg_arena *taskc, u64 flag);
 void reset_task_flag(task_ctx *taskc, u64 flag);
 
 static __always_inline bool use_per_cpu_dsq(void)

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -734,6 +734,12 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 	taskc->cpdom_id = cpuc->cpdom_id;
 
 	/*
+	 * Clean up migration flags since the task placement decision was made.
+	 */
+	if (unlikely(test_task_flag_mask(taskc, LAVD_MASK_MIGRATION)))
+		reset_task_flag(taskc, LAVD_MASK_MIGRATION);
+
+	/*
 	 * Under the CPU bandwidth control with cpu.max, check if the cgroup
 	 * is throttled before executing the task.
 	 *
@@ -2215,6 +2221,54 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init)
 void BPF_STRUCT_OPS(lavd_exit, struct scx_exit_info *ei)
 {
 	UEI_RECORD(uei, ei);
+}
+
+static
+int set_aggressive_migration(void)
+{
+	struct task_struct *curr;
+	struct cpdom_ctx *cpdc;
+	struct cpu_ctx *cpuc;
+	task_ctx *taskc;
+	u32 cpu;
+
+	/*
+	 * When a task is about to call execv() and the current CPU is
+	 * overloaded (is_stealee), set the LAVD_FLAG_MIGRATION_AGGRESSIVE
+	 * flag and preempt itself to trigger aggressive migration right
+	 * now.
+	 *
+	 * Self-preemption is not cheap because it issues a self-IPI.
+	 * We assume calling execve() is rare and we send an IPI only when
+	 * the domain is overloaded, so it should be okay.
+	 */
+	if (nr_cpdoms == 1)
+		return 0;
+
+	cpu = bpf_get_smp_processor_id();
+	if ((curr = bpf_get_current_task_btf()) &&
+	    (taskc = get_task_ctx(curr)) &&
+	    (cpuc = get_cpu_ctx_id(cpu)) &&
+	    (cpdc = MEMBER_VPTR(cpdom_ctxs, [cpuc->cpdom_id])) &&
+	    READ_ONCE(cpdc->is_stealee)) {
+		set_task_flag(taskc, LAVD_FLAG_MIGRATION_AGGRESSIVE);
+		scx_bpf_kick_cpu(cpu, SCX_KICK_PREEMPT);
+	}
+	return 0;
+}
+
+SEC("?tracepoint/syscalls/sys_enter_execve")
+int BPF_PROG(cond_hook_sys_enter_execve)
+{
+	set_aggressive_migration();
+	return 0;
+}
+
+SEC("?tracepoint/syscalls/sys_enter_execveat")
+int BPF_PROG(cond_hook_sys_enter_execveat)
+{
+	set_aggressive_migration();
+	return 0;
 }
 
 SCX_OPS_DEFINE(lavd_ops,

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -164,6 +164,12 @@ bool test_task_flag(task_ctx __arg_arena *taskc, u64 flag)
 }
 
 __hidden
+bool test_task_flag_mask(task_ctx __arg_arena *taskc, u64 flag)
+{
+	return (taskc->flags & flag);
+}
+
+__hidden
 void set_task_flag(task_ctx __arg_arena *taskc, u64 flag)
 {
 	taskc->flags |= flag;


### PR DESCRIPTION
This series optimizes task placement in the LAVD scheduler with aggressive load balancing during execve().

- Execve-Driven Migration: Triggers immediate migration for tasks calling execve(), as address space replacement makes current cache locality irrelevant.
- Code Refactoring: Modularizes neighbor-domain migration logic to support these new policies.