### PR TITLE
Change BUFSIZE to use queued_task_ctx type

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -183,7 +183,7 @@ pub struct BpfScheduler<'cb> {
 //
 // NOTE: make the buffer aligned to 64-bits to prevent misaligned dereferences when accessing the
 // buffer using a pointer.
-const BUFSIZE: usize = std::mem::size_of::<QueuedTask>();
+const BUFSIZE: usize = size_of::<queued_task_ctx>();
 
 #[repr(align(8))]
 struct AlignedBuffer([u8; BUFSIZE]);


### PR DESCRIPTION
This resolves an issue, when extending the `QueuedTask` struct within a `rustland_core based scheduler`
The following error is then thrown

```sh
thread 'main' (74915) panicked at scheds/rust/scx_rustland/src/bpf.rs:255:23:
copy_from_slice: source slice length (88) does not match destination slice length (96)
```

This happens because if you have modified the `QueuedTask` struct, then the original check calculates the length of the struct, which no longer matches the length of the buf from bpf, this changes moves the length restriction to the length of the bpf buf, so that userspace changes/logic can be added without impacting the buf.