### PR TITLE
scx_utils: Add is_scx_running for sysfs check

### DIFF
--- a/scheds/rust/scx_beerland/src/main.rs
+++ b/scheds/rust/scx_beerland/src/main.rs
@@ -588,6 +588,14 @@ fn main() -> Result<()> {
     let mut open_object = MaybeUninit::uninit();
     loop {
         let mut sched = Scheduler::init(&opts, &mut open_object)?;
+        if build_id::is_scx_running(SCHEDULER_NAME) {
+            info!("{:} starts running", SCHEDULER_NAME);
+        } else {
+            warn!(
+                "{:} initialized, but not found in /sys/kernel/sched_ext/root/ops",
+                SCHEDULER_NAME
+            );
+        }
         if !sched.run(shutdown.clone())?.should_restart() {
             break;
         }

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -697,6 +697,14 @@ fn main() -> Result<()> {
     let mut open_object = MaybeUninit::uninit();
     loop {
         let mut sched = Scheduler::init(&opts, &mut open_object)?;
+        if build_id::is_scx_running(SCHEDULER_NAME) {
+            info!("{:} starts running", SCHEDULER_NAME);
+        } else {
+            warn!(
+                "{:} initialized, but not found in /sys/kernel/sched_ext/root/ops",
+                SCHEDULER_NAME
+            );
+        }
         if !sched.run(shutdown.clone())?.should_restart() {
             if sched.user_restart {
                 continue;

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -805,6 +805,14 @@ fn main() -> Result<()> {
     let mut open_object = MaybeUninit::uninit();
     loop {
         let mut sched = Scheduler::init(&opts, &mut open_object)?;
+        if build_id::is_scx_running(SCHEDULER_NAME) {
+            info!("{:} starts running", SCHEDULER_NAME);
+        } else {
+            warn!(
+                "{:} initialized, but not found in /sys/kernel/sched_ext/root/ops",
+                SCHEDULER_NAME
+            );
+        }
         if !sched.run(shutdown.clone())?.should_restart() {
             break;
         }

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -981,6 +981,14 @@ fn main() -> Result<()> {
     let mut open_object = MaybeUninit::uninit();
     loop {
         let mut sched = Scheduler::init(&opts, &mut open_object)?;
+        if build_id::is_scx_running(SCHEDULER_NAME) {
+            info!("{:} starts running", SCHEDULER_NAME);
+        } else {
+            warn!(
+                "{:} initialized, but not found in /sys/kernel/sched_ext/root/ops",
+                SCHEDULER_NAME
+            );
+        }
         if !sched.run(shutdown.clone())?.should_restart() {
             if sched.user_restart {
                 continue;

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -29,7 +29,7 @@ use scx_utils::libbpf_clap_opts::LibbpfOpts;
 use scx_utils::UserExitInfo;
 use stats::Metrics;
 
-const SCHEDULER_NAME: &str = "RustLand";
+const SCHEDULER_NAME: &str = "scx_rustland";
 
 /// scx_rustland: user-space scheduler written in Rust
 ///
@@ -424,6 +424,14 @@ fn main() -> Result<()> {
     let mut open_object = MaybeUninit::uninit();
     loop {
         let mut sched = Scheduler::init(&opts, &mut open_object)?;
+        if build_id::is_scx_running(SCHEDULER_NAME) {
+            info!("{:} starts running", SCHEDULER_NAME);
+        } else {
+            warn!(
+                "{:} initialized, but not found in /sys/kernel/sched_ext/root/ops",
+                SCHEDULER_NAME
+            );
+        }
         if !sched.run()?.should_restart() {
             break;
         }

--- a/scheds/rust/scx_tickless/src/main.rs
+++ b/scheds/rust/scx_tickless/src/main.rs
@@ -350,6 +350,14 @@ fn main() -> Result<()> {
     let mut open_object = MaybeUninit::uninit();
     loop {
         let mut sched = Scheduler::init(&opts, &mut open_object)?;
+        if build_id::is_scx_running(SCHEDULER_NAME) {
+            info!("{:} starts running", SCHEDULER_NAME);
+        } else {
+            warn!(
+                "{:} initialized, but not found in /sys/kernel/sched_ext/root/ops",
+                SCHEDULER_NAME
+            );
+        }
         if !sched.run(shutdown.clone())?.should_restart() {
             break;
         }


### PR DESCRIPTION
Print an info log to confirm the scheduler execution has begun, making it more intuitive for users to verify the status.