### PR TITLE
scx_rustland_core: Fix borrow error and clippy warnings

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -206,6 +206,7 @@ fn set_ctrlc_handler(shutdown: Arc<AtomicBool>) -> Result<(), anyhow::Error> {
 }
 
 impl<'cb> BpfScheduler<'cb> {
+    #[allow(clippy::too_many_arguments)]
     pub fn init(
         open_object: &'cb mut MaybeUninit<OpenObject>,
         open_opts: Option<bpf_object_open_opts>,
@@ -555,7 +556,7 @@ impl<'cb> BpfScheduler<'cb> {
             vtime,
             enq_cnt,
             ..
-        } = &mut dispatched_task.as_mut();
+        } = dispatched_task;
 
         *pid = task.pid;
         *cpu = task.cpu;


### PR DESCRIPTION
```rust
$ cargo clippy --fix --bin "scx_rustland" 
...
warning: this function has too many arguments (8/7)
   --> scheds/rust/scx_rustland/src/bpf.rs:209:5
    |
209 | /     pub fn init(
210 | |         open_object: &'cb mut MaybeUninit<OpenObject>,
211 | |         open_opts: Option<bpf_object_open_opts>,
212 | |         exit_dump_len: u32,
...   |
217 | |         name: &str,
218 | |     ) -> Result<Self> {
    | |_____________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
    = note: `#[warn(clippy::too_many_arguments)]` on by default

warning: this call to `as_mut` does nothing
   --> scheds/rust/scx_rustland/src/bpf.rs:558:18
    |
558 |         } = &mut dispatched_task.as_mut();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `dispatched_task`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_asref
    = note: `#[warn(clippy::useless_asref)]` on by default

warning: `scx_rustland` (bin "scx_rustland") generated 2 warnings (run `cargo clippy --fix --bin "scx_rustland"` to apply 1 suggestion)
```