### PR TITLE
scx_rustland_core: Fold NUMA-local idle CPU selection into pick_idle_cpu()

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -212,6 +212,7 @@ impl<'cb> BpfScheduler<'cb> {
         partial: bool,
         debug: bool,
         builtin_idle: bool,
+        numa_local: bool,
         slice_ns: u64,
         name: &str,
     ) -> Result<Self> {
@@ -259,10 +260,14 @@ impl<'cb> BpfScheduler<'cb> {
         if partial {
             skel.struct_ops.rustland_mut().flags |= *compat::SCX_OPS_SWITCH_PARTIAL;
         }
+        if numa_local {
+            skel.struct_ops.rustland_mut().flags |= *compat::SCX_OPS_BUILTIN_IDLE_PER_NODE;
+        }
         skel.struct_ops.rustland_mut().exit_dump_len = exit_dump_len;
         skel.maps.rodata_data.as_mut().unwrap().usersched_pid = std::process::id();
         skel.maps.rodata_data.as_mut().unwrap().khugepaged_pid = Self::khugepaged_pid();
         skel.maps.rodata_data.as_mut().unwrap().builtin_idle = builtin_idle;
+        skel.maps.rodata_data.as_mut().unwrap().numa_local = numa_local;
         skel.maps.rodata_data.as_mut().unwrap().slice_ns = slice_ns;
         skel.maps.rodata_data.as_mut().unwrap().debug = debug;
         let _ = Self::set_scx_ops_name(&mut skel.struct_ops.rustland_mut().name, name);

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -108,6 +108,9 @@ const volatile bool debug;
 /* Rely on the in-kernel idle CPU selection policy */
 const volatile bool builtin_idle;
 
+/* Enable NUMA-local idle CPU selection */
+const volatile bool numa_local;
+
 /* Allow to use bpf_printk() only when @debug is set */
 #define dbg_msg(_fmt, ...) do {						\
 	if (debug)							\
@@ -352,6 +355,17 @@ static inline bool cpus_share_cache(s32 this_cpu, s32 that_cpu)
 }
 
 /*
+ * Return the preferred NUMA node of task @p, or NUMA_NO_NODE if not set.
+ */
+static inline s32 get_task_numa_node(const struct task_struct *p)
+{
+	if (bpf_core_field_exists(p->numa_preferred_nid))
+		return p->numa_preferred_nid;
+
+	return NUMA_NO_NODE;
+}
+
+/*
  * Return true if @this_cpu is faster than @that_cpu, false otherwise.
  */
 static inline bool is_cpu_faster(s32 this_cpu, s32 that_cpu)
@@ -433,6 +447,17 @@ static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, u64 wake_flags)
 			return prev_cpu;
 
 		prev_cpu = this_cpu;
+	}
+
+	/*
+	 * Prefer a NUMA-local idle CPU if the task has a preferred node and
+	 * NUMA-local selection is enabled.
+	 */
+	if (numa_local && bpf_ksym_exists(scx_bpf_pick_idle_cpu_node)) {
+		s32 numa_node = get_task_numa_node(p);
+		if (numa_node != NUMA_NO_NODE)
+			return scx_bpf_pick_idle_cpu_node(p->cpus_ptr, numa_node,
+							  SCX_PICK_IDLE_IN_NODE);
 	}
 
 	/*

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -116,6 +116,7 @@ impl<'a> Scheduler<'a> {
             false,    // partial (false = include all tasks)
             false,    // debug (false = debug mode off)
             true,     // builtin_idle (true = allow BPF to use idle CPUs if available)
+            false,    // numa_local (false = ignore NUMA locality when selecting target CPUs)
             SLICE_NS, // default time slice (for tasks automatically dispatched by the backend)
             "rlfifo", // name of the scx ops
         )?;

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -84,6 +84,12 @@ struct Opts {
     #[clap(short = 'l', long, action = clap::ArgAction::SetTrue)]
     percpu_local: bool,
 
+    /// Enable NUMA-local idle CPU selection. When enabled, tasks with a preferred NUMA node will
+    /// preferentially be assigned an idle CPU from that node. This is opt-in as NUMA balancing
+    /// overhead may be undesirable on certain workloads.
+    #[clap(short = 'n', long, action = clap::ArgAction::SetTrue)]
+    numa_local: bool,
+
     /// If specified, only tasks which have their scheduling policy set to SCHED_EXT using
     /// sched_setscheduler(2) are switched. Otherwise, all tasks are switched.
     #[clap(short = 'p', long, action = clap::ArgAction::SetTrue)]
@@ -174,6 +180,7 @@ impl<'a> Scheduler<'a> {
             opts.partial,
             opts.verbose,
             true, // Enable built-in idle CPU selection policy
+            opts.numa_local,
             slice_ns_min,
             "rustland",
         )?;


### PR DESCRIPTION
Add get_task_numa_node() to retrieve a task's preferred NUMA node and integrate scx_bpf_pick_idle_cpu_node() directly into pick_idle_cpu(), so callers automatically get NUMA-local selection on kernels >= 6.15 without any per-callsite logic.

## Test
My laptop doesn't have NUMA nodes, so I couldn't get valid test results with stress-ng and [Aquarium](https://webglsamples.org/aquarium/aquarium.html) there -- hence the use of the NUMA server for these metrics.

```sh
$ ./schbench -m 2 -t 128 -r 30
$ lscpu
...
NUMA:                        
  NUMA node(s):              2
  NUMA node0 CPU(s):         0-111
  NUMA node1 CPU(s):         112-223
```
The patch reduces 99th percentile wakeup latencies by approximately 10% and increases overall throughput.

<details>
<summary> Test with schbench </summary>

```shell
## origin
Wakeup Latencies percentiles (usec) runtime 10 (s) (78964 total samples)
	  50.0th: 1322       (23692 samples)
	  90.0th: 3060       (31593 samples)
	* 99.0th: 5304       (7084 samples)
	  99.9th: 6968       (713 samples)
	  min=1, max=8217
Request Latencies percentiles (usec) runtime 10 (s) (78747 total samples)
	  50.0th: 27808      (22473 samples)
	  90.0th: 35136      (31217 samples)
	* 99.0th: 58176      (7077 samples)
	  99.9th: 87680      (711 samples)
	  min=22128, max=162655
RPS percentiles (requests) runtime 10 (s) (11 total samples)
	  20.0th: 7832       (3 samples)
	* 50.0th: 7880       (4 samples)
	  90.0th: 7912       (3 samples)
	  min=7677, max=7922
sched delay: message 1569 (usec) worker 1413 (usec)
current rps: 7909.36
Wakeup Latencies percentiles (usec) runtime 20 (s) (158149 total samples)
	  50.0th: 1354       (47589 samples)
	  90.0th: 3012       (63132 samples)
	* 99.0th: 5288       (14142 samples)
	  99.9th: 7032       (1419 samples)
	  min=1, max=8623
Request Latencies percentiles (usec) runtime 20 (s) (157941 total samples)
	  50.0th: 27808      (45603 samples)
	  90.0th: 34752      (62585 samples)
	* 99.0th: 58176      (14191 samples)
	  99.9th: 89472      (1413 samples)
	  min=22128, max=162655
RPS percentiles (requests) runtime 20 (s) (21 total samples)
	  20.0th: 7832       (5 samples)
	* 50.0th: 7880       (6 samples)
	  90.0th: 7928       (8 samples)
	  min=7677, max=7990
sched delay: message 1588 (usec) worker 1414 (usec)
current rps: 7895.73
Wakeup Latencies percentiles (usec) runtime 30 (s) (237823 total samples)
	  50.0th: 1374       (71695 samples)
	  90.0th: 2972       (94745 samples)
	* 99.0th: 5176       (21419 samples)
	  99.9th: 6936       (2111 samples)
	  min=1, max=8844
Request Latencies percentiles (usec) runtime 30 (s) (237639 total samples)
	  50.0th: 27808      (69342 samples)
	  90.0th: 34240      (93612 samples)
	* 99.0th: 57920      (21240 samples)
	  99.9th: 89472      (2122 samples)
	  min=22128, max=163826
RPS percentiles (requests) runtime 30 (s) (31 total samples)
	  20.0th: 7848       (8 samples)
	* 50.0th: 7912       (12 samples)
	  90.0th: 7960       (8 samples)
	  min=7677, max=7990
sched delay: message 1593 (usec) worker 1413 (usec)
current rps: 7954.08
Wakeup Latencies percentiles (usec) runtime 30 (s) (237882 total samples)
	  50.0th: 1374       (71709 samples)
	  90.0th: 2980       (94937 samples)
	* 99.0th: 5176       (21262 samples)
	  99.9th: 6936       (2111 samples)
	  min=1, max=8844
Request Latencies percentiles (usec) runtime 30 (s) (237930 total samples)
	  50.0th: 27808      (69401 samples)
	  90.0th: 34240      (93685 samples)
	* 99.0th: 57920      (21276 samples)
	  99.9th: 89472      (2124 samples)
	  min=10701, max=163826
RPS percentiles (requests) runtime 30 (s) (31 total samples)
	  20.0th: 7848       (8 samples)
	* 50.0th: 7912       (12 samples)
	  90.0th: 7960       (8 samples)
	  min=7677, max=7990
average rps: 7931.00
sched delay: message 0 (usec) worker 0 (usec)

## with patch
Wakeup Latencies percentiles (usec) runtime 10 (s) (79131 total samples)
	  50.0th: 1474       (23812 samples)
	  90.0th: 2852       (31576 samples)
	* 99.0th: 4648       (7082 samples)
	  99.9th: 6536       (712 samples)
	  min=1, max=12124
Request Latencies percentiles (usec) runtime 10 (s) (78917 total samples)
	  50.0th: 27872      (23889 samples)
	  90.0th: 34112      (30310 samples)
	* 99.0th: 60864      (7075 samples)
	  99.9th: 95616      (707 samples)
	  min=22069, max=147207
RPS percentiles (requests) runtime 10 (s) (11 total samples)
	  20.0th: 7800       (3 samples)
	* 50.0th: 7880       (3 samples)
	  90.0th: 7944       (4 samples)
	  min=7658, max=7955
sched delay: message 1584 (usec) worker 1415 (usec)
current rps: 7880.12
Wakeup Latencies percentiles (usec) runtime 20 (s) (158569 total samples)
	  50.0th: 1478       (47613 samples)
	  90.0th: 2852       (63432 samples)
	* 99.0th: 4616       (14197 samples)
	  99.9th: 6120       (1420 samples)
	  min=1, max=12124
Request Latencies percentiles (usec) runtime 20 (s) (158354 total samples)
	  50.0th: 27872      (48787 samples)
	  90.0th: 33856      (59986 samples)
	* 99.0th: 60608      (14194 samples)
	  99.9th: 94336      (1423 samples)
	  min=22069, max=159921
RPS percentiles (requests) runtime 20 (s) (21 total samples)
	  20.0th: 7880       (7 samples)
	* 50.0th: 7912       (4 samples)
	  90.0th: 7960       (9 samples)
	  min=7658, max=7977
sched delay: message 1589 (usec) worker 1416 (usec)
current rps: 7888.12
Wakeup Latencies percentiles (usec) runtime 30 (s) (238116 total samples)
	  50.0th: 1474       (71732 samples)
	  90.0th: 2852       (94918 samples)
	* 99.0th: 4664       (21445 samples)
	  99.9th: 6136       (2092 samples)
	  min=1, max=12124
Request Latencies percentiles (usec) runtime 30 (s) (237914 total samples)
	  50.0th: 27808      (68197 samples)
	  90.0th: 33728      (94937 samples)
	* 99.0th: 60096      (21283 samples)
	  99.9th: 95104      (2139 samples)
	  min=22069, max=164006
RPS percentiles (requests) runtime 30 (s) (31 total samples)
	  20.0th: 7880       (8 samples)
	* 50.0th: 7928       (11 samples)
	  90.0th: 7960       (10 samples)
	  min=7658, max=7977
sched delay: message 1596 (usec) worker 1415 (usec)
current rps: 7971.23
Wakeup Latencies percentiles (usec) runtime 30 (s) (238225 total samples)
	  50.0th: 1474       (71761 samples)
	  90.0th: 2852       (94988 samples)
	* 99.0th: 4664       (21445 samples)
	  99.9th: 6136       (2092 samples)
	  min=1, max=12124
Request Latencies percentiles (usec) runtime 30 (s) (238255 total samples)
	  50.0th: 27808      (68262 samples)
	  90.0th: 33728      (95009 samples)
	* 99.0th: 60096      (21319 samples)
	  99.9th: 95104      (2142 samples)
	  min=14626, max=164006
RPS percentiles (requests) runtime 30 (s) (31 total samples)
	  20.0th: 7880       (8 samples)
	* 50.0th: 7928       (11 samples)
	  90.0th: 7960       (10 samples)
	  min=7658, max=7977
average rps: 7941.83
sched delay: message 0 (usec) worker 0 (usec)
```

</details>