### PR TITLE
scx_utils: Fix off-by-one bug in Cpumask

### DIFF
--- a/rust/scx_utils/src/cpumask.rs
+++ b/rust/scx_utils/src/cpumask.rs
@@ -120,7 +120,7 @@ impl Cpumask {
                 let lsb = v.trailing_zeros() as usize;
                 v &= !(1 << lsb);
                 let cpu = index * 8 + lsb;
-                if cpu > *NR_CPU_IDS {
+                if cpu >= *NR_CPU_IDS {
                     bail!(
                         concat!(
                             "Found cpu ({}) in cpumask ({}) which is larger",


### PR DESCRIPTION
Corrected an off-by-one error that would cause `scx_bpfland` to crash with an invalid domain mask:

```bash
$ grep -c ^processor /proc/cpuinfo
16
$ sudo scx_bpfland -m 0xffffff
14:59:00 [INFO] NUMA nodes: 1
14:59:00 [INFO] Disabling NUMA optimizations

thread 'main' panicked at /build/scx-gGhlzx/scx-1.0.20/vendor/bitvec/src/slice.rs:1585:3:
index 16 out of range: Excluded(16)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

With this patch applied:

```bash
$ sudo ./target/release/scx_bpfland -m 0xffffff
15:00:40 [INFO] NUMA nodes: 1
15:00:40 [INFO] Disabling NUMA optimizations
Error: failed to resolve primary domain '0xffffff': Found cpu (16) in cpumask (0xffffff) which is larger than the number of cpus on the machine (16)
```


Suggested-by: Andrea Righi <arighi@nvidia.com>