### PR TITLE
scx_layered: replace manual resource cleanup with RAII guards

### DIFF
--- a/scheds/include/lib/cleanup.bpf.h
+++ b/scheds/include/lib/cleanup.bpf.h
@@ -130,3 +130,6 @@ static inline class_rcu_t class_rcu_constructor(void)
 /* BPF spin lock */
 DEFINE_GUARD(spin_lock, struct bpf_spin_lock *, bpf_spin_lock(_T),
 	     bpf_spin_unlock(_T))
+
+/* Task reference from bpf_task_from_pid / bpf_task_acquire */
+DEFINE_FREE(task, struct task_struct *, if (_T) bpf_task_release(_T))

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.h
@@ -20,7 +20,7 @@
 
 #include "intf.h"
 #include "dsq.bpf.h"
-#include "cleanup.bpf.h"
+#include <lib/cleanup.bpf.h>
 
 extern const volatile u32 nr_llc;
 


### PR DESCRIPTION
scx_layered's BPF code has numerous manual acquire/release pairs for RCU read locks, idle cpumasks, and BPF cpumasks. Many of these have multiple early-return or goto-based cleanup paths that are easy to get wrong when modifying the code.

Move cleanup.bpf.h from scx_mitosis to the shared scheds/include/lib/ location and add DEFINE_FREE(task, ...) for task references. Then convert all manual resource management in scx_layered to use RAII constructs:

 - RCU read locks: scoped_guard(rcu) / guard(rcu)() (11 sites)
 - Idle cpumasks: __free(idle_cpumask) (5 sites)
 - BPF cpumasks: __free(bpf_cpumask) + no_free_ptr() for kptr xchg (2 sites)
 - Task references: __free(task) in antistall_set() DSQ iteration

The two patterns left manual are tp_cgroup_attach_task() (hand-over-hand thread list traversal that doesn't map to scoped cleanup) and bpf_kptr_xchg() old-value releases (inherently non-scoped).

Pure refactoring with no behavioral changes.