### PR TITLE
Disable veristat for scxcash and scxtop

### DIFF
--- a/tools/scxcash/Cargo.toml
+++ b/tools/scxcash/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/sched-ext/scx"
 description = "Cache Usage Analyzer for sched_ext Schedulers"
 build = "build.rs"
 
+[package.metadata.veristat]
+disable = true
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -10,6 +10,9 @@ description = "sched_ext scheduler tool for observability"
 [package.metadata.scx]
 ci.use_clippy = true
 
+[package.metadata.veristat]
+disable = true
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = [


### PR DESCRIPTION
Both tools attach to tracepoints/fentry targets that may not exist in the CI kernel's BTF (fentry/do_fault, tp_btf/gpu_mem_total, tp_btf/hw_pressure_update, tp_btf/sched_process_hang). These are correctly handled at runtime via optional attachment (scxtop) or will need conditional logic (scxcash), but veristat verifies all programs statically regardless and fails.