### PR TITLE
scx_raw_pmu / scxtop: update procfs from 0.15.1 to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,12 +526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,12 +1840,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -1992,17 +1980,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "io-uring"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,7 +1996,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -2203,12 +2180,6 @@ checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
 dependencies = [
  "bitflags 2.10.0",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2595,7 +2566,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3035,7 +3006,7 @@ checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 1.0.8",
  "tracing",
@@ -3098,21 +3069,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "procfs"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "chrono",
- "flate2",
- "hex",
- "lazy_static",
- "rustix 0.36.17",
 ]
 
 [[package]]
@@ -3564,20 +3520,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305efbd14fde4139eb501df5f136994bb520b033fa9fbdce287507dc23b8c7ed"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
@@ -3958,7 +3900,7 @@ dependencies = [
  "anyhow",
  "csv",
  "include_dir",
- "procfs 0.15.1",
+ "procfs",
  "regex",
  "scx_utils",
  "serde",
@@ -3975,7 +3917,7 @@ dependencies = [
  "libbpf-rs",
  "libc",
  "plain",
- "procfs 0.18.0",
+ "procfs",
  "scx_cargo",
  "scx_rustland_core",
  "scx_utils",
@@ -3993,7 +3935,7 @@ dependencies = [
  "log",
  "ordered-float 3.9.2",
  "plain",
- "procfs 0.18.0",
+ "procfs",
  "scx_cargo",
  "scx_rustland_core",
  "scx_stats",
@@ -4197,7 +4139,7 @@ dependencies = [
  "num-format",
  "perfetto_protos",
  "plain",
- "procfs 0.15.1",
+ "procfs",
  "protobuf",
  "rand",
  "ratatui 0.29.0",
@@ -5499,15 +5441,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -5540,21 +5473,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5615,12 +5533,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -5639,12 +5551,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5660,12 +5566,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5699,12 +5599,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5720,12 +5614,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5747,12 +5635,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5768,12 +5650,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/rust/scx_raw_pmu/Cargo.toml
+++ b/rust/scx_raw_pmu/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-2.0-only"
 anyhow = "1.0.65"
 csv = "1.3.1"
 include_dir = "0.7.4"
-procfs = "0.15.1"
+procfs = "0.18.0"
 regex = "1.11.2"
 scx_utils = { path = "../scx_utils", version = "1.0.26" }
 serde = { version = "1.0.215", features = ["derive"] }

--- a/rust/scx_raw_pmu/src/json.rs
+++ b/rust/scx_raw_pmu/src/json.rs
@@ -1,6 +1,7 @@
 use anyhow::bail;
 use csv::Reader;
 use procfs::CpuInfo;
+use procfs::Current as _;
 use regex::Regex;
 use serde::Deserialize;
 use serde::Deserializer;
@@ -9,8 +10,6 @@ use std::env;
 use std::env::consts::ARCH;
 use std::ffi::OsString;
 use std::fs;
-use std::fs::File;
-use std::io::BufReader;
 use std::path::Path;
 
 use crate::resources::ResourceDir;
@@ -140,10 +139,7 @@ impl PMUManager {
     /// Identify the architecture of the local machine and
     /// retrieve the paths to the relevant JSON files.
     fn identify_architecture() -> Result<String> {
-        let file = File::open("/proc/cpuinfo")?;
-        let bufreader = BufReader::new(file);
-
-        let cpuinfo = CpuInfo::from_reader(bufreader)?;
+        let cpuinfo = CpuInfo::current()?;
         Ok(format!(
             "{}-{}-{:X}",
             cpuinfo.fields["vendor_id"],

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -30,7 +30,7 @@ log = "0.4.17"
 num-format = { version = "0.4.3", features = ["with-serde", "with-system-locale"] }
 perfetto_protos = "0.51.1"
 plain = "0.2.3"
-procfs = "0.15.1"
+procfs = "0.18.0"
 protobuf = "3.7.2"
 rand = "0.8.5"
 ratatui = { version = "0.29.0", features = ["serde", "macros"] }

--- a/tools/scxtop/src/cpu_stats.rs
+++ b/tools/scxtop/src/cpu_stats.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use procfs::{CpuTime, KernelStats};
+use procfs::{CpuTime, CurrentSI as _, KernelStats};
 use std::collections::BTreeMap;
 use sysinfo::System;
 
@@ -73,7 +73,7 @@ impl CpuStatTracker {
         self.prev = std::mem::take(&mut self.current);
         self.system_prev = std::mem::take(&mut self.system_current);
 
-        let kernel_stats = KernelStats::new()?;
+        let kernel_stats = KernelStats::current()?;
         let cpu_stat_data = kernel_stats.cpu_time;
 
         // Read CPU frequencies from sysinfo (should be refreshed by background thread)
@@ -115,7 +115,7 @@ mod tests {
 
     #[test]
     fn test_convert_to_stat_snapshot_success() {
-        let kernel_stats = KernelStats::new().unwrap();
+        let kernel_stats = KernelStats::current().unwrap();
         let mut cpu_time = kernel_stats.total;
 
         // We'll just take over the cpu_time in order to test it
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "missing iowait")]
     fn test_convert_to_stat_snapshot_missing_iowait_panics() {
-        let kernel_stats = KernelStats::new().unwrap();
+        let kernel_stats = KernelStats::current().unwrap();
         let mut cpu_time = kernel_stats.total;
 
         // We'll just take over the cpu_time in order to test it

--- a/tools/scxtop/src/mem_stats.rs
+++ b/tools/scxtop/src/mem_stats.rs
@@ -4,7 +4,7 @@
 // GNU General Public License version 2.
 
 use anyhow::Result;
-use procfs::Meminfo;
+use procfs::{Current as _, Meminfo};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
@@ -75,7 +75,7 @@ pub struct MemStatSnapshot {
 
 impl MemStatSnapshot {
     pub fn update(&mut self) -> Result<()> {
-        let meminfo = Meminfo::new()?;
+        let meminfo = Meminfo::current()?;
 
         // Save previous values for delta calculation
         self.prev_swap_pages_in = self.swap_pages_in;


### PR DESCRIPTION
To unblock internal Meta builds.