### PR TITLE
scx_cosmos: Add tick hook for preemption enforcement

### DIFF
--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -244,6 +244,13 @@ struct Opts {
     #[clap(short = 'd', long, action = clap::ArgAction::SetTrue)]
     no_deferred_wakeup: bool,
 
+    /// Disable tick-based preemption enforcement.
+    ///
+    /// By default, the scheduler preempts tasks that exceed their time slice when the system is
+    /// busy or SMT contention is detected. Use this flag to disable this behavior.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    no_tick_preempt: bool,
+
     /// Enable address space affinity.
     ///
     /// This option allows to keep tasks that share the same address space (e.g., threads of the
@@ -453,6 +460,7 @@ impl<'a> Scheduler<'a> {
         rodata.nr_node_ids = topo.nodes.len() as u32;
         rodata.no_wake_sync = opts.no_wake_sync;
         rodata.avoid_smt = opts.avoid_smt;
+        rodata.tick_preempt = !opts.no_tick_preempt;
         rodata.mm_affinity = opts.mm_affinity;
 
         // Enable perf event scheduling settings.


### PR DESCRIPTION
Without a tick callback, cosmos relies entirely on voluntary yields for CPU handoff. This means a CPU-bound task can hold the CPU well beyond its 10µs time slice, starving latency-sensitive workloads like nginx workers waiting on epoll wakeups.

The tick hook enforces preemption in three cases:

1. Slice enforcement: preempt tasks that exceed their weighted time slice, ensuring no task monopolizes a CPU.

2. Priority-aware preemption: when the system is busy and tasks are queued in the shared DSQ, preempt low-frequency wakers (batch work) so high-frequency sleepers like nginx workers get the CPU sooner.

3. SMT rebalancing: when avoid_smt is enabled and the SMT sibling has gone busy, trigger rescheduling so select_cpu can find a less contended core.