### PR TITLE
scx_lavd: Restrict slice boosting based on CPU utilization.

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -71,6 +71,7 @@ enum consts_internal {
 	LAVD_SLICE_MAX_NS_DFL		= (5ULL * NSEC_PER_MSEC), /* max time slice */
 	LAVD_SLICE_BOOST_BONUS		= LAVD_SLICE_MIN_NS_DFL,
 	LAVD_SLICE_BOOST_MAX		= (500ULL * NSEC_PER_MSEC),
+	LAVD_SLICE_BOOST_UTIL_WALL	= p2s(95), /* < 95%: cpu utilization threshold for slice boost */
 	LAVD_ACC_RUNTIME_MAX		= LAVD_SLICE_MAX_NS_DFL,
 	LAVD_TASK_LAG_MAX		= (500ULL * NSEC_PER_MSEC),
 	LAVD_DL_COMPETE_WINDOW		= ((300ULL * NSEC_PER_MSEC) >> 16), /* assuming task's latency

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -229,7 +229,14 @@ bool have_scheduled(task_ctx __arg_arena *taskc)
 __hidden
 bool can_boost_slice(void)
 {
-	return sys_stat.nr_queued_task <= sys_stat.nr_active;
+	/*
+	 * When CPU utilization is too high (>= 95%), do not boost the
+	 * time slice. Checking the number of queued tasks alone is not
+	 * sufficient, especially when many tasks are slice-boosted and
+	 * unlikely relinquish CPUs soon.
+	 */
+	return (sys_stat.avg_util_wall <= LAVD_SLICE_BOOST_UTIL_WALL) &&
+	       (sys_stat.nr_queued_task <= sys_stat.nr_active);
 }
 
 __hidden


### PR DESCRIPTION
Currently, can_boost_slice() only evaluates the number of queued tasks against active CPUs. This check is insufficient during high-load scenarios where tasks with boosted slices may hold onto CPUs for extended periods, preventing timely relinquishment.

To harden this condition, introduce LAVD_SLICE_BOOST_UTIL_WALL (95%). Slice boosting is now permitted only when wall-clock CPU utilization is below this threshold, ensuring the system maintains better responsiveness under heavy pressure.

### Steps to reproduce the stuttering problem without this PR:
1. `stress-ng --cpu $(nproc)`
2. Open a youtube video https://www.youtube.com/watch?v=koGoEk_BwXU
3. It is usually smooth
4. `sudo ./target/release/scx_lavd`
5. Now the video and audio get choppy/stutter.
