### PR TITLE
scx_cosmos: Add CPU capacity awareness

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/intf.h
+++ b/scheds/rust/scx_cosmos/src/bpf/intf.h
@@ -32,4 +32,9 @@ struct cpu_arg {
 	s32 cpu_id;
 };
 
+struct domain_arg {
+	s32 cpu_id;
+	s32 sibling_cpu_id;
+};
+
 #endif /* __INTF_H */

--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2025 Andrea Righi <arighi@nvidia.com>
  */
 #include <scx/common.bpf.h>
+#include <scx/percpu.bpf.h>
 #include "intf.h"
 
 char _license[] SEC("license") = "GPL";
@@ -72,6 +73,11 @@ const volatile bool preferred_idle_scan = false;
  * CPUs sorted by their capacity in descendent order.
  */
 const volatile u64 preferred_cpus[MAX_CPUS];
+
+/*
+ * Cache CPU capacity values.
+ */
+const volatile u64 cpu_capacity[MAX_CPUS];
 
 /*
  * Enable cpufreq integration.
@@ -229,6 +235,7 @@ struct cpu_ctx {
 	u64 last_update;
 	u64 perf_lvl;
 	u64 perf_events;
+	struct bpf_cpumask __kptr *smt;
 };
 
 struct {
@@ -471,6 +478,95 @@ static inline bool is_cpu_idle(s32 cpu)
 }
 
 /*
+ * Return the SMT sibling CPU of a @cpu.
+ */
+static s32 smt_sibling(s32 cpu)
+{
+	const struct cpumask *smt;
+	struct cpu_ctx *cctx;
+
+	cctx = try_lookup_cpu_ctx(cpu);
+	if (!cctx)
+		return cpu;
+
+	smt = cast_mask(cctx->smt);
+	if (!smt)
+		return cpu;
+
+	return bpf_cpumask_first(smt);
+}
+
+/*
+ * Return true if the CPU is part of a fully busy SMT core, false
+ * otherwise.
+ *
+ * If SMT is disabled or SMT contention avoidance is disabled, always
+ * return false (since there's no SMT contention or it's ignored).
+ */
+static bool is_smt_contended(s32 cpu)
+{
+	const struct cpumask *idle_mask;
+	bool is_contended;
+
+	if (!smt_enabled)
+		return false;
+
+	/*
+	 * If the sibling SMT CPU is not idle and there are other full-idle
+	 * SMT cores available, consider the current CPU as contended.
+	 */
+	idle_mask = scx_bpf_get_idle_cpumask();
+	is_contended = !bpf_cpumask_test_cpu(smt_sibling(cpu), idle_mask) &&
+		       !bpf_cpumask_empty(idle_mask);
+	scx_bpf_put_cpumask(idle_mask);
+
+	return is_contended;
+}
+
+/*
+ * Return true if @cpu is valid, otherwise trigger an error and return
+ * false.
+ */
+static inline bool is_cpu_valid(s32 cpu)
+{
+	u64 max_cpu = MIN(nr_cpu_ids, MAX_CPUS);
+
+	if (cpu < 0 || cpu >= max_cpu) {
+		scx_bpf_error("invalid CPU id: %d", cpu);
+		return false;
+	}
+	return true;
+}
+
+/*
+ * Return true if @this_cpu and @that_cpu are in the same LLC, false
+ * otherwise.
+ */
+static inline bool cpus_share_cache(s32 this_cpu, s32 that_cpu)
+{
+	if (this_cpu == that_cpu)
+		return true;
+
+	if (!is_cpu_valid(this_cpu) || !is_cpu_valid(that_cpu))
+		return false;
+
+	return cpu_llc_id(this_cpu) == cpu_llc_id(that_cpu);
+}
+/*
+ * Return true if @this_cpu is faster than @that_cpu, false otherwise.
+ */
+static inline bool is_cpu_faster(s32 this_cpu, s32 that_cpu)
+{
+	if (this_cpu == that_cpu)
+		return false;
+
+	if (!is_cpu_valid(this_cpu) || !is_cpu_valid(that_cpu))
+		return false;
+
+	return cpu_capacity[this_cpu] > cpu_capacity[that_cpu];
+}
+
+/*
  * Try to pick the best idle CPU based on the @preferred_cpus ranking.
  * Return a full-idle SMT core if @do_idle_smt is true, or any idle CPU if
  * @do_idle_smt is false.
@@ -578,12 +674,21 @@ out:
 }
 
 /*
+ * Return true in case of a task wakeup, false otherwise.
+ */
+static inline bool is_wakeup(u64 wake_flags)
+{
+	return wake_flags & SCX_WAKE_TTWU;
+}
+
+/*
  * Pick an optimal idle CPU for task @p (as close as possible to
  * @prev_cpu).
  *
  * Return the CPU id or a negative value if an idle CPU can't be found.
  */
-static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, u64 wake_flags, bool from_enqueue)
+static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, s32 this_cpu,
+			 u64 wake_flags, bool from_enqueue)
 {
 	const struct cpumask *mask = cast_mask(primary_cpumask);
 	s32 cpu;
@@ -601,6 +706,28 @@ static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, u64 wake_flags, bo
 	 */
 	if (no_wake_sync)
 		wake_flags &= ~SCX_WAKE_SYNC;
+
+	/*
+	 * On wakeup if the waker's CPU is faster than the wakee's CPU, try
+	 * to move the wakee closer to the waker.
+	 *
+	 * In presence of hybrid cores this helps to naturally migrate
+	 * tasks over to the faster cores.
+	 */
+	if (primary_all && is_wakeup(wake_flags) && this_cpu >= 0 &&
+	    is_cpu_faster(this_cpu, prev_cpu)) {
+		/*
+		 * If both the waker's CPU and the wakee's CPU are in the
+		 * same LLC and the wakee's CPU is a fully idle SMT core,
+		 * don't migrate.
+		 */
+		if (cpus_share_cache(this_cpu, prev_cpu) &&
+		    !is_smt_contended(prev_cpu) &&
+		    scx_bpf_test_and_clear_cpu_idle(prev_cpu))
+			return prev_cpu;
+
+		prev_cpu = this_cpu;
+	}
 
 	/*
 	 * Fallback to the old API if the kernel doesn't support
@@ -706,6 +833,31 @@ static int init_cpumask(struct bpf_cpumask **p_cpumask)
 	return *p_cpumask ? 0 : -ENOMEM;
 }
 
+SEC("syscall")
+int enable_sibling_cpu(struct domain_arg *input)
+{
+	struct cpu_ctx *cctx;
+	struct bpf_cpumask *mask, **pmask;
+	int err = 0;
+
+	cctx = try_lookup_cpu_ctx(input->cpu_id);
+	if (!cctx)
+		return -ENOENT;
+
+	pmask = &cctx->smt;
+	err = init_cpumask(pmask);
+	if (err)
+		return err;
+
+	bpf_rcu_read_lock();
+	mask = *pmask;
+	if (mask)
+		bpf_cpumask_set_cpu(input->sibling_cpu_id, mask);
+	bpf_rcu_read_unlock();
+
+	return err;
+}
+
 /*
  * Called from user-space to add CPUs to the the primary domain.
  */
@@ -761,52 +913,15 @@ static int wakeup_timerfn(void *map, int *key, struct bpf_timer *timer)
 }
 
 /*
- * Return true if the CPU is part of a fully busy SMT core, false
- * otherwise.
- *
- * If SMT is disabled or SMT contention avoidance is disabled, always
- * return false (since there's no SMT contention or it's ignored).
+ * Return true if the task should attempt a migration, false otherwise.
  */
-static bool is_smt_contended(s32 cpu)
-{
-	const struct cpumask *smt;
-	bool is_contended;
-
-	if (!smt_enabled || !avoid_smt)
-		return false;
-
-	smt = scx_bpf_get_idle_smtmask();
-	is_contended = bpf_cpumask_empty(smt);
-	scx_bpf_put_cpumask(smt);
-
-	return is_contended;
-}
-
-/*
- * Return true if we should attempt a task migration to an idle CPU, false
- * otherwise.
- */
-static bool need_migrate(const struct task_struct *p, s32 prev_cpu, u64 enq_flags)
+static bool task_should_migrate(struct task_struct *p, u64 enq_flags)
 {
 	/*
-	 * Per-CPU tasks are not allowed to migrate.
+	 * Attempt a migration on wakeup (task was not running) and only if
+	 * ops.select_cpu() has not been called already.
 	 */
-	if (is_pcpu_task(p))
-		return false;
-
-	/*
-	 * Always attempt to migrate if we're contending an SMT core.
-	 */
-	if (is_smt_contended(prev_cpu))
-		return true;
-
-	/*
-	 * Attempt a migration on wakeup (if ops.select_cpu() was skipped)
-	 * or if the task was re-enqueued due to a higher scheduling class
-	 * stealing the CPU it was queued on.
-	 */
-	return (!__COMPAT_is_enq_cpu_selected(enq_flags) && !scx_bpf_task_running(p)) ||
-	       (enq_flags & SCX_ENQ_REENQ);
+	return !__COMPAT_is_enq_cpu_selected(enq_flags) && !scx_bpf_task_running(p);
 }
 
 /*
@@ -859,7 +974,16 @@ s32 BPF_STRUCT_OPS(cosmos_select_cpu, struct task_struct *p, s32 prev_cpu, u64 w
 	struct task_ctx *tctx;
 	bool is_busy = is_system_busy();
 	s32 cpu, this_cpu = bpf_get_smp_processor_id();
+	bool is_this_cpu_allowed = bpf_cpumask_test_cpu(this_cpu, p->cpus_ptr);
 	int new_cpu;
+
+	/*
+	 * Make sure @prev_cpu is usable, otherwise try to move close to
+	 * the waker's CPU. If the waker's CPU is also not usable, then
+	 * pick the first usable CPU.
+	 */
+	if (!bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr))
+		prev_cpu = is_this_cpu_allowed ? this_cpu : bpf_cpumask_first(p->cpus_ptr);
 
 	/*
 	 * When the waker and wakee share the same address space and were previously
@@ -898,7 +1022,8 @@ s32 BPF_STRUCT_OPS(cosmos_select_cpu, struct task_struct *p, s32 prev_cpu, u64 w
 	 * task to ops.enqueue(). Dispatching directly from here, even if
 	 * we can't find an idle CPU, allows to save some locking overhead.
 	 */
-	cpu = pick_idle_cpu(p, prev_cpu, wake_flags, false);
+	cpu = pick_idle_cpu(p, prev_cpu, is_this_cpu_allowed ? this_cpu : -1,
+			    wake_flags, false);
 	if (cpu >= 0 || !is_busy)
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p), 0);
 
@@ -953,8 +1078,11 @@ void BPF_STRUCT_OPS(cosmos_enqueue, struct task_struct *p, u64 enq_flags)
 	 * Attempt to dispatch directly to an idle CPU if the task can
 	 * migrate.
 	 */
-	if (need_migrate(p, prev_cpu, enq_flags)) {
-		cpu = pick_idle_cpu(p, prev_cpu, 0, true);
+	if (task_should_migrate(p, enq_flags)) {
+		if (is_pcpu_task(p))
+			cpu = scx_bpf_test_and_clear_cpu_idle(prev_cpu) ? prev_cpu : -EBUSY;
+		else
+			cpu = pick_idle_cpu(p, prev_cpu, -1, 0, true);
 		if (cpu >= 0) {
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, task_slice(p), enq_flags);
 			if (cpu != prev_cpu || !scx_bpf_task_running(p))
@@ -964,19 +1092,22 @@ void BPF_STRUCT_OPS(cosmos_enqueue, struct task_struct *p, u64 enq_flags)
 	}
 
 	/*
-	 * Keep using the same CPU if the system is not busy, otherwise
-	 * fallback to the shared DSQ.
+	 * Keep using the same CPU if the system is not busy.
 	 */
 	if (!is_system_busy()) {
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p), enq_flags);
-		if (!__COMPAT_is_enq_cpu_selected(enq_flags) && !scx_bpf_task_running(p))
+		if (task_should_migrate(p, enq_flags))
 			wakeup_cpu(prev_cpu);
 		return;
 	}
 
+	/*
+	 * Dispatch the task to the shared DSQ.
+	 */
 	scx_bpf_dsq_insert_vtime(p, shared_dsq(prev_cpu),
 				 task_slice(p), task_dl(p, tctx), enq_flags);
-	if (!__COMPAT_is_enq_cpu_selected(enq_flags) && !scx_bpf_task_running(p))
+
+	if (task_should_migrate(p, enq_flags))
 		wakeup_cpu(prev_cpu);
 }
 
@@ -994,7 +1125,7 @@ void BPF_STRUCT_OPS(cosmos_dispatch, s32 cpu, struct task_struct *prev)
 	 * wants to run on this SMT core, allow the previous task to run
 	 * for another time slot.
 	 */
-	if (prev && (prev->scx.flags & SCX_TASK_QUEUED) && !is_smt_contended(cpu))
+	if (prev && (prev->scx.flags & SCX_TASK_QUEUED))
 		prev->scx.slice = task_slice(prev);
 }
 

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -12,7 +12,7 @@ pub use bpf_intf::*;
 
 mod stats;
 use std::collections::HashSet;
-use std::ffi::c_int;
+use std::ffi::{c_int, c_ulong};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::mem::MaybeUninit;
@@ -468,12 +468,13 @@ impl<'a> Scheduler<'a> {
         rodata.busy_threshold = opts.cpu_busy_thresh * 1024 / 100;
 
         // Generate the list of available CPUs sorted by capacity in descending order.
+        let mut cpus: Vec<_> = topo.all_cpus.values().collect();
+        cpus.sort_by_key(|cpu| std::cmp::Reverse(cpu.cpu_capacity));
+        for (i, cpu) in cpus.iter().enumerate() {
+            rodata.cpu_capacity[cpu.id] = cpu.cpu_capacity as c_ulong;
+            rodata.preferred_cpus[i] = cpu.id as u64;
+        }
         if opts.preferred_idle_scan {
-            let mut cpus: Vec<_> = topo.all_cpus.values().collect();
-            cpus.sort_by_key(|cpu| std::cmp::Reverse(cpu.cpu_capacity));
-            for (i, cpu) in cpus.iter().enumerate() {
-                rodata.preferred_cpus[i] = cpu.id as u64;
-            }
             info!(
                 "Preferred CPUs: {:?}",
                 &rodata.preferred_cpus[0..cpus.len()]
@@ -560,6 +561,11 @@ impl<'a> Scheduler<'a> {
             }
         }
 
+        // Initialize SMT domains.
+        if smt_enabled {
+            Self::init_smt_domains(&mut skel, &topo)?;
+        }
+
         // Attach the scheduler.
         let struct_ops = Some(scx_ops_attach!(skel, cosmos_ops)?);
         let stats_server = StatsServer::new(stats::server_data()).launch()?;
@@ -589,6 +595,44 @@ impl<'a> Scheduler<'a> {
         let out = prog.test_run(input).unwrap();
         if out.return_value != 0 {
             return Err(out.return_value);
+        }
+
+        Ok(())
+    }
+
+    fn enable_sibling_cpu(
+        skel: &mut BpfSkel<'_>,
+        cpu: usize,
+        sibling_cpu: usize,
+    ) -> Result<(), u32> {
+        let prog = &mut skel.progs.enable_sibling_cpu;
+        let mut args = domain_arg {
+            cpu_id: cpu as c_int,
+            sibling_cpu_id: sibling_cpu as c_int,
+        };
+        let input = ProgramInput {
+            context_in: Some(unsafe {
+                std::slice::from_raw_parts_mut(
+                    &mut args as *mut _ as *mut u8,
+                    std::mem::size_of_val(&args),
+                )
+            }),
+            ..Default::default()
+        };
+        let out = prog.test_run(input).unwrap();
+        if out.return_value != 0 {
+            return Err(out.return_value);
+        }
+
+        Ok(())
+    }
+
+    fn init_smt_domains(skel: &mut BpfSkel<'_>, topo: &Topology) -> Result<(), std::io::Error> {
+        let smt_siblings = topo.sibling_cpus();
+
+        info!("SMT sibling CPUs: {:?}", smt_siblings);
+        for (cpu, sibling_cpu) in smt_siblings.iter().enumerate() {
+            Self::enable_sibling_cpu(skel, cpu, *sibling_cpu as usize).unwrap();
         }
 
         Ok(())


### PR DESCRIPTION
On task wakeup, when using the default idle CPU selection policy, if the waker's CPU has higher capacity than the wakee's CPU, attempt to place the wakee on a CPU closer in capacity to the waker.

NOTE: This logic is already used in scx_bpfland and scx_beerland with positive results, so extend the same approach to scx_cosmos as well.

cc: @balbirs-nv 