### PR TITLE
scx_cosmos: update flags

### DIFF
--- a/services/scx
+++ b/services/scx
@@ -2,4 +2,4 @@
 SCX_SCHEDULER=scx_cosmos
 
 # Set custom flags for each scheduler, below is an example of how to use
-SCX_FLAGS='-s 20000 -c 0 -p 0'
+SCX_FLAGS='-s 700 -S


### PR DESCRIPTION
The -s 700 parameter sets the time slice length to match the one used by the EEVDF scheduler, ensuring that scx_cosmos remains consistent with it in terms of CPU time quant