### PR TITLE
scx_bpfland: add TIMELY v2 mode behind --timely flag

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -10,13 +10,13 @@
  * Maximum time a task can wait in the scheduler's queue before triggering
  * a stall.
  */
-#define STARVATION_MS	5000ULL
+#define STARVATION_MS 5000ULL
 
 /*
  * Maximum amount of CPUs supported by the scheduler when flat or preferred
  * idle CPU scan is enabled.
  */
-#define MAX_CPUS	1024
+#define MAX_CPUS 1024
 
 /*
  * Maximum rate of task wakeups/sec (tasks with a higher rate are capped to
@@ -26,17 +26,31 @@
  * number must be multiplied by 10 to determine the actual limit in
  * wakeups/sec.
  */
-#define MAX_WAKEUP_FREQ		64ULL
+#define MAX_WAKEUP_FREQ 64ULL
+
+/*
+ * Enable TIMELY mode: when true, the scheduler uses TIMELY's delay-driven
+ * feedback for adaptive time slices and pressure-aware load balancing.
+ */
+const volatile bool timely_enabled;
+
+/*
+ * TIMELY-specific constants for v2 locality and pressure-aware load balancing.
+ */
+#define V2_LOCALITY_NONE 0U
+#define V2_LOCALITY_BASE 1U
+#define V2_LOCALITY_CONGESTED 2U
 
 char _license[] SEC("license") = "GPL";
 
 /* Allow to use bpf_printk() only when @debug is set */
-#define dbg_msg(_fmt, ...) do {				\
-	if (debug)					\
-		bpf_printk(_fmt, ##__VA_ARGS__);	\
-} while(0)
+#define dbg_msg(_fmt, ...)                               \
+	do {                                             \
+		if (debug)                               \
+			bpf_printk(_fmt, ##__VA_ARGS__); \
+	} while (0)
 
- /* Report additional debugging information */
+/* Report additional debugging information */
 const volatile bool debug;
 
 /*
@@ -114,7 +128,25 @@ const volatile u64 cpu_capacity[MAX_CPUS];
 /*
  * Scheduling statistics.
  */
-volatile u64 nr_kthread_dispatches, nr_direct_dispatches, nr_shared_dispatches;
+volatile u64 nr_kthread_dispatches, nr_direct_dispatches, nr_shared_dispatches,
+	nr_delay_recovery_dispatches, nr_delay_middle_add_dispatches,
+	nr_delay_fast_recovery_dispatches, nr_delay_rate_limited_dispatches,
+	nr_gain_floor_dispatches, nr_gain_ceiling_dispatches,
+	nr_delay_low_region_samples, nr_delay_mid_region_samples,
+	nr_delay_high_region_samples, nr_gain_floor_resident_samples,
+	nr_gain_mid_resident_samples, nr_gain_ceiling_resident_samples,
+	nr_idle_select_path_picks, nr_idle_enqueue_path_picks,
+	nr_idle_prev_cpu_picks, nr_idle_primary_picks, nr_idle_spill_picks,
+	nr_idle_pick_failures, nr_idle_primary_domain_misses,
+	nr_idle_global_misses, nr_waker_cpu_biases, nr_keep_running_reuses,
+	nr_keep_running_queue_empty, nr_keep_running_smt_blocked,
+	nr_keep_running_queued_work, nr_dispatch_cpu_dsq_consumes,
+	nr_dispatch_node_dsq_consumes, nr_v2_locality_cpu_dispatches,
+	nr_v2_congested_locality_cpu_dispatches,
+	nr_v2_delay_locality_cpu_dispatches, nr_v2_local_head_biases,
+	nr_v2_pressure_mode_entries, nr_v2_pressure_mode_exits,
+	nr_v2_pressure_shared_dispatches, nr_v2_expand_mode_dispatches,
+	nr_v2_contract_mode_dispatches, nr_cpu_release_reenqueue;
 
 /*
  * Amount of currently running tasks.
@@ -132,14 +164,62 @@ volatile u64 nr_online_cpus;
 static u64 nr_cpu_ids;
 
 /*
+ * TIMELY tunables.
+ */
+const volatile u64 timely_tlow_ns	      = 5000ULL * NSEC_PER_USEC;
+const volatile u64 timely_thigh_ns	      = 50000ULL * NSEC_PER_USEC;
+const volatile u32 timely_gain_min_fp	      = 128U;
+const volatile u32 timely_gain_max_fp	      = 1024U;
+const volatile u32 timely_gain_step_fp	      = 32U;
+const volatile u32 timely_hai_thresh_fp	      = 768U;
+const volatile u32 timely_hai_multiplier      = 2U;
+const volatile u32 timely_backoff_low_fp      = 768U;
+const volatile u32 timely_backoff_high_fp     = 960U;
+const volatile u32 timely_backoff_gradient_fp = 992U;
+const volatile u64 timely_gradient_margin_ns  = 125ULL * NSEC_PER_USEC;
+const volatile u64 timely_control_interval_ns = 500ULL * NSEC_PER_USEC;
+
+/*
+ * TIMELY v2 locality fallback tunables.
+ */
+const volatile bool v2_locality_fallback;
+const volatile u64  v2_locality_wakeup_freq = 8ULL;
+const volatile u64  v2_locality_max_cpuq    = 0ULL;
+const volatile u64  v2_locality_congested_nodeq;
+const volatile u64  v2_locality_congested_max_cpuq;
+const volatile bool v2_local_head_bias;
+const volatile u64  v2_local_head_bias_slack_ns;
+const volatile u32  v2_pressure_enter_streak;
+const volatile u32  v2_pressure_exit_streak;
+
+/*
+ * v2 pressure-aware load-balancing thresholds.
+ *
+ * The scheduler operates in two modes:
+ * - CONTRACT (locality-first): Favor staying on the current/favored CPU set
+ * - EXPAND (balance-first): More aggressively spread work to reduce delay
+ */
+const volatile u32 v2ExpandThreshold   = 75;
+const volatile u32 v2ContractThreshold = 50;
+
+/*
+ * v2 global pressure state for load-balancing decisions.
+ */
+volatile u32 v2_global_pressure;
+volatile u32 v2_expand_mode;
+volatile u32 v2_primary_domain_busy;
+volatile u64 v2_expand_mode_entries;
+volatile u64 v2_expand_mode_exits;
+
+/*
  * Runtime throttling.
  *
  * Throttle the CPUs by injecting @throttle_ns idle time every @slice_max.
  */
-const volatile u64 throttle_ns;
+const volatile u64   throttle_ns;
 static volatile bool cpus_throttled;
 
-static inline bool is_throttled(void)
+static inline bool   is_throttled(void)
 {
 	return READ_ONCE(cpus_throttled);
 }
@@ -196,10 +276,10 @@ struct {
  * Per-CPU context.
  */
 struct cpu_ctx {
-	u64 tot_runtime;
-	u64 prev_runtime;
-	u64 last_running;
-	u64 perf_lvl;
+	u64			   tot_runtime;
+	u64			   prev_runtime;
+	u64			   last_running;
+	u64			   perf_lvl;
 	struct bpf_cpumask __kptr *smt;
 	struct bpf_cpumask __kptr *l2_cpumask;
 	struct bpf_cpumask __kptr *l3_cpumask;
@@ -232,6 +312,17 @@ struct task_ctx {
 	u64 wakeup_freq;
 	u64 last_woke_at;
 	u64 avg_runtime;
+	/* TIMELY-specific fields (valid when timely_enabled=true) */
+	u64 timely_last_enqueued_at;
+	u32 timely_gain_fp;
+	u64 timely_last_gain_update_at;
+	u64 timely_last_delay_sample_at;
+	u64 timely_avg_queue_delay;
+	s64 timely_avg_queue_gradient;
+	u32 timely_hai_streak;
+	u32 v2_pressure_streak;
+	u32 v2_recovery_streak;
+	u32 v2_pressure_mode;
 };
 
 /* Map that contains task-local storage. */
@@ -247,8 +338,8 @@ struct {
  */
 struct task_ctx *try_lookup_task_ctx(const struct task_struct *p)
 {
-	return bpf_task_storage_get(&task_ctx_stor,
-					(struct task_struct *)p, 0, 0);
+	return bpf_task_storage_get(&task_ctx_stor, (struct task_struct *)p, 0,
+				    0);
 }
 
 /*
@@ -297,8 +388,8 @@ static inline bool is_pcpu_task(const struct task_struct *p)
  * Return true if @p1's deadline is less than @p2's deadline, false
  * otherwise.
  */
-static inline bool
-is_deadline_min(const struct task_struct *p1, const struct task_struct *p2)
+static inline bool is_deadline_min(const struct task_struct *p1,
+				   const struct task_struct *p2)
 {
 	if (!p1)
 		return false;
@@ -318,7 +409,8 @@ static inline const struct cpumask *get_idle_cpumask(s32 cpu)
 	if (!numa_enabled)
 		return scx_bpf_get_idle_cpumask();
 
-	return __COMPAT_scx_bpf_get_idle_cpumask_node(__COMPAT_scx_bpf_cpu_node(cpu));
+	return __COMPAT_scx_bpf_get_idle_cpumask_node(
+		__COMPAT_scx_bpf_cpu_node(cpu));
 }
 
 /*
@@ -332,7 +424,8 @@ static inline const struct cpumask *get_idle_smtmask(s32 cpu)
 	if (!numa_enabled)
 		return scx_bpf_get_idle_smtmask();
 
-	return __COMPAT_scx_bpf_get_idle_smtmask_node(__COMPAT_scx_bpf_cpu_node(cpu));
+	return __COMPAT_scx_bpf_get_idle_smtmask_node(
+		__COMPAT_scx_bpf_cpu_node(cpu));
 }
 
 /*
@@ -356,8 +449,8 @@ static inline bool is_cpu_valid(s32 cpu)
  */
 static inline bool cpus_share_cache(s32 this_cpu, s32 that_cpu)
 {
-        if (this_cpu == that_cpu)
-                return true;
+	if (this_cpu == that_cpu)
+		return true;
 
 	if (!is_cpu_valid(this_cpu) || !is_cpu_valid(that_cpu))
 		return false;
@@ -370,8 +463,8 @@ static inline bool cpus_share_cache(s32 this_cpu, s32 that_cpu)
  */
 static inline bool is_cpu_faster(s32 this_cpu, s32 that_cpu)
 {
-        if (this_cpu == that_cpu)
-                return false;
+	if (this_cpu == that_cpu)
+		return false;
 
 	if (!is_cpu_valid(this_cpu) || !is_cpu_valid(that_cpu))
 		return false;
@@ -385,7 +478,7 @@ static inline bool is_cpu_faster(s32 this_cpu, s32 that_cpu)
 static s32 smt_sibling(s32 cpu)
 {
 	const struct cpumask *smt;
-	struct cpu_ctx *cctx;
+	struct cpu_ctx	     *cctx;
 
 	cctx = try_lookup_cpu_ctx(cpu);
 	if (!cctx)
@@ -408,7 +501,7 @@ static s32 smt_sibling(s32 cpu)
 static bool is_smt_contended(s32 cpu)
 {
 	const struct cpumask *idle_mask;
-	bool is_contended;
+	bool		      is_contended;
 
 	if (!smt_enabled)
 		return false;
@@ -417,7 +510,7 @@ static bool is_smt_contended(s32 cpu)
 	 * If the sibling SMT CPU is not idle and there are other full-idle
 	 * SMT cores available, consider the current CPU as contended.
 	 */
-	idle_mask = get_idle_cpumask(cpu);
+	idle_mask    = get_idle_cpumask(cpu);
 	is_contended = !bpf_cpumask_test_cpu(smt_sibling(cpu), idle_mask) &&
 		       !bpf_cpumask_empty(idle_mask);
 	scx_bpf_put_cpumask(idle_mask);
@@ -438,8 +531,10 @@ static inline bool is_wakeup(u64 wake_flags)
  * Return a full-idle SMT core if @do_idle_smt is true, or any idle CPU if
  * @do_idle_smt is false.
  */
-static s32 pick_idle_cpu_pref_smt(struct task_struct *p, s32 prev_cpu, bool is_prev_allowed,
-				  const struct cpumask *primary, const struct cpumask *smt)
+static s32 pick_idle_cpu_pref_smt(struct task_struct *p, s32 prev_cpu,
+				  bool			is_prev_allowed,
+				  const struct cpumask *primary,
+				  const struct cpumask *smt)
 {
 	u64 max_cpus = MIN(nr_cpu_ids, MAX_CPUS);
 	int i;
@@ -450,10 +545,12 @@ static s32 pick_idle_cpu_pref_smt(struct task_struct *p, s32 prev_cpu, bool is_p
 	    scx_bpf_test_and_clear_cpu_idle(prev_cpu))
 		return prev_cpu;
 
-	bpf_for(i, 0, max_cpus) {
+	bpf_for(i, 0, max_cpus)
+	{
 		s32 cpu = preferred_cpus[i];
 
-		if ((cpu == prev_cpu) || !bpf_cpumask_test_cpu(cpu, p->cpus_ptr))
+		if ((cpu == prev_cpu) ||
+		    !bpf_cpumask_test_cpu(cpu, p->cpus_ptr))
 			continue;
 
 		if ((!primary || bpf_cpumask_test_cpu(cpu, primary)) &&
@@ -473,10 +570,10 @@ static s32 pick_idle_cpu_scan(struct task_struct *p, s32 prev_cpu)
 {
 	const struct cpumask *smt, *primary;
 	bool is_prev_allowed = bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr);
-	s32 cpu;
+	s32  cpu;
 
 	primary = !primary_all ? cast_mask(primary_cpumask) : NULL;
-	smt = smt_enabled ? get_idle_smtmask(prev_cpu) : NULL;
+	smt	= smt_enabled ? get_idle_smtmask(prev_cpu) : NULL;
 
 	/*
 	 * If the task can't migrate, there's no point looking for other
@@ -495,7 +592,8 @@ static s32 pick_idle_cpu_scan(struct task_struct *p, s32 prev_cpu)
 			 * Try to pick a full-idle core in the primary
 			 * domain.
 			 */
-			cpu = pick_idle_cpu_pref_smt(p, prev_cpu, is_prev_allowed, primary, smt);
+			cpu = pick_idle_cpu_pref_smt(
+				p, prev_cpu, is_prev_allowed, primary, smt);
 			if (cpu >= 0)
 				goto out;
 		}
@@ -503,7 +601,8 @@ static s32 pick_idle_cpu_scan(struct task_struct *p, s32 prev_cpu)
 		/*
 		 * Try to pick any idle CPU in the primary domain.
 		 */
-		cpu = pick_idle_cpu_pref_smt(p, prev_cpu, is_prev_allowed, primary, NULL);
+		cpu = pick_idle_cpu_pref_smt(p, prev_cpu, is_prev_allowed,
+					     primary, NULL);
 		if (cpu >= 0)
 			goto out;
 	}
@@ -512,7 +611,8 @@ static s32 pick_idle_cpu_scan(struct task_struct *p, s32 prev_cpu)
 		/*
 		 * Try to pick any full-idle core in the system.
 		 */
-		cpu = pick_idle_cpu_pref_smt(p, prev_cpu, is_prev_allowed, NULL, smt);
+		cpu = pick_idle_cpu_pref_smt(p, prev_cpu, is_prev_allowed, NULL,
+					     smt);
 		if (cpu >= 0)
 			goto out;
 	}
@@ -539,7 +639,7 @@ static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, s32 this_cpu,
 			 u64 wake_flags, bool from_enqueue)
 {
 	const struct cpumask *primary = cast_mask(primary_cpumask);
-	s32 cpu;
+	s32		      cpu;
 
 	/*
 	 * Use lightweight idle CPU scanning when flat or preferred idle
@@ -599,7 +699,8 @@ static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, s32 this_cpu,
 	 * there first.
 	 */
 	if (!primary_all && primary) {
-		cpu = scx_bpf_select_cpu_and(p, prev_cpu, wake_flags, primary, 0);
+		cpu = scx_bpf_select_cpu_and(p, prev_cpu, wake_flags, primary,
+					     0);
 		if (cpu >= 0)
 			return cpu;
 	}
@@ -662,13 +763,13 @@ static u64 task_dl(struct task_struct *p, s32 cpu, struct task_ctx *tctx)
 	 * drain at average slice usage.
 	 */
 	const u64 STARVATION_THRESH = STARVATION_MS * NSEC_PER_MSEC / 10;
-	const u64 q_thresh = MAX(STARVATION_THRESH / slice_max, 1);
+	const u64 q_thresh	    = MAX(STARVATION_THRESH / slice_max, 1);
 
-	u64 nr_queued = scx_bpf_dsq_nr_queued(cpu_dsq(cpu)) +
-			scx_bpf_dsq_nr_queued(node_dsq(cpu));
-	u64 lag_scale = MAX(tctx->wakeup_freq, 1);
-	u64 awake_max = scale_by_task_weight_inverse(p, slice_lag);
-	u64 vtime_min;
+	u64	  nr_queued	    = scx_bpf_dsq_nr_queued(cpu_dsq(cpu)) +
+				      scx_bpf_dsq_nr_queued(node_dsq(cpu));
+	u64	  lag_scale	    = MAX(tctx->wakeup_freq, 1);
+	u64	  awake_max = scale_by_task_weight_inverse(p, slice_lag);
+	u64	  vtime_min;
 
 	/*
 	 * Queue pressure factor = q_thresh / (q_thresh + nr_queued), applied to
@@ -680,7 +781,8 @@ static u64 task_dl(struct task_struct *p, s32 cpu, struct task_ctx *tctx)
 	if (nr_queued * slice_max >= STARVATION_THRESH)
 		lag_scale = 1;
 	else
-		lag_scale = MAX(lag_scale * q_thresh / (q_thresh + nr_queued), 1);
+		lag_scale =
+			MAX(lag_scale * q_thresh / (q_thresh + nr_queued), 1);
 
 	/*
 	 * Cap the partial accumulated vruntime since last sleep in
@@ -730,52 +832,263 @@ static u64 task_slice(const struct task_struct *p, s32 cpu)
 }
 
 /*
- * Pick a target CPU for a task which is being woken up.
- *
- * If a task is dispatched here, ops.enqueue() will be skipped: task will be
- * dispatched directly to the CPU returned by this callback.
+ * TIMELY helpers (used only when timely_enabled=true)
  */
-s32 BPF_STRUCT_OPS(bpfland_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wake_flags)
+
+static void record_idle_pick_result(s32 cpu, s32 prev_cpu, bool from_enqueue)
 {
-	s32 cpu, this_cpu = bpf_get_smp_processor_id();
-	bool is_this_cpu_allowed = bpf_cpumask_test_cpu(this_cpu, p->cpus_ptr);
+	const struct cpumask *primary =
+		!primary_all ? cast_mask(primary_cpumask) : NULL;
 
-	/*
-	 * Make sure @prev_cpu is usable, otherwise try to move close to
-	 * the waker's CPU. If the waker's CPU is also not usable, then
-	 * pick the first usable CPU.
-	 */
-	if (!bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr))
-		prev_cpu = is_this_cpu_allowed ? this_cpu : bpf_cpumask_first(p->cpus_ptr);
-
-	/*
-	 * Try to find an idle CPU and dispatch the task directly to the
-	 * target CPU.
-	 */
-	cpu = pick_idle_cpu(p, prev_cpu, is_this_cpu_allowed ? this_cpu : -1,
-			    wake_flags, false);
-	if (cpu >= 0) {
-		struct task_ctx *tctx;
-
-		tctx = try_lookup_task_ctx(p);
-		if (tctx) {
-			scx_bpf_dsq_insert_vtime(p, cpu_dsq(cpu),
-						 task_slice(p, cpu), task_dl(p, cpu, tctx), 0);
-			__sync_fetch_and_add(&nr_direct_dispatches, 1);
-		}
-		return cpu;
+	if (cpu < 0) {
+		__sync_fetch_and_add(&nr_idle_pick_failures, 1);
+		return;
 	}
 
-	return prev_cpu;
+	if (from_enqueue)
+		__sync_fetch_and_add(&nr_idle_enqueue_path_picks, 1);
+	else
+		__sync_fetch_and_add(&nr_idle_select_path_picks, 1);
+
+	if (cpu == prev_cpu)
+		__sync_fetch_and_add(&nr_idle_prev_cpu_picks, 1);
+
+	if (primary_all || !primary || bpf_cpumask_test_cpu(cpu, primary))
+		__sync_fetch_and_add(&nr_idle_primary_picks, 1);
+	else
+		__sync_fetch_and_add(&nr_idle_spill_picks, 1);
 }
 
-/*
- * Return true if the task should be forced to stay on the same CPU, false
- * otherwise.
- */
-static bool is_task_sticky(const struct task_ctx *tctx)
+static bool is_delay_pressured(const struct task_ctx *tctx)
 {
-	return sticky_tasks && tctx->avg_runtime < 10 * NSEC_PER_USEC;
+	const u32 TIMELY_GAIN_ONE = 1024U;
+	u64	  low_target, high_target;
+	u32	  gain;
+	s64	  gradient_margin;
+
+	if (!tctx || !tctx->timely_avg_queue_delay)
+		return false;
+
+	low_target	= MAX(timely_tlow_ns, 1);
+	high_target	= MAX(timely_thigh_ns, low_target + 1);
+	gain		= tctx->timely_gain_fp ?: TIMELY_GAIN_ONE;
+	gradient_margin = (s64)MAX(timely_gradient_margin_ns, 1);
+
+	if (tctx->timely_avg_queue_delay > high_target)
+		return true;
+
+	if (tctx->timely_avg_queue_delay > low_target &&
+	    (gain < TIMELY_GAIN_ONE ||
+	     tctx->timely_avg_queue_gradient > gradient_margin))
+		return true;
+
+	return false;
+}
+
+static inline bool is_pressure_mode_active(const struct task_ctx *tctx)
+{
+	return tctx && tctx->v2_pressure_mode;
+}
+
+static void update_pressure_mode(struct task_ctx *tctx)
+{
+	if (!tctx || !v2_pressure_enter_streak || !v2_pressure_exit_streak)
+		return;
+
+	if (is_delay_pressured(tctx)) {
+		if (tctx->v2_pressure_streak < v2_pressure_enter_streak)
+			tctx->v2_pressure_streak++;
+		tctx->v2_recovery_streak = 0;
+
+		if (!tctx->v2_pressure_mode &&
+		    tctx->v2_pressure_streak >= v2_pressure_enter_streak) {
+			tctx->v2_pressure_mode = 1;
+			__sync_fetch_and_add(&nr_v2_pressure_mode_entries, 1);
+		}
+		return;
+	}
+
+	tctx->v2_pressure_streak = 0;
+
+	if (!tctx->v2_pressure_mode) {
+		tctx->v2_recovery_streak = 0;
+		return;
+	}
+
+	if (tctx->v2_recovery_streak < v2_pressure_exit_streak) {
+		tctx->v2_recovery_streak++;
+		return;
+	}
+	tctx->v2_pressure_mode	 = 0;
+	tctx->v2_recovery_streak = 0;
+	__sync_fetch_and_add(&nr_v2_pressure_mode_exits, 1);
+}
+
+static void update_global_pressure(const struct task_ctx *tctx)
+{
+	u32 expand_threshold, contract_threshold;
+	u32 new_pressure, old_pressure;
+	u32 primary_busy_pct;
+
+	if (!v2_pressure_enter_streak || !v2_pressure_exit_streak)
+		return;
+
+	primary_busy_pct = 0;
+	u32 online_cpus	 = READ_ONCE(nr_online_cpus);
+	if (online_cpus > 0) {
+		u64 running	 = READ_ONCE(nr_running);
+		u64 product	 = running * 100ULL;
+		primary_busy_pct = (u32)(product / online_cpus);
+		primary_busy_pct = MIN(primary_busy_pct, 100U);
+		__sync_val_compare_and_swap(&v2_primary_domain_busy,
+					    v2_primary_domain_busy,
+					    primary_busy_pct);
+	}
+
+	old_pressure = READ_ONCE(v2_global_pressure);
+	new_pressure = old_pressure;
+
+	if (tctx && is_delay_pressured(tctx)) {
+		new_pressure = old_pressure - (old_pressure >> 2) + 25;
+	} else {
+		new_pressure = old_pressure - (old_pressure >> 3);
+	}
+	new_pressure = MIN(new_pressure, 100U);
+
+	__sync_val_compare_and_swap(&v2_global_pressure, old_pressure,
+				    new_pressure);
+
+	u32 expand_th	= READ_ONCE(v2ExpandThreshold);
+	u32 contract_th = READ_ONCE(v2ContractThreshold);
+
+	if (expand_th == 0)
+		expand_th = 1;
+	if (contract_th >= expand_th)
+		contract_th = expand_th - 1;
+
+	expand_threshold   = expand_th;
+	contract_threshold = contract_th;
+
+	if (!v2_expand_mode) {
+		if (new_pressure >= expand_threshold ||
+		    primary_busy_pct >= expand_threshold) {
+			if (__sync_val_compare_and_swap(&v2_expand_mode, 0,
+							1) == 0) {
+				__sync_fetch_and_add(&v2_expand_mode_entries,
+						     1);
+			}
+		}
+	} else {
+		if (new_pressure < contract_threshold &&
+		    primary_busy_pct < contract_threshold) {
+			if (__sync_val_compare_and_swap(&v2_expand_mode, 1,
+							0) == 1) {
+				__sync_fetch_and_add(&v2_expand_mode_exits, 1);
+			}
+		}
+	}
+}
+
+static inline bool is_expand_mode_active(void)
+{
+	return READ_ONCE(v2_expand_mode);
+}
+
+static bool should_expand_skip_locality(const struct task_ctx *tctx)
+{
+	if (is_expand_mode_active()) {
+		if (!tctx)
+			return true;
+		bool wake_heavy = tctx->wakeup_freq >=
+				  MAX(v2_locality_wakeup_freq, 1);
+		if (wake_heavy)
+			return false;
+		return true;
+	}
+
+	if (tctx && tctx->v2_pressure_mode) {
+		u32 primary_busy = READ_ONCE(v2_primary_domain_busy);
+		if (primary_busy >= v2ExpandThreshold / 2)
+			return true;
+	}
+
+	return false;
+}
+
+static u32 locality_fallback_kind(const struct task_struct *p,
+				  const struct task_ctx *tctx, s32 prev_cpu,
+				  bool *from_delay_pressure)
+{
+	u64  cpuq, nodeq;
+	bool wake_heavy, delay_pressured;
+
+	if (from_delay_pressure)
+		*from_delay_pressure = false;
+
+	if (!v2_locality_fallback || !tctx || is_pcpu_task(p))
+		return V2_LOCALITY_NONE;
+
+	wake_heavy	= tctx->wakeup_freq >= MAX(v2_locality_wakeup_freq, 1);
+	delay_pressured = is_delay_pressured(tctx);
+	if (!wake_heavy && !delay_pressured)
+		return V2_LOCALITY_NONE;
+
+	cpuq  = scx_bpf_dsq_nr_queued(cpu_dsq(prev_cpu));
+	nodeq = scx_bpf_dsq_nr_queued(node_dsq(prev_cpu));
+
+	if (cpuq <= v2_locality_max_cpuq && cpuq < nodeq)
+		goto use_local;
+
+	if (v2_locality_congested_nodeq &&
+	    nodeq >= v2_locality_congested_nodeq &&
+	    cpuq <= v2_locality_congested_max_cpuq)
+		goto use_congested;
+
+	return V2_LOCALITY_NONE;
+
+use_local:
+	if (from_delay_pressure)
+		*from_delay_pressure = delay_pressured && !wake_heavy;
+	return V2_LOCALITY_BASE;
+
+use_congested:
+	if (from_delay_pressure)
+		*from_delay_pressure = delay_pressured && !wake_heavy;
+	return V2_LOCALITY_CONGESTED;
+}
+
+static bool should_bias_local_head(const struct task_struct *p,
+				   const struct task_struct *q,
+				   bool *from_delay_pressure)
+{
+	struct task_ctx *tctx;
+	bool		 wake_heavy, delay_pressured;
+	u64		 slack, diff;
+
+	if (from_delay_pressure)
+		*from_delay_pressure = false;
+
+	if (!v2_local_head_bias || !p || !q)
+		return false;
+
+	tctx = try_lookup_task_ctx(p);
+	if (!tctx)
+		return false;
+	wake_heavy	= tctx->wakeup_freq >= MAX(v2_locality_wakeup_freq, 1);
+	delay_pressured = is_delay_pressured(tctx);
+	if (!wake_heavy && !delay_pressured)
+		return false;
+	if (p->scx.dsq_vtime <= q->scx.dsq_vtime)
+		return false;
+
+	slack = v2_local_head_bias_slack_ns;
+	if (!slack)
+		return false;
+
+	diff = p->scx.dsq_vtime - q->scx.dsq_vtime;
+	if (from_delay_pressure)
+		*from_delay_pressure = delay_pressured && !wake_heavy;
+	return diff <= slack;
 }
 
 /*
@@ -791,6 +1104,14 @@ static u64 calc_avg(u64 old_val, u64 new_val)
 }
 
 /*
+ * Signed EWMA for delay gradient (can go negative).
+ */
+static s64 calc_avg_s64(s64 old_val, s64 new_val)
+{
+	return (old_val - (old_val >> 2)) + (new_val >> 2);
+}
+
+/*
  * Update the average frequency of an event.
  *
  * The frequency is computed from the given interval since the last event
@@ -799,10 +1120,19 @@ static u64 calc_avg(u64 old_val, u64 new_val)
  */
 static u64 update_freq(u64 freq, u64 interval)
 {
-        u64 new_freq;
+	u64 new_freq;
 
-        new_freq = (100 * NSEC_PER_MSEC) / interval;
-        return calc_avg(freq, new_freq);
+	new_freq = (100 * NSEC_PER_MSEC) / interval;
+	return calc_avg(freq, new_freq);
+}
+
+/*
+ * Return true if the task should be forced to stay on the same CPU, false
+ * otherwise.
+ */
+static bool is_task_sticky(const struct task_ctx *tctx)
+{
+	return sticky_tasks && tctx->avg_runtime < 10 * NSEC_PER_USEC;
 }
 
 /*
@@ -821,12 +1151,67 @@ static bool task_should_migrate(struct task_struct *p, u64 enq_flags)
 }
 
 /*
+ * Consume and dispatch the first task from @dsq_id. If the first task can't be
+ * dispatched on the corresponding DSQ, redirect the task to a proper CPU.
+ */
+static bool consume_first_task(u64 dsq_id, struct task_struct *p)
+{
+	if (!p)
+		return false;
+
+	return scx_bpf_dsq_move_to_local(dsq_id, 0);
+}
+
+/*
+ * Pick a target CPU for a task which is being woken up.
+ *
+ * If a task is dispatched here, ops.enqueue() will be skipped: task will be
+ * dispatched directly to the CPU returned by this callback.
+ */
+static s32 do_bpfland_select_cpu(struct task_struct *p, s32 prev_cpu,
+				 u64 wake_flags)
+{
+	s32  cpu, this_cpu = bpf_get_smp_processor_id();
+	bool is_this_cpu_allowed = bpf_cpumask_test_cpu(this_cpu, p->cpus_ptr);
+
+	/*
+	 * Make sure @prev_cpu is usable, otherwise try to move close to
+	 * the waker's CPU. If the waker's CPU is also not usable, then
+	 * pick the first usable CPU.
+	 */
+	if (!bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr))
+		prev_cpu = is_this_cpu_allowed ? this_cpu :
+						 bpf_cpumask_first(p->cpus_ptr);
+
+	/*
+	 * Try to find an idle CPU and dispatch the task directly to the
+	 * target CPU.
+	 */
+	cpu = pick_idle_cpu(p, prev_cpu, is_this_cpu_allowed ? this_cpu : -1,
+			    wake_flags, false);
+	if (cpu >= 0) {
+		struct task_ctx *tctx;
+
+		tctx = try_lookup_task_ctx(p);
+		if (tctx) {
+			scx_bpf_dsq_insert_vtime(p, cpu_dsq(cpu),
+						 task_slice(p, cpu),
+						 task_dl(p, cpu, tctx), 0);
+			__sync_fetch_and_add(&nr_direct_dispatches, 1);
+		}
+		return cpu;
+	}
+
+	return prev_cpu;
+}
+
+/*
  * Dispatch all the other tasks that were not dispatched directly in
  * select_cpu().
  */
-void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
+static void do_bpfland_enqueue(struct task_struct *p, u64 enq_flags)
 {
-	s32 prev_cpu = scx_bpf_task_cpu(p);
+	s32		 prev_cpu = scx_bpf_task_cpu(p);
 	struct task_ctx *tctx;
 
 	tctx = try_lookup_task_ctx(p);
@@ -839,7 +1224,8 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	 * locking pressure on the per-CPU and per-node DSQs.
 	 */
 	if (is_task_sticky(tctx)) {
-		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p, prev_cpu), enq_flags);
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p, prev_cpu),
+				   enq_flags);
 		__sync_fetch_and_add(&nr_direct_dispatches, 1);
 		return;
 	}
@@ -850,7 +1236,8 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	 * per-node DSQs.
 	 */
 	if (local_kthreads && is_kthread(p) && p->nr_cpus_allowed == 1) {
-		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p, prev_cpu), enq_flags);
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p, prev_cpu),
+				   enq_flags);
 		__sync_fetch_and_add(&nr_kthread_dispatches, 1);
 		return;
 	}
@@ -870,10 +1257,13 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	 */
 	if (is_pcpu_task(p)) {
 		if (local_pcpu)
-			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p, prev_cpu), enq_flags);
+			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL,
+					   task_slice(p, prev_cpu), enq_flags);
 		else
 			scx_bpf_dsq_insert_vtime(p, cpu_dsq(prev_cpu),
-						 task_slice(p, prev_cpu), task_dl(p, prev_cpu, tctx), enq_flags);
+						 task_slice(p, prev_cpu),
+						 task_dl(p, prev_cpu, tctx),
+						 enq_flags);
 		__sync_fetch_and_add(&nr_direct_dispatches, 1);
 		return;
 	}
@@ -886,13 +1276,17 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 		s32 cpu;
 
 		if (is_pcpu_task(p))
-			cpu = scx_bpf_test_and_clear_cpu_idle(prev_cpu) ? prev_cpu : -EBUSY;
+			cpu = scx_bpf_test_and_clear_cpu_idle(prev_cpu) ?
+				      prev_cpu :
+				      -EBUSY;
 		else
 			cpu = pick_idle_cpu(p, prev_cpu, -1, 0, true);
 
 		if (cpu >= 0) {
 			scx_bpf_dsq_insert_vtime(p, cpu_dsq(cpu),
-						 task_slice(p, cpu), task_dl(p, cpu, tctx), enq_flags);
+						 task_slice(p, cpu),
+						 task_dl(p, cpu, tctx),
+						 enq_flags);
 			__sync_fetch_and_add(&nr_direct_dispatches, 1);
 
 			if (prev_cpu != cpu || !scx_bpf_task_running(p))
@@ -905,8 +1299,8 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	 * Dispatch the task to the node DSQ, using the deadline-based
 	 * scheduling.
 	 */
-	scx_bpf_dsq_insert_vtime(p, node_dsq(prev_cpu),
-				 task_slice(p, prev_cpu), task_dl(p, prev_cpu, tctx), enq_flags);
+	scx_bpf_dsq_insert_vtime(p, node_dsq(prev_cpu), task_slice(p, prev_cpu),
+				 task_dl(p, prev_cpu, tctx), enq_flags);
 	__sync_fetch_and_add(&nr_shared_dispatches, 1);
 
 	/*
@@ -943,19 +1337,7 @@ static bool keep_running(const struct task_struct *p, s32 cpu)
 	return true;
 }
 
-/*
- * Consume and dispatch the first task from @dsq_id. If the first task can't be
- * dispatched on the corresponding DSQ, redirect the task to a proper CPU.
- */
-static bool consume_first_task(u64 dsq_id, struct task_struct *p)
-{
-	if (!p)
-		return false;
-
-	return scx_bpf_dsq_move_to_local(dsq_id, 0);
-}
-
-void BPF_STRUCT_OPS(bpfland_dispatch, s32 cpu, struct task_struct *prev)
+static void do_bpfland_dispatch(s32 cpu, struct task_struct *prev)
 {
 	struct task_struct *p = __COMPAT_scx_bpf_dsq_peek(cpu_dsq(cpu));
 	struct task_struct *q = __COMPAT_scx_bpf_dsq_peek(node_dsq(cpu));
@@ -972,10 +1354,12 @@ void BPF_STRUCT_OPS(bpfland_dispatch, s32 cpu, struct task_struct *prev)
 	 * run on @cpu.
 	 */
 	if (!is_deadline_min(q, p)) {
-		if (consume_first_task(cpu_dsq(cpu), p) || consume_first_task(node_dsq(cpu), q))
+		if (consume_first_task(cpu_dsq(cpu), p) ||
+		    consume_first_task(node_dsq(cpu), q))
 			return;
 	} else {
-		if (consume_first_task(node_dsq(cpu), q) || consume_first_task(cpu_dsq(cpu), p))
+		if (consume_first_task(node_dsq(cpu), q) ||
+		    consume_first_task(cpu_dsq(cpu), p))
 			return;
 	}
 
@@ -993,9 +1377,9 @@ void BPF_STRUCT_OPS(bpfland_dispatch, s32 cpu, struct task_struct *prev)
  */
 static void update_cpu_load(struct task_struct *p, struct task_ctx *tctx)
 {
-	u64 now = bpf_ktime_get_ns();
-	s32 cpu = scx_bpf_task_cpu(p);
-	u64 perf_lvl, delta_runtime, delta_t;
+	u64		now = bpf_ktime_get_ns();
+	s32		cpu = scx_bpf_task_cpu(p);
+	u64		perf_lvl, delta_runtime, delta_t;
 	struct cpu_ctx *cctx;
 
 	/*
@@ -1017,7 +1401,8 @@ static void update_cpu_load(struct task_struct *p, struct task_ctx *tctx)
 	 * bump up the performance level to the max.
 	 */
 	delta_runtime = cctx->tot_runtime - cctx->prev_runtime;
-	perf_lvl = MIN(delta_runtime * SCX_CPUPERF_ONE / delta_t, SCX_CPUPERF_ONE);
+	perf_lvl =
+		MIN(delta_runtime * SCX_CPUPERF_ONE / delta_t, SCX_CPUPERF_ONE);
 	if (perf_lvl >= SCX_CPUPERF_ONE - SCX_CPUPERF_ONE / 4)
 		perf_lvl = SCX_CPUPERF_ONE;
 	cctx->perf_lvl = perf_lvl;
@@ -1032,7 +1417,7 @@ static void update_cpu_load(struct task_struct *p, struct task_ctx *tctx)
 	cctx->prev_runtime = cctx->tot_runtime;
 }
 
-void BPF_STRUCT_OPS(bpfland_running, struct task_struct *p)
+static void do_bpfland_running(struct task_struct *p)
 {
 	struct task_ctx *tctx;
 
@@ -1064,12 +1449,12 @@ void BPF_STRUCT_OPS(bpfland_running, struct task_struct *p)
  * Update task statistics when the task is releasing the CPU (either
  * voluntarily or because it expires its assigned time slice).
  */
-void BPF_STRUCT_OPS(bpfland_stopping, struct task_struct *p, bool runnable)
+static void do_bpfland_stopping(struct task_struct *p, bool runnable)
 {
 	u64 now = bpf_ktime_get_ns(), slice, delta_vtime, delta_runtime;
 	s32 cpu = scx_bpf_task_cpu(p);
 	struct task_ctx *tctx;
-	struct cpu_ctx *cctx;
+	struct cpu_ctx	*cctx;
 
 	__sync_fetch_and_sub(&nr_running, 1);
 
@@ -1105,9 +1490,9 @@ void BPF_STRUCT_OPS(bpfland_stopping, struct task_struct *p, bool runnable)
 	cctx->tot_runtime += delta_runtime;
 }
 
-void BPF_STRUCT_OPS(bpfland_runnable, struct task_struct *p, u64 enq_flags)
+static void do_bpfland_runnable(struct task_struct *p, u64 enq_flags)
 {
-	u64 now = bpf_ktime_get_ns(), delta_t;
+	u64		 now = bpf_ktime_get_ns(), delta_t;
 	struct task_ctx *tctx;
 
 	tctx = try_lookup_task_ctx(p);
@@ -1121,12 +1506,12 @@ void BPF_STRUCT_OPS(bpfland_runnable, struct task_struct *p, u64 enq_flags)
 	 * last wakeup, then cap the result to avoid large spikes.
 	 */
 	delta_t = now > tctx->last_woke_at ? now - tctx->last_woke_at : 1;
-	tctx->wakeup_freq = update_freq(tctx->wakeup_freq, delta_t);
-	tctx->wakeup_freq = MIN(tctx->wakeup_freq, MAX_WAKEUP_FREQ);
+	tctx->wakeup_freq  = update_freq(tctx->wakeup_freq, delta_t);
+	tctx->wakeup_freq  = MIN(tctx->wakeup_freq, MAX_WAKEUP_FREQ);
 	tctx->last_woke_at = now;
 }
 
-void BPF_STRUCT_OPS(bpfland_enable, struct task_struct *p)
+static void do_bpfland_enable(struct task_struct *p)
 {
 	/*
 	 * Initialize the task vruntime to the current global vruntime.
@@ -1134,8 +1519,8 @@ void BPF_STRUCT_OPS(bpfland_enable, struct task_struct *p)
 	p->scx.dsq_vtime = vtime_now;
 }
 
-s32 BPF_STRUCT_OPS(bpfland_init_task, struct task_struct *p,
-		   struct scx_init_task_args *args)
+static s32 do_bpfland_init_task(struct task_struct	  *p,
+				struct scx_init_task_args *args)
 {
 	struct task_ctx *tctx;
 
@@ -1147,16 +1532,21 @@ s32 BPF_STRUCT_OPS(bpfland_init_task, struct task_struct *p,
 	return 0;
 }
 
+static void do_bpfland_exit(struct scx_exit_info *ei)
+{
+	UEI_RECORD(uei, ei);
+}
+
 /*
  * Evaluate the amount of online CPUs.
  */
 static s32 get_nr_online_cpus(void)
 {
 	const struct cpumask *online_cpumask;
-	int cpus;
+	int		      cpus;
 
 	online_cpumask = scx_bpf_get_online_cpumask();
-	cpus = bpf_cpumask_weight(online_cpumask);
+	cpus	       = bpf_cpumask_weight(online_cpumask);
 	scx_bpf_put_cpumask(online_cpumask);
 
 	return cpus;
@@ -1165,7 +1555,7 @@ static s32 get_nr_online_cpus(void)
 static int init_cpumask(struct bpf_cpumask **cpumask)
 {
 	struct bpf_cpumask *mask;
-	int err = 0;
+	int		    err = 0;
 
 	/*
 	 * Do nothing if the mask is already initialized.
@@ -1188,16 +1578,16 @@ static int init_cpumask(struct bpf_cpumask **cpumask)
 SEC("syscall")
 int enable_sibling_cpu(struct domain_arg *input)
 {
-	struct cpu_ctx *cctx;
+	struct cpu_ctx	   *cctx;
 	struct bpf_cpumask *mask, **pmask;
-	int err = 0;
+	int		    err = 0;
 
-	cctx = try_lookup_cpu_ctx(input->cpu_id);
+	cctx			= try_lookup_cpu_ctx(input->cpu_id);
 	if (!cctx)
 		return -ENOENT;
 
 	pmask = &cctx->smt;
-	err = init_cpumask(pmask);
+	err   = init_cpumask(pmask);
 	if (err)
 		return err;
 
@@ -1214,7 +1604,7 @@ SEC("syscall")
 int enable_primary_cpu(struct cpu_arg *input)
 {
 	struct bpf_cpumask *mask;
-	int err = 0;
+	int		    err = 0;
 
 	/* Make sure the primary CPU mask is initialized */
 	err = init_cpumask(&primary_cpumask);
@@ -1246,11 +1636,12 @@ int enable_primary_cpu(struct cpu_arg *input)
 static void init_cpuperf_target(void)
 {
 	const struct cpumask *online_cpumask;
-	u64 perf_lvl;
-	s32 cpu;
+	u64		      perf_lvl;
+	s32		      cpu;
 
 	online_cpumask = scx_bpf_get_online_cpumask();
-	bpf_for(cpu, 0, nr_cpu_ids) {
+	bpf_for(cpu, 0, nr_cpu_ids)
+	{
 		if (!bpf_cpumask_test_cpu(cpu, online_cpumask))
 			continue;
 
@@ -1270,9 +1661,9 @@ static void init_cpuperf_target(void)
 static int throttle_timerfn(void *map, int *key, struct bpf_timer *timer)
 {
 	bool throttled = is_throttled();
-	u64 flags, duration;
-	s32 cpu;
-	int err;
+	u64  flags, duration;
+	s32  cpu;
+	int  err;
 
 	/*
 	 * Stop the CPUs sending a preemption IPI (SCX_KICK_PREEMPT) if we
@@ -1282,10 +1673,10 @@ static int throttle_timerfn(void *map, int *key, struct bpf_timer *timer)
 	 * sleep.
 	 */
 	if (throttled) {
-		flags = SCX_KICK_IDLE;
+		flags	 = SCX_KICK_IDLE;
 		duration = slice_max;
 	} else {
-		flags = SCX_KICK_PREEMPT;
+		flags	 = SCX_KICK_PREEMPT;
 		duration = throttle_ns;
 	}
 
@@ -1294,8 +1685,7 @@ static int throttle_timerfn(void *map, int *key, struct bpf_timer *timer)
 	 */
 	set_throttled(!throttled);
 
-	bpf_for(cpu, 0, nr_cpu_ids)
-		scx_bpf_kick_cpu(cpu, flags);
+	bpf_for(cpu, 0, nr_cpu_ids) scx_bpf_kick_cpu(cpu, flags);
 
 	/*
 	 * Re-arm the duty-cycle timer setting the runtime or the idle time
@@ -1311,12 +1701,12 @@ static int throttle_timerfn(void *map, int *key, struct bpf_timer *timer)
 s32 BPF_STRUCT_OPS_SLEEPABLE(bpfland_init)
 {
 	struct bpf_timer *timer;
-	int err, i;
-	u32 key = 0;
+	int		  err, i;
+	u32		  key = 0;
 
 	/* Initialize amount of online and possible CPUs */
 	nr_online_cpus = get_nr_online_cpus();
-	nr_cpu_ids = scx_bpf_nr_cpu_ids();
+	nr_cpu_ids     = scx_bpf_nr_cpu_ids();
 
 	/* Initialize CPUs and NUMA properties */
 	init_cpuperf_target();
@@ -1324,13 +1714,15 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(bpfland_init)
 	/*
 	 * Create the per-CPU DSQs.
 	 */
-	bpf_for(i, 0, nr_cpu_ids) {
-		int node = __COMPAT_scx_bpf_cpu_node(i);
+	bpf_for(i, 0, nr_cpu_ids)
+	{
+		int node   = __COMPAT_scx_bpf_cpu_node(i);
 		u64 dsq_id = i;
 
-		err = scx_bpf_create_dsq(dsq_id, node);
+		err	   = scx_bpf_create_dsq(dsq_id, node);
 		if (err) {
-			scx_bpf_error("failed to create DSQ %llu: %d", dsq_id, err);
+			scx_bpf_error("failed to create DSQ %llu: %d", dsq_id,
+				      err);
 			return err;
 		}
 	}
@@ -1338,12 +1730,14 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(bpfland_init)
 	/*
 	 * Create the per-node DSQs.
 	 */
-	bpf_for(i, 0, __COMPAT_scx_bpf_nr_node_ids()) {
+	bpf_for(i, 0, __COMPAT_scx_bpf_nr_node_ids())
+	{
 		u64 dsq_id = nr_cpu_ids + i;
 
-		err = scx_bpf_create_dsq(dsq_id, i);
+		err	   = scx_bpf_create_dsq(dsq_id, i);
 		if (err) {
-			scx_bpf_error("failed to create DSQ %llu: %d", dsq_id, err);
+			scx_bpf_error("failed to create DSQ %llu: %d", dsq_id,
+				      err);
 			return err;
 		}
 	}
@@ -1375,21 +1769,499 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(bpfland_init)
 	return 0;
 }
 
-void BPF_STRUCT_OPS(bpfland_exit, struct scx_exit_info *ei)
+/*
+ * TIMELY op implementations (used when timely_enabled=true)
+ */
+
+static s32 do_timely_select_cpu(struct task_struct *p, s32 prev_cpu,
+				u64 wake_flags)
+{
+	s32  cpu, this_cpu = bpf_get_smp_processor_id();
+	bool is_this_cpu_allowed = bpf_cpumask_test_cpu(this_cpu, p->cpus_ptr);
+
+	if (!bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr))
+		prev_cpu = is_this_cpu_allowed ? this_cpu :
+						 bpf_cpumask_first(p->cpus_ptr);
+
+	cpu = pick_idle_cpu(p, prev_cpu, is_this_cpu_allowed ? this_cpu : -1,
+			    wake_flags, false);
+	record_idle_pick_result(cpu, prev_cpu, false);
+	if (cpu >= 0) {
+		struct task_ctx *tctx;
+
+		tctx = try_lookup_task_ctx(p);
+		if (!tctx)
+			return cpu;
+		scx_bpf_dsq_insert_vtime(p, cpu_dsq(cpu),
+					 task_slice(p, cpu),
+					 task_dl(p, cpu, tctx), 0);
+		__sync_fetch_and_add(&nr_direct_dispatches, 1);
+		return cpu;
+	}
+
+	return prev_cpu;
+}
+
+static void do_timely_enqueue(struct task_struct *p, u64 enq_flags)
+{
+	s32		 prev_cpu		      = scx_bpf_task_cpu(p);
+	bool		 locality_from_delay_pressure = false;
+	bool		 pressure_mode_active;
+	u32		 fallback_kind = V2_LOCALITY_NONE;
+	struct task_ctx *tctx;
+
+	tctx = try_lookup_task_ctx(p);
+	if (!tctx)
+		return;
+	pressure_mode_active	      = is_pressure_mode_active(tctx);
+	tctx->timely_last_enqueued_at = bpf_ktime_get_ns();
+
+	if (is_task_sticky(tctx)) {
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p, prev_cpu),
+				   enq_flags);
+		__sync_fetch_and_add(&nr_direct_dispatches, 1);
+		return;
+	}
+
+	if (local_kthreads && is_kthread(p) && p->nr_cpus_allowed == 1) {
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p, prev_cpu),
+				   enq_flags);
+		__sync_fetch_and_add(&nr_kthread_dispatches, 1);
+		return;
+	}
+
+	if (is_pcpu_task(p)) {
+		if (local_pcpu)
+			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL,
+					   task_slice(p, prev_cpu), enq_flags);
+		else
+			scx_bpf_dsq_insert_vtime(p, cpu_dsq(prev_cpu),
+						 task_slice(p, prev_cpu),
+						 task_dl(p, prev_cpu, tctx),
+						 enq_flags);
+		__sync_fetch_and_add(&nr_direct_dispatches, 1);
+		return;
+	}
+
+	if (task_should_migrate(p, enq_flags)) {
+		s32 cpu;
+
+		if (is_pcpu_task(p))
+			cpu = scx_bpf_test_and_clear_cpu_idle(prev_cpu) ?
+				      prev_cpu :
+				      -EBUSY;
+		else
+			cpu = pick_idle_cpu(p, prev_cpu, -1, 0, true);
+		record_idle_pick_result(cpu, prev_cpu, true);
+
+		if (cpu >= 0) {
+			scx_bpf_dsq_insert_vtime(p, cpu_dsq(cpu),
+						 task_slice(p, cpu),
+						 task_dl(p, cpu, tctx),
+						 enq_flags);
+			__sync_fetch_and_add(&nr_direct_dispatches, 1);
+
+			if (prev_cpu != cpu || !scx_bpf_task_running(p))
+				scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+			return;
+		}
+
+		if (!should_expand_skip_locality(tctx))
+			fallback_kind = locality_fallback_kind(
+				p, tctx, prev_cpu,
+				&locality_from_delay_pressure);
+	}
+
+	if (fallback_kind != V2_LOCALITY_NONE) {
+		scx_bpf_dsq_insert_vtime(p, cpu_dsq(prev_cpu),
+					 task_slice(p, prev_cpu),
+					 task_dl(p, prev_cpu, tctx), enq_flags);
+		__sync_fetch_and_add(&nr_direct_dispatches, 1);
+		__sync_fetch_and_add(&nr_v2_locality_cpu_dispatches, 1);
+		if (fallback_kind == V2_LOCALITY_CONGESTED)
+			__sync_fetch_and_add(
+				&nr_v2_congested_locality_cpu_dispatches, 1);
+		if (locality_from_delay_pressure)
+			__sync_fetch_and_add(
+				&nr_v2_delay_locality_cpu_dispatches, 1);
+		scx_bpf_kick_cpu(prev_cpu, SCX_KICK_IDLE);
+		return;
+	}
+
+	scx_bpf_dsq_insert_vtime(p, node_dsq(prev_cpu), task_slice(p, prev_cpu),
+				 task_dl(p, prev_cpu, tctx), enq_flags);
+	__sync_fetch_and_add(&nr_shared_dispatches, 1);
+	if (is_expand_mode_active()) {
+		__sync_fetch_and_add(&nr_v2_expand_mode_dispatches, 1);
+	} else {
+		__sync_fetch_and_add(&nr_v2_contract_mode_dispatches, 1);
+	}
+	if (pressure_mode_active)
+		__sync_fetch_and_add(&nr_v2_pressure_shared_dispatches, 1);
+
+	if (task_should_migrate(p, enq_flags))
+		scx_bpf_kick_cpu(prev_cpu, SCX_KICK_IDLE);
+}
+
+static bool timely_keep_running(const struct task_struct *p, s32 cpu)
+{
+	if (!is_task_queued(p)) {
+		__sync_fetch_and_add(&nr_keep_running_queue_empty, 1);
+		return false;
+	}
+
+	if (is_pcpu_task(p))
+		return true;
+
+	if (is_smt_contended(cpu)) {
+		__sync_fetch_and_add(&nr_keep_running_smt_blocked, 1);
+		return false;
+	}
+
+	return true;
+}
+
+static void do_timely_cpu_release(s32 cpu, struct scx_cpu_release_args *args)
+{
+	scx_bpf_reenqueue_local();
+	__sync_fetch_and_add(&nr_cpu_release_reenqueue, 1);
+}
+
+static void do_timely_dispatch(s32 cpu, struct task_struct *prev)
+{
+	struct task_struct *p = __COMPAT_scx_bpf_dsq_peek(cpu_dsq(cpu));
+	struct task_struct *q = __COMPAT_scx_bpf_dsq_peek(node_dsq(cpu));
+	bool		    had_queued_work = (p || q);
+	bool		    consumed	    = false;
+	bool local_head_bias = should_bias_local_head(p, q, NULL);
+
+	if (is_throttled())
+		return;
+
+	if (local_head_bias || !is_deadline_min(q, p)) {
+		if (consume_first_task(cpu_dsq(cpu), p)) {
+			__sync_fetch_and_add(&nr_dispatch_cpu_dsq_consumes, 1);
+			if (local_head_bias)
+				__sync_fetch_and_add(&nr_v2_local_head_biases,
+						     1);
+			consumed = true;
+			return;
+		}
+		if (consume_first_task(node_dsq(cpu), q)) {
+			__sync_fetch_and_add(&nr_dispatch_node_dsq_consumes, 1);
+			consumed = true;
+			return;
+		}
+	} else {
+		if (consume_first_task(node_dsq(cpu), q)) {
+			__sync_fetch_and_add(&nr_dispatch_node_dsq_consumes, 1);
+			consumed = true;
+			return;
+		}
+		if (consume_first_task(cpu_dsq(cpu), p)) {
+			__sync_fetch_and_add(&nr_dispatch_cpu_dsq_consumes, 1);
+			consumed = true;
+			return;
+		}
+	}
+
+	if (prev && !consumed && !had_queued_work &&
+	    timely_keep_running(prev, cpu)) {
+		__sync_fetch_and_add(&nr_keep_running_reuses, 1);
+		prev->scx.slice = task_slice(prev, cpu);
+	} else if (prev && !consumed && had_queued_work) {
+		__sync_fetch_and_add(&nr_keep_running_queued_work, 1);
+	}
+}
+
+static void do_timely_running(struct task_struct *p)
+{
+	u64		 now = bpf_ktime_get_ns();
+	struct task_ctx *tctx;
+
+	__sync_fetch_and_add(&nr_running, 1);
+
+	tctx = try_lookup_task_ctx(p);
+	if (!tctx)
+		return;
+
+	tctx->last_run_at = now;
+
+	update_cpu_load(p, tctx);
+
+	if (time_before(vtime_now, p->scx.dsq_vtime))
+		vtime_now = p->scx.dsq_vtime;
+
+	/*
+	 * TIMELY delay tracking: evaluate queue delay and update gain.
+	 */
+	if (tctx->timely_last_enqueued_at > 0) {
+		u64  delay	      = now - tctx->timely_last_enqueued_at;
+		u64  low_target	      = MAX(timely_tlow_ns, 1);
+		u64  high_target      = MAX(timely_thigh_ns, low_target + 1);
+		u64  control_interval = timely_control_interval_ns;
+		u32  old_gain	      = tctx->timely_gain_fp ?: 1024U;
+		bool gain_changed     = false;
+
+		if (old_gain <= timely_gain_min_fp) {
+			__sync_fetch_and_add(&nr_gain_floor_resident_samples,
+					     1);
+		} else if (old_gain >= 1024U) {
+			__sync_fetch_and_add(&nr_gain_ceiling_resident_samples,
+					     1);
+		} else {
+			__sync_fetch_and_add(&nr_gain_mid_resident_samples, 1);
+		}
+
+		if (tctx->timely_avg_queue_delay > high_target) {
+			__sync_fetch_and_add(&nr_delay_high_region_samples, 1);
+		} else if (tctx->timely_avg_queue_delay <= low_target) {
+			__sync_fetch_and_add(&nr_delay_low_region_samples, 1);
+		} else {
+			__sync_fetch_and_add(&nr_delay_mid_region_samples, 1);
+		}
+
+		if (tctx->timely_last_gain_update_at &&
+		    tctx->timely_last_delay_sample_at -
+				    tctx->timely_last_gain_update_at <
+			    control_interval) {
+			__sync_fetch_and_add(&nr_delay_rate_limited_dispatches,
+					     1);
+		} else {
+			s64 gradient =
+				(s64)delay - (s64)tctx->timely_avg_queue_delay;
+			u32 action   = 0;
+			u32 new_gain = old_gain;
+
+			if (delay > high_target) {
+				if (old_gain < timely_gain_max_fp) {
+					new_gain = MIN(
+						old_gain + timely_gain_step_fp,
+						timely_gain_max_fp);
+					action = 1;
+					if (new_gain >= timely_gain_max_fp)
+						__sync_fetch_and_add(
+							&nr_gain_ceiling_dispatches,
+							1);
+				} else {
+					__sync_fetch_and_add(
+						&nr_gain_ceiling_dispatches, 1);
+				}
+			} else if (delay < low_target) {
+				if (old_gain > timely_gain_min_fp) {
+					if (gradient < 0 &&
+					    old_gain >=
+						    timely_gain_step_fp +
+							    timely_gain_min_fp) {
+						new_gain = old_gain -
+							   timely_gain_step_fp;
+						action	 = 2;
+					} else if (gradient >= 0) {
+						new_gain = old_gain -
+							   (old_gain >> 3);
+						action	 = 3;
+					}
+				}
+				if (action == 0 || action == 3)
+					__sync_fetch_and_add(
+						&nr_delay_rate_limited_dispatches,
+						1);
+			} else {
+				u32 hai_th = timely_hai_thresh_fp;
+				if (gradient > 0 && old_gain < hai_th) {
+					new_gain = MIN(
+						old_gain *
+							timely_hai_multiplier,
+						timely_gain_max_fp);
+					action = 4;
+					__sync_fetch_and_add(
+						&nr_delay_rate_limited_dispatches,
+						1);
+				} else if (gradient < 0 && old_gain < hai_th) {
+					new_gain =
+						old_gain + timely_gain_step_fp;
+					action = 5;
+				} else if (old_gain < 1024U) {
+					new_gain = old_gain +
+						   (1024U - old_gain) / 8;
+					action	 = 6;
+				}
+			}
+
+			if (new_gain != old_gain) {
+				tctx->timely_gain_fp		 = new_gain;
+				tctx->timely_last_gain_update_at = now;
+				gain_changed			 = true;
+			}
+
+			tctx->timely_avg_queue_delay =
+				calc_avg(tctx->timely_avg_queue_delay, delay);
+			tctx->timely_avg_queue_gradient = calc_avg_s64(
+				tctx->timely_avg_queue_gradient, gradient);
+
+			if (gain_changed) {
+				if (action == 1 || action == 5 || action == 6)
+					__sync_fetch_and_add(
+						&nr_delay_recovery_dispatches,
+						1);
+				else if (action == 2 || action == 4)
+					__sync_fetch_and_add(
+						&nr_delay_fast_recovery_dispatches,
+						1);
+				else if (action == 3)
+					__sync_fetch_and_add(
+						&nr_delay_middle_add_dispatches,
+						1);
+			}
+
+			if (new_gain <= timely_gain_min_fp)
+				__sync_fetch_and_add(&nr_gain_floor_dispatches,
+						     1);
+			if (new_gain >= timely_gain_max_fp)
+				__sync_fetch_and_add(
+					&nr_gain_ceiling_dispatches, 1);
+		}
+
+		tctx->timely_last_delay_sample_at = now;
+		tctx->timely_last_enqueued_at	  = 0;
+		update_pressure_mode(tctx);
+		update_global_pressure(tctx);
+	}
+}
+
+static void do_timely_stopping(struct task_struct *p, bool runnable)
+{
+	u64 now = bpf_ktime_get_ns(), slice, delta_vtime, delta_runtime;
+	s32 cpu = scx_bpf_task_cpu(p);
+	struct task_ctx *tctx;
+	struct cpu_ctx	*cctx;
+
+	__sync_fetch_and_sub(&nr_running, 1);
+
+	tctx = try_lookup_task_ctx(p);
+	if (!tctx)
+		return;
+
+	slice		  = now - tctx->last_run_at;
+
+	tctx->avg_runtime = calc_avg(tctx->avg_runtime, slice);
+
+	delta_vtime	  = scale_by_task_weight_inverse(p, slice);
+	p->scx.dsq_vtime += delta_vtime;
+	tctx->awake_vtime += delta_vtime;
+
+	cctx = try_lookup_cpu_ctx(cpu);
+	if (!cctx)
+		return;
+	delta_runtime = now - cctx->last_running;
+	cctx->tot_runtime += delta_runtime;
+}
+
+static void do_timely_runnable(struct task_struct *p, u64 enq_flags)
+{
+	u64		 now = bpf_ktime_get_ns(), delta_t;
+	struct task_ctx *tctx;
+
+	tctx = try_lookup_task_ctx(p);
+	if (!tctx)
+		return;
+
+	tctx->awake_vtime = 0;
+
+	delta_t = now > tctx->last_woke_at ? now - tctx->last_woke_at : 1;
+	tctx->wakeup_freq  = update_freq(tctx->wakeup_freq, delta_t);
+	tctx->wakeup_freq  = MIN(tctx->wakeup_freq, MAX_WAKEUP_FREQ);
+	tctx->last_woke_at = now;
+}
+
+static void do_timely_exit(struct scx_exit_info *ei)
 {
 	UEI_RECORD(uei, ei);
 }
 
-SCX_OPS_DEFINE(bpfland_ops,
-	       .select_cpu		= (void *)bpfland_select_cpu,
-	       .enqueue			= (void *)bpfland_enqueue,
-	       .dispatch		= (void *)bpfland_dispatch,
-	       .running			= (void *)bpfland_running,
-	       .stopping		= (void *)bpfland_stopping,
-	       .runnable		= (void *)bpfland_runnable,
-	       .enable			= (void *)bpfland_enable,
-	       .init_task		= (void *)bpfland_init_task,
-	       .init			= (void *)bpfland_init,
-	       .exit			= (void *)bpfland_exit,
-	       .timeout_ms		= STARVATION_MS,
-	       .name			= "bpfland");
+/*
+ * Dispatch wrappers that call either bpfland or timely implementation
+ * based on the timely_enabled flag.
+ */
+s32 BPF_STRUCT_OPS(dispatch_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wake_flags)
+{
+	if (timely_enabled)
+		return do_timely_select_cpu(p, prev_cpu, wake_flags);
+	return do_bpfland_select_cpu(p, prev_cpu, wake_flags);
+}
+
+void BPF_STRUCT_OPS(dispatch_enqueue, struct task_struct *p, u64 enq_flags)
+{
+	if (timely_enabled)
+		do_timely_enqueue(p, enq_flags);
+	else
+		do_bpfland_enqueue(p, enq_flags);
+}
+
+void BPF_STRUCT_OPS(dispatch_dispatch, s32 cpu, struct task_struct *prev)
+{
+	if (timely_enabled)
+		do_timely_dispatch(cpu, prev);
+	else
+		do_bpfland_dispatch(cpu, prev);
+}
+
+void BPF_STRUCT_OPS(dispatch_running, struct task_struct *p)
+{
+	if (timely_enabled)
+		do_timely_running(p);
+	else
+		do_bpfland_running(p);
+}
+
+void BPF_STRUCT_OPS(dispatch_stopping, struct task_struct *p, bool runnable)
+{
+	if (timely_enabled)
+		do_timely_stopping(p, runnable);
+	else
+		do_bpfland_stopping(p, runnable);
+}
+
+void BPF_STRUCT_OPS(dispatch_runnable, struct task_struct *p, u64 enq_flags)
+{
+	if (timely_enabled)
+		do_timely_runnable(p, enq_flags);
+	else
+		do_bpfland_runnable(p, enq_flags);
+}
+
+void BPF_STRUCT_OPS(dispatch_enable, struct task_struct *p)
+{
+	do_bpfland_enable(p);
+}
+
+s32 BPF_STRUCT_OPS(dispatch_init_task, struct task_struct *p, struct scx_init_task_args *args)
+{
+	return do_bpfland_init_task(p, args);
+}
+
+void BPF_STRUCT_OPS(dispatch_cpu_release, s32 cpu, struct scx_cpu_release_args *args)
+{
+	if (timely_enabled)
+		do_timely_cpu_release(cpu, args);
+}
+
+void BPF_STRUCT_OPS(dispatch_exit, struct scx_exit_info *ei)
+{
+	if (timely_enabled)
+		do_timely_exit(ei);
+	else
+		do_bpfland_exit(ei);
+}
+
+SCX_OPS_DEFINE(bpfland_ops, .select_cpu = (void *)dispatch_select_cpu,
+	       .enqueue	  = (void *)dispatch_enqueue,
+	       .dispatch  = (void *)dispatch_dispatch,
+	       .cpu_release = (void *)dispatch_cpu_release,
+	       .running	  = (void *)dispatch_running,
+	       .stopping  = (void *)dispatch_stopping,
+	       .runnable  = (void *)dispatch_runnable,
+	       .enable	  = (void *)dispatch_enable,
+	       .init_task = (void *)dispatch_init_task,
+	       .init = (void *)bpfland_init, .exit = (void *)dispatch_exit,
+	       .timeout_ms = STARVATION_MS, .name = "bpfland");

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -113,6 +113,9 @@ fn cpus_to_cpumask(cpus: &Vec<usize>) -> String {
 /// scheduling statistics.
 ///
 /// The BPF part makes all the scheduling decisions (see src/bpf/main.bpf.c).
+///
+/// When the --timely flag is set, the scheduler enables TIMELY's delay-driven feedback for
+/// adaptive time slices and pressure-aware load balancing.
 #[derive(Debug, Parser)]
 struct Opts {
     /// Exit debug dump buffer length. 0 indicates default.
@@ -221,6 +224,106 @@ struct Opts {
     /// With this option enabled the CPU frequency will be automatically scaled based on the load.
     #[clap(short = 'f', long, action = clap::ArgAction::SetTrue)]
     cpufreq: bool,
+
+    /// Enable TIMELY mode: use TIMELY's delay-driven feedback for adaptive time slices
+    /// and pressure-aware load balancing.
+    #[clap(short = 'T', long, action = clap::ArgAction::SetTrue)]
+    timely: bool,
+
+    /// TIMELY lower delay threshold in microseconds.
+    ///
+    /// When the queue delay is below this threshold, the scheduler increases the time slice.
+    #[clap(long, default_value = "5000")]
+    timely_tlow_us: u64,
+
+    /// TIMELY higher delay threshold in microseconds.
+    ///
+    /// When the queue delay is above this threshold, the scheduler decreases the time slice.
+    #[clap(long, default_value = "50000")]
+    timely_thigh_us: u64,
+
+    /// TIMELY minimum gain value (fixed-point).
+    #[clap(long, default_value = "128")]
+    timely_gain_min: u32,
+
+    /// TIMELY gain step (fixed-point).
+    #[clap(long, default_value = "32")]
+    timely_gain_step: u32,
+
+    /// TIMELY HAI threshold (fixed-point).
+    #[clap(long, default_value = "768")]
+    timely_hai_thresh: u32,
+
+    /// TIMELY HAI multiplier.
+    #[clap(long, default_value = "2")]
+    timely_hai_multiplier: u32,
+
+    /// TIMELY backoff low threshold (fixed-point).
+    #[clap(long, default_value = "768")]
+    timely_backoff_low: u32,
+
+    /// TIMELY backoff high threshold (fixed-point).
+    #[clap(long, default_value = "960")]
+    timely_backoff_high: u32,
+
+    /// TIMELY backoff gradient (fixed-point).
+    #[clap(long, default_value = "992")]
+    timely_backoff_gradient: u32,
+
+    /// TIMELY gradient margin in microseconds.
+    #[clap(long, default_value = "125")]
+    timely_gradient_margin_us: u64,
+
+    /// TIMELY control interval in microseconds.
+    #[clap(long, default_value = "500")]
+    timely_control_interval_us: u64,
+
+    /// TIMELY v2: enable locality fallback.
+    ///
+    /// When no idle CPU is available, wake-heavy tasks may fall back to prev_cpu's local DSQ
+    /// instead of always entering the shared node queue.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    timely_v2_locality_fallback: bool,
+
+    /// TIMELY v2: wakeup-frequency threshold for locality fallback.
+    #[clap(long, default_value = "8")]
+    timely_v2_locality_wakeup_freq: u64,
+
+    /// TIMELY v2: maximum allowed local per-CPU queue depth for locality fallback.
+    #[clap(long, default_value = "0")]
+    timely_v2_locality_max_cpuq: u64,
+
+    /// TIMELY v2: minimum shared node-queue depth for broadened locality fallback.
+    #[clap(long, default_value = "0")]
+    timely_v2_locality_congested_nodeq: u64,
+
+    /// TIMELY v2: maximum local per-CPU queue depth for broadened locality fallback.
+    #[clap(long, default_value = "0")]
+    timely_v2_locality_congested_max_cpuq: u64,
+
+    /// TIMELY v2: enable local-head dispatch bias.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    timely_v2_local_head_bias: bool,
+
+    /// TIMELY v2: local-head bias slack in microseconds.
+    #[clap(long, default_value = "250")]
+    timely_v2_local_head_bias_slack_us: u64,
+
+    /// TIMELY v2: consecutive delay-pressured samples to enter pressure mode.
+    #[clap(long, default_value = "3")]
+    timely_v2_pressure_enter_streak: u32,
+
+    /// TIMELY v2: consecutive recovered samples to exit pressure mode.
+    #[clap(long, default_value = "3")]
+    timely_v2_pressure_exit_streak: u32,
+
+    /// TIMELY v2: expand mode threshold (% of CPUs with work to trigger expand).
+    #[clap(long, default_value = "75")]
+    timely_v2_expand_threshold: u32,
+
+    /// TIMELY v2: contract mode threshold (% of CPUs with work to exit expand).
+    #[clap(long, default_value = "50")]
+    timely_v2_contract_threshold: u32,
 
     /// Enable stats monitoring with the specified interval.
     #[clap(long)]
@@ -344,6 +447,32 @@ impl<'a> Scheduler<'a> {
         rodata.slice_lag = opts.slice_us_lag * 1000;
         rodata.throttle_ns = opts.throttle_us * 1000;
         rodata.primary_all = domain.weight() == *NR_CPU_IDS;
+
+        // TIMELY settings (only effective when timely_enabled=true)
+        rodata.timely_enabled = opts.timely;
+        rodata.timely_tlow_ns = opts.timely_tlow_us * 1000;
+        rodata.timely_thigh_ns = opts.timely_thigh_us * 1000;
+        rodata.timely_gain_min_fp = opts.timely_gain_min;
+        rodata.timely_gain_max_fp = 1024;
+        rodata.timely_gain_step_fp = opts.timely_gain_step;
+        rodata.timely_hai_thresh_fp = opts.timely_hai_thresh;
+        rodata.timely_hai_multiplier = opts.timely_hai_multiplier;
+        rodata.timely_backoff_low_fp = opts.timely_backoff_low;
+        rodata.timely_backoff_high_fp = opts.timely_backoff_high;
+        rodata.timely_backoff_gradient_fp = opts.timely_backoff_gradient;
+        rodata.timely_gradient_margin_ns = opts.timely_gradient_margin_us * 1000;
+        rodata.timely_control_interval_ns = opts.timely_control_interval_us * 1000;
+        rodata.v2_locality_fallback = opts.timely_v2_locality_fallback;
+        rodata.v2_locality_wakeup_freq = opts.timely_v2_locality_wakeup_freq;
+        rodata.v2_locality_max_cpuq = opts.timely_v2_locality_max_cpuq;
+        rodata.v2_locality_congested_nodeq = opts.timely_v2_locality_congested_nodeq;
+        rodata.v2_locality_congested_max_cpuq = opts.timely_v2_locality_congested_max_cpuq;
+        rodata.v2_local_head_bias = opts.timely_v2_local_head_bias;
+        rodata.v2_local_head_bias_slack_ns = opts.timely_v2_local_head_bias_slack_us * 1000;
+        rodata.v2_pressure_enter_streak = opts.timely_v2_pressure_enter_streak;
+        rodata.v2_pressure_exit_streak = opts.timely_v2_pressure_exit_streak;
+        rodata.v2ExpandThreshold = opts.timely_v2_expand_threshold;
+        rodata.v2ContractThreshold = opts.timely_v2_contract_threshold;
 
         // Generate the list of available CPUs sorted by capacity in descending order.
         let mut cpus: Vec<_> = topo.all_cpus.values().collect();
@@ -591,6 +720,44 @@ impl<'a> Scheduler<'a> {
             nr_kthread_dispatches: bss_data.nr_kthread_dispatches,
             nr_direct_dispatches: bss_data.nr_direct_dispatches,
             nr_shared_dispatches: bss_data.nr_shared_dispatches,
+            nr_delay_recovery_dispatches: bss_data.nr_delay_recovery_dispatches,
+            nr_delay_middle_add_dispatches: bss_data.nr_delay_middle_add_dispatches,
+            nr_delay_fast_recovery_dispatches: bss_data.nr_delay_fast_recovery_dispatches,
+            nr_delay_rate_limited_dispatches: bss_data.nr_delay_rate_limited_dispatches,
+            nr_gain_floor_dispatches: bss_data.nr_gain_floor_dispatches,
+            nr_gain_ceiling_dispatches: bss_data.nr_gain_ceiling_dispatches,
+            nr_delay_low_region_samples: bss_data.nr_delay_low_region_samples,
+            nr_delay_mid_region_samples: bss_data.nr_delay_mid_region_samples,
+            nr_delay_high_region_samples: bss_data.nr_delay_high_region_samples,
+            nr_gain_floor_resident_samples: bss_data.nr_gain_floor_resident_samples,
+            nr_gain_mid_resident_samples: bss_data.nr_gain_mid_resident_samples,
+            nr_gain_ceiling_resident_samples: bss_data.nr_gain_ceiling_resident_samples,
+            nr_idle_select_path_picks: bss_data.nr_idle_select_path_picks,
+            nr_idle_enqueue_path_picks: bss_data.nr_idle_enqueue_path_picks,
+            nr_idle_prev_cpu_picks: bss_data.nr_idle_prev_cpu_picks,
+            nr_idle_primary_picks: bss_data.nr_idle_primary_picks,
+            nr_idle_spill_picks: bss_data.nr_idle_spill_picks,
+            nr_idle_pick_failures: bss_data.nr_idle_pick_failures,
+            nr_idle_primary_domain_misses: bss_data.nr_idle_primary_domain_misses,
+            nr_idle_global_misses: bss_data.nr_idle_global_misses,
+            nr_waker_cpu_biases: bss_data.nr_waker_cpu_biases,
+            nr_keep_running_reuses: bss_data.nr_keep_running_reuses,
+            nr_keep_running_queue_empty: bss_data.nr_keep_running_queue_empty,
+            nr_keep_running_smt_blocked: bss_data.nr_keep_running_smt_blocked,
+            nr_keep_running_queued_work: bss_data.nr_keep_running_queued_work,
+            nr_dispatch_cpu_dsq_consumes: bss_data.nr_dispatch_cpu_dsq_consumes,
+            nr_dispatch_node_dsq_consumes: bss_data.nr_dispatch_node_dsq_consumes,
+            nr_v2_locality_cpu_dispatches: bss_data.nr_v2_locality_cpu_dispatches,
+            nr_v2_congested_locality_cpu_dispatches: bss_data
+                .nr_v2_congested_locality_cpu_dispatches,
+            nr_v2_delay_locality_cpu_dispatches: bss_data.nr_v2_delay_locality_cpu_dispatches,
+            nr_v2_local_head_biases: bss_data.nr_v2_local_head_biases,
+            nr_v2_pressure_mode_entries: bss_data.nr_v2_pressure_mode_entries,
+            nr_v2_pressure_mode_exits: bss_data.nr_v2_pressure_mode_exits,
+            nr_v2_pressure_shared_dispatches: bss_data.nr_v2_pressure_shared_dispatches,
+            nr_v2_expand_mode_dispatches: bss_data.nr_v2_expand_mode_dispatches,
+            nr_v2_contract_mode_dispatches: bss_data.nr_v2_contract_mode_dispatches,
+            nr_cpu_release_reenqueue: bss_data.nr_cpu_release_reenqueue,
         }
     }
 

--- a/scheds/rust/scx_bpfland/src/stats.rs
+++ b/scheds/rust/scx_bpfland/src/stats.rs
@@ -25,19 +25,99 @@ pub struct Metrics {
     pub nr_direct_dispatches: u64,
     #[stat(desc = "Number of regular task dispatches")]
     pub nr_shared_dispatches: u64,
+    // TIMELY stats (zero when timely mode is disabled)
+    #[stat(desc = "Number of delay recovery dispatches")]
+    pub nr_delay_recovery_dispatches: u64,
+    #[stat(desc = "Number of delay middle add dispatches")]
+    pub nr_delay_middle_add_dispatches: u64,
+    #[stat(desc = "Number of delay fast recovery dispatches")]
+    pub nr_delay_fast_recovery_dispatches: u64,
+    #[stat(desc = "Number of delay rate-limited dispatches")]
+    pub nr_delay_rate_limited_dispatches: u64,
+    #[stat(desc = "Number of gain floor dispatches")]
+    pub nr_gain_floor_dispatches: u64,
+    #[stat(desc = "Number of gain ceiling dispatches")]
+    pub nr_gain_ceiling_dispatches: u64,
+    #[stat(desc = "Number of delay low region samples")]
+    pub nr_delay_low_region_samples: u64,
+    #[stat(desc = "Number of delay mid region samples")]
+    pub nr_delay_mid_region_samples: u64,
+    #[stat(desc = "Number of delay high region samples")]
+    pub nr_delay_high_region_samples: u64,
+    #[stat(desc = "Number of gain floor resident samples")]
+    pub nr_gain_floor_resident_samples: u64,
+    #[stat(desc = "Number of gain mid resident samples")]
+    pub nr_gain_mid_resident_samples: u64,
+    #[stat(desc = "Number of gain ceiling resident samples")]
+    pub nr_gain_ceiling_resident_samples: u64,
+    #[stat(desc = "Number of idle select path picks")]
+    pub nr_idle_select_path_picks: u64,
+    #[stat(desc = "Number of idle enqueue path picks")]
+    pub nr_idle_enqueue_path_picks: u64,
+    #[stat(desc = "Number of idle prev CPU picks")]
+    pub nr_idle_prev_cpu_picks: u64,
+    #[stat(desc = "Number of idle primary picks")]
+    pub nr_idle_primary_picks: u64,
+    #[stat(desc = "Number of idle spill picks")]
+    pub nr_idle_spill_picks: u64,
+    #[stat(desc = "Number of idle pick failures")]
+    pub nr_idle_pick_failures: u64,
+    #[stat(desc = "Number of idle primary domain misses")]
+    pub nr_idle_primary_domain_misses: u64,
+    #[stat(desc = "Number of idle global misses")]
+    pub nr_idle_global_misses: u64,
+    #[stat(desc = "Number of waker CPU biases")]
+    pub nr_waker_cpu_biases: u64,
+    #[stat(desc = "Number of keep running reuses")]
+    pub nr_keep_running_reuses: u64,
+    #[stat(desc = "Number of keep running queue empty")]
+    pub nr_keep_running_queue_empty: u64,
+    #[stat(desc = "Number of keep running SMT blocked")]
+    pub nr_keep_running_smt_blocked: u64,
+    #[stat(desc = "Number of keep running queued work")]
+    pub nr_keep_running_queued_work: u64,
+    #[stat(desc = "Number of dispatch CPU DSQ consumes")]
+    pub nr_dispatch_cpu_dsq_consumes: u64,
+    #[stat(desc = "Number of dispatch node DSQ consumes")]
+    pub nr_dispatch_node_dsq_consumes: u64,
+    #[stat(desc = "Number of v2 locality CPU dispatches")]
+    pub nr_v2_locality_cpu_dispatches: u64,
+    #[stat(desc = "Number of v2 congested locality CPU dispatches")]
+    pub nr_v2_congested_locality_cpu_dispatches: u64,
+    #[stat(desc = "Number of v2 delay locality CPU dispatches")]
+    pub nr_v2_delay_locality_cpu_dispatches: u64,
+    #[stat(desc = "Number of v2 local head biases")]
+    pub nr_v2_local_head_biases: u64,
+    #[stat(desc = "Number of v2 pressure mode entries")]
+    pub nr_v2_pressure_mode_entries: u64,
+    #[stat(desc = "Number of v2 pressure mode exits")]
+    pub nr_v2_pressure_mode_exits: u64,
+    #[stat(desc = "Number of v2 pressure shared dispatches")]
+    pub nr_v2_pressure_shared_dispatches: u64,
+    #[stat(desc = "Number of v2 expand mode dispatches")]
+    pub nr_v2_expand_mode_dispatches: u64,
+    #[stat(desc = "Number of v2 contract mode dispatches")]
+    pub nr_v2_contract_mode_dispatches: u64,
+    #[stat(desc = "Number of CPU release reenqueues")]
+    pub nr_cpu_release_reenqueue: u64,
 }
 
 impl Metrics {
     fn format<W: Write>(&self, w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "[{}] tasks -> r: {:>2}/{:<2} | dispatch -> k: {:<5} d: {:<5} s: {:<5}",
+            "[{}] tasks -> r: {:>2}/{:<2} | dispatch -> k: {:<5} d: {:<5} s: {:<5} | timely -> rec: {:<5} mid: {:<5} rl: {:<5} min: {:<5} max: {:<5}",
             crate::SCHEDULER_NAME,
             self.nr_running,
             self.nr_cpus,
             self.nr_kthread_dispatches,
             self.nr_direct_dispatches,
-            self.nr_shared_dispatches
+            self.nr_shared_dispatches,
+            self.nr_delay_recovery_dispatches,
+            self.nr_delay_middle_add_dispatches,
+            self.nr_delay_rate_limited_dispatches,
+            self.nr_gain_floor_dispatches,
+            self.nr_gain_ceiling_dispatches
         )?;
         Ok(())
     }
@@ -47,6 +127,70 @@ impl Metrics {
             nr_kthread_dispatches: self.nr_kthread_dispatches - rhs.nr_kthread_dispatches,
             nr_direct_dispatches: self.nr_direct_dispatches - rhs.nr_direct_dispatches,
             nr_shared_dispatches: self.nr_shared_dispatches - rhs.nr_shared_dispatches,
+            nr_delay_recovery_dispatches: self.nr_delay_recovery_dispatches
+                - rhs.nr_delay_recovery_dispatches,
+            nr_delay_middle_add_dispatches: self.nr_delay_middle_add_dispatches
+                - rhs.nr_delay_middle_add_dispatches,
+            nr_delay_fast_recovery_dispatches: self.nr_delay_fast_recovery_dispatches
+                - rhs.nr_delay_fast_recovery_dispatches,
+            nr_delay_rate_limited_dispatches: self.nr_delay_rate_limited_dispatches
+                - rhs.nr_delay_rate_limited_dispatches,
+            nr_gain_floor_dispatches: self.nr_gain_floor_dispatches - rhs.nr_gain_floor_dispatches,
+            nr_gain_ceiling_dispatches: self.nr_gain_ceiling_dispatches
+                - rhs.nr_gain_ceiling_dispatches,
+            nr_delay_low_region_samples: self.nr_delay_low_region_samples
+                - rhs.nr_delay_low_region_samples,
+            nr_delay_mid_region_samples: self.nr_delay_mid_region_samples
+                - rhs.nr_delay_mid_region_samples,
+            nr_delay_high_region_samples: self.nr_delay_high_region_samples
+                - rhs.nr_delay_high_region_samples,
+            nr_gain_floor_resident_samples: self.nr_gain_floor_resident_samples
+                - rhs.nr_gain_floor_resident_samples,
+            nr_gain_mid_resident_samples: self.nr_gain_mid_resident_samples
+                - rhs.nr_gain_mid_resident_samples,
+            nr_gain_ceiling_resident_samples: self.nr_gain_ceiling_resident_samples
+                - rhs.nr_gain_ceiling_resident_samples,
+            nr_idle_select_path_picks: self.nr_idle_select_path_picks
+                - rhs.nr_idle_select_path_picks,
+            nr_idle_enqueue_path_picks: self.nr_idle_enqueue_path_picks
+                - rhs.nr_idle_enqueue_path_picks,
+            nr_idle_prev_cpu_picks: self.nr_idle_prev_cpu_picks - rhs.nr_idle_prev_cpu_picks,
+            nr_idle_primary_picks: self.nr_idle_primary_picks - rhs.nr_idle_primary_picks,
+            nr_idle_spill_picks: self.nr_idle_spill_picks - rhs.nr_idle_spill_picks,
+            nr_idle_pick_failures: self.nr_idle_pick_failures - rhs.nr_idle_pick_failures,
+            nr_idle_primary_domain_misses: self.nr_idle_primary_domain_misses
+                - rhs.nr_idle_primary_domain_misses,
+            nr_idle_global_misses: self.nr_idle_global_misses - rhs.nr_idle_global_misses,
+            nr_waker_cpu_biases: self.nr_waker_cpu_biases - rhs.nr_waker_cpu_biases,
+            nr_keep_running_reuses: self.nr_keep_running_reuses - rhs.nr_keep_running_reuses,
+            nr_keep_running_queue_empty: self.nr_keep_running_queue_empty
+                - rhs.nr_keep_running_queue_empty,
+            nr_keep_running_smt_blocked: self.nr_keep_running_smt_blocked
+                - rhs.nr_keep_running_smt_blocked,
+            nr_keep_running_queued_work: self.nr_keep_running_queued_work
+                - rhs.nr_keep_running_queued_work,
+            nr_dispatch_cpu_dsq_consumes: self.nr_dispatch_cpu_dsq_consumes
+                - rhs.nr_dispatch_cpu_dsq_consumes,
+            nr_dispatch_node_dsq_consumes: self.nr_dispatch_node_dsq_consumes
+                - rhs.nr_dispatch_node_dsq_consumes,
+            nr_v2_locality_cpu_dispatches: self.nr_v2_locality_cpu_dispatches
+                - rhs.nr_v2_locality_cpu_dispatches,
+            nr_v2_congested_locality_cpu_dispatches: self.nr_v2_congested_locality_cpu_dispatches
+                - rhs.nr_v2_congested_locality_cpu_dispatches,
+            nr_v2_delay_locality_cpu_dispatches: self.nr_v2_delay_locality_cpu_dispatches
+                - rhs.nr_v2_delay_locality_cpu_dispatches,
+            nr_v2_local_head_biases: self.nr_v2_local_head_biases - rhs.nr_v2_local_head_biases,
+            nr_v2_pressure_mode_entries: self.nr_v2_pressure_mode_entries
+                - rhs.nr_v2_pressure_mode_entries,
+            nr_v2_pressure_mode_exits: self.nr_v2_pressure_mode_exits
+                - rhs.nr_v2_pressure_mode_exits,
+            nr_v2_pressure_shared_dispatches: self.nr_v2_pressure_shared_dispatches
+                - rhs.nr_v2_pressure_shared_dispatches,
+            nr_v2_expand_mode_dispatches: self.nr_v2_expand_mode_dispatches
+                - rhs.nr_v2_expand_mode_dispatches,
+            nr_v2_contract_mode_dispatches: self.nr_v2_contract_mode_dispatches
+                - rhs.nr_v2_contract_mode_dispatches,
+            nr_cpu_release_reenqueue: self.nr_cpu_release_reenqueue - rhs.nr_cpu_release_reenqueue,
             ..self.clone()
         }
     }


### PR DESCRIPTION
## Summary

Add TIMELY's delay-driven feedback for adaptive time slices and pressure-aware load balancing as an optional mode in `scx_bpfland`.

When `--timely` is enabled:
- **Delay-based time slice adaptation** using TIMELY's gain algorithm
- **Locality fallback** for wake-heavy tasks to reduce lock contention
- **Pressure-aware expand/contract load balancing** mode (locality-first when healthy, balance-first under pressure)

All TIMELY v2 behavior is guarded behind the `timely_enabled` flag, so the default behavior remains unchanged when `--timely` is not set.

### Design Rationale

This implements the changes requested in PR #3463, merging TIMELY v2 behavior into `scx_bpfland` behind a `--timely` flag, as suggested by @arighi.

Per the TIMELY paper, delay is the main control signal. Swift (TIMELY v2) strengthens this into cleaner policy shifts:
- **Contract (low pressure)**: Locality-first, favor favored CPU set
- **Expand (sustained pressure)**: Balance-first, spread work to reduce queue delay

### Changes

- `scheds/rust/scx_bpfland/src/main.rs`: Add `--timely` flag and TIMELY v2 command-line options
- `scheds/rust/scx_bpfland/src/bpf/main.bpf.c`: Add TIMELY v2 BPF implementation with dispatch wrappers
- `scheds/rust/scx_bpfland/src/stats.rs`: Add TIMELY v2 statistics

### References

- TIMELY paper: https://research.google.com/pubs/timely-rtt-based-congestion-control-for-the-datacenter/
- Swift paper: https://research.google.com/pubs/swift-delay-is-simple-and-effective-for-congestion-control-in-the-datacenter/
- Original scx_timely v2 PR: https://github.com/sched-ext/scx/pull/3463