### PR TITLE
scx_lavd: Faster load balancing with budget-controlled invariant runtime

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -174,9 +174,21 @@ int plan_x_cpdom_migration(void)
 
 		/*
 		 * Under-loaded active domains become a stealer.
+		 * Ingress budget = half the deficit below fair share.
 		 */
 		if (cpdomc->nr_active_cpus &&
 		    cpdomc->load_invr <= stealer_threshold) {
+			u64 stealer_budget = 0;
+
+			if (total_cap_sum > 0) {
+				u64 fair_share = total_load_invr *
+					cpdomc->cap_sum_active_cpus /
+					total_cap_sum;
+				if (fair_share > cpdomc->load_invr)
+					stealer_budget = (fair_share -
+						cpdomc->load_invr) / 2;
+			}
+			WRITE_ONCE(cpdomc->stealer_budget_invr, stealer_budget);
 			WRITE_ONCE(cpdomc->stealee_budget_invr, 0);
 			WRITE_ONCE(cpdomc->is_stealer, true);
 			WRITE_ONCE(cpdomc->is_stealee, false);
@@ -208,6 +220,7 @@ int plan_x_cpdom_migration(void)
 			}
 
 			WRITE_ONCE(cpdomc->stealee_budget_invr, budget);
+			WRITE_ONCE(cpdomc->stealer_budget_invr, 0);
 			WRITE_ONCE(cpdomc->is_stealer, false);
 			WRITE_ONCE(cpdomc->is_stealee, true);
 			nr_stealee++;
@@ -218,6 +231,7 @@ int plan_x_cpdom_migration(void)
 		 * Otherwise, keep tasks as it is.
 		 */
 		WRITE_ONCE(cpdomc->stealee_budget_invr, 0);
+		WRITE_ONCE(cpdomc->stealer_budget_invr, 0);
 		WRITE_ONCE(cpdomc->is_stealer, false);
 		WRITE_ONCE(cpdomc->is_stealee, false);
 	}
@@ -238,6 +252,7 @@ reset_and_skip_lb:
 
 			cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpdom_id]);
 			WRITE_ONCE(cpdomc->stealee_budget_invr, 0);
+			WRITE_ONCE(cpdomc->stealer_budget_invr, 0);
 			WRITE_ONCE(cpdomc->is_stealer, false);
 			WRITE_ONCE(cpdomc->is_stealee, false);
 		}

--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -18,6 +18,7 @@
 
 
 extern const volatile u8	mig_delta_pct;
+extern const volatile u8	no_fast_lb;
 extern const volatile u64	lb_low_util_wall;
 
 u64 __attribute__ ((noinline)) calc_mig_delta(u64 avg_load_invr, int nz_qlen,
@@ -56,7 +57,12 @@ classify_cpdom(struct cpdom_ctx *cpdomc, u64 total_load_invr,
 	if (!cpdomc)
 		return 0;
 
-	if (cpdomc->nr_active_cpus && total_cap_sum > 0) {
+	if (no_fast_lb && sys_stat.nr_active_cpdoms) {
+		u64 avg = total_load_invr / sys_stat.nr_active_cpdoms;
+		x_mig_delta = calc_mig_delta(avg, nz_qlen, mig_delta_factor);
+		stealer_threshold = avg - x_mig_delta;
+		stealee_threshold = avg + x_mig_delta;
+	} else if (cpdomc->nr_active_cpus && total_cap_sum > 0) {
 		fair_share_invr = total_load_invr *
 			     cpdomc->cap_sum_active_cpus /
 			     total_cap_sum;
@@ -169,13 +175,21 @@ int plan_x_cpdom_migration(void)
 		 * and queued load (qload_invr, tracked atomically via
 		 * account/unaccount at enqueue/running).
 		 */
-		cpdomc->load_invr = cpdomc->avg_util_invr_sum +
-				    cpdomc->qload_invr;
+		if (no_fast_lb) {
+			u64 qlen = cpdomc->nr_queued_task;
+			u64 qlen_invr = (qlen << (LAVD_SHIFT * 3)) /
+					cpdomc->cap_sum_active_cpus;
+			cpdomc->load_invr = util + qlen_invr;
+			if (qlen)
+				nz_qlen++;
+		} else {
+			cpdomc->load_invr = cpdomc->avg_util_invr_sum +
+					    cpdomc->qload_invr;
+			if (cpdomc->qload_invr)
+				nz_qlen++;
+		}
 		total_load_invr += cpdomc->load_invr;
 		total_cap_sum += cpdomc->cap_sum_active_cpus;
-
-		if (cpdomc->qload_invr)
-			nz_qlen++;
 	}
 
 	/*
@@ -317,6 +331,10 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 	if (!cpdomc->nr_active_cpus)
 		return false;
 
+	if (no_fast_lb &&
+	    !prob_x_out_of_y(1, cpdomc->nr_active_cpus * LAVD_CPDOM_MIG_PROB_FT))
+		return false;
+
 	/*
 	 * Traverse neighbor compute domains in distance order.
 	 */
@@ -381,8 +399,13 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 			 * helpers.
 			 */
 			if (consume_dsq(cpdomc_pick, dsq_id)) {
-				decrement_stealee_budget(cpdomc_pick, task_load);
-				decrement_stealer_budget(cpdomc, task_load);
+				if (no_fast_lb) {
+					WRITE_ONCE(cpdomc_pick->is_stealee, false);
+					WRITE_ONCE(cpdomc->is_stealer, false);
+				} else {
+					decrement_stealee_budget(cpdomc_pick, task_load);
+					decrement_stealer_budget(cpdomc, task_load);
+				}
 				return true;
 			}
 		}

--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -20,11 +20,17 @@
 extern const volatile u8	mig_delta_pct;
 extern const volatile u64	lb_low_util_wall;
 
-u64 __attribute__ ((noinline)) calc_mig_delta(u64 avg_load_invr, int nz_qlen)
+u64 __attribute__ ((noinline)) calc_mig_delta(u64 avg_load_invr, int nz_qlen,
+					      u64 mig_delta_factor)
 {
 	/*
 	 * Note that added "noinline" to make the verifier happy.
+	 * When mig_delta_factor > 0, the user specified a fixed
+	 * migration delta percentage; otherwise use the dynamic
+	 * shift-based heuristic.
 	 */
+	if (mig_delta_factor > 0)
+		return avg_load_invr * mig_delta_factor / LAVD_SCALE;
 	if (nz_qlen >= sys_stat.nr_active_cpdoms)
 		return avg_load_invr >> LAVD_CPDOM_MIG_SHIFT_OL;
 	if (nz_qlen == 0)
@@ -32,35 +38,116 @@ u64 __attribute__ ((noinline)) calc_mig_delta(u64 avg_load_invr, int nz_qlen)
 	return avg_load_invr >> LAVD_CPDOM_MIG_SHIFT;
 }
 
+/*
+ * Classify a single compute domain as stealer, stealee, or neutral.
+ * Returns 1 if the domain became a stealee, 0 otherwise.
+ * Marked noinline so the verifier analyses it separately from the
+ * calling loop, keeping the jump complexity of the caller manageable.
+ */
+int __attribute__((noinline))
+classify_cpdom(struct cpdom_ctx *cpdomc, u64 total_load_invr,
+	       u64 total_cap_sum, int nz_qlen, u64 mig_delta_factor)
+{
+	u64 x_mig_delta = 0;
+	u64 fair_share_invr = 0;
+	u64 stealer_threshold = 0;
+	u64 stealee_threshold = 0;
+
+	if (!cpdomc)
+		return 0;
+
+	if (cpdomc->nr_active_cpus && total_cap_sum > 0) {
+		fair_share_invr = total_load_invr *
+			     cpdomc->cap_sum_active_cpus /
+			     total_cap_sum;
+
+		x_mig_delta = calc_mig_delta(
+				fair_share_invr, nz_qlen,
+				mig_delta_factor);
+
+		stealer_threshold = fair_share_invr - x_mig_delta;
+		stealee_threshold = fair_share_invr + x_mig_delta;
+	}
+
+	/*
+	 * Under-loaded active domains become a stealer.
+	 * Ingress budget = half the deficit below fair share.
+	 */
+	if (cpdomc->nr_active_cpus &&
+	    cpdomc->load_invr <= stealer_threshold) {
+		u64 stealer_budget = 0;
+
+		if (fair_share_invr > cpdomc->load_invr)
+			stealer_budget = (fair_share_invr -
+					  cpdomc->load_invr) / 2;
+
+		WRITE_ONCE(cpdomc->stealer_budget_invr, stealer_budget);
+		WRITE_ONCE(cpdomc->stealee_budget_invr, 0);
+		WRITE_ONCE(cpdomc->is_stealer, true);
+		WRITE_ONCE(cpdomc->is_stealee, false);
+		return 0;
+	}
+
+	/*
+	 * Over-loaded or non-active domains become a stealee.
+	 * Egress budget = half the excess above fair share. Halving
+	 * (rather than draining the full excess) avoids two failure
+	 * modes:
+	 * - Ping-pong: prevent overshooting. Moving everything in one
+	 *   round may trigger the imbalance and ping-pong effect.
+	 * - Thundering-herd: without a per-round limit, every stealer
+	 *   that sees this domain can migrate out the tasks from it and
+	 *   drain it past the fair share in a single round.
+	 *
+	 * Also skip domains with nothing to steal: a domain may appear
+	 * overloaded due to running task utilization (avg_util_invr_sum)
+	 * but have an empty DSQ — trying to steal from it would waste
+	 * cycles and could cause oscillation.
+	 */
+	if (!cpdomc->nr_active_cpus ||
+	    cpdomc->load_invr >= stealee_threshold) {
+		u64 stealee_budget_invr = 0;
+
+		if (cpdomc->qload_invr == 0)
+			goto reset_role;
+
+		if (cpdomc->load_invr > fair_share_invr)
+			stealee_budget_invr = (cpdomc->load_invr -
+					       fair_share_invr) / 2;
+
+		if (!stealee_budget_invr)
+			goto reset_role;
+
+		WRITE_ONCE(cpdomc->stealee_budget_invr, stealee_budget_invr);
+		WRITE_ONCE(cpdomc->stealer_budget_invr, 0);
+		WRITE_ONCE(cpdomc->is_stealer, false);
+		WRITE_ONCE(cpdomc->is_stealee, true);
+		return 1;
+	}
+
+reset_role:
+	WRITE_ONCE(cpdomc->stealee_budget_invr, 0);
+	WRITE_ONCE(cpdomc->stealer_budget_invr, 0);
+	WRITE_ONCE(cpdomc->is_stealer, false);
+	WRITE_ONCE(cpdomc->is_stealee, false);
+	return 0;
+}
+
 __weak
 int plan_x_cpdom_migration(void)
 {
 	struct cpdom_ctx *cpdomc;
 	u64 cpdom_id;
-	u32 stealer_threshold, stealee_threshold, nr_stealee = 0;
-	u64 avg_load_invr = 0, min_load_invr = U64_MAX, max_load_invr = 0;
-	u64 total_load_invr = 0, total_cap_sum = 0;
+	u32 nr_stealee = 0;
 	u64 max_avg_util_wall = 0;
-	u64 x_mig_delta, util;
+	u64 util;
+	u64 total_load_invr = 0;
+	u64 total_cap_sum = 0;
 	bool overflow_running = false;
 	int nz_qlen = 0;
 
 	/*
-	 * The load balancing aims for two goals:
-	 *
-	 * 1) The *non-scaled* CPU utilizations of all active CPUs should be
-	 * the same or similar. This helps to maintain low latency
-	 * when the system is underloaded.
-	 *
-	 * 2) The *scaled* queue lengths of active compute domains should be
-	 * the same or similar. Using scaled queue length allows putting more
-	 * tasks to the powerful compute domains. This helps to maintain high
-	 * throughput when the system is overloaded.
-	 */
-
-
-	/*
-	 * Calculate scaled load for each active compute domain.
+	 * Calculate load for each active compute domain.
 	 */
 	bpf_for(cpdom_id, 0, nr_cpdoms) {
 		if (cpdom_id >= LAVD_CPDOM_MAX_NR)
@@ -68,22 +155,11 @@ int plan_x_cpdom_migration(void)
 
 		cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpdom_id]);
 		if (!cpdomc->nr_active_cpus) {
-			/*
-			 * If tasks are running on an overflow domain,
-			 * need load balancing.
-			 */
-			if (cpdomc->cur_util_wall_sum > 0) {
+			if (cpdomc->cur_util_wall_sum > 0)
 				overflow_running = true;
-				cpdomc->load_invr = U64_MAX;
-			}
-			else
-				cpdomc->load_invr = 0;
 			continue;
 		}
 
-		/*
-		 * Track max per-CPU util for the low-util LB skip check.
-		 */
 		util = (cpdomc->avg_util_wall_sum << LAVD_SHIFT) / cpdomc->nr_active_cpus;
 		if ((util >> LAVD_SHIFT) > max_avg_util_wall)
 			max_avg_util_wall = util >> LAVD_SHIFT;
@@ -95,19 +171,12 @@ int plan_x_cpdom_migration(void)
 		 */
 		cpdomc->load_invr = cpdomc->avg_util_invr_sum +
 				    cpdomc->qload_invr;
-		avg_load_invr += cpdomc->load_invr;
 		total_load_invr += cpdomc->load_invr;
 		total_cap_sum += cpdomc->cap_sum_active_cpus;
 
-		if (min_load_invr > cpdomc->load_invr)
-			min_load_invr = cpdomc->load_invr;
-		if (max_load_invr < cpdomc->load_invr)
-			max_load_invr = cpdomc->load_invr;
 		if (cpdomc->qload_invr)
 			nz_qlen++;
 	}
-	if (sys_stat.nr_active_cpdoms)
-		avg_load_invr /= sys_stat.nr_active_cpdoms;
 
 	/*
 	 * When the highest per-CPU utilization among all compute
@@ -118,133 +187,34 @@ int plan_x_cpdom_migration(void)
 		goto reset_and_skip_lb;
 
 	/*
-	 * Determine the criteria for stealer and stealee domains.
-	 * The more the system is loaded, the tighter criteria will be chosen.
-	 * When mig_delta_pct is set (non-zero), use it as a fixed percentage
-	 * instead of the dynamic calculation.
+	 * Classify stealer and stealee domains using per-domain
+	 * capacity-proportional targets. Each domain's target is its
+	 * fair share of total system load scaled by its capacity
+	 * proportion.
 	 */
-	if (mig_delta_pct > 0) {
-		u64 mig_delta_factor = (mig_delta_pct << LAVD_SHIFT) / 100;
-		x_mig_delta = avg_load_invr * mig_delta_factor / LAVD_SCALE;
-	} else {
-		x_mig_delta = calc_mig_delta(avg_load_invr, nz_qlen);
-	}
-	stealer_threshold = avg_load_invr - x_mig_delta;
-	stealee_threshold = avg_load_invr + x_mig_delta;
+	u64 mig_delta_factor = 0;
+	if (mig_delta_pct > 0)
+		mig_delta_factor = (mig_delta_pct << LAVD_SHIFT) / 100;
 
-	/*
-	 * If there is no overloaded domain (no stealees), skip load balancing.
-	 * Clear all stealer/stealee roles to prevent stale state from previous
-	 * balancing rounds from triggering incorrect migrations. While some
-	 * domains may be underloaded (stealers), migration is unnecessary
-	 * without overloaded domains (stealees) to steal from.
-	 *  <~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~>
-	 * [stealer_threshold ... avg_load_invr ... max_load_invr ... stealee_threshold]
-	 *            -------------------------------------->
-	 */
-	if ((stealee_threshold > max_load_invr) && !overflow_running)
-		goto reset_and_skip_lb;
-
-	/*
-	 * At this point, there is at least one overloaded domain (stealee),
-	 * indicated by the following condition:
-	 *    stealee_threshold <= max_load_invr || overflow_running
-	 *
-	 * Adjust the stealer threshold to minimum scaled load to ensure that
-	 * there exists at least one stealer.
-	 */
-	if (stealer_threshold < min_load_invr) {
-		/*
-		 * If there is a overloaded domain, always try to steal.
-		 *  <~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~>
-		 * [stealer_threshold ... min_load_invr ... avg_load_invr ... stealee_threshold ... max_load_invr]
-		 *                        <--------------------------------------------------------------->
-		 */
-		stealer_threshold = min_load_invr;
-	}
-
-	/*
-	 * Determine stealer and stealee domains.
-	 */
 	bpf_for(cpdom_id, 0, nr_cpdoms) {
 		if (cpdom_id >= LAVD_CPDOM_MAX_NR)
 			break;
 
 		cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpdom_id]);
 
-		/*
-		 * Under-loaded active domains become a stealer.
-		 * Ingress budget = half the deficit below fair share.
-		 */
-		if (cpdomc->nr_active_cpus &&
-		    cpdomc->load_invr <= stealer_threshold) {
-			u64 stealer_budget = 0;
-
-			if (total_cap_sum > 0) {
-				u64 fair_share = total_load_invr *
-					cpdomc->cap_sum_active_cpus /
-					total_cap_sum;
-				if (fair_share > cpdomc->load_invr)
-					stealer_budget = (fair_share -
-						cpdomc->load_invr) / 2;
-			}
-			WRITE_ONCE(cpdomc->stealer_budget_invr, stealer_budget);
-			WRITE_ONCE(cpdomc->stealee_budget_invr, 0);
-			WRITE_ONCE(cpdomc->is_stealer, true);
-			WRITE_ONCE(cpdomc->is_stealee, false);
-			continue;
-		}
-
-		/*
-		 * Over-loaded or non-active domains become a stealee.
-		 * Budget = half the excess load above capacity-proportional
-		 * fair share. Halving (rather than draining the full excess)
-		 * avoids two failure modes:
-		 * - Ping-pong: prevent overshooting. Moving everything in one
-		 *   round may trigger the imbalance and ping-pong effect.
-		 * - Thundering-herd: without a per-round limit, every stealer
-		 *   that sees this domain can migrate out the tasks from it and
-		 *   drain it past the fair share in a single round.
-		 */
-		if (!cpdomc->nr_active_cpus ||
-		    cpdomc->load_invr >= stealee_threshold) {
-			u64 budget = 0;
-
-			if (cpdomc->nr_active_cpus && total_cap_sum > 0) {
-				u64 fair_share = total_load_invr *
-					cpdomc->cap_sum_active_cpus /
-					total_cap_sum;
-				if (cpdomc->load_invr > fair_share)
-					budget = (cpdomc->load_invr -
-						  fair_share) / 2;
-			}
-
-			WRITE_ONCE(cpdomc->stealee_budget_invr, budget);
-			WRITE_ONCE(cpdomc->stealer_budget_invr, 0);
-			WRITE_ONCE(cpdomc->is_stealer, false);
-			WRITE_ONCE(cpdomc->is_stealee, true);
-			nr_stealee++;
-			continue;
-		}
-
-		/*
-		 * Otherwise, keep tasks as it is.
-		 */
-		WRITE_ONCE(cpdomc->stealee_budget_invr, 0);
-		WRITE_ONCE(cpdomc->stealer_budget_invr, 0);
-		WRITE_ONCE(cpdomc->is_stealer, false);
-		WRITE_ONCE(cpdomc->is_stealee, false);
+		nr_stealee += classify_cpdom(cpdomc, total_load_invr,
+					     total_cap_sum, nz_qlen,
+					     mig_delta_factor);
 	}
+
+	if (nr_stealee == 0 && !overflow_running)
+		goto reset_and_skip_lb;
 
 	sys_stat.nr_stealee = nr_stealee;
 
 	return 0;
 
 reset_and_skip_lb:
-	/*
-	 * To avoid the expensive reset loop, only reset if there exists
-	 * stealers/stealees in the previous round.
-	 */
 	if (sys_stat.nr_stealee > 0) {
 		bpf_for(cpdom_id, 0, nr_cpdoms) {
 			if (cpdom_id >= LAVD_CPDOM_MAX_NR)

--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -354,22 +354,43 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 			if (!READ_ONCE(cpdomc_pick->is_stealee) || !cpdomc_pick->is_valid)
 				continue;
 
+			if (READ_ONCE(cpdomc_pick->stealee_budget_invr) <= 0)
+				continue;
+
 			dsq_id = pick_most_loaded_dsq(cpdomc_pick);
 
 			/*
-			 * If task stealing is successful, mark the stealer
-			 * and the stealee's job done. By marking done,
-			 * those compute domains would not be involved in
-			 * load balancing until the end of this round,
-			 * so this helps gradual migration. Note that multiple
-			 * stealers can steal tasks from the same stealee.
-			 * However, we don't coordinate concurrent stealing
-			 * because the chance is low and there is no harm
-			 * in slight over-stealing.
+			 * Peek at the head task to get its size for budget
+			 * accounting.
+			 *
+			 * TOCTOU: the task peeked here may not be the one
+			 * actually consumed by consume_dsq() below. To be more
+			 * specific, another CPU may grab the head first, or the
+			 * task may become ineligible during the window between
+			 * the peek and the consume_dsq. The budget is just a
+			 * hint, and over-debiting will be self-corrected
+			 * because the next LB round recomputes budgets from
+			 * scratch.
+			 */
+			u64 task_load = 0;
+			struct task_struct *peek_p =
+				__COMPAT_scx_bpf_dsq_peek(dsq_id);
+			if (peek_p) {
+				task_ctx *peek_taskc = get_task_ctx(peek_p);
+				if (peek_taskc)
+					task_load = task_load_metric(peek_taskc);
+			}
+
+			/*
+			 * On success, decrement both egress and ingress
+			 * budgets. The stealer stays active for the
+			 * entire round. Budget exhaustion clears the
+			 * is_stealee/is_stealer flags via the decrement
+			 * helpers.
 			 */
 			if (consume_dsq(cpdomc_pick, dsq_id)) {
-				WRITE_ONCE(cpdomc_pick->is_stealee, false);
-				WRITE_ONCE(cpdomc->is_stealer, false);
+				decrement_stealee_budget(cpdomc_pick, task_load);
+				decrement_stealer_budget(cpdomc, task_load);
 				return true;
 			}
 		}

--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -266,6 +266,18 @@ static bool consume_dsq(struct cpdom_ctx *cpdomc, u64 dsq_id)
 	return ret;
 }
 
+u64 __attribute__((noinline)) dsq_peek_task_load(u64 dsq_id)
+{
+	struct task_struct *peek_p = __COMPAT_scx_bpf_dsq_peek(dsq_id);
+
+	if (peek_p) {
+		task_ctx *peek_taskc = get_task_ctx(peek_p);
+		if (peek_taskc)
+			return task_load_metric(peek_taskc);
+	}
+	return 0;
+}
+
 u64 __attribute__((noinline)) pick_most_loaded_dsq(struct cpdom_ctx *cpdomc)
 {
 	u64 pick_dsq_id = -ENOENT;
@@ -382,14 +394,7 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 			 * because the next LB round recomputes budgets from
 			 * scratch.
 			 */
-			u64 task_load = 0;
-			struct task_struct *peek_p =
-				__COMPAT_scx_bpf_dsq_peek(dsq_id);
-			if (peek_p) {
-				task_ctx *peek_taskc = get_task_ctx(peek_p);
-				if (peek_taskc)
-					task_load = task_load_metric(peek_taskc);
-			}
+			u64 task_load = dsq_peek_task_load(dsq_id);
 
 			/*
 			 * On success, decrement both egress and ingress
@@ -465,14 +470,7 @@ static bool force_to_steal_task(struct cpdom_ctx *cpdomc)
 			/*
 			 * Peek at the head task to get its size.
 			 */
-			u64 task_load = 0;
-			struct task_struct *peek_p =
-				__COMPAT_scx_bpf_dsq_peek(dsq_id);
-			if (peek_p) {
-				task_ctx *peek_taskc = get_task_ctx(peek_p);
-				if (peek_taskc)
-					task_load = task_load_metric(peek_taskc);
-			}
+			u64 task_load = dsq_peek_task_load(dsq_id);
 
 			/*
 			 * Force steal is unconditional for work

--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -39,6 +39,7 @@ int plan_x_cpdom_migration(void)
 	u64 cpdom_id;
 	u32 stealer_threshold, stealee_threshold, nr_stealee = 0;
 	u64 avg_load_invr = 0, min_load_invr = U64_MAX, max_load_invr = 0;
+	u64 total_load_invr = 0, total_cap_sum = 0;
 	u64 max_avg_util_wall = 0;
 	u64 x_mig_delta, util;
 	bool overflow_running = false;
@@ -95,6 +96,8 @@ int plan_x_cpdom_migration(void)
 		cpdomc->load_invr = cpdomc->avg_util_invr_sum +
 				    cpdomc->qload_invr;
 		avg_load_invr += cpdomc->load_invr;
+		total_load_invr += cpdomc->load_invr;
+		total_cap_sum += cpdomc->cap_sum_active_cpus;
 
 		if (min_load_invr > cpdomc->load_invr)
 			min_load_invr = cpdomc->load_invr;
@@ -174,6 +177,7 @@ int plan_x_cpdom_migration(void)
 		 */
 		if (cpdomc->nr_active_cpus &&
 		    cpdomc->load_invr <= stealer_threshold) {
+			WRITE_ONCE(cpdomc->stealee_budget_invr, 0);
 			WRITE_ONCE(cpdomc->is_stealer, true);
 			WRITE_ONCE(cpdomc->is_stealee, false);
 			continue;
@@ -181,9 +185,29 @@ int plan_x_cpdom_migration(void)
 
 		/*
 		 * Over-loaded or non-active domains become a stealee.
+		 * Budget = half the excess load above capacity-proportional
+		 * fair share. Halving (rather than draining the full excess)
+		 * avoids two failure modes:
+		 * - Ping-pong: prevent overshooting. Moving everything in one
+		 *   round may trigger the imbalance and ping-pong effect.
+		 * - Thundering-herd: without a per-round limit, every stealer
+		 *   that sees this domain can migrate out the tasks from it and
+		 *   drain it past the fair share in a single round.
 		 */
 		if (!cpdomc->nr_active_cpus ||
 		    cpdomc->load_invr >= stealee_threshold) {
+			u64 budget = 0;
+
+			if (cpdomc->nr_active_cpus && total_cap_sum > 0) {
+				u64 fair_share = total_load_invr *
+					cpdomc->cap_sum_active_cpus /
+					total_cap_sum;
+				if (cpdomc->load_invr > fair_share)
+					budget = (cpdomc->load_invr -
+						  fair_share) / 2;
+			}
+
+			WRITE_ONCE(cpdomc->stealee_budget_invr, budget);
 			WRITE_ONCE(cpdomc->is_stealer, false);
 			WRITE_ONCE(cpdomc->is_stealee, true);
 			nr_stealee++;
@@ -193,6 +217,7 @@ int plan_x_cpdom_migration(void)
 		/*
 		 * Otherwise, keep tasks as it is.
 		 */
+		WRITE_ONCE(cpdomc->stealee_budget_invr, 0);
 		WRITE_ONCE(cpdomc->is_stealer, false);
 		WRITE_ONCE(cpdomc->is_stealee, false);
 	}
@@ -212,6 +237,7 @@ reset_and_skip_lb:
 				break;
 
 			cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpdom_id]);
+			WRITE_ONCE(cpdomc->stealee_budget_invr, 0);
 			WRITE_ONCE(cpdomc->is_stealer, false);
 			WRITE_ONCE(cpdomc->is_stealee, false);
 		}

--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -40,7 +40,7 @@ int plan_x_cpdom_migration(void)
 	u32 stealer_threshold, stealee_threshold, nr_stealee = 0;
 	u64 avg_load_invr = 0, min_load_invr = U64_MAX, max_load_invr = 0;
 	u64 max_avg_util_wall = 0;
-	u64 x_mig_delta, util, qlen, qlen_invr;
+	u64 x_mig_delta, util;
 	bool overflow_running = false;
 	int nz_qlen = 0;
 
@@ -73,7 +73,7 @@ int plan_x_cpdom_migration(void)
 			 */
 			if (cpdomc->cur_util_wall_sum > 0) {
 				overflow_running = true;
-				cpdomc->load_invr = U32_MAX;
+				cpdomc->load_invr = U64_MAX;
 			}
 			else
 				cpdomc->load_invr = 0;
@@ -81,21 +81,26 @@ int plan_x_cpdom_migration(void)
 		}
 
 		/*
-		 * Use avg_util_wall_sum for stable load balancing decisions.
+		 * Track max per-CPU util for the low-util LB skip check.
 		 */
 		util = (cpdomc->avg_util_wall_sum << LAVD_SHIFT) / cpdomc->nr_active_cpus;
 		if ((util >> LAVD_SHIFT) > max_avg_util_wall)
 			max_avg_util_wall = util >> LAVD_SHIFT;
-		qlen = cpdomc->nr_queued_task;
-		qlen_invr = (qlen << (LAVD_SHIFT * 3)) / cpdomc->cap_sum_active_cpus;
-		cpdomc->load_invr = util + qlen_invr;
+
+		/*
+		 * Domain load combines running load (avg_util_invr_sum)
+		 * and queued load (qload_invr, tracked atomically via
+		 * account/unaccount at enqueue/running).
+		 */
+		cpdomc->load_invr = cpdomc->avg_util_invr_sum +
+				    cpdomc->qload_invr;
 		avg_load_invr += cpdomc->load_invr;
 
 		if (min_load_invr > cpdomc->load_invr)
 			min_load_invr = cpdomc->load_invr;
 		if (max_load_invr < cpdomc->load_invr)
 			max_load_invr = cpdomc->load_invr;
-		if (qlen)
+		if (cpdomc->qload_invr)
 			nz_qlen++;
 	}
 	if (sys_stat.nr_active_cpdoms)

--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -318,14 +318,6 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 		return false;
 
 	/*
-	 * Probabilistically make a go or no go decision to avoid the
-	 * thundering herd problem. In other words, one out of nr_cpus
-	 * will try to steal a task at a moment.
-	 */
-	if (!prob_x_out_of_y(1, cpdomc->nr_active_cpus * LAVD_CPDOM_MIG_PROB_FT))
-		return false;
-
-	/*
 	 * Traverse neighbor compute domains in distance order.
 	 */
 	for (int i = 0; i < LAVD_CPDOM_MAX_DIST; i++) {

--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -439,8 +439,28 @@ static bool force_to_steal_task(struct cpdom_ctx *cpdomc)
 
 			dsq_id = pick_most_loaded_dsq(cpdomc_pick);
 
-			if (consume_dsq(cpdomc_pick, dsq_id))
+			/*
+			 * Peek at the head task to get its size.
+			 */
+			u64 task_load = 0;
+			struct task_struct *peek_p =
+				__COMPAT_scx_bpf_dsq_peek(dsq_id);
+			if (peek_p) {
+				task_ctx *peek_taskc = get_task_ctx(peek_p);
+				if (peek_taskc)
+					task_load = task_load_metric(peek_taskc);
+			}
+
+			/*
+			 * Force steal is unconditional for work
+			 * conservation. Decrement budgets to keep
+			 * the accounting consistent.
+			 */
+			if (consume_dsq(cpdomc_pick, dsq_id)) {
+				decrement_stealee_budget(cpdomc_pick, task_load);
+				decrement_stealer_budget(cpdomc, task_load);
 				return true;
+			}
 		}
 	}
 

--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -605,16 +605,13 @@ s32 migrate_to_neighbor(struct pick_ctx *ctx, struct cpdom_ctx *cpdc,
 			cpu = pick_idle_cpu_at_cpdom(ctx, mig_cpdom, scope, is_idle);
 			if (cpu >= 0) {
 				/*
-				 * If task donation is successful, mark the stealer
-				 * and the stealee's job done. By marking done,
-				 * those compute domains would not be involved in
-				 * load balancing until the end of this round,
-				 * so this helps gradual migration. It is racy
-				 * in task stealings and donations, but we don't
-				 * care because a slight over-migration does not matter.
+				 * Leave both stealer and stealee flags
+				 * active for the round. Donation redirects
+				 * a waking task — it was never queued in
+				 * the stealee domain, so don't touch the
+				 * budget. Flags are cleared only by budget
+				 * exhaustion in the stealing path.
 				 */
-				WRITE_ONCE(mig_cpdc->is_stealer, false);
-				WRITE_ONCE(cpdc->is_stealee, false);
 				*sticky_cpdom = mig_cpdom;
 				break;
 			}

--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -17,6 +17,8 @@
 #include <bpf/bpf_tracing.h>
 #include <lib/cgroup.h>
 
+extern const volatile u8	no_fast_lb;
+
 struct sticky_ctx {
 	/*
 	 * For test_cpu_stickable().
@@ -612,6 +614,10 @@ s32 migrate_to_neighbor(struct pick_ctx *ctx, struct cpdom_ctx *cpdc,
 				 * budget. Flags are cleared only by budget
 				 * exhaustion in the stealing path.
 				 */
+				if (no_fast_lb) {
+					WRITE_ONCE(mig_cpdc->is_stealer, false);
+					WRITE_ONCE(cpdc->is_stealee, false);
+				}
 				*sticky_cpdom = mig_cpdom;
 				break;
 			}

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -285,6 +285,8 @@ struct cpdom_ctx {
 	u32	cap_sum_turb;		    /* sum of capacity for turbulent CPUs in this cpdom */
 	u16	nr_steady_cpus;		    /* count of steady CPUs in this cpdom */
 	u16	nr_turb_cpus;		    /* count of turbulent CPUs in this cpdom */
+
+	s64	stealee_budget_invr;		    /* egress budget: how much load can leave this domain per round */
 } __attribute__((aligned(CACHELINE_SIZE)));
 
 #define get_neighbor_id(cpdomc, d, i) ((cpdomc)->neighbor_ids[((d) * LAVD_CPDOM_MAX_NR) + (i)])

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -292,6 +292,37 @@ struct cpdom_ctx {
 
 #define get_neighbor_id(cpdomc, d, i) ((cpdomc)->neighbor_ids[((d) * LAVD_CPDOM_MAX_NR) + (i)])
 
+/*
+ * Atomically subtract @amount from the stealee's egress budget. Concurrent
+ * stealers on other CPUs may call this in parallel, so use __sync_fetch_and_sub
+ * to avoid race conditions. The signed s64 field lets the counter go slightly
+ * negative on underflow; once it happens, the <= 0 check clears the stealee
+ * flag so further stealers skip this domain for the rest of the round. Budgets
+ * are recomputed from scratch each LB round. Hopefully, transient negativity is
+ * harmless.
+ */
+static __always_inline void decrement_stealee_budget(struct cpdom_ctx *cpdomc,
+						     u64 amount)
+{
+	__sync_fetch_and_sub(&cpdomc->stealee_budget_invr, amount);
+
+	if (READ_ONCE(cpdomc->stealee_budget_invr) <= 0)
+		WRITE_ONCE(cpdomc->is_stealee, false);
+}
+
+/*
+ * Atomically subtract @amount from the stealer's ingress budget.
+ * Same rationale as decrement_stealee_budget().
+ */
+static __always_inline void decrement_stealer_budget(struct cpdom_ctx *cpdomc,
+						     u64 amount)
+{
+	__sync_fetch_and_sub(&cpdomc->stealer_budget_invr, amount);
+
+	if (READ_ONCE(cpdomc->stealer_budget_invr) <= 0)
+		WRITE_ONCE(cpdomc->is_stealer, false);
+}
+
 extern struct cpdom_ctx		cpdom_ctxs[LAVD_CPDOM_MAX_NR];
 extern struct bpf_cpumask	cpdom_cpumask[LAVD_CPDOM_MAX_NR];
 extern int			nr_cpdoms;

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -287,6 +287,7 @@ struct cpdom_ctx {
 	u16	nr_turb_cpus;		    /* count of turbulent CPUs in this cpdom */
 
 	s64	stealee_budget_invr;		    /* egress budget: how much load can leave this domain per round */
+	s64	stealer_budget_invr;		    /* ingress budget: how much additional load this stealer can accept */
 } __attribute__((aligned(CACHELINE_SIZE)));
 
 #define get_neighbor_id(cpdomc, d, i) ((cpdomc)->neighbor_ids[((d) * LAVD_CPDOM_MAX_NR) + (i)])

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -226,6 +226,8 @@ struct task_ctx {
 	u64	last_slice_used_wall;	/* time(ns) used in last scheduled interval: [last running, last stopping] */
 	u32	cpu_id;			/* where a task is running now */
 	u32	prev_cpu_id;		/* where a task ran last time */
+	u8	queued_in_cpdom_id;	/* cpdom this task's load is counted in; LAVD_CPDOM_MAX_NR = not queued */
+	u32	queued_load_snapshot;	/* task_load_metric() value snapshotted at enqueue time */
 	pid_t	pid;			/* pid for this task */
 	pid_t	waker_pid;		/* last waker's PID */
 
@@ -256,7 +258,8 @@ struct cpdom_ctx {
 	u8	is_stealee;			    /* stealer domain should steal tasks from this domain */
 	u16	nr_active_cpus;			    /* the number of active CPUs in this compute domain */
 	u16	nr_acpus_temp;			    /* temp for nr_active_cpus */
-	u32	load_invr;			    /* invariant load considering DSQ length and invariant CPU utilization */
+	u64	qload_invr;			    /* queued load: sum of task_load_metric() for all queued tasks, tracked atomically */
+	u64	load_invr;			    /* domain load for balancing: avg_util_invr_sum + qload_invr */
 	u32	nr_queued_task;			    /* the number of queued tasks in this domain */
 	u32	cur_util_wall_sum;		    /* the sum of CPU utilization in the current interval */
 	u32	avg_util_wall_sum;		    /* the sum of average CPU utilization */
@@ -282,7 +285,6 @@ struct cpdom_ctx {
 	u32	cap_sum_turb;		    /* sum of capacity for turbulent CPUs in this cpdom */
 	u16	nr_steady_cpus;		    /* count of steady CPUs in this cpdom */
 	u16	nr_turb_cpus;		    /* count of turbulent CPUs in this cpdom */
-
 } __attribute__((aligned(CACHELINE_SIZE)));
 
 #define get_neighbor_id(cpdomc, d, i) ((cpdomc)->neighbor_ids[((d) * LAVD_CPDOM_MAX_NR) + (i)])
@@ -640,6 +642,19 @@ u32 preemption_vulnerability(u16 normalized_lat_cri, u32 util_est)
 	u32 lat_step = normalized_lat_cri / LAVD_VULN_THRESH_STEP_SIZE;
 	u32 util_step = util_est / LAVD_VULN_THRESH_STEP_SIZE;
 	return lat_step * LAVD_VULN_THRESH_UTIL_STEPS + util_step;
+}
+
+/*
+ * Return the task's load contribution for queued load tracking.
+ * Uses RAVG util_est: [0, 1024], 128ms half-life, tracks duty cycle.
+ * Updated in lavd_runnable/lavd_quiescent — active under sched_ext.
+ *
+ * Note: kernel PELT p->se.avg.util_avg is NOT updated when sched_ext
+ * is enabled (tasks bypass CFS), so it cannot be used here.
+ */
+static __always_inline u32 task_load_metric(task_ctx *taskc)
+{
+	return taskc->util_est;
 }
 
 extern struct bpf_cpumask __kptr *turbo_cpumask; /* CPU mask for turbo CPUs */

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -218,6 +218,9 @@ const volatile u64	slice_max_ns = LAVD_SLICE_MAX_NS_DFL;
  */
 const volatile u8	mig_delta_pct = 0;
 
+/* Disable batch-migration load balancer; set via --no-fast-lb. */
+const volatile u8	no_fast_lb = 0;
+
 /*
  * Skip periodic load balancing when average system utilization is below this
  * threshold. The value is pre-scaled by userspace. 0 = disabled.

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -610,6 +610,59 @@ static bool can_direct_dispatch(struct cpu_ctx *cpuc, bool is_cpu_idle)
 		cpuc->avg_util_wall < lb_local_dsq_util_wall);
 }
 
+/*
+ * qload_invr is incremented/decremented atomically at every enqueue and
+ * dequeue, unlike other cpdom stats that are aggregated from per-CPU
+ * counters at the sys_stat interval. Migration decisions in
+ * plan_x_cpdom_migration() and try_to_steal_task() need the fresh
+ * per-domain queued-load value (sum of task sizes currently queued) at
+ * steal time; a sys_stat snapshot would be up to one interval (10 ms)
+ * stale and could misclassify a domain that just drained or absorbed
+ * a burst.
+ */
+static __always_inline void account_queued_load(task_ctx *taskc,
+						u8 cpdom_id)
+{
+	struct cpdom_ctx *cpdomc;
+
+	if (cpdom_id >= LAVD_CPDOM_MAX_NR)
+		return;
+
+	/*
+	 * Skip if already accounted: prevent double-add when a task
+	 * walks through multiple enqueue paths before running.
+	 */
+	if (READ_ONCE(taskc->queued_in_cpdom_id) < LAVD_CPDOM_MAX_NR)
+		return;
+
+	/*
+	 * Snapshot the load value at enqueue time. The unaccount path
+	 * subtracts this exact snapshot, preventing drift when util_est
+	 * changes between enqueue and dequeue.
+	 */
+	u32 load = task_load_metric(taskc);
+	cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpdom_id]);
+	if (cpdomc)
+		__sync_fetch_and_add(&cpdomc->qload_invr, load);
+	taskc->queued_load_snapshot = load;
+	WRITE_ONCE(taskc->queued_in_cpdom_id, cpdom_id);
+}
+
+static __always_inline void unaccount_queued_load(task_ctx *taskc)
+{
+	struct cpdom_ctx *cpdomc;
+	u8 cpdom_id = READ_ONCE(taskc->queued_in_cpdom_id);
+
+	if (cpdom_id >= LAVD_CPDOM_MAX_NR)
+		return;
+
+	cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpdom_id]);
+	if (cpdomc)
+		__sync_fetch_and_sub(&cpdomc->qload_invr,
+				     taskc->queued_load_snapshot);
+	WRITE_ONCE(taskc->queued_in_cpdom_id, LAVD_CPDOM_MAX_NR);
+}
+
 s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 		   u64 wake_flags)
 {
@@ -695,6 +748,7 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 				goto out;
 			p->scx.dsq_vtime = calc_when_to_run(p, ictx.taskc);
 			p->scx.slice = LAVD_SLICE_MAX_NS_DFL;
+			account_queued_load(ictx.taskc, cpuc->cpdom_id);
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, p->scx.slice, 0);
 			goto out;
 		}
@@ -846,6 +900,7 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 		scx_bpf_dsq_insert_vtime(p, dsq_id, p->scx.slice,
 					 p->scx.dsq_vtime, enq_flags);
 	}
+	account_queued_load(taskc, cpuc->cpdom_id);
 
 	/*
 	 * If a new overflow CPU was assigned while finding a proper DSQ,
@@ -907,6 +962,7 @@ int enqueue_cb(struct task_struct __arg_trusted *p, task_ctx *taskc)
 	 */
 	dsq_id = get_target_dsq_id(p, cpuc, taskc);
 	scx_bpf_dsq_insert_vtime(p, dsq_id, p->scx.slice, p->scx.dsq_vtime, 0);
+	account_queued_load(taskc, cpuc->cpdom_id);
 
 	/*
 	 * Kick the target CPU if it is idle.
@@ -920,18 +976,22 @@ void BPF_STRUCT_OPS(lavd_dequeue, struct task_struct *p, u64 deq_flags)
 	task_ctx *taskc;
 	int ret;
 
-	/*
-	 * ATQ is used only when enable_cpu_bw is on.
-	 * So, we don't need to cancel an ATQ operation if it is not on.
-	 */
-	if (!enable_cpu_bw)
-		return;
-
 	taskc = get_task_ctx(p);
 	if (!taskc) {
 		debugln("Failed to lookup task_ctx for task %d", p->pid);
 		return;
 	}
+
+	/*
+	 * If the task is currently running, it was already unaccounted
+	 * in lavd_running(). Skip for non-running dequeues only
+	 * (SCX_DEQ_CORE_SCHED_EXEC, migration, etc.).
+	 */
+	if (p != __COMPAT_scx_bpf_cpu_curr(scx_bpf_task_cpu(p)))
+		unaccount_queued_load(taskc);
+
+	if (!enable_cpu_bw)
+		return;
 
 	if ((ret = scx_cgroup_bw_cancel((u64)taskc)))
 		debugln("Failed to cancel task %d with %d", p->pid, ret);
@@ -1346,6 +1406,8 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 		scx_bpf_error("Failed to lookup context for task %d", p->pid);
 		return;
 	}
+
+	unaccount_queued_load(taskc);
 
 	/*
 	 * If the sched_ext core directly dispatched a task, calculating the
@@ -1851,6 +1913,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init_task, struct task_struct *p,
 
 	taskc->suggested_cpu_id = scx_bpf_task_cpu(p);
 	taskc->pinned_cpu_id = -ENOENT;
+	WRITE_ONCE(taskc->queued_in_cpdom_id, LAVD_CPDOM_MAX_NR);
 	taskc->pid = p->pid;
 	taskc->cgrp_id = args->cgroup->kn->id;
 
@@ -1870,6 +1933,7 @@ s32 BPF_STRUCT_OPS(lavd_exit_task, struct task_struct *p,
 		   struct scx_exit_task_args *args)
 {
 	struct cpu_ctx *cpuc = get_cpu_ctx();
+	task_ctx *taskc = get_task_ctx(p);
 
 	/*
 	 * Drop the local CPU's task_ctx cache entry if it points at @p.
@@ -1879,6 +1943,14 @@ s32 BPF_STRUCT_OPS(lavd_exit_task, struct task_struct *p,
 	if (cpuc && (cpuc->cached_task == (u64)p ||
 		     cpuc->cached_pid == p->pid))
 		cpuc->cached_pid = 0;
+
+	/*
+	 * If the task is not the current task on its CPU, it may
+	 * still be queued. Unaccount its load. If running,
+	 * lavd_running() already unaccounted it.
+	 */
+	if (taskc && p != __COMPAT_scx_bpf_cpu_curr(scx_bpf_task_cpu(p)))
+		unaccount_queued_load(taskc);
 
 	scx_task_free(p);
 	return 0;

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -193,6 +193,12 @@ struct Opts {
     #[clap(long = "no-futex-boost", action = clap::ArgAction::SetTrue)]
     no_futex_boost: bool,
 
+    /// Default: --no-fast-lb is deactivated (fast load balancer is on).
+    /// Disable the fast (batch-migration) load balancer and fall back to
+    /// the pre-fast-lb load-balancer behavior.
+    #[clap(long = "no-fast-lb", action = clap::ArgAction::SetTrue)]
+    no_fast_lb: bool,
+
     /// Disable preemption.
     #[clap(long = "no-preemption", action = clap::ArgAction::SetTrue)]
     no_preemption: bool,
@@ -686,6 +692,7 @@ impl<'a> Scheduler<'a> {
         rodata.lb_low_util_wall = ((opts.lb_low_util_pct as u64) << 10) / 100;
         rodata.lb_local_dsq_util_wall = ((opts.lb_local_dsq_util_pct as u64) << 10) / 100;
         rodata.no_use_em = opts.no_use_em as u8;
+        rodata.no_fast_lb = opts.no_fast_lb as u8;
         rodata.no_wake_sync = opts.no_wake_sync;
         rodata.no_slice_boost = opts.no_slice_boost;
         rodata.per_cpu_dsq = opts.per_cpu_dsq;


### PR DESCRIPTION
This series is a first draft for discussion. It replaces LAVD's
one-task-per-steal load balancer with budget-controlled batch migration
using invariant runtime as the fundamental element to improve load
distribution accuracy and establish the foundation for future selective
migration. We can iterate on top of this. The patches are organized in
four parts.

### Part 1: Instrumentation

  f4295f7edd22 scx_lavd: Track system-wide average invariant runtime
  5acd23286228 scx_lavd: Track per-domain queued invariant load

Track system-wide average invariant runtime and per-domain queued
invariant load. queued_load_invr is the sum of each queued task's
avg_runtime_invr, maintained incrementally via atomic add/sub across all
enqueue and dequeue paths. This replaces the task-count approximation
with actual task-size-aware load information.

### Part 2: Budget framework

  1ea86ccb4f5b scx_lavd: Add migration budget for stealee domains
  280172ac4706 scx_lavd: Use actual queued task sizes instead of task count
  82ed9c672c5f scx_lavd: Add migration budget for stealer domains

Introduce symmetric migration budgets for both stealee and stealer
domains. Each stealee budget is half the domain's excess queued load
above its capacity-proportional fair share. Each stealer budget is half
its deficit below fair share. Replace the task-count-based load equation
with actual queued task sizes in load_invr to improve stealer/stealee
classification accuracy.

### Part 3: Budget enforcement

  c3cabcd7a2e9 scx_lavd: Budget-controlled task stealing in try_to_steal_task()
  2667d85c1f88 scx_lavd: Decrement budget on force steal for consistent accounting
  8677592e67bd scx_lavd: Remove flag clearing from migrate_to_neighbor()

Enforce budgets in try_to_steal_task() and force_to_steal_task() by
peeking at the DSQ head for actual task size before consuming. Flags are
cleared only when budget is exhausted. Remove flag clearing from the
donation path since donated tasks were never queued in the source
domain.

### Part 4: Migration delta and cleanup

  870cf5a463ee scx_lavd: Capacity-proportional migration delta
  43da9aa72337 scx_lavd: Fix budget decrement unit mismatch with load_invr
  97e1b9b15c64 scx_lavd: Remove probabilistic entry gate from try_to_steal_task()

Replace the flat system-wide threshold with capacity-proportional fair
share targets so heterogeneous domains are correctly classified. Align
budget decrement units with the load_invr space used for budget
computation. Remove the probabilistic entry gate from
try_to_steal_task(), which is now gated by budget control.
