### PR TITLE
scx_layered: Fix dead_code warning

### DIFF
--- a/scheds/rust/scx_layered/src/layer_core_growth.rs
+++ b/scheds/rust/scx_layered/src/layer_core_growth.rs
@@ -307,6 +307,7 @@ struct LayerCoreOrderGenerator<'a> {
 }
 
 impl<'a> LayerCoreOrderGenerator<'a> {
+    #[allow(dead_code)]
     fn has_topology_preference(&self) -> bool {
         self.spec.nodes().len() > 0 || self.spec.llcs().len() > 0
     }


### PR DESCRIPTION
```rs
warning: method `has_topology_preference` is never used
   --> scheds/rust/scx_layered/src/layer_core_growth.rs:310:8
    |
309 | impl<'a> LayerCoreOrderGenerator<'a> {
    | ------------------------------------ method in this implementation
310 |     fn has_topology_preference(&self) -> bool {
    |        ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: `scx_layered` (lib) generated 1 warning
```