### PR TITLE
mitosis: fix overflow panic in demand metrics during cell reconfig

### DIFF
--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -1049,7 +1049,7 @@ impl<'a> Scheduler<'a> {
             // Lent time: non-owner cell tasks running on this CPU
             let total_on_cpu: u64 = cpu_ctx.running_ns.iter().sum();
             let owner_on_cpu = cpu_ctx.running_ns[owner];
-            lent_ns[owner] += total_on_cpu - owner_on_cpu;
+            lent_ns[owner] += total_on_cpu.saturating_sub(owner_on_cpu);
         }
 
         // Compute deltas since last collection interval
@@ -1062,9 +1062,9 @@ impl<'a> Scheduler<'a> {
 
         for cell in 0..MAX_CELLS {
             let delta_running =
-                total_running_ns[cell].wrapping_sub(self.prev_cell_running_ns[cell]);
-            let delta_on_own = on_own_ns[cell].wrapping_sub(self.prev_cell_own_ns[cell]);
-            let delta_lent = lent_ns[cell].wrapping_sub(self.prev_cell_lent_ns[cell]);
+                total_running_ns[cell].saturating_sub(self.prev_cell_running_ns[cell]);
+            let delta_on_own = on_own_ns[cell].saturating_sub(self.prev_cell_own_ns[cell]);
+            let delta_lent = lent_ns[cell].saturating_sub(self.prev_cell_lent_ns[cell]);
 
             self.prev_cell_running_ns[cell] = total_running_ns[cell];
             self.prev_cell_own_ns[cell] = on_own_ns[cell];
@@ -1122,10 +1122,10 @@ impl<'a> Scheduler<'a> {
                     .smoothed_util_pct = self.smoothed_util[cell];
             }
 
-            global_running_delta += delta_running;
-            global_borrowed_delta += delta_borrowed;
-            global_lent_delta += delta_lent;
-            global_capacity += capacity;
+            global_running_delta = global_running_delta.saturating_add(delta_running);
+            global_borrowed_delta = global_borrowed_delta.saturating_add(delta_borrowed);
+            global_lent_delta = global_lent_delta.saturating_add(delta_lent);
+            global_capacity = global_capacity.saturating_add(capacity);
         }
 
         let global_util_pct = if global_capacity > 0 {


### PR DESCRIPTION
## Summary

- Use saturating arithmetic in collect_demand_metrics() to prevent overflow panics when CPU ownership changes between cells

##  Details
collect_demand_metrics() aggregates per-CPU BPF running_ns counters into per-cell totals: total_running_ns, on_own_ns, and lent_ns. The BPF-side counters are monotonically increasing (mitosis.bpf.c:1498, *running += used, sole write site), but two of the Rust-side aggregates depend on which cell owns each CPU (cpu_ctx.cell):
- on_own_ns[cell] (line 1052-1053): only counts a CPU's running_ns[cell] when cpu_ctx.cell == cell
- lent_ns[owner] (line 1064-1066): sums non-owner running time, attributed to the CPU's current owner

When apply_cell_config reassigns a CPU from cell A to cell B (mitosis.bpf.c:2435, cctx->cell = cell_id), the running_ns counters are not reset. On the next collect_demand_metrics call, the CPU's running_ns[A] no longer contributes to on_own_ns[A] (ownership check fails) and its foreign-task time is now attributed to lent_ns[B] instead of lent_ns[A]. Both on_own_ns[A] and lent_ns[A] decrease.

The old code used wrapping_sub to compute deltas, producing near-u64::MAX values on backward movement. These were then accumulated with +=, which panics in debug builds (Rust's default debug_assertions overflow checking).

Three changes:
1. Line 1066 (total_on_cpu - owner_on_cpu -> saturating_sub): Defensive — this subtraction cannot underflow with a consistent cpu_ctx snapshot since owner_on_cpu is one term of total_on_cpu, but aligns with the pattern.
2. Lines 1079-1081 (wrapping_sub -> saturating_sub): The necessary fix. on_own_ns and lent_ns are not monotonic across reconfigs. total_running_ns is monotonic (unconditional sum at line 1050-1051, no ownership dependency) so saturating_sub is a no-op for it, but keeps the code uniform.
3. Lines 1139-1142 (+= -> saturating_add): After fix #2 individual deltas are clamped to zero, so this cannot overflow in practice, but makes the intent explicit.

A zero delta for one collection interval after reconfig means the aggregate shifted due to ownership change, not actual work. The affected values feed smoothed_util (line 1120, EWMA with default alpha=0.3) which drives maybe_rebalance() (line 655, 672) CPU redistribution decisions. A single zero sample causes a one-interval dip in the EWMA (e.g. 80% -> 56%), but maybe_rebalance() requires the utilization spread across cells to exceed a threshold (default 20%) AND a cooldown (default 5s) between events, making spurious rebalancing from a single transient dip unlikely.

## Test plan

- 44 scx_mitosis unit tests pass
- Gauntlet with all 6 flags — overflow panic eliminated (was the dominant failure: 12 of 17 failures in the first 42 gauntlet tests)
