### PR TITLE
Cargo: limit the number of compiled workspace elements

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+
+[build]
+jobs = 6


### PR DESCRIPTION
It turns out that our workspace is large. It won't get any smaller, and it will only get bigger. By default, Rust/Cargo builds a lot of objects at once. I was thinking of putting a limit in config.toml. 