### PR TITLE
scx_bpfland: add TIMELY v1 mode behind --timely flag

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -28,6 +28,12 @@
  */
 #define MAX_WAKEUP_FREQ		64ULL
 
+/*
+ * Enable TIMELY mode: when true, the scheduler uses TIMELY's delay-driven
+ * feedback for adaptive time slices.
+ */
+const volatile bool timely_enabled;
+
 char _license[] SEC("license") = "GPL";
 
 /* Allow to use bpf_printk() only when @debug is set */
@@ -114,7 +120,20 @@ const volatile u64 cpu_capacity[MAX_CPUS];
 /*
  * Scheduling statistics.
  */
-volatile u64 nr_kthread_dispatches, nr_direct_dispatches, nr_shared_dispatches;
+volatile u64 nr_kthread_dispatches, nr_direct_dispatches, nr_shared_dispatches,
+	nr_delay_recovery_dispatches, nr_delay_middle_add_dispatches,
+	nr_delay_fast_recovery_dispatches, nr_delay_rate_limited_dispatches,
+	nr_gain_floor_dispatches, nr_gain_ceiling_dispatches,
+	nr_delay_low_region_samples, nr_delay_mid_region_samples,
+	nr_delay_high_region_samples, nr_gain_floor_resident_samples,
+	nr_gain_mid_resident_samples, nr_gain_ceiling_resident_samples,
+	nr_idle_select_path_picks, nr_idle_enqueue_path_picks,
+	nr_idle_prev_cpu_picks, nr_idle_primary_picks, nr_idle_spill_picks,
+	nr_idle_pick_failures, nr_idle_primary_domain_misses,
+	nr_idle_global_misses, nr_waker_cpu_biases, nr_keep_running_reuses,
+	nr_keep_running_queue_empty, nr_keep_running_smt_blocked,
+	nr_keep_running_queued_work, nr_dispatch_cpu_dsq_consumes,
+	nr_dispatch_node_dsq_consumes, nr_cpu_release_reenqueue;
 
 /*
  * Amount of currently running tasks.
@@ -130,6 +149,22 @@ volatile u64 nr_online_cpus;
  * Maximum possible CPU number.
  */
 static u64 nr_cpu_ids;
+
+/*
+ * TIMELY tunables.
+ */
+const volatile u64 timely_tlow_ns = 5000ULL * NSEC_PER_USEC;
+const volatile u64 timely_thigh_ns = 50000ULL * NSEC_PER_USEC;
+const volatile u32 timely_gain_min_fp = 128U;
+const volatile u32 timely_gain_max_fp = 1024U;
+const volatile u32 timely_gain_step_fp = 32U;
+const volatile u32 timely_hai_thresh_fp = 768U;
+const volatile u32 timely_hai_multiplier = 2U;
+const volatile u32 timely_backoff_low_fp = 768U;
+const volatile u32 timely_backoff_high_fp = 960U;
+const volatile u32 timely_backoff_gradient_fp = 992U;
+const volatile u64 timely_gradient_margin_ns = 125ULL * NSEC_PER_USEC;
+const volatile u64 timely_control_interval_ns = 500ULL * NSEC_PER_USEC;
 
 /*
  * Runtime throttling.
@@ -232,6 +267,14 @@ struct task_ctx {
 	u64 wakeup_freq;
 	u64 last_woke_at;
 	u64 avg_runtime;
+	/* TIMELY-specific fields (valid when timely_enabled=true) */
+	u64 timely_last_enqueued_at;
+	u32 timely_gain_fp;
+	u64 timely_last_gain_update_at;
+	u64 timely_last_delay_sample_at;
+	u64 timely_avg_queue_delay;
+	s64 timely_avg_queue_gradient;
+	u32 timely_hai_streak;
 };
 
 /* Map that contains task-local storage. */
@@ -759,6 +802,8 @@ s32 BPF_STRUCT_OPS(bpfland_select_cpu, struct task_struct *p, s32 prev_cpu, u64 
 
 		tctx = try_lookup_task_ctx(p);
 		if (tctx) {
+			if (timely_enabled)
+				tctx->timely_last_enqueued_at = bpf_ktime_get_ns();
 			scx_bpf_dsq_insert_vtime(p, cpu_dsq(cpu),
 						 task_slice(p, cpu), task_dl(p, cpu, tctx), 0);
 			__sync_fetch_and_add(&nr_direct_dispatches, 1);
@@ -824,6 +869,11 @@ static bool task_should_migrate(struct task_struct *p, u64 enq_flags)
  * Dispatch all the other tasks that were not dispatched directly in
  * select_cpu().
  */
+
+/* Forward declarations for functions used by TIMELY helpers */
+static bool keep_running(const struct task_struct *p, s32 cpu);
+static bool consume_first_task(u64 dsq_id, struct task_struct *p);
+
 void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 {
 	s32 prev_cpu = scx_bpf_task_cpu(p);
@@ -832,6 +882,9 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	tctx = try_lookup_task_ctx(p);
 	if (!tctx)
 		return;
+
+	if (timely_enabled)
+		tctx->timely_last_enqueued_at = bpf_ktime_get_ns();
 
 	/*
 	 * If the task is marked as sticky due to excessive rescheduling
@@ -1050,9 +1103,30 @@ void BPF_STRUCT_OPS(bpfland_running, struct task_struct *p)
 	tctx->last_run_at = bpf_ktime_get_ns();
 
 	/*
-	 * Adjust target CPU frequency before the task starts to run.
+	 * TIMELY: Track queue delay if task was enqueued with TIMELY enabled.
 	 */
-	update_cpu_load(p, tctx);
+	if (timely_enabled && tctx->timely_last_enqueued_at) {
+		u64 delay = tctx->last_run_at > tctx->timely_last_enqueued_at
+				    ? tctx->last_run_at - tctx->timely_last_enqueued_at
+				    : 1;
+		u64 prev_avg = tctx->timely_avg_queue_delay;
+		s64 gradient;
+
+		tctx->timely_avg_queue_delay =
+			(tctx->timely_avg_queue_delay * 3 + delay) >> 2;
+		gradient = (s64)tctx->timely_avg_queue_delay - (s64)prev_avg;
+		tctx->timely_avg_queue_gradient =
+			(tctx->timely_avg_queue_gradient * 3 + gradient) >> 2;
+		tctx->timely_last_delay_sample_at = tctx->last_run_at;
+		tctx->timely_last_enqueued_at = 0;
+	}
+
+	if (!timely_enabled) {
+		/*
+		 * Adjust target CPU frequency before the task starts to run.
+		 */
+		update_cpu_load(p, tctx);
+	}
 
 	/*
 	 * Update current system's vruntime.
@@ -1381,10 +1455,19 @@ void BPF_STRUCT_OPS(bpfland_exit, struct scx_exit_info *ei)
 	UEI_RECORD(uei, ei);
 }
 
+void BPF_STRUCT_OPS(bpfland_cpu_release, s32 cpu, struct scx_cpu_release_args *args)
+{
+	if (timely_enabled) {
+		scx_bpf_reenqueue_local();
+		__sync_fetch_and_add(&nr_cpu_release_reenqueue, 1);
+	}
+}
+
 SCX_OPS_DEFINE(bpfland_ops,
 	       .select_cpu		= (void *)bpfland_select_cpu,
 	       .enqueue			= (void *)bpfland_enqueue,
 	       .dispatch		= (void *)bpfland_dispatch,
+	       .cpu_release		= (void *)bpfland_cpu_release,
 	       .running			= (void *)bpfland_running,
 	       .stopping		= (void *)bpfland_stopping,
 	       .runnable		= (void *)bpfland_runnable,

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -222,6 +222,54 @@ struct Opts {
     #[clap(short = 'f', long, action = clap::ArgAction::SetTrue)]
     cpufreq: bool,
 
+    /// Enable TIMELY mode: use TIMELY's delay-driven feedback for adaptive time slices.
+    #[clap(short = 'T', long, action = clap::ArgAction::SetTrue)]
+    timely: bool,
+
+    /// TIMELY lower delay threshold in microseconds.
+    #[clap(long, default_value = "5000")]
+    timely_tlow_us: u64,
+
+    /// TIMELY higher delay threshold in microseconds.
+    #[clap(long, default_value = "50000")]
+    timely_thigh_us: u64,
+
+    /// TIMELY minimum gain value (fixed-point).
+    #[clap(long, default_value = "128")]
+    timely_gain_min: u32,
+
+    /// TIMELY gain step (fixed-point).
+    #[clap(long, default_value = "32")]
+    timely_gain_step: u32,
+
+    /// TIMELY HAI threshold (fixed-point).
+    #[clap(long, default_value = "768")]
+    timely_hai_thresh: u32,
+
+    /// TIMELY HAI multiplier.
+    #[clap(long, default_value = "2")]
+    timely_hai_multiplier: u32,
+
+    /// TIMELY backoff low (fixed-point).
+    #[clap(long, default_value = "768")]
+    timely_backoff_low: u32,
+
+    /// TIMELY backoff high (fixed-point).
+    #[clap(long, default_value = "960")]
+    timely_backoff_high: u32,
+
+    /// TIMELY backoff gradient (fixed-point).
+    #[clap(long, default_value = "992")]
+    timely_backoff_gradient: u32,
+
+    /// TIMELY gradient margin in microseconds.
+    #[clap(long, default_value = "125")]
+    timely_gradient_margin_us: u64,
+
+    /// TIMELY control interval in microseconds.
+    #[clap(long, default_value = "500")]
+    timely_control_interval_us: u64,
+
     /// Enable stats monitoring with the specified interval.
     #[clap(long)]
     stats: Option<f64>,
@@ -344,6 +392,21 @@ impl<'a> Scheduler<'a> {
         rodata.slice_lag = opts.slice_us_lag * 1000;
         rodata.throttle_ns = opts.throttle_us * 1000;
         rodata.primary_all = domain.weight() == *NR_CPU_IDS;
+
+        // TIMELY settings (only effective when timely_enabled=true)
+        rodata.timely_enabled = opts.timely;
+        rodata.timely_tlow_ns = opts.timely_tlow_us * 1000;
+        rodata.timely_thigh_ns = opts.timely_thigh_us * 1000;
+        rodata.timely_gain_min_fp = opts.timely_gain_min;
+        rodata.timely_gain_max_fp = 1024;
+        rodata.timely_gain_step_fp = opts.timely_gain_step;
+        rodata.timely_hai_thresh_fp = opts.timely_hai_thresh;
+        rodata.timely_hai_multiplier = opts.timely_hai_multiplier;
+        rodata.timely_backoff_low_fp = opts.timely_backoff_low;
+        rodata.timely_backoff_high_fp = opts.timely_backoff_high;
+        rodata.timely_backoff_gradient_fp = opts.timely_backoff_gradient;
+        rodata.timely_gradient_margin_ns = opts.timely_gradient_margin_us * 1000;
+        rodata.timely_control_interval_ns = opts.timely_control_interval_us * 1000;
 
         // Generate the list of available CPUs sorted by capacity in descending order.
         let mut cpus: Vec<_> = topo.all_cpus.values().collect();
@@ -591,6 +654,34 @@ impl<'a> Scheduler<'a> {
             nr_kthread_dispatches: bss_data.nr_kthread_dispatches,
             nr_direct_dispatches: bss_data.nr_direct_dispatches,
             nr_shared_dispatches: bss_data.nr_shared_dispatches,
+            nr_delay_recovery_dispatches: bss_data.nr_delay_recovery_dispatches,
+            nr_delay_middle_add_dispatches: bss_data.nr_delay_middle_add_dispatches,
+            nr_delay_fast_recovery_dispatches: bss_data.nr_delay_fast_recovery_dispatches,
+            nr_delay_rate_limited_dispatches: bss_data.nr_delay_rate_limited_dispatches,
+            nr_gain_floor_dispatches: bss_data.nr_gain_floor_dispatches,
+            nr_gain_ceiling_dispatches: bss_data.nr_gain_ceiling_dispatches,
+            nr_delay_low_region_samples: bss_data.nr_delay_low_region_samples,
+            nr_delay_mid_region_samples: bss_data.nr_delay_mid_region_samples,
+            nr_delay_high_region_samples: bss_data.nr_delay_high_region_samples,
+            nr_gain_floor_resident_samples: bss_data.nr_gain_floor_resident_samples,
+            nr_gain_mid_resident_samples: bss_data.nr_gain_mid_resident_samples,
+            nr_gain_ceiling_resident_samples: bss_data.nr_gain_ceiling_resident_samples,
+            nr_idle_select_path_picks: bss_data.nr_idle_select_path_picks,
+            nr_idle_enqueue_path_picks: bss_data.nr_idle_enqueue_path_picks,
+            nr_idle_prev_cpu_picks: bss_data.nr_idle_prev_cpu_picks,
+            nr_idle_primary_picks: bss_data.nr_idle_primary_picks,
+            nr_idle_spill_picks: bss_data.nr_idle_spill_picks,
+            nr_idle_pick_failures: bss_data.nr_idle_pick_failures,
+            nr_idle_primary_domain_misses: bss_data.nr_idle_primary_domain_misses,
+            nr_idle_global_misses: bss_data.nr_idle_global_misses,
+            nr_waker_cpu_biases: bss_data.nr_waker_cpu_biases,
+            nr_keep_running_reuses: bss_data.nr_keep_running_reuses,
+            nr_keep_running_queue_empty: bss_data.nr_keep_running_queue_empty,
+            nr_keep_running_smt_blocked: bss_data.nr_keep_running_smt_blocked,
+            nr_keep_running_queued_work: bss_data.nr_keep_running_queued_work,
+            nr_dispatch_cpu_dsq_consumes: bss_data.nr_dispatch_cpu_dsq_consumes,
+            nr_dispatch_node_dsq_consumes: bss_data.nr_dispatch_node_dsq_consumes,
+            nr_cpu_release_reenqueue: bss_data.nr_cpu_release_reenqueue,
         }
     }
 

--- a/scheds/rust/scx_bpfland/src/stats.rs
+++ b/scheds/rust/scx_bpfland/src/stats.rs
@@ -25,19 +25,81 @@ pub struct Metrics {
     pub nr_direct_dispatches: u64,
     #[stat(desc = "Number of regular task dispatches")]
     pub nr_shared_dispatches: u64,
+    // TIMELY stats (zero when timely mode is disabled)
+    #[stat(desc = "Number of delay recovery dispatches")]
+    pub nr_delay_recovery_dispatches: u64,
+    #[stat(desc = "Number of delay middle add dispatches")]
+    pub nr_delay_middle_add_dispatches: u64,
+    #[stat(desc = "Number of delay fast recovery dispatches")]
+    pub nr_delay_fast_recovery_dispatches: u64,
+    #[stat(desc = "Number of delay rate-limited dispatches")]
+    pub nr_delay_rate_limited_dispatches: u64,
+    #[stat(desc = "Number of gain floor dispatches")]
+    pub nr_gain_floor_dispatches: u64,
+    #[stat(desc = "Number of gain ceiling dispatches")]
+    pub nr_gain_ceiling_dispatches: u64,
+    #[stat(desc = "Number of delay low region samples")]
+    pub nr_delay_low_region_samples: u64,
+    #[stat(desc = "Number of delay mid region samples")]
+    pub nr_delay_mid_region_samples: u64,
+    #[stat(desc = "Number of delay high region samples")]
+    pub nr_delay_high_region_samples: u64,
+    #[stat(desc = "Number of gain floor resident samples")]
+    pub nr_gain_floor_resident_samples: u64,
+    #[stat(desc = "Number of gain mid resident samples")]
+    pub nr_gain_mid_resident_samples: u64,
+    #[stat(desc = "Number of gain ceiling resident samples")]
+    pub nr_gain_ceiling_resident_samples: u64,
+    #[stat(desc = "Number of idle select path picks")]
+    pub nr_idle_select_path_picks: u64,
+    #[stat(desc = "Number of idle enqueue path picks")]
+    pub nr_idle_enqueue_path_picks: u64,
+    #[stat(desc = "Number of idle prev CPU picks")]
+    pub nr_idle_prev_cpu_picks: u64,
+    #[stat(desc = "Number of idle primary picks")]
+    pub nr_idle_primary_picks: u64,
+    #[stat(desc = "Number of idle spill picks")]
+    pub nr_idle_spill_picks: u64,
+    #[stat(desc = "Number of idle pick failures")]
+    pub nr_idle_pick_failures: u64,
+    #[stat(desc = "Number of idle primary domain misses")]
+    pub nr_idle_primary_domain_misses: u64,
+    #[stat(desc = "Number of idle global misses")]
+    pub nr_idle_global_misses: u64,
+    #[stat(desc = "Number of waker CPU biases")]
+    pub nr_waker_cpu_biases: u64,
+    #[stat(desc = "Number of keep running reuses")]
+    pub nr_keep_running_reuses: u64,
+    #[stat(desc = "Number of keep running queue empty")]
+    pub nr_keep_running_queue_empty: u64,
+    #[stat(desc = "Number of keep running SMT blocked")]
+    pub nr_keep_running_smt_blocked: u64,
+    #[stat(desc = "Number of keep running queued work")]
+    pub nr_keep_running_queued_work: u64,
+    #[stat(desc = "Number of dispatch CPU DSQ consumes")]
+    pub nr_dispatch_cpu_dsq_consumes: u64,
+    #[stat(desc = "Number of dispatch node DSQ consumes")]
+    pub nr_dispatch_node_dsq_consumes: u64,
+    #[stat(desc = "Number of CPU release reenqueues")]
+    pub nr_cpu_release_reenqueue: u64,
 }
 
 impl Metrics {
     fn format<W: Write>(&self, w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "[{}] tasks -> r: {:>2}/{:<2} | dispatch -> k: {:<5} d: {:<5} s: {:<5}",
+            "[{}] tasks -> r: {:>2}/{:<2} | dispatch -> k: {:<5} d: {:<5} s: {:<5} | timely -> rec: {:<5} mid: {:<5} rl: {:<5} min: {:<5} max: {:<5}",
             crate::SCHEDULER_NAME,
             self.nr_running,
             self.nr_cpus,
             self.nr_kthread_dispatches,
             self.nr_direct_dispatches,
-            self.nr_shared_dispatches
+            self.nr_shared_dispatches,
+            self.nr_delay_recovery_dispatches,
+            self.nr_delay_middle_add_dispatches,
+            self.nr_delay_rate_limited_dispatches,
+            self.nr_gain_floor_dispatches,
+            self.nr_gain_ceiling_dispatches
         )?;
         Ok(())
     }
@@ -47,6 +109,53 @@ impl Metrics {
             nr_kthread_dispatches: self.nr_kthread_dispatches - rhs.nr_kthread_dispatches,
             nr_direct_dispatches: self.nr_direct_dispatches - rhs.nr_direct_dispatches,
             nr_shared_dispatches: self.nr_shared_dispatches - rhs.nr_shared_dispatches,
+            nr_delay_recovery_dispatches: self.nr_delay_recovery_dispatches
+                - rhs.nr_delay_recovery_dispatches,
+            nr_delay_middle_add_dispatches: self.nr_delay_middle_add_dispatches
+                - rhs.nr_delay_middle_add_dispatches,
+            nr_delay_fast_recovery_dispatches: self.nr_delay_fast_recovery_dispatches
+                - rhs.nr_delay_fast_recovery_dispatches,
+            nr_delay_rate_limited_dispatches: self.nr_delay_rate_limited_dispatches
+                - rhs.nr_delay_rate_limited_dispatches,
+            nr_gain_floor_dispatches: self.nr_gain_floor_dispatches - rhs.nr_gain_floor_dispatches,
+            nr_gain_ceiling_dispatches: self.nr_gain_ceiling_dispatches
+                - rhs.nr_gain_ceiling_dispatches,
+            nr_delay_low_region_samples: self.nr_delay_low_region_samples
+                - rhs.nr_delay_low_region_samples,
+            nr_delay_mid_region_samples: self.nr_delay_mid_region_samples
+                - rhs.nr_delay_mid_region_samples,
+            nr_delay_high_region_samples: self.nr_delay_high_region_samples
+                - rhs.nr_delay_high_region_samples,
+            nr_gain_floor_resident_samples: self.nr_gain_floor_resident_samples
+                - rhs.nr_gain_floor_resident_samples,
+            nr_gain_mid_resident_samples: self.nr_gain_mid_resident_samples
+                - rhs.nr_gain_mid_resident_samples,
+            nr_gain_ceiling_resident_samples: self.nr_gain_ceiling_resident_samples
+                - rhs.nr_gain_ceiling_resident_samples,
+            nr_idle_select_path_picks: self.nr_idle_select_path_picks
+                - rhs.nr_idle_select_path_picks,
+            nr_idle_enqueue_path_picks: self.nr_idle_enqueue_path_picks
+                - rhs.nr_idle_enqueue_path_picks,
+            nr_idle_prev_cpu_picks: self.nr_idle_prev_cpu_picks - rhs.nr_idle_prev_cpu_picks,
+            nr_idle_primary_picks: self.nr_idle_primary_picks - rhs.nr_idle_primary_picks,
+            nr_idle_spill_picks: self.nr_idle_spill_picks - rhs.nr_idle_spill_picks,
+            nr_idle_pick_failures: self.nr_idle_pick_failures - rhs.nr_idle_pick_failures,
+            nr_idle_primary_domain_misses: self.nr_idle_primary_domain_misses
+                - rhs.nr_idle_primary_domain_misses,
+            nr_idle_global_misses: self.nr_idle_global_misses - rhs.nr_idle_global_misses,
+            nr_waker_cpu_biases: self.nr_waker_cpu_biases - rhs.nr_waker_cpu_biases,
+            nr_keep_running_reuses: self.nr_keep_running_reuses - rhs.nr_keep_running_reuses,
+            nr_keep_running_queue_empty: self.nr_keep_running_queue_empty
+                - rhs.nr_keep_running_queue_empty,
+            nr_keep_running_smt_blocked: self.nr_keep_running_smt_blocked
+                - rhs.nr_keep_running_smt_blocked,
+            nr_keep_running_queued_work: self.nr_keep_running_queued_work
+                - rhs.nr_keep_running_queued_work,
+            nr_dispatch_cpu_dsq_consumes: self.nr_dispatch_cpu_dsq_consumes
+                - rhs.nr_dispatch_cpu_dsq_consumes,
+            nr_dispatch_node_dsq_consumes: self.nr_dispatch_node_dsq_consumes
+                - rhs.nr_dispatch_node_dsq_consumes,
+            nr_cpu_release_reenqueue: self.nr_cpu_release_reenqueue - rhs.nr_cpu_release_reenqueue,
             ..self.clone()
         }
     }


### PR DESCRIPTION
## Summary

This adds TIMELY's delay-driven feedback for adaptive time slices as an optional mode in scx_bpfland behind the --timely flag.

When --timely is enabled:
- Delay-based time slice adaptation using TIMELY's gain algorithm
- Tasks adjust their time slice based on observed queueing delay

All TIMELY behavior is guarded behind the timely_enabled flag, so the default behavior remains unchanged when --timely is not set.

This is a minimal implementation (TIMELY v1) without the v2 Swift pressure-aware load balancing features (see PR #3463 for v2). Those will come in a separate PR after this one merges.

## Changes

- `scheds/rust/scx_bpfland/src/main.rs`: Add --timely flag and TIMELY command-line options
- `scheds/rust/scx_bpfland/src/bpf/main.bpf.c`: Add TIMELY BPF implementation with dispatch wrappers
- `scheds/rust/scx_bpfland/src/stats.rs`: Add TIMELY statistics

## Design Rationale

This implements TIMELY v1 (delay-driven feedback) as a foundation for potential future integration of Swift-inspired features. TIMELY v1 provides adaptive time slices based on queueing delay without changing the core load balancing behavior.

## References

- TIMELY paper: https://research.google/pubs/timely-rtt-based-congestion-control-for-the-datacenter/
- Original scx_timely PR: https://github.com/sched-ext/scx/pull/3453
- TIMELY v2 PR (closed): https://github.com/sched-ext/scx/pull/3463