### PR TITLE
sched: add scx_pandemonium scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3979,6 +3979,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "scx_pandemonium"
+version = "5.4.12"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ctrlc",
+ "flate2",
+ "libbpf-rs",
+ "libc",
+ "regex",
+ "scx_cargo",
+]
+
+[[package]]
 name = "scx_raw_pmu"
 version = "0.1.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "scheds/rust/scx_layered",
     "scheds/rust/scx_mitosis",
     "scheds/rust/scx_p2dq",
+    "scheds/rust/scx_pandemonium",
     "scheds/rust/scx_rlfifo",
     "scheds/rust/scx_rustland",
     "scheds/rust/scx_rusty",

--- a/scheds/rust/scx_pandemonium/Cargo.toml
+++ b/scheds/rust/scx_pandemonium/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "scx_pandemonium"
+version = "5.4.12"
+edition = "2021"
+
+[dependencies]
+libbpf-rs = { version = "=0.26.1" }
+libc = "0.2.175"
+anyhow = "1.0.65"
+clap = { version = "4.5.41", features = ["derive"] }
+ctrlc = { version = "3.4.7", features = ["termination"] }
+flate2 = "1.1.2"
+regex = "1.11.2"
+
+[dev-dependencies]
+libc = "0.2.175"
+
+[build-dependencies]
+scx_cargo = { path = "../../../rust/scx_cargo", version = "1.0.27" }

--- a/scheds/rust/scx_pandemonium/LICENSE
+++ b/scheds/rust/scx_pandemonium/LICENSE
@@ -1,0 +1,338 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/scheds/rust/scx_pandemonium/README.md
+++ b/scheds/rust/scx_pandemonium/README.md
@@ -1,0 +1,521 @@
+# PANDEMONIUM
+
+Built in Rust and C23, PANDEMONIUM is a Linux kernel scheduler built for sched_ext. Utilizing BPF patterns, PANDEMONIUM classifies every task by its behavior--wakeup frequency, context switch rate, runtime, sleep patterns--and adapts scheduling decisions in real time. Single-thread adaptive control loop (zero mutexes), three-tier behavioral dispatch, overflow sojourn rescue, longrun detection with deficit tightening, dual burst detection (CUSUM + wakeup rate), L2 cache affinity placement, sleep-informed batch tuning, CoDel-inspired sojourn rescue, classification-gated DSQ routing, workload regime detection, vtime ceiling, hard starvation rescue, and a persistent process database that learns task classifications across lifetimes.
+
+PANDEMONIUM is included in the [sched-ext/scx](https://github.com/sched-ext/scx) project alongside scx_rusty, scx_lavd, scx_layered, scx_cosmos, and the rest of the sched_ext family. Thank you to Piotr Gorski and the sched-ext team. PANDEMONIUM is made possible by contributions from the sched_ext, CachyOS, Gentoo, OpenSUSE and Arch communities within the Linux ecosystem.
+
+## Performance
+
+Benchmarked on 12 AMD Zen CPUs, kernel 6.18.13-arch1-1, clang 21.1.6, 3 iterations.
+
+### Burst P99 (fork/exec storm under CPU saturation)
+
+| Cores | EEVDF    | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) | scx_bpfland |
+|-------|----------|-------------------|------------------------|-------------|
+| 2     | 2,773us  | 1,228us           | **821us**              | 3,181us     |
+| 4     | 2,883us  | **1,285us**       | 1,594us                | 2,005us     |
+| 8     | 2,886us  | **1,092us**       | 1,239us                | 2,006us     |
+| 12    | 2,280us  | 1,231us           | **1,021us**            | 2,007us     |
+
+Both modes beat EEVDF and scx_bpfland at every core count. Overflow sojourn rescue and dual burst detection (CUSUM + wakeup rate) keep burst response sub-2ms.
+
+### P99 Wakeup Latency (interactive probe under CPU saturation)
+
+| Cores | EEVDF    | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) | scx_bpfland |
+|-------|----------|-------------------|------------------------|-------------|
+| 2     | 1,953us  | 1,922us           | **929us**              | 3,060us     |
+| 4     | 1,358us  | **1,012us**       | 1,690us                | 2,011us     |
+| 8     | 1,711us  | **1,041us**       | 830us                  | 2,005us     |
+| 12    | **718us**| 909us             | 1,284us                | 2,007us     |
+
+ADAPTIVE wins at 2C, BPF beats EEVDF at 4C and 8C. Both modes beat scx_bpfland at every core count.
+
+### Longrun P99 (interactive latency with sustained CPU-bound long-runners)
+
+| Cores | EEVDF    | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) | scx_bpfland |
+|-------|----------|-------------------|------------------------|-------------|
+| 2     | 2,295us  | **440us**         | 568us                  | 2,020us     |
+| 4     | 1,395us  | **912us**         | 1,338us                | 2,001us     |
+| 8     | **557us**| 1,009us           | 1,741us                | 2,005us     |
+| 12    | **418us**| 993us             | 1,957us                | 1,999us     |
+
+Longrun detection tightens deficit ratio to 1:1 under sustained batch pressure. BPF mode sub-1ms at 2C and 4C.
+
+### Mixed Latency P99 (interactive + batch concurrent)
+
+| Cores | EEVDF    | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) | scx_bpfland |
+|-------|----------|-------------------|------------------------|-------------|
+| 2     | 2,759us  | **520us**         | 1,026us                | 2,167us     |
+| 4     | **974us**| 1,075us           | 1,386us                | 1,999us     |
+| 8     | 2,183us  | **968us**         | 1,217us                | 2,004us     |
+| 12    | 2,100us  | **999us**         | 1,737us                | 2,000us     |
+
+BPF mode sub-1ms at 2C, 8C, and 12C under mixed interactive+batch workloads.
+
+### Throughput (kernel build, vs EEVDF baseline, 3 iterations)
+
+| Cores | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) | scx_bpfland |
+|-------|-------------------|------------------------|-------------|
+| 2     | +2.6%             | +18.8%                 | +5.2%       |
+| 4     | +3.5%             | +2.7%                  | +0.4%       |
+| 8     | +3.9%             | +2.9%                  | +3.8%       |
+| 12    | +1.7%             | +0.6%                  | +1.9%       |
+
+### Deadline Jitter (16.6ms frame target, miss ratio)
+
+| Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) | scx_bpfland |
+|-------|---------|-------------------|------------------------|-------------|
+| 8     | 11.3%   | **8.1%**          | **4.3%**               | 56.5%       |
+| 12    | 11.9%   | **4.4%**          | **6.8%**               | 56.3%       |
+
+At 8+ cores, PANDEMONIUM ADAPTIVE misses 4.3% of frame deadlines at 8C. BPF mode hits 4.4% at 12C vs EEVDF's 11.9%. scx_bpfland misses 56%.
+
+## Key Features
+
+### Dispatch Order
+
+0. Overflow sojourn rescue (aging overflow DSQ tasks > threshold, deficit-gated)
+1. Per-CPU DSQ (direct placement from enqueue, zero contention, counts toward deficit)
+2. Deficit counter (DRR: force batch if budget exhausted + starving; longrun tightens budget)
+3. Hard starvation rescue (core-count-scaled absolute safety net)
+4. Node interactive overflow (LAT_CRITICAL + INTERACTIVE, vtime-ordered)
+5. Batch sojourn rescue (CoDel: rescue if oldest batch > threshold)
+6. Node batch overflow (normal fallback for batch tasks)
+7. Cross-node steal (interactive + batch per remote node)
+8. KEEP_RUNNING if prev still wants CPU and nothing queued
+
+### Three-Tier Enqueue
+
+- **Idle CPU Fast Path**: `select_cpu()` places wakeups directly to per-CPU DSQ (depth-gated: 1 slot at <4 CPUs, 2 at 4+), kicks with `SCX_KICK_IDLE`
+- **Node-Local Placement with L2 Affinity**: `enqueue()` tries L2 sibling first (INTERACTIVE/BATCH with affinity_mode > 0), then falls back to any idle CPU within the NUMA node, always dispatching to the per-node shared DSQ. LAT_CRITICAL and kernel threads (PF_KTHREAD) skip affinity for fastest-available placement
+- **Wakeup Preemption**: All wakeups get node DSQ dispatch with `SCX_KICK_PREEMPT`. A task waking from sleep has external input to deliver regardless of behavioral tier. The classifier operates on historical behavior; the wakeup is the real-time latency signal. LAT_CRITICAL also gets preemption on requeue (compositor guarantee). Batch requeues skip to overflow DSQ
+- **NUMA-Scoped Overflow**: Per-node overflow DSQ with classification-gated routing. Immature INTERACTIVE tasks (`ewma_age < 2`) route to batch DSQ until EWMA classifies them. LAT_CRITICAL tasks are never redirected
+- **Event-Driven Preemption**: `tick()` checks `interactive_waiting` flag and preempts batch tasks above `preempt_thresh_ns`. During `burst_mode`, preempt threshold drops to 0 (immediate preemption). Zero polling -- no BPF timer
+
+### Overflow Sojourn Rescue
+
+Per-CPU DSQ dominance under sustained load makes all downstream anti-starvation logic unreachable -- 90%+ of dispatches serve per-CPU DSQ while overflow tasks age indefinitely. Dispatch Step 0 checks both overflow DSQs for tasks aging past `overflow_sojourn_rescue_ns` (core-count-scaled: 2ms per core, clamped 4-10ms) and serves them before per-CPU DSQ. CAS-based timestamp management prevents races across CPUs.
+
+### Longrun Detection
+
+Tracks sustained batch DSQ pressure. When batch DSQ is non-empty for >2 seconds, `longrun_mode` activates:
+- Deficit ratio tightens from `nr_cpu_ids * ratio` to `nr_cpu_ids * 1`, quadrupling batch dispatch share
+- `task_slice()` uses `burst_slice_ns` (1ms) instead of regime slice (up to 4ms)
+- Rust adaptive layer: sleep-informed batch adjustment skipped, affinity forced to WEAK (spread batch across CPUs)
+
+### Dual Burst Detection
+
+- **CUSUM**: Statistical change-point detection (Page, 1954) monitors total enqueue rate. Samples every 64th enqueue, EWMA baseline with 25% slack. Effective for BPF mode (1ms slices) where enqueue rate spikes during fork storms
+- **Wakeup Rate Counter**: Absolute threshold -- `nr_cpu_ids * 2` wakeups per tick = fork storm. No calibration needed, works immediately on first tick. Effective for adaptive mode (4ms slices) where CUSUM is rate-bounded
+- Either firing activates `burst_mode`: preempt threshold drops to 0, task_slice uses `burst_slice_ns`
+- Split DSQ routing always active. Burst handled via slice reduction and preempt override, not DSQ reorganization
+
+### Vtime Ceiling
+
+High-vtime daemons sort to the tail of the batch DSQ while fresh burst tasks take the head. Sojourn rescue dispatches from the head, so daemons starve. The ceiling caps batch deadline at `vtime_now + 30ms`, keeping every task within 6 sojourn cycles of the head. Gated at >=8 cores -- at 2-4 cores the batch DSQ is shallow enough that sojourn rescue reaches every task naturally.
+
+### Hard Starvation Rescue
+
+Absolute safety net. Computed as the minimum of two linear functions: `min(25ms * nr_cpus, 500ms / max(1, nr_cpus/4))`, clamped to 20-500ms. Short at low core counts (fast starvation: 2C = 50ms) and at high core counts (dispatch contention: 128C = 20ms), peaks in the middle (8C = 200ms). Fires before the interactive DSQ and guarantees batch service regardless of interactive pressure.
+
+### Batch DSQ Separation
+
+Batch tasks enqueue to dedicated per-node batch overflow DSQs instead of sharing vtime-ordered DSQs with interactive tasks. Separate DSQs give dispatch explicit control: interactive overflow first, then sojourn rescue, then batch fallback.
+
+### CoDel Sojourn Rescue
+
+`batch_enqueue_ns` records when the batch DSQ transitions from empty to non-empty. `dispatch()` rescues batch tasks waiting longer than `sojourn_thresh_ns`. The threshold is set by the Rust adaptive layer from observed dispatch rate: target = 4x dispatch interval, EWMA-smoothed (7/8 old + 1/8 new), clamped to core-count-aware floor/ceiling.
+
+### Deficit Counter (DRR)
+
+After `interactive_budget` consecutive interactive dispatches without batch service, forces one batch dispatch. Budget scales with core count: `nr_cpus * ratio` where ratio = `min(4, 2 + nr_cpus/2)` (2C: 6, 4C+: same as nr_cpus * 4). Per-CPU DSQ dispatches count toward the deficit. During longrun mode, budget tightens to `nr_cpu_ids * 1`.
+
+### Behavioral Classification
+
+- **Latency-Criticality Score**: `lat_cri = (wakeup_freq * csw_rate) / effective_runtime` where `effective_runtime = avg_runtime + (runtime_dev >> 1)`
+- **Three Tiers**: LAT_CRITICAL (1.5x avg_runtime slices, preemptive kicks), INTERACTIVE (2x avg_runtime), BATCH (configurable ceiling via adaptive layer)
+- **EWMA Classification**: All tasks go through full EWMA classification in `runnable()`. Wakeup frequency, context switch rate, and runtime variance drive `lat_cri` scoring
+- **CPU-Bound Demotion**: Tasks with avg_runtime above `cpu_bound_thresh_ns` (regime-dependent) are demoted from INTERACTIVE to BATCH. Reversed when the task sleeps
+- **Kworker Floor**: Workqueue workers (PF_WQ_WORKER) floor at TIER_INTERACTIVE -- kernel I/O completion handlers are latency-critical infrastructure regardless of EWMA score
+- **Compositor Boosting**: BPF hash map populated by Rust at startup. Default compositors (kwin, gnome-shell, mutter, sway, Hyprland, picom, weston, labwc, wayfire, niri) always LAT_CRITICAL. User-extensible via `--compositor` CLI flag
+
+### L2 Cache Affinity
+
+- **Active Placement**: `find_idle_l2_sibling()` in enqueue Tier 1 finds idle CPUs in the same L2 domain. Bounded loop (max 8 iterations), verifier-safe
+- **Affinity Mode**: Per-regime knob (LIGHT=WEAK, MIXED=STRONG, HEAVY=WEAK). Longrun overrides to WEAK
+- **Kernel Thread Bypass**: kworkers and ksoftirqd (PF_KTHREAD) skip L2 affinity entirely
+- **Per-Dispatch Tracking**: Every dispatch compares the selected CPU's L2 domain against the task's last CPU
+- **Per-Tier Hit/Miss Counters**: Separate L2 hit rates for BATCH, INTERACTIVE, and LAT_CRITICAL tiers
+
+### Process Classification Database (procdb)
+
+- **Cross-Lifecycle Learning**: BPF publishes mature task profiles (tier + avg_runtime) keyed by `comm[16]` to an observation map
+- **Confidence Scoring**: Rust ingests observations, tracks EWMA convergence stability, and promotes profiles to "confident" when avg_runtime stabilizes
+- **Warm-Start on Spawn**: `enable()` applies learned classification from prior runs
+- **EWMA Validation**: Confident tasks still run through full behavioral classification in `runnable()`. ProcDb provides the initial state; EWMA validates and corrects
+- **Persistent Memory**: Saved to `~/.cache/pandemonium/procdb.bin` on shutdown (atomic write). Zero cold-start penalty after the first run
+- **Deterministic Eviction**: When the profile cache is full, eviction sorts by (staleness, observations, comm)
+
+### Sleep-Aware Scheduling
+
+- **quiescent() Callback**: Records sleep timestamp
+- **Sleep Duration Tracking**: `running()` classifies sleep into BPF per-CPU histogram (IO-WAIT / SHORT IO / MODERATE / IDLE)
+- **Sleep-Informed Batch Tuning**: IO-heavy (>60% io_pct) extends batch slices +25%, idle-heavy (<15%) tightens -25%, dead zone unchanged. 25ms ceiling. Skipped during longrun mode
+- **Wakeup Latency Histograms**: Per-CPU BPF histograms (3 tiers x 12 buckets), approximately 20ns per wakeup
+
+### Adaptive Control Loop
+
+- **One Thread, Zero Mutexes**: Single monitor thread, 1-second control loop. Reads BPF histogram maps, computes P99, adjusts knobs
+- **Workload Regime Detection**: LIGHT (idle >50%), MIXED (10-50%), HEAVY (<10%) with Schmitt trigger hysteresis and 2-tick hold
+- **Regime Profiles**:
+  - LIGHT: slice 2ms, preempt 1ms, batch 20ms, affinity WEAK
+  - MIXED: slice 1ms, preempt 1ms, batch 20ms (scaled: nr_cpus * 5ms cap), affinity STRONG
+  - HEAVY: slice 4ms, preempt 2ms, batch 20ms, affinity WEAK
+- **Knob Adjustment Layering**:
+  1. `regime_knobs()` sets baseline
+  2. `sleep_adjust_batch_ns()` adjusts for IO/idle pattern (skipped during longrun)
+  3. Dispatch-rate sojourn threshold (EWMA, core-count-aware floor/ceil)
+  4. Tighten check: P99 above ceiling tightens slice_ns by 25% (MIXED only)
+  5. Graduated relax: step back toward baseline by 500us/tick with 2-second hold
+  6. Longrun override: force WEAK affinity, skip sleep adjustment
+- **Core-Count-Aware Sojourn**: Floor = `clamp(nr_cpus * 1ms, 2ms, 6ms)`, ceiling = floor * 2. Dispatch rate normalized to actual elapsed time (not assumed 1s)
+- **P99 Ceilings**: LIGHT 3ms, MIXED 5ms, HEAVY 10ms
+
+### Core-Count Scaling
+
+All scheduling parameters scale dynamically with `nr_cpus` using clamped linear formulas. No special-casing, no lookup tables -- every value is a calculation.
+
+| Parameter | Formula | 2C | 4C | 8C | 12C |
+|-----------|---------|----|----|----|----|
+| Sojourn floor | `clamp(nr_cpus * 1ms, 2ms, 6ms)` | 2ms | 4ms | 6ms | 6ms |
+| Sojourn ceiling | `floor * 2` | 4ms | 8ms | 12ms | 12ms |
+| Overflow rescue | `clamp(nr_cpus * 2ms, 4ms, 10ms)` | 4ms | 8ms | 10ms | 10ms |
+| Starvation rescue | `clamp(min(25ms * N, 500ms / max(1,N/4)), 20ms, 500ms)` | 50ms | 100ms | 200ms | 167ms |
+| Deficit budget | `nr_cpus * min(4, 2 + nr_cpus/2)` | 6 | 16 | 32 | 48 |
+| Per-CPU DSQ depth | `nr_cpus < 4 ? 1 : 2` | 1 | 2 | 2 | 2 |
+| Mixed batch cap | `nr_cpus * 5ms` (no-op above base) | 10ms | 20ms | 20ms | 20ms |
+| Mixed slice cap | `nr_cpus * 500us` (no-op above base) | 1ms | 1ms | 1ms | 1ms |
+
+- **CPU Hotplug**: `cpu_online`/`cpu_offline` callbacks prevent sched_ext auto-exit during CPU restriction
+- **Topology Detection**: Parses sysfs for physical packages, L2/L3 cache domains, NUMA nodes
+- **BPF-Verifier Safe**: All EWMA uses bit shifts, no floats. All shared state uses GCC __sync builtins (CAS, atomic add, test-and-set)
+
+## Architecture
+
+```
+pandemonium.py           Build/install/benchmark manager (Python)
+pandemonium_common.py    Shared infrastructure (logging, build, CPU management,
+                           scheduler detection, tracefs, statistics)
+export_scx.py            Automated import into sched-ext/scx monorepo
+src/
+  main.rs              Entry point, CLI, scheduler loop, telemetry
+  scheduler.rs         BPF skeleton lifecycle, tuning knobs I/O, histogram reads
+  adaptive.rs          Adaptive control loop (single monitor thread, histogram P99,
+                         sleep adjustment, sojourn threshold, tighten/relax,
+                         longrun override, core-count-aware sojourn)
+  tuning.rs            Regime knobs, stability scoring, sleep adjustment
+  procdb.rs            Process classification database (observe -> learn -> predict -> persist)
+  topology.rs          CPU topology detection (sysfs -> cache_domain + l2_siblings BPF maps)
+  event.rs             Pre-allocated ring buffer for stats time series
+  log.rs               Logging macros
+  lib.rs               Library root
+  bpf/
+    main.bpf.c         BPF scheduler (GNU C23)
+    intf.h             Shared structs: tuning_knobs, pandemonium_stats, task_class_entry
+  cli/
+    mod.rs             Shared constants, helpers
+    check.rs           Dependency + kernel config verification
+    run.rs             Build, sudo execution, dmesg, log management
+    bench.rs           A/B benchmarking
+    probe.rs           Interactive wakeup probe
+    report.rs          Statistics, formatting
+    test_gate.rs       Test gate orchestration
+    child_guard.rs     RAII child process guard
+    death_pipe.rs      Orphan detection via pipe POLLHUP
+build.rs               vmlinux.h generation + C23 patching + BPF compilation
+tests/
+  pandemonium-tests.py Test orchestrator (bench-scale, bench-trace, bench-contention,
+                         bench-pcpu, bench-scx)
+  contention.rs        Contention stress tests (44 tests: sojourn, relax, tighten,
+                         longrun, sleep-informed batch, regime hold, P99 histogram)
+  adaptive.rs          Adaptive layer tests (29 tests: regime, stability, sleep, telemetry)
+  event.rs             Unit tests (ring buffer)
+  procdb.rs            Process database tests (26 tests: confidence, eviction, persistence)
+  scale.rs             Latency scaling benchmark
+include/
+  scx/                 Vendored sched_ext headers
+```
+
+### BPF Scheduler (main.bpf.c)
+
+```
+select_cpu()  ->  Idle CPU found?  ->  Per-CPU DSQ (depth-gated, KICK_IDLE)
+                      |                  (depth: 1 at <4C, 2 at 4C+)
+                      v (no)
+enqueue()     ->  L2 sibling idle?  ->  Node DSQ + kick (L2-affine placement)
+                  (skip for LAT_CRITICAL    |
+                   and kernel threads)      v (no)
+              ->  Wakeup or          ->  Node DSQ + KICK_PREEMPT
+                  LAT_CRITICAL?          (all wakeups, any tier)
+                      |
+                      v (batch requeue)
+              ->  BATCH or immature  ->  Per-node batch overflow DSQ (sojourn tracked)
+                  INTERACTIVE?           (classification gate: ewma_age < 2)
+                  (vtime ceiling at       |
+                   >=8 cores)             v (classified INTERACTIVE)
+              ->  Per-node interactive overflow DSQ
+
+dispatch()    ->  Overflow sojourn rescue (core-count-scaled threshold, deficit-gated)
+              ->  Per-CPU DSQ (direct placement, counts toward deficit)
+              ->  Deficit counter (DRR: force batch if budget + starving, longrun tightens)
+              ->  Hard starvation rescue (core-count-scaled safety net)
+              ->  Node interactive overflow (LAT_CRITICAL + INTERACTIVE)
+              ->  Batch sojourn rescue (CoDel: rescue if oldest > threshold)
+              ->  Node batch overflow (normal fallback)
+              ->  Cross-node steal (interactive + batch per remote node)
+              ->  KEEP_RUNNING if nothing queued
+
+tick()        ->  Burst detection (CUSUM + wakeup rate -> burst_mode)
+              ->  Longrun detection (batch DSQ non-empty >2s -> longrun_mode)
+              ->  Sojourn enforcement (kick batch CPUs when batch DSQ starving)
+              ->  interactive_waiting?  ->  Preempt batch (thresh=0 during burst)
+```
+
+### Adaptive Layer (adaptive.rs)
+
+```
+BPF per-CPU histograms              Monitor Thread (1s loop)
+(wake_lat_hist, sleep_hist)  --->   Read + drain histograms
+                                    Compute P99 per tier
+                                      |
+                                      v
+                                    regime_knobs() -> baseline
+                                      -> sleep_adjust_batch_ns() (skip if longrun)
+                                        -> dispatch-rate sojourn threshold (core-count-aware)
+                                          -> tighten check -> P99 ceiling
+                                            -> graduated relax -> step toward baseline
+                                      -> longrun override -> WEAK affinity, base batch
+                                      |
+                                      v
+                                    BPF reads knobs on next dispatch
+
+L2 placement:      affinity_mode knob -> BPF enqueue (WEAK during longrun)
+Sojourn threshold: sojourn_thresh_ns knob -> BPF dispatch (core-count-scaled)
+```
+
+One thread, zero mutexes. BPF produces histograms, Rust reads them once per second. Rust writes knobs, BPF reads them on the very next scheduling decision.
+
+### Process Database (procdb.rs)
+
+```
+BPF stopping()                    Rust monitor                    BPF enable()
+  |                                |                                |
+  v                                v                                v
+task_class_observe  -------->  ingest()  -------->  task_class_init
+(comm -> tier, avg_runtime)    confidence scoring   (comm -> tier, avg_runtime)
+                               EWMA convergence     warm-start -> EWMA validates
+                               detection
+
+~/.cache/pandemonium/procdb.bin
+  ^                    |
+  |  save() on         |  load() on startup
+  |  shutdown          |  -> flush_predictions()
+  |  (atomic write)    v
+  +--- Rust monitor ---+
+```
+
+### Tuning Knobs (BPF map)
+
+| Knob | Default | Purpose |
+|------|---------|---------|
+| `slice_ns` | 1ms | Interactive/lat_cri slice ceiling |
+| `preempt_thresh_ns` | 1ms | Tick preemption threshold (0 during burst) |
+| `lag_scale` | 4 | Deadline lag multiplier (higher = more vtime credit) |
+| `batch_slice_ns` | 20ms | Batch task slice ceiling (sleep-adjusted) |
+| `burst_slice_ns` | 1ms | Slice ceiling during burst/longrun mode |
+| `cpu_bound_thresh_ns` | 2.5ms | CPU-bound demotion threshold (regime-dependent) |
+| `lat_cri_thresh_high` | 32 | Classifier: LAT_CRITICAL threshold |
+| `lat_cri_thresh_low` | 8 | Classifier: INTERACTIVE threshold |
+| `affinity_mode` | 1 | L2 placement (0=OFF, 1=WEAK, 2=STRONG) |
+| `sojourn_thresh_ns` | 5ms | Batch DSQ rescue threshold (set by Rust, core-count-aware) |
+
+## Requirements
+
+- Linux kernel 6.12+ with `CONFIG_SCHED_CLASS_EXT=y`
+- Rust toolchain
+- clang (BPF compilation)
+- system libbpf
+- bpftool (first build only -- generates vmlinux.h, can be uninstalled after)
+- Root privileges (`CAP_SYS_ADMIN`)
+
+```bash
+# Arch Linux
+pacman -S clang libbpf bpf rust
+```
+
+## Build & Install
+
+```bash
+# Build manager (recommended)
+./pandemonium.py rebuild        # Force clean rebuild
+./pandemonium.py install        # Build + install to /usr/local/bin + systemd service file
+./pandemonium.py status         # Show build/install status
+./pandemonium.py clean          # Wipe build artifacts
+
+# Manual
+CARGO_TARGET_DIR=/tmp/pandemonium-build cargo build --release
+```
+
+vmlinux.h is generated from the running kernel's BTF via bpftool on first build and cached at `~/.cache/pandemonium/vmlinux.h`. Subsequent builds use the cache -- bpftool is not needed after the first build.
+
+After install, start and enable manually:
+
+```bash
+sudo systemctl start pandemonium          # Start now (one-time)
+sudo systemctl enable pandemonium         # Start on boot (after confirming it works)
+```
+
+Note: the source directory path contains spaces, so `CARGO_TARGET_DIR=/tmp/pandemonium-build` is required for the vendored libbpf Makefile.
+
+## Usage
+
+```bash
+# Run the scheduler (default: adaptive mode)
+sudo pandemonium
+
+# BPF-only mode (no Rust adaptive control loop)
+sudo pandemonium --no-adaptive
+
+# Override CPU count for scaling formulas
+sudo pandemonium --nr-cpus 4
+
+# Add custom compositor process names (boosted to LAT_CRITICAL)
+sudo pandemonium --compositor gamescope --compositor picom-next
+
+# Subcommands
+pandemonium check        # Verify dependencies and kernel config
+pandemonium start        # Build + sudo run + dmesg capture + log management
+pandemonium bench        # A/B benchmark (EEVDF vs PANDEMONIUM)
+pandemonium test         # Full test gate (unit + integration)
+pandemonium test-scale   # A/B scaling benchmark with CPU hotplug
+pandemonium probe        # Standalone interactive wakeup probe
+pandemonium dmesg        # Filtered kernel log for sched_ext/pandemonium
+```
+
+### Monitoring
+
+Per-second telemetry (printed to stdout while running):
+
+```
+d/s: 251000  idle: 5% shared: 230000  preempt: 12  keep: 0  kick: H=8000 S=22000 enq: W=8000 R=22000 wake: 4us p99: 10us L2: B=67% I=72% LC=85% procdb: 42/5 sleep: io=87% sjrn: 3ms/5ms rescue: 0 [MIXED]
+```
+
+During fork/exec storms, burst mode activates:
+
+```
+d/s: 380000  idle: 1% shared: 360000  preempt: 45  keep: 0  kick: H=15000 S=35000 enq: W=15000 R=35000 wake: 12us p99: 85us L2: B=45% I=68% LC=82% procdb: 42/5 sleep: io=92% sjrn: 1ms/5ms rescue: 3 [HEAVY BURST]
+```
+
+During sustained batch pressure, longrun mode activates:
+
+```
+d/s: 180000  idle: 2% shared: 170000  preempt: 8  keep: 0  kick: H=6000 S=18000 enq: W=6000 R=18000 wake: 6us p99: 15us L2: B=55% I=70% LC=80% procdb: 42/5 sleep: io=30% sjrn: 8ms/10ms rescue: 1 [HEAVY LONGRUN]
+```
+
+| Counter | Meaning |
+|---------|---------|
+| d/s | Total dispatches per second |
+| idle | Placed via select_cpu idle fast path (%) |
+| shared | Enqueue -> per-node DSQ |
+| preempt | Tick preemptions (batch task yielded) |
+| kick H/S | Hard (PREEMPT) / Soft (nudge) kicks |
+| enq W/R | Wakeup / Re-enqueue counts |
+| wake | Average wakeup-to-run latency |
+| p99 | P99 wakeup latency (from histogram) |
+| L2: B/I/LC | L2 cache hit rate per tier (Batch/Interactive/Lat_Critical) |
+| procdb | Total profiles / confident predictions |
+| sleep: io | I/O-wait sleep pattern percentage |
+| sjrn | Batch sojourn: current wait / threshold (ms) |
+| rescue | Overflow sojourn rescue dispatches this tick |
+| [REGIME] | Current workload regime (LIGHT/MIXED/HEAVY) |
+| BURST | Burst detection active (CUSUM or wakeup rate) |
+| LONGRUN | Sustained batch pressure detected (>2s) |
+
+## Benchmarking
+
+```bash
+# Full benchmark (throughput + latency + burst + longrun + mixed + deadline + IPC + launch)
+./pandemonium.py bench-scale
+./pandemonium.py bench-scale --iterations 3
+./pandemonium.py bench-scale --iterations 3 --core-counts 4,8,12
+./pandemonium.py bench-scale --burst       # Burst-only mode
+./pandemonium.py bench-scale --longrun     # Longrun-only mode
+./pandemonium.py bench-scale --mixed       # Mixed-only mode (burst + longrun combined)
+./pandemonium.py bench-scale --deadline    # Deadline jitter only
+./pandemonium.py bench-scale --ipc         # IPC round-trip latency only
+./pandemonium.py bench-scale --launch      # Fork/exec launch latency only
+
+# Crash-detection stress test with BPF trace capture
+./pandemonium.py bench-trace
+./pandemonium.py bench-trace --iterations 3 --core-counts 4,8,12
+
+# Contention stress test (6 phases targeting adaptive features)
+./pandemonium.py bench-contention
+./pandemonium.py bench-contention --iterations 3 --core-counts 4,8,12
+./pandemonium.py bench-contention --phase regime-sweep   # Single phase
+
+# Per-CPU DSQ correctness (burst, steal balance, sojourn rescue)
+./pandemonium.py bench-pcpu
+./pandemonium.py bench-pcpu --core-counts 4,8,12
+
+# sched-ext/scx CI compatibility (functional + stress-ng)
+./pandemonium.py bench-scx
+./pandemonium.py bench-scx --core-counts 2
+./pandemonium.py bench-scx --duration 60 --stress-duration 60
+```
+
+All benchmarks compare across core counts via CPU hotplug (2, 4, 8, ..., max). Results are archived to `~/.cache/pandemonium/` in Prometheus exposition format (.prom) for cross-build regression tracking. Human-readable reports are saved as .log files.
+
+## Testing
+
+```bash
+# Unit tests (no root required)
+CARGO_TARGET_DIR=/tmp/pandemonium-build cargo test --release
+
+# Full test gate (requires root + sched_ext kernel)
+pandemonium test
+
+# Scaling benchmark (EEVDF vs PANDEMONIUM, CPU hotplug, requires root)
+./pandemonium.py bench-scale
+```
+
+110 tests across 6 test files:
+
+| File | Tests | Coverage |
+|------|-------|----------|
+| tests/contention.rs | 44 | Sojourn EWMA, graduated relax, tighten/spike detection, longrun override, sleep-informed batch, regime hold hysteresis, P99 histogram edge cases, stability score |
+| tests/adaptive.rs | 29 | Regime detection, tuning knobs, stability scoring, sleep adjustment, telemetry gating |
+| tests/procdb.rs | 26 | Profile confidence, eviction, persistence, determinism |
+| src/main.rs | 6 | Topology parsing |
+| tests/event.rs | 5 | Ring buffer, snapshot, summary |
+| tests/gate.rs | 5 | BPF lifecycle, latency (require root, ignored offline) |
+
+## sched-ext/scx Integration
+
+PANDEMONIUM is included in the sched-ext/scx monorepo. `export_scx.py` automates the import:
+
+```bash
+./export_scx.py /path/to/scx
+```
+
+The script copies source files into `scheds/rust/scx_pandemonium/`, renames the crate, strips `[profile.release]` (the workspace provides its own), replaces `build.rs` with a `scx_cargo::BpfBuilder` version, swaps `libbpf-cargo` for `scx_cargo` in build dependencies, registers the workspace member, and runs `cargo fmt`.
+
+## Attribution
+
+- `include/scx/*` headers from the [sched_ext](https://github.com/sched-ext/scx) project (GPL-2.0)
+- vmlinux.h generated from the running kernel's BTF (cached after first build)
+- Included in the [sched-ext/scx](https://github.com/sched-ext/scx) project
+
+## License
+
+GPL-2.0

--- a/scheds/rust/scx_pandemonium/build.rs
+++ b/scheds/rust/scx_pandemonium/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    scx_cargo::BpfBuilder::new()
+        .unwrap()
+        .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
+        .enable_skel("src/bpf/main.bpf.c", "main")
+        .build()
+        .unwrap();
+}

--- a/scheds/rust/scx_pandemonium/src/adaptive.rs
+++ b/scheds/rust/scx_pandemonium/src/adaptive.rs
@@ -1,0 +1,456 @@
+// PANDEMONIUM ADAPTIVE CONTROL LOOP
+// SINGLE-THREAD CLOSED-LOOP TUNING SYSTEM
+//
+// ONE THREAD: MONITOR LOOP (1-SECOND CONTROL LOOP)
+//   READS BPF PER-CPU HISTOGRAMS FOR P99 COMPUTATION.
+//   DETECTS WORKLOAD REGIME. SETS BASELINE KNOBS.
+//   TIGHTENS ON P99 SPIKES. RELAXES GRADUALLY AFTER P99 NORMALIZES.
+//
+// BPF PRODUCES HISTOGRAMS, RUST READS AND REACTS. RUST WRITES KNOBS,
+// BPF READS THEM ON THE VERY NEXT SCHEDULING DECISION.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::procdb::ProcessDb;
+use crate::scheduler::{PandemoniumStats, Scheduler};
+use crate::tuning::{self, detect_regime, scaled_regime_knobs, Regime, TuningKnobs, HIST_BUCKETS};
+
+// REGIME THRESHOLDS, PROFILES, AND KNOB COMPUTATION LIVE IN tuning.rs
+// (ZERO BPF DEPENDENCIES, TESTABLE OFFLINE)
+
+// TIGHTEN PARAMETERS
+
+const MIN_SLICE_NS: u64 = 500_000; // 500US FLOOR
+
+// GRADUATED RELAX: STEP TOWARD BASELINE AFTER P99 NORMALIZES
+const RELAX_STEP_NS: u64 = 500_000; // RELAX BY 500US PER TICK
+const RELAX_HOLD_TICKS: u32 = 2; // WAIT 2S OF GOOD P99 BEFORE STEPPING
+
+// SLEEP PATTERN BUCKETS: CLASSIFY IO-WAIT VS IDLE WORKLOADS
+const SLEEP_BUCKETS: usize = 4;
+
+// MONITOR LOOP
+
+// 1-SECOND CONTROL LOOP. READS BPF HISTOGRAMS, COMPUTES P99,
+// DETECTS WORKLOAD REGIME, TIGHTENS/RELAXES KNOBS.
+// RUNS ON THE MAIN THREAD.
+pub fn monitor_loop(
+    sched: &mut Scheduler,
+    shutdown: &'static AtomicBool,
+    verbose: bool,
+    nr_cpus: u64,
+) -> Result<bool> {
+    let mut prev = PandemoniumStats::default();
+    let mut prev_hist = [[0u64; HIST_BUCKETS]; 3];
+    let mut prev_sleep = [0u64; SLEEP_BUCKETS];
+    let mut regime = Regime::Mixed;
+    let mut relax_counter: u32 = 0;
+    let mut tightened = false;
+    let mut pending_regime = regime;
+    let mut regime_hold: u32 = 0;
+    let mut light_ticks: u64 = 0;
+    let mut mixed_ticks: u64 = 0;
+    let mut heavy_ticks: u64 = 0;
+    let mut stability_score: u32 = 0;
+    let mut spike_count: u32 = 0;
+    let mut tick_counter: u64 = 0;
+    let mut tighten_events: u64 = 0;
+    let mut prev_tighten_events: u64 = 0;
+    let sojourn_floor_ns: u64 = (nr_cpus * 1_000_000).clamp(2_000_000, 6_000_000);
+    let sojourn_ceil_ns: u64 = sojourn_floor_ns * 2;
+    let mut sojourn_thresh_ns: u64 = sojourn_floor_ns;
+
+    let mut procdb = match ProcessDb::new() {
+        Ok(db) => Some(db),
+        Err(e) => {
+            log_warn!("PROCDB INIT FAILED: {}", e);
+            None
+        }
+    };
+
+    // APPLY INITIAL REGIME
+    sched.write_tuning_knobs(&scaled_regime_knobs(regime, nr_cpus))?;
+
+    while !shutdown.load(Ordering::Relaxed) && !sched.exited() {
+        let tick_start = std::time::Instant::now();
+        std::thread::sleep(Duration::from_secs(1));
+        let elapsed_ns = tick_start.elapsed().as_nanos() as u64;
+
+        let stats = sched.read_stats();
+
+        // COMPUTE DELTAS
+        let delta_d = stats.nr_dispatches.wrapping_sub(prev.nr_dispatches);
+        let delta_idle = stats.nr_idle_hits.wrapping_sub(prev.nr_idle_hits);
+        let delta_shared = stats.nr_shared.wrapping_sub(prev.nr_shared);
+        let delta_preempt = stats.nr_preempt.wrapping_sub(prev.nr_preempt);
+        let delta_keep = stats.nr_keep_running.wrapping_sub(prev.nr_keep_running);
+        let delta_wake_sum = stats.wake_lat_sum.wrapping_sub(prev.wake_lat_sum);
+        let delta_wake_samples = stats.wake_lat_samples.wrapping_sub(prev.wake_lat_samples);
+        let delta_hard = stats.nr_hard_kicks.wrapping_sub(prev.nr_hard_kicks);
+        let delta_soft = stats.nr_soft_kicks.wrapping_sub(prev.nr_soft_kicks);
+        let delta_enq_wake = stats.nr_enq_wakeup.wrapping_sub(prev.nr_enq_wakeup);
+        let delta_enq_requeue = stats.nr_enq_requeue.wrapping_sub(prev.nr_enq_requeue);
+        let delta_rescue = stats
+            .nr_overflow_rescue
+            .wrapping_sub(prev.nr_overflow_rescue);
+        let wake_avg_us = if delta_wake_samples > 0 {
+            delta_wake_sum / delta_wake_samples / 1000
+        } else {
+            0
+        };
+
+        // PER-PATH LATENCY
+        let d_idle_sum = stats.wake_lat_idle_sum.wrapping_sub(prev.wake_lat_idle_sum);
+        let d_idle_cnt = stats.wake_lat_idle_cnt.wrapping_sub(prev.wake_lat_idle_cnt);
+        let d_kick_sum = stats.wake_lat_kick_sum.wrapping_sub(prev.wake_lat_kick_sum);
+        let d_kick_cnt = stats.wake_lat_kick_cnt.wrapping_sub(prev.wake_lat_kick_cnt);
+        let lat_idle_us = if d_idle_cnt > 0 {
+            d_idle_sum / d_idle_cnt / 1000
+        } else {
+            0
+        };
+        let lat_kick_us = if d_kick_cnt > 0 {
+            d_kick_sum / d_kick_cnt / 1000
+        } else {
+            0
+        };
+        let delta_reenq = stats.nr_reenqueue.wrapping_sub(prev.nr_reenqueue);
+
+        // L2 CACHE AFFINITY DELTAS
+        let dl2_hb = stats.nr_l2_hit_batch.wrapping_sub(prev.nr_l2_hit_batch);
+        let dl2_mb = stats.nr_l2_miss_batch.wrapping_sub(prev.nr_l2_miss_batch);
+        let dl2_hi = stats
+            .nr_l2_hit_interactive
+            .wrapping_sub(prev.nr_l2_hit_interactive);
+        let dl2_mi = stats
+            .nr_l2_miss_interactive
+            .wrapping_sub(prev.nr_l2_miss_interactive);
+        let dl2_hl = stats
+            .nr_l2_hit_lat_crit
+            .wrapping_sub(prev.nr_l2_hit_lat_crit);
+        let dl2_ml = stats
+            .nr_l2_miss_lat_crit
+            .wrapping_sub(prev.nr_l2_miss_lat_crit);
+        let l2_pct_b = if dl2_hb + dl2_mb > 0 {
+            dl2_hb * 100 / (dl2_hb + dl2_mb)
+        } else {
+            0
+        };
+        let l2_pct_i = if dl2_hi + dl2_mi > 0 {
+            dl2_hi * 100 / (dl2_hi + dl2_mi)
+        } else {
+            0
+        };
+        let l2_pct_l = if dl2_hl + dl2_ml > 0 {
+            dl2_hl * 100 / (dl2_hl + dl2_ml)
+        } else {
+            0
+        };
+
+        let idle_pct = if delta_d > 0 {
+            delta_idle * 100 / delta_d
+        } else {
+            0
+        };
+
+        // READ HISTOGRAMS (CUMULATIVE, COMPUTE DELTAS)
+        let cur_hist = sched.read_wake_lat_hist();
+        let mut delta_hist = [[0u64; HIST_BUCKETS]; 3];
+        for tier in 0..3 {
+            for b in 0..HIST_BUCKETS {
+                delta_hist[tier][b] = cur_hist[tier][b].wrapping_sub(prev_hist[tier][b]);
+            }
+        }
+
+        // COMPUTE P99 PER TIER
+        let tp99_b_ns = tuning::compute_p99_from_histogram(&delta_hist[0]);
+        let tp99_i_ns = tuning::compute_p99_from_histogram(&delta_hist[1]);
+        let tp99_l_ns = tuning::compute_p99_from_histogram(&delta_hist[2]);
+
+        // AGGREGATE P99
+        let mut agg = [0u64; HIST_BUCKETS];
+        for t in 0..3 {
+            for b in 0..HIST_BUCKETS {
+                agg[b] += delta_hist[t][b];
+            }
+        }
+        let p99_ns = tuning::compute_p99_from_histogram(&agg);
+
+        // SLEEP HISTOGRAM
+        let cur_sleep = sched.read_sleep_hist();
+        let mut delta_sleep = [0u64; SLEEP_BUCKETS];
+        for i in 0..SLEEP_BUCKETS {
+            delta_sleep[i] = cur_sleep[i].wrapping_sub(prev_sleep[i]);
+        }
+        let sleep_total: u64 = delta_sleep.iter().sum();
+        let io_pct = if sleep_total > 0 {
+            (delta_sleep[0] + delta_sleep[1]) * 100 / sleep_total
+        } else {
+            0
+        };
+
+        // DETECT REGIME (SCHMITT TRIGGER + 2-TICK HOLD)
+        let detected = detect_regime(regime, idle_pct);
+
+        let mut regime_changed_this_tick = false;
+        if detected != regime {
+            if detected == pending_regime {
+                regime_hold += 1;
+            } else {
+                pending_regime = detected;
+                regime_hold = 1;
+            }
+            if regime_hold >= 2 {
+                regime = detected;
+                sched.write_tuning_knobs(&scaled_regime_knobs(regime, nr_cpus))?;
+                regime_changed_this_tick = true;
+                tightened = false;
+                relax_counter = 0;
+                spike_count = 0;
+            }
+        } else {
+            pending_regime = regime;
+            regime_hold = 0;
+        }
+
+        // TIGHTEN CHECK: P99 SPIKE DETECTION
+        // REQUIRE 2 CONSECUTIVE ABOVE-CEILING TICKS BEFORE TIGHTENING.
+        // ONLY TIGHTEN IN MIXED: LIGHT HAS NO CONTENTION (POINTLESS),
+        // HEAVY IS FULLY SATURATED (MORE PREEMPTION JUST ADDS OVERHEAD).
+        if !tightened && !regime_changed_this_tick {
+            let ceiling = regime.p99_ceiling();
+            if tuning::should_reflex_tighten(p99_ns, tp99_i_ns, ceiling) {
+                spike_count += 1;
+                if spike_count >= 2 && regime == Regime::Mixed {
+                    let current = sched.read_tuning_knobs();
+                    let new_slice = (current.slice_ns * 3 / 4).max(MIN_SLICE_NS);
+                    let knobs = TuningKnobs {
+                        slice_ns: new_slice,
+                        preempt_thresh_ns: new_slice,
+                        ..current
+                    };
+                    sched.write_tuning_knobs(&knobs)?;
+                    tightened = true;
+                    tighten_events += 1;
+                    spike_count = 0;
+                }
+            } else {
+                spike_count = 0;
+            }
+        }
+
+        // GRADUATED RELAX: STEP SLICE TOWARD BASELINE (BATCH UNTOUCHED)
+        if tightened && !regime_changed_this_tick {
+            let ceiling = regime.p99_ceiling();
+            let baseline = scaled_regime_knobs(regime, nr_cpus);
+            if p99_ns <= ceiling {
+                relax_counter += 1;
+                if relax_counter >= RELAX_HOLD_TICKS {
+                    let current = sched.read_tuning_knobs();
+                    if current.slice_ns < baseline.slice_ns {
+                        let new_slice = (current.slice_ns + RELAX_STEP_NS).min(baseline.slice_ns);
+                        let knobs = TuningKnobs {
+                            slice_ns: new_slice,
+                            preempt_thresh_ns: baseline.preempt_thresh_ns.min(new_slice),
+                            batch_slice_ns: current.batch_slice_ns,
+                            ..baseline
+                        };
+                        sched.write_tuning_knobs(&knobs)?;
+                        if new_slice >= baseline.slice_ns {
+                            tightened = false;
+                        }
+                    } else {
+                        tightened = false;
+                    }
+                    relax_counter = 0;
+                }
+            } else {
+                relax_counter = 0;
+            }
+        }
+
+        // SLEEP-INFORMED BATCH TUNING (EVERY TICK)
+        let baseline = scaled_regime_knobs(regime, nr_cpus);
+        let longrun_active = stats.longrun_mode_active > 0;
+
+        // LONGRUN OVERRIDE: DURING SUSTAINED BATCH PRESSURE (>2S),
+        // USE BASE BATCH SLICE (SKIP SLEEP ADJUSTMENT -- LONG-RUNNERS ARE
+        // CPU-BOUND, NOT IO-BOUND) AND WEAKEN AFFINITY TO SPREAD BATCH
+        // TASKS ACROSS MORE CPUS INSTEAD OF CONCENTRATING ON HOTSPOTS.
+        // BURST IS OWNED ENTIRELY BY BPF (CUSUM + WAKEUP RATE IN TICK).
+        let final_batch = if longrun_active {
+            baseline.batch_slice_ns
+        } else {
+            tuning::sleep_adjust_batch_ns(baseline.batch_slice_ns, io_pct)
+        };
+        let final_affinity = if longrun_active {
+            tuning::AFFINITY_WEAK
+        } else {
+            baseline.affinity_mode
+        };
+
+        // DISPATCH-RATE ADAPTIVE SOJOURN THRESHOLD
+        // MEASURE, DON'T ASSUME. DISPATCH RATE REFLECTS ACTUAL SYSTEM
+        // CAPACITY (PHYSICAL CORES, SMT, FREQUENCY, WORKLOAD INTENSITY).
+        // NORMALIZED TO ACTUAL ELAPSED TIME (SLEEP OVERSHOOTS UNDER LOAD).
+        const SOJOURN_MULTIPLIER: u64 = 4; // 4X DISPATCH INTERVAL
+
+        if delta_d > 0 && elapsed_ns > 0 {
+            let dispatch_rate = delta_d * 1_000_000_000 / elapsed_ns;
+            let interval_ns = if dispatch_rate > 0 {
+                1_000_000_000 / dispatch_rate
+            } else {
+                0
+            };
+            let target =
+                (interval_ns * SOJOURN_MULTIPLIER).clamp(sojourn_floor_ns, sojourn_ceil_ns);
+            // EWMA: 7/8 OLD + 1/8 NEW (SMOOTH, NO JITTER)
+            sojourn_thresh_ns = sojourn_thresh_ns - (sojourn_thresh_ns >> 3) + (target >> 3);
+        }
+
+        {
+            let current = sched.read_tuning_knobs();
+            if current.batch_slice_ns != final_batch
+                || current.sojourn_thresh_ns != sojourn_thresh_ns
+                || current.affinity_mode != final_affinity
+            {
+                sched.write_tuning_knobs(&TuningKnobs {
+                    batch_slice_ns: final_batch,
+                    sojourn_thresh_ns,
+                    affinity_mode: final_affinity,
+                    ..current
+                })?;
+            }
+        }
+
+        // STABILITY TRACKING
+        let tighten_delta = tighten_events.wrapping_sub(prev_tighten_events);
+        prev_tighten_events = tighten_events;
+        stability_score = tuning::compute_stability_score(
+            stability_score,
+            regime_changed_this_tick,
+            tighten_delta,
+            p99_ns,
+            regime.p99_ceiling(),
+        );
+
+        // PROCESS CLASSIFICATION DATABASE: INGEST, PREDICT, EVICT
+        let (db_total, db_confident) = if let Some(ref mut db) = procdb {
+            db.ingest();
+            db.flush_predictions();
+            db.tick();
+            db.summary()
+        } else {
+            (0, 0)
+        };
+
+        let p99_us = p99_ns / 1000;
+        let tp99_b = tp99_b_ns / 1000;
+        let tp99_i = tp99_i_ns / 1000;
+        let tp99_l = tp99_l_ns / 1000;
+        let knobs = sched.read_tuning_knobs();
+
+        let sojourn_ms = stats.batch_sojourn_ns / 1_000_000;
+        let sojourn_thresh_ms = sojourn_thresh_ns / 1_000_000;
+        let delta_burst = stats.burst_mode_active.wrapping_sub(prev.burst_mode_active);
+        let burst_label = if delta_burst > 0 { " BURST" } else { "" };
+        let longrun_label = if stats.longrun_mode_active > 0 {
+            " LONGRUN"
+        } else {
+            ""
+        };
+
+        if verbose && tuning::should_print_telemetry(tick_counter, stability_score) {
+            println!(
+                "d/s: {:<8} idle: {}% shared: {:<6} preempt: {:<4} keep: {:<4} kick: H={:<4} S={:<4} enq: W={:<4} R={:<4} wake: {}us p99: {}us [B:{} I:{} L:{}] lat_idle: {}us lat_kick: {}us procdb: {}/{} sleep: io={}% slice: {}us batch: {}us reenq: {} sjrn: {}ms/{}ms rescue: {} l2: B={}% I={}% L={}% [{}{}{}]",
+                delta_d, idle_pct, delta_shared, delta_preempt, delta_keep,
+                delta_hard, delta_soft, delta_enq_wake, delta_enq_requeue,
+                wake_avg_us, p99_us, tp99_b, tp99_i, tp99_l,
+                lat_idle_us, lat_kick_us,
+                db_total, db_confident,
+                io_pct, knobs.slice_ns / 1000, knobs.batch_slice_ns / 1000,
+                delta_reenq, sojourn_ms, sojourn_thresh_ms,
+                delta_rescue,
+                l2_pct_b, l2_pct_i, l2_pct_l, regime.label(), burst_label, longrun_label,
+            );
+        }
+
+        sched.log.snapshot(
+            delta_d,
+            delta_idle,
+            delta_shared,
+            delta_preempt,
+            delta_keep,
+            wake_avg_us,
+            delta_hard,
+            delta_soft,
+            lat_idle_us,
+            lat_kick_us,
+        );
+
+        match regime {
+            Regime::Light => light_ticks += 1,
+            Regime::Mixed => mixed_ticks += 1,
+            Regime::Heavy => heavy_ticks += 1,
+        }
+
+        tick_counter += 1;
+        prev_hist = cur_hist;
+        prev_sleep = cur_sleep;
+        prev = stats;
+    }
+
+    // PROCDB: SAVE LEARNED CLASSIFICATIONS TO DISK
+    if let Some(ref db) = procdb {
+        let path = ProcessDb::default_path();
+        match db.save(&path) {
+            Ok(()) => {
+                let (total, confident) = db.summary();
+                log_info!(
+                    "PROCDB: SAVED {}/{} PROFILES TO {}",
+                    confident,
+                    total,
+                    path.display()
+                );
+            }
+            Err(e) => log_warn!("PROCDB SAVE FAILED: {}", e),
+        }
+    }
+
+    // KNOBS SUMMARY: CAPTURED BY TEST HARNESS FOR ARCHIVE
+    let final_knobs = sched.read_tuning_knobs();
+    let final_stats = sched.read_stats();
+    let l2_total_b = final_stats.nr_l2_hit_batch + final_stats.nr_l2_miss_batch;
+    let l2_total_i = final_stats.nr_l2_hit_interactive + final_stats.nr_l2_miss_interactive;
+    let l2_total_l = final_stats.nr_l2_hit_lat_crit + final_stats.nr_l2_miss_lat_crit;
+    let l2_cum_b = if l2_total_b > 0 {
+        final_stats.nr_l2_hit_batch * 100 / l2_total_b
+    } else {
+        0
+    };
+    let l2_cum_i = if l2_total_i > 0 {
+        final_stats.nr_l2_hit_interactive * 100 / l2_total_i
+    } else {
+        0
+    };
+    let l2_cum_l = if l2_total_l > 0 {
+        final_stats.nr_l2_hit_lat_crit * 100 / l2_total_l
+    } else {
+        0
+    };
+    println!(
+        "[KNOBS] regime={} slice_ns={} batch_ns={} preempt_ns={} demotion_ns={} lag={} tightened={} tighten_events={} ticks=L:{}/M:{}/H:{} l2_hit=B:{}%/I:{}%/L:{}%",
+        regime.label(), final_knobs.slice_ns, final_knobs.batch_slice_ns,
+        final_knobs.preempt_thresh_ns, final_knobs.cpu_bound_thresh_ns,
+        final_knobs.lag_scale, tightened, tighten_events,
+        light_ticks, mixed_ticks, heavy_ticks,
+        l2_cum_b, l2_cum_i, l2_cum_l,
+    );
+
+    // READ UEI EXIT REASON
+    let should_restart = sched.read_exit_info();
+    Ok(should_restart)
+}

--- a/scheds/rust/scx_pandemonium/src/bpf/intf.h
+++ b/scheds/rust/scx_pandemonium/src/bpf/intf.h
@@ -1,0 +1,86 @@
+// PANDEMONIUM SHARED INTERFACE
+// CONSTANTS AND STRUCTURES SHARED BETWEEN BPF (C23) AND RUST
+
+#ifndef __INTF_H
+#define __INTF_H
+
+// BINDGEN/SCX COMPATIBILITY: provide kernel types unconditionally.
+// vmlinux.h also typedefs these in BPF context; C11+ permits
+// duplicate compatible typedefs, so no conflict.
+typedef unsigned long long u64;
+typedef unsigned char u8;
+
+// BPF VERIFIER LOOP BOUNDS
+#define MAX_CPUS  1024
+#define MAX_NODES 32
+
+// KERNEL PROCESS FLAGS (NOT IN vmlinux.h -- THESE ARE #define MACROS)
+#define PF_KTHREAD 0x00200000
+
+// TUNING KNOBS -- RUST ADAPTIVE LOOP WRITES THESE, BPF READS THEM
+// SINGLE-ELEMENT BPF_MAP_TYPE_ARRAY, UPDATED EVERY 50-1000MS
+struct tuning_knobs {
+	u64 slice_ns;           // BASE TIME SLICE (DEFAULT 1MS)
+	u64 preempt_thresh_ns;  // TICK PREEMPTION THRESHOLD (DEFAULT 1MS)
+	u64 lag_scale;          // DEADLINE LAG MULTIPLIER (DEFAULT 4)
+	u64 batch_slice_ns;     // BATCH TASK SLICE CEILING (DEFAULT 20MS)
+	u64 cpu_bound_thresh_ns; // CPU-BOUND DEMOTION THRESHOLD (REGIME-DEPENDENT)
+	u64 lat_cri_thresh_high; // CLASSIFIER: LAT_CRITICAL THRESHOLD (DEFAULT 32)
+	u64 lat_cri_thresh_low;  // CLASSIFIER: INTERACTIVE THRESHOLD (DEFAULT 8)
+	u64 affinity_mode;      // L2 PLACEMENT: 0=OFF, 1=WEAK, 2=STRONG
+	u64 sojourn_thresh_ns;  // BATCH DSQ RESCUE THRESHOLD (SET BY RUST)
+	u64 burst_slice_ns;     // SLICE CEILING DURING BURST/LONGRUN (SET BY RUST, DEFAULT 1MS)
+};
+
+// PER-CPU STATISTICS (BPF_MAP_TYPE_PERCPU_ARRAY VALUE)
+// RUST READS THESE FOR WORKLOAD REGIME DETECTION
+struct pandemonium_stats {
+	u64 nr_dispatches;      // TOTAL TASKS DISPATCHED (ALL PATHS)
+	u64 nr_idle_hits;       // SELECT_CPU FAST PATH -> SCX_DSQ_LOCAL
+	u64 nr_shared;          // ENQUEUE -> PER-NODE SHARED DSQ
+	u64 nr_preempt;         // TICK PREEMPTIONS (BATCH TASK YIELDED)
+	u64 wake_lat_sum;       // SUM WAKEUP->RUN LATENCY (NS)
+	u64 wake_lat_max;       // MAX WAKEUP->RUN LATENCY (NS)
+	u64 wake_lat_samples;   // COUNT OF WAKEUP LATENCY SAMPLES
+	u64 nr_keep_running;    // TASKS REPLENISHED VIA keep_running()
+	u64 nr_hard_kicks;      // ENQUEUE: SCX_KICK_PREEMPT (FRESH WAKEUP)
+	u64 nr_soft_kicks;      // ENQUEUE: SOFT NUDGE (RE-ENQUEUE)
+	u64 nr_enq_wakeup;      // ENQUEUE: TASK JUST WOKE UP (AWAKE_VTIME==0)
+	u64 nr_enq_requeue;     // ENQUEUE: TASK RE-ENQUEUED (AWAKE_VTIME>0)
+	u64 wake_lat_idle_sum;  // LATENCY SUM: IDLE FAST PATH (NS)
+	u64 wake_lat_idle_cnt;  // LATENCY COUNT: IDLE FAST PATH
+	u64 wake_lat_kick_sum;  // LATENCY SUM: HARD-KICKED ENQUEUE (NS)
+	u64 wake_lat_kick_cnt;  // LATENCY COUNT: HARD-KICKED ENQUEUE
+	u64 nr_procdb_hits;     // ENABLE: PRE-LEARNED CLASSIFICATION APPLIED
+	// L2 CACHE AFFINITY INSTRUMENTATION (PHASE 2: MEASURE)
+	// COUNTED IN select_cpu() IDLE PATH AND enqueue() TIER 1
+	u64 nr_l2_hit_batch;
+	u64 nr_l2_miss_batch;
+	u64 nr_l2_hit_interactive;
+	u64 nr_l2_miss_interactive;
+	u64 nr_l2_hit_lat_crit;
+	u64 nr_l2_miss_lat_crit;
+	// CPU RELEASE: TASKS RESCUED FROM LOCAL DSQ BY scx_bpf_reenqueue_local()
+	u64 nr_reenqueue;
+	// CODEL SOJOURN: CURRENT BATCH WAIT AGE (NS), WRITTEN BY tick()
+	u64 batch_sojourn_ns;
+	// CUSUM: 1 IF BURST MODE ACTIVE, 0 OTHERWISE, WRITTEN BY tick()
+	u64 burst_mode_active;
+	// LONGRUN: 1 IF SUSTAINED BATCH PRESSURE DETECTED, 0 OTHERWISE, WRITTEN BY tick()
+	u64 longrun_mode_active;
+	// OVERFLOW SOJOURN RESCUE: TASKS DISPATCHED BY STEP 0 OVERFLOW AMPLIFICATION
+	u64 nr_overflow_rescue;
+};
+
+// PROCESS CLASSIFICATION: BPF OBSERVES, RUST LEARNS, BPF APPLIES
+// SHARED BETWEEN BPF MAPS (task_class_observe, task_class_init) AND RUST (procdb.rs)
+struct task_class_entry {
+	u8  tier;
+	u8  _pad[7];
+	u64 avg_runtime;
+	u64 runtime_dev;    // EWMA |RUNTIME - AVG_RUNTIME|
+	u64 wakeup_freq;    // WAKEUP FREQUENCY (EWMA)
+	u64 csw_rate;       // CONTEXT SWITCH RATE (EWMA)
+};
+
+#endif // __INTF_H

--- a/scheds/rust/scx_pandemonium/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_pandemonium/src/bpf/main.bpf.c
@@ -1,0 +1,1579 @@
+// PANDEMONIUM -- SCHED_EXT KERNEL SCHEDULER
+// ADAPTIVE DESKTOP SCHEDULING FOR LINUX
+//
+// BPF: BEHAVIORAL CLASSIFICATION + MULTI-TIER DISPATCH
+// RUST: ADAPTIVE CONTROL LOOP + REAL-TIME TELEMETRY
+//
+// ARCHITECTURE:
+//   SELECT_CPU IDLE FAST PATH -> PER-CPU DSQ (DEPTH-GATED, VISIBLE, STEALABLE)
+//   ENQUEUE IDLE FOUND -> NODE DSQ (SHARED, ANY CPU DRAINS)
+//   ENQUEUE INTERACTIVE PREEMPT -> NODE DSQ (SHARED, KICKED CPU DRAINS)
+//   ENQUEUE FALLBACK -> PER-NODE OVERFLOW DSQ (VTIME-ORDERED)
+//   DISPATCH -> OWN PER-CPU, L2 WORK STEAL, NODE OVERFLOW, CROSS-NODE, KEEP
+//   TICK -> PER-CPU SOJOURN (LOCAL + ROTATING SCAN) + BATCH PREEMPTION
+//
+// BEHAVIORAL CLASSIFICATION (FROM v0.9.4):
+//   LAT_CRI SCORE = (WAKEUP_FREQ * CSW_RATE) / AVG_RUNTIME
+//   THREE TIERS: LAT_CRITICAL, INTERACTIVE, BATCH
+//   PER-TIER SLICING: 1.5X AVG_RUNTIME, 2X AVG_RUNTIME, KNOB BASE
+//   COMPOSITOR AUTO-BOOST TO LAT_CRITICAL
+
+#include <scx/common.bpf.h>
+#include <scx/compat.bpf.h>
+#include "intf.h"
+
+char _license[] SEC("license") = "GPL";
+
+// CONFIGURATION (SET BY RUST VIA RODATA BEFORE LOAD)
+
+const volatile u64 nr_cpu_ids = 1;
+
+// BEHAVIORAL CONSTANTS
+
+// TEST: CUMULATIVE BURST COUNTER FOR RUST TELEMETRY VISIBILITY.
+// INCREMENTS PER-CPU STAT EACH TICK BURST IS DETECTED INSTEAD OF
+// SNAPSHOT (WHICH THE 1HZ RUST POLL ALWAYS MISSES). DISABLE FOR
+// PRODUCTION -- THE PER-TICK INCREMENT IS UNNECESSARY OVERHEAD
+// ONCE TELEMETRY VALIDATION IS COMPLETE.
+#define BURST_COUNTER_TEST 1
+#define TRACE_SCHED 1
+
+#define TIER_BATCH        0
+#define TIER_INTERACTIVE  1
+#define TIER_LAT_CRITICAL 2
+
+#define LAT_CRI_THRESH_HIGH  32
+#define LAT_CRI_THRESH_LOW   8
+#define LAT_CRI_CAP          255
+
+#define WEIGHT_LAT_CRITICAL  256   // 2X
+#define WEIGHT_INTERACTIVE   192   // 1.5X
+#define WEIGHT_BATCH         128   // 1X
+
+#define EWMA_AGE_MATURE      8
+#define EWMA_AGE_CAP         16
+#define MAX_WAKEUP_FREQ      64
+#define MAX_CSW_RATE         512
+#define LAG_CAP_NS           (40ULL * 1000000ULL)
+
+#define SLICE_MIN_NS 100000     // 100US FLOOR
+#define STARVATION_RESCUE_NS (500ULL * 1000000ULL) // 500MS HARD LIMIT
+// OVERFLOW SOJOURN RESCUE: COMPUTED IN init() FROM nr_cpu_ids
+// 2C: 4MS, 4C: 8MS, 5C+: 10MS. SEE pandemonium_init().
+
+
+// GLOBALS
+
+static u32 nr_nodes;
+static u64 vtime_now;
+
+// TICK-BASED INTERACTIVE PREEMPTION SIGNAL
+// SET BY enqueue() WHEN NON-BATCH TASK HITS OVERFLOW DSQ.
+// CLEARED BY tick() AFTER PREEMPTING A BATCH TASK.
+static bool interactive_waiting;
+
+// SOJOURN TRACKERS: RECORD WHEN OVERFLOW DSQs TRANSITION FROM EMPTY.
+// DISPATCH STEP 0 CHECKS THESE TO RESCUE OVERFLOW TASKS AGING PAST
+// overflow_sojourn_rescue_ns. WITHOUT THIS, PER-CPU DSQ DOMINANCE
+// UNDER SUSTAINED LOAD MAKES ALL DOWNSTREAM ANTI-STARVATION LOGIC
+// (DEFICIT, SOJOURN, STARVATION_RESCUE) UNREACHABLE.
+static u64 batch_enqueue_ns;
+static u64 interactive_enqueue_ns;
+
+// PER-CPU DSQ SOJOURN: TRACKS WHEN EACH PER-CPU DSQ TRANSITIONS
+// FROM EMPTY. DISPATCH AND TICK CHECK THESE TO DETECT STALE TASKS.
+// WORK STEALING + DEPTH GATE HANDLE MOST CASES; THIS IS THE SAFETY NET.
+static u64 pcpu_enqueue_ns[MAX_CPUS];
+
+// DEFICIT COUNTER: ANTI-STARVATION INTERLEAVE (DRR)
+// COUNTS DISPATCHES SINCE LAST BATCH SERVICE. WHEN interactive_run
+// EXCEEDS interactive_budget AND BATCH IS STARVING, FORCE ONE BATCH
+// DISPATCH. PROPORTIONAL: BUDGET = nr_cpu_ids * ratio (RATIO SCALES 2-4).
+static u64 interactive_run;
+static u64 interactive_budget;
+static u64 starvation_rescue_ns;
+static u64 overflow_sojourn_rescue_ns;
+static u32 pcpu_depth_base;
+
+// CUSUM BURST DETECTION (TOTAL-ENQUEUE)
+// MONITORS ENQUEUE RATE TO DETECT FORK/EXEC STORMS.
+// SAMPLES EVERY 64TH ENQUEUE: TRACKS TIME INTERVAL (SHORTER = BURST).
+// EFFECTIVE FOR BPF-ONLY (1MS SLICES). RATE-BOUNDED UNDER ADAPTIVE (4MS).
+static u64 cusum_enq_count;
+static u64 cusum_last_check_ns;
+static u64 cusum_interval_ewma;
+static u64 cusum_s;
+static u64 cusum_lock;
+static bool burst_mode;
+
+// WAKEUP RATE COUNTER: ABSOLUTE BURST DETECTION FOR ADAPTIVE MODE.
+// TOTAL-ENQUEUE CUSUM IS RATE-BOUNDED BY NCPU/SLICE_NS -- WITH 4MS HEAVY
+// SLICES, FORK STORMS DON'T CHANGE THE RATE ENOUGH TO TRIGGER.
+// ABSOLUTE RATE COUNTER: COUNT WAKEUPS SINCE LAST tick(). IF COUNT EXCEEDS
+// THRESHOLD (nr_cpu_ids * 2), THAT'S A FORK STORM. NO CALIBRATION NEEDED.
+static u64 wake_rate_count;
+
+// LONGRUN DETECTION
+// TRACKS SUSTAINED BATCH DSQ PRESSURE. WHEN BATCH DSQ IS NON-EMPTY
+// FOR > LONGRUN_THRESH_NS, TIGHTEN DEFICIT RATIO TO INCREASE BATCH SHARE.
+// CLEARS WHEN BATCH DSQ EMPTIES.
+#define LONGRUN_THRESH_NS (2000ULL * 1000000ULL)
+static bool longrun_mode;
+
+// USER EXIT
+
+UEI_DEFINE(uei);
+
+// MAPS
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct tuning_knobs);
+} tuning_knobs_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct pandemonium_stats);
+} stats_map SEC(".maps");
+
+// CACHE DOMAIN MAP: l2_domain[cpu] = group_id
+// POPULATED BY RUST AT STARTUP FROM SYSFS TOPOLOGY
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_CPUS);
+	__type(key, u32);
+	__type(value, u32);
+} cache_domain SEC(".maps");
+
+// PROCESS CLASSIFICATION DATABASE: BPF OBSERVES, RUST LEARNS, BPF APPLIES
+// OBSERVE: BPF WRITES MATURE TASK CLASSIFICATION, RUST DRAINS EVERY SECOND
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 512);
+	__type(key, char[16]);
+	__type(value, struct task_class_entry);
+} task_class_observe SEC(".maps");
+
+// INIT: RUST WRITES PREDICTIONS, BPF READS IN enable() FOR NEW TASKS
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 512);
+	__type(key, char[16]);
+	__type(value, struct task_class_entry);
+} task_class_init SEC(".maps");
+
+// COMPOSITOR MAP: RUST POPULATES AT STARTUP, BPF LOOKS UP IN runnable()
+// KEY: COMM NAME (16 BYTES), VALUE: UNUSED (EXISTENCE = COMPOSITOR)
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 32);
+	__type(key, char[16]);
+	__type(value, u8);
+} compositor_map SEC(".maps");
+
+// L2 SIBLINGS MAP: FLAT ARRAY FOR L2-AWARE CPU PLACEMENT
+// l2_siblings[group_id * MAX_L2_SIBLINGS + slot] = cpu_id
+// SENTINEL: (u32)-1 MARKS END OF GROUP
+// POPULATED BY RUST AT STARTUP FROM CpuTopology
+#define MAX_L2_SIBLINGS 8
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 512);
+	__type(key, u32);
+	__type(value, u32);
+} l2_siblings SEC(".maps");
+
+// WAKEUP LATENCY HISTOGRAM: 3 TIERS x 12 BUCKETS = 36 ENTRIES PER CPU
+// BPF INCREMENTS IN running(); RUST READS ONCE PER SECOND IN MONITOR LOOP
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 36);
+	__type(key, u32);
+	__type(value, u64);
+} wake_lat_hist SEC(".maps");
+
+// SLEEP DURATION HISTOGRAM: 4 BUCKETS PER CPU
+// BPF INCREMENTS IN running(); RUST READS ONCE PER SECOND
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 4);
+	__type(key, u32);
+	__type(value, u64);
+} sleep_hist SEC(".maps");
+
+// PER-TASK CONTEXT
+
+struct task_ctx {
+	u64 awake_vtime;
+	u64 last_run_at;
+	u64 wakeup_freq;
+	u64 last_woke_at;
+	u64 avg_runtime;
+	u64 runtime_dev;     // EWMA OF |RUNTIME - AVG_RUNTIME| (VARIANCE SIGNAL)
+	u64 cached_weight;
+	u64 prev_nvcsw;
+	u64 csw_rate;
+	u64 lat_cri;
+	u64 sleep_start_ns;  // SET IN quiescent(), USED IN running()
+	u32 tier;
+	u32 ewma_age;
+	s32 last_cpu;        // LAST CPU THIS TASK RAN ON (FOR CACHE AFFINITY)
+	u8  dispatch_path;   // 0=IDLE, 1=HARD_KICK, 2=SOFT_KICK
+	u8  _pad[3];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_TASK_STORAGE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__type(key, int);
+	__type(value, struct task_ctx);
+} task_ctx_stor SEC(".maps");
+
+// HELPERS
+
+static __always_inline struct pandemonium_stats *get_stats(void)
+{
+	u32 zero = 0;
+	return bpf_map_lookup_elem(&stats_map, &zero);
+}
+
+static __always_inline struct tuning_knobs *get_knobs(void)
+{
+	u32 zero = 0;
+	return bpf_map_lookup_elem(&tuning_knobs_map, &zero);
+}
+
+static __always_inline struct task_ctx *lookup_task_ctx(const struct task_struct *p)
+{
+	return bpf_task_storage_get(&task_ctx_stor,
+				    (struct task_struct *)p, 0, 0);
+}
+
+static __always_inline struct task_ctx *ensure_task_ctx(struct task_struct *p)
+{
+	struct task_ctx zero = {};
+	return bpf_task_storage_get(&task_ctx_stor, p, &zero,
+				    BPF_LOCAL_STORAGE_GET_F_CREATE);
+}
+
+// L2 CACHE AFFINITY INSTRUMENTATION
+// COMPARE SELECTED CPU'S L2 DOMAIN WITH TASK'S LAST_CPU DOMAIN.
+// INCREMENT PER-TIER HIT/MISS COUNTERS. CALLED FROM select_cpu() AND enqueue().
+
+static __always_inline void count_l2_affinity(struct pandemonium_stats *s,
+					       const struct task_ctx *tctx,
+					       s32 cpu)
+{
+	u32 lcpu = (u32)tctx->last_cpu;
+	u32 ncpu = (u32)cpu;
+	u32 *ld = bpf_map_lookup_elem(&cache_domain, &lcpu);
+	u32 *nd = bpf_map_lookup_elem(&cache_domain, &ncpu);
+	bool hit = ld && nd && *ld == *nd;
+
+	if (tctx->tier == TIER_BATCH) {
+		if (hit) s->nr_l2_hit_batch += 1;
+		else     s->nr_l2_miss_batch += 1;
+	} else if (tctx->tier == TIER_INTERACTIVE) {
+		if (hit) s->nr_l2_hit_interactive += 1;
+		else     s->nr_l2_miss_interactive += 1;
+	} else {
+		if (hit) s->nr_l2_hit_lat_crit += 1;
+		else     s->nr_l2_miss_lat_crit += 1;
+	}
+}
+
+// L2 CACHE PLACEMENT: FIND IDLE SIBLING IN SAME L2 DOMAIN
+// BOUNDED LOOP (MAX 8 ITERATIONS), VERIFIER-SAFE.
+// RETURNS IDLE CPU IN SAME L2 GROUP, OR -1 IF NONE FOUND.
+
+static __always_inline s32 find_idle_l2_sibling(const struct task_ctx *tctx)
+{
+	if (tctx->last_cpu < 0)
+		return -1;
+
+	u32 lcpu = (u32)tctx->last_cpu;
+	u32 *group = bpf_map_lookup_elem(&cache_domain, &lcpu);
+	if (!group)
+		return -1;
+
+	u32 base = *group * MAX_L2_SIBLINGS;
+	for (int i = 0; i < MAX_L2_SIBLINGS; i++) {
+		u32 key = base + i;
+		u32 *val = bpf_map_lookup_elem(&l2_siblings, &key);
+		if (!val || *val == (u32)-1)
+			break;
+		s32 cpu = (s32)*val;
+		if (scx_bpf_test_and_clear_cpu_idle(cpu))
+			return cpu;
+	}
+	return -1;
+}
+
+// HISTOGRAM BUCKETING: MATCHES HIST_EDGES_NS AND SLEEP_EDGES_NS IN RUST
+
+static __always_inline u32 lat_bucket(u64 lat_ns)
+{
+	if (lat_ns <= 10000) return 0;
+	if (lat_ns <= 25000) return 1;
+	if (lat_ns <= 50000) return 2;
+	if (lat_ns <= 100000) return 3;
+	if (lat_ns <= 250000) return 4;
+	if (lat_ns <= 500000) return 5;
+	if (lat_ns <= 1000000) return 6;
+	if (lat_ns <= 2000000) return 7;
+	if (lat_ns <= 5000000) return 8;
+	if (lat_ns <= 10000000) return 9;
+	if (lat_ns <= 20000000) return 10;
+	return 11;
+}
+
+static __always_inline u32 sleep_bucket(u64 sleep_ns)
+{
+	if (sleep_ns <= 1000000) return 0;
+	if (sleep_ns <= 10000000) return 1;
+	if (sleep_ns <= 100000000) return 2;
+	return 3;
+}
+
+// EWMA
+
+static __always_inline u64 calc_avg(u64 old_val, u64 new_val, u32 age)
+{
+	if (age < EWMA_AGE_MATURE)
+		return (old_val >> 1) + (new_val >> 1);
+	return old_val - (old_val >> 3) + (new_val >> 3);
+}
+
+static __always_inline u64 update_freq(u64 freq, u64 interval_ns, u32 age)
+{
+	if (interval_ns == 0)
+		interval_ns = 1;
+	u64 new_freq = (100ULL * 1000000ULL) / interval_ns;
+	return calc_avg(freq, new_freq, age);
+}
+
+// BEHAVIORAL CLASSIFICATION
+
+// LAT_CRI SCORE: HIGH WAKEUP FREQ + HIGH CSW RATE + SHORT RUNTIME = CRITICAL
+static __always_inline u64 compute_lat_cri(u64 wakeup_freq, u64 csw_rate,
+					    u64 avg_runtime_ns,
+					    u64 runtime_dev_ns)
+{
+	u64 effective_runtime_ns = avg_runtime_ns + (runtime_dev_ns >> 1);
+	u64 avg_runtime_ms = effective_runtime_ns >> 20;
+	if (avg_runtime_ms == 0)
+		avg_runtime_ms = 1;
+	u64 score = (wakeup_freq * csw_rate) / avg_runtime_ms;
+	if (score > LAT_CRI_CAP)
+		score = LAT_CRI_CAP;
+	return score;
+}
+
+static __always_inline u32 classify_tier(u64 lat_cri,
+					  const struct tuning_knobs *knobs)
+{
+	u64 thresh_high = knobs ? knobs->lat_cri_thresh_high : LAT_CRI_THRESH_HIGH;
+	u64 thresh_low  = knobs ? knobs->lat_cri_thresh_low  : LAT_CRI_THRESH_LOW;
+	if (lat_cri >= thresh_high)
+		return TIER_LAT_CRITICAL;
+	if (lat_cri >= thresh_low)
+		return TIER_INTERACTIVE;
+	return TIER_BATCH;
+}
+
+// COMPOSITOR DETECTION: MAP LOOKUP (POPULATED BY RUST AT STARTUP)
+// STACK-LOCAL KEY COPY: BPF VERIFIER REJECTS DIRECT p->comm POINTER
+static __always_inline bool is_compositor(const struct task_struct *p)
+{
+	char key[16] = {};
+	unsigned int i;
+	for (i = 0; i < 15 && p->comm[i]; i++)
+		key[i] = p->comm[i];
+	return bpf_map_lookup_elem(&compositor_map, key) != NULL;
+}
+
+// TRACE: FAST 4-BYTE COMM CHECK FOR SCHEDULER PROCESS TRACING
+// CATCHES "pandemonium" WITH ZERO MAP OVERHEAD. DISABLE VIA TRACE_SCHED=0.
+static __always_inline bool is_sched_task(const struct task_struct *p)
+{
+	return p->comm[0] == 'p' && p->comm[1] == 'a' &&
+	       p->comm[2] == 'n' && p->comm[3] == 'd';
+}
+
+// EFFECTIVE WEIGHT: TIER-BASED MULTIPLIER ON NICE WEIGHT
+static __always_inline u64 effective_weight(const struct task_struct *p,
+					     const struct task_ctx *tctx)
+{
+	u64 weight = p->scx.weight;
+	u64 behavioral;
+
+	if (tctx->tier == TIER_LAT_CRITICAL)
+		behavioral = WEIGHT_LAT_CRITICAL;
+	else if (tctx->tier == TIER_INTERACTIVE)
+		behavioral = WEIGHT_INTERACTIVE;
+	else
+		behavioral = WEIGHT_BATCH;
+
+	return weight * behavioral >> 7;
+}
+
+// SCHEDULING HELPERS
+
+// DEADLINE = DSQ_VTIME + AWAKE_VTIME
+// PER-TASK LAG SCALING: INTERACTIVE TASKS GET MORE VTIME CREDIT
+// QUEUE-PRESSURE SCALING: CREDIT SHRINKS WHEN DSQ IS DEEP
+// TIER-BASED AWAKE CAP: PREVENTS BOOST EXPLOITATION
+static __always_inline u64 task_deadline(struct task_struct *p,
+					 struct task_ctx *tctx,
+					 u64 dsq_id,
+					 const struct tuning_knobs *knobs)
+{
+	u64 knob_scale = knobs ? knobs->lag_scale : 4;
+	u64 lag_scale = (tctx->wakeup_freq * knob_scale) >> 2;
+	if (lag_scale < 1)
+		lag_scale = 1;
+	if (lag_scale > MAX_WAKEUP_FREQ)
+		lag_scale = MAX_WAKEUP_FREQ;
+
+	// QUEUE-PRESSURE SCALING
+	u64 nr_queued = scx_bpf_dsq_nr_queued(dsq_id);
+	if (nr_queued > 8)
+		lag_scale = 1;
+	else if (nr_queued > 4 && lag_scale > 2)
+		lag_scale >>= 1;
+
+	// CLAMP VTIME TO PREVENT UNBOUNDED BOOST AFTER LONG SLEEP
+	u64 vtime_floor = vtime_now - LAG_CAP_NS * lag_scale;
+	if (time_before(p->scx.dsq_vtime, vtime_floor))
+		p->scx.dsq_vtime = vtime_floor;
+
+	// TIER-BASED AWAKE CAP
+	u64 awake_cap;
+	if (tctx->tier == TIER_LAT_CRITICAL)
+		awake_cap = 20ULL * 1000000ULL;
+	else if (tctx->tier == TIER_INTERACTIVE)
+		awake_cap = 30ULL * 1000000ULL;
+	else
+		awake_cap = LAG_CAP_NS;
+
+	if (tctx->awake_vtime > awake_cap)
+		tctx->awake_vtime = awake_cap;
+
+	return p->scx.dsq_vtime + tctx->awake_vtime;
+}
+
+// PER-TIER DYNAMIC SLICING
+// LAT_CRITICAL: 1.5X AVG_RUNTIME (TIGHT -- FAST PREEMPTION)
+// INTERACTIVE:  2X AVG_RUNTIME (RESPONSIVE)
+// BATCH:        KNOB BASE SLICE (CONTROLLED BY ADAPTIVE LAYER)
+static __always_inline u64 task_slice(const struct task_ctx *tctx,
+				      const struct tuning_knobs *knobs)
+{
+	u64 base_slice = knobs ? ((burst_mode || longrun_mode)
+		? knobs->burst_slice_ns : knobs->slice_ns) : 1000000;
+	u64 base;
+
+	if (tctx->tier == TIER_LAT_CRITICAL) {
+		base = tctx->avg_runtime + (tctx->avg_runtime >> 1);
+		if (base > base_slice)
+			base = base_slice;
+		if (base < SLICE_MIN_NS)
+			base = SLICE_MIN_NS;
+		return base;
+	}
+
+	if (tctx->tier == TIER_INTERACTIVE) {
+		base = tctx->avg_runtime << 1;
+		if (base > base_slice)
+			base = base_slice;
+		if (base < SLICE_MIN_NS)
+			base = SLICE_MIN_NS;
+		return base;
+	}
+
+	// BATCH: DEDICATED CEILING FROM RUST ADAPTIVE LAYER.
+	// WEIGHT-SCALED: HIGHER BEHAVIORAL WEIGHT = LONGER SLICE.
+	u64 batch_ceil = knobs ? knobs->batch_slice_ns : 20000000;
+	if (batch_ceil < SLICE_MIN_NS)
+		batch_ceil = SLICE_MIN_NS;
+
+	base = batch_ceil * tctx->cached_weight >> 7;
+	if (base > batch_ceil)
+		base = batch_ceil;
+	if (base < SLICE_MIN_NS)
+		base = SLICE_MIN_NS;
+
+	return base;
+}
+
+// SCHEDULING CALLBACKS
+
+// SELECT_CPU: FAST-PATH IDLE CPU DISPATCH TO PER-CPU DSQ
+// DISPATCHES TO NAMED PER-CPU DSQ (u64)cpu -- VISIBLE TO WORK STEALING
+// AND SOJOURN RESCUE. DEPTH-GATED: IF PER-CPU DSQ ALREADY HAS TASKS,
+// SPILL TO SHARED NODE DSQ SO ANY CPU CAN GRAB IT.
+// THE CPU IS IDLE SO IT ENTERS dispatch() IMMEDIATELY AND DRAINS.
+s32 BPF_STRUCT_OPS(pandemonium_select_cpu, struct task_struct *p,
+		   s32 prev_cpu, u64 wake_flags)
+{
+	bool is_idle = false;
+	s32 cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
+
+	if (is_idle) {
+		struct task_ctx *tctx = lookup_task_ctx(p);
+		struct tuning_knobs *knobs = get_knobs();
+		u64 sl = tctx ? task_slice(tctx, knobs) : 1000000;
+
+		u32 depth_thresh = burst_mode ? 1 : pcpu_depth_base;
+		if ((u64)cpu < nr_cpu_ids &&
+		    scx_bpf_dsq_nr_queued((u64)cpu) < depth_thresh) {
+			// PER-CPU DSQ: CACHE-HOT, VISIBLE, STEALABLE
+			u64 dl = tctx ? task_deadline(p, tctx, (u64)cpu, knobs)
+				      : vtime_now;
+			scx_bpf_dsq_insert_vtime(p, (u64)cpu, sl, dl, 0);
+			if ((u32)cpu < MAX_CPUS)
+				__sync_val_compare_and_swap(
+					&pcpu_enqueue_ns[cpu], 0,
+					bpf_ktime_get_ns());
+		} else {
+			// DEPTH EXCEEDED: SPILL TO SHARED NODE DSQ
+			s32 node = __COMPAT_scx_bpf_cpu_node(cpu);
+			if (node < 0 || (u32)node >= nr_nodes) node = 0;
+			u64 node_dsq = nr_cpu_ids + (u64)node;
+			u64 dl = tctx ? task_deadline(p, tctx, node_dsq, knobs)
+				      : vtime_now;
+			scx_bpf_dsq_insert_vtime(p, node_dsq, sl, dl, 0);
+			__sync_val_compare_and_swap(
+				&interactive_enqueue_ns, 0,
+				bpf_ktime_get_ns());
+		}
+
+		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+		__sync_fetch_and_add(&interactive_run, 1);
+
+		if (tctx)
+			tctx->dispatch_path = 0;
+
+		struct pandemonium_stats *s = get_stats();
+		if (s) {
+			s->nr_idle_hits += 1;
+			s->nr_dispatches += 1;
+			if (tctx)
+				count_l2_affinity(s, tctx, cpu);
+		}
+
+#if TRACE_SCHED
+		if (is_sched_task(p))
+			bpf_printk("PAND: select_cpu pid=%d cpu=%d", p->pid, cpu);
+#endif
+	}
+
+	return cpu;
+}
+
+// ENQUEUE: THREE-TIER PLACEMENT WITH BEHAVIORAL PREEMPTION
+// TIER 1: IDLE CPU ON NODE -> PER-CPU DSQ (DEPTH-GATED) + KICK
+// TIER 2: INTERACTIVE/LAT_CRITICAL -> PER-CPU DSQ (DEPTH-GATED) + HARD PREEMPT
+// TIER 3: FALLBACK -> PER-NODE OVERFLOW DSQ + SELECTIVE KICK
+void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
+		    u64 enq_flags)
+{
+	s32 node = __COMPAT_scx_bpf_cpu_node(scx_bpf_task_cpu(p));
+	if (node < 0 || (u32)node >= nr_nodes) node = 0;
+	u64 node_dsq = nr_cpu_ids + (u64)node;
+
+	struct task_ctx *tctx = lookup_task_ctx(p);
+	struct tuning_knobs *knobs = get_knobs();
+	u64 sl = tctx ? task_slice(tctx, knobs) : 1000000;
+	u64 dl;
+
+	// CLASSIFY: WAKEUP VS RE-ENQUEUE
+	bool is_wakeup = tctx && tctx->awake_vtime == 0;
+
+	// TIER 1: IDLE CPU -> NODE DSQ + KICK
+	// L2 PLACEMENT: TRY IDLE SIBLING IN SAME L2 DOMAIN FIRST.
+	// LAT_CRITICAL AND KERNEL THREADS SKIP AFFINITY -- FASTEST CPU WINS.
+	// TASK GOES TO SHARED NODE DSQ SO ANY CPU ON THE NODE CAN DRAIN IT.
+	s32 cpu = -1;
+	if (knobs && knobs->affinity_mode > 0 && tctx &&
+	    tctx->tier != TIER_LAT_CRITICAL &&
+	    !(p->flags & PF_KTHREAD)) {
+		cpu = find_idle_l2_sibling(tctx);
+	}
+	if (cpu < 0)
+		cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(p->cpus_ptr, node, 0);
+	if (cpu >= 0 && (u64)cpu < nr_cpu_ids) {
+		dl = tctx ? task_deadline(p, tctx, node_dsq, knobs)
+			  : vtime_now;
+		scx_bpf_dsq_insert_vtime(p, node_dsq, sl, dl, enq_flags);
+
+		u64 kick_flag = (tctx && tctx->tier != TIER_BATCH)
+			      ? SCX_KICK_PREEMPT : SCX_KICK_IDLE;
+		scx_bpf_kick_cpu(cpu, kick_flag);
+
+		if (tctx)
+			tctx->dispatch_path = 0;
+
+		struct pandemonium_stats *s = get_stats();
+		if (s) {
+			s->nr_shared += 1;
+			s->nr_dispatches += 1;
+			if (is_wakeup)
+				s->nr_enq_wakeup += 1;
+			else
+				s->nr_enq_requeue += 1;
+			if (tctx)
+				count_l2_affinity(s, tctx, cpu);
+		}
+#if TRACE_SCHED
+		if (is_sched_task(p))
+			bpf_printk("PAND: enq tier1 pid=%d cpu=%d", p->pid, cpu);
+#endif
+		return;
+	}
+
+	// TIER 2: WAKEUP PREEMPTION -- NODE DSQ + SELECTIVE KICK
+	// ALL WAKEUPS GET NODE DSQ DISPATCH: A TASK WAKING FROM SLEEP
+	// HAS EXTERNAL INPUT TO DELIVER (TIMER, IO, USER) REGARDLESS OF
+	// BEHAVIORAL TIER. THE CLASSIFIER OPERATES ON HISTORICAL BEHAVIOR;
+	// THE WAKEUP IS THE REAL-TIME LATENCY SIGNAL.
+	// LAT_CRITICAL ALSO GETS PREEMPTION ON REQUEUE (COMPOSITOR GUARANTEE).
+	// ONLINE GUARD: pick_any_cpu_node() CAN RETURN OFFLINE CPUs DURING
+	// HOTPLUG. OFFLINE CPUs HAVE NO CURRENT TASK (cpu_curr == NULL).
+	if (tctx &&
+	    (tctx->tier == TIER_LAT_CRITICAL || is_wakeup)) {
+		cpu = __COMPAT_scx_bpf_pick_any_cpu_node(
+			p->cpus_ptr, node, 0);
+		if (cpu >= 0 && (u64)cpu < nr_cpu_ids &&
+		    __COMPAT_scx_bpf_cpu_curr(cpu)) {
+			dl = task_deadline(p, tctx, node_dsq, knobs);
+			scx_bpf_dsq_insert_vtime(p, node_dsq, sl, dl,
+						  enq_flags);
+
+			u64 kick_flag = (is_wakeup ||
+				 tctx->tier == TIER_LAT_CRITICAL)
+				? SCX_KICK_PREEMPT : SCX_KICK_IDLE;
+			scx_bpf_kick_cpu(cpu, kick_flag);
+			tctx->dispatch_path = 1;
+
+			struct pandemonium_stats *s = get_stats();
+			if (s) {
+				s->nr_shared += 1;
+				s->nr_dispatches += 1;
+				s->nr_hard_kicks += 1;
+				if (is_wakeup)
+					s->nr_enq_wakeup += 1;
+				else
+					s->nr_enq_requeue += 1;
+			}
+#if TRACE_SCHED
+			if (is_sched_task(p))
+				bpf_printk("PAND: enq tier2 pid=%d cpu=%d", p->pid, cpu);
+#endif
+			return;
+		}
+	}
+
+	// TIER 3: NODE OVERFLOW DSQ + SELECTIVE KICK
+	// ONLY BATCH-CLASSIFIED TASKS GO TO BATCH DSQ.
+	// IMMATURE TASKS (ewma_age < 2) STAY IN INTERACTIVE DSQ TO PREVENT
+	// STARVATION DURING BURST SPAWNS -- NEW THREADS STARTING WITH
+	// ewma_age=0 WOULD FLOOD THE BATCH DSQ AND STARVE FOR 30-40S
+	// WAITING FOR SOJOURN RESCUE THAT NEVER REACHES THE TAIL.
+	// LAT_CRITICAL (COMPOSITORS) ARE NEVER REDIRECTED.
+	u64 target_dsq = (tctx && tctx->tier == TIER_BATCH)
+		? (nr_cpu_ids + nr_nodes + (u64)node)
+		: node_dsq;
+
+	// SOJOURN TRACKING: RECORD WHEN OVERFLOW DSQs TRANSITION FROM EMPTY.
+	// DISPATCH STEP 0 CHECKS THESE TO RESCUE TASKS AGING PAST THRESHOLD.
+	if (target_dsq != node_dsq)
+		__sync_val_compare_and_swap(&batch_enqueue_ns, 0, bpf_ktime_get_ns());
+	if (target_dsq == node_dsq)
+		__sync_val_compare_and_swap(&interactive_enqueue_ns, 0, bpf_ktime_get_ns());
+
+	dl = tctx ? task_deadline(p, tctx, target_dsq, knobs) : vtime_now;
+
+	// VTIME CEILING: PREVENT UNBOUNDED STARVATION DURING BURST.
+	// HIGH-VTIME DAEMONS SORT TO THE TAIL OF THE VTIME-ORDERED BATCH DSQ
+	// WHILE FRESH BURST TASKS WITH LOW VTIME TAKE THE HEAD. SOJOURN RESCUE
+	// DISPATCHES FROM THE HEAD, SO DAEMONS AT THE TAIL STARVE.
+	// THE CEILING CAPS DEADLINE AT vtime_now + 30MS, KEEPING EVERY BATCH
+	// TASK WITHIN 6 SOJOURN CYCLES OF THE HEAD.
+	// GATED AT >= 8 CORES: ON LOW CORE COUNTS THE BATCH DSQ IS SHALLOW
+	// ENOUGH THAT SOJOURN RESCUE REACHES EVERY TASK NATURALLY. THE CEILING
+	// COMPRESSES VTIME AND DESTROYS PRIORITY DIFFERENTIATION AT 2-4 CORES.
+	if (target_dsq != node_dsq && nr_cpu_ids >= 8) {
+		u64 vtime_ceiling = vtime_now + (LAG_CAP_NS * 3 >> 2);
+		if (time_after(dl, vtime_ceiling))
+			dl = vtime_ceiling;
+	}
+
+	scx_bpf_dsq_insert_vtime(p, target_dsq, sl, dl, enq_flags);
+
+#if TRACE_SCHED
+	if (is_sched_task(p))
+		bpf_printk("PAND: enq tier3 pid=%d dsq=%llu tier=%d", p->pid, target_dsq, tctx ? tctx->tier : -1);
+#endif
+
+	// ARM TICK SAFETY NET: SIGNAL THAT INTERACTIVE TASKS ARE WAITING IN OVERFLOW.
+	// tick() CHECKS THIS FLAG TO PREEMPT BATCH TASKS VIA preempt_thresh_ns.
+	if (tctx && tctx->tier != TIER_BATCH)
+		interactive_waiting = true;
+
+	u64 kick_flags = is_wakeup ? SCX_KICK_PREEMPT : 0;
+	scx_bpf_kick_cpu(scx_bpf_task_cpu(p), kick_flags);
+
+	if (tctx)
+		tctx->dispatch_path = is_wakeup ? 1 : 2;
+
+	struct pandemonium_stats *s = get_stats();
+	if (s) {
+		s->nr_shared += 1;
+		if (is_wakeup) {
+			s->nr_enq_wakeup += 1;
+			s->nr_hard_kicks += 1;
+		} else {
+			s->nr_enq_requeue += 1;
+			s->nr_soft_kicks += 1;
+		}
+	}
+
+	// WAKEUP RATE COUNTER: INCREMENT ON EVERY WAKEUP.
+	// tick() READS AND RESETS THIS EVERY KERNEL TICK (1-4MS).
+	// THRESHOLD: nr_cpu_ids * 2 WAKEUPS PER TICK = FORK STORM.
+	if (is_wakeup)
+		__sync_fetch_and_add(&wake_rate_count, 1);
+
+	// TOTAL-ENQUEUE CUSUM: SAMPLE EVERY 64TH ENQUEUE.
+	// TRACKS TIME INTERVAL PER 64 ENQUEUES (SHORTER = HIGHER RATE).
+	// EWMA BASELINE SELF-TUNES TO ACTUAL SYSTEM CAPACITY.
+	// EFFECTIVE FOR BPF (1MS SLICES) WHERE RATE INCREASES DURING BURST.
+	// RATE-BOUNDED UNDER ADAPTIVE (4MS SLICES) -- WAKEUP CUSUM ABOVE
+	// COVERS THAT CASE. EITHER CUSUM FIRING ACTIVATES burst_mode IN tick().
+	u64 count = __sync_fetch_and_add(&cusum_enq_count, 1);
+	if ((count & 63) == 0) {
+		if (__sync_bool_compare_and_swap(&cusum_lock, 0, 1)) {
+			u64 now = bpf_ktime_get_ns();
+			u64 interval = now - cusum_last_check_ns;
+			cusum_last_check_ns = now;
+
+			if (cusum_interval_ewma == 0) {
+				cusum_interval_ewma = interval;
+			} else {
+				cusum_interval_ewma = cusum_interval_ewma
+					- (cusum_interval_ewma >> 3)
+					+ (interval >> 3);
+			}
+
+			u64 k = cusum_interval_ewma >> 2;
+			if (interval + k < cusum_interval_ewma)
+				cusum_s += (cusum_interval_ewma - interval - k);
+			else
+				cusum_s >>= 1;
+			__sync_lock_test_and_set(&cusum_lock, 0);
+		}
+	}
+}
+
+// DISPATCH: CPU IS IDLE AND NEEDS WORK
+// HYBRID PER-CPU + NODE DSQ DESIGN (v5.4.8):
+//   SELECT_CPU -> PER-CPU DSQ (DEPTH-GATED, VISIBLE, STEALABLE)
+//   ENQUEUE TIER 1/2 -> NODE DSQ (SHARED, ANY CPU DRAINS)
+//   ENQUEUE TIER 3 -> PER-NODE BATCH/INTERACTIVE DSQ
+//
+// 0. OWN PER-CPU DSQ (CACHE-HOT, ZERO CONTENTION)
+// 1. L2 WORK STEALING (SIBLING PER-CPU DSQs, SAME CACHE DOMAIN)
+// 2. DEFICIT GATE + OVERFLOW SOJOURN RESCUE (AGING OVERFLOW DSQ TASKS)
+// 3. DEFICIT CHECK (DRR: FORCE BATCH RESCUE AFTER BUDGET EXHAUSTED)
+// 4. HARD STARVATION RESCUE (ABSOLUTE SAFETY NET FOR BATCH)
+// 5. NODE INTERACTIVE OVERFLOW (ALL INTERACTIVE TASKS, VTIME-ORDERED)
+// 6. BATCH SOJOURN RESCUE + NODE BATCH OVERFLOW
+// 7. CROSS-NODE STEAL (BOTH INTERACTIVE AND BATCH PER REMOTE NODE)
+// 8. KEEP_RUNNING IF PREV STILL WANTS CPU AND NOTHING QUEUED
+void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
+{
+	s32 node = __COMPAT_scx_bpf_cpu_node(cpu);
+	if (node < 0 || (u32)node >= nr_nodes) node = 0;
+	u64 node_dsq = nr_cpu_ids + (u64)node;
+	u64 batch_dsq = nr_cpu_ids + nr_nodes + (u64)node;
+	struct pandemonium_stats *s;
+	u64 now = bpf_ktime_get_ns();
+
+	// STEP 0: OWN PER-CPU DSQ -- HIGHEST PRIORITY, CACHE-HOT
+	if ((u64)cpu < nr_cpu_ids &&
+	    scx_bpf_dsq_move_to_local((u64)cpu)) {
+		if ((u32)cpu < MAX_CPUS &&
+		    scx_bpf_dsq_nr_queued((u64)cpu) == 0) {
+			u64 old = pcpu_enqueue_ns[cpu];
+			if (old > 0)
+				__sync_val_compare_and_swap(
+					&pcpu_enqueue_ns[cpu], old, 0);
+		}
+		__sync_fetch_and_add(&interactive_run, 1);
+		s = get_stats();
+		if (s)
+			s->nr_dispatches += 1;
+		// SOJOURN GATE: ONLY RETURN IF SHARED DSQs ARE NOT STARVING.
+		// IF EITHER OVERFLOW DSQ HAS TASKS AGING PAST THRESHOLD,
+		// FALL THROUGH SO DOWNSTREAM RESCUE LOGIC CAN FIRE.
+		{
+			u64 ie = interactive_enqueue_ns;
+			u64 be = batch_enqueue_ns;
+			if ((ie == 0 || (now - ie) <= overflow_sojourn_rescue_ns) &&
+			    (be == 0 || (now - be) <= overflow_sojourn_rescue_ns))
+				return;
+		}
+	}
+
+	// STEP 1: L2 WORK STEALING -- PULL FROM SIBLING PER-CPU DSQs
+	// SAME L2 CACHE DOMAIN = MINIMAL CACHE PENALTY ON STEAL.
+	// BOUNDED LOOP (MAX_L2_SIBLINGS), SAME PATTERN AS find_idle_l2_sibling.
+	u32 my_cpu = (u32)cpu;
+	u32 *group = bpf_map_lookup_elem(&cache_domain, &my_cpu);
+	if (group) {
+		u32 base = *group * MAX_L2_SIBLINGS;
+		for (int i = 0; i < MAX_L2_SIBLINGS; i++) {
+			u32 key = base + i;
+			u32 *val = bpf_map_lookup_elem(&l2_siblings, &key);
+			if (!val || *val == (u32)-1)
+				break;
+			u32 sibling = *val;
+			if (sibling == my_cpu || sibling >= nr_cpu_ids)
+				continue;
+			if (scx_bpf_dsq_move_to_local((u64)sibling)) {
+				if (sibling < MAX_CPUS &&
+				    scx_bpf_dsq_nr_queued((u64)sibling) == 0) {
+					u64 old = pcpu_enqueue_ns[sibling];
+					if (old > 0)
+						__sync_val_compare_and_swap(
+							&pcpu_enqueue_ns[sibling],
+							old, 0);
+				}
+				__sync_fetch_and_add(&interactive_run, 1);
+				s = get_stats();
+				if (s)
+					s->nr_dispatches += 1;
+				// SOJOURN GATE: SAME CHECK AS STEP 0.
+				{
+					u64 ie = interactive_enqueue_ns;
+					u64 be = batch_enqueue_ns;
+					if ((ie == 0 || (now - ie) <= overflow_sojourn_rescue_ns) &&
+					    (be == 0 || (now - be) <= overflow_sojourn_rescue_ns))
+						return;
+				}
+				break;
+			}
+		}
+	}
+
+	struct tuning_knobs *knobs = get_knobs();
+	u64 sojourn_thresh = knobs ? knobs->sojourn_thresh_ns : 5000000;
+	u64 oldest = batch_enqueue_ns;
+	bool batch_starving = oldest > 0 && (now - oldest) > sojourn_thresh;
+	u64 effective_budget = longrun_mode ? nr_cpu_ids : interactive_budget;
+
+	// DEFICIT GATE: WHEN INTERACTIVE HAS EXCEEDED ITS BUDGET AND BATCH
+	// IS STARVING, SKIP INTERACTIVE OVERFLOW RESCUE SO BATCH
+	// GETS SERVED VIA DEFICIT CHECK OR STARVATION RESCUE INSTEAD.
+	if (interactive_run >= effective_budget && batch_starving)
+		goto skip_interactive_rescue;
+
+	// STEP 2: OVERFLOW SOJOURN AMPLIFICATION
+	// WHEN OVERFLOW DSQs HAVE TASKS AGING PAST 10MS, SERVE THEM.
+	u64 int_oldest = interactive_enqueue_ns;
+	if (int_oldest > 0 &&
+	    (now - int_oldest) > overflow_sojourn_rescue_ns) {
+		if (scx_bpf_dsq_move_to_local(node_dsq)) {
+			if (scx_bpf_dsq_nr_queued(node_dsq) == 0) {
+				u64 old_iens = interactive_enqueue_ns;
+				if (old_iens > 0)
+					__sync_val_compare_and_swap(&interactive_enqueue_ns, old_iens, 0);
+			} else {
+				interactive_enqueue_ns = bpf_ktime_get_ns();
+			}
+			__sync_fetch_and_add(&interactive_run, 1);
+			s = get_stats();
+			if (s) {
+				s->nr_dispatches += 1;
+				s->nr_overflow_rescue += 1;
+			}
+			return;
+		}
+		u64 old_iens = interactive_enqueue_ns;
+		if (old_iens > 0)
+			__sync_val_compare_and_swap(&interactive_enqueue_ns, old_iens, 0);
+	}
+
+skip_interactive_rescue:;
+
+	// BATCH OVERFLOW RESCUE
+	u64 bat_oldest = batch_enqueue_ns;
+	if (bat_oldest > 0 &&
+	    (now - bat_oldest) > overflow_sojourn_rescue_ns) {
+		if (scx_bpf_dsq_move_to_local(batch_dsq)) {
+			if (scx_bpf_dsq_nr_queued(batch_dsq) == 0) {
+				u64 old_bens = batch_enqueue_ns;
+				if (old_bens > 0)
+					__sync_val_compare_and_swap(&batch_enqueue_ns, old_bens, 0);
+			} else {
+				batch_enqueue_ns = bpf_ktime_get_ns();
+			}
+			__sync_lock_test_and_set(&interactive_run, 0);
+			s = get_stats();
+			if (s) {
+				s->nr_dispatches += 1;
+				s->nr_overflow_rescue += 1;
+			}
+			return;
+		}
+		u64 old_bens = batch_enqueue_ns;
+		if (old_bens > 0)
+			__sync_val_compare_and_swap(&batch_enqueue_ns, old_bens, 0);
+	}
+
+	// DEFICIT COUNTER: ANTI-STARVATION INTERLEAVE (DRR)
+	// AFTER interactive_budget DISPATCHES WITHOUT BATCH SERVICE,
+	// FORCE ONE BATCH DISPATCH WHEN BATCH IS STARVING.
+	// PROPORTIONAL: BUDGET = nr_cpu_ids * 4 (SET IN init()).
+	// LONGRUN OVERRIDE: WHEN SUSTAINED BATCH PRESSURE (>2S), TIGHTEN
+	// FROM nr_cpu_ids*4 TO nr_cpu_ids*1, QUADRUPLING BATCH SHARE.
+	if (interactive_run >= effective_budget && batch_starving) {
+		if (scx_bpf_dsq_move_to_local(batch_dsq)) {
+			if (scx_bpf_dsq_nr_queued(batch_dsq) == 0) {
+				u64 old_bens = batch_enqueue_ns;
+				if (old_bens > 0)
+					__sync_val_compare_and_swap(&batch_enqueue_ns, old_bens, 0);
+			} else {
+				batch_enqueue_ns = bpf_ktime_get_ns();
+			}
+			__sync_lock_test_and_set(&interactive_run, 0);
+			s = get_stats();
+			if (s)
+				s->nr_dispatches += 1;
+			return;
+		}
+		__sync_lock_test_and_set(&interactive_run, 0);
+	}
+
+	// HARD STARVATION RESCUE: ABSOLUTE SAFETY NET
+	// THE DEFICIT COUNTER IS THE ONLY PATH THAT SERVES BATCH WHEN THE
+	// INTERACTIVE DSQ IS NON-EMPTY. IF IT FAILS (LOST INCREMENTS UNDER
+	// CONTENTION, SLOW ACCUMULATION ON HIGH CORE COUNTS), BATCH TASKS
+	// STARVE UNTIL THE KERNEL WATCHDOG KILLS THE SCHEDULER.
+	// THIS CHECK FIRES BEFORE THE INTERACTIVE DSQ AND GUARANTEES BATCH
+	// SERVICE WITHIN 500MS REGARDLESS OF INTERACTIVE PRESSURE.
+	if (oldest > 0 &&
+	    (now - oldest) > starvation_rescue_ns) {
+		if (scx_bpf_dsq_move_to_local(batch_dsq)) {
+			if (scx_bpf_dsq_nr_queued(batch_dsq) == 0) {
+				u64 old_bens = batch_enqueue_ns;
+				if (old_bens > 0)
+					__sync_val_compare_and_swap(&batch_enqueue_ns, old_bens, 0);
+			} else {
+				batch_enqueue_ns = bpf_ktime_get_ns();
+			}
+			__sync_lock_test_and_set(&interactive_run, 0);
+			s = get_stats();
+			if (s)
+				s->nr_dispatches += 1;
+			return;
+		}
+	}
+
+	// NODE INTERACTIVE OVERFLOW: LATCRIT + INTERACTIVE TASKS
+	// INTERACTIVE FIRST WITHIN EACH BUDGET CYCLE. NO PRIORITY INVERSION.
+	if (scx_bpf_dsq_move_to_local(node_dsq)) {
+		if (scx_bpf_dsq_nr_queued(node_dsq) == 0) {
+			u64 old_iens = interactive_enqueue_ns;
+			if (old_iens > 0)
+				__sync_val_compare_and_swap(&interactive_enqueue_ns, old_iens, 0);
+		} else {
+			interactive_enqueue_ns = bpf_ktime_get_ns();
+		}
+		__sync_fetch_and_add(&interactive_run, 1);
+		s = get_stats();
+		if (s)
+			s->nr_dispatches += 1;
+		return;
+	}
+
+	// BATCH SOJOURN RESCUE: CODEL-INSPIRED STARVATION SAFETY NET.
+	// FIRES WHEN INTERACTIVE OVERFLOW IS EMPTY AND BATCH IS STARVING.
+	// THRESHOLD SET BY RUST ADAPTIVE LAYER FROM OBSERVED DISPATCH RATE.
+	if (batch_starving) {
+		if (scx_bpf_dsq_move_to_local(batch_dsq)) {
+			if (scx_bpf_dsq_nr_queued(batch_dsq) == 0) {
+				u64 old_bens = batch_enqueue_ns;
+				if (old_bens > 0)
+					__sync_val_compare_and_swap(&batch_enqueue_ns, old_bens, 0);
+			} else {
+				batch_enqueue_ns = bpf_ktime_get_ns();
+			}
+			s = get_stats();
+			if (s)
+				s->nr_dispatches += 1;
+			return;
+		}
+	}
+
+	// NODE BATCH OVERFLOW: NORMAL FALLBACK FOR BATCH TASKS
+	if (scx_bpf_dsq_move_to_local(batch_dsq)) {
+		if (scx_bpf_dsq_nr_queued(batch_dsq) == 0) {
+			u64 old_bens = batch_enqueue_ns;
+			if (old_bens > 0)
+				__sync_val_compare_and_swap(&batch_enqueue_ns, old_bens, 0);
+		} else {
+			batch_enqueue_ns = bpf_ktime_get_ns();
+		}
+		s = get_stats();
+		if (s)
+			s->nr_dispatches += 1;
+		return;
+	}
+
+	// CROSS-NODE STEAL
+	for (u32 n = 0; n < nr_nodes && n < MAX_NODES; n++) {
+		if (n != (u32)node) {
+			if (scx_bpf_dsq_move_to_local(nr_cpu_ids + (u64)n)) {
+				s = get_stats();
+				if (s)
+					s->nr_dispatches += 1;
+				return;
+			}
+			if (scx_bpf_dsq_move_to_local(nr_cpu_ids + nr_nodes + (u64)n)) {
+				s = get_stats();
+				if (s)
+					s->nr_dispatches += 1;
+				return;
+			}
+		}
+	}
+
+	// NOTHING IN ANY DSQ -- KEEP PREV RUNNING IF POSSIBLE
+	if (prev && !(prev->flags & PF_EXITING) &&
+	    (prev->scx.flags & SCX_TASK_QUEUED)) {
+		struct task_ctx *tctx = lookup_task_ctx(prev);
+		prev->scx.slice = tctx ? task_slice(tctx, knobs) :
+				  (knobs ? knobs->slice_ns : 1000000);
+		s = get_stats();
+		if (s) {
+			s->nr_keep_running += 1;
+			s->nr_dispatches += 1;
+		}
+	}
+}
+
+// RUNNABLE: TASK WAKES UP -- BEHAVIORAL CLASSIFICATION ENGINE
+void BPF_STRUCT_OPS(pandemonium_runnable, struct task_struct *p,
+		    u64 enq_flags)
+{
+	struct task_ctx *tctx = lookup_task_ctx(p);
+	if (!tctx)
+		return;
+
+	u64 now = bpf_ktime_get_ns();
+	tctx->awake_vtime = 0;
+
+	// FAST PATH: BRAND-NEW TASKS (< 2 WAKEUPS)
+	if (tctx->ewma_age < 2) {
+		tctx->last_woke_at = now;
+		tctx->prev_nvcsw = p->nvcsw;
+		tctx->ewma_age += 1;
+		return;
+	}
+
+	// WAKEUP FREQUENCY
+	u64 delta_t = now > tctx->last_woke_at ? now - tctx->last_woke_at : 1;
+	tctx->wakeup_freq = update_freq(tctx->wakeup_freq, delta_t,
+					 tctx->ewma_age);
+	if (tctx->wakeup_freq > MAX_WAKEUP_FREQ)
+		tctx->wakeup_freq = MAX_WAKEUP_FREQ;
+	tctx->last_woke_at = now;
+
+	if (tctx->ewma_age < EWMA_AGE_CAP)
+		tctx->ewma_age += 1;
+
+	// VOLUNTARY CONTEXT SWITCH RATE
+	u64 nvcsw = p->nvcsw;
+	u64 csw_delta = nvcsw > tctx->prev_nvcsw ? nvcsw - tctx->prev_nvcsw : 0;
+	tctx->prev_nvcsw = nvcsw;
+
+	if (csw_delta > 0 && delta_t > 0) {
+		u64 csw_freq = csw_delta * (100ULL * 1000000ULL) / delta_t;
+		tctx->csw_rate = calc_avg(tctx->csw_rate, csw_freq,
+					   tctx->ewma_age);
+	} else {
+		tctx->csw_rate = calc_avg(tctx->csw_rate, 0, tctx->ewma_age);
+	}
+	if (tctx->csw_rate > MAX_CSW_RATE)
+		tctx->csw_rate = MAX_CSW_RATE;
+
+	// BEHAVIORAL CLASSIFICATION
+	tctx->lat_cri = compute_lat_cri(tctx->wakeup_freq, tctx->csw_rate,
+					 tctx->avg_runtime, tctx->runtime_dev);
+	struct tuning_knobs *knobs = get_knobs();
+	u32 new_tier = classify_tier(tctx->lat_cri, knobs);
+
+	// COMPOSITOR BOOST: ALWAYS LAT_CRITICAL
+	if (new_tier != TIER_LAT_CRITICAL && is_compositor(p))
+		new_tier = TIER_LAT_CRITICAL;
+
+	// KWORKER FLOOR: WORKQUEUE WORKERS HANDLE I/O COMPLETIONS, TIMER
+	// CALLBACKS, AND DEFERRED INTERRUPT WORK. USERSPACE BLOCKS ON THESE.
+	// THEIR LOW EWMA SCORES (INFREQUENT WAKEUPS, LONG RUNTIMES) PUSH
+	// THEM TO BATCH, BUT THEY ARE LATENCY-CRITICAL KERNEL INFRASTRUCTURE.
+	if (new_tier == TIER_BATCH && (p->flags & PF_WQ_WORKER))
+		new_tier = TIER_INTERACTIVE;
+
+	tctx->tier = new_tier;
+}
+
+// RUNNING: TASK STARTS EXECUTING -- ADVANCE VTIME, RECORD WAKE LATENCY
+void BPF_STRUCT_OPS(pandemonium_running, struct task_struct *p)
+{
+#if TRACE_SCHED
+	if (is_sched_task(p))
+		bpf_printk("PAND: running pid=%d cpu=%d", p->pid, bpf_get_smp_processor_id());
+#endif
+	u64 cur = vtime_now;
+	for (int i = 0; i < 4; i++) {
+		if (!time_before(cur, p->scx.dsq_vtime))
+			break;
+		if (__sync_bool_compare_and_swap(&vtime_now, cur, p->scx.dsq_vtime))
+			break;
+		cur = vtime_now;
+	}
+
+	struct task_ctx *tctx = lookup_task_ctx(p);
+	if (!tctx) {
+		struct tuning_knobs *knobs = get_knobs();
+		p->scx.slice = knobs ? knobs->slice_ns : 1000000;
+		return;
+	}
+
+	u64 now = bpf_ktime_get_ns();
+	tctx->last_run_at = now;
+
+	// WAKEUP-TO-RUN LATENCY
+	// ONLY RECORD ONCE PER WAKEUP: CLEAR last_woke_at AFTER RECORDING.
+	if (tctx->last_woke_at && now > tctx->last_woke_at) {
+		u64 wake_lat = now - tctx->last_woke_at;
+		u8 path = tctx->dispatch_path;
+
+		// SLEEP DURATION: TIME BETWEEN quiescent() AND runnable()
+		u64 sleep_dur = 0;
+		if (tctx->sleep_start_ns > 0 &&
+		    tctx->last_woke_at > tctx->sleep_start_ns) {
+			sleep_dur = tctx->last_woke_at - tctx->sleep_start_ns;
+			tctx->sleep_start_ns = 0;
+		}
+
+		tctx->last_woke_at = 0;
+
+		struct pandemonium_stats *s = get_stats();
+		if (s) {
+			s->wake_lat_samples += 1;
+			s->wake_lat_sum += wake_lat;
+			if (wake_lat > s->wake_lat_max)
+				s->wake_lat_max = wake_lat;
+
+			if (path == 0) {
+				s->wake_lat_idle_sum += wake_lat;
+				s->wake_lat_idle_cnt += 1;
+			} else if (path == 1) {
+				s->wake_lat_kick_sum += wake_lat;
+				s->wake_lat_kick_cnt += 1;
+			}
+		}
+
+		// HISTOGRAM: BPF-SIDE LATENCY BUCKETING (NO RING BUFFER)
+		u32 tier_idx = (u32)tctx->tier;
+		if (tier_idx > 2) tier_idx = 2;
+		u32 bucket = lat_bucket(wake_lat);
+		u32 hist_key = tier_idx * 12 + bucket;
+		u64 *hist_val = bpf_map_lookup_elem(&wake_lat_hist, &hist_key);
+		if (hist_val)
+			*hist_val += 1;
+
+		if (sleep_dur > 0) {
+			u32 sbucket = sleep_bucket(sleep_dur);
+			u64 *sval = bpf_map_lookup_elem(&sleep_hist, &sbucket);
+			if (sval)
+				*sval += 1;
+		}
+	}
+
+	struct tuning_knobs *knobs = get_knobs();
+	p->scx.slice = task_slice(tctx, knobs);
+}
+
+// STOPPING: TASK YIELDS CPU -- CHARGE VTIME WITH TIER-BASED WEIGHT
+void BPF_STRUCT_OPS(pandemonium_stopping, struct task_struct *p,
+		    bool runnable)
+{
+	struct task_ctx *tctx = lookup_task_ctx(p);
+	if (!tctx)
+		return;
+
+	tctx->cached_weight = effective_weight(p, tctx);
+	tctx->last_cpu = bpf_get_smp_processor_id();
+	u64 weight = tctx->cached_weight;
+
+	u64 now = bpf_ktime_get_ns();
+	u64 slice = now > tctx->last_run_at ? now - tctx->last_run_at : 0;
+	{
+		u64 avg = tctx->avg_runtime;
+		u64 diff = slice > avg ? slice - avg : avg - slice;
+		tctx->avg_runtime = calc_avg(avg, slice, tctx->ewma_age);
+		tctx->runtime_dev = calc_avg(tctx->runtime_dev, diff,
+					      tctx->ewma_age);
+	}
+
+	// PROCDB: PUBLISH TASK CLASSIFICATION FOR USERSPACE
+	// INITIAL AT EWMA MATURITY, THEN EVERY 64 SCHEDULING EVENTS
+	// RE-PUBLISHING KEEPS PROCDB FRESH FOR LONG-LIVED TASKS
+	if (tctx->ewma_age == EWMA_AGE_MATURE ||
+	    (tctx->ewma_age > EWMA_AGE_MATURE && tctx->ewma_age % 64 == 0)) {
+		struct task_class_entry obs = {};
+		obs.tier = (u8)tctx->tier;
+		obs.avg_runtime = tctx->avg_runtime;
+		obs.runtime_dev = tctx->runtime_dev;
+		obs.wakeup_freq = tctx->wakeup_freq;
+		obs.csw_rate = tctx->csw_rate;
+		char key[16];
+		__builtin_memcpy(key, p->comm, 16);
+		bpf_map_update_elem(&task_class_observe, key, &obs, BPF_ANY);
+	}
+
+	u64 delta_vtime;
+	if (weight > 0)
+		delta_vtime = (slice << 7) / weight;
+	else
+		delta_vtime = slice;
+
+	p->scx.dsq_vtime += delta_vtime;
+	tctx->awake_vtime += delta_vtime;
+}
+
+// TICK: SOJOURN ENFORCEMENT + EVENT-DRIVEN BATCH PREEMPTION
+// FIRES ON EVERY KERNEL SCHEDULER TICK (HZ-DEPENDENT, 1-4MS) REGARDLESS
+// OF SLICE LENGTH. TWO RESPONSIBILITIES:
+// 1. SOJOURN: WRITE BATCH WAIT AGE TO STATS FOR RUST ADAPTIVE LAYER.
+//    IF BATCH STARVING PAST THRESHOLD AND CURRENT TASK IS BATCH, KICK
+//    CPU TO FORCE DISPATCH. THRESHOLD SET BY RUST FROM DISPATCH RATE.
+// 2. PREEMPTION: WHEN INTERACTIVE IS WAITING AND BATCH HAS RUN PAST
+//    THRESHOLD, PREEMPT TO MAINTAIN INTERACTIVE RESPONSIVENESS.
+void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
+{
+	// SOJOURN: COMPUTE BATCH WAIT AGE AND WRITE TO STATS FOR RUST
+	struct pandemonium_stats *s = get_stats();
+	struct tuning_knobs *knobs = get_knobs();
+
+	// BURST DETECTION: TOTAL-ENQUEUE CUSUM OR WAKEUP RATE COUNTER.
+	// CUSUM: EFFECTIVE FOR BPF (1MS SLICES) WHERE ENQUEUE RATE SPIKES DURING BURST.
+	// WAKEUP RATE: EFFECTIVE FOR ADAPTIVE (4MS SLICES) WHERE CUSUM IS RATE-BOUNDED.
+	// ABSOLUTE THRESHOLD: nr_cpu_ids * 2 WAKEUPS PER TICK INTERVAL = FORK STORM.
+	// NO CALIBRATION NEEDED -- WORKS IMMEDIATELY ON FIRST TICK.
+	// burst_mode REDUCES SLICE (burst_slice_ns) AND PREEMPT THRESHOLD (0).
+	bool cusum_burst = cusum_interval_ewma > 0 &&
+		cusum_s > (cusum_interval_ewma << 1);
+	u64 wakeups = __sync_fetch_and_add(&wake_rate_count, 0);
+	bool wake_burst = wakeups > (nr_cpu_ids << 1);
+	if (bpf_get_smp_processor_id() == 0)
+		__sync_lock_test_and_set(&wake_rate_count, 0);
+
+	burst_mode = cusum_burst || wake_burst;
+
+	if (s) {
+
+#if BURST_COUNTER_TEST
+		if (burst_mode) s->burst_mode_active++;
+#else
+		s->burst_mode_active = burst_mode ? 1 : 0;
+#endif
+		s->longrun_mode_active = longrun_mode ? 1 : 0;
+	}
+
+	u64 bens = batch_enqueue_ns;
+	if (bens > 0) {
+		u64 now = bpf_ktime_get_ns();
+		u64 sojourn = now - bens;
+		if (s)
+			s->batch_sojourn_ns = sojourn;
+
+		// LONGRUN DETECTION: SUSTAINED BATCH PRESSURE
+		// BATCH DSQ NON-EMPTY FOR > 2S SETS longrun_mode, WHICH
+		// TIGHTENS THE DEFICIT RATIO IN dispatch() FROM nr_cpu_ids*4
+		// TO nr_cpu_ids*1 (QUADRUPLING BATCH'S DISPATCH SHARE).
+		longrun_mode = sojourn > LONGRUN_THRESH_NS;
+
+		// SOJOURN ENFORCEMENT: THRESHOLD SET BY RUST ADAPTIVE LAYER
+		// FROM OBSERVED DISPATCH RATE. IF BATCH STARVING PAST THRESHOLD
+		// AND CURRENT TASK IS BATCH, KICK THIS CPU TO FORCE DISPATCH.
+		// ONLY PREEMPT BATCH: INTERACTIVE/LATCRIT SLICES ARE ALREADY
+		// SHORT (CAPPED AT slice_ns) AND WILL YIELD QUICKLY ON THEIR OWN.
+		u64 sojourn_thresh = knobs ? knobs->sojourn_thresh_ns : 5000000;
+		if (sojourn > sojourn_thresh) {
+			struct task_ctx *tctx = lookup_task_ctx(p);
+			if (tctx && tctx->tier == TIER_BATCH) {
+				scx_bpf_kick_cpu(scx_bpf_task_cpu(p), SCX_KICK_PREEMPT);
+				return;
+			}
+		}
+	} else {
+		longrun_mode = false;
+		if (s)
+			s->batch_sojourn_ns = 0;
+	}
+
+	// PER-CPU DSQ SOJOURN: CHECK OWN DSQ + ROTATING GLOBAL SCAN.
+	// LOCAL CHECK: CATCHES STALE TASKS ON THIS CPU.
+	// GLOBAL SCAN: CATCHES STALE TASKS ON IDLE CPUS WHERE tick() NEVER
+	// FIRES. ROTATES 4 CPUS PER TICK SO ALL CPUS GET COVERED OVER TIME.
+	{
+		u32 this_cpu = bpf_get_smp_processor_id();
+		u64 now2 = bpf_ktime_get_ns();
+		u64 pcpu_sojourn_thresh = knobs
+			? knobs->sojourn_thresh_ns : 5000000;
+
+		// LOCAL: OWN PER-CPU DSQ
+		if (this_cpu < MAX_CPUS) {
+			u64 pcpu_oldest = pcpu_enqueue_ns[this_cpu];
+			if (pcpu_oldest > 0 &&
+			    (now2 - pcpu_oldest) > pcpu_sojourn_thresh) {
+				scx_bpf_kick_cpu(this_cpu,
+						 SCX_KICK_PREEMPT);
+				return;
+			}
+		}
+
+		// GLOBAL: ROTATING SCAN OF REMOTE PER-CPU DSQs
+		// SHIFT BY 20 (~1ms ROTATION) TO AVOID u64 DIVISION.
+		// CONSTANT MODULO (MAX_CPUS) + MASK FOR VERIFIER SAFETY.
+		u32 scan_base = (u32)(now2 >> 20);
+		for (int i = 0; i < 4; i++) {
+			u32 scan_cpu = (scan_base + (u32)i) &
+				       (MAX_CPUS - 1);
+			if (scan_cpu == this_cpu)
+				continue;
+			if (scan_cpu >= nr_cpu_ids)
+				continue;
+			u64 remote_stamp =
+				pcpu_enqueue_ns[scan_cpu & (MAX_CPUS - 1)];
+			if (remote_stamp > 0 &&
+			    (now2 - remote_stamp) > pcpu_sojourn_thresh)
+				scx_bpf_kick_cpu(scan_cpu,
+						 SCX_KICK_PREEMPT);
+		}
+	}
+
+	if (!interactive_waiting)
+		return;
+
+	struct task_ctx *tctx = lookup_task_ctx(p);
+	if (!tctx)
+		return;
+
+	u64 thresh = burst_mode ? 0 : (knobs ? knobs->preempt_thresh_ns : 1000000);
+
+	if (tctx->tier == TIER_BATCH && tctx->avg_runtime >= thresh) {
+		scx_bpf_kick_cpu(scx_bpf_task_cpu(p), SCX_KICK_PREEMPT);
+		interactive_waiting = false;
+		if (!s)
+			s = get_stats();
+		if (s)
+			s->nr_preempt += 1;
+	}
+}
+
+// ENABLE: NEW TASK ENTERS SCHED_EXT
+void BPF_STRUCT_OPS(pandemonium_enable, struct task_struct *p)
+{
+	p->scx.dsq_vtime = vtime_now;
+
+	struct task_ctx *tctx = ensure_task_ctx(p);
+	if (tctx) {
+		tctx->awake_vtime = 0;
+		tctx->last_run_at = 0;
+		tctx->wakeup_freq = 20;
+		tctx->last_woke_at = bpf_ktime_get_ns();
+		tctx->avg_runtime = 100000;
+		tctx->cached_weight = WEIGHT_INTERACTIVE;
+		tctx->prev_nvcsw = p->nvcsw;
+		tctx->csw_rate = 0;
+		tctx->lat_cri = 0;
+		tctx->tier = TIER_INTERACTIVE;
+		tctx->ewma_age = 0;
+		tctx->dispatch_path = 0;
+
+		// PROCDB: APPLY LEARNED CLASSIFICATION FROM PRIOR RUNS
+		char key[16];
+		__builtin_memcpy(key, p->comm, 16);
+		struct task_class_entry *init_entry =
+		    bpf_map_lookup_elem(&task_class_init, key);
+		if (init_entry) {
+			tctx->tier = (u32)init_entry->tier;
+			tctx->avg_runtime = init_entry->avg_runtime;
+			tctx->runtime_dev = init_entry->runtime_dev;
+			tctx->wakeup_freq = init_entry->wakeup_freq;
+			tctx->csw_rate = init_entry->csw_rate;
+			tctx->cached_weight = effective_weight(p, tctx);
+			struct pandemonium_stats *s = get_stats();
+			if (s)
+				s->nr_procdb_hits += 1;
+		}
+	}
+}
+
+// INIT: DETECT TOPOLOGY, CREATE DSQs, CALIBRATE
+s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
+{
+	u32 zero = 0;
+
+	nr_nodes = __COMPAT_scx_bpf_nr_node_ids();
+	if (nr_nodes < 1)
+		nr_nodes = 1;
+	if (nr_nodes > nr_cpu_ids)
+		nr_nodes = nr_cpu_ids;
+
+	// PER-CPU DSQs: USED BY SELECT_CPU ONLY (v5.4.8)
+	// SELECT_CPU DISPATCHES TO PER-CPU DSQ (CACHE-HOT, VISIBLE, STEALABLE).
+	// ENQUEUE ALWAYS USES SHARED NODE DSQ (EVEN DISTRIBUTION).
+	// VISIBILITY LAYERS:
+	//   1. L2 WORK STEALING IN DISPATCH -- IDLE CPUs PULL FROM SIBLINGS
+	//   2. ROTATING TICK SCAN -- CATCHES STALE TASKS ON IDLE CPUs
+	//   3. PER-CPU SOJOURN RESCUE -- THRESHOLD CEILING ON INVISIBILITY
+	for (u32 i = 0; i < nr_cpu_ids && i < MAX_CPUS; i++)
+		scx_bpf_create_dsq(i, -1);
+
+	// CREATE PER-NODE INTERACTIVE OVERFLOW DSQs (DSQ ID = nr_cpu_ids + NODE)
+	for (u32 i = 0; i < nr_nodes && i < MAX_NODES; i++)
+		scx_bpf_create_dsq(nr_cpu_ids + i, (s32)i);
+
+	// CREATE PER-NODE BATCH OVERFLOW DSQs (DSQ ID = nr_cpu_ids + nr_nodes + NODE)
+	for (u32 i = 0; i < nr_nodes && i < MAX_NODES; i++)
+		scx_bpf_create_dsq(nr_cpu_ids + nr_nodes + i, (s32)i);
+
+	// ANTI-STARVATION BUDGET: SCALE RATIO WITH CORE COUNT
+	// 2C: RATIO=3 (BUDGET=6), 4C+: RATIO=4 (SAME AS BEFORE)
+	{
+		u64 ratio = 2 + (nr_cpu_ids >> 1);
+		if (ratio > 4) ratio = 4;
+		interactive_budget = nr_cpu_ids * ratio;
+		if (interactive_budget < 2) interactive_budget = 2;
+	}
+
+	// STARVATION RESCUE: MIN OF TWO LINEAR FUNCTIONS
+	// linear_up: SHORT AT LOW CORES (FAST STARVATION)
+	// linear_down: SHORT AT HIGH CORES (DISPATCH CONTENTION)
+	// 2C: 50MS, 4C: 100MS, 8C: 200MS, 12C: 167MS, 128C: 20MS
+	{
+		u64 linear_up = nr_cpu_ids * 25000000ULL;
+		u64 sr_divisor = nr_cpu_ids / 4;
+		if (sr_divisor < 1) sr_divisor = 1;
+		u64 linear_down = 500000000ULL / sr_divisor;
+		starvation_rescue_ns = linear_up < linear_down
+			? linear_up : linear_down;
+		if (starvation_rescue_ns < 20000000ULL)
+			starvation_rescue_ns = 20000000ULL;
+		if (starvation_rescue_ns > 500000000ULL)
+			starvation_rescue_ns = 500000000ULL;
+	}
+
+	// OVERFLOW SOJOURN RESCUE: SCALE WITH CORE COUNT
+	// 2C: 4MS, 4C: 8MS, 5C+: 10MS (CAPPED AT OLD STATIC VALUE)
+	overflow_sojourn_rescue_ns = nr_cpu_ids * 2000000ULL;
+	if (overflow_sojourn_rescue_ns < 4000000ULL)
+		overflow_sojourn_rescue_ns = 4000000ULL;
+	if (overflow_sojourn_rescue_ns > 10000000ULL)
+		overflow_sojourn_rescue_ns = 10000000ULL;
+
+	// PER-CPU DSQ DEPTH GATE: 1 BELOW 4 CPUS, 2 AT 4+
+	pcpu_depth_base = (nr_cpu_ids < 4) ? 1 : 2;
+
+	// CUSUM BURST DETECTION: CALIBRATES ON FIRST 64 ENQUEUES
+	cusum_last_check_ns = bpf_ktime_get_ns();
+	cusum_interval_ewma = 0;
+	cusum_s = 0;
+	burst_mode = false;
+	longrun_mode = false;
+
+	// WAKEUP RATE COUNTER: NO CALIBRATION NEEDED
+	wake_rate_count = 0;
+
+	// INITIALIZE DEFAULT TUNING KNOBS
+	struct tuning_knobs *knobs = bpf_map_lookup_elem(&tuning_knobs_map, &zero);
+	if (knobs) {
+		knobs->slice_ns = 1000000;
+		knobs->preempt_thresh_ns = 1000000;
+		knobs->lag_scale = 4;
+		knobs->batch_slice_ns = 20000000;        // 20MS FLAT DEFAULT
+		knobs->cpu_bound_thresh_ns = 2500000;    // 2.5MS (RESERVED FOR FUTURE USE)
+		knobs->lat_cri_thresh_high = LAT_CRI_THRESH_HIGH; // 32
+		knobs->lat_cri_thresh_low  = LAT_CRI_THRESH_LOW;  // 8
+		knobs->affinity_mode = 0;                // OFF BY DEFAULT (RUST SETS PER REGIME)
+		knobs->sojourn_thresh_ns = 5000000;      // 5MS DEFAULT (RUST OVERRIDES)
+		knobs->burst_slice_ns = 1000000;         // 1MS DEFAULT (BURST/LONGRUN CEILING)
+	}
+
+	return 0;
+}
+
+// EXIT: RECORD EXIT INFO FOR USERSPACE
+void BPF_STRUCT_OPS(pandemonium_exit, struct scx_exit_info *ei)
+{
+	UEI_RECORD(uei, ei);
+}
+
+// QUIESCENT: TASK GOES TO SLEEP -- RECORD TIMESTAMP FOR SLEEP ANALYSIS
+void BPF_STRUCT_OPS(pandemonium_quiescent, struct task_struct *p,
+		    u64 deq_flags)
+{
+	struct task_ctx *tctx = lookup_task_ctx(p);
+	if (tctx)
+		tctx->sleep_start_ns = bpf_ktime_get_ns();
+}
+
+// CPU RELEASE: RESCUE STRANDED TASKS WHEN RT/DL PREEMPTS OUR CPU
+// CALLED WHEN THE KERNEL TAKES A CPU AWAY FROM SCHED_EXT (DL SERVER,
+// RT TASKS, PIPEWIRE). WITHOUT THIS, TASKS THAT dispatch() MOVED TO THE
+// LOCAL DSQ VIA scx_bpf_dsq_move_to_local() GET STUCK, TRIGGERING THE
+// WATCHDOG. EVERY REFERENCE SCHEDULER IMPLEMENTS THIS.
+void BPF_STRUCT_OPS(pandemonium_cpu_release, s32 cpu,
+		    struct scx_cpu_release_args *args)
+{
+	u32 nr = scx_bpf_reenqueue_local();
+	if (nr > 0) {
+		struct pandemonium_stats *s = get_stats();
+		if (s)
+			s->nr_reenqueue += nr;
+	}
+}
+
+// CPU HOTPLUG CALLBACKS
+void BPF_STRUCT_OPS(pandemonium_cpu_online, s32 cpu) {}
+void BPF_STRUCT_OPS(pandemonium_cpu_offline, s32 cpu) {}
+
+SCX_OPS_DEFINE(pandemonium_ops,
+	       .select_cpu   = (void *)pandemonium_select_cpu,
+	       .enqueue      = (void *)pandemonium_enqueue,
+	       .dispatch     = (void *)pandemonium_dispatch,
+	       .runnable     = (void *)pandemonium_runnable,
+	       .running      = (void *)pandemonium_running,
+	       .stopping     = (void *)pandemonium_stopping,
+	       .tick         = (void *)pandemonium_tick,
+	       .enable       = (void *)pandemonium_enable,
+	       .quiescent    = (void *)pandemonium_quiescent,
+	       .cpu_release  = (void *)pandemonium_cpu_release,
+	       .cpu_online   = (void *)pandemonium_cpu_online,
+	       .cpu_offline  = (void *)pandemonium_cpu_offline,
+	       .init         = (void *)pandemonium_init,
+	       .exit         = (void *)pandemonium_exit,
+	       .flags        = SCX_OPS_BUILTIN_IDLE_PER_NODE,
+	       .name         = "pandemonium");

--- a/scheds/rust/scx_pandemonium/src/bpf_skel.rs
+++ b/scheds/rust/scx_pandemonium/src/bpf_skel.rs
@@ -1,0 +1,3 @@
+// GENERATED BPF SKELETON
+// COMPILED FROM src/bpf/main.bpf.c BY libbpf-cargo AT BUILD TIME
+include!(concat!(env!("OUT_DIR"), "/main_skel.rs"));

--- a/scheds/rust/scx_pandemonium/src/cli/bench.rs
+++ b/scheds/rust/scx_pandemonium/src/cli/bench.rs
@@ -1,0 +1,645 @@
+use std::fs::{self, File};
+use std::os::unix::process::CommandExt;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Result};
+use clap::ValueEnum;
+
+use super::child_guard::ChildGuard;
+use super::report::{format_delta, format_latency_delta, mean_stdev, percentile, save_report};
+use super::{binary_path, is_scx_active, self_exe, wait_for_activation, LOG_DIR, TARGET_DIR};
+
+#[derive(Clone, ValueEnum)]
+pub enum BenchMode {
+    /// A/B using own compilation as workload
+    #[value(name = "self")]
+    SelfBuild,
+    /// Compile + interactive probe (wakeup latency)
+    Contention,
+    /// Compile + audio playback (xruns)
+    Mixed,
+    /// A/B with user-provided command
+    Cmd,
+}
+
+// BUILD RELEASE BINARY AND RUN BENCH, SAVING LOGS
+pub fn run_bench_run(
+    mode: BenchMode,
+    cmd: Option<&str>,
+    iterations: usize,
+    clean_cmd: Option<&str>,
+    sched_args: &[String],
+) -> Result<()> {
+    fs::create_dir_all(LOG_DIR)?;
+
+    let build_out = File::create(format!("{}/build.out", LOG_DIR))?;
+    let build_err = File::create(format!("{}/build.err", LOG_DIR))?;
+    let status = Command::new("cargo")
+        .args(["build", "--release"])
+        .env("CARGO_TARGET_DIR", TARGET_DIR)
+        .stdout(Stdio::from(build_out))
+        .stderr(Stdio::from(build_err))
+        .status()?;
+    if !status.success() {
+        bail!("BUILD FAILED. SEE {}/build.err", LOG_DIR);
+    }
+
+    let extra_args: Vec<String> = sched_args.to_vec();
+
+    let bench_out = File::create(format!("{}/bench.out", LOG_DIR))?;
+    let bench_err = File::create(format!("{}/bench.err", LOG_DIR))?;
+    let mut bench_cmd = Command::new(binary_path());
+    let mode_name = mode
+        .to_possible_value()
+        .ok_or_else(|| anyhow::anyhow!("INVALID BENCH MODE"))?
+        .get_name()
+        .to_string();
+    bench_cmd
+        .arg("bench")
+        .arg("--mode")
+        .arg(mode_name)
+        .arg("--iterations")
+        .arg(iterations.to_string());
+    if let Some(c) = cmd {
+        bench_cmd.arg("--cmd").arg(c);
+    }
+    if let Some(cc) = clean_cmd {
+        bench_cmd.arg("--clean-cmd").arg(cc);
+    }
+    if !extra_args.is_empty() {
+        bench_cmd.arg("--").args(extra_args);
+    }
+
+    let status = bench_cmd
+        .stdout(Stdio::from(bench_out))
+        .stderr(Stdio::from(bench_err))
+        .status()?;
+    if !status.success() {
+        bail!("BENCH FAILED. SEE {}/bench.err", LOG_DIR);
+    }
+
+    log_info!("Build logs: {}/build.out {}/build.err", LOG_DIR, LOG_DIR);
+    log_info!("Bench logs: {}/bench.out {}/bench.err", LOG_DIR, LOG_DIR);
+    Ok(())
+}
+
+fn timed_run(cmd: &str) -> Option<f64> {
+    log_info!("Running: {}", cmd);
+    let start = Instant::now();
+    let result = Command::new("sh")
+        .args(["-c", cmd])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output();
+    let elapsed = start.elapsed().as_secs_f64();
+    match result {
+        Ok(r) if r.status.success() => {
+            log_info!("Completed in {:.2}s", elapsed);
+            Some(elapsed)
+        }
+        Ok(r) => {
+            let stderr = String::from_utf8_lossy(&r.stderr);
+            log_error!(
+                "Command failed (exit {}): {}",
+                r.status.code().unwrap_or(-1),
+                &stderr[..stderr.len().min(500)]
+            );
+            None
+        }
+        Err(e) => {
+            log_error!("Command failed: {}", e);
+            None
+        }
+    }
+}
+
+fn start_scheduler(sched_args: &[String]) -> Result<ChildGuard> {
+    let bin = binary_path();
+    let mut args = Vec::new();
+    args.extend(sched_args.iter().cloned());
+
+    let child = Command::new("sudo")
+        .arg(&bin)
+        .args(&args)
+        .process_group(0)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    Ok(ChildGuard::new(child))
+}
+
+fn stop_scheduler(guard: &mut ChildGuard) {
+    guard.stop();
+}
+
+fn ensure_scheduler_started(sched_args: &[String]) -> Result<ChildGuard> {
+    let guard = start_scheduler(sched_args)?;
+    if !wait_for_activation(10) {
+        bail!("PANDEMONIUM DID NOT ACTIVATE WITHIN 10S");
+    }
+    log_info!("PANDEMONIUM is active");
+    std::thread::sleep(Duration::from_secs(2));
+    Ok(guard)
+}
+
+pub fn run_bench(
+    mode: BenchMode,
+    cmd: Option<&str>,
+    iterations: usize,
+    clean_cmd: Option<&str>,
+    sched_args: &[String],
+) -> Result<()> {
+    match mode {
+        BenchMode::SelfBuild => bench_general(
+            &format!("CARGO_TARGET_DIR={} cargo build --release", TARGET_DIR),
+            iterations,
+            Some(&format!("cargo clean --target-dir {}", TARGET_DIR)),
+            sched_args,
+        ),
+        BenchMode::Cmd => {
+            let cmd = cmd.ok_or_else(|| anyhow::anyhow!("--cmd required for --mode cmd"))?;
+            bench_general(cmd, iterations, clean_cmd, sched_args)
+        }
+        BenchMode::Mixed => bench_mixed(sched_args),
+        BenchMode::Contention => bench_contention(sched_args),
+    }
+}
+
+// A/B BENCHMARK: EEVDF VS PANDEMONIUM (GENERIC)
+fn bench_general(
+    cmd: &str,
+    iterations: usize,
+    clean_cmd: Option<&str>,
+    sched_args: &[String],
+) -> Result<()> {
+    let sep = "=".repeat(60);
+    log_info!("PANDEMONIUM A/B benchmark");
+    log_info!("Command: {}", cmd);
+    log_info!("Iterations: {}", iterations);
+    if let Some(cc) = clean_cmd {
+        log_info!("Clean cmd: {}", cc);
+    }
+
+    if is_scx_active() {
+        bail!("SCHED_EXT IS ALREADY ACTIVE. STOP IT BEFORE BENCHMARKING.");
+    }
+
+    // PHASE 1: EEVDF BASELINE
+    log_info!("Phase 1: EEVDF baseline");
+    let mut eevdf_times = Vec::new();
+    for i in 0..iterations {
+        log_info!("Iteration {}/{}", i + 1, iterations);
+        if let Some(cc) = clean_cmd {
+            let _ = Command::new("sh").args(["-c", cc]).output();
+        }
+        match timed_run(cmd) {
+            Some(t) => eevdf_times.push(t),
+            None => bail!("ABORTING BENCHMARK: COMMAND FAILED"),
+        }
+    }
+
+    // PHASE 2: START PANDEMONIUM
+    log_info!("Phase 2: starting PANDEMONIUM");
+    let mut pand_proc = ensure_scheduler_started(sched_args)?;
+
+    // PHASE 3: PANDEMONIUM BENCHMARK
+    log_info!("Phase 3: PANDEMONIUM benchmark");
+    let mut pand_times = Vec::new();
+    for i in 0..iterations {
+        log_info!("Iteration {}/{}", i + 1, iterations);
+        if let Some(cc) = clean_cmd {
+            let _ = Command::new("sh").args(["-c", cc]).output();
+        }
+        match timed_run(cmd) {
+            Some(t) => pand_times.push(t),
+            None => {
+                stop_scheduler(&mut pand_proc);
+                bail!("ABORTING BENCHMARK: COMMAND FAILED");
+            }
+        }
+    }
+
+    // PHASE 4: STOP
+    log_info!("Phase 4: stopping PANDEMONIUM");
+    stop_scheduler(&mut pand_proc);
+    log_info!("PANDEMONIUM stopped");
+
+    // RESULTS
+    let (eevdf_mean, eevdf_std) = mean_stdev(&eevdf_times);
+    let (pand_mean, pand_std) = mean_stdev(&pand_times);
+    let delta_pct = if eevdf_mean > 0.0 {
+        ((pand_mean - eevdf_mean) / eevdf_mean) * 100.0
+    } else {
+        0.0
+    };
+
+    let mut report = Vec::new();
+    report.push(sep.clone());
+    report.push("BENCHMARK RESULTS".to_string());
+    report.push(sep.clone());
+    report.push(format!("COMMAND: {}", cmd));
+    report.push(format!("ITERATIONS: {}", iterations));
+    report.push(String::new());
+    report.push(format!(
+        "EEVDF:       {:.2}s +/- {:.2}s",
+        eevdf_mean, eevdf_std
+    ));
+    report.push(format!(
+        "  RUNS: {}",
+        eevdf_times
+            .iter()
+            .map(|t| format!("{:.2}s", t))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+    report.push(format!(
+        "PANDEMONIUM: {:.2}s +/- {:.2}s",
+        pand_mean, pand_std
+    ));
+    report.push(format!(
+        "  RUNS: {}",
+        pand_times
+            .iter()
+            .map(|t| format!("{:.2}s", t))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+    report.push(String::new());
+    report.push(format_delta(delta_pct, "BUILD"));
+    report.push(sep.clone());
+
+    let report_text = report.join("\n") + "\n";
+    for line in &report {
+        println!("{}", line);
+    }
+
+    let path = save_report(&report_text, "benchmark")?;
+    println!("\nSAVED TO {}", path);
+    Ok(())
+}
+
+// PW-TOP SNAPSHOT: CAPTURE PIPEWIRE XRUN COUNTS
+fn pw_top_snapshot() -> Vec<(String, i64)> {
+    let mut child = match Command::new("pw-top")
+        .arg("-b")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    std::thread::sleep(Duration::from_millis(1500));
+    let _ = child.kill();
+    let output = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(_) => return Vec::new(),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut entries = Vec::new();
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with("S ") {
+            continue;
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 10 {
+            continue;
+        }
+        if !matches!(parts[0], "R" | "S" | "C") {
+            continue;
+        }
+        if let Ok(err) = parts[8].parse::<i64>() {
+            let name = parts[9..]
+                .join(" ")
+                .trim_start_matches(['+', ' '])
+                .to_string();
+            entries.push((name, err));
+        }
+    }
+    entries
+}
+
+fn pw_audio_playing() -> bool {
+    Command::new("pactl")
+        .args(["list", "sink-inputs", "short"])
+        .output()
+        .map(|o| o.status.success() && !o.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+fn pw_get_xruns() -> i64 {
+    pw_top_snapshot().iter().map(|(_, err)| err).sum()
+}
+
+// MIXED BENCHMARK: COMPILE + AUDIO
+fn bench_mixed(sched_args: &[String]) -> Result<()> {
+    let sep = "=".repeat(60);
+    log_info!("PANDEMONIUM mixed workload benchmark");
+
+    if !pw_audio_playing() {
+        bail!("NO AUDIO PLAYING. START AUDIO PLAYBACK FIRST.");
+    }
+
+    let entries = pw_top_snapshot();
+    log_info!("Active PipeWire nodes:");
+    for (name, err) in &entries {
+        log_info!("  {} (xruns: {})", name, err);
+    }
+
+    if is_scx_active() {
+        bail!("SCHED_EXT IS ALREADY ACTIVE. STOP IT BEFORE BENCHMARKING.");
+    }
+
+    let build_cmd = format!("CARGO_TARGET_DIR={} cargo build --release", TARGET_DIR);
+    let clean_cmd = format!("cargo clean --target-dir {}", TARGET_DIR);
+
+    let sched_args = sched_args.to_vec();
+
+    // PHASE 1: EEVDF
+    log_info!("Phase 1: EEVDF (default scheduler)");
+    let _ = Command::new("sh").args(["-c", &clean_cmd]).output();
+    let xruns_before = pw_get_xruns();
+    log_info!("Xruns before: {}", xruns_before);
+    let eevdf_time = timed_run(&build_cmd).ok_or_else(|| anyhow::anyhow!("BUILD FAILED"))?;
+    let xruns_after = pw_get_xruns();
+    let eevdf_xruns = xruns_after - xruns_before;
+    log_info!("Xruns after: {} (delta: {})", xruns_after, eevdf_xruns);
+
+    // PHASE 2: START PANDEMONIUM
+    log_info!("Phase 2: starting PANDEMONIUM");
+    let mut pand_proc = ensure_scheduler_started(&sched_args)?;
+
+    // PHASE 3: PANDEMONIUM
+    log_info!("Phase 3: PANDEMONIUM");
+    let _ = Command::new("sh").args(["-c", &clean_cmd]).output();
+    let xruns_before = pw_get_xruns();
+    log_info!("Xruns before: {}", xruns_before);
+    let pand_time = match timed_run(&build_cmd) {
+        Some(t) => t,
+        None => {
+            stop_scheduler(&mut pand_proc);
+            bail!("BUILD FAILED");
+        }
+    };
+    let xruns_after = pw_get_xruns();
+    let pand_xruns = xruns_after - xruns_before;
+    log_info!("Xruns after: {} (delta: {})", xruns_after, pand_xruns);
+
+    // PHASE 4: STOP
+    log_info!("Phase 4: stopping PANDEMONIUM");
+    stop_scheduler(&mut pand_proc);
+    log_info!("PANDEMONIUM stopped");
+
+    // RESULTS
+    let delta_pct = if eevdf_time > 0.0 {
+        ((pand_time - eevdf_time) / eevdf_time) * 100.0
+    } else {
+        0.0
+    };
+    let xrun_delta = pand_xruns - eevdf_xruns;
+
+    let mut report = Vec::new();
+    report.push(sep.clone());
+    report.push("MIXED WORKLOAD BENCHMARK RESULTS".to_string());
+    report.push(sep.clone());
+    report.push("WORKLOAD: CARGO BUILD --RELEASE + AUDIO PLAYBACK".to_string());
+    report.push(String::new());
+    report.push(format!(
+        "{:<16} {:>12} {:>12}",
+        "SCHEDULER", "BUILD TIME", "AUDIO XRUNS"
+    ));
+    report.push(format!(
+        "{} {} {}",
+        "-".repeat(16),
+        "-".repeat(12),
+        "-".repeat(12)
+    ));
+    report.push(format!(
+        "{:<16} {:>11.2}s {:>12}",
+        "EEVDF", eevdf_time, eevdf_xruns
+    ));
+    report.push(format!(
+        "{:<16} {:>11.2}s {:>12}",
+        "PANDEMONIUM", pand_time, pand_xruns
+    ));
+    report.push(String::new());
+    report.push(format_delta(delta_pct, "BUILD"));
+    if xrun_delta < 0 {
+        report.push(format!(
+            "XRUN DELTA:  {:+} (PANDEMONIUM HAS FEWER AUDIO GLITCHES)",
+            xrun_delta
+        ));
+    } else if xrun_delta > 0 {
+        report.push(format!(
+            "XRUN DELTA:  {:+} (PANDEMONIUM HAS MORE AUDIO GLITCHES)",
+            xrun_delta
+        ));
+    } else {
+        report.push("XRUN DELTA:  0 (SAME AUDIO QUALITY)".to_string());
+    }
+    report.push(sep.clone());
+
+    let report_text = report.join("\n") + "\n";
+    for line in &report {
+        println!("{}", line);
+    }
+
+    let path = save_report(&report_text, "mixed")?;
+    println!("\nSAVED TO {}", path);
+    Ok(())
+}
+
+// CONTENTION BENCHMARK: COMPILE + INTERACTIVE PROBE
+fn bench_contention(sched_args: &[String]) -> Result<()> {
+    let sep = "=".repeat(60);
+    log_info!("PANDEMONIUM contention benchmark");
+    log_info!("Workload: cargo build --release + interactive probe (10ms sleep/wake)");
+
+    if is_scx_active() {
+        bail!("SCHED_EXT IS ALREADY ACTIVE. STOP IT BEFORE BENCHMARKING.");
+    }
+
+    let build_cmd = format!("CARGO_TARGET_DIR={} cargo build --release", TARGET_DIR);
+    let clean_cmd = format!("cargo clean --target-dir {}", TARGET_DIR);
+
+    // COPY SELF TO SAFE LOCATION -- cargo clean DELETES THE TARGET DIR
+    // WHICH CONTAINS THE VERY BINARY WE'RE RUNNING FROM
+    std::fs::create_dir_all(super::LOG_DIR)?;
+    let probe_exe = format!("{}/probe", super::LOG_DIR);
+    std::fs::copy(self_exe(), &probe_exe)?;
+
+    let sched_args = sched_args.to_vec();
+
+    struct PhaseResult {
+        name: String,
+        build_time: f64,
+        samples: usize,
+        median: f64,
+        p99: f64,
+        worst: f64,
+    }
+
+    let phases: Vec<(&str, bool)> = vec![("EEVDF (DEFAULT)", false), ("PANDEMONIUM", true)];
+
+    let mut results = Vec::new();
+
+    for (phase_name, use_scheduler) in &phases {
+        log_info!("Phase: {}", phase_name);
+
+        let mut pand_proc = if *use_scheduler {
+            Some(ensure_scheduler_started(&sched_args)?)
+        } else {
+            None
+        };
+
+        // CLEAN BUILD
+        let _ = Command::new("sh").args(["-c", &clean_cmd]).output();
+
+        // START PROBE WITH DEATH PIPE + PROCESS GROUP
+        let (death_read, death_write) = super::death_pipe::create_death_pipe()
+            .map_err(|e| anyhow::anyhow!("DEATH PIPE: {}", e))?;
+        let death_write_copy = death_write;
+        let probe_proc = unsafe {
+            Command::new(&probe_exe)
+                .arg("probe")
+                .arg("--death-pipe-fd")
+                .arg(death_read.to_string())
+                .process_group(0)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::null())
+                .pre_exec(move || {
+                    libc::close(death_write_copy);
+                    libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM as libc::c_ulong);
+                    Ok(())
+                })
+                .spawn()?
+        };
+        super::death_pipe::close_fd(death_read);
+        let probe_guard = ChildGuard::new(probe_proc);
+
+        // RUN BUILD
+        log_info!("Building...");
+        let build_start = Instant::now();
+        let build_result = Command::new("sh")
+            .args(["-c", &build_cmd])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()?;
+        let build_time = build_start.elapsed().as_secs_f64();
+
+        if !build_result.status.success() {
+            log_error!(
+                "Build failed (exit {})",
+                build_result.status.code().unwrap_or(-1)
+            );
+            drop(probe_guard);
+            super::death_pipe::close_fd(death_write);
+            if let Some(ref mut p) = pand_proc {
+                stop_scheduler(p);
+            }
+            bail!("BUILD FAILED");
+        }
+
+        // LET PROBE SETTLE
+        std::thread::sleep(Duration::from_secs(1));
+
+        // STOP PROBE AND COLLECT OUTPUT
+        unsafe {
+            libc::killpg(probe_guard.id() as i32, libc::SIGTERM);
+        }
+        let probe_child = probe_guard.into_child();
+        let probe_output = probe_child.wait_with_output()?;
+        super::death_pipe::close_fd(death_write);
+        let probe_stdout = String::from_utf8_lossy(&probe_output.stdout);
+
+        // STOP SCHEDULER IF RUNNING
+        if let Some(ref mut p) = pand_proc {
+            stop_scheduler(p);
+            log_info!("PANDEMONIUM stopped");
+        }
+
+        // PARSE PROBE OUTPUT
+        let mut overshoots: Vec<f64> = probe_stdout
+            .lines()
+            .filter_map(|line| line.trim().parse::<f64>().ok())
+            .collect();
+        overshoots.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        let n = overshoots.len();
+        let med = percentile(&overshoots, 50.0);
+        let p99 = percentile(&overshoots, 99.0);
+        let worst = overshoots.last().copied().unwrap_or(0.0);
+
+        log_info!("Build time: {:.2}s", build_time);
+        log_info!("Probe samples: {}", n);
+        log_info!("Median overshoot: {:.0}us", med);
+        log_info!("P99 overshoot: {:.0}us", p99);
+        log_info!("Worst overshoot: {:.0}us", worst);
+
+        results.push(PhaseResult {
+            name: phase_name.to_string(),
+            build_time,
+            samples: n,
+            median: med,
+            p99,
+            worst,
+        });
+    }
+
+    // REPORT
+    let eevdf = &results[0];
+    let pand = &results[1];
+
+    let build_delta = if eevdf.build_time > 0.0 {
+        ((pand.build_time - eevdf.build_time) / eevdf.build_time) * 100.0
+    } else {
+        0.0
+    };
+    let med_delta = pand.median - eevdf.median;
+    let p99_delta = pand.p99 - eevdf.p99;
+
+    let mut report = Vec::new();
+    report.push(sep.clone());
+    report.push("CONTENTION BENCHMARK RESULTS".to_string());
+    report.push(sep.clone());
+    report
+        .push("WORKLOAD: CARGO BUILD --RELEASE + INTERACTIVE PROBE (10MS SLEEP/WAKE)".to_string());
+    report.push(String::new());
+    report.push(format!(
+        "{:<24} {:>8} {:>8} {:>8} {:>8} {:>8}",
+        "SCHEDULER", "BUILD", "SAMPLES", "MEDIAN", "P99", "WORST"
+    ));
+    report.push(format!(
+        "{} {} {} {} {} {}",
+        "-".repeat(24),
+        "-".repeat(8),
+        "-".repeat(8),
+        "-".repeat(8),
+        "-".repeat(8),
+        "-".repeat(8),
+    ));
+    for r in &results {
+        report.push(format!(
+            "{:<24} {:>7.2}s {:>8} {:>7.0}us {:>7.0}us {:>7.0}us",
+            r.name, r.build_time, r.samples, r.median, r.p99, r.worst,
+        ));
+    }
+    report.push(String::new());
+    report.push(format_delta(build_delta, "BUILD"));
+    report.push(format_latency_delta(med_delta, "MEDIAN"));
+    report.push(format_latency_delta(p99_delta, "P99"));
+    report.push(sep.clone());
+
+    let report_text = report.join("\n") + "\n";
+    for line in &report {
+        println!("{}", line);
+    }
+
+    let path = save_report(&report_text, "contention")?;
+    println!("\nSAVED TO {}", path);
+    Ok(())
+}

--- a/scheds/rust/scx_pandemonium/src/cli/check.rs
+++ b/scheds/rust/scx_pandemonium/src/cli/check.rs
@@ -1,0 +1,129 @@
+use std::io::Read;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::Result;
+
+fn check_tool(name: &str) -> bool {
+    Command::new("which")
+        .arg(name)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn check_kernel_version() -> bool {
+    let release = std::fs::read_to_string("/proc/sys/kernel/osrelease")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let parts: Vec<&str> = release.split('.').collect();
+    if parts.len() >= 2 {
+        if let (Ok(major), Ok(minor)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>()) {
+            if major > 6 || (major == 6 && minor >= 12) {
+                log_info!("Kernel {} (>= 6.12)", release);
+                return true;
+            }
+            log_error!(
+                "Kernel {}.{} is too old. PANDEMONIUM requires 6.12+.",
+                major,
+                minor
+            );
+            log_error!("sched_ext (CONFIG_SCHED_CLASS_EXT) was merged in Linux 6.12.");
+            return false;
+        }
+    }
+    log_warn!("Cannot parse kernel version from '{}'", release);
+    false
+}
+
+fn check_vmlinux_cache() -> bool {
+    let cache = Path::new("/tmp/pandemonium-vmlinux.h");
+    if cache.exists() && cache.metadata().map(|m| m.len() > 1000).unwrap_or(false) {
+        let size = cache.metadata().map(|m| m.len() / 1024).unwrap_or(0);
+        log_info!("vmlinux.h cached ({size} KB)");
+        return true;
+    }
+    log_warn!("vmlinux.h not cached (will be downloaded on first build)");
+    true
+}
+
+fn check_kernel_config() -> bool {
+    let file = match std::fs::File::open("/proc/config.gz") {
+        Ok(f) => f,
+        Err(_) => {
+            log_warn!("/proc/config.gz not found (skipped)");
+            return true;
+        }
+    };
+    let mut decoder = flate2::read::GzDecoder::new(file);
+    let mut config = String::new();
+    if decoder.read_to_string(&mut config).is_err() {
+        log_warn!("/proc/config.gz unreadable (skipped)");
+        return true;
+    }
+    let found = config.contains("CONFIG_SCHED_CLASS_EXT=y");
+    if found {
+        log_info!("CONFIG_SCHED_CLASS_EXT=y found");
+    } else {
+        log_error!("CONFIG_SCHED_CLASS_EXT not found -- sched_ext may not be available");
+    }
+    found
+}
+
+pub fn run_check() -> Result<()> {
+    log_info!("PANDEMONIUM dependency check");
+
+    let mut ok = true;
+    let tools = ["cargo", "rustc", "clang", "sudo"];
+    for tool in &tools {
+        if check_tool(tool) {
+            log_info!("  {:<24}OK", tool);
+        } else {
+            log_error!("  {:<24}MISSING", tool);
+            ok = false;
+        }
+    }
+
+    log_info!("Kernel version:");
+    if !check_kernel_version() {
+        ok = false;
+    }
+
+    log_info!("Kernel config:");
+    if !check_kernel_config() {
+        ok = false;
+    }
+
+    log_info!("Build cache:");
+    check_vmlinux_cache();
+
+    let scx_path = Path::new("/sys/kernel/sched_ext/root/ops");
+    if scx_path.exists() {
+        let active = std::fs::read_to_string(scx_path).unwrap_or_default();
+        let active = active.trim();
+        if active.is_empty() {
+            log_info!("sched_ext available (no scheduler active)");
+        } else {
+            log_info!("sched_ext active ({})", active);
+        }
+    } else {
+        log_error!("sched_ext not available (sysfs path missing)");
+        ok = false;
+    }
+
+    if ok {
+        log_info!("All checks passed");
+    } else {
+        log_error!("Some checks failed");
+        if !check_tool("cargo") || !check_tool("rustc") {
+            log_info!("  Install Rust: https://rustup.rs");
+        }
+        if !check_tool("clang") {
+            log_info!("  Install clang: pacman -S clang");
+        }
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/scheds/rust/scx_pandemonium/src/cli/child_guard.rs
+++ b/scheds/rust/scx_pandemonium/src/cli/child_guard.rs
@@ -1,0 +1,85 @@
+use std::process::Child;
+use std::time::{Duration, Instant};
+
+/// RAII guard for a spawned child process. Tracks its process group ID.
+/// On drop, executes three-phase shutdown (muEmacs pattern):
+///   1. SIGINT to process group (graceful -- scheduler has ctrlc handler)
+///   2. Poll try_wait() for 500ms
+///   3. SIGKILL to process group (force)
+pub struct ChildGuard {
+    child: Option<Child>,
+    pgid: i32,
+}
+
+impl ChildGuard {
+    /// Wrap a child process. PGID is assumed to equal child PID
+    /// (requires the child to have been spawned with `.process_group(0)`).
+    pub fn new(child: Child) -> Self {
+        let pgid = child.id() as i32;
+        Self {
+            child: Some(child),
+            pgid,
+        }
+    }
+
+    pub fn id(&self) -> u32 {
+        self.child.as_ref().map(|c| c.id()).unwrap_or(0)
+    }
+
+    /// Three-phase shutdown: SIGINT → wait 500ms → SIGKILL.
+    /// Targets the entire process group via killpg.
+    pub fn stop(&mut self) {
+        let child = match self.child.as_mut() {
+            Some(c) => c,
+            None => return,
+        };
+
+        // CHECK IF ALREADY EXITED
+        if let Ok(Some(_)) = child.try_wait() {
+            return;
+        }
+
+        // PHASE 1: SIGINT TO PROCESS GROUP
+        unsafe {
+            libc::killpg(self.pgid, libc::SIGINT);
+        }
+
+        // PHASE 2: WAIT UP TO 500MS
+        let deadline = Instant::now() + Duration::from_millis(500);
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => {
+                    if Instant::now() >= deadline {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                Err(_) => break,
+            }
+        }
+
+        // PHASE 3: SIGKILL TO PROCESS GROUP
+        unsafe {
+            libc::killpg(self.pgid, libc::SIGKILL);
+        }
+        let _ = child.wait();
+    }
+
+    /// Consume the guard and return the inner Child without triggering
+    /// the Drop cleanup. Caller becomes responsible for the process.
+    /// Use this when you need wait_with_output() for stdout capture.
+    pub fn into_child(mut self) -> Child {
+        self.child
+            .take()
+            .expect("ChildGuard: child already consumed")
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if self.child.is_some() {
+            self.stop();
+        }
+    }
+}

--- a/scheds/rust/scx_pandemonium/src/cli/death_pipe.rs
+++ b/scheds/rust/scx_pandemonium/src/cli/death_pipe.rs
@@ -1,0 +1,54 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Create a pipe for parent-death detection.
+/// Returns (read_fd, write_fd). Neither end has CLOEXEC set.
+/// Parent holds write_fd open. Child monitors read_fd for POLLHUP.
+pub fn create_death_pipe() -> Result<(i32, i32), std::io::Error> {
+    let mut fds = [0i32; 2];
+    let ret = unsafe { libc::pipe2(fds.as_mut_ptr(), 0) };
+    if ret < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok((fds[0], fds[1]))
+}
+
+pub fn close_fd(fd: i32) {
+    if fd >= 0 {
+        unsafe {
+            libc::close(fd);
+        }
+    }
+}
+
+/// Monitor a death pipe FD in a background thread.
+/// When the write end closes (parent dies), POLLHUP fires and `running`
+/// is set to false, triggering the probe's graceful shutdown.
+pub fn spawn_death_watcher(death_fd: i32, running: &'static AtomicBool) {
+    std::thread::Builder::new()
+        .name("death-watcher".into())
+        .spawn(move || {
+            let mut pfd = libc::pollfd {
+                fd: death_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            while running.load(Ordering::Relaxed) {
+                let ret = unsafe { libc::poll(&mut pfd, 1, 100) };
+                if ret > 0 && (pfd.revents & (libc::POLLHUP | libc::POLLERR)) != 0 {
+                    running.store(false, Ordering::Relaxed);
+                    break;
+                }
+                if ret < 0 {
+                    let err = std::io::Error::last_os_error();
+                    if err.kind() != std::io::ErrorKind::Interrupted {
+                        running.store(false, Ordering::Relaxed);
+                        break;
+                    }
+                }
+            }
+            unsafe {
+                libc::close(death_fd);
+            }
+        })
+        .ok();
+}

--- a/scheds/rust/scx_pandemonium/src/cli/mod.rs
+++ b/scheds/rust/scx_pandemonium/src/cli/mod.rs
@@ -1,0 +1,36 @@
+pub mod bench;
+pub mod check;
+pub mod child_guard;
+pub mod death_pipe;
+pub mod probe;
+pub mod report;
+pub mod run;
+pub mod stress;
+pub mod test_gate;
+pub const TARGET_DIR: &str = "/tmp/pandemonium-build";
+pub const LOG_DIR: &str = "/tmp/pandemonium";
+
+pub fn binary_path() -> String {
+    format!("{}/release/pandemonium", TARGET_DIR)
+}
+
+pub fn self_exe() -> std::path::PathBuf {
+    std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from(binary_path()))
+}
+
+pub fn is_scx_active() -> bool {
+    std::fs::read_to_string("/sys/kernel/sched_ext/root/ops")
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false)
+}
+
+pub fn wait_for_activation(timeout_secs: u64) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed().as_secs() < timeout_secs {
+        if is_scx_active() {
+            return true;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    false
+}

--- a/scheds/rust/scx_pandemonium/src/cli/probe.rs
+++ b/scheds/rust/scx_pandemonium/src/cli/probe.rs
@@ -1,0 +1,57 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static RUNNING: AtomicBool = AtomicBool::new(true);
+
+// PRE-ALLOCATED SAMPLE BUFFER -- NO I/O DURING MEASUREMENT
+const MAX_SAMPLES: usize = 16384;
+
+/// Interactive wakeup probe.
+/// When PANDEMONIUM is running, BPF records latencies to ring buffer.
+/// For EEVDF baseline, we measure in userspace.
+/// Either way: ZERO I/O during measurement, bulk output at end.
+pub fn run_probe(death_pipe_fd: Option<i32>) {
+    ctrlc::set_handler(move || {
+        RUNNING.store(false, Ordering::Relaxed);
+    })
+    .ok();
+
+    if let Some(fd) = death_pipe_fd {
+        super::death_pipe::spawn_death_watcher(fd, &RUNNING);
+    }
+
+    let mut samples: Vec<i64> = Vec::with_capacity(MAX_SAMPLES);
+
+    let target_ns: i64 = 10_000_000; // 10MS SLEEP TARGET
+    let req = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: target_ns,
+    };
+
+    // HOT LOOP: MEASURE + BUFFER. ZERO I/O.
+    while RUNNING.load(Ordering::Relaxed) && samples.len() < MAX_SAMPLES {
+        let mut t0 = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        let mut t1 = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        unsafe {
+            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut t0);
+            libc::nanosleep(&req, std::ptr::null_mut());
+            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut t1);
+        }
+        let elapsed_ns = (t1.tv_sec - t0.tv_sec) * 1_000_000_000 + (t1.tv_nsec - t0.tv_nsec);
+        let overshoot_us = (elapsed_ns - target_ns).max(0) / 1000;
+        samples.push(overshoot_us);
+    }
+
+    // BULK OUTPUT AT END -- USE write() DIRECTLY TO MINIMIZE OVERHEAD
+    use std::io::Write;
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    for s in &samples {
+        let _ = writeln!(handle, "{}", s);
+    }
+}

--- a/scheds/rust/scx_pandemonium/src/cli/report.rs
+++ b/scheds/rust/scx_pandemonium/src/cli/report.rs
@@ -1,0 +1,80 @@
+use anyhow::Result;
+
+use super::LOG_DIR;
+
+fn chrono_stamp() -> String {
+    let output = std::process::Command::new("date")
+        .arg("+%Y%m%d-%H%M%S")
+        .output()
+        .ok();
+    match output {
+        Some(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+pub fn save_report(content: &str, prefix: &str) -> Result<String> {
+    std::fs::create_dir_all(LOG_DIR)?;
+    let stamp = chrono_stamp();
+    let path = format!("{}/{}-{}.log", LOG_DIR, prefix, stamp);
+    std::fs::write(&path, content)?;
+    Ok(path)
+}
+
+pub fn mean_stdev(values: &[f64]) -> (f64, f64) {
+    let n = values.len();
+    if n == 0 {
+        return (0.0, 0.0);
+    }
+    let m: f64 = values.iter().sum::<f64>() / n as f64;
+    if n == 1 {
+        return (m, 0.0);
+    }
+    let variance: f64 = values.iter().map(|x| (x - m).powi(2)).sum::<f64>() / (n - 1) as f64;
+    (m, variance.sqrt())
+}
+
+pub fn percentile(sorted_vals: &[f64], p: f64) -> f64 {
+    if sorted_vals.is_empty() {
+        return 0.0;
+    }
+    let idx = (sorted_vals.len() as f64 * p / 100.0) as usize;
+    let idx = idx.min(sorted_vals.len() - 1);
+    sorted_vals[idx]
+}
+
+pub fn format_delta(delta_pct: f64, label: &str) -> String {
+    if delta_pct < 0.0 {
+        format!(
+            "{} DELTA: {:+.1}% (PANDEMONIUM IS {:.1}% FASTER)",
+            label,
+            delta_pct,
+            delta_pct.abs()
+        )
+    } else if delta_pct > 0.0 {
+        format!(
+            "{} DELTA: {:+.1}% (PANDEMONIUM IS {:.1}% SLOWER)",
+            label, delta_pct, delta_pct
+        )
+    } else {
+        format!("{} DELTA: 0.0% (NO DIFFERENCE)", label)
+    }
+}
+
+pub fn format_latency_delta(delta_us: f64, label: &str) -> String {
+    if delta_us < 0.0 {
+        format!(
+            "{} LATENCY DELTA: {:+.0}us (PANDEMONIUM IS {:.0}us BETTER)",
+            label,
+            delta_us,
+            delta_us.abs()
+        )
+    } else if delta_us > 0.0 {
+        format!(
+            "{} LATENCY DELTA: {:+.0}us (PANDEMONIUM IS {:.0}us WORSE)",
+            label, delta_us, delta_us
+        )
+    } else {
+        format!("{} LATENCY DELTA: 0us (SAME)", label)
+    }
+}

--- a/scheds/rust/scx_pandemonium/src/cli/run.rs
+++ b/scheds/rust/scx_pandemonium/src/cli/run.rs
@@ -1,0 +1,237 @@
+use std::io::{BufRead, BufReader};
+use std::os::unix::process::CommandExt;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+
+use super::{binary_path, LOG_DIR, TARGET_DIR};
+
+fn build_scheduler() -> Result<()> {
+    log_info!("Building PANDEMONIUM (release)...");
+
+    let project_root = env!("CARGO_MANIFEST_DIR");
+    let output = Command::new("cargo")
+        .args(["build", "--release"])
+        .env("CARGO_TARGET_DIR", TARGET_DIR)
+        .current_dir(project_root)
+        .stderr(Stdio::piped())
+        .stdout(Stdio::null())
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("BUILD FAILED:\n{}", stderr);
+    }
+
+    let bin = binary_path();
+    let size = std::fs::metadata(&bin).map(|m| m.len() / 1024).unwrap_or(0);
+    log_info!("Build complete: {} ({} KB)", bin, size);
+    Ok(())
+}
+
+fn capture_dmesg_cursor() -> Option<String> {
+    let output = Command::new("journalctl")
+        .args(["-k", "--no-pager", "-n", "1", "--show-cursor"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.trim().lines().rev() {
+        if line.starts_with("-- cursor:") {
+            return Some(line.splitn(2, ':').nth(1)?.trim().to_string());
+        }
+    }
+    None
+}
+
+fn capture_dmesg_after(cursor: Option<&str>) -> String {
+    let mut cmd = Command::new("journalctl");
+    cmd.args(["-k", "--no-pager"]);
+    if let Some(c) = cursor {
+        cmd.args(["--after-cursor", c]);
+    }
+    let output = match cmd.output() {
+        Ok(o) if o.status.success() => o,
+        _ => return String::new(),
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut relevant = Vec::new();
+    for line in stdout.lines() {
+        if line.is_empty() || line.starts_with("-- ") {
+            continue;
+        }
+        let low = line.to_lowercase();
+        if low.contains("sched_ext") || low.contains("scx") || low.contains("pandemonium") {
+            relevant.push(line.to_string());
+        }
+    }
+    relevant.join("\n")
+}
+
+fn save_logs(
+    scheduler_output: &str,
+    dmesg: &str,
+    returncode: i32,
+) -> Result<(String, String, String)> {
+    std::fs::create_dir_all(LOG_DIR)?;
+
+    let stamp = chrono_stamp();
+
+    let sched_path = format!("{}/run-{}.log", LOG_DIR, stamp);
+    std::fs::write(&sched_path, scheduler_output)?;
+
+    let dmesg_path = format!("{}/dmesg-{}.log", LOG_DIR, stamp);
+    std::fs::write(
+        &dmesg_path,
+        if dmesg.is_empty() {
+            "(NO RELEVANT KERNEL MESSAGES)\n"
+        } else {
+            dmesg
+        },
+    )?;
+
+    let report_path = format!("{}/report-{}.log", LOG_DIR, stamp);
+    let report = format!(
+        "PANDEMONIUM RUN -- {stamp}\n\
+         EXIT CODE: {returncode}\n\n\
+         SCHEDULER OUTPUT\n\
+         {scheduler_output}\n\n\
+         KERNEL LOG (DMESG)\n\
+         {dmesg_text}\n",
+        dmesg_text = if dmesg.is_empty() {
+            "(NO RELEVANT KERNEL MESSAGES)"
+        } else {
+            dmesg
+        },
+    );
+    std::fs::write(&report_path, &report)?;
+
+    let latest = format!("{}/latest.log", LOG_DIR);
+    let _ = std::fs::remove_file(&latest);
+    let _ = std::os::unix::fs::symlink(&report_path, &latest);
+
+    Ok((sched_path, dmesg_path, report_path))
+}
+
+fn chrono_stamp() -> String {
+    let output = Command::new("date").arg("+%Y%m%d-%H%M%S").output().ok();
+    match output {
+        Some(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+pub fn run_start(observe: bool, sched_args: &[String]) -> Result<()> {
+    // BUILD FIRST
+    build_scheduler()?;
+
+    let bin = binary_path();
+    if !Path::new(&bin).exists() {
+        bail!("BINARY NOT FOUND AT {}", bin);
+    }
+
+    let mut cmd_args = Vec::new();
+    if observe {
+        cmd_args.push("--verbose".to_string());
+        cmd_args.push("--dump-log".to_string());
+    }
+    cmd_args.extend(sched_args.iter().cloned());
+
+    let full_cmd = format!("sudo {} {}", bin, cmd_args.join(" "));
+    log_info!("Running: {}", full_cmd);
+
+    let cursor = capture_dmesg_cursor();
+
+    let mut child = Command::new("sudo")
+        .arg(&bin)
+        .args(&cmd_args)
+        .process_group(0)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let stdout = child.stdout.take().unwrap();
+    let reader = BufReader::new(stdout);
+    let mut output_lines = Vec::new();
+
+    for line in reader.lines() {
+        match line {
+            Ok(l) => {
+                println!("{}", l);
+                output_lines.push(l);
+            }
+            Err(_) => break,
+        }
+    }
+
+    let status = child.wait()?;
+
+    let scheduler_output = output_lines.join("\n");
+    let returncode = status.code().unwrap_or(-1);
+
+    log_info!("PANDEMONIUM exited with code {}", returncode);
+
+    // BRIEF PAUSE FOR KERNEL LOG FLUSH
+    std::thread::sleep(Duration::from_millis(200));
+    let dmesg = capture_dmesg_after(cursor.as_deref());
+
+    // SAVE LOGS
+    let (sched_path, dmesg_path, report_path) = save_logs(&scheduler_output, &dmesg, returncode)?;
+
+    // PRINT DMESG
+    if dmesg.is_empty() {
+        log_info!("Kernel log: no relevant sched_ext messages");
+    } else {
+        log_info!("Kernel log ({} lines):", dmesg.lines().count());
+        for line in dmesg.lines() {
+            println!("  {}", line);
+        }
+    }
+
+    match returncode {
+        0 => log_info!("Status: clean exit"),
+        130 => log_info!("Status: user interrupted (CTRL+C)"),
+        _ => log_warn!("Status: exit code {}", returncode),
+    }
+
+    log_info!("Logs saved to {}/", LOG_DIR);
+    log_info!("  scheduler: {}", sched_path);
+    log_info!("  dmesg:     {}", dmesg_path);
+    log_info!("  combined:  {}", report_path);
+    log_info!("  latest:    {}/latest.log", LOG_DIR);
+
+    Ok(())
+}
+
+pub fn run_dmesg() -> Result<()> {
+    let output = Command::new("journalctl")
+        .args(["-k", "--no-pager", "-n", "50"])
+        .output()?;
+
+    if !output.status.success() {
+        bail!("journalctl failed");
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut found = false;
+    for line in stdout.lines() {
+        if line.is_empty() || line.starts_with("-- ") {
+            continue;
+        }
+        let low = line.to_lowercase();
+        if low.contains("sched_ext") || low.contains("scx") || low.contains("pandemonium") {
+            println!("{}", line);
+            found = true;
+        }
+    }
+
+    if !found {
+        log_info!("No recent sched_ext/PANDEMONIUM kernel messages");
+    }
+
+    Ok(())
+}

--- a/scheds/rust/scx_pandemonium/src/cli/stress.rs
+++ b/scheds/rust/scx_pandemonium/src/cli/stress.rs
@@ -1,0 +1,25 @@
+// CPU-PINNED STRESS WORKER FOR BENCH-SCALE
+// PURE COMPUTE SPIN LOOP. MATCHES THE WORKLOAD PROFILE OF BATCH CPU-BOUND TASKS.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static RUNNING: AtomicBool = AtomicBool::new(true);
+
+pub fn run_stress_worker(cpu: u32) {
+    ctrlc::set_handler(move || {
+        RUNNING.store(false, Ordering::Relaxed);
+    })
+    .ok();
+
+    unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        libc::CPU_SET(cpu as usize, &mut set);
+        libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &set);
+    }
+
+    let mut x: u64 = 1;
+    while RUNNING.load(Ordering::Relaxed) {
+        x = x.wrapping_mul(6364136223846793005).wrapping_add(1);
+    }
+    std::hint::black_box(x);
+}

--- a/scheds/rust/scx_pandemonium/src/cli/test_gate.rs
+++ b/scheds/rust/scx_pandemonium/src/cli/test_gate.rs
@@ -1,0 +1,49 @@
+use std::process::Command;
+
+use anyhow::{bail, Result};
+
+use super::TARGET_DIR;
+
+pub fn run_test_gate() -> Result<()> {
+    let project_root = env!("CARGO_MANIFEST_DIR");
+
+    log_info!("PANDEMONIUM test gate");
+
+    // LAYER 1: UNIT TESTS (NO ROOT)
+    log_info!("Layer 1: Rust unit tests");
+    let l1 = Command::new("cargo")
+        .args(["test", "--release"])
+        .env("CARGO_TARGET_DIR", TARGET_DIR)
+        .current_dir(project_root)
+        .status()?;
+
+    if !l1.success() {
+        bail!("LAYER 1 FAILED -- SKIPPING REMAINING LAYERS");
+    }
+
+    // LAYERS 2-5: INTEGRATION TESTS (REQUIRES ROOT)
+    log_info!("Layers 2-5: integration (requires root)");
+    let l2 = Command::new("sudo")
+        .args([
+            "-E",
+            &format!("CARGO_TARGET_DIR={}", TARGET_DIR),
+            "cargo",
+            "test",
+            "--test",
+            "gate",
+            "--release",
+            "--",
+            "--ignored",
+            "--test-threads=1",
+            "full_gate",
+        ])
+        .env("CARGO_TARGET_DIR", TARGET_DIR)
+        .current_dir(project_root)
+        .status()?;
+
+    if !l2.success() {
+        std::process::exit(l2.code().unwrap_or(1));
+    }
+
+    Ok(())
+}

--- a/scheds/rust/scx_pandemonium/src/event.rs
+++ b/scheds/rust/scx_pandemonium/src/event.rs
@@ -1,0 +1,224 @@
+// PANDEMONIUM EVENT LOG
+// RECORDS STATS SNAPSHOTS DURING SCHEDULER EXECUTION
+// PRE-ALLOCATED RING BUFFER. NO HEAP ALLOCATION DURING MONITORING.
+// WRAPS AROUND AT CAPACITY -- OLDEST ENTRIES OVERWRITTEN.
+
+pub const MAX_SNAPSHOTS: usize = 8192;
+
+#[derive(Clone, Copy)]
+pub struct Snapshot {
+    pub ts_ns: u64,
+    pub dispatches: u64,
+    pub idle_hits: u64,
+    pub shared: u64,
+    pub preempt: u64,
+    pub keep_run: u64,
+    pub wake_avg_us: u64,
+    pub hard_kicks: u64,
+    pub soft_kicks: u64,
+    pub lat_idle_us: u64,
+    pub lat_kick_us: u64,
+}
+
+pub struct EventLog {
+    snapshots: Vec<Snapshot>,
+    head: usize,
+    len: usize,
+}
+
+impl EventLog {
+    pub fn new() -> Self {
+        Self {
+            snapshots: vec![
+                Snapshot {
+                    ts_ns: 0,
+                    dispatches: 0,
+                    idle_hits: 0,
+                    shared: 0,
+                    preempt: 0,
+                    keep_run: 0,
+                    wake_avg_us: 0,
+                    hard_kicks: 0,
+                    soft_kicks: 0,
+                    lat_idle_us: 0,
+                    lat_kick_us: 0
+                };
+                MAX_SNAPSHOTS
+            ],
+            head: 0,
+            len: 0,
+        }
+    }
+
+    // RECORD ONE STATS SNAPSHOT. CALLED ONCE PER SECOND FROM THE MONITOR LOOP.
+    // OVERWRITES OLDEST ENTRY WHEN FULL.
+    pub fn snapshot(
+        &mut self,
+        dispatches: u64,
+        idle_hits: u64,
+        shared: u64,
+        preempt: u64,
+        keep_run: u64,
+        wake_avg_us: u64,
+        hard_kicks: u64,
+        soft_kicks: u64,
+        lat_idle_us: u64,
+        lat_kick_us: u64,
+    ) {
+        self.snapshots[self.head] = Snapshot {
+            ts_ns: now_ns(),
+            dispatches,
+            idle_hits,
+            shared,
+            preempt,
+            keep_run,
+            wake_avg_us,
+            hard_kicks,
+            soft_kicks,
+            lat_idle_us,
+            lat_kick_us,
+        };
+        self.head = (self.head + 1) % MAX_SNAPSHOTS;
+        if self.len < MAX_SNAPSHOTS {
+            self.len += 1;
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn head(&self) -> usize {
+        self.head
+    }
+
+    pub fn get(&self, idx: usize) -> &Snapshot {
+        &self.snapshots[idx]
+    }
+
+    // ITERATE SNAPSHOTS IN CHRONOLOGICAL ORDER
+    pub fn iter_chronological(&self) -> impl Iterator<Item = &Snapshot> {
+        let start = if self.len < MAX_SNAPSHOTS {
+            0
+        } else {
+            self.head
+        };
+        (0..self.len).map(move |i| &self.snapshots[(start + i) % MAX_SNAPSHOTS])
+    }
+
+    // DUMP THE TIME SERIES AFTER EXECUTION
+    pub fn dump(&self) {
+        if self.len == 0 {
+            return;
+        }
+
+        let mut iter = self.iter_chronological();
+        let first = iter.next().unwrap();
+        let base_ts = first.ts_ns;
+
+        println!(
+            "\n{:<10} {:<12} {:<10} {:<10} {:<10} {:<10} {:<10} {:<8} {:<8} {:<10} {:<10}",
+            "TIME_S",
+            "DISPATCH/S",
+            "IDLE/S",
+            "SHARED/S",
+            "PREEMPT",
+            "KEEP_RUN",
+            "WAKE_US",
+            "KICK_H",
+            "KICK_S",
+            "LAT_IDLE",
+            "LAT_KICK"
+        );
+        println!(
+            "{:<10.1} {:<12} {:<10} {:<10} {:<10} {:<10} {:<10} {:<8} {:<8} {:<10} {:<10}",
+            0.0,
+            first.dispatches,
+            first.idle_hits,
+            first.shared,
+            first.preempt,
+            first.keep_run,
+            first.wake_avg_us,
+            first.hard_kicks,
+            first.soft_kicks,
+            first.lat_idle_us,
+            first.lat_kick_us
+        );
+
+        for s in iter {
+            let elapsed_s = (s.ts_ns - base_ts) as f64 / 1_000_000_000.0;
+            println!(
+                "{:<10.1} {:<12} {:<10} {:<10} {:<10} {:<10} {:<10} {:<8} {:<8} {:<10} {:<10}",
+                elapsed_s,
+                s.dispatches,
+                s.idle_hits,
+                s.shared,
+                s.preempt,
+                s.keep_run,
+                s.wake_avg_us,
+                s.hard_kicks,
+                s.soft_kicks,
+                s.lat_idle_us,
+                s.lat_kick_us
+            );
+        }
+
+        if self.len == MAX_SNAPSHOTS {
+            println!(
+                "\n(RING BUFFER WRAPPED -- SHOWING MOST RECENT {} SNAPSHOTS)",
+                MAX_SNAPSHOTS
+            );
+        }
+        println!("TOTAL SNAPSHOTS: {}", self.len);
+    }
+
+    // SUMMARY STATISTICS
+    pub fn summary(&self) {
+        if self.len < 2 {
+            return;
+        }
+
+        let snapshots: Vec<&Snapshot> = self.iter_chronological().collect();
+
+        let total_d: u64 = snapshots.iter().map(|s| s.dispatches).sum();
+        let total_idle: u64 = snapshots.iter().map(|s| s.idle_hits).sum();
+        let total_shared: u64 = snapshots.iter().map(|s| s.shared).sum();
+        let total_preempt: u64 = snapshots.iter().map(|s| s.preempt).sum();
+        let total_keep: u64 = snapshots.iter().map(|s| s.keep_run).sum();
+
+        let peak_d = snapshots.iter().map(|s| s.dispatches).max().unwrap_or(0);
+
+        let elapsed_ns = snapshots.last().unwrap().ts_ns - snapshots.first().unwrap().ts_ns;
+        let elapsed_s = elapsed_ns as f64 / 1_000_000_000.0;
+
+        println!("\nPANDEMONIUM SUMMARY");
+        println!("  TOTAL DISPATCHES:  {}", total_d);
+        println!("  TOTAL IDLE HITS:   {}", total_idle);
+        println!("  TOTAL SHARED:      {}", total_shared);
+        println!("  TOTAL PREEMPT:     {}", total_preempt);
+        println!("  TOTAL KEEP_RUN:    {}", total_keep);
+        println!("  PEAK DISPATCH/S:   {}", peak_d);
+        if elapsed_s > 0.0 {
+            println!("  AVG DISPATCH/S:    {:.0}", total_d as f64 / elapsed_s);
+            let idle_pct = if total_d > 0 {
+                total_idle as f64 / total_d as f64 * 100.0
+            } else {
+                0.0
+            };
+            println!("  IDLE HIT RATE:     {:.1}%", idle_pct);
+        }
+        println!("  ELAPSED:           {:.1}s", elapsed_s);
+        println!("  SAMPLES:           {}", self.len);
+    }
+}
+
+fn now_ns() -> u64 {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    unsafe {
+        libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
+    }
+    (ts.tv_sec as u64) * 1_000_000_000 + (ts.tv_nsec as u64)
+}

--- a/scheds/rust/scx_pandemonium/src/lib.rs
+++ b/scheds/rust/scx_pandemonium/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod event;
+pub mod procdb;
+pub mod tuning;

--- a/scheds/rust/scx_pandemonium/src/log.rs
+++ b/scheds/rust/scx_pandemonium/src/log.rs
@@ -1,0 +1,31 @@
+// PANDEMONIUM STRUCTURED LOGGING
+// TIMESTAMPED [HH:MM:SS] [LEVEL] FORMAT
+// MIRRORS pandemonium.py AND tests/scale.rs PATTERN
+
+pub fn _timestamp() -> String {
+    unsafe {
+        let mut t: libc::time_t = 0;
+        libc::time(&mut t);
+        let mut tm: libc::tm = std::mem::zeroed();
+        libc::localtime_r(&t, &mut tm);
+        format!("[{:02}:{:02}:{:02}]", tm.tm_hour, tm.tm_min, tm.tm_sec)
+    }
+}
+
+macro_rules! log_info {
+    ($($arg:tt)*) => {
+        println!("{} [INFO]   {}", crate::log::_timestamp(), format!($($arg)*))
+    };
+}
+
+macro_rules! log_warn {
+    ($($arg:tt)*) => {
+        println!("{} [WARN]   {}", crate::log::_timestamp(), format!($($arg)*))
+    };
+}
+
+macro_rules! log_error {
+    ($($arg:tt)*) => {
+        println!("{} [ERROR]  {}", crate::log::_timestamp(), format!($($arg)*))
+    };
+}

--- a/scheds/rust/scx_pandemonium/src/main.rs
+++ b/scheds/rust/scx_pandemonium/src/main.rs
@@ -1,0 +1,452 @@
+// PANDEMONIUM -- SCHED_EXT KERNEL SCHEDULER
+// ADAPTIVE DESKTOP SCHEDULING FOR LINUX
+//
+// SCHEDULING DECISIONS HAPPEN IN BPF (ZERO KERNEL-USERSPACE ROUND TRIPS)
+// RUST USERSPACE HANDLES: ADAPTIVE CONTROL LOOP, MONITORING, BENCHMARKING
+
+#[allow(non_upper_case_globals)]
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(dead_code)]
+mod bpf_skel;
+
+#[macro_use]
+mod log;
+mod adaptive;
+mod cli;
+mod procdb;
+mod scheduler;
+mod topology;
+mod tuning;
+
+use std::mem::MaybeUninit;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use scheduler::Scheduler;
+
+static SHUTDOWN: AtomicBool = AtomicBool::new(false);
+
+#[derive(Parser)]
+#[command(name = "pandemonium")]
+#[command(version)]
+#[command(about = "PANDEMONIUM -- ADAPTIVE LINUX SCHEDULER")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<SubCmd>,
+
+    #[arg(short, long)]
+    verbose: bool,
+
+    #[arg(long)]
+    dump_log: bool,
+
+    /// Override CPU count for scaling formulas (default: auto-detect)
+    #[arg(long)]
+    nr_cpus: Option<u64>,
+
+    /// Run BPF scheduler only, disable Rust adaptive control loop
+    #[arg(long)]
+    no_adaptive: bool,
+
+    /// Additional compositor process names to boost to LAT_CRITICAL
+    #[arg(long)]
+    compositor: Vec<String>,
+}
+
+#[derive(Subcommand)]
+enum SubCmd {
+    /// Check dependencies and kernel config
+    Check,
+
+    /// Run interactive wakeup probe (stdout: overshoot_us per line)
+    Probe(ProbeArgs),
+
+    /// Build, run with sudo, capture output + dmesg, save logs
+    Start(StartArgs),
+
+    /// Show filtered kernel dmesg for sched_ext/pandemonium
+    Dmesg,
+
+    /// A/B benchmark (EEVDF baseline vs PANDEMONIUM)
+    Bench(BenchArgs),
+
+    /// Build release then run bench (logs to /tmp/pandemonium)
+    BenchRun(BenchRunArgs),
+
+    /// Run test gate (unit + integration)
+    Test,
+
+    /// CPU-pinned stress worker for bench-scale (internal use)
+    StressWorker(StressWorkerArgs),
+}
+
+#[derive(Parser)]
+struct ProbeArgs {
+    /// Death pipe FD for orphan detection (internal use)
+    #[arg(long)]
+    death_pipe_fd: Option<i32>,
+}
+
+#[derive(Parser)]
+struct StressWorkerArgs {
+    /// CPU to pin the stress worker to
+    #[arg(long)]
+    cpu: u32,
+}
+
+#[derive(Parser)]
+struct StartArgs {
+    /// Run with --verbose --dump-log
+    #[arg(long)]
+    observe: bool,
+
+    /// Extra args forwarded to `pandemonium run`
+    #[arg(last = true)]
+    sched_args: Vec<String>,
+}
+
+#[derive(Parser)]
+struct BenchArgs {
+    /// Benchmark mode
+    #[arg(long, value_enum)]
+    mode: cli::bench::BenchMode,
+
+    /// Command to benchmark (for --mode cmd)
+    #[arg(long)]
+    cmd: Option<String>,
+
+    /// Number of iterations per phase
+    #[arg(long, default_value_t = 3)]
+    iterations: usize,
+
+    /// Clean command between iterations (for --mode cmd)
+    #[arg(long)]
+    clean_cmd: Option<String>,
+
+    /// Extra args forwarded to `pandemonium run`
+    #[arg(last = true)]
+    sched_args: Vec<String>,
+}
+
+#[derive(Parser)]
+struct BenchRunArgs {
+    /// Benchmark mode
+    #[arg(long, value_enum)]
+    mode: cli::bench::BenchMode,
+
+    /// Command to benchmark (for --mode cmd)
+    #[arg(long)]
+    cmd: Option<String>,
+
+    /// Number of iterations per phase
+    #[arg(long, default_value_t = 3)]
+    iterations: usize,
+
+    /// Clean command between iterations (for --mode cmd)
+    #[arg(long)]
+    clean_cmd: Option<String>,
+
+    /// Extra args forwarded to `pandemonium run`
+    #[arg(last = true)]
+    sched_args: Vec<String>,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    let verbose = cli.verbose;
+    let dump_log = cli.dump_log;
+    let nr_cpus = cli.nr_cpus;
+    let no_adaptive = cli.no_adaptive;
+    let extra_compositors = cli.compositor;
+
+    match cli.command {
+        None => run_scheduler(verbose, dump_log, nr_cpus, no_adaptive, &extra_compositors),
+        Some(SubCmd::Check) => cli::check::run_check(),
+        Some(SubCmd::Probe(args)) => {
+            cli::probe::run_probe(args.death_pipe_fd);
+            Ok(())
+        }
+        Some(SubCmd::Start(args)) => cli::run::run_start(args.observe, &args.sched_args),
+        Some(SubCmd::Dmesg) => cli::run::run_dmesg(),
+        Some(SubCmd::Bench(args)) => cli::bench::run_bench(
+            args.mode,
+            args.cmd.as_deref(),
+            args.iterations,
+            args.clean_cmd.as_deref(),
+            &args.sched_args,
+        ),
+        Some(SubCmd::BenchRun(args)) => cli::bench::run_bench_run(
+            args.mode,
+            args.cmd.as_deref(),
+            args.iterations,
+            args.clean_cmd.as_deref(),
+            &args.sched_args,
+        ),
+        Some(SubCmd::Test) => cli::test_gate::run_test_gate(),
+        Some(SubCmd::StressWorker(args)) => {
+            cli::stress::run_stress_worker(args.cpu);
+            Ok(())
+        }
+    }
+}
+
+// DEFAULT COMPOSITORS: BOOSTED TO LAT_CRITICAL VIA BPF MAP LOOKUP
+const DEFAULT_COMPOSITORS: &[&str] = &[
+    "kwin",
+    "gnome-shell",
+    "mutter",
+    "sway",
+    "Hyprland",
+    "picom",
+    "weston",
+    "labwc",
+    "wayfire",
+    "niri",
+    "pandemonium",
+];
+
+fn run_scheduler(
+    verbose: bool,
+    dump_log: bool,
+    nr_cpus: Option<u64>,
+    no_adaptive: bool,
+    extra_compositors: &[String],
+) -> Result<()> {
+    ctrlc::set_handler(move || {
+        SHUTDOWN.store(true, Ordering::Relaxed);
+    })?;
+
+    let nr_cpus_display =
+        nr_cpus.unwrap_or_else(|| libbpf_rs::num_possible_cpus().unwrap_or(1) as u64);
+    let governor = std::fs::read_to_string("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    log_info!("PANDEMONIUM v{}", env!("CARGO_PKG_VERSION"));
+    log_info!(
+        "CPUS: {} (governor: {})",
+        nr_cpus_display,
+        if governor.is_empty() {
+            "unknown"
+        } else {
+            &governor
+        }
+    );
+    log_info!("VERBOSE: {}", verbose);
+
+    let mut is_restart = false;
+    loop {
+        // ON RESTART, WAIT FOR KERNEL STRUCT_OPS CLEANUP.
+        // DETACH IS ASYNCHRONOUS -- UNDER HEAVY LOAD (12C SATURATED),
+        // THE KERNEL NEEDS TIME TO FULLY UNREGISTER THE OLD SCHEDULER.
+        if is_restart {
+            std::thread::sleep(Duration::from_secs(2));
+        }
+
+        let mut open_object = MaybeUninit::uninit();
+        let mut sched = Scheduler::init(&mut open_object, nr_cpus)?;
+
+        // POPULATE CACHE TOPOLOGY MAP AT STARTUP
+        match topology::CpuTopology::detect(nr_cpus_display as usize) {
+            Ok(topo) => {
+                topo.log_summary();
+                if let Err(e) = topo.populate_bpf_map(&sched) {
+                    log_warn!("CACHE TOPOLOGY MAP WRITE FAILED: {}", e);
+                }
+                if let Err(e) = topo.populate_l2_siblings_map(&sched) {
+                    log_warn!("L2 SIBLINGS MAP WRITE FAILED: {}", e);
+                }
+            }
+            Err(e) => log_warn!("CACHE TOPOLOGY DETECT FAILED: {}", e),
+        }
+
+        // POPULATE COMPOSITOR MAP: DEFAULT + USER-SUPPLIED NAMES
+        for name in DEFAULT_COMPOSITORS {
+            if let Err(e) = sched.write_compositor(name) {
+                log_warn!("COMPOSITOR MAP WRITE FAILED: {} ({})", name, e);
+            }
+        }
+        for name in extra_compositors {
+            if let Err(e) = sched.write_compositor(name) {
+                log_warn!("COMPOSITOR MAP WRITE FAILED: {} ({})", name, e);
+            }
+        }
+
+        let should_restart = if no_adaptive {
+            // BPF-ONLY MODE: SCHEDULER RUNS WITH DEFAULT KNOBS, NO RUST TUNING
+            // STILL PRINTS STATS SO BENCHMARKS GET TELEMETRY FOR BOTH PHASES
+            log_info!("PANDEMONIUM IS ACTIVE (BPF ONLY, CTRL+C TO EXIT)");
+            let mut prev = scheduler::PandemoniumStats::default();
+            while !SHUTDOWN.load(Ordering::Relaxed) && !sched.exited() {
+                std::thread::sleep(Duration::from_secs(1));
+
+                let stats = sched.read_stats();
+
+                let delta_d = stats.nr_dispatches.wrapping_sub(prev.nr_dispatches);
+                let delta_idle = stats.nr_idle_hits.wrapping_sub(prev.nr_idle_hits);
+                let delta_shared = stats.nr_shared.wrapping_sub(prev.nr_shared);
+                let delta_preempt = stats.nr_preempt.wrapping_sub(prev.nr_preempt);
+                let delta_keep = stats.nr_keep_running.wrapping_sub(prev.nr_keep_running);
+                let delta_wake_sum = stats.wake_lat_sum.wrapping_sub(prev.wake_lat_sum);
+                let delta_wake_samples = stats.wake_lat_samples.wrapping_sub(prev.wake_lat_samples);
+                let delta_hard = stats.nr_hard_kicks.wrapping_sub(prev.nr_hard_kicks);
+                let delta_soft = stats.nr_soft_kicks.wrapping_sub(prev.nr_soft_kicks);
+                let delta_enq_wake = stats.nr_enq_wakeup.wrapping_sub(prev.nr_enq_wakeup);
+                let delta_enq_requeue = stats.nr_enq_requeue.wrapping_sub(prev.nr_enq_requeue);
+                let wake_avg_us = if delta_wake_samples > 0 {
+                    delta_wake_sum / delta_wake_samples / 1000
+                } else {
+                    0
+                };
+
+                let d_idle_sum = stats.wake_lat_idle_sum.wrapping_sub(prev.wake_lat_idle_sum);
+                let d_idle_cnt = stats.wake_lat_idle_cnt.wrapping_sub(prev.wake_lat_idle_cnt);
+                let d_kick_sum = stats.wake_lat_kick_sum.wrapping_sub(prev.wake_lat_kick_sum);
+                let d_kick_cnt = stats.wake_lat_kick_cnt.wrapping_sub(prev.wake_lat_kick_cnt);
+                let lat_idle_us = if d_idle_cnt > 0 {
+                    d_idle_sum / d_idle_cnt / 1000
+                } else {
+                    0
+                };
+                let lat_kick_us = if d_kick_cnt > 0 {
+                    d_kick_sum / d_kick_cnt / 1000
+                } else {
+                    0
+                };
+                let delta_procdb = stats.nr_procdb_hits.wrapping_sub(prev.nr_procdb_hits);
+                let delta_reenq = stats.nr_reenqueue.wrapping_sub(prev.nr_reenqueue);
+
+                // L2 CACHE AFFINITY DELTAS
+                let dl2_hb = stats.nr_l2_hit_batch.wrapping_sub(prev.nr_l2_hit_batch);
+                let dl2_mb = stats.nr_l2_miss_batch.wrapping_sub(prev.nr_l2_miss_batch);
+                let dl2_hi = stats
+                    .nr_l2_hit_interactive
+                    .wrapping_sub(prev.nr_l2_hit_interactive);
+                let dl2_mi = stats
+                    .nr_l2_miss_interactive
+                    .wrapping_sub(prev.nr_l2_miss_interactive);
+                let dl2_hl = stats
+                    .nr_l2_hit_lat_crit
+                    .wrapping_sub(prev.nr_l2_hit_lat_crit);
+                let dl2_ml = stats
+                    .nr_l2_miss_lat_crit
+                    .wrapping_sub(prev.nr_l2_miss_lat_crit);
+                let l2_pct_b = if dl2_hb + dl2_mb > 0 {
+                    dl2_hb * 100 / (dl2_hb + dl2_mb)
+                } else {
+                    0
+                };
+                let l2_pct_i = if dl2_hi + dl2_mi > 0 {
+                    dl2_hi * 100 / (dl2_hi + dl2_mi)
+                } else {
+                    0
+                };
+                let l2_pct_l = if dl2_hl + dl2_ml > 0 {
+                    dl2_hl * 100 / (dl2_hl + dl2_ml)
+                } else {
+                    0
+                };
+
+                let idle_pct = if delta_d > 0 {
+                    delta_idle * 100 / delta_d
+                } else {
+                    0
+                };
+
+                let sojourn_ms = stats.batch_sojourn_ns / 1_000_000;
+                let delta_burst = stats.burst_mode_active.wrapping_sub(prev.burst_mode_active);
+                let burst_label = if delta_burst > 0 { " BURST" } else { "" };
+                let longrun_label = if stats.longrun_mode_active > 0 {
+                    " LONGRUN"
+                } else {
+                    ""
+                };
+
+                if verbose {
+                    println!(
+                        "d/s: {:<8} idle: {}% shared: {:<6} preempt: {:<4} keep: {:<4} kick: H={:<4} S={:<4} enq: W={:<4} R={:<4} wake: {}us lat_idle: {}us lat_kick: {}us procdb: {} reenq: {} sjrn: {}ms l2: B={}% I={}% L={}% [BPF{}{}]",
+                        delta_d, idle_pct, delta_shared, delta_preempt, delta_keep,
+                        delta_hard, delta_soft, delta_enq_wake, delta_enq_requeue,
+                        wake_avg_us, lat_idle_us, lat_kick_us, delta_procdb,
+                        delta_reenq, sojourn_ms, l2_pct_b, l2_pct_i, l2_pct_l,
+                        burst_label, longrun_label,
+                    );
+                }
+
+                sched.log.snapshot(
+                    delta_d,
+                    delta_idle,
+                    delta_shared,
+                    delta_preempt,
+                    delta_keep,
+                    wake_avg_us,
+                    delta_hard,
+                    delta_soft,
+                    lat_idle_us,
+                    lat_kick_us,
+                );
+
+                prev = stats;
+            }
+
+            // KNOBS SUMMARY: CAPTURED BY TEST HARNESS FOR ARCHIVE
+            let knobs = sched.read_tuning_knobs();
+            let final_stats = sched.read_stats();
+            let l2_total_b = final_stats.nr_l2_hit_batch + final_stats.nr_l2_miss_batch;
+            let l2_total_i = final_stats.nr_l2_hit_interactive + final_stats.nr_l2_miss_interactive;
+            let l2_total_l = final_stats.nr_l2_hit_lat_crit + final_stats.nr_l2_miss_lat_crit;
+            let l2_cum_b = if l2_total_b > 0 {
+                final_stats.nr_l2_hit_batch * 100 / l2_total_b
+            } else {
+                0
+            };
+            let l2_cum_i = if l2_total_i > 0 {
+                final_stats.nr_l2_hit_interactive * 100 / l2_total_i
+            } else {
+                0
+            };
+            let l2_cum_l = if l2_total_l > 0 {
+                final_stats.nr_l2_hit_lat_crit * 100 / l2_total_l
+            } else {
+                0
+            };
+            println!(
+                "[KNOBS] regime=BPF slice_ns={} batch_ns={} preempt_ns={} demotion_ns={} lag={} l2_hit=B:{}%/I:{}%/L:{}%",
+                knobs.slice_ns, knobs.batch_slice_ns,
+                knobs.preempt_thresh_ns, knobs.cpu_bound_thresh_ns,
+                knobs.lag_scale, l2_cum_b, l2_cum_i, l2_cum_l,
+            );
+
+            sched.read_exit_info()
+        } else {
+            // ADAPTIVE MODE: BPF + SINGLE-THREAD MONITOR LOOP
+            log_info!("PANDEMONIUM IS ACTIVE (CTRL+C TO EXIT)");
+            adaptive::monitor_loop(&mut sched, &SHUTDOWN, verbose, nr_cpus_display)?
+        };
+
+        log_info!("PANDEMONIUM IS SHUTTING DOWN");
+
+        if dump_log {
+            sched.log.dump();
+        }
+        sched.log.summary();
+
+        if !should_restart || SHUTDOWN.load(Ordering::Relaxed) {
+            break;
+        }
+
+        // RESET SHUTDOWN FOR RESTART
+        SHUTDOWN.store(false, Ordering::Relaxed);
+        log_info!("RESTARTING PANDEMONIUM...");
+        is_restart = true;
+    }
+
+    log_info!("Shutdown complete");
+    Ok(())
+}

--- a/scheds/rust/scx_pandemonium/src/procdb.rs
+++ b/scheds/rust/scx_pandemonium/src/procdb.rs
@@ -1,0 +1,421 @@
+// PANDEMONIUM PROCESS CLASSIFICATION DATABASE
+// BPF OBSERVES MATURE TASK BEHAVIOR, RUST LEARNS PATTERNS, BPF APPLIES
+//
+// PROBLEM: EVERY NEW TASK ENTERS AS TIER_INTERACTIVE IN BPF enable().
+// SHORT-LIVED PROCESSES (cc1, as, ld DURING COMPILATION) NEVER SURVIVE
+// LONG ENOUGH TO GET RECLASSIFIED. HUNDREDS OF MISCLASSIFIED TASKS PER
+// SECOND DURING make -j12, EACH FIRING PREEMPT KICKS AND GETTING SHORT
+// INTERACTIVE SLICES.
+//
+// SOLUTION: BPF WRITES OBSERVATIONS TO AN LRU MAP WHEN A TASK'S EWMA
+// MATURES (ewma_age == 8). RUST DRAINS OBSERVATIONS EVERY SECOND,
+// MERGES INTO A HASHMAP WITH EWMA DECAY, AND WRITES CONFIDENT
+// PREDICTIONS BACK TO A BPF HASH MAP. NEW TASKS WITH MATCHING comm
+// START WITH THE CORRECT TIER AND avg_runtime FROM enable().
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use libbpf_rs::MapCore;
+
+fn _timestamp() -> String {
+    unsafe {
+        let mut t: libc::time_t = 0;
+        libc::time(&mut t);
+        let mut tm: libc::tm = std::mem::zeroed();
+        libc::localtime_r(&t, &mut tm);
+        format!("[{:02}:{:02}:{:02}]", tm.tm_hour, tm.tm_min, tm.tm_sec)
+    }
+}
+
+macro_rules! procdb_info {
+    ($($arg:tt)*) => { println!("{} [INFO]   {}", _timestamp(), format!($($arg)*)) };
+}
+macro_rules! procdb_warn {
+    ($($arg:tt)*) => { println!("{} [WARN]   {}", _timestamp(), format!($($arg)*)) };
+}
+
+const OBSERVE_PIN: &str = "/sys/fs/bpf/pandemonium/task_class_observe";
+const INIT_PIN: &str = "/sys/fs/bpf/pandemonium/task_class_init";
+
+pub const MIN_OBSERVATIONS: u32 = 3;
+pub const MIN_CONFIDENCE: f64 = 0.6;
+pub const MAX_PROFILES: usize = 512;
+pub const STALE_TICKS: u64 = 60;
+
+const PROCDB_MAGIC: &[u8; 4] = b"PDDB";
+const PROCDB_VERSION: u32 = 2;
+const PROCDB_PATH: &str = ".cache/pandemonium/procdb.bin";
+const ENTRY_SIZE: usize = 64;
+const V1_ENTRY_SIZE: usize = 40;
+
+// MATCHES struct task_class_entry IN intf.h
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct TaskClassEntry {
+    pub tier: u8,
+    pub _pad: [u8; 7],
+    pub avg_runtime: u64,
+    pub runtime_dev: u64,
+    pub wakeup_freq: u64,
+    pub csw_rate: u64,
+}
+
+// COMPILE-TIME ABI SAFETY: MUST MATCH struct task_class_entry IN intf.h
+const _: () = assert!(std::mem::size_of::<TaskClassEntry>() == 40);
+
+#[derive(Default)]
+pub struct TaskProfile {
+    pub tier_votes: [u32; 3], // COUNT PER TIER: [BATCH, INTERACTIVE, LAT_CRITICAL]
+    pub avg_runtime_ns: u64,
+    pub runtime_dev_ns: u64,
+    pub wakeup_freq: u64,
+    pub csw_rate: u64,
+    pub observations: u32,
+    pub last_seen_tick: u64,
+}
+
+impl TaskProfile {
+    pub fn confidence(&self) -> f64 {
+        let total: u32 = self.tier_votes.iter().sum();
+        if total == 0 {
+            return 0.0;
+        }
+        let max_count = *self.tier_votes.iter().max().unwrap_or(&0);
+        max_count as f64 / total as f64
+    }
+
+    pub fn dominant_tier(&self) -> u8 {
+        self.tier_votes
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, c)| *c)
+            .map(|(i, _)| i as u8)
+            .unwrap_or(1) // INTERACTIVE DEFAULT
+    }
+
+    // MULTI-DIMENSIONAL CONFIDENCE: TIER AGREEMENT * BEHAVIORAL STABILITY
+    // HIGH RUNTIME VARIANCE REDUCES CONFIDENCE EVEN WITH STRONG TIER AGREEMENT
+    pub fn behavioral_confidence(&self) -> f64 {
+        if self.observations < MIN_OBSERVATIONS {
+            return 0.0;
+        }
+        let tier_conf = self.confidence();
+        let dev_ratio = if self.avg_runtime_ns > 0 {
+            self.runtime_dev_ns as f64 / self.avg_runtime_ns as f64
+        } else {
+            1.0
+        };
+        let stability = (1.0 - dev_ratio.min(1.0)).max(0.0);
+        tier_conf * (0.5 + 0.5 * stability)
+    }
+}
+
+pub struct ProcessDb {
+    pub observe: Option<libbpf_rs::MapHandle>,
+    pub init: Option<libbpf_rs::MapHandle>,
+    pub profiles: HashMap<[u8; 16], TaskProfile>,
+    pub tick: u64,
+}
+
+impl ProcessDb {
+    pub fn default_path() -> PathBuf {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".into());
+        PathBuf::from(home).join(PROCDB_PATH)
+    }
+
+    pub fn new() -> Result<Self> {
+        let observe = libbpf_rs::MapHandle::from_pinned_path(OBSERVE_PIN)?;
+        let init = libbpf_rs::MapHandle::from_pinned_path(INIT_PIN)?;
+
+        let db_path = Self::default_path();
+        let profiles = match Self::load_from_disk(&db_path) {
+            Ok(p) => {
+                if !p.is_empty() {
+                    procdb_info!(
+                        "PROCDB: LOADED {} PROFILES FROM {}",
+                        p.len(),
+                        db_path.display()
+                    );
+                }
+                p
+            }
+            Err(e) => {
+                procdb_warn!("PROCDB LOAD: {}", e);
+                HashMap::new()
+            }
+        };
+
+        let db = Self {
+            observe: Some(observe),
+            init: Some(init),
+            profiles,
+            tick: 0,
+        };
+
+        db.flush_predictions();
+        Ok(db)
+    }
+
+    // DRAIN OBSERVATIONS FROM BPF LRU MAP, MERGE INTO PROFILES
+    pub fn ingest(&mut self) {
+        let observe = match &self.observe {
+            Some(m) => m,
+            None => return,
+        };
+        let keys: Vec<Vec<u8>> = observe.keys().collect();
+        for key in &keys {
+            if let Ok(Some(val)) = observe.lookup(key, libbpf_rs::MapFlags::ANY) {
+                if val.len() >= std::mem::size_of::<TaskClassEntry>() {
+                    let entry: TaskClassEntry =
+                        unsafe { std::ptr::read_unaligned(val.as_ptr() as *const TaskClassEntry) };
+
+                    let mut comm = [0u8; 16];
+                    let copy_len = key.len().min(16);
+                    comm[..copy_len].copy_from_slice(&key[..copy_len]);
+
+                    let profile = self.profiles.entry(comm).or_insert(TaskProfile {
+                        ..Default::default()
+                    });
+
+                    let tier_idx = (entry.tier as usize).min(2);
+                    profile.tier_votes[tier_idx] += 1;
+                    if profile.observations == 0 {
+                        profile.avg_runtime_ns = entry.avg_runtime;
+                        profile.runtime_dev_ns = entry.runtime_dev;
+                        profile.wakeup_freq = entry.wakeup_freq;
+                        profile.csw_rate = entry.csw_rate;
+                    } else {
+                        // EWMA: 7/8 OLD + 1/8 NEW
+                        profile.avg_runtime_ns =
+                            (profile.avg_runtime_ns * 7 + entry.avg_runtime) / 8;
+                        profile.runtime_dev_ns =
+                            (profile.runtime_dev_ns * 7 + entry.runtime_dev) / 8;
+                        profile.wakeup_freq = (profile.wakeup_freq * 7 + entry.wakeup_freq) / 8;
+                        profile.csw_rate = (profile.csw_rate * 7 + entry.csw_rate) / 8;
+                    }
+                    profile.observations += 1;
+                    profile.last_seen_tick = self.tick;
+                }
+            }
+            let _ = observe.delete(key);
+        }
+    }
+
+    // WRITE CONFIDENT PREDICTIONS TO BPF INIT MAP
+    pub fn flush_predictions(&self) {
+        let init = match &self.init {
+            Some(m) => m,
+            None => return,
+        };
+        for (comm, profile) in &self.profiles {
+            if profile.behavioral_confidence() >= MIN_CONFIDENCE {
+                let entry = TaskClassEntry {
+                    tier: profile.dominant_tier(),
+                    _pad: [0; 7],
+                    avg_runtime: profile.avg_runtime_ns,
+                    runtime_dev: profile.runtime_dev_ns,
+                    wakeup_freq: profile.wakeup_freq,
+                    csw_rate: profile.csw_rate,
+                };
+
+                let val = unsafe {
+                    std::slice::from_raw_parts(
+                        &entry as *const TaskClassEntry as *const u8,
+                        std::mem::size_of::<TaskClassEntry>(),
+                    )
+                };
+                let _ = init.update(comm.as_slice(), val, libbpf_rs::MapFlags::ANY);
+            }
+        }
+    }
+
+    // EVICT STALE PROFILES, CAP TOTAL ENTRIES
+    pub fn tick(&mut self) {
+        self.tick += 1;
+
+        // REMOVE PROFILES NOT SEEN IN 60 SECONDS
+        let tick = self.tick;
+        let stale: Vec<[u8; 16]> = self
+            .profiles
+            .iter()
+            .filter(|(_, p)| tick - p.last_seen_tick > STALE_TICKS)
+            .map(|(k, _)| *k)
+            .collect();
+        for comm in &stale {
+            self.profiles.remove(comm);
+            if let Some(ref init) = self.init {
+                let _ = init.delete(comm.as_slice());
+            }
+        }
+
+        // CAP ENTRIES: EVICT OLDEST FIRST, TIE-BREAK BY OBSERVATIONS THEN COMM
+        if self.profiles.len() > MAX_PROFILES {
+            let mut entries: Vec<([u8; 16], u64, u32)> = self
+                .profiles
+                .iter()
+                .map(|(k, v)| (*k, v.last_seen_tick, v.observations))
+                .collect();
+            entries.sort_by(|a, b| (a.1, a.2, a.0).cmp(&(b.1, b.2, b.0)));
+            let to_remove = self.profiles.len() - MAX_PROFILES;
+            for (k, _, _) in entries.into_iter().take(to_remove) {
+                self.profiles.remove(&k);
+                if let Some(ref init) = self.init {
+                    let _ = init.delete(k.as_slice());
+                }
+            }
+        }
+    }
+
+    // (TOTAL PROFILES, CONFIDENT PROFILES)
+    pub fn summary(&self) -> (usize, usize) {
+        let total = self.profiles.len();
+        let confident = self
+            .profiles
+            .values()
+            .filter(|p| p.behavioral_confidence() >= MIN_CONFIDENCE)
+            .count();
+        (total, confident)
+    }
+
+    // SERIALIZE CONFIDENT PROFILES TO DISK (ATOMIC WRITE)
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let entries: Vec<_> = self
+            .profiles
+            .iter()
+            .filter(|(_, p)| p.behavioral_confidence() >= MIN_CONFIDENCE)
+            .collect();
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let tmp_path = path.with_extension("bin.tmp");
+        let mut f = std::fs::File::create(&tmp_path)?;
+
+        // HEADER: MAGIC + VERSION + COUNT
+        f.write_all(PROCDB_MAGIC)?;
+        f.write_all(&PROCDB_VERSION.to_le_bytes())?;
+        f.write_all(&(entries.len() as u32).to_le_bytes())?;
+
+        // ENTRIES: 64 BYTES EACH (V2)
+        for (comm, profile) in &entries {
+            let tier = profile.dominant_tier();
+            let total_votes: u32 = profile.tier_votes.iter().sum();
+
+            f.write_all(comm.as_slice())?; // 16 bytes
+            f.write_all(&[tier])?; // 1 byte
+            f.write_all(&[0u8; 7])?; // 7 bytes pad
+            f.write_all(&profile.avg_runtime_ns.to_le_bytes())?; // 8 bytes
+            f.write_all(&profile.runtime_dev_ns.to_le_bytes())?; // 8 bytes
+            f.write_all(&profile.wakeup_freq.to_le_bytes())?; // 8 bytes
+            f.write_all(&profile.csw_rate.to_le_bytes())?; // 8 bytes
+            f.write_all(&profile.observations.to_le_bytes())?; // 4 bytes
+            f.write_all(&total_votes.to_le_bytes())?; // 4 bytes
+        }
+
+        drop(f);
+        std::fs::rename(&tmp_path, path)?;
+        Ok(())
+    }
+
+    // DESERIALIZE PROFILES FROM DISK (RETURNS EMPTY ON CORRUPTION)
+    pub fn load_from_disk(path: &Path) -> Result<HashMap<[u8; 16], TaskProfile>> {
+        let data = match std::fs::read(path) {
+            Ok(d) => d,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(HashMap::new());
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+        if data.len() < 12 {
+            procdb_warn!("PROCDB: FILE TOO SHORT ({} BYTES)", data.len());
+            return Ok(HashMap::new());
+        }
+
+        // VALIDATE MAGIC
+        if &data[0..4] != PROCDB_MAGIC {
+            procdb_warn!("PROCDB: BAD MAGIC {:?}", &data[0..4]);
+            return Ok(HashMap::new());
+        }
+
+        // VALIDATE VERSION
+        let version = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
+        let entry_size = match version {
+            1 => V1_ENTRY_SIZE,
+            2 => ENTRY_SIZE,
+            _ => {
+                procdb_warn!("PROCDB: UNKNOWN VERSION {}", version);
+                return Ok(HashMap::new());
+            }
+        };
+
+        // VALIDATE COUNT VS FILE SIZE
+        let count = u32::from_le_bytes([data[8], data[9], data[10], data[11]]) as usize;
+        let expected_size = 12 + count * entry_size;
+        if data.len() < expected_size {
+            procdb_warn!(
+                "PROCDB: TRUNCATED (EXPECTED {} BYTES, GOT {})",
+                expected_size,
+                data.len()
+            );
+            return Ok(HashMap::new());
+        }
+
+        let mut profiles = HashMap::new();
+        let mut offset = 12;
+
+        for _ in 0..count {
+            let mut comm = [0u8; 16];
+            comm.copy_from_slice(&data[offset..offset + 16]);
+            offset += 16;
+
+            let tier = data[offset] as usize;
+            offset += 8; // tier + 7 pad
+
+            let avg_runtime = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+            offset += 8;
+
+            // V2: READ EXTRA BEHAVIORAL FIELDS
+            let (runtime_dev, wakeup_freq, csw_rate) = if version >= 2 {
+                let rd = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+                offset += 8;
+                let wf = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+                offset += 8;
+                let cr = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+                offset += 8;
+                (rd, wf, cr)
+            } else {
+                (0, 0, 0)
+            };
+
+            let observations = u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap());
+            offset += 4;
+
+            let total_votes = u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap());
+            offset += 4;
+
+            // RECONSTRUCT: ALL VOTES GO TO DOMINANT TIER (CONFIDENCE = 1.0)
+            let mut tier_votes = [0u32; 3];
+            tier_votes[tier.min(2)] = total_votes;
+
+            profiles.insert(
+                comm,
+                TaskProfile {
+                    tier_votes,
+                    avg_runtime_ns: avg_runtime,
+                    runtime_dev_ns: runtime_dev,
+                    wakeup_freq,
+                    csw_rate,
+                    observations,
+                    last_seen_tick: 0,
+                },
+            );
+        }
+
+        Ok(profiles)
+    }
+}

--- a/scheds/rust/scx_pandemonium/src/scheduler.rs
+++ b/scheds/rust/scx_pandemonium/src/scheduler.rs
@@ -1,0 +1,377 @@
+// PANDEMONIUM SCHEDULER
+// WRAPS THE BPF SKELETON: OPEN, CONFIGURE, LOAD, ATTACH, SHUTDOWN
+// MONITORING AND ADAPTIVE CONTROL LIVE IN adaptive.rs
+
+use std::mem::MaybeUninit;
+
+use anyhow::Result;
+use libbpf_rs::skel::{OpenSkel, SkelBuilder};
+use libbpf_rs::MapCore;
+
+use crate::bpf_skel::*;
+use crate::tuning::TuningKnobs;
+use scx_pandemonium::event::EventLog;
+
+// SCX EXIT CODES (FROM KERNEL)
+const SCX_EXIT_NONE: i32 = 0;
+const SCX_ECODE_RST_MASK: u64 = 1 << 16;
+
+// SCX DSQ FLAGS (STABLE KERNEL ABI -- sched_ext/sched.h)
+const SCX_DSQ_FLAG_BUILTIN: u64 = 1u64 << 63;
+const SCX_DSQ_FLAG_LOCAL_ON: u64 = 1u64 << 62;
+
+// MATCHES struct pandemonium_stats IN BPF (intf.h)
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+pub struct PandemoniumStats {
+    pub nr_dispatches: u64,
+    pub nr_idle_hits: u64,
+    pub nr_shared: u64,
+    pub nr_preempt: u64,
+    pub wake_lat_sum: u64,
+    pub wake_lat_max: u64,
+    pub wake_lat_samples: u64,
+    pub nr_keep_running: u64,
+    pub nr_hard_kicks: u64,
+    pub nr_soft_kicks: u64,
+    pub nr_enq_wakeup: u64,
+    pub nr_enq_requeue: u64,
+    pub wake_lat_idle_sum: u64,
+    pub wake_lat_idle_cnt: u64,
+    pub wake_lat_kick_sum: u64,
+    pub wake_lat_kick_cnt: u64,
+    pub nr_procdb_hits: u64,
+    pub nr_l2_hit_batch: u64,
+    pub nr_l2_miss_batch: u64,
+    pub nr_l2_hit_interactive: u64,
+    pub nr_l2_miss_interactive: u64,
+    pub nr_l2_hit_lat_crit: u64,
+    pub nr_l2_miss_lat_crit: u64,
+    pub nr_reenqueue: u64,
+    pub batch_sojourn_ns: u64,
+    pub burst_mode_active: u64,
+    pub longrun_mode_active: u64,
+    pub nr_overflow_rescue: u64,
+}
+
+// COMPILE-TIME ABI SAFETY: MUST MATCH STRUCT LAYOUTS IN intf.h
+const _: () = assert!(std::mem::size_of::<PandemoniumStats>() == 224);
+const _: () = assert!(std::mem::size_of::<TuningKnobs>() == 80);
+
+// TuningKnobs lives in tuning.rs (zero BPF dependencies, testable offline)
+
+const KNOBS_PIN: &str = "/sys/fs/bpf/pandemonium/tuning_knobs";
+
+pub struct Scheduler<'a> {
+    skel: MainSkel<'a>,
+    _link: libbpf_rs::Link,
+    pub log: EventLog,
+}
+
+impl<'a> Scheduler<'a> {
+    pub fn init(
+        open_object: &'a mut MaybeUninit<libbpf_rs::OpenObject>,
+        nr_cpus_override: Option<u64>,
+    ) -> Result<Self> {
+        // OPEN
+        let builder = MainSkelBuilder::default();
+        let mut open_skel = builder.open(open_object)?;
+
+        // CONFIGURE RODATA (BEFORE LOAD)
+        let rodata = open_skel.maps.rodata_data.as_mut().unwrap();
+
+        let possible = libbpf_rs::num_possible_cpus()? as u64;
+        rodata.nr_cpu_ids = nr_cpus_override.unwrap_or(possible);
+
+        // POPULATE SCX ENUM VALUES
+        rodata.__SCX_DSQ_FLAG_BUILTIN = SCX_DSQ_FLAG_BUILTIN;
+        rodata.__SCX_DSQ_FLAG_LOCAL_ON = SCX_DSQ_FLAG_LOCAL_ON;
+        rodata.__SCX_DSQ_INVALID = SCX_DSQ_FLAG_BUILTIN;
+        rodata.__SCX_DSQ_GLOBAL = SCX_DSQ_FLAG_BUILTIN | 1;
+        rodata.__SCX_DSQ_LOCAL = SCX_DSQ_FLAG_BUILTIN | SCX_DSQ_FLAG_LOCAL_ON;
+        rodata.__SCX_DSQ_LOCAL_ON = SCX_DSQ_FLAG_BUILTIN | SCX_DSQ_FLAG_LOCAL_ON | 1;
+        rodata.__SCX_DSQ_LOCAL_CPU_MASK = 0xFFFFFFFF;
+
+        // POPULATE SCX_KICK_* ENUM VALUES
+        rodata.__SCX_KICK_IDLE = 1;
+        rodata.__SCX_KICK_PREEMPT = 2;
+        rodata.__SCX_KICK_WAIT = 4;
+
+        // LOAD (VALIDATES BPF WITH KERNEL)
+        let mut skel = open_skel.load()?;
+
+        // ATTACH STRUCT_OPS
+        let link = skel.maps.pandemonium_ops.attach_struct_ops()?;
+
+        // PIN MAPS FOR USERSPACE ACCESS (NON-FATAL: bpffs may not be mounted)
+        let pin_dir = "/sys/fs/bpf/pandemonium";
+        let bpffs_ok = std::fs::create_dir_all(pin_dir).is_ok();
+        if bpffs_ok {
+            std::fs::remove_file(KNOBS_PIN).ok();
+            skel.maps.tuning_knobs_map.pin(KNOBS_PIN).ok();
+
+            let cache_pin = "/sys/fs/bpf/pandemonium/cache_domain";
+            std::fs::remove_file(cache_pin).ok();
+            skel.maps.cache_domain.pin(cache_pin).ok();
+
+            let observe_pin = "/sys/fs/bpf/pandemonium/task_class_observe";
+            std::fs::remove_file(observe_pin).ok();
+            skel.maps.task_class_observe.pin(observe_pin).ok();
+
+            let init_pin = "/sys/fs/bpf/pandemonium/task_class_init";
+            std::fs::remove_file(init_pin).ok();
+            skel.maps.task_class_init.pin(init_pin).ok();
+
+            let compositor_pin = "/sys/fs/bpf/pandemonium/compositor_map";
+            std::fs::remove_file(compositor_pin).ok();
+            skel.maps.compositor_map.pin(compositor_pin).ok();
+        } else {
+            log_warn!("BPFFS NOT AVAILABLE: map pinning skipped (scheduler still functional)");
+        }
+
+        Ok(Self {
+            skel,
+            _link: link,
+            log: EventLog::new(),
+        })
+    }
+
+    // SUM PER-CPU STATS INTO A SINGLE TOTAL
+    pub fn read_stats(&self) -> PandemoniumStats {
+        let key = 0u32.to_ne_bytes();
+        let mut total = PandemoniumStats::default();
+
+        let percpu_vals = match self
+            .skel
+            .maps
+            .stats_map
+            .lookup_percpu(&key, libbpf_rs::MapFlags::ANY)
+        {
+            Ok(Some(v)) => v,
+            _ => return total,
+        };
+
+        for cpu_val in &percpu_vals {
+            if cpu_val.len() >= std::mem::size_of::<PandemoniumStats>() {
+                let stats: PandemoniumStats = unsafe {
+                    std::ptr::read_unaligned(cpu_val.as_ptr() as *const PandemoniumStats)
+                };
+                total.nr_dispatches += stats.nr_dispatches;
+                total.nr_idle_hits += stats.nr_idle_hits;
+                total.nr_shared += stats.nr_shared;
+                total.nr_preempt += stats.nr_preempt;
+                total.wake_lat_sum += stats.wake_lat_sum;
+                if stats.wake_lat_max > total.wake_lat_max {
+                    total.wake_lat_max = stats.wake_lat_max;
+                }
+                total.wake_lat_samples += stats.wake_lat_samples;
+                total.nr_keep_running += stats.nr_keep_running;
+                total.nr_hard_kicks += stats.nr_hard_kicks;
+                total.nr_soft_kicks += stats.nr_soft_kicks;
+                total.nr_enq_wakeup += stats.nr_enq_wakeup;
+                total.nr_enq_requeue += stats.nr_enq_requeue;
+                total.wake_lat_idle_sum += stats.wake_lat_idle_sum;
+                total.wake_lat_idle_cnt += stats.wake_lat_idle_cnt;
+                total.wake_lat_kick_sum += stats.wake_lat_kick_sum;
+                total.wake_lat_kick_cnt += stats.wake_lat_kick_cnt;
+                total.nr_procdb_hits += stats.nr_procdb_hits;
+                total.nr_l2_hit_batch += stats.nr_l2_hit_batch;
+                total.nr_l2_miss_batch += stats.nr_l2_miss_batch;
+                total.nr_l2_hit_interactive += stats.nr_l2_hit_interactive;
+                total.nr_l2_miss_interactive += stats.nr_l2_miss_interactive;
+                total.nr_l2_hit_lat_crit += stats.nr_l2_hit_lat_crit;
+                total.nr_l2_miss_lat_crit += stats.nr_l2_miss_lat_crit;
+                total.nr_reenqueue += stats.nr_reenqueue;
+                if stats.batch_sojourn_ns > total.batch_sojourn_ns {
+                    total.batch_sojourn_ns = stats.batch_sojourn_ns;
+                }
+                total.burst_mode_active += stats.burst_mode_active;
+                if stats.longrun_mode_active > total.longrun_mode_active {
+                    total.longrun_mode_active = stats.longrun_mode_active;
+                }
+            }
+        }
+
+        total
+    }
+
+    // WRITE TUNING KNOBS TO BPF MAP -- CALLED BY MONITOR THREAD
+    pub fn write_tuning_knobs(&self, knobs: &TuningKnobs) -> Result<()> {
+        let key = 0u32.to_ne_bytes();
+        let value = unsafe {
+            std::slice::from_raw_parts(
+                knobs as *const TuningKnobs as *const u8,
+                std::mem::size_of::<TuningKnobs>(),
+            )
+        };
+        self.skel
+            .maps
+            .tuning_knobs_map
+            .update(&key, value, libbpf_rs::MapFlags::ANY)?;
+        Ok(())
+    }
+
+    // READ CURRENT TUNING KNOBS FROM BPF MAP
+    pub fn read_tuning_knobs(&self) -> TuningKnobs {
+        let key = 0u32.to_ne_bytes();
+        match self
+            .skel
+            .maps
+            .tuning_knobs_map
+            .lookup(&key, libbpf_rs::MapFlags::ANY)
+        {
+            Ok(Some(v)) if v.len() >= std::mem::size_of::<TuningKnobs>() => unsafe {
+                std::ptr::read_unaligned(v.as_ptr() as *const TuningKnobs)
+            },
+            _ => TuningKnobs::default(),
+        }
+    }
+
+    // READ WAKEUP LATENCY HISTOGRAM: 3 TIERS x 12 BUCKETS
+    // SUMS ACROSS ALL CPUs (PERCPU_ARRAY). RETURNS CUMULATIVE COUNTS.
+    pub fn read_wake_lat_hist(&self) -> [[u64; 12]; 3] {
+        let mut result = [[0u64; 12]; 3];
+        for key_idx in 0u32..36 {
+            let key = key_idx.to_ne_bytes();
+            if let Ok(Some(percpu_vals)) = self
+                .skel
+                .maps
+                .wake_lat_hist
+                .lookup_percpu(&key, libbpf_rs::MapFlags::ANY)
+            {
+                let tier = (key_idx / 12) as usize;
+                let bucket = (key_idx % 12) as usize;
+                for cpu_val in &percpu_vals {
+                    if cpu_val.len() >= std::mem::size_of::<u64>() {
+                        let val: u64 =
+                            unsafe { std::ptr::read_unaligned(cpu_val.as_ptr() as *const u64) };
+                        result[tier][bucket] += val;
+                    }
+                }
+            }
+        }
+        result
+    }
+
+    // READ SLEEP DURATION HISTOGRAM: 4 BUCKETS
+    // SUMS ACROSS ALL CPUs (PERCPU_ARRAY). RETURNS CUMULATIVE COUNTS.
+    pub fn read_sleep_hist(&self) -> [u64; 4] {
+        let mut result = [0u64; 4];
+        for key_idx in 0u32..4 {
+            let key = key_idx.to_ne_bytes();
+            if let Ok(Some(percpu_vals)) = self
+                .skel
+                .maps
+                .sleep_hist
+                .lookup_percpu(&key, libbpf_rs::MapFlags::ANY)
+            {
+                for cpu_val in &percpu_vals {
+                    if cpu_val.len() >= std::mem::size_of::<u64>() {
+                        let val: u64 =
+                            unsafe { std::ptr::read_unaligned(cpu_val.as_ptr() as *const u64) };
+                        result[key_idx as usize] += val;
+                    }
+                }
+            }
+        }
+        result
+    }
+
+    // POPULATE CACHE DOMAIN MAP FROM TOPOLOGY DATA AT STARTUP
+    pub fn write_cache_domain(&self, cpu: u32, l2_group: u32) -> Result<()> {
+        let key = cpu.to_ne_bytes();
+        let val = l2_group.to_ne_bytes();
+        self.skel
+            .maps
+            .cache_domain
+            .update(&key, &val, libbpf_rs::MapFlags::ANY)?;
+        Ok(())
+    }
+
+    // POPULATE L2 SIBLINGS MAP ENTRY
+    pub fn write_l2_sibling(&self, group_id: u32, slot: u32, cpu: u32) -> Result<()> {
+        let key = (group_id * 8 + slot).to_ne_bytes();
+        let val = cpu.to_ne_bytes();
+        self.skel
+            .maps
+            .l2_siblings
+            .update(&key, &val, libbpf_rs::MapFlags::ANY)?;
+        Ok(())
+    }
+
+    // POPULATE COMPOSITOR MAP ENTRY
+    pub fn write_compositor(&self, name: &str) -> Result<()> {
+        let mut key = [0u8; 16];
+        let bytes = name.as_bytes();
+        let len = bytes.len().min(15);
+        key[..len].copy_from_slice(&bytes[..len]);
+        let val = [1u8];
+        self.skel
+            .maps
+            .compositor_map
+            .update(&key, &val, libbpf_rs::MapFlags::ANY)?;
+        Ok(())
+    }
+
+    // READ UEI EXIT INFO. RETURNS (should_restart).
+    pub fn read_exit_info(&self) -> bool {
+        let data = self.skel.maps.data_data.as_ref().unwrap();
+        let kind = data.uei.kind;
+        let exit_code = data.uei.exit_code;
+
+        if kind != SCX_EXIT_NONE {
+            let reason_bytes: &[u8] =
+                unsafe { std::slice::from_raw_parts(data.uei.reason.as_ptr() as *const u8, 128) };
+            let msg_bytes: &[u8] =
+                unsafe { std::slice::from_raw_parts(data.uei.msg.as_ptr() as *const u8, 1024) };
+
+            let reason = std::str::from_utf8(reason_bytes)
+                .unwrap_or("unknown")
+                .trim_end_matches('\0');
+            let msg = std::str::from_utf8(msg_bytes)
+                .unwrap_or("")
+                .trim_end_matches('\0');
+
+            log_warn!("BPF exit: kind={} code={}", kind, exit_code);
+            if !reason.is_empty() {
+                log_warn!("BPF exit reason: {}", reason);
+            }
+            if !msg.is_empty() {
+                log_warn!("BPF exit msg: {}", msg);
+            }
+        }
+
+        (exit_code as u64 & SCX_ECODE_RST_MASK) != 0
+    }
+
+    pub fn exited(&self) -> bool {
+        self.skel.maps.data_data.as_ref().unwrap().uei.kind != SCX_EXIT_NONE
+    }
+}
+
+impl Drop for Scheduler<'_> {
+    fn drop(&mut self) {
+        let _ = self.skel.maps.tuning_knobs_map.unpin(KNOBS_PIN);
+        let _ = self
+            .skel
+            .maps
+            .cache_domain
+            .unpin("/sys/fs/bpf/pandemonium/cache_domain");
+        let _ = self
+            .skel
+            .maps
+            .task_class_observe
+            .unpin("/sys/fs/bpf/pandemonium/task_class_observe");
+        let _ = self
+            .skel
+            .maps
+            .task_class_init
+            .unpin("/sys/fs/bpf/pandemonium/task_class_init");
+        let _ = self
+            .skel
+            .maps
+            .compositor_map
+            .unpin("/sys/fs/bpf/pandemonium/compositor_map");
+        let _ = std::fs::remove_dir("/sys/fs/bpf/pandemonium");
+    }
+}

--- a/scheds/rust/scx_pandemonium/src/topology.rs
+++ b/scheds/rust/scx_pandemonium/src/topology.rs
@@ -1,0 +1,184 @@
+// PANDEMONIUM CPU CACHE TOPOLOGY
+// PARSES SYSFS AT STARTUP, POPULATES BPF MAP FOR CACHE-AWARE DISPATCH
+//
+// BPF dispatch() USES THE CACHE DOMAIN MAP TO PREFER TASKS THAT LAST
+// RAN ON THE SAME CPU OR AN L2 SIBLING. THIS PRESERVES CACHE WARMTH
+// AND REDUCES THE THROUGHPUT GAP CAUSED BY BLIND NODE-DSQ CONSUMPTION.
+
+use anyhow::Result;
+
+use crate::scheduler::Scheduler;
+
+pub struct CpuTopology {
+    pub nr_cpus: usize,
+    pub l2_domain: Vec<u32>,      // l2_domain[cpu] = group_id
+    pub l2_groups: Vec<Vec<u32>>, // l2_groups[group_id] = [cpu, ...]
+}
+
+impl CpuTopology {
+    pub fn detect(nr_cpus: usize) -> Result<Self> {
+        let mut l2_domain = vec![0u32; nr_cpus];
+        let mut seen_groups: Vec<Vec<u32>> = Vec::new();
+
+        for cpu in 0..nr_cpus {
+            let path = format!(
+                "/sys/devices/system/cpu/cpu{}/cache/index2/shared_cpu_list",
+                cpu
+            );
+            let content = match std::fs::read_to_string(&path) {
+                Ok(s) => s,
+                Err(_) => {
+                    // CPU MIGHT BE OFFLINE OR HAVE NO L2 INFO -- ASSIGN OWN GROUP
+                    l2_domain[cpu] = cpu as u32;
+                    continue;
+                }
+            };
+
+            let members = parse_cpu_list(content.trim());
+
+            // CHECK IF THIS GROUP ALREADY EXISTS
+            let group_id = match seen_groups.iter().position(|g| *g == members) {
+                Some(id) => id as u32,
+                None => {
+                    let id = seen_groups.len() as u32;
+                    seen_groups.push(members.clone());
+                    id
+                }
+            };
+
+            l2_domain[cpu] = group_id;
+        }
+
+        Ok(Self {
+            nr_cpus,
+            l2_domain,
+            l2_groups: seen_groups,
+        })
+    }
+
+    // WRITE L2 DOMAIN MAP TO BPF ARRAY VIA SCHEDULER
+    pub fn populate_bpf_map(&self, sched: &Scheduler) -> Result<()> {
+        for cpu in 0..self.nr_cpus {
+            sched.write_cache_domain(cpu as u32, self.l2_domain[cpu])?;
+        }
+        Ok(())
+    }
+
+    // WRITE L2 SIBLINGS FLAT ARRAY TO BPF MAP
+    // l2_siblings[group_id * 8 + slot] = cpu_id, SENTINEL u32::MAX MARKS END
+    pub fn populate_l2_siblings_map(&self, sched: &Scheduler) -> Result<()> {
+        const MAX_L2_SIBLINGS: usize = 8;
+        for (gid, members) in self.l2_groups.iter().enumerate() {
+            for (slot, &cpu) in members.iter().enumerate().take(MAX_L2_SIBLINGS) {
+                sched.write_l2_sibling(gid as u32, slot as u32, cpu)?;
+            }
+            if members.len() < MAX_L2_SIBLINGS {
+                sched.write_l2_sibling(gid as u32, members.len() as u32, u32::MAX)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn log_summary(&self) {
+        for (gid, members) in self.l2_groups.iter().enumerate() {
+            let cpus: Vec<String> = members.iter().map(|c| c.to_string()).collect();
+            log_info!("L2 GROUP {}: [{}]", gid, cpus.join(","));
+        }
+        log_info!(
+            "L2 GROUPS: {} across {} CPUs",
+            self.l2_groups.len(),
+            self.nr_cpus
+        );
+    }
+}
+
+// PARSE KERNEL CPU LIST FORMAT: "0,6" or "0-2,6-8" or "3"
+fn parse_cpu_list(s: &str) -> Vec<u32> {
+    let mut result = Vec::new();
+    for part in s.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        if let Some((start, end)) = part.split_once('-') {
+            if let (Ok(s), Ok(e)) = (start.parse::<u32>(), end.parse::<u32>()) {
+                for cpu in s..=e {
+                    result.push(cpu);
+                }
+            }
+        } else if let Ok(cpu) = part.parse::<u32>() {
+            result.push(cpu);
+        }
+    }
+    result.sort();
+    result.dedup();
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single() {
+        assert_eq!(parse_cpu_list("3"), vec![3]);
+    }
+
+    #[test]
+    fn parse_comma() {
+        assert_eq!(parse_cpu_list("0,6"), vec![0, 6]);
+    }
+
+    #[test]
+    fn parse_range() {
+        assert_eq!(parse_cpu_list("0-2,6-8"), vec![0, 1, 2, 6, 7, 8]);
+    }
+
+    #[test]
+    fn parse_mixed() {
+        assert_eq!(parse_cpu_list("0-2,5,9-11"), vec![0, 1, 2, 5, 9, 10, 11]);
+    }
+
+    #[test]
+    fn parse_empty() {
+        assert_eq!(parse_cpu_list(""), Vec::<u32>::new());
+    }
+
+    #[test]
+    fn detect_topology() {
+        // RUNS ON ANY MACHINE -- VERIFIES SANE OUTPUT
+        let nr_cpus = std::fs::read_dir("/sys/devices/system/cpu")
+            .unwrap()
+            .filter(|e| {
+                e.as_ref()
+                    .map(|e| {
+                        e.file_name().to_string_lossy().starts_with("cpu")
+                            && e.file_name().to_string_lossy()[3..].parse::<u32>().is_ok()
+                    })
+                    .unwrap_or(false)
+            })
+            .count();
+
+        if nr_cpus == 0 {
+            return; // NO CPUS VISIBLE (CONTAINER?)
+        }
+
+        let topo = CpuTopology::detect(nr_cpus).unwrap();
+        assert_eq!(topo.nr_cpus, nr_cpus);
+        assert_eq!(topo.l2_domain.len(), nr_cpus);
+
+        // EVERY CPU MUST HAVE A VALID GROUP ID
+        let max_group = topo.l2_groups.len() as u32;
+        for cpu in 0..nr_cpus {
+            assert!(
+                topo.l2_domain[cpu] < max_group || topo.l2_domain[cpu] == cpu as u32,
+                "CPU {} has invalid l2 group {}",
+                cpu,
+                topo.l2_domain[cpu]
+            );
+        }
+
+        // AT LEAST ONE GROUP MUST EXIST
+        assert!(!topo.l2_groups.is_empty());
+    }
+}

--- a/scheds/rust/scx_pandemonium/src/tuning.rs
+++ b/scheds/rust/scx_pandemonium/src/tuning.rs
@@ -1,0 +1,310 @@
+// PANDEMONIUM TUNING TYPES
+// PURE-RUST MODULE: ZERO BPF DEPENDENCIES
+// SHARED BETWEEN BINARY CRATE (scheduler.rs, adaptive.rs) AND LIB CRATE (tests)
+
+// REGIME THRESHOLDS (SCHMITT TRIGGER)
+// DIRECTIONAL HYSTERESIS PREVENTS OSCILLATION AT REGIME BOUNDARIES.
+// WIDE DEAD ZONES: MUST CLEARLY ENTER A REGIME AND CLEARLY LEAVE IT.
+
+pub const HEAVY_ENTER_PCT: u64 = 10; // ENTER HEAVY: IDLE < 10%
+pub const HEAVY_EXIT_PCT: u64 = 25; // LEAVE HEAVY: IDLE > 25%
+pub const LIGHT_ENTER_PCT: u64 = 50; // ENTER LIGHT: IDLE > 50%
+pub const LIGHT_EXIT_PCT: u64 = 30; // LEAVE LIGHT: IDLE < 30%
+
+// REGIME PROFILES
+// PREEMPT_THRESH CONTROLS WHEN TICK PREEMPTS BATCH TASKS (IF INTERACTIVE WAITING).
+// BATCH_SLICE_NS CONTROLS MAX UNINTERRUPTED BATCH RUN WHEN NO INTERACTIVE WAITING.
+// CPU_BOUND_THRESH_NS CONTROLS DEMOTION THRESHOLD PER REGIME (FEATURE 5).
+
+const LIGHT_SLICE_NS: u64 = 2_000_000; // 2MS
+const LIGHT_PREEMPT_NS: u64 = 1_000_000; // 1MS: AGGRESSIVE
+const LIGHT_LAG_SCALE: u64 = 6;
+const LIGHT_BATCH_NS: u64 = 20_000_000; // 20MS: NO CONTENTION, LET BATCH RIP
+
+const MIXED_SLICE_NS: u64 = 1_000_000; // 1MS: TIGHT INTERACTIVE CONTROL
+const MIXED_PREEMPT_NS: u64 = 1_000_000; // 1MS: MATCH FOR CLEAN ENFORCEMENT
+const MIXED_LAG_SCALE: u64 = 4;
+const MIXED_BATCH_NS: u64 = 20_000_000; // 20MS: MATCHES LIGHT/HEAVY/BPF DEFAULT
+
+const HEAVY_SLICE_NS: u64 = 4_000_000; // 4MS: WIDER FOR THROUGHPUT
+const HEAVY_PREEMPT_NS: u64 = 2_000_000; // 2MS: SLIGHTLY RELAXED
+const HEAVY_LAG_SCALE: u64 = 2;
+const HEAVY_BATCH_NS: u64 = 20_000_000; // 20MS: LET BATCH RIP
+
+// P99 CEILINGS
+
+const LIGHT_P99_CEIL_NS: u64 = 3_000_000; // 3MS
+const MIXED_P99_CEIL_NS: u64 = 5_000_000; // 5MS: BELOW 16MS FRAME BUDGET
+const HEAVY_P99_CEIL_NS: u64 = 10_000_000; // 10MS: HEAVY LOAD, REALISTIC
+
+// CPU-BOUND DEMOTION THRESHOLDS
+// PER-REGIME: LENIENT IN LIGHT, AGGRESSIVE IN HEAVY
+
+pub const LIGHT_DEMOTION_NS: u64 = 3_500_000; // 3.5MS: LENIENT, FEW CONTEND
+pub const MIXED_DEMOTION_NS: u64 = 2_500_000; // 2.5MS: CURRENT CPU_BOUND_THRESH_NS
+pub const HEAVY_DEMOTION_NS: u64 = 2_000_000; // 2.0MS: AGGRESSIVE
+
+// CLASSIFIER THRESHOLDS
+// LAT_CRI SCORE BOUNDARIES FOR TIER CLASSIFICATION
+// EXPOSED AS TUNING KNOBS FOR RUNTIME ADJUSTMENT
+
+pub const DEFAULT_LAT_CRI_THRESH_HIGH: u64 = 32; // >= THIS: LAT_CRITICAL
+pub const DEFAULT_LAT_CRI_THRESH_LOW: u64 = 8; // >= THIS: INTERACTIVE, BELOW: BATCH
+
+// TUNING KNOBS
+// MATCHES struct tuning_knobs IN BPF (intf.h)
+
+// AFFINITY MODE: L2 PLACEMENT STRENGTH
+pub const AFFINITY_OFF: u64 = 0;
+pub const AFFINITY_WEAK: u64 = 1;
+pub const AFFINITY_STRONG: u64 = 2;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct TuningKnobs {
+    pub slice_ns: u64,
+    pub preempt_thresh_ns: u64,
+    pub lag_scale: u64,
+    pub batch_slice_ns: u64,
+    pub cpu_bound_thresh_ns: u64,
+    pub lat_cri_thresh_high: u64,
+    pub lat_cri_thresh_low: u64,
+    pub affinity_mode: u64,
+    pub sojourn_thresh_ns: u64,
+    pub burst_slice_ns: u64,
+}
+
+impl Default for TuningKnobs {
+    fn default() -> Self {
+        Self {
+            slice_ns: 1_000_000,
+            preempt_thresh_ns: 1_000_000,
+            lag_scale: 4,
+            batch_slice_ns: 20_000_000,
+            cpu_bound_thresh_ns: MIXED_DEMOTION_NS,
+            lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
+            lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
+            affinity_mode: AFFINITY_OFF,
+            sojourn_thresh_ns: 5_000_000,
+            burst_slice_ns: 1_000_000,
+        }
+    }
+}
+
+// REGIME
+
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Regime {
+    Light = 0,
+    Mixed = 1,
+    Heavy = 2,
+}
+
+impl Regime {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Light => "LIGHT",
+            Self::Mixed => "MIXED",
+            Self::Heavy => "HEAVY",
+        }
+    }
+
+    pub fn p99_ceiling(self) -> u64 {
+        match self {
+            Self::Light => LIGHT_P99_CEIL_NS,
+            Self::Mixed => MIXED_P99_CEIL_NS,
+            Self::Heavy => HEAVY_P99_CEIL_NS,
+        }
+    }
+}
+
+// REGIME KNOBS
+
+pub fn regime_knobs(r: Regime) -> TuningKnobs {
+    match r {
+        Regime::Light => TuningKnobs {
+            slice_ns: LIGHT_SLICE_NS,
+            preempt_thresh_ns: LIGHT_PREEMPT_NS,
+            lag_scale: LIGHT_LAG_SCALE,
+            batch_slice_ns: LIGHT_BATCH_NS,
+            cpu_bound_thresh_ns: LIGHT_DEMOTION_NS,
+            lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
+            lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
+            affinity_mode: AFFINITY_WEAK,
+            sojourn_thresh_ns: 5_000_000,
+            burst_slice_ns: 1_000_000,
+        },
+        Regime::Mixed => TuningKnobs {
+            slice_ns: MIXED_SLICE_NS,
+            preempt_thresh_ns: MIXED_PREEMPT_NS,
+            lag_scale: MIXED_LAG_SCALE,
+            batch_slice_ns: MIXED_BATCH_NS,
+            cpu_bound_thresh_ns: MIXED_DEMOTION_NS,
+            lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
+            lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
+            affinity_mode: AFFINITY_STRONG,
+            sojourn_thresh_ns: 5_000_000,
+            burst_slice_ns: 1_000_000,
+        },
+        Regime::Heavy => TuningKnobs {
+            slice_ns: HEAVY_SLICE_NS,
+            preempt_thresh_ns: HEAVY_PREEMPT_NS,
+            lag_scale: HEAVY_LAG_SCALE,
+            batch_slice_ns: HEAVY_BATCH_NS,
+            cpu_bound_thresh_ns: HEAVY_DEMOTION_NS,
+            lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
+            lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
+            affinity_mode: AFFINITY_WEAK,
+            sojourn_thresh_ns: 5_000_000,
+            burst_slice_ns: 1_000_000,
+        },
+    }
+}
+
+// CORE-COUNT-AWARE REGIME KNOBS
+// AT LOW CORE COUNTS, TIME SLICES MUST BE SHORTER TO MAINTAIN ADEQUATE
+// DISPATCH FREQUENCY. HEAVY AT 2C WITH 4MS SLICES = 250 DISPATCHES/S/CORE,
+// TOO COARSE FOR DEADLINE AND IPC WORKLOADS.
+// SCALE: slice = min(BASE, nr_cpus * 500US), preempt = min(BASE, nr_cpus * 250US).
+// MIXED ALSO SCALES: BATCH_SLICE CAPS AT nr_cpus * 5MS (2C: 10MS VS 20MS BASE).
+
+pub fn scaled_regime_knobs(r: Regime, nr_cpus: u64) -> TuningKnobs {
+    let mut knobs = regime_knobs(r);
+    match r {
+        Regime::Heavy | Regime::Light => {
+            let slice_cap = nr_cpus * 500_000;
+            let preempt_cap = nr_cpus * 250_000;
+            knobs.slice_ns = knobs.slice_ns.min(slice_cap);
+            knobs.preempt_thresh_ns = knobs.preempt_thresh_ns.min(preempt_cap);
+        }
+        Regime::Mixed => {
+            let slice_cap = nr_cpus * 500_000;
+            let preempt_cap = nr_cpus * 500_000;
+            knobs.slice_ns = knobs.slice_ns.min(slice_cap);
+            knobs.preempt_thresh_ns = knobs.preempt_thresh_ns.min(preempt_cap);
+            let batch_cap = nr_cpus * 5_000_000;
+            knobs.batch_slice_ns = knobs.batch_slice_ns.min(batch_cap);
+        }
+    }
+    knobs
+}
+
+// REGIME DETECTION (SCHMITT TRIGGER)
+// DIRECTION-AWARE: CURRENT REGIME DETERMINES WHICH THRESHOLDS APPLY.
+// DEAD ZONES PREVENT OSCILLATION THAT SINGLE-BOUNDARY DETECTION CAUSED.
+
+pub fn detect_regime(current: Regime, idle_pct: u64) -> Regime {
+    match current {
+        Regime::Light => {
+            if idle_pct < LIGHT_EXIT_PCT {
+                Regime::Mixed
+            } else {
+                Regime::Light
+            }
+        }
+        Regime::Mixed => {
+            if idle_pct > LIGHT_ENTER_PCT {
+                Regime::Light
+            } else if idle_pct < HEAVY_ENTER_PCT {
+                Regime::Heavy
+            } else {
+                Regime::Mixed
+            }
+        }
+        Regime::Heavy => {
+            if idle_pct > HEAVY_EXIT_PCT {
+                Regime::Mixed
+            } else {
+                Regime::Heavy
+            }
+        }
+    }
+}
+
+// STABILITY MODE
+
+pub const STABILITY_THRESHOLD: u32 = 10; // CONSECUTIVE STABLE TICKS BEFORE HIBERNATE
+
+pub fn compute_stability_score(
+    prev_score: u32,
+    regime_changed: bool,
+    reflex_events_delta: u64,
+    p99_ns: u64,
+    p99_ceiling_ns: u64,
+) -> u32 {
+    if regime_changed || reflex_events_delta > 0 || p99_ns > p99_ceiling_ns / 2 {
+        return 0;
+    }
+    (prev_score + 1).min(STABILITY_THRESHOLD)
+}
+
+// TELEMETRY GATING
+
+pub fn should_print_telemetry(tick_counter: u64, stability_score: u32) -> bool {
+    if stability_score >= STABILITY_THRESHOLD {
+        tick_counter % 2 == 0
+    } else {
+        true
+    }
+}
+
+// P99 HISTOGRAM
+
+pub const HIST_BUCKETS: usize = 12;
+pub const HIST_EDGES_NS: [u64; HIST_BUCKETS] = [
+    10_000,     // 10us
+    25_000,     // 25us
+    50_000,     // 50us
+    100_000,    // 100us
+    250_000,    // 250us
+    500_000,    // 500us
+    1_000_000,  // 1ms
+    2_000_000,  // 2ms
+    5_000_000,  // 5ms
+    10_000_000, // 10ms
+    20_000_000, // 20ms
+    u64::MAX,   // +inf
+];
+
+// COMPUTE P99 FROM DRAINED HISTOGRAM COUNTS. PURE FUNCTION.
+// CAP AT 20MS (LAST REAL BUCKET) -- +INF WOULD POISON EVERY COMPARISON.
+pub fn compute_p99_from_histogram(counts: &[u64; HIST_BUCKETS]) -> u64 {
+    let total: u64 = counts.iter().sum();
+    if total == 0 {
+        return 0;
+    }
+    let threshold = (total * 99 + 99) / 100;
+    let mut cumulative = 0u64;
+    for i in 0..HIST_BUCKETS {
+        cumulative += counts[i];
+        if cumulative >= threshold {
+            return HIST_EDGES_NS[i].min(HIST_EDGES_NS[HIST_BUCKETS - 2]);
+        }
+    }
+    HIST_EDGES_NS[HIST_BUCKETS - 2]
+}
+
+// REFLEX TIGHTEN DECISION: USES BOTH AGGREGATE AND INTERACTIVE P99.
+// TIGHTEN IF EITHER EXCEEDS CEILING (INTERACTIVE STARVATION HIDDEN IN AGGREGATE).
+pub fn should_reflex_tighten(aggregate_p99: u64, interactive_p99: u64, ceiling: u64) -> bool {
+    aggregate_p99 > ceiling || interactive_p99 > ceiling
+}
+
+// SLEEP-INFORMED BATCH TUNING
+// IO-HEAVY: EXTEND BATCH SLICES (+25%) -- IO-BOUND TASKS BATCH BETWEEN FREQUENT SHORT SLEEPS
+// IDLE-HEAVY: TIGHTEN BATCH SLICES (-25%) -- SPORADIC USER INPUT NEEDS FASTER PREEMPTION
+
+pub const BATCH_MAX_NS: u64 = 25_000_000; // 25MS CEILING
+
+pub fn sleep_adjust_batch_ns(base_batch_ns: u64, io_pct: u64) -> u64 {
+    if io_pct > 60 {
+        // IO-HEAVY: EXTEND BATCH SLICES (+25%)
+        (base_batch_ns * 5 / 4).min(BATCH_MAX_NS)
+    } else if io_pct < 15 {
+        // IDLE-HEAVY: TIGHTEN BATCH SLICES (-25%)
+        (base_batch_ns * 3 / 4).max(base_batch_ns / 2)
+    } else {
+        base_batch_ns
+    }
+}


### PR DESCRIPTION
scx_pandemonium: An Adaptive Linux Scheduler 

Behavioral classification scheduler designed for interactive desktop workloads. Classifies tasks in real-time and routes them through a multi-tier dispatch system optimized for latency-sensitive applications (games, compositors, media)   
while maintaining batch throughput.

Architecture

- Behavioral classification: LAT_CRI = (wakeup_freq * csw_rate) / avg_runtime — three tiers: LAT_CRITICAL, INTERACTIVE, BATCH with per-tier time slicing
- select_cpu fast path: SCX_DSQ_LOCAL — direct to kernel local runqueue, zero contention
- enqueue tier 1/2: Shared per-node DSQ with targeted kicks — any CPU on the node can drain, eliminates single-CPU starvation
- enqueue tier 3: Per-node overflow DSQ (vtime-ordered) with sojourn-based rescue
- Anti-starvation: Deficit-round-robin interleave, sojourn amplification, hard starvation rescue
- Rust adaptive layer: Real-time telemetry, CUSUM burst detection, dynamic knob adjustment
