### PR TITLE
scx_layered: Remove duplicate taskc null check in match_one

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -3063,11 +3063,6 @@ static __noinline bool match_one(struct layer *layer, struct layer_match *match,
 
 			u64 avg_runtime_us = taskc->runtime_avg / 1000;
 
-			if (!taskc) {
-				scx_bpf_error("could not find task");
-				return false;
-			}
-
 			/* To match, we must get min <= time < max. */
 			return match->min_avg_runtime_us <= avg_runtime_us &&
 				avg_runtime_us < match->max_avg_runtime_us;


### PR DESCRIPTION
In the MATCH_AVG_RUNTIME case, taskc is already null-checked right after lookup_task_ctx_may_fail(). The second identical check after the dereference is dead code. Remove it.