### PR TITLE
scx_bpfland: Aggressively avoid SMT contention

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -882,7 +882,8 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	 * Attempt to dispatch directly to an idle CPU if ops.select_cpu() was
 	 * skipped.
 	 */
-	if (task_should_migrate(p, enq_flags)) {
+	if (task_should_migrate(p, enq_flags) ||
+	    (!is_pcpu_task(p) && is_smt_contended(prev_cpu))) {
 		s32 cpu;
 
 		if (is_pcpu_task(p))


### PR DESCRIPTION
We try to avoid SMT contention only on task wakeup. However, long-running CPU-intensive tasks may not trigger wakeup at all, so they never get a chance to be migrated to fully-idle SMT cores if their current CPU has a busy sibling.

Fix this by checking for SMT contention at each enqueue.