### PR TITLE
scxtop: Fix perf event handling for tracepoints and improve profiling

### DIFF
--- a/tools/scxtop/src/mcp/perf_profiling.rs
+++ b/tools/scxtop/src/mcp/perf_profiling.rs
@@ -61,17 +61,23 @@ pub struct PerfProfilingConfig {
     pub max_samples: usize,
     /// Duration to collect in seconds (0 for manual stop)
     pub duration_secs: u64,
+    /// Counting-only mode: no BPF attachment, just count events.
+    /// Automatically set for tracepoints; can be explicitly set when
+    /// stack traces are not needed.
+    #[serde(default)]
+    pub counting_only: bool,
 }
 
 impl Default for PerfProfilingConfig {
     fn default() -> Self {
         Self {
-            event: "hw:cpu-clock".to_string(),
+            event: "hw:cycles".to_string(),
             freq: 99,
             cpu: -1,
             pid: -1,
             max_samples: 10000,
             duration_secs: 0,
+            counting_only: false,
         }
     }
 }
@@ -151,8 +157,12 @@ impl PerfProfiler {
         self.start_time = Some(Instant::now());
 
         // Attach perf events if we have the required components
-        if self.bpf_attacher.is_some() && self.topology.is_some() {
-            self.attach_perf_events(&config)?;
+        if self.topology.is_some() {
+            if config.counting_only {
+                self.open_counting_events(&config)?;
+            } else if self.bpf_attacher.is_some() {
+                self.attach_perf_events(&config)?;
+            }
         }
 
         self.config = Some(config);
@@ -184,6 +194,7 @@ impl PerfProfiler {
         );
 
         let mut attached_count = 0;
+        let mut last_error: Option<String> = None;
         let cpus: Vec<usize> = topology.all_cpus.keys().copied().collect();
         log::debug!("Total CPUs available: {}", cpus.len());
 
@@ -199,16 +210,34 @@ impl PerfProfiler {
 
             self.configure_perf_event_attr(&mut attr, &config.event)?;
 
-            // Configure for sampling with instruction pointer
             // Stack traces are collected by BPF program using bpf_get_stack()
-            attr.sample_type = perf::bindings::PERF_SAMPLE_IP as u64;
-            attr.__bindgen_anon_1.sample_period = config.freq as u64;
-            attr.set_freq(0); // Use period mode (sample every N events)
-            attr.set_disabled(0);
             attr.set_exclude_kernel(0);
             attr.set_exclude_hv(0);
-            attr.set_inherit(1);
-            attr.set_pinned(1);
+            attr.set_freq(0);
+
+            attr.set_disabled(0);
+
+            if attr.type_ == perf::bindings::PERF_TYPE_TRACEPOINT {
+                // Tracepoints: sample every occurrence, no PMU-specific flags
+                attr.__bindgen_anon_1.sample_period = 1;
+            } else {
+                // Hardware/software events: sample with IP capture
+                attr.sample_type = perf::bindings::PERF_SAMPLE_IP as u64;
+                attr.__bindgen_anon_1.sample_period = config.freq as u64;
+                attr.set_inherit(if config.pid == -1 { 1 } else { 0 });
+                attr.set_pinned(1);
+            }
+
+            log::debug!(
+                "perf_event_open attr: type={}, size={}, config={}, sample_period={}, sample_type={:#x}, cpu={}, pid={}",
+                attr.type_,
+                attr.size,
+                attr.config,
+                unsafe { attr.__bindgen_anon_1.sample_period },
+                attr.sample_type,
+                cpu_id,
+                config.pid
+            );
 
             // Open perf event for this specific CPU
             let perf_fd = unsafe {
@@ -216,19 +245,23 @@ impl PerfProfiler {
                     &mut attr as *mut perf::bindings::perf_event_attr,
                     config.pid,
                     cpu_id as i32,
-                    -1, // group_fd
-                    0,  // flags
+                    -1,        // group_fd
+                    1u64 << 3, // PERF_FLAG_FD_CLOEXEC
                 )
             };
 
-            if perf_fd <= 0 {
+            if perf_fd < 0 {
                 let err = std::io::Error::last_os_error();
-                log::warn!(
-                    "Failed to open perf event for CPU {}: {} (errno: {})",
+                let msg = format!(
+                    "perf_event_open failed for CPU {}: {} (errno: {})",
                     cpu_id,
                     err,
                     err.raw_os_error().unwrap_or(0)
                 );
+                log::warn!("{}", msg);
+                if last_error.is_none() {
+                    last_error = Some(msg);
+                }
                 continue;
             }
 
@@ -265,12 +298,14 @@ impl PerfProfiler {
                     attached_count += 1;
                 }
                 Err(e) => {
-                    log::error!(
-                        "Failed to attach BPF program to perf fd={} for CPU {}: {}",
-                        perf_fd,
-                        cpu_id,
-                        e
+                    let msg = format!(
+                        "BPF attach failed for perf fd={} CPU {}: {}",
+                        perf_fd, cpu_id, e
                     );
+                    log::error!("{}", msg);
+                    if last_error.is_none() {
+                        last_error = Some(msg);
+                    }
                     unsafe {
                         libc::close(perf_fd);
                     }
@@ -279,8 +314,11 @@ impl PerfProfiler {
         }
 
         if attached_count == 0 {
-            log::error!("Failed to attach perf events to any CPU - no CPUs attached!");
-            return Err(anyhow!("Failed to attach perf events to any CPU"));
+            let detail = last_error.unwrap_or_else(|| "unknown error".to_string());
+            return Err(anyhow!(
+                "Failed to attach perf events to any CPU: {}",
+                detail
+            ));
         }
 
         log::info!(
@@ -299,6 +337,104 @@ impl PerfProfiler {
         Ok(())
     }
 
+    /// Open perf events in counting-only mode (no BPF attachment).
+    /// Used for tracepoints or when stack traces are not needed.
+    fn open_counting_events(&mut self, config: &PerfProfilingConfig) -> Result<()> {
+        use scx_utils::perf;
+
+        let topology = self
+            .topology
+            .as_ref()
+            .ok_or_else(|| anyhow!("Topology not set"))?;
+
+        log::info!(
+            "Opening counting perf events for '{}' (cpu={}, pid={})",
+            config.event,
+            config.cpu,
+            config.pid
+        );
+
+        let mut opened_count = 0;
+        let mut last_error: Option<String> = None;
+        let cpus: Vec<usize> = topology.all_cpus.keys().copied().collect();
+
+        for cpu_id in cpus {
+            if config.cpu >= 0 && cpu_id != config.cpu as usize {
+                continue;
+            }
+
+            let mut attr: perf::bindings::perf_event_attr = unsafe { std::mem::zeroed() };
+            attr.size = std::mem::size_of::<perf::bindings::perf_event_attr>() as u32;
+
+            self.configure_perf_event_attr(&mut attr, &config.event)?;
+
+            // Counting mode: no sampling, just count events
+            attr.set_disabled(0);
+            attr.set_exclude_kernel(0);
+            attr.set_exclude_hv(0);
+            attr.set_freq(0);
+            attr.set_inherit(if config.pid == -1 { 1 } else { 0 });
+            attr.set_pinned(1);
+
+            let perf_fd = unsafe {
+                perf::perf_event_open(
+                    &mut attr as *mut perf::bindings::perf_event_attr,
+                    config.pid,
+                    cpu_id as i32,
+                    -1,
+                    1u64 << 3, // PERF_FLAG_FD_CLOEXEC
+                )
+            };
+
+            if perf_fd < 0 {
+                let err = std::io::Error::last_os_error();
+                let msg = format!(
+                    "perf_event_open (counting) failed for CPU {}: {} (errno: {})",
+                    cpu_id,
+                    err,
+                    err.raw_os_error().unwrap_or(0)
+                );
+                log::warn!("{}", msg);
+                if last_error.is_none() {
+                    last_error = Some(msg);
+                }
+                continue;
+            }
+
+            if unsafe { perf::ioctls::enable(perf_fd, 0) } < 0 {
+                let err = std::io::Error::last_os_error();
+                log::error!(
+                    "Failed to enable counting perf event fd={} for CPU {}: {}",
+                    perf_fd,
+                    cpu_id,
+                    err
+                );
+                unsafe {
+                    libc::close(perf_fd);
+                }
+                continue;
+            }
+
+            self.perf_fds.push(perf_fd);
+            opened_count += 1;
+        }
+
+        if opened_count == 0 {
+            let detail = last_error.unwrap_or_else(|| "unknown error".to_string());
+            return Err(anyhow!(
+                "Failed to open counting perf events on any CPU: {}",
+                detail
+            ));
+        }
+
+        log::info!(
+            "Opened {} counting perf events for '{}'",
+            opened_count,
+            config.event
+        );
+        Ok(())
+    }
+
     /// Configure perf_event_attr based on event string
     fn configure_perf_event_attr(
         &self,
@@ -311,20 +447,29 @@ impl PerfProfiler {
         // - "cache-misses", "cycles", "instructions" (hardware events)
         // - "cpu-clock", "task-clock" (software events)
         // - "hw:cache-misses", "sw:cpu-clock" (explicit subsystem)
+        // - "tracepoint:subsystem:event" (tracepoint events)
 
-        let (subsystem, event_name) = if event_str.contains(':') {
-            let parts: Vec<&str> = event_str.split(':').collect();
-            if parts.len() != 2 {
-                return Err(anyhow!("Invalid event format: {}", event_str));
+        let parts: Vec<&str> = event_str.splitn(3, ':').collect();
+
+        let (subsystem, event_name, tp_event) = match parts.len() {
+            3 => {
+                // tracepoint:subsystem:event
+                (parts[0], parts[1], Some(parts[2]))
             }
-            (parts[0], parts[1])
-        } else {
-            // Try to infer subsystem from event name
-            match event_str.to_lowercase().as_str() {
-                "cpu-clock" | "task-clock" | "context-switches" | "page-faults"
-                | "minor-faults" | "major-faults" | "migrations" => ("sw", event_str),
-                _ => ("hw", event_str), // Default to hardware
+            2 => {
+                // hw:cycles or sw:cpu-clock
+                (parts[0], parts[1], None)
             }
+            1 => {
+                // Bare event name — infer subsystem
+                let name = parts[0];
+                match name.to_lowercase().as_str() {
+                    "cpu-clock" | "task-clock" | "context-switches" | "page-faults"
+                    | "minor-faults" | "major-faults" | "migrations" => ("sw", name, None),
+                    _ => ("hw", name, None),
+                }
+            }
+            _ => return Err(anyhow!("Invalid event format: {}", event_str)),
         };
 
         match subsystem.to_lowercase().as_str() {
@@ -395,12 +540,30 @@ impl PerfProfiler {
                     }
                 }
             }
+            "tracepoint" => {
+                let tp_name = tp_event.ok_or_else(|| {
+                    anyhow!(
+                        "Tracepoint format must be 'tracepoint:subsystem:event', got: {}",
+                        event_str
+                    )
+                })?;
+                attr.type_ = perf::bindings::PERF_TYPE_TRACEPOINT;
+                // Look up tracepoint ID from debugfs/tracefs
+                let tp_id = Self::resolve_tracepoint_id(event_name, tp_name)?;
+                attr.config = tp_id;
+            }
             _ => {
-                return Err(anyhow!("Unknown subsystem: {}", subsystem));
+                return Err(anyhow!("Unknown event subsystem '{}'. Use 'hw:', 'sw:', or 'tracepoint:subsystem:event'", subsystem));
             }
         }
 
         Ok(())
+    }
+
+    /// Resolve a tracepoint subsystem:event name to its numeric ID
+    fn resolve_tracepoint_id(subsystem: &str, event: &str) -> Result<u64> {
+        use crate::profiling_events::perf::perf_event_config;
+        perf_event_config(subsystem, event)
     }
 
     /// Stop profiling
@@ -492,8 +655,15 @@ impl PerfProfiler {
             .map(|start| start.elapsed().as_millis())
             .unwrap_or(0);
 
+        let counting_only = self
+            .config
+            .as_ref()
+            .map(|c| c.counting_only)
+            .unwrap_or(false);
+
         serde_json::json!({
             "status": format!("{:?}", self.status),
+            "mode": if counting_only { "counting" } else { "sampling" },
             "samples_collected": self.samples_collected,
             "duration_ms": duration_ms,
             "config": self.config,
@@ -502,6 +672,16 @@ impl PerfProfiler {
 
     /// Get results with symbolization (done on-demand to avoid Send issues)
     pub fn get_results(&self, limit: usize, include_stacks: bool) -> serde_json::Value {
+        let is_counting = self
+            .config
+            .as_ref()
+            .map(|c| c.counting_only)
+            .unwrap_or(false);
+
+        if is_counting {
+            return self.get_counting_results();
+        }
+
         use crate::symbol_data::SymbolData;
 
         // Create SymbolData fresh for symbolization (avoids Send issues)
@@ -560,6 +740,53 @@ impl PerfProfiler {
             "symbols": symbols,
             "total_samples": symbol_data.total_samples(),
             "samples_collected": self.samples_collected,
+        })
+    }
+
+    /// Get results for counting-only mode
+    fn get_counting_results(&self) -> serde_json::Value {
+        let duration_ms = self
+            .start_time
+            .map(|start| start.elapsed().as_millis())
+            .unwrap_or(0);
+
+        // Read per-CPU counts
+        let mut per_cpu_counts: Vec<serde_json::Value> = Vec::new();
+        let mut total_count: u64 = 0;
+
+        for (i, &fd) in self.perf_fds.iter().enumerate() {
+            let mut count: u64 = 0;
+            let size = std::mem::size_of::<u64>();
+            let ret = unsafe { libc::read(fd, &mut count as *mut _ as *mut libc::c_void, size) };
+            if ret == size as isize {
+                per_cpu_counts.push(serde_json::json!({
+                    "cpu_index": i,
+                    "count": count,
+                }));
+                total_count += count;
+            }
+        }
+
+        let event = self
+            .config
+            .as_ref()
+            .map(|c| c.event.as_str())
+            .unwrap_or("unknown");
+
+        let rate = if duration_ms > 0 {
+            (total_count as f64 / duration_ms as f64) * 1000.0
+        } else {
+            0.0
+        };
+
+        serde_json::json!({
+            "mode": "counting",
+            "event": event,
+            "total_count": total_count,
+            "duration_ms": duration_ms,
+            "rate_per_sec": format!("{:.1}", rate),
+            "num_cpus": per_cpu_counts.len(),
+            "per_cpu": per_cpu_counts,
         })
     }
 

--- a/tools/scxtop/src/mcp/perfetto_analyzer_registry.rs
+++ b/tools/scxtop/src/mcp/perfetto_analyzer_registry.rs
@@ -660,7 +660,7 @@ impl TraceAnalyzer for WakeupChainAnalyzerWrapper {
 
         let start = std::time::Instant::now();
         let analyzer = WakeupChainDetector::new(trace);
-        let result = analyzer.find_wakeup_chains(20);
+        let result = analyzer.find_wakeup_chains_parallel(20);
         let duration = start.elapsed();
 
         AnalyzerResult {

--- a/tools/scxtop/src/mcp/perfetto_analyzers_extended.rs
+++ b/tools/scxtop/src/mcp/perfetto_analyzers_extended.rs
@@ -7,6 +7,7 @@
 
 use super::perfetto_parser::{Percentiles, PerfettoTrace};
 use perfetto_protos::ftrace_event::ftrace_event;
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -652,6 +653,143 @@ impl WakeupChainDetector {
                 }
             }
         }
+
+        chains.sort_by(|a, b| {
+            b.criticality_score
+                .partial_cmp(&a.criticality_score)
+                .unwrap()
+        });
+
+        chains.into_iter().take(limit).collect()
+    }
+
+    /// Find critical wakeup chains using parallel per-CPU collection
+    pub fn find_wakeup_chains_parallel(&self, limit: usize) -> Vec<WakeupChain> {
+        // Phase 1: Parallel per-CPU event collection
+        #[allow(clippy::type_complexity)]
+        let per_cpu_data: Vec<(HashMap<i32, Vec<WakeupChainEvent>>, HashMap<i32, u64>)> =
+            (0..self.trace.num_cpus())
+                .into_par_iter()
+                .map(|cpu| {
+                    let mut cpu_wakeup_map: HashMap<i32, Vec<WakeupChainEvent>> = HashMap::new();
+                    let mut cpu_schedule_times: HashMap<i32, u64> = HashMap::new();
+                    let events = self.trace.get_events_by_cpu(cpu as u32);
+
+                    for event_with_idx in events {
+                        if let Some(ts) = event_with_idx.event.timestamp {
+                            match &event_with_idx.event.event {
+                                Some(ftrace_event::Event::SchedWakeup(wakeup)) => {
+                                    if let (Some(wakee_pid), Some(waker_pid)) =
+                                        (wakeup.pid, event_with_idx.event.pid)
+                                    {
+                                        cpu_wakeup_map.entry(wakee_pid).or_default().push(
+                                            WakeupChainEvent {
+                                                wakee_pid,
+                                                waker_pid: waker_pid as i32,
+                                                wakee_comm: wakeup.comm.clone().unwrap_or_default(),
+                                                waker_comm: String::new(),
+                                                wakeup_ts: ts,
+                                                schedule_ts: None,
+                                            },
+                                        );
+                                    }
+                                }
+                                Some(ftrace_event::Event::SchedSwitch(switch)) => {
+                                    if let Some(next_pid) = switch.next_pid {
+                                        cpu_schedule_times.insert(next_pid, ts);
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+
+                    (cpu_wakeup_map, cpu_schedule_times)
+                })
+                .collect();
+
+        // Phase 1b: Merge per-CPU results
+        let mut wakeup_map: HashMap<i32, Vec<WakeupChainEvent>> = HashMap::new();
+        let mut schedule_times: HashMap<i32, u64> = HashMap::new();
+        for (cpu_wakeups, cpu_schedules) in per_cpu_data {
+            for (pid, events) in cpu_wakeups {
+                wakeup_map.entry(pid).or_default().extend(events);
+            }
+            for (pid, ts) in cpu_schedules {
+                schedule_times
+                    .entry(pid)
+                    .and_modify(|existing| *existing = (*existing).max(ts))
+                    .or_insert(ts);
+            }
+        }
+
+        // Phase 2: Match wakeups to schedules
+        for wakeup_list in wakeup_map.values_mut() {
+            for wakeup_event in wakeup_list {
+                if let Some(&schedule_ts) = schedule_times.get(&wakeup_event.wakee_pid) {
+                    if schedule_ts >= wakeup_event.wakeup_ts {
+                        wakeup_event.schedule_ts = Some(schedule_ts);
+                    }
+                }
+            }
+        }
+
+        // Phase 3: Build chains in parallel by partitioning PIDs
+        let pids: Vec<i32> = wakeup_map.keys().copied().collect();
+        let wakeup_map_ref = &wakeup_map;
+
+        let mut chains: Vec<WakeupChain> = pids
+            .into_par_iter()
+            .flat_map(|wakee_pid| {
+                let mut pid_chains = Vec::new();
+                if let Some(wakeups) = wakeup_map_ref.get(&wakee_pid) {
+                    // Only process first wakeup per PID (matches visited set behavior)
+                    if let Some(wakeup) = wakeups.first() {
+                        let mut chain = vec![wakeup.clone()];
+                        let mut current_waker = wakeup.waker_pid;
+
+                        // Follow chain backwards
+                        for _ in 0..10 {
+                            if let Some(waker_wakeups) = wakeup_map_ref.get(&current_waker) {
+                                if let Some(waker_wakeup) = waker_wakeups
+                                    .iter()
+                                    .filter(|w| w.wakeup_ts <= wakeup.wakeup_ts)
+                                    .max_by_key(|w| w.wakeup_ts)
+                                {
+                                    chain.push(waker_wakeup.clone());
+                                    current_waker = waker_wakeup.waker_pid;
+                                } else {
+                                    break;
+                                }
+                            } else {
+                                break;
+                            }
+                        }
+
+                        if chain.len() > 1 {
+                            chain.reverse();
+
+                            let total_latency: u64 = chain
+                                .iter()
+                                .filter_map(|e| {
+                                    e.schedule_ts.map(|s| s.saturating_sub(e.wakeup_ts))
+                                })
+                                .sum();
+
+                            let chain_len = chain.len();
+                            pid_chains.push(WakeupChain {
+                                chain,
+                                total_latency_ns: total_latency,
+                                chain_length: chain_len,
+                                criticality_score: (chain_len as f64)
+                                    * (total_latency as f64 / 1_000_000.0),
+                            });
+                        }
+                    }
+                }
+                pid_chains
+            })
+            .collect();
 
         chains.sort_by(|a, b| {
             b.criticality_score

--- a/tools/scxtop/src/mcp/tools.rs
+++ b/tools/scxtop/src/mcp/tools.rs
@@ -162,19 +162,19 @@ impl McpTools {
             },
             McpTool {
                 name: "start_perf_profiling".to_string(),
-                description: "Start perf profiling with stack trace collection and symbolization"
+                description: "Start perf profiling. Hardware/software events collect stack traces via BPF sampling. Tracepoints use counting-only mode (event counts, no stacks)."
                     .to_string(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
                         "event": {
                             "type": "string",
-                            "description": "Event to profile: 'hw:cpu-clock', 'sw:task-clock', or 'tracepoint:subsystem:event'",
-                            "default": "hw:cpu-clock"
+                            "description": "Event to profile: 'hw:cycles', 'sw:cpu-clock', 'sw:task-clock', or 'tracepoint:subsystem:event'",
+                            "default": "hw:cycles"
                         },
                         "freq": {
                             "type": "integer",
-                            "description": "Sampling frequency in Hz (e.g., 99)",
+                            "description": "Sample period (sample every N events). For hw:cycles this is cycle count, for sw:cpu-clock this is clock ticks. Ignored for tracepoints (always samples every event).",
                             "default": 99
                         },
                         "cpu": {
@@ -211,7 +211,7 @@ impl McpTools {
             McpTool {
                 name: "get_perf_results".to_string(),
                 description:
-                    "Get perf profiling results with symbolized stack traces and top functions"
+                    "Get perf profiling results. For sampling mode: symbolized stack traces and top functions. For counting mode (tracepoints): event counts per CPU."
                         .to_string(),
                 input_schema: json!({
                     "type": "object",
@@ -1618,26 +1618,72 @@ impl McpTools {
             .as_ref()
             .ok_or_else(|| anyhow!("Perf profiler not available"))?;
 
+        let user_event = args.get("event").and_then(|v| v.as_str());
+        let event = user_event.unwrap_or("hw:cycles").to_string();
+        let freq = args.get("freq").and_then(|v| v.as_u64()).unwrap_or(99) as u32;
+        let cpu = args.get("cpu").and_then(|v| v.as_i64()).unwrap_or(-1) as i32;
+        let pid = args.get("pid").and_then(|v| v.as_i64()).unwrap_or(-1) as i32;
+        let max_samples = args
+            .get("max_samples")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(10000) as usize;
+        let duration_secs = args
+            .get("duration_secs")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+
+        // Tracepoints require counting-only mode (BPF_PROG_TYPE_PERF_EVENT
+        // cannot attach to tracepoint perf events)
+        let is_tracepoint = event.starts_with("tracepoint:");
+        let counting_only = is_tracepoint;
+
         let config = PerfProfilingConfig {
-            event: args
-                .get("event")
-                .and_then(|v| v.as_str())
-                .unwrap_or("hw:cpu-clock")
-                .to_string(),
-            freq: args.get("freq").and_then(|v| v.as_u64()).unwrap_or(99) as u32,
-            cpu: args.get("cpu").and_then(|v| v.as_i64()).unwrap_or(-1) as i32,
-            pid: args.get("pid").and_then(|v| v.as_i64()).unwrap_or(-1) as i32,
-            max_samples: args
-                .get("max_samples")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(10000) as usize,
-            duration_secs: args
-                .get("duration_secs")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0),
+            event: event.clone(),
+            freq,
+            cpu,
+            pid,
+            max_samples,
+            duration_secs,
+            counting_only,
         };
 
-        profiler.start(config.clone())?;
+        match profiler.start(config) {
+            Ok(()) => {}
+            Err(e) if user_event.is_none() => {
+                // User didn't specify an event and hw:cycles failed;
+                // fall back to sw:cpu-clock (works in VMs without PMU)
+                log::warn!(
+                    "Failed to start hw:cycles ({}), falling back to sw:cpu-clock",
+                    e
+                );
+                let fallback = PerfProfilingConfig {
+                    event: "sw:cpu-clock".to_string(),
+                    freq,
+                    cpu,
+                    pid,
+                    max_samples,
+                    duration_secs,
+                    counting_only: false,
+                };
+                profiler.start(fallback)?;
+            }
+            Err(e) => return Err(e),
+        }
+
+        // Read back the actual event from the profiler (may have changed due to fallback)
+        let actual_event = profiler
+            .get_status()
+            .get("config")
+            .and_then(|c| c.get("event"))
+            .and_then(|e| e.as_str())
+            .unwrap_or(&event)
+            .to_string();
+
+        let mode_desc = if counting_only {
+            "Counting events (no stack traces for tracepoints)"
+        } else {
+            "Collecting stack traces for both kernel and userspace"
+        };
 
         Ok(json!({
             "content": [{
@@ -1645,35 +1691,38 @@ impl McpTools {
                 "text": format!(
                     "Perf profiling started:\n\
                      - Event: {}\n\
-                     - Frequency: {} Hz\n\
+                     - Mode: {}\n\
+                     - Frequency: {}\n\
                      - CPU: {}\n\
                      - PID: {}\n\
                      - Max samples: {}\n\
                      - Duration: {} seconds\n\n\
-                     Collecting stack traces for both kernel and userspace...\n\
+                     {}...\n\
                      Use stop_perf_profiling to stop and get_perf_results to retrieve results.",
-                    config.event,
-                    config.freq,
-                    if config.cpu == -1 {
+                    actual_event,
+                    if counting_only { "counting" } else { "sampling" },
+                    freq,
+                    if cpu == -1 {
                         "all".to_string()
                     } else {
-                        config.cpu.to_string()
+                        cpu.to_string()
                     },
-                    if config.pid == -1 {
+                    if pid == -1 {
                         "all".to_string()
                     } else {
-                        config.pid.to_string()
+                        pid.to_string()
                     },
-                    if config.max_samples == 0 {
+                    if max_samples == 0 {
                         "unlimited".to_string()
                     } else {
-                        config.max_samples.to_string()
+                        max_samples.to_string()
                     },
-                    if config.duration_secs == 0 {
+                    if duration_secs == 0 {
                         "manual".to_string()
                     } else {
-                        config.duration_secs.to_string()
-                    }
+                        duration_secs.to_string()
+                    },
+                    mode_desc
                 )
             }]
         }))
@@ -2758,7 +2807,11 @@ impl McpTools {
                 let analyzer = WakeupChainDetector::new(trace);
                 // Cap wakeup chains to prevent massive output
                 let chain_limit = limit.min(10);
-                let chains = analyzer.find_wakeup_chains(chain_limit);
+                let chains = if use_parallel {
+                    analyzer.find_wakeup_chains_parallel(chain_limit)
+                } else {
+                    analyzer.find_wakeup_chains(chain_limit)
+                };
                 let total_chains = chains.len();
 
                 // Truncate chain events to max 10 per chain
@@ -3315,7 +3368,7 @@ impl McpTools {
                 "wakeup_chains" => {
                     use super::perfetto_analyzers_extended::WakeupChainDetector;
                     let analyzer = WakeupChainDetector::new(trace.clone());
-                    let chains = analyzer.find_wakeup_chains(10);
+                    let chains = analyzer.find_wakeup_chains_parallel(10);
                     export_data["wakeup_chains"] = json!(chains);
                 }
                 "latency_breakdown" => {

--- a/tools/scxtop/tests/mcp_perf_profiling_tests.rs
+++ b/tools/scxtop/tests/mcp_perf_profiling_tests.rs
@@ -12,12 +12,13 @@ use std::time::Duration;
 #[test]
 fn test_perf_profiling_config_default() {
     let config = PerfProfilingConfig::default();
-    assert_eq!(config.event, "hw:cpu-clock");
+    assert_eq!(config.event, "hw:cycles");
     assert_eq!(config.freq, 99);
     assert_eq!(config.cpu, -1);
     assert_eq!(config.pid, -1);
     assert_eq!(config.max_samples, 10000);
     assert_eq!(config.duration_secs, 0);
+    assert!(!config.counting_only);
 }
 
 #[test]
@@ -37,6 +38,7 @@ fn test_shared_perf_profiler_start() {
         pid: -1,
         max_samples: 1000,
         duration_secs: 0,
+        counting_only: false,
     };
 
     let result = profiler.start(config);
@@ -92,6 +94,7 @@ fn test_shared_perf_profiler_add_sample() {
         pid: -1,
         max_samples: 10,
         duration_secs: 0,
+        counting_only: false,
     };
 
     profiler.start(config).unwrap();
@@ -124,6 +127,7 @@ fn test_shared_perf_profiler_should_stop_max_samples() {
         pid: -1,
         max_samples: 3,
         duration_secs: 0,
+        counting_only: false,
     };
 
     profiler.start(config).unwrap();
@@ -157,6 +161,7 @@ fn test_shared_perf_profiler_should_stop_duration() {
         pid: -1,
         max_samples: 0,   // unlimited
         duration_secs: 1, // 1 second
+        counting_only: false,
     };
 
     profiler.start(config).unwrap();
@@ -361,6 +366,7 @@ fn test_perf_profiler_config_validation() {
         pid: 1234,
         max_samples: 5000,
         duration_secs: 10,
+        counting_only: false,
     };
 
     assert_eq!(config1.event, "sw:task-clock");
@@ -467,6 +473,7 @@ fn test_perf_profiler_with_topology() {
         pid: -1,
         max_samples: 0,
         duration_secs: 10,
+        counting_only: false,
     };
 
     let result = profiler.start(config);
@@ -506,6 +513,7 @@ fn test_perf_config_serialization() {
         pid: 1234,
         max_samples: 5000,
         duration_secs: 10,
+        counting_only: false,
     };
 
     // Serialize to JSON
@@ -520,4 +528,5 @@ fn test_perf_config_serialization() {
     assert_eq!(config.pid, config2.pid);
     assert_eq!(config.max_samples, config2.max_samples);
     assert_eq!(config.duration_secs, config2.duration_secs);
+    assert_eq!(config.counting_only, config2.counting_only);
 }


### PR DESCRIPTION
Add counting-only mode for tracepoint events since BPF_PROG_TYPE_PERF_EVENT cannot attach to tracepoint perf events. Tracepoints now use perf counters to track event counts per CPU rather than attempting BPF-based stack sampling.

Key changes:
- Add counting_only field to PerfProfilingConfig, auto-set for tracepoints
- Add open_counting_events() and read_counting_total() for counter-based profiling
- Add tracepoint event parsing (tracepoint:subsystem:event format) via tracefs
- Change default event from hw:cpu-clock to hw:cycles with automatic fallback to sw:cpu-clock when PMU is unavailable (e.g. in VMs)
- Fix perf_event_open: check fd < 0 (not <= 0), add PERF_FLAG_FD_CLOEXEC, differentiate attr config between tracepoints and hw/sw events
- Improve error reporting by propagating first error details on total failure
- Add cache event MCP analyzer to perfetto analyzers