### PR TITLE
scx_rustland_core: use scx_bpf_task_set_slice/dsq_vtime() when available

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -913,7 +913,7 @@ void BPF_STRUCT_OPS(rustland_dispatch, s32 cpu, struct task_struct *prev)
 	 */
 	if (prev && is_queued(prev) &&
 	    (!is_usersched_task(prev) || usersched_has_pending_tasks()))
-		prev->scx.slice = slice_ns;
+		scx_bpf_task_set_slice(prev, slice_ns);
 }
 
 void BPF_STRUCT_OPS(rustland_runnable, struct task_struct *p, u64 enq_flags)
@@ -989,8 +989,8 @@ void BPF_STRUCT_OPS(rustland_stopping, struct task_struct *p, bool runnable)
  */
 void BPF_STRUCT_OPS(rustland_enable, struct task_struct *p)
 {
-	p->scx.dsq_vtime = 0;
-	p->scx.slice = slice_ns;
+	scx_bpf_task_set_dsq_vtime(p, 0);
+	scx_bpf_task_set_slice(p, slice_ns);
 }
 
 /*


### PR DESCRIPTION
Replace direct writes to p->scx.slice and p->scx.dsq_vtime with the new scx_bpf_task_set_slice() and scx_bpf_task_set_dsq_vtime() kfuncs where available, falling back to direct field writes on older kernels.

```
$ vng 
          _      _
   __   _(_)_ __| |_ _ __ ___   ___       _ __   __ _
   \ \ / / |  __| __|  _   _ \ / _ \_____|  _ \ / _  |
    \ V /| | |  | |_| | | | | |  __/_____| | | | (_| |
     \_/ |_|_|   \__|_| |_| |_|\___|     |_| |_|\__  |
                                                |___/
   kernel version: 7.0.0-rc2+ x86_64
   (CTRL+d to exit)

$ sudo ./target/release/scx_rustland
01:19:22 [INFO] RustLand version 1.1.0-g0e681b18ad22 x86_64-unknown-linux-gnu - scx_rustland_core 2.4.11
^CEXIT: unregistered from user space
01:19:23 [INFO] Unregister RustLand scheduler

$ sudo dmesg
...
[   82.785112] sched_ext: Writing directly to p->scx.slice/dsq_vtime is deprecated, use scx_bpf_task_set_slice/dsq_vtime()
[   82.786061] sched_ext: Writing directly to p->scx.slice/dsq_vtime is deprecated, use scx_bpf_task_set_slice/dsq_vtime()
[   82.786064] sched_ext: Writing directly to p->scx.slice/dsq_vtime is deprecated, use scx_bpf_task_set_slice/dsq_vtime()
[   82.804559] sched_ext: BPF scheduler "rustland_1.1.0_g0e681b18ad22_x86_64_unknown_linux_gnu" enabled
[  116.818663] sched_ext: BPF scheduler "rustland_1.1.0_g0e681b18ad22_x86_64_unknown_linux_gnu" disabled (unregistered from user space)
```

I'm also wondering, since scx_bpf_task_set_slice()/dsq_vtime() return bool, should we also change the function type?