### PR TITLE
scx_cosmos: Drop ops.cpu_release()

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -1079,16 +1079,6 @@ void BPF_STRUCT_OPS(cosmos_dispatch, s32 cpu, struct task_struct *prev)
 		prev->scx.slice = task_slice(prev);
 }
 
-void BPF_STRUCT_OPS(cosmos_cpu_release, s32 cpu, struct scx_cpu_release_args *args)
-{
-	/*
-	 * A higher scheduler class stole the CPU, re-enqueue all the tasks
-	 * that are waiting on this CPU and give them a chance to pick
-	 * another idle CPU.
-	 */
-	scx_bpf_reenqueue_local();
-}
-
 void BPF_STRUCT_OPS(cosmos_runnable, struct task_struct *p, u64 enq_flags)
 {
 	u64 now = scx_bpf_now(), delta_t;
@@ -1292,7 +1282,6 @@ SCX_OPS_DEFINE(cosmos_ops,
 	       .runnable		= (void *)cosmos_runnable,
 	       .running			= (void *)cosmos_running,
 	       .stopping		= (void *)cosmos_stopping,
-	       .cpu_release		= (void *)cosmos_cpu_release,
 	       .enable			= (void *)cosmos_enable,
 	       .init_task		= (void *)cosmos_init_task,
 	       .exit_task		= (void *)cosmos_exit_task,


### PR DESCRIPTION
ops.cpu_release() is deprecated in newer kernels. Moreover, we don't need to do any special action to handle high priority sched classes stealing CPUs, now that the ext deadline server patch is in the kernel (starting with v7.0).

Therefore, let's just drop ops.cpu_release().