### PR TITLE
scxprof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,6 +3283,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "scxprof"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ctrlc",
+ "libbpf-rs",
+ "libc",
+ "log",
+ "scx_cargo",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scxtop"
 version = "1.0.21"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,6 +3292,7 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "log",
+ "regex",
  "scx_cargo",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "scheds/rust/scx_tickless",
     "scheds/rust/scx_wd40",
     "tools/scxcash",
+    "tools/scxprof",
     "tools/scxtop",
     "tools/vmlinux_docify",
     "tools/xtask",

--- a/tools/scxprof/Cargo.toml
+++ b/tools/scxprof/Cargo.toml
@@ -15,6 +15,7 @@ ctrlc = "3.1"
 libc = "0.2.175"
 libbpf-rs = "=0.26.0-beta.1"
 log = "0.4.17"
+regex = "1.11"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 

--- a/tools/scxprof/Cargo.toml
+++ b/tools/scxprof/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "scxprof"
+version = "0.1.0"
+edition = "2021"
+authors = ["Kumar Kartikeya Dwivedi <memxor@gmail.com>"]
+license = "GPL-2.0-only"
+repository = "https://github.com/sched-ext/scx"
+description = "SCX Workload Profiler"
+build = "build.rs"
+
+[dependencies]
+anyhow = "1.0.65"
+clap = { version = "4.5.28", features = ["derive", "env", "unicode", "wrap_help"] }
+ctrlc = "3.1"
+libc = "0.2.175"
+libbpf-rs = "=0.26.0-beta.1"
+log = "0.4.17"
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.133"
+
+[build-dependencies]
+scx_cargo = { path = "../../rust/scx_cargo", version = "1.0.25" }

--- a/tools/scxprof/build.rs
+++ b/tools/scxprof/build.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+fn main() {
+    scx_cargo::BpfBuilder::new()
+        .unwrap()
+        .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
+        .enable_skel("src/bpf/hints_tls.bpf.c", "hints_tls")
+        .compile_link_gen()
+        .unwrap();
+}

--- a/tools/scxprof/src/bpf/hints_tls.bpf.c
+++ b/tools/scxprof/src/bpf/hints_tls.bpf.c
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "intf.h"
+
+char _license[] SEC("license") = "GPL";
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1024 * 1024);
+} ringbuf SEC(".maps");
+
+SEC("fentry/bpf_map_update_elem")
+int BPF_PROG(trace_map_update, struct bpf_map *map, void *key, void *value, u64 flags)
+{
+    struct hints_event *ev;
+
+    if (map->map_type != BPF_MAP_TYPE_TASK_STORAGE)
+        return 0;
+
+    ev = bpf_ringbuf_reserve(&ringbuf, sizeof(*ev), 0);
+    if (!ev)
+        return 0;
+
+    struct task_struct *task = bpf_get_current_task_btf();
+    ev->pid = task->pid;
+    ev->tgid = task->tgid;
+    ev->hints = *(unsigned long long *)value;
+    ev->timestamp = bpf_ktime_get_ns();
+
+    bpf_ringbuf_submit(ev, 0);
+    return 0;
+}

--- a/tools/scxprof/src/bpf/intf.h
+++ b/tools/scxprof/src/bpf/intf.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+#ifndef __INTF_H
+#define __INTF_H
+
+struct hints_event {
+    int pid;
+    int tgid;
+    unsigned long long hints;
+    unsigned long long timestamp;
+};
+
+#endif

--- a/tools/scxprof/src/bpf_intf.rs
+++ b/tools/scxprof/src/bpf_intf.rs
@@ -1,0 +1,6 @@
+// Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+include!(concat!(env!("OUT_DIR"), "/bpf_intf.rs"));

--- a/tools/scxprof/src/bpf_skel.rs
+++ b/tools/scxprof/src/bpf_skel.rs
@@ -1,0 +1,6 @@
+// Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+include!(concat!(env!("OUT_DIR"), "/bpf_skel.rs"));

--- a/tools/scxprof/src/extract.rs
+++ b/tools/scxprof/src/extract.rs
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use crate::process::PerfScriptRecord;
+use anyhow::{Context as _, Result};
+use clap::Parser;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+#[derive(Debug, Parser)]
+pub struct ExtractOpts {
+    /// Path to perf.jsonl file
+    #[clap(short = 'f', long)]
+    pub file: PathBuf,
+}
+
+pub fn cmd_extract(opts: ExtractOpts) -> Result<()> {
+    let file = File::open(&opts.file).context("failed to open perf.jsonl")?;
+    let reader = BufReader::new(file);
+
+    let mut comm_counts: HashMap<String, u64> = HashMap::new();
+
+    for line in reader.lines() {
+        let line = line.context("failed to read line")?;
+        let record: PerfScriptRecord =
+            serde_json::from_str(&line).context("failed to parse record")?;
+        *comm_counts.entry(record.comm).or_insert(0) += 1;
+    }
+
+    let mut counts: Vec<_> = comm_counts.into_iter().collect();
+    counts.sort_by(|a, b| b.1.cmp(&a.1));
+
+    let total: u64 = counts.iter().map(|(_, c)| c).sum();
+
+    for (comm, count) in counts {
+        let pct = (count as f64 / total as f64) * 100.0;
+        println!("{}: {} ({:.2}%)", comm, count, pct);
+    }
+
+    Ok(())
+}

--- a/tools/scxprof/src/extract.rs
+++ b/tools/scxprof/src/extract.rs
@@ -6,39 +6,111 @@
 use crate::process::PerfScriptRecord;
 use anyhow::{Context as _, Result};
 use clap::Parser;
+use regex::Regex;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
+
+const DEFAULT_WORKLOAD_CGROUP_REGEX: &str = "workload.slice";
+const DEFAULT_WORKLOAD_ALLOTMENT_CGROUP_REGEX: &str = r"workload-tw-[^/]+\.allotment\.slice";
 
 #[derive(Debug, Parser)]
 pub struct ExtractOpts {
     /// Path to perf.jsonl file
     #[clap(short = 'f', long)]
     pub file: PathBuf,
+
+    /// Regex pattern for workload cgroup
+    #[clap(long, default_value = DEFAULT_WORKLOAD_CGROUP_REGEX)]
+    pub workload_cgroup_regex: String,
+
+    /// Regex pattern for workload allotment cgroups
+    #[clap(long, default_value = DEFAULT_WORKLOAD_ALLOTMENT_CGROUP_REGEX)]
+    pub workload_allotment_cgroup_regex: String,
+}
+
+fn classify_cgroup<'a>(cgroup: &'a str, workload_cgroup: &'a str, allotment_re: &Regex) -> &'a str {
+    if !cgroup.contains(workload_cgroup) {
+        return "rest";
+    }
+
+    if let Some(m) = allotment_re.find(cgroup) {
+        return m.as_str();
+    }
+
+    workload_cgroup
+}
+
+struct GroupStats {
+    comm_counts: HashMap<String, u64>,
+    total: u64,
+}
+
+impl GroupStats {
+    fn new() -> Self {
+        Self {
+            comm_counts: HashMap::new(),
+            total: 0,
+        }
+    }
+
+    fn add(&mut self, comm: &str) {
+        *self.comm_counts.entry(comm.to_string()).or_insert(0) += 1;
+        self.total += 1;
+    }
+
+    fn print(&self, group_name: &str, global_total: u64) {
+        let group_pct = (self.total as f64 / global_total as f64) * 100.0;
+        println!("\n{}: {} samples ({:.2}%)", group_name, self.total, group_pct);
+
+        let mut counts: Vec<_> = self.comm_counts.iter().collect();
+        counts.sort_by(|a, b| b.1.cmp(a.1));
+
+        for (comm, count) in counts {
+            let pct = (*count as f64 / self.total as f64) * 100.0;
+            println!("  {}: {} ({:.2}%)", comm, count, pct);
+        }
+    }
 }
 
 pub fn cmd_extract(opts: ExtractOpts) -> Result<()> {
     let file = File::open(&opts.file).context("failed to open perf.jsonl")?;
     let reader = BufReader::new(file);
 
-    let mut comm_counts: HashMap<String, u64> = HashMap::new();
+    let allotment_re = Regex::new(&opts.workload_allotment_cgroup_regex)
+        .context("invalid allotment regex")?;
+    let workload_cgroup = &opts.workload_cgroup_regex;
+
+    let mut groups: HashMap<String, GroupStats> = HashMap::new();
+    let mut global_total: u64 = 0;
 
     for line in reader.lines() {
         let line = line.context("failed to read line")?;
         let record: PerfScriptRecord =
             serde_json::from_str(&line).context("failed to parse record")?;
-        *comm_counts.entry(record.comm).or_insert(0) += 1;
+
+        let group = classify_cgroup(&record.cgroup, workload_cgroup, &allotment_re);
+        groups.entry(group.to_string()).or_insert_with(GroupStats::new).add(&record.comm);
+        global_total += 1;
     }
 
-    let mut counts: Vec<_> = comm_counts.into_iter().collect();
-    counts.sort_by(|a, b| b.1.cmp(&a.1));
+    println!("Total samples: {}", global_total);
 
-    let total: u64 = counts.iter().map(|(_, c)| c).sum();
+    let mut group_names: Vec<_> = groups.keys().cloned().collect();
+    group_names.sort_by(|a, b| {
+        let order = |s: &str| -> u8 {
+            if s == "rest" { 2 }
+            else if s == workload_cgroup { 1 }
+            else { 0 }
+        };
+        order(a).cmp(&order(b)).then_with(|| a.cmp(b))
+    });
 
-    for (comm, count) in counts {
-        let pct = (count as f64 / total as f64) * 100.0;
-        println!("{}: {} ({:.2}%)", comm, count, pct);
+    for name in group_names {
+        if let Some(stats) = groups.get(&name) {
+            stats.print(&name, global_total);
+        }
     }
 
     Ok(())

--- a/tools/scxprof/src/main.rs
+++ b/tools/scxprof/src/main.rs
@@ -9,6 +9,7 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
 mod record;
 mod process;
+mod extract;
 
 pub mod bpf_intf;
 pub mod bpf_skel;
@@ -64,6 +65,8 @@ enum Commands {
     Record(record::RecordOpts),
     /// Process a recorded profile
     Process(process::ProcessOpts),
+    /// Extract data from processed profile
+    Extract(extract::ExtractOpts),
 }
 
 fn main() -> Result<()> {
@@ -73,5 +76,6 @@ fn main() -> Result<()> {
     match opts.command {
         Commands::Record(record_opts) => record::cmd_record(&ctx, record_opts),
         Commands::Process(process_opts) => process::cmd_process(process_opts),
+        Commands::Extract(extract_opts) => extract::cmd_extract(extract_opts),
     }
 }

--- a/tools/scxprof/src/main.rs
+++ b/tools/scxprof/src/main.rs
@@ -3,10 +3,52 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Context as _, Result};
 use clap::{Parser, Subcommand};
-use std::path::PathBuf;
-use std::process::{Child, Command, ExitStatus};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+
+mod record;
+
+pub mod bpf_intf;
+pub mod bpf_skel;
+pub use bpf_skel as bpf;
+
+fn create_eventfd() -> Result<OwnedFd> {
+    let fd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
+    if fd < 0 {
+        bail!("eventfd failed: {}", std::io::Error::last_os_error());
+    }
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+fn signal_eventfd(fd: RawFd) {
+    let val: u64 = 1;
+    unsafe {
+        libc::write(fd, &val as *const u64 as *const libc::c_void, 8);
+    }
+}
+
+pub struct Context {
+    shutdown_fd: OwnedFd,
+}
+
+impl Context {
+    fn new() -> Result<Self> {
+        let shutdown_fd = create_eventfd()?;
+        let raw_fd = shutdown_fd.as_raw_fd();
+
+        ctrlc::set_handler(move || {
+            signal_eventfd(raw_fd);
+        })
+        .context("failed to set Ctrl+C handler")?;
+
+        Ok(Self { shutdown_fd })
+    }
+
+    pub fn shutdown_fd(&self) -> RawFd {
+        self.shutdown_fd.as_raw_fd()
+    }
+}
 
 #[derive(Debug, Parser)]
 #[clap(name = "scxprof", about = "SCX Workload Profiler")]
@@ -18,71 +60,14 @@ struct Opts {
 #[derive(Debug, Subcommand)]
 enum Commands {
     /// Record workload profile using perf
-    Record(RecordOpts),
-}
-
-#[derive(Debug, Parser)]
-struct RecordOpts {
-    /// Output directory for perf.data and other artifacts
-    #[clap(short, long)]
-    output: PathBuf,
-}
-
-struct SpawnedProcess {
-    child: Child,
-    name: String,
-}
-
-impl SpawnedProcess {
-    fn spawn(name: &str, cmd: &mut Command) -> Result<Self> {
-        let child = cmd
-            .spawn()
-            .with_context(|| format!("failed to spawn {}", name))?;
-        Ok(Self {
-            child,
-            name: name.to_string(),
-        })
-    }
-
-    fn wait(mut self) -> Result<ExitStatus> {
-        let status = self
-            .child
-            .wait()
-            .with_context(|| format!("failed to wait for {}", self.name))?;
-        if !status.success() {
-            bail!("{} exited with status: {}", self.name, status);
-        }
-        Ok(status)
-    }
-}
-
-fn cmd_record(opts: RecordOpts) -> Result<()> {
-    std::fs::create_dir_all(&opts.output)
-        .with_context(|| format!("failed to create output directory {:?}", opts.output))?;
-
-    let perf_data = opts.output.join("perf.data");
-
-    let mut cmd = Command::new("perf");
-    cmd.args([
-        "record",
-        "mem",
-        "--all-cgroups",
-        "-p",
-        "--data-page-size",
-        "-o",
-    ])
-    .arg(&perf_data);
-
-    let proc = SpawnedProcess::spawn("perf", &mut cmd)?;
-    proc.wait()?;
-
-    Ok(())
+    Record(record::RecordOpts),
 }
 
 fn main() -> Result<()> {
+    let ctx = Context::new()?;
     let opts = Opts::parse();
 
     match opts.command {
-        Commands::Record(record_opts) => cmd_record(record_opts),
+        Commands::Record(record_opts) => record::cmd_record(&ctx, record_opts),
     }
 }

--- a/tools/scxprof/src/main.rs
+++ b/tools/scxprof/src/main.rs
@@ -8,6 +8,7 @@ use clap::{Parser, Subcommand};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
 mod record;
+mod process;
 
 pub mod bpf_intf;
 pub mod bpf_skel;
@@ -61,6 +62,8 @@ struct Opts {
 enum Commands {
     /// Record workload profile using perf
     Record(record::RecordOpts),
+    /// Process a recorded profile
+    Process(process::ProcessOpts),
 }
 
 fn main() -> Result<()> {
@@ -69,5 +72,6 @@ fn main() -> Result<()> {
 
     match opts.command {
         Commands::Record(record_opts) => record::cmd_record(&ctx, record_opts),
+        Commands::Process(process_opts) => process::cmd_process(process_opts),
     }
 }

--- a/tools/scxprof/src/main.rs
+++ b/tools/scxprof/src/main.rs
@@ -3,14 +3,86 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
-use anyhow::Result;
-use clap::Parser;
+use anyhow::{bail, Context, Result};
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+use std::process::{Child, Command, ExitStatus};
 
 #[derive(Debug, Parser)]
 #[clap(name = "scxprof", about = "SCX Workload Profiler")]
-struct Opts {}
+struct Opts {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Record workload profile using perf
+    Record(RecordOpts),
+}
+
+#[derive(Debug, Parser)]
+struct RecordOpts {
+    /// Output directory for perf.data and other artifacts
+    #[clap(short, long)]
+    output: PathBuf,
+}
+
+struct SpawnedProcess {
+    child: Child,
+    name: String,
+}
+
+impl SpawnedProcess {
+    fn spawn(name: &str, cmd: &mut Command) -> Result<Self> {
+        let child = cmd
+            .spawn()
+            .with_context(|| format!("failed to spawn {}", name))?;
+        Ok(Self {
+            child,
+            name: name.to_string(),
+        })
+    }
+
+    fn wait(mut self) -> Result<ExitStatus> {
+        let status = self
+            .child
+            .wait()
+            .with_context(|| format!("failed to wait for {}", self.name))?;
+        if !status.success() {
+            bail!("{} exited with status: {}", self.name, status);
+        }
+        Ok(status)
+    }
+}
+
+fn cmd_record(opts: RecordOpts) -> Result<()> {
+    std::fs::create_dir_all(&opts.output)
+        .with_context(|| format!("failed to create output directory {:?}", opts.output))?;
+
+    let perf_data = opts.output.join("perf.data");
+
+    let mut cmd = Command::new("perf");
+    cmd.args([
+        "record",
+        "mem",
+        "--all-cgroups",
+        "-p",
+        "--data-page-size",
+        "-o",
+    ])
+    .arg(&perf_data);
+
+    let proc = SpawnedProcess::spawn("perf", &mut cmd)?;
+    proc.wait()?;
+
+    Ok(())
+}
 
 fn main() -> Result<()> {
-    let _opts = Opts::parse();
-    Ok(())
+    let opts = Opts::parse();
+
+    match opts.command {
+        Commands::Record(record_opts) => cmd_record(record_opts),
+    }
 }

--- a/tools/scxprof/src/main.rs
+++ b/tools/scxprof/src/main.rs
@@ -7,9 +7,9 @@ use anyhow::{bail, Context as _, Result};
 use clap::{Parser, Subcommand};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
-mod record;
-mod process;
 mod extract;
+mod process;
+mod record;
 
 pub mod bpf_intf;
 pub mod bpf_skel;

--- a/tools/scxprof/src/main.rs
+++ b/tools/scxprof/src/main.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use anyhow::Result;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[clap(name = "scxprof", about = "SCX Workload Profiler")]
+struct Opts {}
+
+fn main() -> Result<()> {
+    let _opts = Opts::parse();
+    Ok(())
+}

--- a/tools/scxprof/src/process.rs
+++ b/tools/scxprof/src/process.rs
@@ -3,7 +3,7 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
-use crate::record::PERF_SCRIPT_FIELDS;
+use crate::record::{perf_binary, PERF_SCRIPT_FIELDS};
 use anyhow::{bail, Context as _, Result};
 use clap::Parser;
 use serde::Serialize;
@@ -132,7 +132,7 @@ fn generate_perf_script(profile_dir: &Path) -> Result<()> {
         bail!("perf.data not found in profile directory");
     }
 
-    let output = Command::new("perf")
+    let output = Command::new(perf_binary())
         .args([
             "script",
             "-F",

--- a/tools/scxprof/src/process.rs
+++ b/tools/scxprof/src/process.rs
@@ -81,10 +81,7 @@ fn prepare_profile_dir(path: &Path) -> Result<PathBuf> {
 
     let path_str = path.to_string_lossy();
     if !path_str.ends_with(".tar.gz") {
-        bail!(
-            "'{}' is not a directory or tar.gz archive",
-            path.display()
-        );
+        bail!("'{}' is not a directory or tar.gz archive", path.display());
     }
 
     let dir_name = path_str.trim_end_matches(".tar.gz");
@@ -117,10 +114,7 @@ fn create_output_dir(profile_dir: &Path) -> Result<PathBuf> {
     let output_dir = PathBuf::from(format!("{}.out", profile_dir.display()));
 
     if output_dir.exists() {
-        bail!(
-            "output directory '{}' already exists",
-            output_dir.display()
-        );
+        bail!("output directory '{}' already exists", output_dir.display());
     }
 
     fs::create_dir_all(&output_dir).context("failed to create output directory")?;
@@ -251,7 +245,11 @@ fn parse_perf_script_line(line: &str) -> Option<PerfScriptRecord> {
     })
 }
 
-fn parse_perf_script_to_jsonl(perf_script_path: &Path, output_path: &Path, verbose: bool) -> Result<()> {
+fn parse_perf_script_to_jsonl(
+    perf_script_path: &Path,
+    output_path: &Path,
+    verbose: bool,
+) -> Result<()> {
     let file = File::open(perf_script_path).context("failed to open perf.script")?;
     let reader = BufReader::new(file);
 

--- a/tools/scxprof/src/process.rs
+++ b/tools/scxprof/src/process.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use anyhow::{bail, Context as _, Result};
+use clap::Parser;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[derive(Debug, Parser)]
+pub struct ProcessOpts {
+    /// Path to profile file (tar.gz) or directory
+    #[clap(short = 'f', long)]
+    pub file: PathBuf,
+}
+
+pub fn cmd_process(opts: ProcessOpts) -> Result<()> {
+    let profile_dir = prepare_profile_dir(&opts.file)?;
+    print_profile_contents(&profile_dir)?;
+    Ok(())
+}
+
+fn prepare_profile_dir(path: &PathBuf) -> Result<PathBuf> {
+    if path.is_dir() {
+        return Ok(path.clone());
+    }
+
+    let path_str = path.to_string_lossy();
+    if !path_str.ends_with(".tar.gz") {
+        bail!(
+            "'{}' is not a directory or tar.gz archive",
+            path.display()
+        );
+    }
+
+    let dir_name = path_str.trim_end_matches(".tar.gz");
+    let output_dir = PathBuf::from(dir_name);
+
+    if output_dir.exists() {
+        bail!(
+            "output directory '{}' already exists",
+            output_dir.display()
+        );
+    }
+
+    let status = Command::new("tar")
+        .args(["-xzf", &path_str, "-C", "."])
+        .status()
+        .context("failed to run tar")?;
+
+    if !status.success() {
+        bail!("tar extraction failed with status: {}", status);
+    }
+
+    if !output_dir.exists() {
+        bail!(
+            "expected directory '{}' not found after extraction",
+            output_dir.display()
+        );
+    }
+
+    Ok(output_dir)
+}
+
+fn print_profile_contents(profile_dir: &PathBuf) -> Result<()> {
+    println!("Profile '{}':", profile_dir.display());
+
+    let entries: Vec<_> = std::fs::read_dir(profile_dir)
+        .context("failed to read profile directory")?
+        .filter_map(|e| e.ok())
+        .collect();
+
+    if entries.is_empty() {
+        println!("  (empty)");
+        return Ok(());
+    }
+
+    for entry in entries {
+        println!("  {}", entry.file_name().to_string_lossy());
+    }
+
+    Ok(())
+}

--- a/tools/scxprof/src/process.rs
+++ b/tools/scxprof/src/process.rs
@@ -6,7 +6,7 @@
 use crate::record::{perf_binary, PERF_SCRIPT_FIELDS};
 use anyhow::{bail, Context as _, Result};
 use clap::Parser;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -24,7 +24,7 @@ pub struct ProcessOpts {
 }
 
 /// Represents a single perf script sample record
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PerfScriptRecord {
     pub comm: String,
     pub tid: u32,

--- a/tools/scxprof/src/process.rs
+++ b/tools/scxprof/src/process.rs
@@ -273,6 +273,13 @@ fn parse_perf_script_to_jsonl(perf_script_path: &Path, output_path: &Path, verbo
                     }
                     continue;
                 }
+                if record.comm == "perf" || record.comm == "swapper" {
+                    skipped += 1;
+                    if verbose {
+                        eprintln!("skipped (filtered comm): {}", line);
+                    }
+                    continue;
+                }
                 let json = serde_json::to_string(&record).context("failed to serialize record")?;
                 writeln!(writer, "{}", json)?;
                 count += 1;

--- a/tools/scxprof/src/process.rs
+++ b/tools/scxprof/src/process.rs
@@ -3,9 +3,13 @@
 // This software may be used and distributed according to the terms of the
 // GNU General Public License version 2.
 
+use crate::record::PERF_SCRIPT_FIELDS;
 use anyhow::{bail, Context as _, Result};
 use clap::Parser;
-use std::path::PathBuf;
+use serde::Serialize;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[derive(Debug, Parser)]
@@ -15,15 +19,60 @@ pub struct ProcessOpts {
     pub file: PathBuf,
 }
 
+/// Represents a single perf script sample record
+#[derive(Debug, Clone, Serialize)]
+pub struct PerfScriptRecord {
+    pub comm: String,
+    pub tid: u32,
+    pub pid: u32,
+    pub time: String,
+    pub addr: String,
+    pub cgroup: String,
+    pub ip: String,
+    pub sym: String,
+    pub dso: String,
+    pub phys_addr: String,
+    pub data_page_size: u64,
+}
+
 pub fn cmd_process(opts: ProcessOpts) -> Result<()> {
     let profile_dir = prepare_profile_dir(&opts.file)?;
-    print_profile_contents(&profile_dir)?;
+
+    let output_dir = create_output_dir(&profile_dir)?;
+    println!("Output directory: {}", output_dir.display());
+
+    match run_processing(&profile_dir, &output_dir) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = fs::remove_dir_all(&output_dir);
+            Err(e)
+        }
+    }
+}
+
+fn run_processing(profile_dir: &Path, output_dir: &Path) -> Result<()> {
+    let perf_script_src = profile_dir.join("perf.script");
+    let perf_script_dst = output_dir.join("perf.script");
+    let perf_jsonl_dst = output_dir.join("perf.jsonl");
+
+    if !perf_script_src.exists() {
+        println!("Generating perf.script from perf.data...");
+        generate_perf_script(profile_dir)?;
+    }
+
+    println!("Copying perf.script...");
+    fs::copy(&perf_script_src, &perf_script_dst).context("failed to copy perf.script")?;
+
+    println!("Parsing perf.script to generate perf.jsonl...");
+    parse_perf_script_to_jsonl(&perf_script_dst, &perf_jsonl_dst)?;
+
+    print_profile_contents(output_dir)?;
     Ok(())
 }
 
-fn prepare_profile_dir(path: &PathBuf) -> Result<PathBuf> {
+fn prepare_profile_dir(path: &Path) -> Result<PathBuf> {
     if path.is_dir() {
-        return Ok(path.clone());
+        return Ok(path.to_path_buf());
     }
 
     let path_str = path.to_string_lossy();
@@ -38,10 +87,7 @@ fn prepare_profile_dir(path: &PathBuf) -> Result<PathBuf> {
     let output_dir = PathBuf::from(dir_name);
 
     if output_dir.exists() {
-        bail!(
-            "output directory '{}' already exists",
-            output_dir.display()
-        );
+        return Ok(output_dir);
     }
 
     let status = Command::new("tar")
@@ -63,8 +109,179 @@ fn prepare_profile_dir(path: &PathBuf) -> Result<PathBuf> {
     Ok(output_dir)
 }
 
-fn print_profile_contents(profile_dir: &PathBuf) -> Result<()> {
-    println!("Profile '{}':", profile_dir.display());
+fn create_output_dir(profile_dir: &Path) -> Result<PathBuf> {
+    let output_dir = PathBuf::from(format!("{}.out", profile_dir.display()));
+
+    if output_dir.exists() {
+        bail!(
+            "output directory '{}' already exists",
+            output_dir.display()
+        );
+    }
+
+    fs::create_dir_all(&output_dir).context("failed to create output directory")?;
+
+    Ok(output_dir)
+}
+
+fn generate_perf_script(profile_dir: &Path) -> Result<()> {
+    let perf_data_path = profile_dir.join("perf.data");
+    let perf_script_path = profile_dir.join("perf.script");
+
+    if !perf_data_path.exists() {
+        bail!("perf.data not found in profile directory");
+    }
+
+    let output = Command::new("perf")
+        .args([
+            "script",
+            "-F",
+            PERF_SCRIPT_FIELDS,
+            "-i",
+            perf_data_path.to_str().context("invalid perf.data path")?,
+        ])
+        .output()
+        .context("failed to run perf script")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("perf script failed: {}", stderr);
+    }
+
+    fs::write(&perf_script_path, &output.stdout).context("failed to write perf.script")?;
+
+    Ok(())
+}
+
+fn parse_page_size(s: &str) -> u64 {
+    let s = s.trim();
+    if s == "N/A" || s.is_empty() {
+        return 0;
+    }
+    let s_upper = s.to_uppercase();
+    if let Some(num_str) = s_upper.strip_suffix('K') {
+        num_str.parse::<u64>().unwrap_or(0) * 1024
+    } else if let Some(num_str) = s_upper.strip_suffix('M') {
+        num_str.parse::<u64>().unwrap_or(0) * 1024 * 1024
+    } else if let Some(num_str) = s_upper.strip_suffix('G') {
+        num_str.parse::<u64>().unwrap_or(0) * 1024 * 1024 * 1024
+    } else {
+        s.parse::<u64>().unwrap_or(0)
+    }
+}
+
+fn parse_perf_script_line(line: &str) -> Option<PerfScriptRecord> {
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() < 8 {
+        return None;
+    }
+
+    let mut tid_pid_idx = None;
+    for (i, part) in parts.iter().enumerate() {
+        if part.contains('/') {
+            let sub_parts: Vec<&str> = part.split('/').collect();
+            if sub_parts.len() == 2
+                && sub_parts[0].parse::<u32>().is_ok()
+                && sub_parts[1].parse::<u32>().is_ok()
+            {
+                tid_pid_idx = Some(i);
+                break;
+            }
+        }
+    }
+
+    let tid_pid_idx = tid_pid_idx?;
+
+    let comm = parts[..tid_pid_idx].join(" ");
+
+    let tid_pid: Vec<&str> = parts[tid_pid_idx].split('/').collect();
+    let tid = tid_pid[0].parse::<u32>().ok()?;
+    let pid = tid_pid[1].parse::<u32>().ok()?;
+
+    let remaining = &parts[tid_pid_idx + 1..];
+
+    if remaining.len() < 4 {
+        return None;
+    }
+
+    let time = remaining[0].trim_end_matches(':').to_string();
+    let addr = remaining[1].to_string();
+    let cgroup = remaining[2].to_string();
+    let ip = remaining[3].to_string();
+
+    let after_ip = &remaining[4..];
+    let after_ip_str = after_ip.join(" ");
+
+    let (sym, dso, phys_addr, data_page_size) = if let Some(paren_end) = after_ip_str.rfind(')') {
+        if let Some(paren_start) = after_ip_str[..paren_end].rfind('(') {
+            let sym = after_ip_str[..paren_start].trim().to_string();
+            let dso = after_ip_str[paren_start + 1..paren_end].to_string();
+            let after_dso: Vec<&str> = after_ip_str[paren_end + 1..].split_whitespace().collect();
+            let phys_addr = after_dso.first().map(|s| s.to_string()).unwrap_or_default();
+            let data_page_size = parse_page_size(after_dso.get(1).unwrap_or(&"0"));
+            (sym, dso, phys_addr, data_page_size)
+        } else {
+            (after_ip_str, String::new(), String::new(), 0)
+        }
+    } else {
+        (String::new(), String::new(), String::new(), 0)
+    };
+
+    Some(PerfScriptRecord {
+        comm,
+        tid,
+        pid,
+        time,
+        addr,
+        cgroup,
+        ip,
+        sym,
+        dso,
+        phys_addr,
+        data_page_size,
+    })
+}
+
+fn parse_perf_script_to_jsonl(perf_script_path: &Path, output_path: &Path) -> Result<()> {
+    let file = File::open(perf_script_path).context("failed to open perf.script")?;
+    let reader = BufReader::new(file);
+
+    let output_file = File::create(output_path).context("failed to create perf.jsonl")?;
+    let mut writer = BufWriter::new(output_file);
+
+    let mut count = 0;
+    let mut errors = 0;
+
+    for line in reader.lines() {
+        let line = line.context("failed to read line")?;
+        match parse_perf_script_line(&line) {
+            Some(record) => {
+                let json = serde_json::to_string(&record).context("failed to serialize record")?;
+                writeln!(writer, "{}", json)?;
+                count += 1;
+            }
+            None => {
+                if !line.trim().is_empty() {
+                    errors += 1;
+                }
+            }
+        }
+    }
+
+    writer.flush()?;
+
+    println!("Parsed {} records ({} unparseable lines)", count, errors);
+
+    Ok(())
+}
+
+fn print_profile_contents(profile_dir: &Path) -> Result<()> {
+    println!("Output contents:");
 
     let entries: Vec<_> = std::fs::read_dir(profile_dir)
         .context("failed to read profile directory")?
@@ -77,7 +294,9 @@ fn print_profile_contents(profile_dir: &PathBuf) -> Result<()> {
     }
 
     for entry in entries {
-        println!("  {}", entry.file_name().to_string_lossy());
+        let metadata = entry.metadata().ok();
+        let size = metadata.map(|m| m.len()).unwrap_or(0);
+        println!("  {} ({} bytes)", entry.file_name().to_string_lossy(), size);
     }
 
     Ok(())

--- a/tools/scxprof/src/record.rs
+++ b/tools/scxprof/src/record.rs
@@ -32,6 +32,10 @@ pub struct RecordOpts {
     #[clap(short = 't', long, default_value = "30")]
     pub timeout: u64,
 
+    /// Load latency threshold in cycles
+    #[clap(short = 'l', long, default_value = "10")]
+    pub ldlat: u32,
+
     /// Path to the SCX scheduler's task hint map
     #[clap(long)]
     pub hints_map: Option<PathBuf>,
@@ -324,6 +328,8 @@ fn run_recording(ctx: &Context, opts: &RecordOpts) -> Result<bool> {
         "--all-cgroups".to_string(),
         "-p".to_string(),
         "--data-page-size".to_string(),
+        "--ldlat".to_string(),
+        opts.ldlat.to_string(),
         "-o".to_string(),
         perf_data_path.to_string_lossy().to_string(),
     ];

--- a/tools/scxprof/src/record.rs
+++ b/tools/scxprof/src/record.rs
@@ -211,7 +211,9 @@ impl HintsRecorder<'static> {
     }
 
     fn consume_and_write(&mut self) -> Result<()> {
-        self.ringbuf.consume().context("failed to consume ringbuf")?;
+        self.ringbuf
+            .consume()
+            .context("failed to consume ringbuf")?;
         let events: Vec<_> = self.events.borrow_mut().drain(..).collect();
         for ev in &events {
             let json = serde_json::to_string(ev).context("failed to serialize event")?;
@@ -269,7 +271,13 @@ fn poll_fds(fds: &[RawFd], timeout_ms: i32) -> Result<PollResult> {
         })
         .collect();
 
-    let ret = unsafe { libc::poll(pollfds.as_mut_ptr(), pollfds.len() as libc::nfds_t, timeout_ms) };
+    let ret = unsafe {
+        libc::poll(
+            pollfds.as_mut_ptr(),
+            pollfds.len() as libc::nfds_t,
+            timeout_ms,
+        )
+    };
 
     if ret < 0 {
         let err = std::io::Error::last_os_error();
@@ -453,7 +461,8 @@ fn create_archive(output_dir: &Path) -> Result<()> {
 }
 
 /// Fields to extract from perf script output
-pub const PERF_SCRIPT_FIELDS: &str = "comm,tid,pid,time,cgroup,ip,addr,phys_addr,data_page_size,dso,sym";
+pub const PERF_SCRIPT_FIELDS: &str =
+    "comm,tid,pid,time,cgroup,ip,addr,phys_addr,data_page_size,dso,sym";
 
 fn generate_perf_script(ctx: &Context, output_dir: &Path) -> Result<()> {
     let perf_data_path = output_dir.join("perf.data");

--- a/tools/scxprof/src/record.rs
+++ b/tools/scxprof/src/record.rs
@@ -1,0 +1,283 @@
+// Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use crate::bpf::{BpfSkel, BpfSkelBuilder};
+use crate::bpf_intf::hints_event;
+use crate::Context;
+use anyhow::{bail, Context as _, Result};
+use clap::Parser;
+use libbpf_rs::skel::{OpenSkel, SkelBuilder};
+use libbpf_rs::{OpenObject, RingBufferBuilder};
+use serde::Serialize;
+use std::cell::RefCell;
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::rc::Rc;
+
+#[derive(Debug, Parser)]
+pub struct RecordOpts {
+    /// Output directory for recording
+    #[clap(short, long, default_value = "scxprof.out")]
+    pub output: PathBuf,
+
+    /// Path to the SCX scheduler's task hint map
+    #[clap(long)]
+    pub hints_map: Option<PathBuf>,
+
+    /// Disable creating a tar.gz archive after recording
+    #[clap(long)]
+    pub disable_archive: bool,
+}
+
+struct SpawnedProcess {
+    child: Child,
+    pidfd: OwnedFd,
+}
+
+impl SpawnedProcess {
+    fn spawn(cmd: &[String]) -> Result<Self> {
+        let child = Command::new(&cmd[0])
+            .args(&cmd[1..])
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .context("failed to spawn command")?;
+
+        let pid = child.id() as i32;
+        let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) } as RawFd;
+        if fd < 0 {
+            bail!("pidfd_open failed: {}", std::io::Error::last_os_error());
+        }
+
+        Ok(Self {
+            child,
+            pidfd: unsafe { OwnedFd::from_raw_fd(fd) },
+        })
+    }
+
+    fn pidfd(&self) -> RawFd {
+        self.pidfd.as_raw_fd()
+    }
+
+    fn wait(&mut self) -> Result<()> {
+        let status = self.child.wait().context("failed to wait for child")?;
+        if !status.success() {
+            bail!("perf exited with status: {}", status);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct HintsEventRecord {
+    pid: i32,
+    tgid: i32,
+    hints: u64,
+    timestamp: u64,
+}
+
+struct HintsRecorder<'a> {
+    _open_object: Box<MaybeUninit<OpenObject>>,
+    _skel: BpfSkel<'a>,
+    link: Option<libbpf_rs::Link>,
+    ringbuf: libbpf_rs::RingBuffer<'a>,
+    events: Rc<RefCell<Vec<HintsEventRecord>>>,
+    writer: BufWriter<File>,
+}
+
+impl HintsRecorder<'static> {
+    fn new(hints_path: PathBuf) -> Result<Self> {
+        let open_object = Box::new(MaybeUninit::uninit());
+        let open_object_ptr = Box::into_raw(open_object);
+
+        let open_object_ref: &'static mut MaybeUninit<OpenObject> =
+            unsafe { &mut *open_object_ptr };
+
+        let builder = BpfSkelBuilder::default();
+        let open_skel = builder
+            .open(open_object_ref)
+            .context("failed to open BPF skeleton")?;
+        let skel = open_skel.load().context("failed to load BPF skeleton")?;
+
+        let link = skel
+            .progs
+            .trace_map_update
+            .attach()
+            .context("failed to attach BPF program")?;
+
+        let events: Rc<RefCell<Vec<HintsEventRecord>>> = Rc::new(RefCell::new(Vec::new()));
+        let events_clone = events.clone();
+
+        let mut ringbuf_builder = RingBufferBuilder::new();
+        ringbuf_builder
+            .add(&skel.maps.ringbuf, move |data: &[u8]| {
+                if data.len() >= std::mem::size_of::<hints_event>() {
+                    let ev: hints_event =
+                        unsafe { std::ptr::read_unaligned(data.as_ptr() as *const hints_event) };
+                    events_clone.borrow_mut().push(HintsEventRecord {
+                        pid: ev.pid,
+                        tgid: ev.tgid,
+                        hints: ev.hints,
+                        timestamp: ev.timestamp,
+                    });
+                }
+                0
+            })
+            .context("failed to add ringbuf callback")?;
+
+        let ringbuf = ringbuf_builder
+            .build()
+            .context("failed to build ring buffer")?;
+
+        let file = File::create(&hints_path).context("failed to create hints output file")?;
+        let writer = BufWriter::new(file);
+
+        Ok(Self {
+            _open_object: unsafe { Box::from_raw(open_object_ptr) },
+            _skel: skel,
+            link: Some(link),
+            ringbuf,
+            events,
+            writer,
+        })
+    }
+
+    fn ringbuf_fd(&self) -> RawFd {
+        self.ringbuf.epoll_fd()
+    }
+
+    fn consume_and_write(&mut self) -> Result<()> {
+        self.ringbuf.consume().context("failed to consume ringbuf")?;
+        let events: Vec<_> = self.events.borrow_mut().drain(..).collect();
+        for ev in &events {
+            let json = serde_json::to_string(ev).context("failed to serialize event")?;
+            writeln!(self.writer, "{}", json)?;
+        }
+        self.writer.flush()?;
+        Ok(())
+    }
+}
+
+impl Drop for HintsRecorder<'_> {
+    fn drop(&mut self) {
+        self.link.take();
+        let _ = self.ringbuf.consume();
+        let events: Vec<_> = self.events.borrow_mut().drain(..).collect();
+        for ev in &events {
+            if let Ok(json) = serde_json::to_string(ev) {
+                let _ = writeln!(self.writer, "{}", json);
+            }
+        }
+        let _ = self.writer.flush();
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum PollResult {
+    Shutdown,
+    ProcessExited,
+    RingbufReady,
+    Timeout,
+}
+
+fn poll_fds(fds: &[RawFd], timeout_ms: i32) -> Result<PollResult> {
+    let mut pollfds: Vec<libc::pollfd> = fds
+        .iter()
+        .map(|&fd| libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        })
+        .collect();
+
+    let ret = unsafe { libc::poll(pollfds.as_mut_ptr(), pollfds.len() as libc::nfds_t, timeout_ms) };
+
+    if ret < 0 {
+        bail!("poll failed: {}", std::io::Error::last_os_error());
+    }
+
+    if ret == 0 {
+        return Ok(PollResult::Timeout);
+    }
+
+    if pollfds[0].revents & libc::POLLIN != 0 {
+        return Ok(PollResult::Shutdown);
+    }
+    if pollfds[1].revents & libc::POLLIN != 0 {
+        return Ok(PollResult::ProcessExited);
+    }
+    if fds.len() > 2 && pollfds[2].revents & libc::POLLIN != 0 {
+        return Ok(PollResult::RingbufReady);
+    }
+
+    Ok(PollResult::Timeout)
+}
+
+pub fn cmd_record(ctx: &Context, opts: RecordOpts) -> Result<()> {
+    fs::create_dir_all(&opts.output).context("failed to create output directory")?;
+
+    let perf_data_path = opts.output.join("perf.data");
+    let perf_args = vec![
+        "perf".to_string(),
+        "mem".to_string(),
+        "record".to_string(),
+        "--all-cgroups".to_string(),
+        "-p".to_string(),
+        "--data-page-size".to_string(),
+        "-o".to_string(),
+        perf_data_path.to_string_lossy().to_string(),
+    ];
+
+    let mut perf = SpawnedProcess::spawn(&perf_args)?;
+
+    let hints_recorder = if opts.hints_map.is_some() {
+        let hints_path = opts.output.join("hints.json");
+        Some(HintsRecorder::new(hints_path)?)
+    } else {
+        None
+    };
+
+    let mut fds = vec![ctx.shutdown_fd(), perf.pidfd()];
+    if let Some(ref recorder) = hints_recorder {
+        fds.push(recorder.ringbuf_fd());
+    }
+
+    let mut hints_recorder = hints_recorder;
+
+    loop {
+        match poll_fds(&fds, 100)? {
+            PollResult::Shutdown => {
+                unsafe {
+                    libc::kill(perf.child.id() as i32, libc::SIGINT);
+                }
+                perf.wait()?;
+                break;
+            }
+            PollResult::ProcessExited => {
+                perf.wait()?;
+                break;
+            }
+            PollResult::RingbufReady => {
+                if let Some(ref mut recorder) = hints_recorder {
+                    recorder.consume_and_write()?;
+                }
+            }
+            PollResult::Timeout => {
+                if let Some(ref mut recorder) = hints_recorder {
+                    recorder.consume_and_write()?;
+                }
+            }
+        }
+    }
+
+    drop(hints_recorder);
+
+    Ok(())
+}

--- a/tools/scxprof/src/record.rs
+++ b/tools/scxprof/src/record.rs
@@ -52,9 +52,9 @@ pub struct RecordOpts {
     #[clap(long)]
     pub disable_archive: bool,
 
-    /// Disable generating perf.script file during recording
+    /// Generate perf.script file during recording
     #[clap(long)]
-    pub disable_perf_script: bool,
+    pub enable_perf_script: bool,
 }
 
 struct SpawnedProcess {
@@ -321,7 +321,7 @@ pub fn cmd_record(ctx: &Context, opts: RecordOpts) -> Result<()> {
         return Ok(());
     }
 
-    if !opts.disable_perf_script {
+    if opts.enable_perf_script {
         println!("Generating perf.script...");
         if let Err(e) = generate_perf_script(ctx, &opts.output) {
             eprintln!("warning: failed to generate perf.script: {}", e);

--- a/tools/scxprof/src/record.rs
+++ b/tools/scxprof/src/record.rs
@@ -302,6 +302,8 @@ pub fn cmd_record(ctx: &Context, opts: RecordOpts) -> Result<()> {
 
     fs::create_dir_all(&opts.output).context("failed to create output directory")?;
 
+    save_perf_version(&opts.output)?;
+
     let completed = match run_recording(ctx, &opts) {
         Ok(completed) => completed,
         Err(e) => {
@@ -396,6 +398,23 @@ fn run_recording(ctx: &Context, opts: &RecordOpts) -> Result<bool> {
     drop(hints_recorder);
 
     Ok(completed)
+}
+
+fn save_perf_version(output_dir: &Path) -> Result<()> {
+    let version_path = output_dir.join("perf.version");
+
+    let output = Command::new("perf")
+        .arg("version")
+        .output()
+        .context("failed to run perf version")?;
+
+    if !output.status.success() {
+        bail!("perf version failed");
+    }
+
+    fs::write(&version_path, &output.stdout).context("failed to write perf.version")?;
+
+    Ok(())
 }
 
 fn create_archive(output_dir: &Path) -> Result<()> {

--- a/tools/scxprof/src/record.rs
+++ b/tools/scxprof/src/record.rs
@@ -22,6 +22,10 @@ use std::process::{Child, Command, Stdio};
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
+pub fn perf_binary() -> String {
+    std::env::var("SCXPROF_PERF").unwrap_or_else(|_| "perf".to_string())
+}
+
 #[derive(Debug, Parser)]
 pub struct RecordOpts {
     /// Output directory for recording
@@ -335,7 +339,7 @@ pub fn cmd_record(ctx: &Context, opts: RecordOpts) -> Result<()> {
 fn run_recording(ctx: &Context, opts: &RecordOpts) -> Result<bool> {
     let perf_data_path = opts.output.join("perf.data");
     let perf_args = vec![
-        "perf".to_string(),
+        perf_binary(),
         "mem".to_string(),
         "record".to_string(),
         "--all-cgroups".to_string(),
@@ -403,7 +407,7 @@ fn run_recording(ctx: &Context, opts: &RecordOpts) -> Result<bool> {
 fn save_perf_version(output_dir: &Path) -> Result<()> {
     let version_path = output_dir.join("perf.version");
 
-    let output = Command::new("perf")
+    let output = Command::new(perf_binary())
         .arg("version")
         .output()
         .context("failed to run perf version")?;
@@ -461,7 +465,7 @@ fn generate_perf_script(ctx: &Context, output_dir: &Path) -> Result<()> {
 
     let output_file = File::create(&perf_script_path).context("failed to create perf.script")?;
 
-    let child = Command::new("perf")
+    let child = Command::new(perf_binary())
         .args([
             "script",
             "-F",


### PR DESCRIPTION
Introduce a workload profiler tool that is used to extract clusters of threads that should be located together in a soft partition to maximize the chance that memory access locality is preserved and subsequently reduce destructive interference due to CPU scheduling decisions.                                                                                                                                                                                                

  ## Examples                           

  ```bash                                  
  # 1. Record memory access profile (30 seconds by default)                            
  scxprof record -o myprofile          

  # 2. Process the recorded profile        
  scxprof process -f myprofile.tar.gz  

  # 3. Extract cell configuration          
  scxprof extract -f myprofile.out/perf.jsonl                                      

  Commands                                 

  # Record                                   

  scxprof record [OPTIONS]                 

  Options:                                 
    -o, --output <DIR>          Output directory [default: scxprof.out]                
    -t, --timeout <SECONDS>     Recording duration [default: 30]                       
    -l, --ldlat <CYCLES>        Load latency threshold [default: 10]                   
        --enable-perf-script    Generate perf.script during recording                  
        --disable-archive       Keep directory instead of creating tar.gz              

  # Process                                  

  scxprof process [OPTIONS]      
  
  Options:                                 
    -f, --file <PATH>    Path to profile (tar.gz or directory)                         
    -v, --verbose        Print parsing details                                         

  # Extract                                  

  scxprof extract [OPTIONS]                

  Options:                                 
    -f, --file <PATH>                        Path to perf.jsonl file                   
        --workload-cgroup-regex <REGEX>      Workload cgroup pattern [default: workload.slice]                                                                                 
        --workload-allotment-cgroup-regex    Allotment cgroup pattern                  
    -v, --verbose                            Verbosity level (-v summary, -vv detailed)

  Example Workflow                         

  # Record on production host              
  $ scxprof record -t 60 -o prod-profile   

  # Transfer and process                   
  $ scxprof process -f prod-profile.tar.gz 
  Output directory: prod-profile.out       
  Copying perf.script...                   
  Parsing perf.script to generate perf.jsonl...                                        
  Parsed 48231 of 52104 records (3412 skipped, 461 unparseable)                        

  # Extract with verbose stats             
 $ scxprof extract -f prod-profile.out/perf.jsonl -v                                                                                                        
  Total samples: 48231                     

  workload.allotment.slice: 28419 samples (58.92%)                              
    web: 18234 (64.16%)                   
    memcached: 5821 (20.48%)                
    mcrouter: 2104 (7.40%)                 
    ... 12 more below 1%                   

  workload.slice: 15102 samples (31.31%)   
    systemd: 4521 (29.94%)                 
    ... 8 more below 1%                    

  rest: 4710 samples (9.77%)               
    kworker: 1203 (25.54%)                 
    ... 15 more below 1%                   
    
  [                                                                                                                                                                            
    {                                                                                                                                                                          
      "name": "allotment",                                                                                                                                                     
      "match": {                                                                                                                                                               
        "CgroupRegex": "workload\\.allotment\\.slice"                                                                                                                          
      },                                                                                                                                                                       
      "subcells": [                                                                                                                                                            
        {                                                                                                                                                                      
          "name": "web",                                                                                                                                                       
          "matches": [[{"CommPrefix": "web"}]]                                                                                                                                 
        },                                                                                                                                                                     
        {                                                                                                                                                                      
          "name": "memcached",                                                                                                                                                 
          "matches": [[{"CommPrefix": "memcached"}]]                                   
        },                                                                             
        {                                  
          "name": "mcrouter",              
          "matches": [[{"CommPrefix": "mcrouter"}]]                                    
        },                                 
        {                                  
          "name": "rest",                  
          "matches": [[]]                  
        }                                  
      ]                                    
    },                                     
    {                                                                                  
      "name": "workload.slice",                                                        
      "matches": [[{"CgroupContains": "workload.slice"}]],                             
      "subcells": [                        
        {                                                                              
          "name": "rest",                  
          "matches": [[]]                  
        }                                                                              
      ]                                    
    },                                     
    {                                      
      "name": "rest",                      
      "matches": [[]],                     
      "subcells": [                        
        {                                  
          "name": "rest",                  
          "matches": [[]]                  
        }                                  
      ]                                    
    }                                      
  ]