### PR TITLE
scx_cosmos: Track per-CPU utilization instead of global CPU utilization

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -154,9 +154,15 @@ const volatile u64 slice_lag = 20000000ULL;
 const volatile u64 busy_threshold;
 
 /*
- * Current global CPU utilization percentage in the range [0 .. 1024].
+ * Per-CPU user utilization in the range [0 .. 1024], updated periodically
+ * from userspace. Indexed by CPU id.
  */
-volatile u64 cpu_util;
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_CPUS);
+	__type(key, u32);
+	__type(value, u64);
+} cpu_util_map SEC(".maps");
 
 /*
  * Scheduler statistics.
@@ -534,15 +540,27 @@ static inline bool is_pcpu_task(const struct task_struct *p)
 }
 
 /*
- * Return true if the system is busy, false otherwise.
+ * Return true if the given CPU is busy, false otherwise.
  *
- * This function determines when the scheduler needs to switch to
- * deadline-mode (using a shared DSQ) vs round-robin mode (using per-CPU
- * local DSQs).
+ * @cpu should be the CPU of interest: prev_cpu in select_cpu/enqueue, or
+ * scx_bpf_task_cpu(p) in tick.
+ *
+ * This determines when the scheduler needs to switch to deadline-mode
+ * (using a shared DSQ) vs round-robin mode (using per-CPU local DSQs).
  */
-static inline bool is_system_busy(void)
+static inline bool is_cpu_busy(s32 cpu)
 {
-	return cpu_util >= busy_threshold;
+	u64 *util;
+	u64 max_cpu = MIN(nr_cpu_ids, MAX_CPUS);
+
+	if (cpu < 0 || cpu >= max_cpu)
+		return false;
+
+	util = bpf_map_lookup_elem(&cpu_util_map, &cpu);
+	if (!util)
+		return false;
+
+	return *util >= busy_threshold;
 }
 
 /*
@@ -787,7 +805,7 @@ static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, s32 this_cpu,
 	 * scan is enabled, unless the system is busy, in which case the
 	 * cpumask-based scanning is more efficient.
 	 */
-	if ((flat_idle_scan || preferred_idle_scan) && !is_system_busy())
+	if ((flat_idle_scan || preferred_idle_scan) && !is_cpu_busy(prev_cpu))
 		return pick_idle_cpu_flat(p, prev_cpu);
 
 	/*
@@ -1042,7 +1060,7 @@ s32 BPF_STRUCT_OPS(cosmos_select_cpu, struct task_struct *p, s32 prev_cpu, u64 w
 {
 	const struct task_struct *current = (void *)bpf_get_current_task_btf();
 	struct task_ctx *tctx;
-	bool is_busy = is_system_busy();
+	bool is_busy = is_cpu_busy(prev_cpu);
 	s32 cpu, this_cpu = bpf_get_smp_processor_id();
 	bool is_this_cpu_allowed = bpf_cpumask_test_cpu(this_cpu, p->cpus_ptr);
 	int new_cpu;
@@ -1152,7 +1170,7 @@ void BPF_STRUCT_OPS(cosmos_tick, struct task_struct *p)
 		bool cpu_busy = scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | cpu) ||
 				scx_bpf_dsq_nr_queued(shared_dsq(cpu));
 
-		if (smt_contention || (is_system_busy() && cpu_busy))
+		if (smt_contention || (is_cpu_busy(cpu) && cpu_busy))
 			p->scx.slice = 0;
 	}
 }
@@ -1246,9 +1264,9 @@ void BPF_STRUCT_OPS(cosmos_enqueue, struct task_struct *p, u64 enq_flags)
 	}
 
 	/*
-	 * Keep using the same CPU if the system is not busy.
+	 * Keep using the same CPU if that CPU is not busy.
 	 */
-	if (!is_system_busy() && is_primary_cpu(prev_cpu)) {
+	if (!is_cpu_busy(prev_cpu) && is_primary_cpu(prev_cpu)) {
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | prev_cpu, task_slice(p), enq_flags);
 		if (task_should_migrate(p, enq_flags))
 			scx_bpf_kick_cpu(prev_cpu, SCX_KICK_IDLE);

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -1186,8 +1186,6 @@ impl<'a> Scheduler<'a> {
     fn get_metrics(&self) -> Metrics {
         let bss_data = self.skel.maps.bss_data.as_ref().unwrap();
         Metrics {
-            cpu_thresh: self.skel.maps.rodata_data.as_ref().unwrap().busy_threshold,
-            cpu_util: self.skel.maps.bss_data.as_ref().unwrap().cpu_util,
             nr_event_dispatches: bss_data.nr_event_dispatches,
             nr_ev_sticky_dispatches: bss_data.nr_ev_sticky_dispatches,
             nr_gpu_dispatches: bss_data.nr_gpu_dispatches,
@@ -1211,55 +1209,83 @@ impl<'a> Scheduler<'a> {
         }
     }
 
-    fn read_cpu_times() -> Option<CpuTimes> {
+    /// Read per-CPU times from /proc/stat (lines "cpu0", "cpu1", ...).
+    /// Returns one CpuTimes per CPU, in order.
+    fn read_per_cpu_cpu_times(nr_cpus: usize) -> Option<Vec<CpuTimes>> {
         let file = File::open("/proc/stat").ok()?;
         let reader = BufReader::new(file);
+        let mut result = Vec::with_capacity(nr_cpus);
 
         for line in reader.lines() {
             let line = line.ok()?;
-            if line.starts_with("cpu ") {
-                let fields: Vec<&str> = line.split_whitespace().collect();
-                if fields.len() < 5 {
-                    return None;
-                }
-
-                let user: u64 = fields[1].parse().ok()?;
-                let nice: u64 = fields[2].parse().ok()?;
-
-                // Sum the first 8 fields as total time, including idle, system, etc.
-                let total: u64 = fields
-                    .iter()
-                    .skip(1)
-                    .take(8)
-                    .filter_map(|v| v.parse::<u64>().ok())
-                    .sum();
-
-                return Some(CpuTimes { user, nice, total });
+            let line = line.trim();
+            if !line.starts_with("cpu") {
+                continue;
+            }
+            let rest = line.strip_prefix("cpu")?;
+            if rest.starts_with(' ') {
+                // Aggregate line "cpu " - skip.
+                continue;
+            }
+            let cpu_id: usize = rest.split_whitespace().next()?.parse().ok()?;
+            if cpu_id != result.len() {
+                break;
+            }
+            let fields: Vec<&str> = line.split_whitespace().collect();
+            if fields.len() < 5 {
+                return None;
+            }
+            let user: u64 = fields[1].parse().ok()?;
+            let nice: u64 = fields[2].parse().ok()?;
+            let total: u64 = fields
+                .iter()
+                .skip(1)
+                .take(8)
+                .filter_map(|v| v.parse::<u64>().ok())
+                .sum();
+            result.push(CpuTimes { user, nice, total });
+            if result.len() >= nr_cpus {
+                break;
             }
         }
 
-        None
+        if result.len() == nr_cpus {
+            Some(result)
+        } else {
+            None
+        }
     }
 
     fn run(&mut self, shutdown: Arc<AtomicBool>) -> Result<UserExitInfo> {
         let (res_ch, req_ch) = self.stats_server.channels();
 
-        // Periodically evaluate user CPU utilization from user-space and update a global variable
-        // in BPF.
-        //
-        // The BPF scheduler will use this value to determine when the system is idle (using local
-        // DSQs and simple round-robin scheduler) or busy (switching to a deadline-based policy).
+        // Periodically evaluate per-CPU user utilization from userspace and update the
+        // cpu_util_map in BPF. The scheduler uses is_cpu_busy(cpu) with prev_cpu or
+        // scx_bpf_task_cpu(p) to decide per-CPU whether to use local DSQs (round-robin)
+        // or deadline-based shared DSQ.
         let polling_time = Duration::from_millis(self.opts.polling_ms).min(Duration::from_secs(1));
-        let mut prev_cputime = Self::read_cpu_times().expect("Failed to read initial CPU stats");
+        let nr_cpus = *NR_CPU_IDS as usize;
+        let mut prev_cputime =
+            Self::read_per_cpu_cpu_times(nr_cpus).expect("Failed to read initial per-CPU stats");
         let mut last_update = Instant::now();
         let mut last_gpu_sync = Instant::now();
 
         while !shutdown.load(Ordering::Relaxed) && !self.exited() {
-            // Update CPU utilization and GPU PID -> node map (NVML).
+            // Update per-CPU utilization and GPU PID -> node map (NVML).
             if !polling_time.is_zero() && last_update.elapsed() >= polling_time {
-                if let Some(curr_cputime) = Self::read_cpu_times() {
-                    Self::compute_user_cpu_pct(&prev_cputime, &curr_cputime)
-                        .map(|util| self.skel.maps.bss_data.as_mut().unwrap().cpu_util = util);
+                if let Some(curr_cputime) = Self::read_per_cpu_cpu_times(nr_cpus) {
+                    let map = &self.skel.maps.cpu_util_map;
+                    for cpu in 0..nr_cpus {
+                        if let Some(util) =
+                            Self::compute_user_cpu_pct(&prev_cputime[cpu], &curr_cputime[cpu])
+                        {
+                            let _ = map.update(
+                                &(cpu as u32).to_ne_bytes(),
+                                &util.to_ne_bytes(),
+                                MapFlags::ANY,
+                            );
+                        }
+                    }
                     prev_cputime = curr_cputime;
                 }
 

--- a/scheds/rust/scx_cosmos/src/stats.rs
+++ b/scheds/rust/scx_cosmos/src/stats.rs
@@ -15,10 +15,6 @@ use serde::Serialize;
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(top)]
 pub struct Metrics {
-    #[stat(desc = "Average CPU utilization %")]
-    pub cpu_util: u64,
-    #[stat(desc = "Busy utilization threshold %")]
-    pub cpu_thresh: u64,
     #[stat(desc = "Direct dispatch due to high perf events (migration)")]
     pub nr_event_dispatches: u64,
     #[stat(desc = "Kept on same CPU due to perf sticky threshold")]
@@ -31,14 +27,8 @@ impl Metrics {
     fn format<W: Write>(&self, w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "[{}] CPUs {:>5.1}% {} ev_dispatches={} ev_sticky_dispatches={} gpu_dispatches={}",
+            "[{}] ev_dispatches={} ev_sticky_dispatches={} gpu_dispatches={}",
             crate::SCHEDULER_NAME,
-            (self.cpu_util as f64) * 100.0 / 1024.0,
-            if self.cpu_util >= self.cpu_thresh {
-                "[deadline]"
-            } else {
-                "[round-robin]"
-            },
             self.nr_event_dispatches,
             self.nr_ev_sticky_dispatches,
             self.nr_gpu_dispatches,
@@ -51,7 +41,6 @@ impl Metrics {
             nr_event_dispatches: self.nr_event_dispatches - rhs.nr_event_dispatches,
             nr_ev_sticky_dispatches: self.nr_ev_sticky_dispatches - rhs.nr_ev_sticky_dispatches,
             nr_gpu_dispatches: self.nr_gpu_dispatches - rhs.nr_gpu_dispatches,
-            ..self.clone()
         }
     }
 }


### PR DESCRIPTION
The current approach of using a single global CPU utilization metric for deciding when to switch between sticky round-robin and migration deadline scheduling modes is often inaccurate, particularly in large systems with multiple CPUs, as we usually need to use all the CPUs to trigger the utilization threshold.

Therefore, switch to a per-CPU approach by monitoring individual CPU utilizations and making scheduling mode decisions based on the utilization of each CPU separately.