### PR TITLE
scx.service: Deprecate deferred CPU wakeup for scx_cosmos

### DIFF
--- a/services/scx
+++ b/services/scx
@@ -2,4 +2,4 @@
 SCX_SCHEDULER=scx_cosmos
 
 # Set custom flags for each scheduler, below is an example of how to use
-SCX_FLAGS='-s 20000 -d -c 0 -p 0'
+SCX_FLAGS='-s 20000 -c 0 -p 0'


### PR DESCRIPTION
Synchronization with scx-scheds: https://github.com/sched-ext/scx/pull/3403