### PR TITLE
mitosis: avoid deferred LOCAL_ON dispatch for remote CPUs

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/dsq.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/dsq.bpf.h
@@ -212,13 +212,14 @@ static inline dsq_id_t get_cell_llc_dsq_id(u32 cell, u32 llc)
  */
 static inline u64 cpu_dsq_raw(u32 cpu)
 {
-	return ((dsq_id_t){ .cpu_dsq = { .cpu = cpu,
-					 .type = DSQ_TYPE_CPU } }).raw;
+	return ((dsq_id_t){ .cpu_dsq = { .cpu = cpu, .type = DSQ_TYPE_CPU } })
+		.raw;
 }
 
 static inline u64 cell_llc_dsq_raw(u32 cell, u32 llc)
 {
 	return ((dsq_id_t){ .cell_llc_dsq = { .llc  = llc,
 					      .cell = cell,
-					      .type = DSQ_TYPE_CELL_LLC } }).raw;
+					      .type = DSQ_TYPE_CELL_LLC } })
+		.raw;
 }

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -648,14 +648,28 @@ static __always_inline s32 try_pick_idle_cpu(struct task_struct *p,
 	if (cpu >= 0) {
 		cstat_inc(CSTAT_LOCAL, tctx->cell, cctx);
 		/*
-		 * Use SCX_DSQ_LOCAL_ON to explicitly target the idle CPU
-		 * we found. In the select_cpu path this is redundant
-		 * (SCX_DSQ_LOCAL already resolves to the selected CPU),
-		 * but from the enqueue path (put_prev_task_scx ->
-		 * enqueue), SCX_DSQ_LOCAL resolves to task_rq(p) -- not
-		 * the idle CPU we picked.
+		 * LOCAL_ON for a remote CPU is deferred (the kernel
+		 * can't double-lock a remote rq inline). direct_dispatch
+		 * clears ops_state (QUEUEING -> NONE) before deferring,
+		 * so the task has no synchronization protection during
+		 * the deferred window — a cpuset change can narrow
+		 * p->cpus_ptr before dispatch_to_local_dsq runs.
+		 * dispatch_to_local_dsq then calls
+		 * task_can_run_on_remote_rq(enforce=true), killing the
+		 * scheduler.
+		 *
+		 * Use the per-CPU DSQ for remote CPUs instead. It is a
+		 * user-created DSQ, so direct_dispatch enqueues inline
+		 * (no deferral). The kicked CPU pulls from its per-CPU
+		 * DSQ in ops.dispatch.
 		 */
-		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, slice_ns, 0);
+		if (cpu == scx_bpf_task_cpu(p)) {
+			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, slice_ns,
+					   0);
+		} else {
+			scx_bpf_dsq_insert_vtime(p, cpu_dsq_raw(cpu), slice_ns,
+						 p->scx.dsq_vtime, 0);
+		}
 		if (kick)
 			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 		return cpu;
@@ -685,17 +699,22 @@ static __always_inline s32 try_pick_idle_cpu(struct task_struct *p,
 			struct cpu_ctx *target_cctx = lookup_cpu_ctx(cpu);
 			if (target_cctx) {
 				u32 tllc = enable_llc_awareness ?
-					target_cctx->llc : FAKE_FLAT_CELL_LLC;
+						   target_cctx->llc :
+						   FAKE_FLAT_CELL_LLC;
 				if (scx_bpf_dsq_nr_queued(cell_llc_dsq_raw(
 					    target_cctx->cell, tllc)) > 0 ||
-				    scx_bpf_dsq_nr_queued(
-					    cpu_dsq_raw(cpu)) > 0)
+				    scx_bpf_dsq_nr_queued(cpu_dsq_raw(cpu)) > 0)
 					goto no_borrow;
 			}
 			tctx->borrowed = true;
 			cstat_inc(CSTAT_BORROWED, tctx->cell, cctx);
-			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, slice_ns,
-					   0);
+			/*
+			 * Borrowed CPUs are typically remote — use
+			 * per-CPU DSQ to avoid deferred LOCAL_ON
+			 * (see above).
+			 */
+			scx_bpf_dsq_insert_vtime(p, cpu_dsq_raw(cpu), slice_ns,
+						 p->scx.dsq_vtime, 0);
 			if (kick)
 				scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 			return cpu;
@@ -1828,7 +1847,7 @@ static void dump_cell_cpumask(int id)
 
 void BPF_STRUCT_OPS(mitosis_tick, struct task_struct *p)
 {
-	struct cpu_ctx  *cctx;
+	struct cpu_ctx	*cctx;
 	struct task_ctx *tctx;
 
 	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)))


### PR DESCRIPTION
## Summary

- SCX_DSQ_LOCAL_ON targeting a remote CPU is deferred by direct_dispatch() — the kernel can't double-lock a remote rq inline, so it adds the task to ddsp_deferred_locals and executes later (via balance callback, wakeup hook, or irq_work fallback).
- The deferral clears ops_state (QUEUEING → NONE), so the task has no synchronization protection during the deferred window. A cpuset change can narrow p->cpus_ptr before dispatch_to_local_dsq() runs. dispatch_to_local_dsq() then calls task_can_run_on_remote_rq(enforce=true), killing the scheduler.
 - For remote CPUs, dispatch to the mitosis per-CPU DSQ instead. This is a user-created DSQ, so direct_dispatch() enqueues inline via dispatch_enqueue() — no deferral, no race. The kicked CPU pulls from its per-CPU DSQ in ops.dispatch.
- LOCAL_ON remains for same-CPU dispatch (cpu == scx_bpf_task_cpu(p)) where no deferral occurs.

## Test plan

- New llc_cpuset_race stt scenario: rapid cross-LLC cpuset flips under heavy enqueue pressure. 0/2 pass before fix, 4/4 pass after.

## Note
- Includes https://github.com/sched-ext/scx/pull/3469 to avoid conflict wrt/ stacking of fixes/to get things working enough to be able to trigger/fix this issue.