### PR TITLE
scx_lavd: fix typo in LAVD scheduler documentation

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -39,7 +39,7 @@
  * execution of Task B, and Task B's completion triggers Task C. Many
  * event-driven systems can be represented as task graphs.
  *
- *        [Task x] --> [Task B] --> [Task C]
+ *        [Task A] --> [Task B] --> [Task C]
  *
  * We define Task B is more latency-critical in the following cases: a) as Task
  * B's runtime per schedule is shorter (runtime B) b) as Task B wakes Task C


### PR DESCRIPTION
Correct [Task x] to [Task A] in the task graph diagram to match the surrounding text description.