### PR TITLE
scx_cake: Update scx_cargo and scx_utils to current versions

### DIFF
--- a/scheds/rust/scx_cake/Cargo.toml
+++ b/scheds/rust/scx_cake/Cargo.toml
@@ -18,7 +18,7 @@ ratatui = { version = "0.30" }
 crossterm = "0.29"
 arboard = "3.6"
 
-scx_utils = { path = "../../../rust/scx_utils", version = "1.0.25" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.0.26" }
 core_affinity = "0.8"
 quanta = "0.12"
 crossbeam-utils = "0.8"


### PR DESCRIPTION
All other versions of scx_scheds use the latest versions of scx_cargo and scx_utils. Most likely, the update was omitted when merging the PR. 