### PR TITLE
ci: enable Pages auto-configuration in configure-pages action

### DIFF
--- a/.github/workflows/caching-build.yml
+++ b/.github/workflows/caching-build.yml
@@ -98,6 +98,8 @@ jobs:
           sed -i 's%<li><a href="server/index.html">server</a></li>%<li><a href="server/index.html">server</a></li><li><a href="scheduler/sched-ext.html">Kernel Sched Ext Docs</a></li><li><a href="bpf/helpers.html">Kernel Bpf Helpers Docs</a></li>%' target/doc/index.html
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
The pages job failed with "Get Pages site failed" due to the configure-pages action not being able to verify the Pages site configuration. Add enablement: true so the action automatically enables GitHub Pages if not already configured.