### PR TITLE
scxtop: Add DSQ latency, LLC locality, runqueue depth, and fairness

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -317,7 +317,20 @@ impl<'a> App<'a> {
         let stats_client = Some(Arc::new(TokioMutex::new(stats_client)));
         let sample_rate = skel.maps.data_data.as_ref().unwrap().sample_rate;
         let trace_file_prefix = config.trace_file_prefix().to_string();
-        let trace_manager = PerfettoTraceManager::new(trace_file_prefix, None);
+        let mut trace_manager = PerfettoTraceManager::new(trace_file_prefix, None);
+
+        // Embed topology metadata in traces for cross-machine analysis
+        {
+            let mut cpu_to_llc = std::collections::HashMap::new();
+            let mut cpu_to_numa = std::collections::HashMap::new();
+            let mut cpu_to_core = std::collections::HashMap::new();
+            for cpu in topo.all_cpus.values() {
+                cpu_to_llc.insert(cpu.id as u32, cpu.llc_id as u32);
+                cpu_to_numa.insert(cpu.id as u32, cpu.node_id as u32);
+                cpu_to_core.insert(cpu.id as u32, cpu.core_id as u32);
+            }
+            trace_manager.set_topology(cpu_to_llc, cpu_to_numa, cpu_to_core);
+        }
 
         // There isn't a 'is_loaded' method on a prog in libbpf-rs so do the next best thing and
         // try to infer from the fd
@@ -564,7 +577,20 @@ impl<'a> App<'a> {
         // Default sample rate for non-BPF mode
         let sample_rate = 1000; // Default value when BPF is not available
         let trace_file_prefix = config.trace_file_prefix().to_string();
-        let trace_manager = PerfettoTraceManager::new(trace_file_prefix, None);
+        let mut trace_manager = PerfettoTraceManager::new(trace_file_prefix, None);
+
+        // Embed topology metadata in traces for cross-machine analysis
+        {
+            let mut cpu_to_llc = std::collections::HashMap::new();
+            let mut cpu_to_numa = std::collections::HashMap::new();
+            let mut cpu_to_core = std::collections::HashMap::new();
+            for cpu in topo.all_cpus.values() {
+                cpu_to_llc.insert(cpu.id as u32, cpu.llc_id as u32);
+                cpu_to_numa.insert(cpu.id as u32, cpu.node_id as u32);
+                cpu_to_core.insert(cpu.id as u32, cpu.core_id as u32);
+            }
+            trace_manager.set_topology(cpu_to_llc, cpu_to_numa, cpu_to_core);
+        }
 
         // No hardware pressure monitoring without BPF
         let hw_pressure = false;

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -601,6 +601,22 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
             let trace_file = trace_args.output_file.clone();
             let mut trace_manager = PerfettoTraceManager::new(trace_file_prefix, None);
 
+            // Embed topology metadata in traces for cross-machine analysis
+            {
+                use scx_utils::Topology;
+                if let Ok(topo) = Topology::new() {
+                    let mut cpu_to_llc = std::collections::HashMap::new();
+                    let mut cpu_to_numa = std::collections::HashMap::new();
+                    let mut cpu_to_core = std::collections::HashMap::new();
+                    for cpu in topo.all_cpus.values() {
+                        cpu_to_llc.insert(cpu.id as u32, cpu.llc_id as u32);
+                        cpu_to_numa.insert(cpu.id as u32, cpu.node_id as u32);
+                        cpu_to_core.insert(cpu.id as u32, cpu.core_id as u32);
+                    }
+                    trace_manager.set_topology(cpu_to_llc, cpu_to_numa, cpu_to_core);
+                }
+            }
+
             info!("starting trace for {}ms", trace_args.trace_ms);
             trace_manager.start()?;
             let mut tracer = Tracer::new(skel);
@@ -1830,11 +1846,15 @@ fn run_mcp(mcp_args: &scxtop::cli::McpArgs) -> Result<()> {
             })
     } else {
         // One-shot mode: No BPF, just serve static data
+        use std::collections::HashMap;
+        use std::sync::Mutex;
+        let trace_cache = Arc::new(Mutex::new(HashMap::new()));
         let mut server = McpServer::new(mcp_config)
             .with_topology(topo_arc)
             .setup_scheduler_resource()
             .setup_profiling_resources()
             .with_stats_client(None)
+            .with_trace_cache(trace_cache)
             .setup_stats_resources();
         server.run_blocking()
     }

--- a/tools/scxtop/src/mcp/mod.rs
+++ b/tools/scxtop/src/mcp/mod.rs
@@ -21,6 +21,7 @@ pub mod perfetto_analyzers_extended;
 pub mod perfetto_analyzers_io;
 pub mod perfetto_analyzers_irq;
 pub mod perfetto_analyzers_power;
+pub mod perfetto_analyzers_scheduling;
 pub mod perfetto_event_types;
 pub mod perfetto_outlier_analyzer;
 pub mod perfetto_parser;
@@ -91,6 +92,10 @@ pub use perfetto_analyzers_power::{
     CpuIdleStateAnalyzer, CpuIdleStats, FrequencyEvent, IdleEvent, PowerStateAnalyzer,
     PowerStateResult, SuspendResumeEvent,
 };
+pub use perfetto_analyzers_scheduling::{
+    CpuRunqueueStats, DsqLatencyAnalyzer, DsqLatencyStats, FairnessAnalyzer, FairnessStats,
+    LlcLocalityAnalyzer, LlcLocalityStats, PerDsqStats, RunqueueDepthAnalyzer, RunqueueDepthStats,
+};
 pub use perfetto_event_types::{
     event_category, event_type_name, events_in_category, softirq_type_name, EventCategory,
 };
@@ -101,7 +106,7 @@ pub use perfetto_outlier_analyzer::{
 pub use perfetto_parser::{
     CpuEventType, CpuTimeline, CpuTimelineEvent, DsqDescriptor, DsqEvent, FtraceEventWithIndex,
     Percentiles, PerfettoTrace, ProcessInfo, ProcessTimeline, ProcessTimelineEvent,
-    SchedExtEventData, SchedExtMetadata, ThreadInfo,
+    SchedExtEventData, SchedExtMetadata, ThreadInfo, TraceTopology,
 };
 pub use perfetto_parser_enhanced::{
     ClockType, CompatibilityDetector, EventTypeIndex, TraceCapabilities, TraceSource,

--- a/tools/scxtop/src/mcp/perfetto_analyzers_scheduling.rs
+++ b/tools/scxtop/src/mcp/perfetto_analyzers_scheduling.rs
@@ -1,0 +1,651 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use super::perfetto_parser::PerfettoTrace;
+use perfetto_protos::ftrace_event::ftrace_event;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// ============================================================================
+// LLC Locality Analyzer
+// ============================================================================
+
+/// Analyzes cache locality of scheduling decisions using topology data.
+/// Tracks whether wakeups and migrations stay within the same LLC or cross LLC/NUMA boundaries.
+pub struct LlcLocalityAnalyzer {
+    trace: Arc<PerfettoTrace>,
+}
+
+impl LlcLocalityAnalyzer {
+    pub fn new(trace: Arc<PerfettoTrace>) -> Self {
+        Self { trace }
+    }
+
+    /// Analyze LLC locality of migrations.
+    /// Returns None if no topology data is available in the trace.
+    pub fn analyze(&self) -> Option<LlcLocalityStats> {
+        let topology = self.trace.get_topology()?;
+
+        let mut stats = LlcLocalityStats {
+            nr_cpus: topology.nr_cpus,
+            nr_llcs: topology.nr_llcs,
+            nr_numa_nodes: topology.nr_numa_nodes,
+            total_migrations: 0,
+            same_llc_migrations: 0,
+            cross_llc_same_numa_migrations: 0,
+            cross_numa_migrations: 0,
+            per_llc_stats: HashMap::new(),
+            top_cross_llc_processes: Vec::new(),
+        };
+
+        // Initialize per-LLC stats
+        for llc_id in topology.cpu_to_llc.values() {
+            stats.per_llc_stats.entry(*llc_id).or_insert(LlcStats {
+                llc_id: *llc_id,
+                inbound_migrations: 0,
+                outbound_migrations: 0,
+                internal_migrations: 0,
+            });
+        }
+
+        // Track per-process cross-LLC migration counts
+        let mut process_cross_llc: HashMap<i32, usize> = HashMap::new();
+
+        // Analyze sched_migrate events
+        let migrate_events = self.trace.get_events_by_type("sched_migrate");
+        for event in &migrate_events {
+            if let Some(ftrace_event::Event::SchedMigrateTask(migrate)) = &event.event {
+                let orig_cpu = migrate.orig_cpu.unwrap_or(0) as u32;
+                let dest_cpu = migrate.dest_cpu.unwrap_or(0) as u32;
+                let pid = migrate.pid.unwrap_or(0);
+
+                stats.total_migrations += 1;
+
+                let orig_llc = topology.cpu_to_llc.get(&orig_cpu).copied();
+                let dest_llc = topology.cpu_to_llc.get(&dest_cpu).copied();
+                let orig_numa = topology.cpu_to_numa.get(&orig_cpu).copied();
+                let dest_numa = topology.cpu_to_numa.get(&dest_cpu).copied();
+
+                match (orig_llc, dest_llc, orig_numa, dest_numa) {
+                    (Some(ol), Some(dl), Some(on), Some(dn)) => {
+                        if ol == dl {
+                            stats.same_llc_migrations += 1;
+                            if let Some(llc_stats) = stats.per_llc_stats.get_mut(&ol) {
+                                llc_stats.internal_migrations += 1;
+                            }
+                        } else if on == dn {
+                            stats.cross_llc_same_numa_migrations += 1;
+                            *process_cross_llc.entry(pid).or_insert(0) += 1;
+                            if let Some(llc_stats) = stats.per_llc_stats.get_mut(&ol) {
+                                llc_stats.outbound_migrations += 1;
+                            }
+                            if let Some(llc_stats) = stats.per_llc_stats.get_mut(&dl) {
+                                llc_stats.inbound_migrations += 1;
+                            }
+                        } else {
+                            stats.cross_numa_migrations += 1;
+                            *process_cross_llc.entry(pid).or_insert(0) += 1;
+                            if let Some(llc_stats) = stats.per_llc_stats.get_mut(&ol) {
+                                llc_stats.outbound_migrations += 1;
+                            }
+                            if let Some(llc_stats) = stats.per_llc_stats.get_mut(&dl) {
+                                llc_stats.inbound_migrations += 1;
+                            }
+                        }
+                    }
+                    _ => {
+                        // CPU not in topology map, count as cross-LLC to be safe
+                        stats.cross_llc_same_numa_migrations += 1;
+                    }
+                }
+            }
+        }
+
+        // Build top cross-LLC processes
+        let mut cross_llc_sorted: Vec<_> = process_cross_llc.into_iter().collect();
+        cross_llc_sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        let processes = self.trace.get_processes();
+        stats.top_cross_llc_processes = cross_llc_sorted
+            .into_iter()
+            .take(20)
+            .map(|(pid, count)| {
+                let comm = processes
+                    .get(&pid)
+                    .and_then(|p| p.name.clone())
+                    .unwrap_or_default();
+                ProcessCrossLlcStats {
+                    pid,
+                    comm,
+                    cross_llc_count: count,
+                }
+            })
+            .collect();
+
+        Some(stats)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlcLocalityStats {
+    pub nr_cpus: u32,
+    pub nr_llcs: u32,
+    pub nr_numa_nodes: u32,
+    pub total_migrations: usize,
+    pub same_llc_migrations: usize,
+    pub cross_llc_same_numa_migrations: usize,
+    pub cross_numa_migrations: usize,
+    pub per_llc_stats: HashMap<u32, LlcStats>,
+    pub top_cross_llc_processes: Vec<ProcessCrossLlcStats>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlcStats {
+    pub llc_id: u32,
+    pub inbound_migrations: usize,
+    pub outbound_migrations: usize,
+    pub internal_migrations: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessCrossLlcStats {
+    pub pid: i32,
+    pub comm: String,
+    pub cross_llc_count: usize,
+}
+
+// ============================================================================
+// Runqueue Depth Analyzer
+// ============================================================================
+
+/// Analyzes runqueue depth over time per CPU.
+/// Tracks how many runnable tasks are waiting on each CPU by correlating
+/// sched_wakeup (task becomes runnable) and sched_switch (task starts/stops running) events.
+pub struct RunqueueDepthAnalyzer {
+    trace: Arc<PerfettoTrace>,
+}
+
+impl RunqueueDepthAnalyzer {
+    pub fn new(trace: Arc<PerfettoTrace>) -> Self {
+        Self { trace }
+    }
+
+    /// Analyze runqueue depth for all CPUs.
+    /// Returns per-CPU statistics about queue depth over the trace duration.
+    pub fn analyze(&self, cpu_filter: Option<u32>) -> RunqueueDepthStats {
+        let num_cpus = self.trace.num_cpus();
+        let mut per_cpu: HashMap<u32, CpuRunqueueStats> = HashMap::new();
+        let (trace_start, trace_end) = self.trace.time_range();
+        let trace_duration_ns = trace_end.saturating_sub(trace_start);
+
+        // For each CPU, process events chronologically to track runqueue depth
+        for cpu in 0..num_cpus {
+            let cpu_id = cpu as u32;
+            if let Some(filter) = cpu_filter {
+                if cpu_id != filter {
+                    continue;
+                }
+            }
+
+            let events = self.trace.get_events_by_cpu(cpu_id);
+            if events.is_empty() {
+                continue;
+            }
+
+            let mut depth: i64 = 0;
+            let mut max_depth: i64 = 0;
+            let mut depth_samples: Vec<(u64, i64)> = Vec::new(); // (timestamp, depth)
+            let mut total_depth_time: f64 = 0.0; // weighted sum for average
+            let mut last_ts = trace_start;
+
+            for event_with_idx in events {
+                let ts = event_with_idx.event.timestamp.unwrap_or(0);
+
+                match &event_with_idx.event.event {
+                    Some(ftrace_event::Event::SchedWakeup(wakeup)) => {
+                        // Task placed on this CPU's runqueue
+                        if wakeup.target_cpu == Some(cpu_id as i32) {
+                            // Accumulate weighted depth before changing it
+                            if ts > last_ts {
+                                total_depth_time += depth as f64 * (ts - last_ts) as f64;
+                                last_ts = ts;
+                            }
+                            depth += 1;
+                            if depth > max_depth {
+                                max_depth = depth;
+                            }
+                            depth_samples.push((ts, depth));
+                        }
+                    }
+                    Some(ftrace_event::Event::SchedSwitch(switch)) => {
+                        // Accumulate weighted depth before changing it
+                        if ts > last_ts {
+                            total_depth_time += depth as f64 * (ts - last_ts) as f64;
+                            last_ts = ts;
+                        }
+
+                        // If prev task is still runnable (preempted), it goes to runqueue
+                        if let Some(prev_state) = switch.prev_state {
+                            // State 0 = TASK_RUNNING (still runnable, was preempted)
+                            if prev_state == 0 && switch.prev_pid.unwrap_or(0) != 0 {
+                                depth += 1;
+                            }
+                        }
+
+                        // If next task is a real task (not idle), it leaves runqueue
+                        if switch.next_pid.unwrap_or(0) != 0 {
+                            depth -= 1;
+                            if depth < 0 {
+                                depth = 0; // Clamp due to trace start boundary
+                            }
+                        }
+
+                        if depth > max_depth {
+                            max_depth = depth;
+                        }
+                        depth_samples.push((ts, depth));
+                    }
+                    _ => {}
+                }
+            }
+
+            // Final accumulation
+            if trace_end > last_ts {
+                total_depth_time += depth as f64 * (trace_end - last_ts) as f64;
+            }
+
+            let avg_depth = if trace_duration_ns > 0 {
+                total_depth_time / trace_duration_ns as f64
+            } else {
+                0.0
+            };
+
+            // Calculate p99 depth from samples
+            let p99_depth = if !depth_samples.is_empty() {
+                let mut depths: Vec<i64> = depth_samples.iter().map(|(_, d)| *d).collect();
+                depths.sort_unstable();
+                let idx = (depths.len() as f64 * 0.99).ceil() as usize;
+                depths[idx.min(depths.len() - 1)]
+            } else {
+                0
+            };
+
+            per_cpu.insert(
+                cpu_id,
+                CpuRunqueueStats {
+                    cpu_id,
+                    avg_depth,
+                    max_depth,
+                    p99_depth,
+                    sample_count: depth_samples.len(),
+                },
+            );
+        }
+
+        // Build summary
+        let total_cpus = per_cpu.len();
+        let global_avg = if total_cpus > 0 {
+            per_cpu.values().map(|s| s.avg_depth).sum::<f64>() / total_cpus as f64
+        } else {
+            0.0
+        };
+        let global_max = per_cpu.values().map(|s| s.max_depth).max().unwrap_or(0);
+        let cpus_with_high_depth = per_cpu.values().filter(|s| s.max_depth > 10).count();
+
+        RunqueueDepthStats {
+            total_cpus,
+            global_avg_depth: global_avg,
+            global_max_depth: global_max,
+            cpus_with_high_depth,
+            per_cpu,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunqueueDepthStats {
+    pub total_cpus: usize,
+    pub global_avg_depth: f64,
+    pub global_max_depth: i64,
+    pub cpus_with_high_depth: usize,
+    pub per_cpu: HashMap<u32, CpuRunqueueStats>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CpuRunqueueStats {
+    pub cpu_id: u32,
+    pub avg_depth: f64,
+    pub max_depth: i64,
+    pub p99_depth: i64,
+    pub sample_count: usize,
+}
+
+// ============================================================================
+// DSQ Latency Analyzer (Full Implementation)
+// ============================================================================
+
+/// Analyzes DSQ (dispatch queue) latency and queue depth from sched_ext traces.
+/// Uses the properly-parsed DSQ events with UUID-matched latency and nr_queued data.
+pub struct DsqLatencyAnalyzer {
+    trace: Arc<PerfettoTrace>,
+}
+
+impl DsqLatencyAnalyzer {
+    pub fn new(trace: Arc<PerfettoTrace>) -> Self {
+        Self { trace }
+    }
+
+    /// Analyze DSQ latency for all dispatch queues in the trace.
+    pub fn analyze(&self) -> Option<DsqLatencyStats> {
+        if !self.trace.is_scx_trace() {
+            return None;
+        }
+
+        let scx_meta = self.trace.get_scx_metadata()?;
+        let (trace_start, trace_end) = self.trace.time_range();
+        let trace_duration_ns = trace_end.saturating_sub(trace_start);
+
+        let mut per_dsq: Vec<PerDsqStats> = Vec::new();
+        let mut total_events = 0usize;
+
+        for &dsq_id in &scx_meta.dsq_ids {
+            let events = self.trace.get_dsq_events(dsq_id);
+            if events.is_empty() {
+                per_dsq.push(PerDsqStats {
+                    dsq_id,
+                    event_count: 0,
+                    latency_avg_us: 0.0,
+                    latency_p50_us: 0.0,
+                    latency_p95_us: 0.0,
+                    latency_p99_us: 0.0,
+                    latency_max_us: 0.0,
+                    avg_queue_depth: 0.0,
+                    max_queue_depth: 0,
+                    dispatches_per_sec: 0.0,
+                });
+                continue;
+            }
+
+            total_events += events.len();
+
+            // Collect latency values (in microseconds)
+            let mut latencies: Vec<f64> = events
+                .iter()
+                .filter_map(|e| e.latency_us.map(|v| v as f64))
+                .collect();
+            latencies.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+            // Collect queue depth values
+            let mut queue_depths: Vec<i64> = events.iter().filter_map(|e| e.nr_queued).collect();
+
+            let lat_count = latencies.len();
+            let (lat_avg, lat_p50, lat_p95, lat_p99, lat_max) = if lat_count > 0 {
+                let avg = latencies.iter().sum::<f64>() / lat_count as f64;
+                let p50 = latencies[lat_count / 2];
+                let p95 = latencies[(lat_count as f64 * 0.95) as usize];
+                let p99 = latencies[(lat_count as f64 * 0.99).min(lat_count as f64 - 1.0) as usize];
+                let max = latencies[lat_count - 1];
+                (avg, p50, p95, p99, max)
+            } else {
+                (0.0, 0.0, 0.0, 0.0, 0.0)
+            };
+
+            let (avg_qd, max_qd) = if !queue_depths.is_empty() {
+                queue_depths.sort_unstable();
+                let avg = queue_depths.iter().sum::<i64>() as f64 / queue_depths.len() as f64;
+                let max = *queue_depths.last().unwrap();
+                (avg, max)
+            } else {
+                (0.0, 0)
+            };
+
+            let dispatches_per_sec = if trace_duration_ns > 0 {
+                events.len() as f64 / (trace_duration_ns as f64 / 1_000_000_000.0)
+            } else {
+                0.0
+            };
+
+            per_dsq.push(PerDsqStats {
+                dsq_id,
+                event_count: events.len(),
+                latency_avg_us: lat_avg,
+                latency_p50_us: lat_p50,
+                latency_p95_us: lat_p95,
+                latency_p99_us: lat_p99,
+                latency_max_us: lat_max,
+                avg_queue_depth: avg_qd,
+                max_queue_depth: max_qd,
+                dispatches_per_sec,
+            });
+        }
+
+        Some(DsqLatencyStats {
+            scheduler_name: scx_meta.scheduler_name.clone(),
+            total_dsqs: scx_meta.dsq_ids.len(),
+            total_events,
+            per_dsq,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DsqLatencyStats {
+    pub scheduler_name: Option<String>,
+    pub total_dsqs: usize,
+    pub total_events: usize,
+    pub per_dsq: Vec<PerDsqStats>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerDsqStats {
+    pub dsq_id: u64,
+    pub event_count: usize,
+    pub latency_avg_us: f64,
+    pub latency_p50_us: f64,
+    pub latency_p95_us: f64,
+    pub latency_p99_us: f64,
+    pub latency_max_us: f64,
+    pub avg_queue_depth: f64,
+    pub max_queue_depth: i64,
+    pub dispatches_per_sec: f64,
+}
+
+// ============================================================================
+// Fairness / Starvation Analyzer
+// ============================================================================
+
+/// Detects scheduling fairness issues by comparing actual CPU time distribution
+/// against expected fair share. Identifies starved and hogging processes.
+pub struct FairnessAnalyzer {
+    trace: Arc<PerfettoTrace>,
+}
+
+impl FairnessAnalyzer {
+    pub fn new(trace: Arc<PerfettoTrace>) -> Self {
+        Self { trace }
+    }
+
+    /// Analyze scheduling fairness across all processes.
+    pub fn analyze(&self) -> FairnessStats {
+        let num_cpus = self.trace.num_cpus();
+
+        // Calculate per-process runtime from sched_switch events
+        let mut process_runtime: HashMap<i32, u64> = HashMap::new();
+        let mut process_names: HashMap<i32, String> = HashMap::new();
+
+        // Track when each process last started running on each CPU
+        let mut last_switch_in: HashMap<(u32, i32), u64> = HashMap::new();
+
+        for cpu in 0..num_cpus {
+            let cpu_id = cpu as u32;
+            let events = self.trace.get_events_by_cpu(cpu_id);
+
+            for event_with_idx in events {
+                if let Some(ftrace_event::Event::SchedSwitch(switch)) = &event_with_idx.event.event
+                {
+                    let ts = event_with_idx.event.timestamp.unwrap_or(0);
+                    let prev_pid = switch.prev_pid.unwrap_or(0);
+                    let next_pid = switch.next_pid.unwrap_or(0);
+
+                    // Account runtime for prev_pid
+                    if prev_pid != 0 {
+                        if let Some(start_ts) = last_switch_in.remove(&(cpu_id, prev_pid)) {
+                            let runtime = ts.saturating_sub(start_ts);
+                            *process_runtime.entry(prev_pid).or_insert(0) += runtime;
+                        }
+                        if let Some(comm) = &switch.prev_comm {
+                            process_names
+                                .entry(prev_pid)
+                                .or_insert_with(|| comm.clone());
+                        }
+                    }
+
+                    // Mark next_pid as running on this CPU
+                    if next_pid != 0 {
+                        last_switch_in.insert((cpu_id, next_pid), ts);
+                        if let Some(comm) = &switch.next_comm {
+                            process_names
+                                .entry(next_pid)
+                                .or_insert_with(|| comm.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        if process_runtime.is_empty() {
+            return FairnessStats {
+                total_processes: 0,
+                total_cpu_time_ns: 0,
+                fair_share_ns: 0,
+                gini_coefficient: 0.0,
+                max_min_ratio: 0.0,
+                starved_processes: Vec::new(),
+                hogging_processes: Vec::new(),
+            };
+        }
+
+        // Total CPU time across all processes
+        let total_cpu_time: u64 = process_runtime.values().sum();
+        let num_processes = process_runtime.len();
+
+        // Fair share = total CPU time / number of processes
+        let fair_share = total_cpu_time / num_processes as u64;
+
+        // Calculate Gini coefficient
+        let mut runtimes: Vec<u64> = process_runtime.values().copied().collect();
+        runtimes.sort_unstable();
+        let gini = calculate_gini(&runtimes);
+
+        // Max/min ratio (excluding zeros)
+        let non_zero_runtimes: Vec<u64> = runtimes.iter().copied().filter(|&r| r > 0).collect();
+        let max_min_ratio = if non_zero_runtimes.len() >= 2 {
+            let max = *non_zero_runtimes.last().unwrap();
+            let min = *non_zero_runtimes.first().unwrap();
+            if min > 0 {
+                max as f64 / min as f64
+            } else {
+                f64::INFINITY
+            }
+        } else {
+            1.0
+        };
+
+        // Identify starved processes (< 10% of fair share)
+        let starvation_threshold = fair_share / 10;
+        let mut starved: Vec<_> = process_runtime
+            .iter()
+            .filter(|(_, &runtime)| runtime < starvation_threshold && runtime > 0)
+            .map(|(&pid, &runtime)| {
+                let comm = process_names.get(&pid).cloned().unwrap_or_default();
+                let share_pct = if fair_share > 0 {
+                    runtime as f64 / fair_share as f64 * 100.0
+                } else {
+                    0.0
+                };
+                FairnessProcess {
+                    pid,
+                    comm,
+                    runtime_ns: runtime,
+                    fair_share_pct: share_pct,
+                }
+            })
+            .collect();
+        starved.sort_by(|a, b| a.runtime_ns.cmp(&b.runtime_ns));
+
+        // Identify hogging processes (> 10x fair share)
+        let hogging_threshold = fair_share.saturating_mul(10);
+        let mut hogging: Vec<_> = process_runtime
+            .iter()
+            .filter(|(_, &runtime)| runtime > hogging_threshold)
+            .map(|(&pid, &runtime)| {
+                let comm = process_names.get(&pid).cloned().unwrap_or_default();
+                let share_pct = if fair_share > 0 {
+                    runtime as f64 / fair_share as f64 * 100.0
+                } else {
+                    0.0
+                };
+                FairnessProcess {
+                    pid,
+                    comm,
+                    runtime_ns: runtime,
+                    fair_share_pct: share_pct,
+                }
+            })
+            .collect();
+        hogging.sort_by(|a, b| b.runtime_ns.cmp(&a.runtime_ns));
+
+        FairnessStats {
+            total_processes: num_processes,
+            total_cpu_time_ns: total_cpu_time,
+            fair_share_ns: fair_share,
+            gini_coefficient: gini,
+            max_min_ratio,
+            starved_processes: starved,
+            hogging_processes: hogging,
+        }
+    }
+}
+
+/// Calculate the Gini coefficient from a sorted list of values.
+/// Returns 0.0 for perfect equality, 1.0 for maximum inequality.
+fn calculate_gini(sorted_values: &[u64]) -> f64 {
+    let n = sorted_values.len();
+    if n <= 1 {
+        return 0.0;
+    }
+
+    let sum: f64 = sorted_values.iter().map(|&v| v as f64).sum();
+    if sum == 0.0 {
+        return 0.0;
+    }
+
+    let mut numerator = 0.0;
+    for (i, &val) in sorted_values.iter().enumerate() {
+        numerator += (2.0 * (i + 1) as f64 - n as f64 - 1.0) * val as f64;
+    }
+
+    numerator / (n as f64 * sum)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FairnessStats {
+    pub total_processes: usize,
+    pub total_cpu_time_ns: u64,
+    pub fair_share_ns: u64,
+    pub gini_coefficient: f64,
+    pub max_min_ratio: f64,
+    pub starved_processes: Vec<FairnessProcess>,
+    pub hogging_processes: Vec<FairnessProcess>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FairnessProcess {
+    pub pid: i32,
+    pub comm: String,
+    pub runtime_ns: u64,
+    /// Percentage of fair share received (100% = exactly fair)
+    pub fair_share_pct: f64,
+}

--- a/tools/scxtop/src/mcp/perfetto_parser.rs
+++ b/tools/scxtop/src/mcp/perfetto_parser.rs
@@ -32,6 +32,23 @@ pub struct InternTables {
     pub debug_annotation_string_values: HashMap<u64, String>,
 }
 
+/// Topology information embedded in a trace (for cross-machine analysis)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceTopology {
+    /// CPU to LLC (Last Level Cache) ID mapping
+    pub cpu_to_llc: HashMap<u32, u32>,
+    /// CPU to NUMA node ID mapping
+    pub cpu_to_numa: HashMap<u32, u32>,
+    /// CPU to core ID mapping
+    pub cpu_to_core: HashMap<u32, u32>,
+    /// Total number of CPUs
+    pub nr_cpus: u32,
+    /// Total number of LLCs
+    pub nr_llcs: u32,
+    /// Total number of NUMA nodes
+    pub nr_numa_nodes: u32,
+}
+
 /// Core structure for a parsed perfetto trace file
 #[derive(Clone)]
 pub struct PerfettoTrace {
@@ -46,7 +63,6 @@ pub struct PerfettoTrace {
     /// Ftrace events indexed by CPU for efficient per-CPU queries
     ftrace_events_by_cpu: BTreeMap<u32, Vec<FtraceEventWithIndex>>,
     /// DSQ (dispatch queue) events indexed by DSQ ID
-    #[allow(dead_code)] // Reserved for future DSQ latency analysis
     dsq_events: HashMap<u64, Vec<DsqEvent>>,
     /// System statistics indexed by timestamp
     #[allow(dead_code)] // Reserved for future system stats analysis
@@ -55,6 +71,8 @@ pub struct PerfettoTrace {
     time_range: (u64, u64),
     /// sched_ext scheduler metadata (if trace contains sched_ext events)
     scx_metadata: Option<SchedExtMetadata>,
+    /// Topology information extracted from trace metadata (if available)
+    topology: Option<TraceTopology>,
 
     /// NEW: Track events parsed from wprof traces (ONCPU, WAKER, etc.)
     track_events: Vec<super::perfetto_track_event_types::ParsedTrackEvent>,
@@ -254,11 +272,25 @@ impl PerfettoTrace {
     /// Parse a perfetto trace file from disk
     pub fn from_file(path: &Path) -> Result<Self> {
         // Read entire file into memory
-        let bytes = fs::read(path)?;
+        eprintln!("[perfetto_parser] Loading trace file: {:?}", path);
+        let bytes = fs::read(path).map_err(|e| {
+            eprintln!("[perfetto_parser] Failed to read file {:?}: {}", path, e);
+            anyhow!("Failed to read trace file {:?}: {}", path, e)
+        })?;
+        eprintln!(
+            "[perfetto_parser] Read {} bytes, parsing protobuf...",
+            bytes.len()
+        );
 
         // Parse protobuf
-        let trace = Trace::parse_from_bytes(&bytes)
-            .map_err(|e| anyhow!("Failed to parse perfetto trace: {}", e))?;
+        let trace = Trace::parse_from_bytes(&bytes).map_err(|e| {
+            eprintln!("[perfetto_parser] Failed to parse protobuf: {}", e);
+            anyhow!("Failed to parse perfetto trace: {}", e)
+        })?;
+        eprintln!(
+            "[perfetto_parser] Parsed {} packets, building indexes...",
+            trace.packet.len()
+        );
 
         // Build trace structure with indexes
         Self::from_trace(trace)
@@ -277,6 +309,13 @@ impl PerfettoTrace {
         // Track DSQ descriptors as we parse
         let mut dsq_descriptors: HashMap<u64, DsqDescriptor> = HashMap::new();
         let mut has_scx_events = false;
+
+        // UUID-to-DSQ-ID mappings for proper TrackEvent correlation
+        let mut uuid_to_dsq_latency: HashMap<u64, u64> = HashMap::new();
+        let mut uuid_to_dsq_nr_queued: HashMap<u64, u64> = HashMap::new();
+
+        // Topology metadata (if embedded in trace)
+        let mut trace_topology: Option<TraceTopology> = None;
 
         // Track events storage
         let mut track_events: Vec<super::perfetto_track_event_types::ParsedTrackEvent> = Vec::new();
@@ -389,29 +428,59 @@ impl PerfettoTrace {
                         if let Some(counter) = track_desc.counter.as_ref() {
                             if let Some(unit_name) = &counter.unit_name {
                                 // DSQ tracks have unit names like "DSQ 0 latency ns" or "DSQ 0 nr_queued"
-                                if unit_name.contains("DSQ ") && unit_name.contains("latency") {
-                                    // Extract DSQ ID from track UUID
-                                    if let Some(_uuid) = track_desc.uuid {
-                                        // DSQ ID is encoded in the track name
-                                        if let Some(name_str) = &track_desc.static_or_dynamic_name {
-                                            use perfetto_protos::track_descriptor::track_descriptor::Static_or_dynamic_name;
-                                            if let Static_or_dynamic_name::StaticName(name) =
-                                                name_str
+                                if unit_name.contains("DSQ ") {
+                                    let is_latency = unit_name.contains("latency");
+                                    let is_nr_queued = unit_name.contains("nr_queued");
+
+                                    if is_latency || is_nr_queued {
+                                        if let Some(uuid) = track_desc.uuid {
+                                            // Extract DSQ ID from the track name
+                                            if let Some(name_str) =
+                                                &track_desc.static_or_dynamic_name
                                             {
-                                                if let Some(dsq_id) = extract_dsq_id_from_name(name)
+                                                use perfetto_protos::track_descriptor::track_descriptor::Static_or_dynamic_name;
+                                                if let Static_or_dynamic_name::StaticName(name) =
+                                                    name_str
                                                 {
-                                                    has_scx_events = true;
-                                                    dsq_descriptors.entry(dsq_id).or_insert(
-                                                        DsqDescriptor {
-                                                            dsq_id,
-                                                            first_seen: u64::MAX,
-                                                            last_seen: 0,
-                                                            event_count: 0,
-                                                        },
-                                                    );
+                                                    if let Some(dsq_id) =
+                                                        extract_dsq_id_from_name(name)
+                                                    {
+                                                        has_scx_events = true;
+                                                        dsq_descriptors.entry(dsq_id).or_insert(
+                                                            DsqDescriptor {
+                                                                dsq_id,
+                                                                first_seen: u64::MAX,
+                                                                last_seen: 0,
+                                                                event_count: 0,
+                                                            },
+                                                        );
+
+                                                        // Store UUID-to-DSQ mapping for proper event correlation
+                                                        if is_latency {
+                                                            uuid_to_dsq_latency
+                                                                .insert(uuid, dsq_id);
+                                                        } else {
+                                                            uuid_to_dsq_nr_queued
+                                                                .insert(uuid, dsq_id);
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Check for topology metadata (scxtop embeds this as "scxtop_topo:{json}")
+                        if let Some(name_str) = &track_desc.static_or_dynamic_name {
+                            use perfetto_protos::track_descriptor::track_descriptor::Static_or_dynamic_name;
+                            if let Static_or_dynamic_name::StaticName(name) = name_str {
+                                if let Some(json_str) = name.strip_prefix("scxtop_topo:") {
+                                    if let Ok(topo) =
+                                        serde_json::from_str::<TraceTopology>(json_str)
+                                    {
+                                        trace_topology = Some(topo);
                                     }
                                 }
                             }
@@ -516,29 +585,52 @@ impl PerfettoTrace {
                             track_events.push(parsed_event);
                         }
 
-                        // Also extract DSQ events from track events (legacy behavior)
-                        if let Some(_uuid) = track_event.track_uuid {
-                            // Check if this is a DSQ track by looking for it in descriptors
-                            for (&dsq_id, desc) in dsq_descriptors.iter_mut() {
-                                // This is a simplified check - in reality we'd match UUIDs properly
-                                if let Some(ts) = extract_track_event_timestamp(track_event) {
-                                    let ts_ns = ts * 1000; // Convert us to ns
+                        // Extract DSQ events using proper UUID matching
+                        if let Some(uuid) = track_event.track_uuid {
+                            if let Some(ts) = extract_track_event_timestamp(track_event) {
+                                let ts_ns = ts * 1000; // Convert us to ns
+                                let value = extract_counter_value(track_event);
 
-                                    // Extract counter value
-                                    let value = extract_counter_value(track_event);
+                                // Check if this UUID belongs to a DSQ latency track
+                                if let Some(&dsq_id) = uuid_to_dsq_latency.get(&uuid) {
+                                    if let Some(desc) = dsq_descriptors.get_mut(&dsq_id) {
+                                        desc.first_seen = desc.first_seen.min(ts_ns);
+                                        desc.last_seen = desc.last_seen.max(ts_ns);
+                                        desc.event_count += 1;
+                                    }
 
-                                    // Update descriptor
-                                    desc.first_seen = desc.first_seen.min(ts_ns);
-                                    desc.last_seen = desc.last_seen.max(ts_ns);
-                                    desc.event_count += 1;
-
-                                    // Create DSQ event (simplified - would need proper UUID matching)
+                                    // Insert or update DSQ event with latency
                                     dsq_events.entry(dsq_id).or_default().push(DsqEvent {
                                         dsq_id,
                                         timestamp: ts_ns,
                                         latency_us: value,
-                                        nr_queued: None, // Would be filled from separate track
+                                        nr_queued: None,
                                     });
+                                }
+                                // Check if this UUID belongs to a DSQ nr_queued track
+                                else if let Some(&dsq_id) = uuid_to_dsq_nr_queued.get(&uuid) {
+                                    if let Some(desc) = dsq_descriptors.get_mut(&dsq_id) {
+                                        desc.first_seen = desc.first_seen.min(ts_ns);
+                                        desc.last_seen = desc.last_seen.max(ts_ns);
+                                    }
+
+                                    // Try to merge with existing latency event at same timestamp,
+                                    // otherwise create new event with just nr_queued
+                                    let events = dsq_events.entry(dsq_id).or_default();
+                                    let merged = events
+                                        .last_mut()
+                                        .filter(|e| e.timestamp == ts_ns && e.nr_queued.is_none())
+                                        .is_some();
+                                    if merged {
+                                        events.last_mut().unwrap().nr_queued = value;
+                                    } else {
+                                        events.push(DsqEvent {
+                                            dsq_id,
+                                            timestamp: ts_ns,
+                                            latency_us: None,
+                                            nr_queued: value,
+                                        });
+                                    }
                                 }
                             }
                         }
@@ -579,6 +671,7 @@ impl PerfettoTrace {
             system_stats,
             time_range: (min_ts, max_ts),
             scx_metadata,
+            topology: trace_topology,
             track_events,
             track_events_by_pid,
             track_events_by_category,
@@ -707,18 +800,26 @@ impl PerfettoTrace {
             .unwrap_or(false)
     }
 
-    /// Get sched_ext events for a specific DSQ
-    ///
-    /// Returns SchedExtEventData for the specified DSQ extracted from the trace.
-    /// Note: Currently returns simplified data; full DSQ event correlation
-    /// requires UUID matching between TrackDescriptors and TrackEvents.
+    /// Get DSQ events for a specific DSQ ID
+    pub fn get_dsq_events(&self, dsq_id: u64) -> &[DsqEvent] {
+        self.dsq_events
+            .get(&dsq_id)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Get all DSQ events across all DSQs
+    pub fn get_all_dsq_events(&self) -> &HashMap<u64, Vec<DsqEvent>> {
+        &self.dsq_events
+    }
+
+    /// Get topology information embedded in the trace (if available)
+    pub fn get_topology(&self) -> Option<&TraceTopology> {
+        self.topology.as_ref()
+    }
+
+    /// Get sched_ext events for a specific DSQ (legacy interface)
     pub fn get_scx_events_by_dsq(&self, _dsq_id: u64) -> Vec<SchedExtEventData> {
-        // Full implementation would correlate:
-        // 1. TrackDescriptor UUIDs for DSQ tracks
-        // 2. TrackEvent counter values matching those UUIDs
-        // 3. sched_switch events occurring at same timestamp
-        // This requires more complex UUID tracking during parse phase.
-        // For now, DSQ metadata is available via get_scx_metadata()
         Vec::new()
     }
 

--- a/tools/scxtop/src/mcp/protocol.rs
+++ b/tools/scxtop/src/mcp/protocol.rs
@@ -196,7 +196,7 @@ impl JsonRpcError {
     pub fn internal_error(msg: &str) -> Self {
         Self {
             code: -32603,
-            message: "Internal error".to_string(),
+            message: format!("Internal error: {}", msg),
             data: Some(serde_json::json!({"detail": msg})),
         }
     }

--- a/tools/scxtop/src/mcp/tools.rs
+++ b/tools/scxtop/src/mcp/tools.rs
@@ -420,7 +420,7 @@ impl McpTools {
                         },
                         "analysis_type": {
                             "type": "string",
-                            "enum": ["cpu_utilization", "process_runtime", "wakeup_latency", "migration_patterns", "dsq_summary", "task_states", "preemptions", "wakeup_chains", "latency_breakdown", "irq_analysis", "ipi_analysis", "block_io", "network_io", "memory_pressure", "file_io", "cpu_frequency", "cpu_idle", "power_state"],
+                            "enum": ["cpu_utilization", "process_runtime", "wakeup_latency", "migration_patterns", "dsq_summary", "dsq_latency", "task_states", "preemptions", "wakeup_chains", "latency_breakdown", "llc_locality", "runqueue_depth", "fairness", "irq_analysis", "ipi_analysis", "block_io", "network_io", "memory_pressure", "file_io", "cpu_frequency", "cpu_idle", "power_state"],
                             "description": "Type of analysis to perform"
                         },
                         "use_parallel": {
@@ -438,6 +438,10 @@ impl McpTools {
                         "pid": {
                             "type": "integer",
                             "description": "Optional PID filter for process-specific analysis"
+                        },
+                        "cpu": {
+                            "type": "integer",
+                            "description": "Optional CPU filter for cpu_utilization and wakeup_latency analyses"
                         }
                     },
                     "required": ["trace_id", "analysis_type"]
@@ -836,6 +840,81 @@ impl McpTools {
                 }),
             },
             McpTool {
+                name: "analyze_dsq_latency".to_string(),
+                description: "Analyze DSQ (dispatch queue) latency and queue depth statistics per DSQ".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "trace_id": {
+                            "type": "string",
+                            "description": "Trace ID returned from load_perfetto_trace"
+                        }
+                    },
+                    "required": ["trace_id"]
+                }),
+            },
+            McpTool {
+                name: "analyze_llc_locality".to_string(),
+                description: "Analyze cache locality of migrations - tracks same-LLC vs cross-LLC vs cross-NUMA migrations. Requires topology metadata in trace.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "trace_id": {
+                            "type": "string",
+                            "description": "Trace ID returned from load_perfetto_trace"
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Number of top results to return",
+                            "default": 20
+                        }
+                    },
+                    "required": ["trace_id"]
+                }),
+            },
+            McpTool {
+                name: "analyze_runqueue_depth".to_string(),
+                description: "Analyze runqueue depth over time per CPU. Shows how many runnable tasks are queued on each CPU.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "trace_id": {
+                            "type": "string",
+                            "description": "Trace ID returned from load_perfetto_trace"
+                        },
+                        "cpu": {
+                            "type": "integer",
+                            "description": "Optional CPU filter"
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Number of top CPUs to return",
+                            "default": 20
+                        }
+                    },
+                    "required": ["trace_id"]
+                }),
+            },
+            McpTool {
+                name: "analyze_fairness".to_string(),
+                description: "Analyze scheduling fairness using Gini coefficient. Identifies starved and hogging processes.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "trace_id": {
+                            "type": "string",
+                            "description": "Trace ID returned from load_perfetto_trace"
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Number of top starved/hogging processes to return",
+                            "default": 20
+                        }
+                    },
+                    "required": ["trace_id"]
+                }),
+            },
+            McpTool {
                 name: "analyze_task_states".to_string(),
                 description: "Analyze task state transitions (running, runnable, blocked, etc.). Returns verbose per-thread or per-process data.".to_string(),
                 input_schema: json!({
@@ -1107,7 +1186,14 @@ impl McpTools {
             "control_analyzers" => self.tool_control_analyzers(arguments),
             "analyze_waker_wakee" => self.tool_analyze_waker_wakee(arguments),
             "analyze_softirq" => self.tool_analyze_softirq(arguments),
-            "load_perfetto_trace" => self.tool_load_perfetto_trace(arguments),
+            "load_perfetto_trace" => {
+                eprintln!("[mcp] load_perfetto_trace called with args: {}", arguments);
+                let result = self.tool_load_perfetto_trace(arguments);
+                if let Err(ref e) = result {
+                    eprintln!("[mcp] load_perfetto_trace failed: {}", e);
+                }
+                result
+            }
             "query_trace_events" => self.tool_query_trace_events(arguments),
             "analyze_trace_scheduling" => self.tool_analyze_trace_scheduling(arguments),
             "get_process_timeline" => self.tool_get_process_timeline(arguments),
@@ -1139,6 +1225,10 @@ impl McpTools {
             "analyze_cpu_frequency" => self.tool_analyze_cpu_frequency(arguments),
             "analyze_cpu_idle" => self.tool_analyze_cpu_idle(arguments),
             "analyze_power_state" => self.tool_analyze_power_state(arguments),
+            "analyze_dsq_latency" => self.tool_analyze_dsq_latency(arguments),
+            "analyze_llc_locality" => self.tool_analyze_llc_locality(arguments),
+            "analyze_runqueue_depth" => self.tool_analyze_runqueue_depth(arguments),
+            "analyze_fairness" => self.tool_analyze_fairness(arguments),
             _ => Err(anyhow!("Unknown tool: {}", name)),
         }
     }
@@ -2264,6 +2354,8 @@ impl McpTools {
 
         let pid = args.get("pid").and_then(|v| v.as_i64()).map(|v| v as i32);
 
+        let cpu_filter = args.get("cpu").and_then(|v| v.as_u64()).map(|v| v as u32);
+
         // Extract aggregation_mode parameter for task state analysis
         let aggregation_mode = args
             .get("aggregation_mode")
@@ -2294,11 +2386,69 @@ impl McpTools {
                     analyzer.analyze_cpu_utilization()
                 };
 
+                // If a specific CPU is requested, return just that CPU's data
+                if let Some(cpu_id) = cpu_filter {
+                    if let Some(cpu_stats) = stats.get(&cpu_id) {
+                        return Ok(json!({
+                            "content": [{
+                                "type": "text",
+                                "text": serde_json::to_string_pretty(&json!({
+                                    "analysis_type": "cpu_utilization",
+                                    "cpu_filter": cpu_id,
+                                    "cpu": cpu_stats,
+                                })).unwrap()
+                            }]
+                        }));
+                    } else {
+                        return Err(anyhow!("CPU {} not found in trace", cpu_id));
+                    }
+                }
+
+                // Build sorted list for summary
+                let mut cpu_list: Vec<_> = stats.values().collect();
+                cpu_list.sort_by(|a, b| {
+                    b.utilization_percent
+                        .partial_cmp(&a.utilization_percent)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+
+                let total_cpus = cpu_list.len();
+                let avg_util = if total_cpus > 0 {
+                    cpu_list.iter().map(|c| c.utilization_percent).sum::<f64>() / total_cpus as f64
+                } else {
+                    0.0
+                };
+                let high_util = cpu_list
+                    .iter()
+                    .filter(|c| c.utilization_percent > 80.0)
+                    .count();
+                let mid_util = cpu_list
+                    .iter()
+                    .filter(|c| c.utilization_percent >= 50.0 && c.utilization_percent <= 80.0)
+                    .count();
+                let low_util = cpu_list
+                    .iter()
+                    .filter(|c| c.utilization_percent < 10.0)
+                    .count();
+
+                // Return top N and bottom N CPUs instead of all
+                let top_n = limit.min(20);
+                let top_cpus: Vec<_> = cpu_list.iter().take(top_n).collect();
+                let bottom_cpus: Vec<_> = cpu_list.iter().rev().take(top_n.min(5)).collect();
+
                 json!({
                     "analysis_type": "cpu_utilization",
-                    "cpus_analyzed": stats.len(),
+                    "cpus_analyzed": total_cpus,
                     "multi_threaded": use_parallel,
-                    "cpus": stats,
+                    "summary": {
+                        "avg_utilization_percent": avg_util,
+                        "cpus_above_80_pct": high_util,
+                        "cpus_50_to_80_pct": mid_util,
+                        "cpus_below_10_pct": low_util,
+                    },
+                    "top_utilized_cpus": top_cpus,
+                    "bottom_utilized_cpus": bottom_cpus,
+                    "note": format!("Showing top {} and bottom {} of {} CPUs. Use cpu parameter to filter specific CPU, limit to adjust count.", top_n, top_n.min(5), total_cpus),
                 })
             }
             "process_runtime" => {
@@ -2309,11 +2459,13 @@ impl McpTools {
                     analyzer.analyze_process_runtime(pid)
                 };
 
+                let total_processes = stats.len();
                 let limited_stats: Vec<_> = stats.into_iter().take(limit).collect();
 
                 json!({
                     "analysis_type": "process_runtime",
-                    "processes_analyzed": limited_stats.len(),
+                    "total_processes": total_processes,
+                    "processes_shown": limited_stats.len(),
                     "multi_threaded": use_parallel,
                     "pid_filter": pid,
                     "processes": limited_stats,
@@ -2323,18 +2475,83 @@ impl McpTools {
                 let analyzer = WakeupChainAnalyzer::new(trace);
                 let stats = analyzer.analyze_wakeup_latency();
 
+                // If a specific CPU is requested, return just that CPU's data
+                if let Some(cpu_id) = cpu_filter {
+                    if let Some(cpu_stats) = stats.per_cpu_stats.get(&cpu_id) {
+                        return Ok(json!({
+                            "content": [{
+                                "type": "text",
+                                "text": serde_json::to_string_pretty(&json!({
+                                    "analysis_type": "wakeup_latency",
+                                    "cpu_filter": cpu_id,
+                                    "cpu_stats": cpu_stats,
+                                    "global_comparison": {
+                                        "global_avg_latency_ns": stats.avg_latency_ns,
+                                        "global_p99_latency_ns": stats.p99_latency_ns,
+                                    }
+                                })).unwrap()
+                            }]
+                        }));
+                    } else {
+                        return Err(anyhow!("CPU {} not found in wakeup latency data", cpu_id));
+                    }
+                }
+
+                // Sort per-CPU stats by avg latency descending, show top N worst
+                let mut per_cpu_sorted: Vec<_> = stats.per_cpu_stats.values().collect();
+                per_cpu_sorted.sort_by(|a, b| b.avg_latency_ns.cmp(&a.avg_latency_ns));
+                let total_cpus = per_cpu_sorted.len();
+                let top_n = limit.min(20);
+                let worst_cpus: Vec<_> = per_cpu_sorted.iter().take(top_n).collect();
+
                 json!({
                     "analysis_type": "wakeup_latency",
-                    "stats": stats,
+                    "total_wakeups": stats.total_wakeups,
+                    "total_cpus": total_cpus,
+                    "global_stats": {
+                        "min_latency_ns": stats.min_latency_ns,
+                        "max_latency_ns": stats.max_latency_ns,
+                        "avg_latency_ns": stats.avg_latency_ns,
+                        "p50_latency_ns": stats.p50_latency_ns,
+                        "p95_latency_ns": stats.p95_latency_ns,
+                        "p99_latency_ns": stats.p99_latency_ns,
+                        "p999_latency_ns": stats.p999_latency_ns,
+                    },
+                    "worst_cpus_by_avg_latency": worst_cpus,
+                    "note": format!("Showing {} worst CPUs by avg latency out of {}. Use cpu parameter to filter specific CPU, limit to adjust count.", top_n, total_cpus),
                 })
             }
             "migration_patterns" => {
                 let analyzer = PerfettoMigrationAnalyzer::new(trace);
                 let stats = analyzer.analyze_migration_patterns();
 
+                // Sort migrations_by_process by count descending and limit
+                let mut migrations_sorted: Vec<_> = stats.migrations_by_process.iter().collect();
+                migrations_sorted.sort_by(|a, b| b.1.cmp(a.1));
+                let total_processes = migrations_sorted.len();
+                let top_n = limit.min(20);
+                let top_migrators: Vec<_> = migrations_sorted
+                    .iter()
+                    .take(top_n)
+                    .map(|(pid, count)| json!({"pid": pid, "migration_count": count}))
+                    .collect();
+
                 json!({
                     "analysis_type": "migration_patterns",
-                    "stats": stats,
+                    "total_migrations": stats.total_migrations,
+                    "cross_numa_migrations": stats.cross_numa_migrations,
+                    "cross_llc_migrations": stats.cross_llc_migrations,
+                    "latency": {
+                        "min_ns": stats.min_latency_ns,
+                        "max_ns": stats.max_latency_ns,
+                        "avg_ns": stats.avg_latency_ns,
+                        "p50_ns": stats.p50_latency_ns,
+                        "p95_ns": stats.p95_latency_ns,
+                        "p99_ns": stats.p99_latency_ns,
+                    },
+                    "total_processes_migrated": total_processes,
+                    "top_migrating_processes": top_migrators,
+                    "note": format!("Showing top {} of {} migrating processes.", top_n, total_processes),
                 })
             }
             "dsq_summary" => {
@@ -2354,6 +2571,126 @@ impl McpTools {
                 json!({
                     "analysis_type": "dsq_summary",
                     "summary": summary,
+                })
+            }
+            "dsq_latency" => {
+                use super::perfetto_analyzers_scheduling::DsqLatencyAnalyzer;
+                let analyzer = DsqLatencyAnalyzer::new(trace);
+
+                match analyzer.analyze() {
+                    Some(stats) => {
+                        json!({
+                            "analysis_type": "dsq_latency",
+                            "scheduler_name": stats.scheduler_name,
+                            "total_dsqs": stats.total_dsqs,
+                            "total_events": stats.total_events,
+                            "per_dsq": stats.per_dsq,
+                        })
+                    }
+                    None => {
+                        return Ok(json!({
+                            "content": [{
+                                "type": "text",
+                                "text": "This trace does not contain sched_ext (DSQ) data.\n\nDSQ latency analysis requires a trace generated while a sched_ext scheduler is active."
+                            }]
+                        }));
+                    }
+                }
+            }
+            "llc_locality" => {
+                use super::perfetto_analyzers_scheduling::LlcLocalityAnalyzer;
+                let analyzer = LlcLocalityAnalyzer::new(trace);
+
+                match analyzer.analyze() {
+                    Some(stats) => {
+                        // Limit per-LLC stats and top processes
+                        let mut per_llc_sorted: Vec<_> = stats.per_llc_stats.values().collect();
+                        per_llc_sorted
+                            .sort_by(|a, b| b.outbound_migrations.cmp(&a.outbound_migrations));
+                        let top_n = limit.min(20);
+                        let limited_llc: Vec<_> = per_llc_sorted.into_iter().take(top_n).collect();
+                        let limited_procs: Vec<_> =
+                            stats.top_cross_llc_processes.iter().take(top_n).collect();
+
+                        let locality_pct = if stats.total_migrations > 0 {
+                            stats.same_llc_migrations as f64 / stats.total_migrations as f64 * 100.0
+                        } else {
+                            100.0
+                        };
+
+                        json!({
+                            "analysis_type": "llc_locality",
+                            "topology": {
+                                "nr_cpus": stats.nr_cpus,
+                                "nr_llcs": stats.nr_llcs,
+                                "nr_numa_nodes": stats.nr_numa_nodes,
+                            },
+                            "total_migrations": stats.total_migrations,
+                            "same_llc_migrations": stats.same_llc_migrations,
+                            "cross_llc_same_numa_migrations": stats.cross_llc_same_numa_migrations,
+                            "cross_numa_migrations": stats.cross_numa_migrations,
+                            "llc_locality_pct": locality_pct,
+                            "per_llc_stats": limited_llc,
+                            "top_cross_llc_processes": limited_procs,
+                        })
+                    }
+                    None => {
+                        return Ok(json!({
+                            "content": [{
+                                "type": "text",
+                                "text": "No topology data available in this trace.\n\nLLC locality analysis requires topology metadata embedded in the trace. Traces generated by scxtop >= v1.x include this data automatically.\n\nFor older traces, re-record with the latest scxtop version."
+                            }]
+                        }));
+                    }
+                }
+            }
+            "runqueue_depth" => {
+                use super::perfetto_analyzers_scheduling::RunqueueDepthAnalyzer;
+                let analyzer = RunqueueDepthAnalyzer::new(trace);
+                let stats = analyzer.analyze(cpu_filter);
+
+                // Sort CPUs by max depth descending
+                let mut cpu_sorted: Vec<_> = stats.per_cpu.values().collect();
+                cpu_sorted.sort_by(|a, b| b.max_depth.cmp(&a.max_depth));
+                let top_n = limit.min(20);
+                let worst_cpus: Vec<_> = cpu_sorted.iter().take(top_n).collect();
+
+                json!({
+                    "analysis_type": "runqueue_depth",
+                    "total_cpus": stats.total_cpus,
+                    "global_avg_depth": stats.global_avg_depth,
+                    "global_max_depth": stats.global_max_depth,
+                    "cpus_with_high_depth": stats.cpus_with_high_depth,
+                    "worst_cpus_by_max_depth": worst_cpus,
+                    "note": format!("Showing top {} CPUs by max queue depth. Use cpu parameter to filter specific CPU.", top_n),
+                })
+            }
+            "fairness" => {
+                use super::perfetto_analyzers_scheduling::FairnessAnalyzer;
+                let analyzer = FairnessAnalyzer::new(trace);
+                let stats = analyzer.analyze();
+
+                let top_n = limit.min(20);
+                let starved: Vec<_> = stats.starved_processes.iter().take(top_n).collect();
+                let hogging: Vec<_> = stats.hogging_processes.iter().take(top_n).collect();
+
+                json!({
+                    "analysis_type": "fairness",
+                    "total_processes": stats.total_processes,
+                    "total_cpu_time_ns": stats.total_cpu_time_ns,
+                    "fair_share_ns": stats.fair_share_ns,
+                    "gini_coefficient": stats.gini_coefficient,
+                    "max_min_ratio": stats.max_min_ratio,
+                    "interpretation": {
+                        "gini": if stats.gini_coefficient < 0.3 { "Low inequality (good)" }
+                               else if stats.gini_coefficient < 0.6 { "Moderate inequality" }
+                               else { "High inequality (potential starvation)" },
+                    },
+                    "starved_processes_count": stats.starved_processes.len(),
+                    "hogging_processes_count": stats.hogging_processes.len(),
+                    "top_starved": starved,
+                    "top_hogging": hogging,
+                    "note": format!("Showing top {} starved and hogging processes.", top_n),
                 })
             }
             "task_states" => {
@@ -2386,24 +2723,66 @@ impl McpTools {
                 use super::perfetto_analyzers_extended::PreemptionAnalyzer;
                 let analyzer = PreemptionAnalyzer::new(trace);
                 let stats = analyzer.analyze_preemptions(pid);
-                let limited_stats: Vec<_> = stats.into_iter().take(limit).collect();
+                let total_processes = stats.len();
+                let total_preemptions: usize = stats.iter().map(|s| s.preempted_count).sum();
+                let top_n = limit.min(20);
+                // Limit number of processes and truncate preempted_by per process
+                let limited_stats: Vec<_> = stats
+                    .into_iter()
+                    .take(top_n)
+                    .map(|mut s| {
+                        let total_preemptors = s.preempted_by.len();
+                        s.preempted_by.truncate(5);
+                        json!({
+                            "pid": s.pid,
+                            "comm": s.comm,
+                            "preempted_count": s.preempted_count,
+                            "total_unique_preemptors": total_preemptors,
+                            "top_preempted_by": s.preempted_by,
+                        })
+                    })
+                    .collect();
 
                 json!({
                     "analysis_type": "preemptions",
-                    "processes_analyzed": limited_stats.len(),
+                    "total_preemptions": total_preemptions,
+                    "total_processes": total_processes,
+                    "processes_shown": limited_stats.len(),
                     "pid_filter": pid,
                     "processes": limited_stats,
+                    "note": format!("Showing top {} of {} processes. preempted_by limited to top 5 per process.", top_n, total_processes),
                 })
             }
             "wakeup_chains" => {
                 use super::perfetto_analyzers_extended::WakeupChainDetector;
                 let analyzer = WakeupChainDetector::new(trace);
-                let chains = analyzer.find_wakeup_chains(limit);
+                // Cap wakeup chains to prevent massive output
+                let chain_limit = limit.min(10);
+                let chains = analyzer.find_wakeup_chains(chain_limit);
+                let total_chains = chains.len();
+
+                // Truncate chain events to max 10 per chain
+                let limited_chains: Vec<_> = chains
+                    .into_iter()
+                    .map(|mut c| {
+                        let full_length = c.chain.len();
+                        c.chain.truncate(10);
+                        json!({
+                            "chain": c.chain,
+                            "total_latency_ns": c.total_latency_ns,
+                            "chain_length": c.chain_length,
+                            "full_chain_length": full_length,
+                            "criticality_score": c.criticality_score,
+                        })
+                    })
+                    .collect();
 
                 json!({
                     "analysis_type": "wakeup_chains",
-                    "chains_found": chains.len(),
-                    "chains": chains,
+                    "total_chains_found": total_chains,
+                    "chains_shown": limited_chains.len(),
+                    "chains": limited_chains,
+                    "note": format!("Showing top {} chains, events per chain limited to 10.", chain_limit),
                 })
             }
             "latency_breakdown" => {
@@ -3671,6 +4050,30 @@ impl McpTools {
     fn tool_analyze_power_state(&self, args: &Value) -> Result<Value> {
         let mut modified_args = args.clone();
         modified_args["analysis_type"] = json!("power_state");
+        self.tool_analyze_trace_scheduling(&modified_args)
+    }
+
+    fn tool_analyze_dsq_latency(&self, args: &Value) -> Result<Value> {
+        let mut modified_args = args.clone();
+        modified_args["analysis_type"] = json!("dsq_latency");
+        self.tool_analyze_trace_scheduling(&modified_args)
+    }
+
+    fn tool_analyze_llc_locality(&self, args: &Value) -> Result<Value> {
+        let mut modified_args = args.clone();
+        modified_args["analysis_type"] = json!("llc_locality");
+        self.tool_analyze_trace_scheduling(&modified_args)
+    }
+
+    fn tool_analyze_runqueue_depth(&self, args: &Value) -> Result<Value> {
+        let mut modified_args = args.clone();
+        modified_args["analysis_type"] = json!("runqueue_depth");
+        self.tool_analyze_trace_scheduling(&modified_args)
+    }
+
+    fn tool_analyze_fairness(&self, args: &Value) -> Result<Value> {
+        let mut modified_args = args.clone();
+        modified_args["analysis_type"] = json!("fairness");
         self.tool_analyze_trace_scheduling(&modified_args)
     }
 }

--- a/tools/scxtop/src/perfetto_trace.rs
+++ b/tools/scxtop/src/perfetto_trace.rs
@@ -74,6 +74,8 @@ pub struct PerfettoTraceManager {
     sys_stats: BTreeMap<u64, Vec<SysStats>>,
     mem_events: BTreeMap<String, Vec<TrackEvent>>,
     mem_uuids: HashMap<String, u64>,
+    // Topology metadata to embed in trace for cross-machine analysis
+    topology_json: Option<String>,
 }
 
 impl PerfettoTraceManager {
@@ -108,7 +110,39 @@ impl PerfettoTraceManager {
             sys_stats: BTreeMap::new(),
             mem_events: BTreeMap::new(),
             mem_uuids,
+            topology_json: None,
         }
+    }
+
+    /// Set topology metadata to embed in the trace.
+    /// The topology is serialized as a JSON string in a special TrackDescriptor
+    /// so traces can be analyzed on different machines.
+    pub fn set_topology(
+        &mut self,
+        cpu_to_llc: HashMap<u32, u32>,
+        cpu_to_numa: HashMap<u32, u32>,
+        cpu_to_core: HashMap<u32, u32>,
+    ) {
+        let nr_cpus = cpu_to_llc.len() as u32;
+        let nr_llcs = cpu_to_llc
+            .values()
+            .collect::<std::collections::HashSet<_>>()
+            .len() as u32;
+        let nr_numa_nodes = cpu_to_numa
+            .values()
+            .collect::<std::collections::HashSet<_>>()
+            .len() as u32;
+
+        let topo = serde_json::json!({
+            "cpu_to_llc": cpu_to_llc,
+            "cpu_to_numa": cpu_to_numa,
+            "cpu_to_core": cpu_to_core,
+            "nr_cpus": nr_cpus,
+            "nr_llcs": nr_llcs,
+            "nr_numa_nodes": nr_numa_nodes,
+        });
+
+        self.topology_json = Some(topo.to_string());
     }
 
     /// Starts a new perfetto trace.
@@ -400,6 +434,19 @@ impl PerfettoTraceManager {
                     ..TracePacket::default()
                 });
             }
+        }
+
+        // Topology metadata (embedded for cross-machine trace analysis)
+        if let Some(topo_json) = &self.topology_json {
+            let topo_name = format!("scxtop_topo:{}", topo_json);
+            self.trace.packet.push(TracePacket {
+                data: Some(trace_packet::Data::TrackDescriptor(TrackDescriptor {
+                    uuid: Some(self.rng.next_u64()),
+                    static_or_dynamic_name: Some(Static_or_dynamic_name::StaticName(topo_name)),
+                    ..TrackDescriptor::default()
+                })),
+                ..TracePacket::default()
+            });
         }
 
         // dsq latency tracks


### PR DESCRIPTION
Add new Perfetto trace analyzers for scheduling insights:
- DSQ latency and queue depth statistics per dispatch queue
- LLC locality analysis tracking same-LLC vs cross-LLC vs cross-NUMA migrations
- Per-CPU runqueue depth analysis over time
- Scheduling fairness analysis

Also adds CPU filter support to cpu_utilization and wakeup_latency analyses.