### PR TITLE
Cargo.toml: update cargo profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,14 @@ lto = "thin"
 
 [profile.release-tiny]
 inherits = "release"
-lto = "thin"
-strip = true
-incremental = true
+opt-level = "z"
+lto = false
 codegen-units = 1
+strip = true
+panic = "abort"
 
 [profile.release-fast]
 inherits = "release"
 lto = false
-incremental = true
+codegen-units = 32
+panic = "abort"


### PR DESCRIPTION
## 1. Keep ThinLTO in the Default `release` Profile

``` toml
[profile.release]
lto = "thin"
opt-level = 2
incremental = false
```

### Why?

ThinLTO significantly improves cross-crate optimization and runtime
performance.

However, it increases peak memory usage during linking. We keep it
enabled in `release` because:

-   Production builds require optimal runtime performance.
-   ThinLTO offers a good compromise between performance and memory
    compared to full LTO.
-   Removing it globally would reduce scheduler/runtime efficiency.

------------------------------------------------------------------------

## 2. Use `opt-level = 2` Instead of `3`

`opt-level = 3` increases:

-   Compile time
-   LLVM memory usage
-   Risk of OOM in large workspaces

`opt-level = 2` provides:

-   Nearly identical runtime performance in most real-world cases
-   Lower compilation cost
-   Better stability

The performance difference between O2 and O3 is usually marginal
compared to the build-time cost.

------------------------------------------------------------------------

## 3. Disable Incremental Compilation in Release

``` toml
incremental = false
```

### Why?

Incremental compilation:

-   Increases disk IO
-   Increases target directory size
-   Is less useful for clean CI builds
-   Can behave poorly in sandbox/overlayfs environments

Release builds should be deterministic and stable.

------------------------------------------------------------------------

## 4. Introduce a `release-perf` Profile

``` toml
[profile.release-perf]
inherits = "release"
opt-level = 3
```

This profile allows maximum runtime performance when explicitly
requested:

``` bash
cargo build --profile release-perf
```

It exists so we can:

-   Benchmark
-   Validate performance regressions
-   Compare O2 vs O3 behavior

Without forcing O3 on all users.

------------------------------------------------------------------------

## 5. Improve a `release-tiny` Profile

``` toml
[profile.release-tiny]
inherits = "release"
opt-level = "z"
lto = false
codegen-units = 1
strip = true
panic = "abort"
```

### Goals

-   Smallest possible binary
-   Reduced memory usage during compilation

### Why disable LTO here?

ThinLTO is memory-expensive. For size-oriented builds, avoiding LTO:

-   Reduces peak memory
-   Makes builds more stable on low-memory systems

### Why `panic = "abort"`?

-   Smaller binaries
-   No unwinding runtime
-   Suitable for CLI/system tools where panic is fatal

------------------------------------------------------------------------

## 6. Improve a `release-fast` Profile

``` toml
[profile.release-fast]
inherits = "release"
lto = false
codegen-units = 32
panic = "abort"
```

### Goals

-   Faster compilation
-   Lower peak memory usage
-   Avoid ThinLTO-related OOM spikes

### Why increase `codegen-units`?

More codegen units:

-   Improve parallelism
-   Reduce per-unit memory pressure
-   Shorten compile time

Slight runtime optimization tradeoff is acceptable here.

**Logs (time):** 

```
❯ cargo build --profile=release     
warning: /home/lucjan/Patchownia/other/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.44
   Compiling unicode-ident v1.0.23
   Compiling libc v0.2.180
   Compiling autocfg v1.5.0
   Compiling cfg-if v1.0.4
   Compiling serde_core v1.0.228
   Compiling bitflags v2.10.0
   Compiling cfg_aliases v0.2.1
   Compiling getrandom v0.3.3
   Compiling strsim v0.11.1
   Compiling memchr v2.7.5
   Compiling shlex v1.3.0
   Compiling syn v2.0.114
   Compiling heck v0.5.0
   Compiling serde v1.0.228
   Compiling find-msvc-tools v0.1.9
   Compiling anyhow v1.0.101
   Compiling cc v1.2.55
   Compiling thiserror v2.0.18
   Compiling rustix v1.0.8
   Compiling linux-raw-sys v0.9.4
   Compiling serde_json v1.0.145
   Compiling once_cell v1.21.3
   Compiling nix v0.31.1
   Compiling pkg-config v0.3.32
   Compiling camino v1.1.10
   Compiling semver v1.0.26
   Compiling unicode-segmentation v1.12.0
   Compiling prettyplease v0.2.35
   Compiling fastrand v2.3.0
   Compiling log v0.4.27
   Compiling glob v0.3.2
   Compiling vsprintf v2.0.0
   Compiling aho-corasick v1.1.3
   Compiling regex-syntax v0.8.5
   Compiling clang-sys v1.8.1
   Compiling itoa v1.0.15
   Compiling either v1.15.0
   Compiling ryu v1.0.20
   Compiling unicode-xid v0.2.6
   Compiling const_format_proc_macros v0.2.34
   Compiling tempfile v3.20.0
   Compiling xattr v1.5.1
   Compiling filetime v0.2.25
   Compiling same-file v1.0.6
   Compiling twox-hash v2.1.2
   Compiling bindgen v0.72.0
   Compiling ruzstd v0.8.1
   Compiling walkdir v2.5.0
   Compiling tar v0.4.44
   Compiling convert_case v0.6.0
   Compiling num-traits v0.2.19
   Compiling regex-syntax v0.6.29
   Compiling utf8parse v0.2.2
   Compiling unicode-width v0.1.14
   Compiling regex-automata v0.4.9
   Compiling strsim v0.10.0
   Compiling scx_cargo v1.0.27 (/home/lucjan/Patchownia/other/scx/rust/scx_cargo)
   Compiling serde_derive v1.0.228
   Compiling thiserror-impl v2.0.18
   Compiling tracing-attributes v0.1.30
   Compiling clap_derive v4.5.41
   Compiling anstyle-parse v0.2.7
   Compiling libbpf-sys v1.6.3+v1.6.3
   Compiling tracing-core v0.1.34
   Compiling sscanf_macro v0.4.1
   Compiling colorchoice v1.0.4
   Compiling is_terminal_polyfill v1.70.1
   Compiling anstyle-query v1.1.3
   Compiling regex v1.11.2
   Compiling anstyle v1.0.11
   Compiling lazy_static v1.5.0
   Compiling anstream v0.6.19
   Compiling terminal_size v0.4.2
   Compiling iana-time-zone v0.1.63
   Compiling clap_lex v0.7.5
   Compiling unicase v2.8.1
   Compiling minimal-lexical v0.2.1
   Compiling unicode-width v0.2.0
   Compiling nom v7.1.3
   Compiling chrono v0.4.41
   Compiling clap_builder v4.5.41
   Compiling sharded-slab v0.1.7
   Compiling cargo-platform v0.1.9
   Compiling tracing-log v0.2.0
   Compiling thread_local v1.1.9
   Compiling libloading v0.8.8
   Compiling nu-ansi-term v0.50.3
   Compiling smallvec v1.15.1
   Compiling pin-project-lite v0.2.16
   Compiling tracing v0.1.41
   Compiling tracing-subscriber v0.3.20
   Compiling cargo_metadata v0.19.2
   Compiling libbpf-rs v0.26.0
   Compiling cexpr v0.6.0
   Compiling clap v4.5.41
   Compiling const_format v0.2.34
   Compiling itertools v0.13.0
   Compiling memmap2 v0.9.7
   Compiling rustc-hash v2.1.1
   Compiling sscanf v0.4.1
   Compiling libbpf-cargo v0.26.0
   Compiling version-compare v0.1.1
   Compiling crossbeam-utils v0.8.21
   Compiling lock_api v0.4.13
   Compiling parking_lot_core v0.9.11
   Compiling rustversion v1.0.21
   Compiling scopeguard v1.2.0
   Compiling thiserror v1.0.69
   Compiling parking_lot v0.12.4
   Compiling signal-hook-registry v1.4.5
   Compiling futures-core v0.3.31
   Compiling thiserror-impl v1.0.69
   Compiling time-core v0.1.4
   Compiling num-conv v0.1.0
   Compiling static_assertions v1.1.0
   Compiling equivalent v1.0.2
   Compiling hashbrown v0.15.4
   Compiling indexmap v2.10.0
   Compiling parking v2.2.1
   Compiling concurrent-queue v2.5.0
   Compiling futures-io v0.3.31
   Compiling winnow v0.7.12
   Compiling event-listener v5.4.0
   Compiling toml_datetime v0.6.11
   Compiling toml_edit v0.22.27
   Compiling event-listener-strategy v0.5.4
   Compiling num-integer v0.1.46
   Compiling enumflags2_derive v0.7.12
   Compiling slab v0.4.11
   Compiling proc-macro-crate v3.3.0
   Compiling zvariant_utils v3.2.0
   Compiling memoffset v0.9.1
   Compiling zvariant_derive v5.6.0
   Compiling num-bigint v0.4.6
   Compiling futures-lite v2.6.0
   Compiling crossbeam-channel v0.5.15
   Compiling powerfmt v0.2.0
   Compiling deranged v0.4.0
   Compiling num-rational v0.4.2
   Compiling num-iter v0.1.45
   Compiling time-macros v0.2.22
   Compiling num-complex v0.4.6
   Compiling crossbeam-epoch v0.9.18
   Compiling num_threads v0.1.7
   Compiling time v0.3.41
   Compiling num v0.4.3
   Compiling crossbeam-deque v0.8.6
   Compiling enumflags2 v0.7.12
   Compiling matchers v0.2.0
   Compiling async-lock v3.4.0
   Compiling polling v3.8.0
   Compiling vergen v8.3.2
   Compiling nix v0.30.1
   Compiling endi v1.1.0
   Compiling async-task v4.7.1
   Compiling hex v0.4.3
   Compiling zvariant v5.6.0
   Compiling async-io v2.4.1
   Compiling async-channel v2.5.0
   Compiling cargo_metadata v0.18.1
   Compiling radium v0.7.0
   Compiling paste v1.0.15
   Compiling atomic-waker v1.1.2
   Compiling piper v0.2.4
   Compiling zbus_names v4.2.0
   Compiling async-signal v0.2.11
   Compiling crossbeam-queue v0.3.12
   Compiling tap v1.0.1
   Compiling crossbeam v0.8.4
   Compiling wyz v0.5.1
   Compiling zbus_macros v5.8.0
   Compiling async-process v2.3.1
   Compiling scx_utils v1.0.26 (/home/lucjan/Patchownia/other/scx/rust/scx_utils)
   Compiling blocking v1.6.2
   Compiling async-executor v1.13.2
   Compiling async-broadcast v0.7.2
   Compiling ordered-stream v0.2.0
   Compiling serde_repr v0.1.20
   Compiling async-trait v0.1.88
   Compiling funty v2.0.0
   Compiling bitvec v1.0.1
   Compiling zbus v5.8.0
   Compiling scx_stats v1.0.22 (/home/lucjan/Patchownia/other/scx/rust/scx_stats)
   Compiling ident_case v1.0.1
   Compiling fnv v1.0.7
   Compiling darling_core v0.20.11
   Compiling crc32fast v1.5.0
   Compiling allocator-api2 v0.2.21
   Compiling mio v1.0.4
   Compiling termcolor v1.4.1
   Compiling ctrlc v3.4.7
   Compiling simd-adler32 v0.3.7
   Compiling simplelog v0.12.2
   Compiling adler2 v2.0.1
   Compiling signal-hook v0.3.18
   Compiling miniz_oxide v0.8.9
   Compiling darling_macro v0.20.11
   Compiling darling v0.20.11
   Compiling scx_stats_derive v1.0.21 (/home/lucjan/Patchownia/other/scx/rust/scx_stats/scx_stats_derive)
   Compiling bitflags v1.3.2
   Compiling mio v0.8.11
   Compiling indoc v2.0.6
   Compiling seccomp-sys v0.1.3
   Compiling flate2 v1.1.2
   Compiling signal-hook-mio v0.2.4
   Compiling zerocopy v0.8.26
   Compiling version_check v0.9.5
   Compiling castaway v0.2.4
   Compiling num_cpus v1.17.0
   Compiling pin-utils v0.1.0
   Compiling protobuf v3.7.2
   Compiling foldhash v0.1.5
   Compiling foldhash v0.2.0
   Compiling stable_deref_trait v1.2.0
   Compiling rustix v0.38.44
   Compiling hashbrown v0.16.1
   Compiling instability v0.3.7
   Compiling linux-raw-sys v0.4.15
   Compiling io-lifetimes v1.0.11
   Compiling scx_arena v0.1.4 (/home/lucjan/Patchownia/other/scx/rust/scx_arena/scx_arena)
   Compiling protobuf-support v3.7.2
   Compiling itertools v0.14.0
   Compiling ordered-float v3.9.2
   Compiling strum_macros v0.27.2
   Compiling clap_main v0.2.9
   Compiling memoffset v0.6.5
   Compiling rustix v0.36.17
   Compiling home v0.5.11
   Compiling which v4.4.2
   Compiling unicode-truncate v2.0.1
   Compiling seccomp v0.1.2
   Compiling lru v0.16.3
   Compiling kasuari v0.4.11
   Compiling strum v0.27.2
   Compiling ahash v0.8.12
   Compiling compact_str v0.9.0
   Compiling tokio-macros v2.5.0
   Compiling convert_case v0.10.0
   Compiling socket2 v0.5.10
   Compiling openat v0.1.21
   Compiling bytes v1.10.1
   Compiling linux-raw-sys v0.1.4
   Compiling futures-sink v0.3.31
   Compiling plain v0.2.3
   Compiling procfs v0.15.1
   Compiling scx_rustland_core v2.4.10 (/home/lucjan/Patchownia/other/scx/rust/scx_rustland_core)
   Compiling tokio v1.46.1
   Compiling protobuf-parse v3.7.2
   Compiling derive_more-impl v2.1.1
   Compiling ratatui-core v0.1.0
   Compiling enumset_derive v0.12.0
   Compiling enum-map-derive v0.17.0
   Compiling dirs-sys-next v0.1.2
   Compiling protoc-bin-vendored-linux-aarch_64 v3.2.0
   Compiling protoc-bin-vendored-macos-aarch_64 v3.2.0
   Compiling slog v2.7.0
   Compiling protoc-bin-vendored-linux-ppcle_64 v3.2.0
   Compiling byteorder v1.5.0
   Compiling object v0.36.7
   Compiling protoc-bin-vendored-linux-s390_64 v3.2.0
   Compiling protoc-bin-vendored-linux-x86_32 v3.2.0
   Compiling protoc-bin-vendored-linux-x86_64 v3.2.0
   Compiling protoc-bin-vendored-win32 v3.2.0
   Compiling litrs v1.0.0
   Compiling protoc-bin-vendored-macos-x86_64 v3.2.0
   Compiling sorted-vec v0.8.6
   Compiling protoc-bin-vendored v3.2.0
   Compiling document-features v0.2.12
   Compiling enumset v1.1.7
   Compiling dirs-next v2.0.0
   Compiling enum-map v2.7.3
   Compiling nix v0.25.1
   Compiling derive_more v2.1.1
   Compiling protobuf-codegen v3.7.2
   Compiling futures-channel v0.3.31
   Compiling owning_ref v0.4.1
   Compiling threadpool v1.8.1
   Compiling scx_p2dq v1.0.25 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_p2dq)
   Compiling twox-hash v1.6.3
   Compiling erased-serde v0.3.31
   Compiling serde_spanned v0.6.9
   Compiling line-clipping v0.3.5
   Compiling futures-macro v0.3.31
   Compiling getrandom v0.2.16
   Compiling nix v0.29.0
   Compiling gimli v0.31.1
   Compiling rayon-core v1.12.1
   Compiling toml_write v0.1.2
   Compiling cpp_demangle v0.4.4
   Compiling futures-task v0.3.31
   Compiling xi-unicode v0.3.0
   Compiling rustc-demangle v0.1.25
   Compiling cursive_core v0.3.7
   Compiling futures-util v0.3.31
   Compiling rand_core v0.6.4
   Compiling addr2line v0.24.2
   Compiling ratatui-widgets v0.3.0
   Compiling ruzstd v0.7.3
   Compiling fb_procfs v0.7.1
   Compiling perfetto_protos v0.51.1
   Compiling crossterm v0.29.0
   Compiling term v0.7.0
   Compiling ppv-lite86 v0.2.21
   Compiling smartstring v1.0.1
   Compiling crossterm v0.25.0
   Compiling fdeflate v0.3.7
   Compiling scx_userspace_arena v1.0.20 (/home/lucjan/Patchownia/other/scx/rust/scx_userspace_arena)
   Compiling scx_bpf_compat v1.0.20 (/home/lucjan/Patchownia/other/scx/rust/scx_bpf_compat)
   Compiling strum_macros v0.26.4
   Compiling pxfm v0.1.27
   Compiling csv-core v0.1.12
   Compiling sysinfo v0.35.2
   Compiling is-terminal v0.4.16
   Compiling include_dir_macros v0.7.4
   Compiling procfs v0.18.0
   Compiling fallible-iterator v0.3.0
   Compiling blazesym v0.2.0-rc.4
   Compiling gimli v0.32.0
   Compiling strum v0.26.3
   Compiling include_dir v0.7.4
   Compiling slog-term v2.9.1
   Compiling backtrace v0.3.75
   Compiling moxcms v0.7.11
   Compiling csv v1.3.1
   Compiling png v0.18.0
   Compiling cursive v0.20.0
   Compiling rand_chacha v0.3.1
   Compiling ratatui-crossterm v0.1.0
   Compiling futures-executor v0.3.31
   Compiling ratatui-macros v0.7.0
   Compiling toml v0.8.23
   Compiling crossterm v0.28.1
   Compiling unicode-truncate v1.1.0
   Compiling lru v0.12.5
   Compiling compact_str v0.8.1
   Compiling bon-macros v3.8.2
   Compiling wrapcenum-derive v0.4.1
   Compiling scxtop v1.0.22 (/home/lucjan/Patchownia/other/scx/tools/scxtop)
   Compiling procfs-core v0.18.0
   Compiling nvml-wrapper-sys v0.9.0
   Compiling gethostname v1.1.0
   Compiling scx_layered v1.0.23 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_layered)
   Compiling scx_chaos v1.0.23 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_chaos)
   Compiling arrayvec v0.7.6
   Compiling inotify-sys v0.1.5
   Compiling encoding_rs v0.8.35
   Compiling rlimit v0.10.2
   Compiling bytemuck v1.25.0
   Compiling buddy_system_allocator v0.11.0
   Compiling x11rb-protocol v0.13.2
   Compiling cassowary v0.3.0
   Compiling byteorder-lite v0.1.0
   Compiling humantime v2.2.0
   Compiling below-common v0.9.0
   Compiling image v0.25.9
   Compiling num-format v0.4.4
   Compiling ratatui v0.29.0
   Compiling bon v3.8.2
   Compiling inotify v0.11.0
   Compiling x11rb v0.13.2
   Compiling nvml-wrapper v0.11.0
   Compiling rayon v1.10.0
   Compiling scx_bpf_unittests v0.1.6 (/home/lucjan/Patchownia/other/scx/rust/scx_bpf_unittests)
   Compiling ratatui v0.30.0
   Compiling futures v0.3.31
   Compiling rand v0.8.5
   Compiling scx_raw_pmu v0.1.4 (/home/lucjan/Patchownia/other/scx/rust/scx_raw_pmu)
   Compiling log-panics v2.1.0
   Compiling tokio-util v0.7.15
   Compiling scx_rustland v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_rustland)
   Compiling scx_rlfifo v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_rlfifo)
   Compiling clap_complete v4.5.55
   Compiling env_filter v0.1.4
   Compiling scxcash v0.1.5 (/home/lucjan/Patchownia/other/scx/tools/scxcash)
   Compiling scx_beerland v1.0.5 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_beerland)
   Compiling scx_wd40 v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_wd40)
   Compiling scx_tickless v1.0.11 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_tickless)
   Compiling scx_lavd v1.0.21 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_lavd)
   Compiling scx_arena_selftests v1.0.7 (/home/lucjan/Patchownia/other/scx/rust/scx_arena/selftests)
   Compiling scx_cake v1.0.2 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_cake)
   Compiling scx_cosmos v1.0.7 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_cosmos)
   Compiling scx_rusty v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_rusty)
   Compiling scx_bpfland v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_bpfland)
   Compiling scx_flash v1.0.18 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_flash)
   Compiling scx_mitosis v0.0.17 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_mitosis)
   Compiling cargo-platform v0.3.1
   Compiling raw-cpuid v11.6.0
   Compiling errno v0.3.13
   Compiling anpa v0.10.0
   Compiling micromath v2.1.0
   Compiling jiff v0.2.19
   Compiling percent-encoding v2.3.2
   Compiling xdg v2.5.2
   Compiling arboard v3.6.1
   Compiling tachyonfx v0.22.0
   Compiling quanta v0.12.6
   Compiling affinity v0.1.2
   Compiling cargo_metadata v0.23.0
   Compiling env_logger v0.11.8
   Compiling cgroupfs v0.9.0
   Compiling core_affinity v0.8.3
   Compiling clap-num v1.2.0
   Compiling perf-event-open-sys v5.0.0
   Compiling gpoint v0.2.1
   Compiling maplit v1.0.2
   Compiling combinations v0.1.0
   Compiling xtask v0.1.4 (/home/lucjan/Patchownia/other/scx/tools/xtask)
   Compiling vmlinux_docify v0.1.9 (/home/lucjan/Patchownia/other/scx/tools/vmlinux_docify)
    Finished `release` profile [optimized] target(s) in 5m 00s
'cargo build --profile=release' time: 5:00,06s, cpu: 599%
```
```
❯ cargo build --profile=release-tiny
warning: /home/lucjan/Patchownia/other/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.44
   Compiling unicode-ident v1.0.23
   Compiling libc v0.2.180
   Compiling autocfg v1.5.0
   Compiling cfg-if v1.0.4
   Compiling serde_core v1.0.228
   Compiling bitflags v2.10.0
   Compiling cfg_aliases v0.2.1
   Compiling memchr v2.7.5
   Compiling getrandom v0.3.3
   Compiling strsim v0.11.1
   Compiling shlex v1.3.0
   Compiling serde v1.0.228
   Compiling syn v2.0.114
   Compiling find-msvc-tools v0.1.9
   Compiling heck v0.5.0
   Compiling anyhow v1.0.101
   Compiling cc v1.2.55
   Compiling thiserror v2.0.18
   Compiling rustix v1.0.8
   Compiling linux-raw-sys v0.9.4
   Compiling serde_json v1.0.145
   Compiling once_cell v1.21.3
   Compiling nix v0.31.1
   Compiling pkg-config v0.3.32
   Compiling semver v1.0.26
   Compiling camino v1.1.10
   Compiling unicode-segmentation v1.12.0
   Compiling prettyplease v0.2.35
   Compiling fastrand v2.3.0
   Compiling log v0.4.27
   Compiling glob v0.3.2
   Compiling vsprintf v2.0.0
   Compiling aho-corasick v1.1.3
   Compiling itoa v1.0.15
   Compiling clang-sys v1.8.1
   Compiling regex-syntax v0.8.5
   Compiling either v1.15.0
   Compiling ryu v1.0.20
   Compiling unicode-xid v0.2.6
   Compiling const_format_proc_macros v0.2.34
   Compiling tempfile v3.20.0
   Compiling xattr v1.5.1
   Compiling filetime v0.2.25
   Compiling same-file v1.0.6
   Compiling bindgen v0.72.0
   Compiling twox-hash v2.1.2
   Compiling ruzstd v0.8.1
   Compiling tar v0.4.44
   Compiling walkdir v2.5.0
   Compiling convert_case v0.6.0
   Compiling num-traits v0.2.19
   Compiling regex-syntax v0.6.29
   Compiling strsim v0.10.0
   Compiling regex-automata v0.4.9
   Compiling utf8parse v0.2.2
   Compiling unicode-width v0.1.14
   Compiling anstyle-parse v0.2.7
   Compiling scx_cargo v1.0.27 (/home/lucjan/Patchownia/other/scx/rust/scx_cargo)
   Compiling libbpf-sys v1.6.3+v1.6.3
   Compiling tracing-core v0.1.34
   Compiling serde_derive v1.0.228
   Compiling thiserror-impl v2.0.18
   Compiling tracing-attributes v0.1.30
   Compiling clap_derive v4.5.41
   Compiling anstyle-query v1.1.3
   Compiling lazy_static v1.5.0
   Compiling is_terminal_polyfill v1.70.1
   Compiling anstyle v1.0.11
   Compiling colorchoice v1.0.4
   Compiling anstream v0.6.19
   Compiling sscanf_macro v0.4.1
   Compiling regex v1.11.2
   Compiling terminal_size v0.4.2
   Compiling unicode-width v0.2.0
   Compiling iana-time-zone v0.1.63
   Compiling clap_lex v0.7.5
   Compiling unicase v2.8.1
   Compiling minimal-lexical v0.2.1
   Compiling clap_builder v4.5.41
   Compiling chrono v0.4.41
   Compiling nom v7.1.3
   Compiling sharded-slab v0.1.7
   Compiling tracing-log v0.2.0
   Compiling libloading v0.8.8
   Compiling thread_local v1.1.9
   Compiling smallvec v1.15.1
   Compiling cargo-platform v0.1.9
   Compiling nu-ansi-term v0.50.3
   Compiling pin-project-lite v0.2.16
   Compiling tracing v0.1.41
   Compiling cargo_metadata v0.19.2
   Compiling tracing-subscriber v0.3.20
   Compiling libbpf-rs v0.26.0
   Compiling cexpr v0.6.0
   Compiling clap v4.5.41
   Compiling const_format v0.2.34
   Compiling itertools v0.13.0
   Compiling memmap2 v0.9.7
   Compiling rustc-hash v2.1.1
   Compiling sscanf v0.4.1
   Compiling libbpf-cargo v0.26.0
   Compiling version-compare v0.1.1
   Compiling crossbeam-utils v0.8.21
   Compiling lock_api v0.4.13
   Compiling rustversion v1.0.21
   Compiling parking_lot_core v0.9.11
   Compiling scopeguard v1.2.0
   Compiling thiserror v1.0.69
   Compiling parking_lot v0.12.4
   Compiling signal-hook-registry v1.4.5
   Compiling futures-core v0.3.31
   Compiling thiserror-impl v1.0.69
   Compiling time-core v0.1.4
   Compiling num-conv v0.1.0
   Compiling hashbrown v0.15.4
   Compiling equivalent v1.0.2
   Compiling static_assertions v1.1.0
   Compiling indexmap v2.10.0
   Compiling parking v2.2.1
   Compiling concurrent-queue v2.5.0
   Compiling futures-io v0.3.31
   Compiling winnow v0.7.12
   Compiling event-listener v5.4.0
   Compiling toml_datetime v0.6.11
   Compiling toml_edit v0.22.27
   Compiling event-listener-strategy v0.5.4
   Compiling num-integer v0.1.46
   Compiling enumflags2_derive v0.7.12
   Compiling slab v0.4.11
   Compiling proc-macro-crate v3.3.0
   Compiling zvariant_utils v3.2.0
   Compiling memoffset v0.9.1
   Compiling zvariant_derive v5.6.0
   Compiling num-bigint v0.4.6
   Compiling futures-lite v2.6.0
   Compiling crossbeam-channel v0.5.15
   Compiling powerfmt v0.2.0
   Compiling deranged v0.4.0
   Compiling num-rational v0.4.2
   Compiling num-iter v0.1.45
   Compiling time-macros v0.2.22
   Compiling num-complex v0.4.6
   Compiling crossbeam-epoch v0.9.18
   Compiling num_threads v0.1.7
   Compiling time v0.3.41
   Compiling crossbeam-deque v0.8.6
   Compiling num v0.4.3
   Compiling enumflags2 v0.7.12
   Compiling async-lock v3.4.0
   Compiling matchers v0.2.0
   Compiling polling v3.8.0
   Compiling vergen v8.3.2
   Compiling nix v0.30.1
   Compiling async-task v4.7.1
   Compiling endi v1.1.0
   Compiling hex v0.4.3
   Compiling zvariant v5.6.0
   Compiling async-io v2.4.1
   Compiling async-channel v2.5.0
   Compiling cargo_metadata v0.18.1
   Compiling radium v0.7.0
   Compiling atomic-waker v1.1.2
   Compiling paste v1.0.15
   Compiling piper v0.2.4
   Compiling zbus_names v4.2.0
   Compiling async-signal v0.2.11
   Compiling crossbeam-queue v0.3.12
   Compiling tap v1.0.1
   Compiling wyz v0.5.1
   Compiling crossbeam v0.8.4
   Compiling async-process v2.3.1
   Compiling zbus_macros v5.8.0
   Compiling scx_utils v1.0.26 (/home/lucjan/Patchownia/other/scx/rust/scx_utils)
   Compiling blocking v1.6.2
   Compiling async-executor v1.13.2
   Compiling async-broadcast v0.7.2
   Compiling ordered-stream v0.2.0
   Compiling async-trait v0.1.88
   Compiling serde_repr v0.1.20
   Compiling funty v2.0.0
   Compiling bitvec v1.0.1
   Compiling zbus v5.8.0
   Compiling scx_stats v1.0.22 (/home/lucjan/Patchownia/other/scx/rust/scx_stats)
   Compiling ident_case v1.0.1
   Compiling fnv v1.0.7
   Compiling darling_core v0.20.11
   Compiling crc32fast v1.5.0
   Compiling allocator-api2 v0.2.21
   Compiling mio v1.0.4
   Compiling termcolor v1.4.1
   Compiling ctrlc v3.4.7
   Compiling simd-adler32 v0.3.7
   Compiling simplelog v0.12.2
   Compiling adler2 v2.0.1
   Compiling miniz_oxide v0.8.9
   Compiling signal-hook v0.3.18
   Compiling darling_macro v0.20.11
   Compiling darling v0.20.11
   Compiling scx_stats_derive v1.0.21 (/home/lucjan/Patchownia/other/scx/rust/scx_stats/scx_stats_derive)
   Compiling bitflags v1.3.2
   Compiling mio v0.8.11
   Compiling seccomp-sys v0.1.3
   Compiling indoc v2.0.6
   Compiling flate2 v1.1.2
   Compiling zerocopy v0.8.26
   Compiling signal-hook-mio v0.2.4
   Compiling version_check v0.9.5
   Compiling castaway v0.2.4
   Compiling num_cpus v1.17.0
   Compiling foldhash v0.1.5
   Compiling pin-utils v0.1.0
   Compiling protobuf v3.7.2
   Compiling foldhash v0.2.0
   Compiling stable_deref_trait v1.2.0
   Compiling rustix v0.38.44
   Compiling hashbrown v0.16.1
   Compiling instability v0.3.7
   Compiling io-lifetimes v1.0.11
   Compiling linux-raw-sys v0.4.15
   Compiling scx_arena v0.1.4 (/home/lucjan/Patchownia/other/scx/rust/scx_arena/scx_arena)
   Compiling protobuf-support v3.7.2
   Compiling itertools v0.14.0
   Compiling ordered-float v3.9.2
   Compiling strum_macros v0.27.2
   Compiling clap_main v0.2.9
   Compiling memoffset v0.6.5
   Compiling home v0.5.11
   Compiling rustix v0.36.17
   Compiling which v4.4.2
   Compiling unicode-truncate v2.0.1
   Compiling seccomp v0.1.2
   Compiling kasuari v0.4.11
   Compiling strum v0.27.2
   Compiling lru v0.16.3
   Compiling ahash v0.8.12
   Compiling compact_str v0.9.0
   Compiling tokio-macros v2.5.0
   Compiling convert_case v0.10.0
   Compiling socket2 v0.5.10
   Compiling openat v0.1.21
   Compiling bytes v1.10.1
   Compiling plain v0.2.3
   Compiling linux-raw-sys v0.1.4
   Compiling procfs v0.15.1
   Compiling futures-sink v0.3.31
   Compiling scx_rustland_core v2.4.10 (/home/lucjan/Patchownia/other/scx/rust/scx_rustland_core)
   Compiling tokio v1.46.1
   Compiling derive_more-impl v2.1.1
   Compiling ratatui-core v0.1.0
   Compiling protobuf-parse v3.7.2
   Compiling enumset_derive v0.12.0
   Compiling enum-map-derive v0.17.0
   Compiling dirs-sys-next v0.1.2
   Compiling object v0.36.7
   Compiling byteorder v1.5.0
   Compiling protoc-bin-vendored-win32 v3.2.0
   Compiling protoc-bin-vendored-linux-x86_64 v3.2.0
   Compiling protoc-bin-vendored-macos-x86_64 v3.2.0
   Compiling sorted-vec v0.8.6
   Compiling protoc-bin-vendored-macos-aarch_64 v3.2.0
   Compiling litrs v1.0.0
   Compiling protoc-bin-vendored-linux-x86_32 v3.2.0
   Compiling protoc-bin-vendored-linux-s390_64 v3.2.0
   Compiling protoc-bin-vendored-linux-ppcle_64 v3.2.0
   Compiling slog v2.7.0
   Compiling protoc-bin-vendored-linux-aarch_64 v3.2.0
   Compiling protoc-bin-vendored v3.2.0
   Compiling document-features v0.2.12
   Compiling enumset v1.1.7
   Compiling dirs-next v2.0.0
   Compiling enum-map v2.7.3
   Compiling protobuf-codegen v3.7.2
   Compiling nix v0.25.1
   Compiling derive_more v2.1.1
   Compiling futures-channel v0.3.31
   Compiling owning_ref v0.4.1
   Compiling threadpool v1.8.1
   Compiling scx_p2dq v1.0.25 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_p2dq)
   Compiling twox-hash v1.6.3
   Compiling serde_spanned v0.6.9
   Compiling erased-serde v0.3.31
   Compiling line-clipping v0.3.5
   Compiling futures-macro v0.3.31
   Compiling getrandom v0.2.16
   Compiling nix v0.29.0
   Compiling gimli v0.31.1
   Compiling toml_write v0.1.2
   Compiling rustc-demangle v0.1.25
   Compiling rayon-core v1.12.1
   Compiling cpp_demangle v0.4.4
   Compiling xi-unicode v0.3.0
   Compiling futures-task v0.3.31
   Compiling futures-util v0.3.31
   Compiling cursive_core v0.3.7
   Compiling rand_core v0.6.4
   Compiling addr2line v0.24.2
   Compiling ratatui-widgets v0.3.0
   Compiling ruzstd v0.7.3
   Compiling fb_procfs v0.7.1
   Compiling crossterm v0.29.0
   Compiling perfetto_protos v0.51.1
   Compiling term v0.7.0
   Compiling ppv-lite86 v0.2.21
   Compiling smartstring v1.0.1
   Compiling crossterm v0.25.0
   Compiling fdeflate v0.3.7
   Compiling scx_bpf_compat v1.0.20 (/home/lucjan/Patchownia/other/scx/rust/scx_bpf_compat)
   Compiling scx_userspace_arena v1.0.20 (/home/lucjan/Patchownia/other/scx/rust/scx_userspace_arena)
   Compiling strum_macros v0.26.4
   Compiling pxfm v0.1.27
   Compiling csv-core v0.1.12
   Compiling sysinfo v0.35.2
   Compiling is-terminal v0.4.16
   Compiling include_dir_macros v0.7.4
   Compiling blazesym v0.2.0-rc.4
   Compiling fallible-iterator v0.3.0
   Compiling procfs v0.18.0
   Compiling gimli v0.32.0
   Compiling strum v0.26.3
   Compiling include_dir v0.7.4
   Compiling slog-term v2.9.1
   Compiling backtrace v0.3.75
   Compiling moxcms v0.7.11
   Compiling csv v1.3.1
   Compiling png v0.18.0
   Compiling cursive v0.20.0
   Compiling rand_chacha v0.3.1
   Compiling ratatui-crossterm v0.1.0
   Compiling ratatui-macros v0.7.0
   Compiling futures-executor v0.3.31
   Compiling toml v0.8.23
   Compiling crossterm v0.28.1
   Compiling unicode-truncate v1.1.0
   Compiling lru v0.12.5
   Compiling compact_str v0.8.1
   Compiling wrapcenum-derive v0.4.1
   Compiling bon-macros v3.8.2
   Compiling scxtop v1.0.22 (/home/lucjan/Patchownia/other/scx/tools/scxtop)
   Compiling procfs-core v0.18.0
   Compiling nvml-wrapper-sys v0.9.0
   Compiling scx_layered v1.0.23 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_layered)
   Compiling scx_chaos v1.0.23 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_chaos)
   Compiling gethostname v1.1.0
   Compiling arrayvec v0.7.6
   Compiling inotify-sys v0.1.5
   Compiling encoding_rs v0.8.35
   Compiling humantime v2.2.0
   Compiling rlimit v0.10.2
   Compiling bytemuck v1.25.0
   Compiling x11rb-protocol v0.13.2
   Compiling byteorder-lite v0.1.0
   Compiling buddy_system_allocator v0.11.0
   Compiling cassowary v0.3.0
   Compiling image v0.25.9
   Compiling ratatui v0.29.0
   Compiling num-format v0.4.4
   Compiling x11rb v0.13.2
   Compiling below-common v0.9.0
   Compiling bon v3.8.2
   Compiling inotify v0.11.0
   Compiling nvml-wrapper v0.11.0
   Compiling rayon v1.10.0
   Compiling scx_bpf_unittests v0.1.6 (/home/lucjan/Patchownia/other/scx/rust/scx_bpf_unittests)
   Compiling futures v0.3.31
   Compiling ratatui v0.30.0
   Compiling rand v0.8.5
   Compiling scx_raw_pmu v0.1.4 (/home/lucjan/Patchownia/other/scx/rust/scx_raw_pmu)
   Compiling log-panics v2.1.0
   Compiling tokio-util v0.7.15
   Compiling scx_rustland v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_rustland)
   Compiling scx_rlfifo v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_rlfifo)
   Compiling clap_complete v4.5.55
   Compiling env_filter v0.1.4
   Compiling scx_flash v1.0.18 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_flash)
   Compiling scx_mitosis v0.0.17 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_mitosis)
   Compiling scx_wd40 v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_wd40)
   Compiling scx_tickless v1.0.11 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_tickless)
   Compiling scx_cosmos v1.0.7 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_cosmos)
   Compiling scx_cake v1.0.2 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_cake)
   Compiling scxcash v0.1.5 (/home/lucjan/Patchownia/other/scx/tools/scxcash)
   Compiling scx_rusty v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_rusty)
   Compiling scx_beerland v1.0.5 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_beerland)
   Compiling scx_arena_selftests v1.0.7 (/home/lucjan/Patchownia/other/scx/rust/scx_arena/selftests)
   Compiling scx_bpfland v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_bpfland)
   Compiling scx_lavd v1.0.21 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_lavd)
   Compiling cargo-platform v0.3.1
   Compiling raw-cpuid v11.6.0
   Compiling errno v0.3.13
   Compiling anpa v0.10.0
   Compiling xdg v2.5.2
   Compiling percent-encoding v2.3.2
   Compiling jiff v0.2.19
   Compiling micromath v2.1.0
   Compiling tachyonfx v0.22.0
   Compiling quanta v0.12.6
   Compiling arboard v3.6.1
   Compiling affinity v0.1.2
   Compiling env_logger v0.11.8
   Compiling cargo_metadata v0.23.0
   Compiling cgroupfs v0.9.0
   Compiling core_affinity v0.8.3
   Compiling clap-num v1.2.0
   Compiling perf-event-open-sys v5.0.0
   Compiling gpoint v0.2.1
   Compiling combinations v0.1.0
   Compiling maplit v1.0.2
   Compiling xtask v0.1.4 (/home/lucjan/Patchownia/other/scx/tools/xtask)
   Compiling vmlinux_docify v0.1.9 (/home/lucjan/Patchownia/other/scx/tools/vmlinux_docify)
    Finished `release-tiny` profile [optimized] target(s) in 3m 30s
```

```
❯ cargo build --profile=release-fast
warning: /home/lucjan/Patchownia/other/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.44
   Compiling unicode-ident v1.0.23
   Compiling libc v0.2.180
   Compiling autocfg v1.5.0
   Compiling cfg-if v1.0.4
   Compiling serde_core v1.0.228
   Compiling bitflags v2.10.0
   Compiling cfg_aliases v0.2.1
   Compiling strsim v0.11.1
   Compiling getrandom v0.3.3
   Compiling memchr v2.7.5
   Compiling shlex v1.3.0
   Compiling syn v2.0.114
   Compiling serde v1.0.228
   Compiling heck v0.5.0
   Compiling find-msvc-tools v0.1.9
   Compiling anyhow v1.0.101
   Compiling cc v1.2.55
   Compiling thiserror v2.0.18
   Compiling rustix v1.0.8
   Compiling serde_json v1.0.145
   Compiling linux-raw-sys v0.9.4
   Compiling once_cell v1.21.3
   Compiling nix v0.31.1
   Compiling camino v1.1.10
   Compiling pkg-config v0.3.32
   Compiling semver v1.0.26
   Compiling unicode-segmentation v1.12.0
   Compiling prettyplease v0.2.35
   Compiling log v0.4.27
   Compiling fastrand v2.3.0
   Compiling glob v0.3.2
   Compiling vsprintf v2.0.0
   Compiling aho-corasick v1.1.3
   Compiling regex-syntax v0.8.5
   Compiling clang-sys v1.8.1
   Compiling itoa v1.0.15
   Compiling ryu v1.0.20
   Compiling either v1.15.0
   Compiling unicode-xid v0.2.6
   Compiling const_format_proc_macros v0.2.34
   Compiling tempfile v3.20.0
   Compiling xattr v1.5.1
   Compiling filetime v0.2.25
   Compiling bindgen v0.72.0
   Compiling same-file v1.0.6
   Compiling twox-hash v2.1.2
   Compiling walkdir v2.5.0
   Compiling tar v0.4.44
   Compiling ruzstd v0.8.1
   Compiling convert_case v0.6.0
   Compiling num-traits v0.2.19
   Compiling utf8parse v0.2.2
   Compiling regex-syntax v0.6.29
   Compiling unicode-width v0.1.14
   Compiling regex-automata v0.4.9
   Compiling strsim v0.10.0
   Compiling serde_derive v1.0.228
   Compiling thiserror-impl v2.0.18
   Compiling tracing-attributes v0.1.30
   Compiling clap_derive v4.5.41
   Compiling scx_cargo v1.0.27 (/home/lucjan/Patchownia/other/scx/rust/scx_cargo)
   Compiling anstyle-parse v0.2.7
   Compiling libbpf-sys v1.6.3+v1.6.3
   Compiling tracing-core v0.1.34
   Compiling sscanf_macro v0.4.1
   Compiling regex v1.11.2
   Compiling anstyle v1.0.11
   Compiling is_terminal_polyfill v1.70.1
   Compiling colorchoice v1.0.4
   Compiling anstyle-query v1.1.3
   Compiling lazy_static v1.5.0
   Compiling anstream v0.6.19
   Compiling terminal_size v0.4.2
   Compiling iana-time-zone v0.1.63
   Compiling clap_lex v0.7.5
   Compiling minimal-lexical v0.2.1
   Compiling unicase v2.8.1
   Compiling unicode-width v0.2.0
   Compiling nom v7.1.3
   Compiling chrono v0.4.41
   Compiling clap_builder v4.5.41
   Compiling sharded-slab v0.1.7
   Compiling cargo-platform v0.1.9
   Compiling tracing-log v0.2.0
   Compiling libloading v0.8.8
   Compiling thread_local v1.1.9
   Compiling nu-ansi-term v0.50.3
   Compiling pin-project-lite v0.2.16
   Compiling smallvec v1.15.1
   Compiling tracing v0.1.41
   Compiling tracing-subscriber v0.3.20
   Compiling cargo_metadata v0.19.2
   Compiling libbpf-rs v0.26.0
   Compiling cexpr v0.6.0
   Compiling clap v4.5.41
   Compiling const_format v0.2.34
   Compiling itertools v0.13.0
   Compiling memmap2 v0.9.7
   Compiling rustc-hash v2.1.1
   Compiling sscanf v0.4.1
   Compiling libbpf-cargo v0.26.0
   Compiling version-compare v0.1.1
   Compiling crossbeam-utils v0.8.21
   Compiling lock_api v0.4.13
   Compiling parking_lot_core v0.9.11
   Compiling rustversion v1.0.21
   Compiling scopeguard v1.2.0
   Compiling thiserror v1.0.69
   Compiling signal-hook-registry v1.4.5
   Compiling parking_lot v0.12.4
   Compiling futures-core v0.3.31
   Compiling thiserror-impl v1.0.69
   Compiling time-core v0.1.4
   Compiling num-conv v0.1.0
   Compiling hashbrown v0.15.4
   Compiling static_assertions v1.1.0
   Compiling equivalent v1.0.2
   Compiling indexmap v2.10.0
   Compiling parking v2.2.1
   Compiling concurrent-queue v2.5.0
   Compiling futures-io v0.3.31
   Compiling winnow v0.7.12
   Compiling event-listener v5.4.0
   Compiling toml_datetime v0.6.11
   Compiling toml_edit v0.22.27
   Compiling event-listener-strategy v0.5.4
   Compiling num-integer v0.1.46
   Compiling enumflags2_derive v0.7.12
   Compiling slab v0.4.11
   Compiling proc-macro-crate v3.3.0
   Compiling zvariant_utils v3.2.0
   Compiling memoffset v0.9.1
   Compiling zvariant_derive v5.6.0
   Compiling num-bigint v0.4.6
   Compiling futures-lite v2.6.0
   Compiling crossbeam-channel v0.5.15
   Compiling powerfmt v0.2.0
   Compiling deranged v0.4.0
   Compiling num-rational v0.4.2
   Compiling num-iter v0.1.45
   Compiling time-macros v0.2.22
   Compiling num-complex v0.4.6
   Compiling crossbeam-epoch v0.9.18
   Compiling num_threads v0.1.7
   Compiling time v0.3.41
   Compiling num v0.4.3
   Compiling crossbeam-deque v0.8.6
   Compiling enumflags2 v0.7.12
   Compiling async-lock v3.4.0
   Compiling matchers v0.2.0
   Compiling polling v3.8.0
   Compiling vergen v8.3.2
   Compiling nix v0.30.1
   Compiling async-task v4.7.1
   Compiling endi v1.1.0
   Compiling hex v0.4.3
   Compiling zvariant v5.6.0
   Compiling async-io v2.4.1
   Compiling async-channel v2.5.0
   Compiling cargo_metadata v0.18.1
   Compiling radium v0.7.0
   Compiling atomic-waker v1.1.2
   Compiling paste v1.0.15
   Compiling piper v0.2.4
   Compiling async-signal v0.2.11
   Compiling zbus_names v4.2.0
   Compiling crossbeam-queue v0.3.12
   Compiling tap v1.0.1
   Compiling wyz v0.5.1
   Compiling zbus_macros v5.8.0
   Compiling crossbeam v0.8.4
   Compiling async-process v2.3.1
   Compiling scx_utils v1.0.26 (/home/lucjan/Patchownia/other/scx/rust/scx_utils)
   Compiling blocking v1.6.2
   Compiling async-executor v1.13.2
   Compiling async-broadcast v0.7.2
   Compiling ordered-stream v0.2.0
   Compiling serde_repr v0.1.20
   Compiling async-trait v0.1.88
   Compiling funty v2.0.0
   Compiling zbus v5.8.0
   Compiling bitvec v1.0.1
   Compiling scx_stats v1.0.22 (/home/lucjan/Patchownia/other/scx/rust/scx_stats)
   Compiling fnv v1.0.7
   Compiling ident_case v1.0.1
   Compiling darling_core v0.20.11
   Compiling crc32fast v1.5.0
   Compiling allocator-api2 v0.2.21
   Compiling mio v1.0.4
   Compiling termcolor v1.4.1
   Compiling simplelog v0.12.2
   Compiling ctrlc v3.4.7
   Compiling simd-adler32 v0.3.7
   Compiling adler2 v2.0.1
   Compiling miniz_oxide v0.8.9
   Compiling signal-hook v0.3.18
   Compiling darling_macro v0.20.11
   Compiling darling v0.20.11
   Compiling scx_stats_derive v1.0.21 (/home/lucjan/Patchownia/other/scx/rust/scx_stats/scx_stats_derive)
   Compiling bitflags v1.3.2
   Compiling mio v0.8.11
   Compiling signal-hook-mio v0.2.4
   Compiling indoc v2.0.6
   Compiling seccomp-sys v0.1.3
   Compiling flate2 v1.1.2
   Compiling version_check v0.9.5
   Compiling zerocopy v0.8.26
   Compiling castaway v0.2.4
   Compiling num_cpus v1.17.0
   Compiling pin-utils v0.1.0
   Compiling foldhash v0.1.5
   Compiling protobuf v3.7.2
   Compiling rustix v0.38.44
   Compiling foldhash v0.2.0
   Compiling stable_deref_trait v1.2.0
   Compiling hashbrown v0.16.1
   Compiling instability v0.3.7
   Compiling io-lifetimes v1.0.11
   Compiling linux-raw-sys v0.4.15
   Compiling scx_arena v0.1.4 (/home/lucjan/Patchownia/other/scx/rust/scx_arena/scx_arena)
   Compiling protobuf-support v3.7.2
   Compiling itertools v0.14.0
   Compiling ordered-float v3.9.2
   Compiling strum_macros v0.27.2
   Compiling clap_main v0.2.9
   Compiling memoffset v0.6.5
   Compiling rustix v0.36.17
   Compiling home v0.5.11
   Compiling which v4.4.2
   Compiling unicode-truncate v2.0.1
   Compiling strum v0.27.2
   Compiling seccomp v0.1.2
   Compiling lru v0.16.3
   Compiling kasuari v0.4.11
   Compiling compact_str v0.9.0
   Compiling ahash v0.8.12
   Compiling tokio-macros v2.5.0
   Compiling convert_case v0.10.0
   Compiling socket2 v0.5.10
   Compiling openat v0.1.21
   Compiling linux-raw-sys v0.1.4
   Compiling plain v0.2.3
   Compiling bytes v1.10.1
   Compiling procfs v0.15.1
   Compiling futures-sink v0.3.31
   Compiling scx_rustland_core v2.4.10 (/home/lucjan/Patchownia/other/scx/rust/scx_rustland_core)
   Compiling tokio v1.46.1
   Compiling derive_more-impl v2.1.1
   Compiling protobuf-parse v3.7.2
   Compiling ratatui-core v0.1.0
   Compiling enumset_derive v0.12.0
   Compiling enum-map-derive v0.17.0
   Compiling dirs-sys-next v0.1.2
   Compiling object v0.36.7
   Compiling protoc-bin-vendored-linux-x86_32 v3.2.0
   Compiling sorted-vec v0.8.6
   Compiling protoc-bin-vendored-linux-ppcle_64 v3.2.0
   Compiling protoc-bin-vendored-win32 v3.2.0
   Compiling protoc-bin-vendored-macos-x86_64 v3.2.0
   Compiling protoc-bin-vendored-macos-aarch_64 v3.2.0
   Compiling slog v2.7.0
   Compiling protoc-bin-vendored-linux-x86_64 v3.2.0
   Compiling litrs v1.0.0
   Compiling byteorder v1.5.0
   Compiling protoc-bin-vendored-linux-aarch_64 v3.2.0
   Compiling protoc-bin-vendored-linux-s390_64 v3.2.0
   Compiling protoc-bin-vendored v3.2.0
   Compiling document-features v0.2.12
   Compiling dirs-next v2.0.0
   Compiling enum-map v2.7.3
   Compiling enumset v1.1.7
   Compiling nix v0.25.1
   Compiling protobuf-codegen v3.7.2
   Compiling derive_more v2.1.1
   Compiling futures-channel v0.3.31
   Compiling owning_ref v0.4.1
   Compiling threadpool v1.8.1
   Compiling scx_p2dq v1.0.25 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_p2dq)
   Compiling twox-hash v1.6.3
   Compiling serde_spanned v0.6.9
   Compiling erased-serde v0.3.31
   Compiling line-clipping v0.3.5
   Compiling futures-macro v0.3.31
   Compiling getrandom v0.2.16
   Compiling nix v0.29.0
   Compiling rustc-demangle v0.1.25
   Compiling xi-unicode v0.3.0
   Compiling cpp_demangle v0.4.4
   Compiling toml_write v0.1.2
   Compiling futures-task v0.3.31
   Compiling gimli v0.31.1
   Compiling rayon-core v1.12.1
   Compiling futures-util v0.3.31
   Compiling addr2line v0.24.2
   Compiling cursive_core v0.3.7
   Compiling rand_core v0.6.4
   Compiling ratatui-widgets v0.3.0
   Compiling ruzstd v0.7.3
   Compiling fb_procfs v0.7.1
   Compiling crossterm v0.29.0
   Compiling perfetto_protos v0.51.1
   Compiling term v0.7.0
   Compiling ppv-lite86 v0.2.21
   Compiling smartstring v1.0.1
   Compiling crossterm v0.25.0
   Compiling fdeflate v0.3.7
   Compiling scx_userspace_arena v1.0.20 (/home/lucjan/Patchownia/other/scx/rust/scx_userspace_arena)
   Compiling scx_bpf_compat v1.0.20 (/home/lucjan/Patchownia/other/scx/rust/scx_bpf_compat)
   Compiling strum_macros v0.26.4
   Compiling pxfm v0.1.27
   Compiling sysinfo v0.35.2
   Compiling csv-core v0.1.12
   Compiling is-terminal v0.4.16
   Compiling include_dir_macros v0.7.4
   Compiling procfs v0.18.0
   Compiling fallible-iterator v0.3.0
   Compiling blazesym v0.2.0-rc.4
   Compiling include_dir v0.7.4
   Compiling strum v0.26.3
   Compiling slog-term v2.9.1
   Compiling gimli v0.32.0
   Compiling backtrace v0.3.75
   Compiling moxcms v0.7.11
   Compiling csv v1.3.1
   Compiling cursive v0.20.0
   Compiling png v0.18.0
   Compiling rand_chacha v0.3.1
   Compiling ratatui-crossterm v0.1.0
   Compiling ratatui-macros v0.7.0
   Compiling toml v0.8.23
   Compiling futures-executor v0.3.31
   Compiling crossterm v0.28.1
   Compiling unicode-truncate v1.1.0
   Compiling lru v0.12.5
   Compiling compact_str v0.8.1
   Compiling wrapcenum-derive v0.4.1
   Compiling bon-macros v3.8.2
   Compiling scxtop v1.0.22 (/home/lucjan/Patchownia/other/scx/tools/scxtop)
   Compiling procfs-core v0.18.0
   Compiling nvml-wrapper-sys v0.9.0
   Compiling gethostname v1.1.0
   Compiling scx_chaos v1.0.23 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_chaos)
   Compiling scx_layered v1.0.23 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_layered)
   Compiling arrayvec v0.7.6
   Compiling inotify-sys v0.1.5
   Compiling encoding_rs v0.8.35
   Compiling x11rb-protocol v0.13.2
   Compiling byteorder-lite v0.1.0
   Compiling buddy_system_allocator v0.11.0
   Compiling rlimit v0.10.2
   Compiling bytemuck v1.25.0
   Compiling cassowary v0.3.0
   Compiling humantime v2.2.0
   Compiling below-common v0.9.0
   Compiling x11rb v0.13.2
   Compiling ratatui v0.29.0
   Compiling image v0.25.9
   Compiling num-format v0.4.4
   Compiling bon v3.8.2
   Compiling inotify v0.11.0
   Compiling nvml-wrapper v0.11.0
   Compiling rayon v1.10.0
   Compiling futures v0.3.31
   Compiling scx_bpf_unittests v0.1.6 (/home/lucjan/Patchownia/other/scx/rust/scx_bpf_unittests)
   Compiling ratatui v0.30.0
   Compiling rand v0.8.5
   Compiling scx_raw_pmu v0.1.4 (/home/lucjan/Patchownia/other/scx/rust/scx_raw_pmu)
   Compiling log-panics v2.1.0
   Compiling tokio-util v0.7.15
   Compiling scx_rustland v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_rustland)
   Compiling scx_rlfifo v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_rlfifo)
   Compiling clap_complete v4.5.55
   Compiling env_filter v0.1.4
   Compiling scx_rusty v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_rusty)
   Compiling scx_flash v1.0.18 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_flash)
   Compiling scxcash v0.1.5 (/home/lucjan/Patchownia/other/scx/tools/scxcash)
   Compiling scx_bpfland v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_bpfland)
   Compiling scx_wd40 v1.0.20 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_wd40)
   Compiling scx_mitosis v0.0.17 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_mitosis)
   Compiling scx_cosmos v1.0.7 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_cosmos)
   Compiling scx_tickless v1.0.11 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_tickless)
   Compiling scx_lavd v1.0.21 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_lavd)
   Compiling scx_cake v1.0.2 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_cake)
   Compiling scx_arena_selftests v1.0.7 (/home/lucjan/Patchownia/other/scx/rust/scx_arena/selftests)
   Compiling scx_beerland v1.0.5 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_beerland)
   Compiling cargo-platform v0.3.1
   Compiling raw-cpuid v11.6.0
   Compiling errno v0.3.13
   Compiling jiff v0.2.19
   Compiling micromath v2.1.0
   Compiling xdg v2.5.2
   Compiling percent-encoding v2.3.2
   Compiling anpa v0.10.0
   Compiling arboard v3.6.1
   Compiling tachyonfx v0.22.0
   Compiling quanta v0.12.6
   Compiling affinity v0.1.2
   Compiling cargo_metadata v0.23.0
   Compiling env_logger v0.11.8
   Compiling cgroupfs v0.9.0
   Compiling core_affinity v0.8.3
   Compiling clap-num v1.2.0
   Compiling gpoint v0.2.1
   Compiling perf-event-open-sys v5.0.0
   Compiling maplit v1.0.2
   Compiling combinations v0.1.0
   Compiling xtask v0.1.4 (/home/lucjan/Patchownia/other/scx/tools/xtask)
   Compiling vmlinux_docify v0.1.9 (/home/lucjan/Patchownia/other/scx/tools/vmlinux_docify)
    Finished `release-fast` profile [optimized] target(s) in 3m 44s
'cargo build --profile=release-fast' time: 3:44,20s, cpu: 593%
```

**Logs (size):**

```
lucjan at cachyos ~/Patchownia/other/scx/target/release 13:44:24 4845092b cargo-profiles    
❯ ls -lah | awk '$NF ~ /^scx_/'
-rwxr-xr-x   2 lucjan lucjan  26M 02-16 13:26 scx_arena_selftests
-rw-r--r--   1 lucjan lucjan 8,8K 02-16 13:26 scx_arena_selftests.d
-rwxr-xr-x   2 lucjan lucjan 5,4M 02-16 13:25 scx_beerland
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:26 scx_beerland.d
-rwxr-xr-x   2 lucjan lucjan 8,1M 02-16 13:26 scx_bpfland
-rw-r--r--   1 lucjan lucjan 7,9K 02-16 13:26 scx_bpfland.d
-rwxr-xr-x   2 lucjan lucjan 5,8M 02-16 13:24 scx_cake
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:26 scx_cake.d
-rwxr-xr-x   2 lucjan lucjan  17M 02-16 13:24 scx_chaos
-rw-r--r--   1 lucjan lucjan  12K 02-16 13:26 scx_chaos.d
-rwxr-xr-x   2 lucjan lucjan 5,4M 02-16 13:24 scx_cosmos
-rw-r--r--   1 lucjan lucjan 7,9K 02-16 13:26 scx_cosmos.d
-rwxr-xr-x   2 lucjan lucjan 8,2M 02-16 13:26 scx_flash
-rw-r--r--   1 lucjan lucjan 7,9K 02-16 13:26 scx_flash.d
-rwxr-xr-x   2 lucjan lucjan  30M 02-16 13:25 scx_lavd
-rw-r--r--   1 lucjan lucjan  11K 02-16 13:26 scx_lavd.d
-rwxr-xr-x   2 lucjan lucjan  31M 02-16 13:24 scx_layered
-rw-r--r--   1 lucjan lucjan  87K 02-16 13:26 scx_layered.d
-rwxr-xr-x   2 lucjan lucjan 5,9M 02-16 13:24 scx_mitosis
-rw-r--r--   1 lucjan lucjan 8,1K 02-16 13:26 scx_mitosis.d
-rwxr-xr-x   2 lucjan lucjan  18M 02-16 13:25 scx_p2dq
-rw-r--r--   1 lucjan lucjan 9,5K 02-16 13:26 scx_p2dq.d
-rwxr-xr-x   2 lucjan lucjan 3,9M 02-16 13:25 scx_rlfifo
-rw-r--r--   1 lucjan lucjan 7,8K 02-16 13:26 scx_rlfifo.d
-rwxr-xr-x   2 lucjan lucjan 5,4M 02-16 13:25 scx_rustland
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:26 scx_rustland.d
-rwxr-xr-x   2 lucjan lucjan 5,9M 02-16 13:26 scx_rusty
-rw-r--r--   1 lucjan lucjan 8,1K 02-16 13:26 scx_rusty.d
-rwxr-xr-x   2 lucjan lucjan 5,3M 02-16 13:26 scx_tickless
-rw-r--r--   1 lucjan lucjan 7,3K 02-16 13:26 scx_tickless.d
-rwxr-xr-x   2 lucjan lucjan  19M 02-16 13:26 scx_wd40
-rw-r--r--   1 lucjan lucjan  11K 02-16 13:26 scx_wd40.d
```

```
lucjan at cachyos ~/Patchownia/other/scx/target/release-fast 13:44:47 4845092b cargo-profiles    
❯ ls -lah | awk '$NF ~ /^scx_/'
-rwxr-xr-x   2 lucjan lucjan   25M 02-16 13:42 scx_arena_selftests
-rw-r--r--   1 lucjan lucjan  8,9K 02-16 13:42 scx_arena_selftests.d
-rwxr-xr-x   2 lucjan lucjan  4,8M 02-16 13:42 scx_beerland
-rw-r--r--   1 lucjan lucjan  8,0K 02-16 13:42 scx_beerland.d
-rwxr-xr-x   2 lucjan lucjan  6,9M 02-16 13:42 scx_bpfland
-rw-r--r--   1 lucjan lucjan  8,0K 02-16 13:42 scx_bpfland.d
-rwxr-xr-x   2 lucjan lucjan  5,2M 02-16 13:41 scx_cake
-rw-r--r--   1 lucjan lucjan  8,0K 02-16 13:42 scx_cake.d
-rwxr-xr-x   2 lucjan lucjan   16M 02-16 13:41 scx_chaos
-rw-r--r--   1 lucjan lucjan   12K 02-16 13:42 scx_chaos.d
-rwxr-xr-x   2 lucjan lucjan  4,8M 02-16 13:41 scx_cosmos
-rw-r--r--   1 lucjan lucjan  8,0K 02-16 13:42 scx_cosmos.d
-rwxr-xr-x   2 lucjan lucjan  7,0M 02-16 13:42 scx_flash
-rw-r--r--   1 lucjan lucjan  8,0K 02-16 13:42 scx_flash.d
-rwxr-xr-x   2 lucjan lucjan   29M 02-16 13:42 scx_lavd
-rw-r--r--   1 lucjan lucjan   11K 02-16 13:42 scx_lavd.d
-rwxr-xr-x   2 lucjan lucjan   30M 02-16 13:41 scx_layered
-rw-r--r--   1 lucjan lucjan   87K 02-16 13:42 scx_layered.d
-rwxr-xr-x   2 lucjan lucjan  5,2M 02-16 13:41 scx_mitosis
-rw-r--r--   1 lucjan lucjan  8,1K 02-16 13:42 scx_mitosis.d
-rwxr-xr-x   2 lucjan lucjan   17M 02-16 13:42 scx_p2dq
-rw-r--r--   1 lucjan lucjan  9,6K 02-16 13:42 scx_p2dq.d
-rwxr-xr-x   2 lucjan lucjan  3,6M 02-16 13:41 scx_rlfifo
-rw-r--r--   1 lucjan lucjan  7,8K 02-16 13:42 scx_rlfifo.d
-rwxr-xr-x   2 lucjan lucjan  4,9M 02-16 13:41 scx_rustland
-rw-r--r--   1 lucjan lucjan  8,0K 02-16 13:42 scx_rustland.d
-rwxr-xr-x   2 lucjan lucjan  5,2M 02-16 13:41 scx_rusty
-rw-r--r--   1 lucjan lucjan  8,1K 02-16 13:42 scx_rusty.d
-rwxr-xr-x   2 lucjan lucjan  4,7M 02-16 13:42 scx_tickless
-rw-r--r--   1 lucjan lucjan  7,4K 02-16 13:42 scx_tickless.d
-rwxr-xr-x   2 lucjan lucjan   19M 02-16 13:42 scx_wd40
-rw-r--r--   1 lucjan lucjan   11K 02-16 13:42 scx_wd40.d
```

```
❯ ls -lah | awk '$NF ~ /^scx_/'
-rwxr-xr-x   2 lucjan lucjan  26M 02-16 13:30 scx_arena_selftests
-rw-r--r--   1 lucjan lucjan 8,9K 02-16 13:32 scx_arena_selftests.d
-rwxr-xr-x   2 lucjan lucjan 5,4M 02-16 13:32 scx_beerland
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:32 scx_beerland.d
-rwxr-xr-x   2 lucjan lucjan 8,1M 02-16 13:32 scx_bpfland
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:32 scx_bpfland.d
-rwxr-xr-x   2 lucjan lucjan 5,8M 02-16 13:30 scx_cake
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:32 scx_cake.d
-rwxr-xr-x   2 lucjan lucjan  17M 02-16 13:30 scx_chaos
-rw-r--r--   1 lucjan lucjan  12K 02-16 13:32 scx_chaos.d
-rwxr-xr-x   2 lucjan lucjan 5,4M 02-16 13:30 scx_cosmos
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:32 scx_cosmos.d
-rwxr-xr-x   2 lucjan lucjan 8,1M 02-16 13:31 scx_flash
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:32 scx_flash.d
-rwxr-xr-x   2 lucjan lucjan  30M 02-16 13:30 scx_lavd
-rw-r--r--   1 lucjan lucjan  11K 02-16 13:32 scx_lavd.d
-rwxr-xr-x   2 lucjan lucjan  31M 02-16 13:29 scx_layered
-rw-r--r--   1 lucjan lucjan  87K 02-16 13:32 scx_layered.d
-rwxr-xr-x   2 lucjan lucjan 5,8M 02-16 13:29 scx_mitosis
-rw-r--r--   1 lucjan lucjan 8,1K 02-16 13:32 scx_mitosis.d
-rwxr-xr-x   2 lucjan lucjan  18M 02-16 13:31 scx_p2dq
-rw-r--r--   1 lucjan lucjan 9,6K 02-16 13:32 scx_p2dq.d
-rwxr-xr-x   2 lucjan lucjan 3,9M 02-16 13:30 scx_rlfifo
-rw-r--r--   1 lucjan lucjan 7,8K 02-16 13:32 scx_rlfifo.d
-rwxr-xr-x   2 lucjan lucjan 5,4M 02-16 13:30 scx_rustland
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:32 scx_rustland.d
-rwxr-xr-x   2 lucjan lucjan 5,9M 02-16 13:31 scx_rusty
-rw-r--r--   1 lucjan lucjan 8,1K 02-16 13:32 scx_rusty.d
-rwxr-xr-x   2 lucjan lucjan 5,3M 02-16 13:31 scx_tickless
-rw-r--r--   1 lucjan lucjan 7,4K 02-16 13:32 scx_tickless.d
-rwxr-xr-x   2 lucjan lucjan  19M 02-16 13:31 scx_wd40
-rw-r--r--   1 lucjan lucjan  11K 02-16 13:32 scx_wd40.d
```

```
lucjan at cachyos ~/Patchownia/other/scx/target/release-tiny 13:45:22 4845092b cargo-profiles    
❯ ls -lah | awk '$NF ~ /^scx_/'
-rwxr-xr-x   2 lucjan lucjan  24M 02-16 13:38 scx_arena_selftests
-rw-r--r--   1 lucjan lucjan 8,9K 02-16 13:39 scx_arena_selftests.d
-rwxr-xr-x   2 lucjan lucjan 3,2M 02-16 13:37 scx_beerland
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:39 scx_beerland.d
-rwxr-xr-x   2 lucjan lucjan 4,4M 02-16 13:37 scx_bpfland
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:39 scx_bpfland.d
-rwxr-xr-x   2 lucjan lucjan 3,5M 02-16 13:37 scx_cake
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:39 scx_cake.d
-rwxr-xr-x   2 lucjan lucjan  14M 02-16 13:37 scx_chaos
-rw-r--r--   1 lucjan lucjan  12K 02-16 13:39 scx_chaos.d
-rwxr-xr-x   2 lucjan lucjan 3,2M 02-16 13:37 scx_cosmos
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:39 scx_cosmos.d
-rwxr-xr-x   2 lucjan lucjan 4,4M 02-16 13:37 scx_flash
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:39 scx_flash.d
-rwxr-xr-x   2 lucjan lucjan  26M 02-16 13:38 scx_lavd
-rw-r--r--   1 lucjan lucjan  11K 02-16 13:39 scx_lavd.d
-rwxr-xr-x   2 lucjan lucjan  28M 02-16 13:37 scx_layered
-rw-r--r--   1 lucjan lucjan  87K 02-16 13:39 scx_layered.d
-rwxr-xr-x   2 lucjan lucjan 3,4M 02-16 13:37 scx_mitosis
-rw-r--r--   1 lucjan lucjan 8,1K 02-16 13:39 scx_mitosis.d
-rwxr-xr-x   2 lucjan lucjan  15M 02-16 13:37 scx_p2dq
-rw-r--r--   1 lucjan lucjan 9,6K 02-16 13:39 scx_p2dq.d
-rwxr-xr-x   2 lucjan lucjan 2,5M 02-16 13:37 scx_rlfifo
-rw-r--r--   1 lucjan lucjan 7,8K 02-16 13:39 scx_rlfifo.d
-rwxr-xr-x   2 lucjan lucjan 3,3M 02-16 13:37 scx_rustland
-rw-r--r--   1 lucjan lucjan 8,0K 02-16 13:39 scx_rustland.d
-rwxr-xr-x   2 lucjan lucjan 3,5M 02-16 13:37 scx_rusty
-rw-r--r--   1 lucjan lucjan 8,1K 02-16 13:39 scx_rusty.d
-rwxr-xr-x   2 lucjan lucjan 3,2M 02-16 13:37 scx_tickless
-rw-r--r--   1 lucjan lucjan 7,4K 02-16 13:39 scx_tickless.d
-rwxr-xr-x   2 lucjan lucjan  17M 02-16 13:37 scx_wd40
-rw-r--r--   1 lucjan lucjan  11K 02-16 13:39 scx_wd40.d
```

# Build Profile Performance & Size Summary

This document summarizes build time and resulting binary size
differences between the defined Cargo build profiles.

------------------------------------------------------------------------

# Build Time Comparison

  Profile        Build Time   Relative Speed
  -------------- ------------ ----------------
  release        5:00         baseline
  release-perf   4:58         \~same
  release-tiny   3:30         fastest
  release-fast   3:44         fast

## Observations

-   `release-perf` and `release` have nearly identical build times.
-   ThinLTO adds approximately 1.5 minutes compared to non-LTO builds.
-   `release-tiny` builds the fastest.
-   `release-fast` is significantly faster than ThinLTO builds while
    preserving balanced optimizations.

------------------------------------------------------------------------

# Binary Size Comparison (Selected Examples)

  Binary         release   release-fast   release-tiny
  -------------- --------- -------------- --------------
  scx_beerland   5.4M      4.8M           3.2M
  scx_bpfland    8.1M      6.9M           4.4M
  scx_lavd       30M       29M            26M
  scx_layered    31M       30M            28M
  scx_p2dq       18M       17M            15M
  scx_rlfifo     3.9M      3.6M           2.5M
  scx_wd40       19M       19M            17M

------------------------------------------------------------------------

