### PR TITLE
scx_pandemonium: update to v5.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "scx_pandemonium"
-version = "5.4.13"
+version = "5.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/scheds/rust/scx_pandemonium/Cargo.toml
+++ b/scheds/rust/scx_pandemonium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_pandemonium"
-version = "5.4.13"
+version = "5.5.0"
 edition = "2021"
 description = "A behavioral, adaptive sched_ext scheduler with three-tier classification, L2 affinity, and process learning"
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_pandemonium/build.rs
+++ b/scheds/rust/scx_pandemonium/build.rs
@@ -1,4 +1,37 @@
+use std::process::Command;
+
 fn main() {
+    // BUILD ID: GIT SHA, DIRTY FLAG, TARGET TRIPLE
+    // MATCHES scx_utils::build_id FORMAT USED BY OTHER SCX SCHEDULERS.
+    let git_sha = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+
+    let git_dirty = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false);
+
+    let build_id = if git_sha.is_empty() {
+        String::new()
+    } else if git_dirty {
+        format!("-g{}-dirty", git_sha)
+    } else {
+        format!("-g{}", git_sha)
+    };
+
+    let target = std::env::var("TARGET").unwrap_or_default();
+
+    println!("cargo:rustc-env=PANDEMONIUM_BUILD_ID={}", build_id);
+    println!("cargo:rustc-env=PANDEMONIUM_TARGET={}", target);
+
     scx_cargo::BpfBuilder::new()
         .unwrap()
         .enable_intf("src/bpf/intf.h", "bpf_intf.rs")

--- a/scheds/rust/scx_pandemonium/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_pandemonium/src/bpf/main.bpf.c
@@ -651,8 +651,25 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 			p->cpus_ptr, node, 0);
 		if (cpu >= 0 && (u64)cpu < nr_cpu_ids &&
 		    __COMPAT_scx_bpf_cpu_curr(cpu)) {
-			dl = task_deadline(p, tctx, node_dsq, knobs);
-			scx_bpf_dsq_insert_vtime(p, node_dsq, sl, dl,
+			// DEPTH GATE: USE PER-CPU DSQ IF ROOM, ELSE NODE DSQ.
+			// PREVENTS DSQ BUILDUP DURING FORK STORMS.
+			u64 tier2_dsq;
+			if ((u64)cpu < nr_cpu_ids &&
+			    scx_bpf_dsq_nr_queued((u64)cpu) < pcpu_depth_base) {
+				tier2_dsq = (u64)cpu;
+				if ((u32)cpu < MAX_CPUS)
+					__sync_val_compare_and_swap(
+						&pcpu_enqueue_ns[cpu], 0,
+						bpf_ktime_get_ns());
+			} else {
+				tier2_dsq = node_dsq;
+				__sync_val_compare_and_swap(
+					&interactive_enqueue_ns, 0,
+					bpf_ktime_get_ns());
+			}
+
+			dl = task_deadline(p, tctx, tier2_dsq, knobs);
+			scx_bpf_dsq_insert_vtime(p, tier2_dsq, sl, dl,
 						  enq_flags);
 
 			u64 kick_flag = (is_wakeup ||
@@ -673,7 +690,7 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 			}
 #if TRACE_SCHED
 			if (is_sched_task(p))
-				bpf_printk("PAND: enq tier2 pid=%d cpu=%d", p->pid, cpu);
+				bpf_printk("PAND: enq tier2 pid=%d cpu=%d dsq=%llu", p->pid, cpu, tier2_dsq);
 #endif
 			return;
 		}
@@ -705,11 +722,14 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 	// DISPATCHES FROM THE HEAD, SO DAEMONS AT THE TAIL STARVE.
 	// THE CEILING CAPS DEADLINE AT vtime_now + 30MS, KEEPING EVERY BATCH
 	// TASK WITHIN 6 SOJOURN CYCLES OF THE HEAD.
-	// GATED AT >= 8 CORES: ON LOW CORE COUNTS THE BATCH DSQ IS SHALLOW
-	// ENOUGH THAT SOJOURN RESCUE REACHES EVERY TASK NATURALLY. THE CEILING
-	// COMPRESSES VTIME AND DESTROYS PRIORITY DIFFERENTIATION AT 2-4 CORES.
-	if (target_dsq != node_dsq && nr_cpu_ids >= 8) {
-		u64 vtime_ceiling = vtime_now + (LAG_CAP_NS * 3 >> 2);
+	// CORE-SCALED CEILING: WIDER AT LOW CORES (PRESERVE DIFFERENTIATION),
+	// TIGHTER AT HIGH CORES (PREVENT TAIL STARVATION).
+	// 2C: 40MS, 4C: 40MS, 8C: 80MS, 16C: 160MS (CAPPED AT LAG_CAP_NS*4)
+	if (target_dsq != node_dsq) {
+		u64 ceil_scale = nr_cpu_ids >> 2;
+		if (ceil_scale < 1) ceil_scale = 1;
+		if (ceil_scale > 4) ceil_scale = 4;
+		u64 vtime_ceiling = vtime_now + LAG_CAP_NS * ceil_scale;
 		if (time_after(dl, vtime_ceiling))
 			dl = vtime_ceiling;
 	}
@@ -753,9 +773,6 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 	// TOTAL-ENQUEUE CUSUM: SAMPLE EVERY 64TH ENQUEUE.
 	// TRACKS TIME INTERVAL PER 64 ENQUEUES (SHORTER = HIGHER RATE).
 	// EWMA BASELINE SELF-TUNES TO ACTUAL SYSTEM CAPACITY.
-	// EFFECTIVE FOR BPF (1MS SLICES) WHERE RATE INCREASES DURING BURST.
-	// RATE-BOUNDED UNDER ADAPTIVE (4MS SLICES) -- WAKEUP CUSUM ABOVE
-	// COVERS THAT CASE. EITHER CUSUM FIRING ACTIVATES burst_mode IN tick().
 	u64 count = __sync_fetch_and_add(&cusum_enq_count, 1);
 	if ((count & 63) == 0) {
 		if (__sync_bool_compare_and_swap(&cusum_lock, 0, 1)) {
@@ -881,8 +898,13 @@ void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 	// DEFICIT GATE: WHEN INTERACTIVE HAS EXCEEDED ITS BUDGET AND BATCH
 	// IS STARVING, SKIP INTERACTIVE OVERFLOW RESCUE SO BATCH
 	// GETS SERVED VIA DEFICIT CHECK OR STARVATION RESCUE INSTEAD.
-	if (interactive_run >= effective_budget && batch_starving)
-		goto skip_interactive_rescue;
+	// EXCEPTION: IF INTERACTIVE TASKS HAVE BEEN WAITING PAST THE
+	// OVERFLOW SOJOURN THRESHOLD, RESCUE IS MORE URGENT THAN DEFICIT.
+	if (interactive_run >= effective_budget && batch_starving) {
+		u64 ie_gate = interactive_enqueue_ns;
+		if (ie_gate == 0 || (now - ie_gate) <= overflow_sojourn_rescue_ns)
+			goto skip_interactive_rescue;
+	}
 
 	// STEP 2: OVERFLOW SOJOURN AMPLIFICATION
 	// WHEN OVERFLOW DSQs HAVE TASKS AGING PAST 10MS, SERVE THEM.
@@ -1382,7 +1404,9 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 
 	u64 thresh = burst_mode ? 0 : (knobs ? knobs->preempt_thresh_ns : 1000000);
 
-	if (tctx->tier == TIER_BATCH && tctx->avg_runtime >= thresh) {
+	u64 on_cpu = tctx->last_run_at > 0
+		? bpf_ktime_get_ns() - tctx->last_run_at : 0;
+	if (tctx->tier == TIER_BATCH && on_cpu >= thresh) {
 		scx_bpf_kick_cpu(scx_bpf_task_cpu(p), SCX_KICK_PREEMPT);
 		interactive_waiting = false;
 		if (!s)

--- a/scheds/rust/scx_pandemonium/src/main.rs
+++ b/scheds/rust/scx_pandemonium/src/main.rs
@@ -31,8 +31,8 @@ use scheduler::Scheduler;
 static SHUTDOWN: AtomicBool = AtomicBool::new(false);
 
 #[derive(Parser)]
-#[command(name = "pandemonium")]
-#[command(version)]
+#[command(name = "scx_pandemonium")]
+#[command(version = concat!(env!("CARGO_PKG_VERSION"), env!("PANDEMONIUM_BUILD_ID"), " ", env!("PANDEMONIUM_TARGET")))]
 #[command(about = "PANDEMONIUM -- ADAPTIVE LINUX SCHEDULER")]
 struct Cli {
     #[command(subcommand)]
@@ -228,7 +228,17 @@ fn run_scheduler(
         .trim()
         .to_string();
 
-    log_info!("PANDEMONIUM v{}", env!("CARGO_PKG_VERSION"));
+    let smt_on = std::fs::read_to_string("/sys/devices/system/cpu/smt/active")
+        .map(|s| s.trim() == "1")
+        .unwrap_or(false);
+
+    log_info!(
+        "scx_pandemonium {}{} {} SMT {}",
+        env!("CARGO_PKG_VERSION"),
+        env!("PANDEMONIUM_BUILD_ID"),
+        env!("PANDEMONIUM_TARGET"),
+        if smt_on { "on" } else { "off" }
+    );
     log_info!(
         "CPUS: {} (governor: {})",
         nr_cpus_display,


### PR DESCRIPTION
Latency dispatch overhaul. Work fairness.

Users reported rubber banding in CS2 (compulsions, Ryzen 5 7600X),
stutter with YT live + stress (dim-geo, 4C Gentoo), and film jitter
(rallesho, AMD 5700G OpenSUSE). All low-to-mid core count systems
under mixed interactive + CPU-heavy load. Root cause: the dispatch
path couldn't prioritize kicked tasks over per-CPU DSQ obligations,
and tick preemption filtered on behavioral history instead of actual
on-CPU time.

src/bpf/main.bpf.c:

TIER 2 DISPATCH: PER-CPU DSQ WITH DEPTH GATE
- Tier 2 (wakeup/LAT_CRITICAL preemption) now dispatches to the
  kicked CPU's per-CPU DSQ instead of node_dsq. Gives kicked tasks
  Step 0 priority (highest) in the dispatch waterfall.
- Depth gate: if per-CPU DSQ is at pcpu_depth_base, falls back to
  node_dsq with interactive_enqueue_ns tracking. Prevents DSQ
  buildup during fork storms.
- Bench result: latency P99 dropped from 1000-1400us to 75-107us
  at 4-12C. Burst P99 from 2000-8000us to 72-135us.

TICK PREEMPTION: ON-CPU TIME
- tick() preemption check now uses actual on-CPU duration
  (bpf_ktime_get_ns() - last_run_at) instead of EWMA avg_runtime.
- Previously, batch tasks with low avg_runtime (<1ms, e.g. short
  compilation bursts) escaped tick preemption entirely while
  interactive tasks waited in overflow for up to 15ms.

DEFICIT GATE: SOJOURN EXCEPTION
- Deficit gate (interactive_run >= budget && batch_starving) now
  checks interactive_enqueue_ns age before skipping interactive
  rescue. If interactive tasks have been waiting past the overflow
  sojourn threshold, rescue fires regardless of deficit obligation.

VTIME CEILING: CORE-SCALED
- Removed the nr_cpu_ids >= 8 gate that disabled vtime ceiling at
  low core counts. Replaced with core-scaled ceiling:
  LAG_CAP_NS * max(1, nr_cpu_ids/4), capped at 4x.
  2C: 40ms, 4C: 40ms, 8C: 80ms, 16C: 160ms.
- Bench result: ADAPTIVE 4C work skew dropped from 27x to 1.03x.

src/main.rs:
- Override clap version string to scx-standard format.
- Change command name from "pandemonium" to "scx_pandemonium".
- --version now outputs: scx_pandemonium 5.5.0-g<sha> <target_triple>

Cargo.toml:
- Version: 5.4.13 -> 5.5.0.
- Add description field (matches upstream sched-ext/scx Cargo.toml).
- Add license = "GPL-2.0-only" (matches upstream).

pandemonium.py:
- Add bench-fork-thread command (perf bench sched messaging wrapper).

tests/bench-fork-thread.py:
- New benchmark: wraps `perf bench sched messaging -t -g 24 -l 6000`
  (CachyOS default). Cycles through EEVDF, PANDEMONIUM (BPF),
  PANDEMONIUM (ADAPTIVE), and scx_bpfland. Outputs .log and .prom.

DROPPED: last_cpu AFFINITY
- Attempted Tier 2 kick biasing toward tctx->last_cpu for IPC
  cache-hot dispatch. Bench numbers were strong (IPC P99 13us) but
  it crashed under real desktop use -- concentrating kicks on hot
  CPUs starved kworkers on SMT siblings. Cache affinity is already
  handled by select_cpu (prev_cpu preference), find_idle_l2_sibling,
  and L2 work stealing. Removed entirely.

KNOWN ISSUE: fork/thread messaging throughput
- perf bench sched messaging: 95s PANDEMONIUM vs 14s EEVDF/bpfland.
- Per-event BPF overhead in the scheduling hot path is the suspected
  cause. Not a DSQ contention issue (bpfland uses shared DSQs too).
- Under investigation for v5.5.1.

FILES CHANGED:
- src/bpf/main.bpf.c: Tier 2 per-CPU DSQ + depth gate, on-CPU tick
  preemption, deficit gate exception, core-scaled vtime ceiling
- src/main.rs: clap command name + version string override
- Cargo.toml: version bump, description, license
- pandemonium.py: bench-fork-thread command
- tests/bench-fork-thread.py: new benchmark
