### PR TITLE
scx_cosmos: Deprecate deferred CPU wakeups and increase default time slice

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -141,7 +141,7 @@ const volatile bool no_wake_sync;
 /*
  * Default time slice.
  */
-const volatile u64 slice_ns = 10000ULL;
+const volatile u64 slice_ns = 1000000ULL;
 
 /*
  * Maximum runtime that can be charged to a task.

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -122,7 +122,7 @@ struct Opts {
     exit_dump_len: u32,
 
     /// Maximum scheduling slice duration in microseconds.
-    #[clap(short = 's', long, default_value = "10")]
+    #[clap(short = 's', long, default_value = "1000")]
     slice_us: u64,
 
     /// Maximum runtime (since last sleep) that can be charged to a task in microseconds.


### PR DESCRIPTION
Deferred CPU wakeups are only increasing power consumption without providing any significant benefit, so disable them by default and deprecate the option (`-d`).

Moreover, increase the default time slice to 1ms, which is a better compromise between throughput and latency.

@sirlucjan the only required change in scx_loader is drop the option `-d`. But we can also keep it for a while for backward compatibility (it's just ignored for now).