### PR TITLE
scx_lavd: Support partial mode with --partial

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -194,6 +194,12 @@ struct Opts {
     #[clap(long = "enable-cpu-bw", action = clap::ArgAction::SetTrue)]
     enable_cpu_bw: bool,
 
+    /// If specified, only tasks which have their scheduling policy set to
+    /// SCHED_EXT using sched_setscheduler(2) are switched. Otherwise, all
+    /// tasks are switched.
+    #[clap(long = "partial", action = clap::ArgAction::SetTrue)]
+    partial: bool,
+
     ///
     /// Disable core compaction so the scheduler uses all the online CPUs.
     /// The core compaction attempts to minimize the number of actively used
@@ -655,6 +661,10 @@ impl<'a> Scheduler<'a> {
             | *compat::SCX_OPS_ENQ_LAST
             | *compat::SCX_OPS_ENQ_MIGRATION_DISABLED
             | *compat::SCX_OPS_KEEP_BUILTIN_IDLE;
+
+        if opts.partial {
+            skel.struct_ops.lavd_ops_mut().flags |= *compat::SCX_OPS_SWITCH_PARTIAL;
+        }
     }
 
     fn get_msg_seq_id() -> u64 {


### PR DESCRIPTION
Add support for running scx_lavd in partial mode where both SCHED_EXT and SCHED_OTHER tasks can co-exist on a single system.

We're experimenting with sched-ext at work but because our workload is so complex we're not quite ready to go all-in on sched-ext just yet and still want to try out things in partial mode.