### PR TITLE
scx_mitosis: revert dispatch peek to locked iterator approach

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -47,6 +47,7 @@ const volatile bool	     cpu_controller_disabled	     = false;
 const volatile bool	     reject_multicpu_pinning	     = false;
 const volatile bool	     userspace_managed_cell_mode     = false;
 const volatile bool	     enable_borrowing		     = false;
+const volatile bool	     use_lockless_peek		     = false;
 
 /*
  * Global arrays for LLC topology, populated by userspace before load.
@@ -839,6 +840,22 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 }
 
+/*
+ * Peek at the head of a DSQ. By default use a bpf_for_each iterator loop.
+ * When use_lockless_peek is set, use the lockless scx_bpf_dsq_peek() kfunc.
+ */
+static inline struct task_struct *dsq_peek(u64 dsq_id)
+{
+	struct task_struct *p;
+
+	if (use_lockless_peek)
+		return __COMPAT_scx_bpf_dsq_peek(dsq_id);
+
+	bpf_for_each(scx_dsq, p, dsq_id, 0)
+		return p;
+	return NULL;
+}
+
 void BPF_STRUCT_OPS(mitosis_dispatch, s32 cpu, struct task_struct *prev)
 {
 	struct cpu_ctx *cctx;
@@ -865,7 +882,7 @@ void BPF_STRUCT_OPS(mitosis_dispatch, s32 cpu, struct task_struct *prev)
 	}
 
 	/* Peek at cell-LLC DSQ head */
-	p = __COMPAT_scx_bpf_dsq_peek(cell_dsq.raw);
+	p = dsq_peek(cell_dsq.raw);
 	if (p) {
 		min_vtime     = p->scx.dsq_vtime;
 		min_vtime_dsq = cell_dsq;
@@ -873,7 +890,7 @@ void BPF_STRUCT_OPS(mitosis_dispatch, s32 cpu, struct task_struct *prev)
 	}
 
 	/* Peek at CPU DSQ head, prefer if lower vtime */
-	p = __COMPAT_scx_bpf_dsq_peek(cpu_dsq.raw);
+	p = dsq_peek(cpu_dsq.raw);
 	if (p && (!found || time_before(p->scx.dsq_vtime, min_vtime))) {
 		min_vtime     = p->scx.dsq_vtime;
 		min_vtime_dsq = cpu_dsq;

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -57,7 +57,6 @@ use stats::Metrics;
 const SCHEDULER_NAME: &str = "scx_mitosis";
 const MAX_CELLS: usize = bpf_intf::consts_MAX_CELLS as usize;
 const NR_CSTATS: usize = bpf_intf::cell_stat_idx_NR_CSTATS as usize;
-
 /// Epoll token for inotify events (cgroup creation/destruction)
 const INOTIFY_TOKEN: u64 = 1;
 /// Epoll token for stats request wakeups
@@ -165,6 +164,10 @@ struct Opts {
     /// Only meaningful with --cell-parent-cgroup and multiple cells.
     #[clap(long, action = clap::ArgAction::SetTrue)]
     enable_borrowing: bool,
+
+    /// Use lockless scx_bpf_dsq_peek() instead of the default iterator-based peek.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    use_lockless_peek: bool,
 
     /// Enable demand-based CPU rebalancing between cells.
     #[clap(long, action = clap::ArgAction::SetTrue)]
@@ -340,6 +343,7 @@ impl<'a> Scheduler<'a> {
         rodata.userspace_managed_cell_mode = opts.cell_parent_cgroup.is_some();
 
         rodata.enable_borrowing = opts.enable_borrowing;
+        rodata.use_lockless_peek = opts.use_lockless_peek;
 
         match *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP {
             0 => info!("Kernel does not support queued wakeup optimization."),


### PR DESCRIPTION
scx_mitosis: add --use-iter-peek flag to work around lockless peek phantom tasks

Add a dsq_peek() helper that can optionally use the iterator-based DSQ peek path instead of the lockless scx_bpf_dsq_peek() kfunc, controlled by the new --use-iter-peek CLI flag. This works around a potential kernel bug where where the lockless peek can return stale tasks when the DSQ being peeked is empty.

Simply put, peek was always returning a task pointer for both DSQs regardless of whether the DSQ was empty or not. This lead to always checking task vtimes which almost always resulted in selecting the CPU DSQ (perhaps because CPU pinned tasks are less frequent and thus more stale thant cell tasks).

When the CPU DSQ is selected, dispatch tries to move the task to local, and almost always failing, it does not try the cell DSQ before going idle (even though the cell DSQ likely has a task in it).

In testing, this reduces task runnable stalls >100ms from thousands to 0 both baremetal and in virtualization.
