### PR TITLE
scx-service: add missing quote

### DIFF
--- a/services/scx
+++ b/services/scx
@@ -2,4 +2,4 @@
 SCX_SCHEDULER=scx_cosmos
 
 # Set custom flags for each scheduler, below is an example of how to use
-SCX_FLAGS='-s 700 -S
+SCX_FLAGS='-s 700 -S'


### PR DESCRIPTION
Add missinig `'` to SCX_FLAGS. 