### PR TITLE
scx_utils: Handle ops.sub_cgroup_id in older kernels

### DIFF
--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -487,6 +487,16 @@ macro_rules! scx_ops_load {
             use ::anyhow::Context;
             use ::libbpf_rs::skel::OpenSkel;
 
+            {
+                let ops = $skel.struct_ops.[<$ops _mut>]();
+                if ops.sub_cgroup_id > 0 {
+                    if let Ok(false) | Err(_) = scx_utils::compat::struct_has_field("sched_ext_ops", "sub_cgroup_id") {
+                        ::scx_utils::warn!("kernel doesn't support ops.sub_cgroup_id");
+                        ops.sub_cgroup_id = 0;
+                    }
+                }
+            }
+
             scx_utils::uei_set_size!($skel, $ops, $uei);
             $skel.load().context("Failed to load BPF program")
         }

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -160,7 +160,7 @@ static inline long scx_hotplug_seq(void)
  * COMPAT:
  * - v6.17: ops.cgroup_set_bandwidth()
  * - v6.19: ops.cgroup_set_idle()
- * - v7.1:  ops.sub_attach(), ops.sub_detach()
+ * - v7.1:  ops.sub_attach(), ops.sub_detach(), ops.sub_cgroup_id
  */
 #define SCX_OPS_OPEN(__ops_name, __scx_name) ({					\
 	struct __scx_name *__skel;						\
@@ -191,6 +191,11 @@ static inline long scx_hotplug_seq(void)
 	    !__COMPAT_struct_has_field("sched_ext_ops", "sub_detach")) {	\
 		fprintf(stderr, "WARNING: kernel doesn't support ops.sub_detach()\n"); \
 		__skel->struct_ops.__ops_name->sub_detach = NULL;		\
+	}									\
+	if (__skel->struct_ops.__ops_name->sub_cgroup_id > 1 &&		\
+	    !__COMPAT_struct_has_field("sched_ext_ops", "sub_cgroup_id")) { \
+		fprintf(stderr, "WARNING: kernel doesn't support ops.sub_cgroup_id\n"); \
+		__skel->struct_ops.__ops_name->sub_cgroup_id = 1;		\
 	}									\
 	__skel; 								\
 })


### PR DESCRIPTION
Handle ops.sub_cgroup_id in kernel without sub-scheduler support, printing a warning and implicitly resetting it to zero.