### PR TITLE
scx_lavd: fix load confinement in a few domains

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -39,6 +39,7 @@ int plan_x_cpdom_migration(void)
 	u64 cpdom_id;
 	u32 stealer_threshold, stealee_threshold, nr_stealee = 0;
 	u64 avg_load_invr = 0, min_load_invr = U64_MAX, max_load_invr = 0;
+	u64 max_avg_util_wall = 0;
 	u64 x_mig_delta, util, qlen, qlen_invr;
 	bool overflow_running = false;
 	int nz_qlen = 0;
@@ -56,12 +57,6 @@ int plan_x_cpdom_migration(void)
 	 * throughput when the system is overloaded.
 	 */
 
-	/*
-	 * When system utilization is low, periodic load balancing across
-	 * LLC domains is unnecessary since there is plenty of idle capacity.
-	 */
-	if (lb_low_util_wall > 0 && sys_stat.avg_util_wall < lb_low_util_wall)
-		goto reset_and_skip_lb;
 
 	/*
 	 * Calculate scaled load for each active compute domain.
@@ -89,6 +84,8 @@ int plan_x_cpdom_migration(void)
 		 * Use avg_util_wall_sum for stable load balancing decisions.
 		 */
 		util = (cpdomc->avg_util_wall_sum << LAVD_SHIFT) / cpdomc->nr_active_cpus;
+		if ((util >> LAVD_SHIFT) > max_avg_util_wall)
+			max_avg_util_wall = util >> LAVD_SHIFT;
 		qlen = cpdomc->nr_queued_task;
 		qlen_invr = (qlen << (LAVD_SHIFT * 3)) / cpdomc->cap_sum_active_cpus;
 		cpdomc->load_invr = util + qlen_invr;
@@ -103,6 +100,14 @@ int plan_x_cpdom_migration(void)
 	}
 	if (sys_stat.nr_active_cpdoms)
 		avg_load_invr /= sys_stat.nr_active_cpdoms;
+
+	/*
+	 * When the highest per-CPU utilization among all compute
+	 * domains is below the low utilization threshold, there is
+	 * no meaningful workload worth rebalancing across domains.
+	 */
+	if (lb_low_util_wall > 0 && max_avg_util_wall < lb_low_util_wall)
+		goto reset_and_skip_lb;
 
 	/*
 	 * Determine the criteria for stealer and stealee domains.

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -578,7 +578,7 @@ static bool can_direct_dispatch(struct cpu_ctx *cpuc, bool is_cpu_idle)
 {
 	return (is_cpu_idle && !queued_on_cpu(cpuc)) ||
 	       (lb_local_dsq_util_wall > 0 &&
-		sys_stat.avg_util_wall < lb_local_dsq_util_wall);
+		cpuc->avg_util_wall < lb_local_dsq_util_wall);
 }
 
 s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -137,7 +137,7 @@ struct Opts {
 
     /// Low utilization threshold percentage (0-100) for periodic load balancing.
     /// When set to a non-zero value, periodic load balancing is skipped when
-    /// average system utilization is below this percentage.
+    /// the maximum per-domain utilization is below this percentage.
     /// Default is 25 (skip periodic LB below 25% utilization).
     /// Set to 0 to disable. Set to 100 to always skip periodic LB.
     #[clap(long = "lb-low-util-pct", default_value = "25", value_parser=Opts::lb_low_util_pct_range)]
@@ -146,7 +146,7 @@ struct Opts {
     /// Low utilization threshold percentage (0-100) for bypassing deadline
     /// scheduling. When set to a non-zero value, tasks are dispatched directly
     /// to the local DSQ (FIFO) instead of using deadline-based ordering when
-    /// average system utilization is below this percentage.
+    /// the per-CPU utilization is below this percentage.
     /// Default is 10 (bypass deadline scheduling below 10% utilization).
     /// Set to 0 to disable. Set to 100 to always bypass deadline scheduling.
     #[clap(long = "lb-local-dsq-util-pct", default_value = "10", value_parser=Opts::lb_local_dsq_util_pct_range)]


### PR DESCRIPTION
The load balancer's early exit and the direct dispatch bypass both used system-wide average utilization (sys_stat.avg_util_wall) to make decisions. On systems with many LLC domains (e.g., 24 domains on a 192-core EPYC), a workload concentrated on a few domains can show very low system-wide average utilization (e.g., ~3-4% with one fully loaded domain out of 24) while individual domains are heavily loaded (90%+). This caused two problems:

1. plan_x_cpdom_migration() skipped load balancing because sys_stat.avg_util_wall < lb_low_util_wall (25%), preventing stealer/stealee assignment and blocking cross-domain task migration.

2. can_direct_dispatch() bypassed the vtime priority queue when sys_stat.avg_util_wall < lb_local_dsq_util_wall (10%), inserting tasks directly into SCX_DSQ_LOCAL. These tasks are consumed immediately by local CPUs and never appear in domain DSQs, making them invisible to force_to_steal_task(), only consuming from the domain DSQs.

Fix by using per-domain maximum utilization for the load balancer early exit and per-CPU utilization for the direct dispatch bypass.