### PR TITLE
scx_layered: topology-aware cpumask grid display for stats

### DIFF
--- a/rust/scx_utils/src/topology.rs
+++ b/rust/scx_utils/src/topology.rs
@@ -454,8 +454,11 @@ impl Topology {
             let first_llc_id = llc_segments[0].0;
             let prefix = format!("{}N{} L{:02}: ", indent, node.id, first_llc_id);
             let prefix_width = prefix.chars().count();
-            let cont_indent =
-                format!("{}{}", indent, " ".repeat(prefix_width - indent.chars().count()));
+            let cont_indent = format!(
+                "{}{}",
+                indent,
+                " ".repeat(prefix_width - indent.chars().count())
+            );
 
             // Join LLCs with "|", wrapping at LLC boundaries
             let mut line = prefix.clone();
@@ -1423,5 +1426,4 @@ mod tests {
         assert!(header.contains("cpus=  3(  2c)"));
         assert!(header.contains("[  5, 10]"));
     }
-
 }

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -430,13 +430,7 @@ impl LayerStats {
 
         if let Some(topo) = topo {
             let header = topo.format_cpumask_header(&cpumask, self.min_nr_cpus, self.max_nr_cpus);
-            writeln!(
-                w,
-                "  {:<width$}  {}",
-                "",
-                header,
-                width = header_width,
-            )?;
+            writeln!(w, "  {:<width$}  {}", "", header, width = header_width,)?;
             let indent = format!("  {:<width$}  ", "", width = header_width);
             if cpumask.weight() > 0 {
                 topo.format_cpumask_grid(w, &cpumask, &indent, usize::MAX)?;


### PR DESCRIPTION
## Summary
- Add `format_cpumask_grid()`, `cpumask_nr_cores()`, and `format_cpumask_header()` to `Topology` in scx_utils
- Replace raw hex bitmask display in scx_layered monitor stats with a visual grid using Unicode block characters (`░▀▄█`) — one char per physical core
- `|` marks LLC (L3) boundaries; spaces separate groups of up to 8 cores within an LLC (evenly split, e.g. 12 cores = 6+6)
- One line per NUMA node, no wrapping — let the terminal handle it
- Falls back to hex display when topology is unavailable

Example output on a 384-CPU AMD EPYC (2 nodes, 12 LLCs/node, 8 cores/LLC):
```
cpus= 90( 45c) [ 90, 90]
  N0 L00: ░░░░███░|█░░░█░█░|░█░█░░░█|░░░█░░░░|█░░░███░|░░█░░░█░|░░██░░░░|░░░█░█░░|░░░░░░░░|░░░░░░░░|░░░░░░░█|░░░██░█░
  N1 L12: ░░░█░░░░|░░░░░░██|░██░░░█░|░░░░░░░█|░░██░█░█|░█░░█░░░|░░░█░░░░|░███░░░░|░█░░░░░░|░░░░░░░░|░█░░░░░░|░░██░░░░
```

Example on Intel SPR (1 LLC per socket, 56 cores):
```
  N0 L00: ████████ ████████ ████████ ████████ ████████ ████████ ████████
```

## Test plan
- [x] `cargo test -p scx_utils --lib topology::tests` — 9 unit tests
- [x] `cargo build -p scx_layered` — clean build
- [x] Manual verification with `--monitor` on 384-CPU machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)