### PR TITLE
Kconfig: Sync with upstream

### DIFF
--- a/kernel.config
+++ b/kernel.config
@@ -16,8 +16,10 @@ CONFIG_KALLSYMS_ALL=y
 #
 # CONFIG_DEBUG_INFO_REDUCED is not set
 
-# LAVD tracks futex to give an additional time slice for futex holder (i.e., avoiding lock holder preemption) for better system-wide progress.
-# LAVD first tries to use ftrace to trace futex function calls. If that is not available, it tries to use a tracepoint.
+# LAVD tracks futex to give an additional time slice for futex holder
+# (i.e., avoiding lock holder preemption) for better system-wide progress.
+# LAVD first tries to use ftrace to trace futex function calls.
+# If that is not available, it tries to use a tracepoint.
 CONFIG_FUNCTION_TRACER=y
 
 # Enable scheduling debugging
@@ -36,35 +38,24 @@ CONFIG_SCHED_MC=y
 # CONFIG_PREEMPT_NONE is not set
 # CONFIG_PREEMPT_VOLUNTARY is not set
 CONFIG_PREEMPT=y
-CONFIG_PREEMPT_COUNT=y
-CONFIG_PREEMPTION=y
 CONFIG_PREEMPT_DYNAMIC=y
-CONFIG_PREEMPT_RCU=y
 
 # Additional debugging information (useful to catch potential locking issues)
-#
 CONFIG_DEBUG_LOCKDEP=y
 CONFIG_DEBUG_ATOMIC_SLEEP=y
 CONFIG_PROVE_LOCKING=y
 
 # Bpftrace headers (for additional debug info)
-CONFIG_BPF=y
-CONFIG_BPF_SYSCALL=y
-CONFIG_BPF_JIT=y
-CONFIG_HAVE_EBPF_JIT=y
 CONFIG_BPF_EVENTS=y
 CONFIG_FTRACE_SYSCALLS=y
-CONFIG_HAVE_DYNAMIC_FTRACE=y
 CONFIG_DYNAMIC_FTRACE=y
-CONFIG_HAVE_KPROBES=y
 CONFIG_KPROBES=y
 CONFIG_KPROBE_EVENTS=y
-CONFIG_ARCH_SUPPORTS_UPROBES=y
 CONFIG_UPROBES=y
 CONFIG_UPROBE_EVENTS=y
 CONFIG_DEBUG_FS=y
-# more bpftrace to make that work
+
+# Enable access to kernel configuration and headers at runtime
 CONFIG_IKHEADERS=y
 CONFIG_IKCONFIG_PROC=y
 CONFIG_IKCONFIG=y
-


### PR DESCRIPTION
- Remove duplicate entries.
- Drop no-effect entries.
- Refactor comments.

Ref: https://lore.kernel.org/all/aZ0VRpQ5KnpXjNcd@eric-acer/