### PR TITLE
mitosis: check cell DSQ in ops.tick to preempt for queued cell work

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/dsq.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/dsq.bpf.h
@@ -212,13 +212,14 @@ static inline dsq_id_t get_cell_llc_dsq_id(u32 cell, u32 llc)
  */
 static inline u64 cpu_dsq_raw(u32 cpu)
 {
-	return ((dsq_id_t){ .cpu_dsq = { .cpu = cpu,
-					 .type = DSQ_TYPE_CPU } }).raw;
+	return ((dsq_id_t){ .cpu_dsq = { .cpu = cpu, .type = DSQ_TYPE_CPU } })
+		.raw;
 }
 
 static inline u64 cell_llc_dsq_raw(u32 cell, u32 llc)
 {
 	return ((dsq_id_t){ .cell_llc_dsq = { .llc  = llc,
 					      .cell = cell,
-					      .type = DSQ_TYPE_CELL_LLC } }).raw;
+					      .type = DSQ_TYPE_CELL_LLC } })
+		.raw;
 }

--- a/scheds/rust/scx_mitosis/src/bpf/dsq.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/dsq.bpf.h
@@ -205,3 +205,20 @@ static inline dsq_id_t get_cell_llc_dsq_id(u32 cell, u32 llc)
 					     .cell = cell,
 					     .type = DSQ_TYPE_CELL_LLC } };
 }
+
+/*
+ * Raw u64 DSQ ID helpers for contexts where BPF does not support
+ * aggregate (struct/union) return values.
+ */
+static inline u64 cpu_dsq_raw(u32 cpu)
+{
+	return ((dsq_id_t){ .cpu_dsq = { .cpu = cpu,
+					 .type = DSQ_TYPE_CPU } }).raw;
+}
+
+static inline u64 cell_llc_dsq_raw(u32 cell, u32 llc)
+{
+	return ((dsq_id_t){ .cell_llc_dsq = { .llc  = llc,
+					      .cell = cell,
+					      .type = DSQ_TYPE_CELL_LLC } }).raw;
+}

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -685,11 +685,11 @@ static __always_inline s32 try_pick_idle_cpu(struct task_struct *p,
 			struct cpu_ctx *target_cctx = lookup_cpu_ctx(cpu);
 			if (target_cctx) {
 				u32 tllc = enable_llc_awareness ?
-					target_cctx->llc : FAKE_FLAT_CELL_LLC;
+						   target_cctx->llc :
+						   FAKE_FLAT_CELL_LLC;
 				if (scx_bpf_dsq_nr_queued(cell_llc_dsq_raw(
 					    target_cctx->cell, tllc)) > 0 ||
-				    scx_bpf_dsq_nr_queued(
-					    cpu_dsq_raw(cpu)) > 0)
+				    scx_bpf_dsq_nr_queued(cpu_dsq_raw(cpu)) > 0)
 					goto no_borrow;
 			}
 			tctx->borrowed = true;
@@ -1828,20 +1828,22 @@ static void dump_cell_cpumask(int id)
 
 void BPF_STRUCT_OPS(mitosis_tick, struct task_struct *p)
 {
-	struct cpu_ctx  *cctx;
+	struct cpu_ctx	*cctx;
 	struct task_ctx *tctx;
 
 	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)))
 		return;
 
 	/*
-	 * If this CPU's per-CPU DSQ has waiting tasks, zero the
-	 * slice so dispatch runs within this tick rather than
-	 * waiting for the full slice to expire.
+	 * Zero the slice so dispatch runs within this tick when any
+	 * DSQ this CPU services has waiting work:
 	 *
-	 * For cross-cell tasks, also check the native
-	 * cell DSQ — the borrower should yield to native cell
-	 * work that arrived after the borrow started.
+	 *  1. Per-CPU DSQ — pinned tasks waiting on this CPU.
+	 *  2. Cell DSQ — this CPU's cell has queued work while the
+	 *     running task holds the CPU for a full slice. Without
+	 *     this, queued cell DSQ tasks wait up to slice_ns
+	 *     (20ms) for dispatch to run. For borrowed tasks this
+	 *     also reclaims the CPU when native cell work arrives.
 	 */
 	{
 		u64 cdsq = cpu_dsq_raw(scx_bpf_task_cpu(p));
@@ -1850,11 +1852,12 @@ void BPF_STRUCT_OPS(mitosis_tick, struct task_struct *p)
 			return;
 		}
 	}
-	if (tctx->cell != cctx->cell) {
+	{
 		u32 llc = enable_llc_awareness ? cctx->llc : FAKE_FLAT_CELL_LLC;
 		u64 cldsq = cell_llc_dsq_raw(cctx->cell, llc);
 		if (scx_bpf_dsq_nr_queued(cldsq) > 0) {
 			p->scx.slice = 0;
+			return;
 		}
 	}
 }

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -677,6 +677,21 @@ static __always_inline s32 try_pick_idle_cpu(struct task_struct *p,
 		}
 		cpu = pick_idle_cpu_from(p, borrowable, prev_cpu, idle_smtmask);
 		if (cpu >= 0) {
+			/*
+			 * Check if the target CPU's native cell has
+			 * waiting work before borrowing. If so, skip
+			 * — the native cell needs this CPU.
+			 */
+			struct cpu_ctx *target_cctx = lookup_cpu_ctx(cpu);
+			if (target_cctx) {
+				u32 tllc = enable_llc_awareness ?
+					target_cctx->llc : FAKE_FLAT_CELL_LLC;
+				if (scx_bpf_dsq_nr_queued(cell_llc_dsq_raw(
+					    target_cctx->cell, tllc)) > 0 ||
+				    scx_bpf_dsq_nr_queued(
+					    cpu_dsq_raw(cpu)) > 0)
+					goto no_borrow;
+			}
 			tctx->borrowed = true;
 			cstat_inc(CSTAT_BORROWED, tctx->cell, cctx);
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, slice_ns,
@@ -686,6 +701,7 @@ static __always_inline s32 try_pick_idle_cpu(struct task_struct *p,
 			return cpu;
 		}
 	}
+no_borrow:
 
 	return -EBUSY;
 }
@@ -1810,6 +1826,39 @@ static void dump_cell_cpumask(int id)
 	dump_cpumask(cell_cpumask);
 }
 
+void BPF_STRUCT_OPS(mitosis_tick, struct task_struct *p)
+{
+	struct cpu_ctx  *cctx;
+	struct task_ctx *tctx;
+
+	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)))
+		return;
+
+	/*
+	 * If this CPU's per-CPU DSQ has waiting tasks, zero the
+	 * slice so dispatch runs within this tick rather than
+	 * waiting for the full slice to expire.
+	 *
+	 * For cross-cell tasks, also check the native
+	 * cell DSQ — the borrower should yield to native cell
+	 * work that arrived after the borrow started.
+	 */
+	{
+		u64 cdsq = cpu_dsq_raw(scx_bpf_task_cpu(p));
+		if (scx_bpf_dsq_nr_queued(cdsq) > 0) {
+			p->scx.slice = 0;
+			return;
+		}
+	}
+	if (tctx->cell != cctx->cell) {
+		u32 llc = enable_llc_awareness ? cctx->llc : FAKE_FLAT_CELL_LLC;
+		u64 cldsq = cell_llc_dsq_raw(cctx->cell, llc);
+		if (scx_bpf_dsq_nr_queued(cldsq) > 0) {
+			p->scx.slice = 0;
+		}
+	}
+}
+
 void BPF_STRUCT_OPS(mitosis_dump, struct scx_dump_ctx *dctx)
 {
 	dsq_id_t	dsq_id;
@@ -2546,6 +2595,7 @@ SCX_OPS_DEFINE(mitosis,
 	       .dispatch		= (void *)mitosis_dispatch,
 	       .running			= (void *)mitosis_running,
 	       .stopping		= (void *)mitosis_stopping,
+	       .tick			= (void *)mitosis_tick,
 	       .set_cpumask		= (void *)mitosis_set_cpumask,
 	       .init_task		= (void *)mitosis_init_task,
 	       .cgroup_init		= (void *)mitosis_cgroup_init,


### PR DESCRIPTION
## Summary

- ops.tick checked the per-CPU DSQ and (for borrowed tasks) the native cell DSQ, but never checked the running task's own cell DSQ.
- When work arrived on the cell DSQ while a task held the CPU, update_curr_scx (ext.c:957-958) decremented slice each tick. Until slice reached zero, task_tick_scx (ext.c:2777) did not call resched_curr, so balance_one (ext.c:2147) and ops.dispatch never ran. The cell DSQ work waited up to slice_ns (20ms, SCX_SLICE_DFL at ext.h:30).
- Fix: check the cell DSQ unconditionally in ops.tick. Zeroing slice when cell DSQ work is waiting triggers resched_curr (ext.c:2778) → schedule() → balance_one → ops.dispatch within the current tick. This also subsumes the old cross-cell check — for borrowed tasks, cctx->cell is the CPU's native cell, so the same check reclaims the CPU when native cell work arrives.

## Test plan

- io_borrowing on smt-2llc: 0/5 → 5/5 pass
- dynamic_remove, cpuset_change, borrowing_rebalancing: all failing → 3/3 pass each

## Note
- PR includes https://github.com/sched-ext/scx/pull/3469 -- conceptually this is a different issue (i.e. for a separate class of test failures), but it does depend upon that PR.