### PR TITLE
scx_lavd: Add missing return after scx_bpf_error() in lavd_cgroup_move()

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -2172,8 +2172,10 @@ void BPF_STRUCT_OPS(lavd_cgroup_move, struct task_struct *p,
 	task_ctx *taskc;
 
 	taskc = get_task_ctx(p);
-	if (!taskc)
-	       scx_bpf_error("Failed to get a task context: %d", p->pid);
+	if (!taskc) {
+		scx_bpf_error("Failed to get a task context: %d", p->pid);
+		return;
+	}
 	taskc->cgrp_id = to->kn->id;
 }
 


### PR DESCRIPTION
Prevent null pointer dereference when get_task_ctx() returns NULL. Without the early return, execution continued and dereferenced taskc on the next line.

Fixes: #3446