### PR TITLE
mitosis: use SCX_DSQ_LOCAL_ON in try_pick_idle_cpu

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -648,15 +648,12 @@ static __always_inline s32 try_pick_idle_cpu(struct task_struct *p,
 	if (cpu >= 0) {
 		cstat_inc(CSTAT_LOCAL, tctx->cell, cctx);
 		/*
-		 * Use SCX_DSQ_LOCAL_ON to target the idle CPU we found,
-		 * not SCX_DSQ_LOCAL which resolves to task_rq(p) -- the
-		 * CPU the task just ran on. Without this, when called
-		 * from put_prev_task_scx -> enqueue, the task goes back
-		 * to the current CPU's local DSQ while the idle CPU gets
-		 * kicked and finds nothing. This pins tasks to their
-		 * current CPU, starving per-CPU DSQ tasks (kworkers)
-		 * because ops.dispatch is never called when the local
-		 * DSQ is non-empty.
+		 * Use SCX_DSQ_LOCAL_ON to explicitly target the idle CPU
+		 * we found. In the select_cpu path this is redundant
+		 * (SCX_DSQ_LOCAL already resolves to the selected CPU),
+		 * but from the enqueue path (put_prev_task_scx ->
+		 * enqueue), SCX_DSQ_LOCAL resolves to task_rq(p) -- not
+		 * the idle CPU we picked.
 		 */
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, slice_ns, 0);
 		if (kick)


### PR DESCRIPTION
## Summary

`try_pick_idle_cpu` dispatches to `SCX_DSQ_LOCAL` after finding an idle CPU, but `SCX_DSQ_LOCAL` resolves to `task_rq(p)` — the CPU the task last ran on, not the idle CPU that was found. When called from the `put_prev_task_scx` -> enqueue path, the task goes back onto its current CPU's local DSQ while the idle CPU gets kicked and finds nothing.

This causes per-CPU DSQ starvation: the local DSQ on the current CPU always has a task, so `balance_one` (ext.c:2193) skips `ops.dispatch` entirely. Tasks on per-CPU DSQs (pinned kworkers) are never considered and stall indefinitely.

## Fix

Use `SCX_DSQ_LOCAL_ON | cpu` instead of `SCX_DSQ_LOCAL` in both the cell-local and borrowing paths of `try_pick_idle_cpu`. `SCX_DSQ_LOCAL_ON` resolves to the specified CPU's local DSQ regardless of `task_rq(p)`.

## Test plan

- [x] Verified pinned kworkers no longer stall on per-CPU DSQs during scheduling under load