### PR TITLE
scx_layered: Fix qrt_layer_id init to use MAX_LAYERS instead of MAX_LLCS

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -3960,7 +3960,7 @@ s32 BPF_STRUCT_OPS(layered_init_task, struct task_struct *p,
 	taskc->refresh_layer = true;
 	taskc->llc_id = MAX_LLCS;
 	taskc->pinned_node = MAX_NUMA_NODES;
-	taskc->qrt_layer_id = MAX_LLCS;
+	taskc->qrt_layer_id = MAX_LAYERS;
 	taskc->qrt_llc_id = MAX_LLCS;
 
 	/*


### PR DESCRIPTION
qrt_layer_id is a layer index, so its sentinel value should be MAX_LAYERS, not MAX_LLCS. The adjacent qrt_llc_id correctly uses MAX_LLCS.