### PR TITLE
scxtop: Ignore missing threads during initialization

### DIFF
--- a/tools/scxtop/src/proc_data.rs
+++ b/tools/scxtop/src/proc_data.rs
@@ -106,8 +106,9 @@ impl ProcData {
         let process = Process::new(self.tgid)?;
 
         for thread in process.tasks()?.flatten() {
-            let thread_data = ThreadData::new(thread, self.max_data_size)?;
-            self.threads.insert(thread_data.tid, thread_data);
+            if let Ok(thread_data) = ThreadData::new(thread, self.max_data_size) {
+                self.threads.insert(thread_data.tid, thread_data);
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Threads may terminate while scanning /proc/<pid>/task/, causing ThreadData::new() to fail. Previously, propagating this error caused the entire initialization to fail or panic during tests.

Ignore these errors to gracefully handle TOCTOU race conditions and ensure stable data collection for surviving threads.

```shell
$ cargo test
...
failures:

---- proc_data::tests::test_thread_operations stdout ----

thread 'proc_data::tests::test_thread_operations' panicked at tools/scxtop/src/proc_data.rs:263:34:
called `Result::unwrap()` on an `Err` value: File not found: /proc/2149206/task/2149344/stat


failures:
    proc_data::tests::test_thread_operations
```