### PR TITLE
scxtop: replace is_multiple_of() with % operator for stable Rust compat

### DIFF
--- a/tools/scxtop/src/mcp/perf_profiling.rs
+++ b/tools/scxtop/src/mcp/perf_profiling.rs
@@ -633,7 +633,8 @@ impl PerfProfiler {
         self.samples.push(sample);
         self.samples_collected += 1;
 
-        if self.samples_collected.is_multiple_of(100) {
+        #[allow(clippy::manual_is_multiple_of)]
+        if self.samples_collected % 100 == 0 {
             log::debug!("Collected {} samples so far", self.samples_collected);
         }
 


### PR DESCRIPTION
is_multiple_of() is an unstable library feature (rust-lang#128101) not available on stable/older Rust toolchains, breaking compilation on Rust < 1.87.

The only real difference between is_multiple_of(n) and % n == 0 is the divisor-is-zero case: is_multiple_of(0) returns false instead of panicking. Here the divisor is the literal 100 — it can never be zero — so the unstable feature buys nothing over a plain modulo check.

Fixes: #3308