### PR TITLE
mitosis: fix yielder starvation via vtime clamp split

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -826,11 +826,20 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 		return;
 	}
 	/*
-	 * Limit the amount of budget that an idling task can accumulate
-	 * to one slice.
+	 * Clamp vtime so tasks don't accumulate too much credit.
+	 * Wakeups get up to one slice of credit (they were sleeping).
+	 * Re-enqueues (yield, slice expiry) get no credit — their
+	 * vtime reflects actual CPU usage. Without this distinction,
+	 * yielders perpetually win the PRIQ by resetting to
+	 * basis_vtime - slice_ns on every re-enqueue.
 	 */
-	if (time_before(vtime, basis_vtime - slice_ns))
-		vtime = basis_vtime - slice_ns;
+	if (enq_flags & SCX_ENQ_WAKEUP) {
+		if (time_before(vtime, basis_vtime - slice_ns))
+			vtime = basis_vtime - slice_ns;
+	} else {
+		if (time_before(vtime, basis_vtime))
+			vtime = basis_vtime;
+	}
 
 	scx_bpf_dsq_insert_vtime(p, tctx->dsq.raw, slice_ns, vtime, enq_flags);
 


### PR DESCRIPTION
Edit: something about pr is off -- stt needs to be able to trigger dumps when things go sideways from userspace independent of watchdog to sort this out.

## Summary

The backward vtime clamp in `mitosis_enqueue` (`basis_vtime - slice_ns`) gives tasks up to one slice of credit below the current cell clock. For tasks waking from sleep, this is correct — they shouldn't be penalized for idling. But for tasks re-enqueued via yield or slice expiry, the clamp resets their vtime to `basis_vtime - slice_ns` on every re-enqueue, giving them perpetually lowest vtime in the PRIQ. Yielding tasks monopolize dispatch and starve all other tasks in the cell.

On oversubscribed cells (e.g. 16 CpuSpin workers on 2 cpuset-constrained CPUs with a YieldHeavy worker), the yielder's vtime is always one slice below the cell clock while CpuSpin workers are at or above it. The yielder wins every dispatch, runs for microseconds, yields, re-enqueues with the clamp resetting its vtime, and wins again. CpuSpin workers stall for 5+ seconds.

## Fix

Split the clamp by enqueue reason:
 - **Wakeups** (`SCX_ENQ_WAKEUP`): clamp to `basis_vtime - slice_ns` (one slice of credit, as before)
 - **Re-enqueues** (yield, slice expiry): clamp to `basis_vtime` (no credit — vtime reflects actual CPU usage)

## Test plan

 - [x] `rebalancing_cpuset/rebal` on odd-3llc (6 CPUs): 0/10 → 10/10 pass (16 CpuSpin + 1 YieldHeavy on 2-CPU cpuset cell)
 - [x] `dispatch_contention`, `oversubscribed`, `stall_detect`, `proportional`, `sched_fifo`, `sched_rr`, `cpuset_aligned`, `cpuset_misaligned`, `rebalancing` — all pass
 - [x] All rebalancing variants pass: `rebalancing_dynamic`, `rebalancing_many`, `rebalancing_oscillate`, `rebalancing_shift`