### PR TITLE
scx_rustland_core: Expose numa_preferred_nid to user-space

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -79,6 +79,7 @@ pub const RL_CPU_ANY: i32 = bpf_intf::RL_CPU_ANY as i32;
 pub struct QueuedTask {
     pub pid: i32,             // pid that uniquely identifies a task
     pub cpu: i32,             // CPU previously used by the task
+    pub numa_node: i32,       // Preferred NUMA node
     pub nr_cpus_allowed: u64, // Number of CPUs that the task can use
     pub flags: u64,           // task's enqueue flags
     pub start_ts: u64,        // Timestamp since last time the task ran on a CPU (in ns)
@@ -158,6 +159,7 @@ impl EnqueuedMessage {
         QueuedTask {
             pid: self.inner.pid,
             cpu: self.inner.cpu,
+            numa_node: self.inner.numa_node,
             nr_cpus_allowed: self.inner.nr_cpus_allowed,
             flags: self.inner.flags,
             start_ts: self.inner.start_ts,
@@ -495,11 +497,12 @@ impl<'cb> BpfScheduler<'cb> {
 
     // Pick an idle CPU for the target PID.
     #[allow(dead_code)]
-    pub fn select_cpu(&mut self, pid: i32, cpu: i32, flags: u64) -> i32 {
+    pub fn select_cpu(&mut self, pid: i32, cpu: i32, numa_node: i32, flags: u64) -> i32 {
         let prog = &mut self.skel.progs.rs_select_cpu;
         let mut args = task_cpu_arg {
             pid: pid as c_int,
             cpu: cpu as c_int,
+            numa_node: numa_node as c_int,
             flags: flags as c_ulong,
         };
         let input = ProgramInput {

--- a/rust/scx_rustland_core/assets/bpf/intf.h
+++ b/rust/scx_rustland_core/assets/bpf/intf.h
@@ -66,6 +66,7 @@ enum {
 struct task_cpu_arg {
 	pid_t pid;
 	s32 cpu;
+	s32 numa_node;
 	u64 flags;
 };
 
@@ -86,6 +87,7 @@ struct domain_arg {
 struct queued_task_ctx {
 	s32 pid;
 	s32 cpu; /* CPU where the task is running */
+	s32 numa_node; /* Preferred NUMA node */
 	u64 nr_cpus_allowed; /* Number of CPUs that the task can use */
 	u64 flags; /* Task enqueue flags */
 	u64 start_ts; /* Timestamp since last time the task ran on a CPU */

--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -645,22 +645,28 @@ int rs_select_cpu(struct task_cpu_arg *input)
 		return -EINVAL;
 
 	bpf_rcu_read_lock();
-	/*
-	 * Kernels that don't provide scx_bpf_select_cpu_and() only allow
-	 * to use the built-in idle CPU selection policy only from
-	 * ops.select_cpu() and opt.enqueue(), return any idle CPU usable
-	 * by the task in this case.
-	 */
-	if (!__COMPAT_HAS_scx_bpf_select_cpu_and) {
-		if (!scx_bpf_test_and_clear_cpu_idle(cpu))
-			cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
+	if (input->numa_node != NUMA_NO_NODE &&
+	    bpf_ksym_exists(scx_bpf_pick_idle_cpu_node)) {
+		cpu = scx_bpf_pick_idle_cpu_node(p->cpus_ptr, input->numa_node,
+						 SCX_PICK_IDLE_IN_NODE);
 	} else {
 		/*
-		 * Set SCX_WAKE_TTWU, pretending to be a wakeup, to prioritize
-		 * faster CPU selection (we probably want to add an option to allow
-		 * the user-space scheduler to use this logic or not).
+		 * Kernels that don't provide scx_bpf_select_cpu_and() only allow
+		 * to use the built-in idle CPU selection policy only from
+		 * ops.select_cpu() and opt.enqueue(), return any idle CPU usable
+		 * by the task in this case.
 		 */
-		cpu = pick_idle_cpu(p, cpu, SCX_WAKE_TTWU);
+		if (!__COMPAT_HAS_scx_bpf_select_cpu_and) {
+			if (!scx_bpf_test_and_clear_cpu_idle(cpu))
+				cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
+		} else {
+			/*
+			 * Set SCX_WAKE_TTWU, pretending to be a wakeup, to prioritize
+			 * faster CPU selection (we probably want to add an option to allow
+			 * the user-space scheduler to use this logic or not).
+			 */
+			cpu = pick_idle_cpu(p, cpu, SCX_WAKE_TTWU);
+		}
 	}
 	bpf_rcu_read_unlock();
 
@@ -679,6 +685,7 @@ static void get_task_info(struct queued_task_ctx *task,
 {
 	task->pid = p->pid;
 	task->cpu = prev_cpu;
+	task->numa_node = get_task_numa_node(p);
 	task->nr_cpus_allowed = p->nr_cpus_allowed;
 	task->flags = enq_flags;
 	task->start_ts = tctx->start_ts;

--- a/scheds/rust/scx_rlfifo/src/main.rs
+++ b/scheds/rust/scx_rlfifo/src/main.rs
@@ -139,7 +139,9 @@ impl<'a> Scheduler<'a> {
             // prioritizing its previously used CPU (task.cpu).
             //
             // If we can't find any idle CPU, run on the first CPU available.
-            let cpu = self.bpf.select_cpu(task.pid, task.cpu, task.flags);
+            let cpu = self
+                .bpf
+                .select_cpu(task.pid, task.cpu, task.numa_node, task.flags);
             dispatched_task.cpu = if cpu >= 0 { cpu } else { RL_CPU_ANY };
 
             // Determine the task's time slice: assign value inversely proportional to the number

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -297,10 +297,12 @@ impl<'a> Scheduler<'a> {
         dispatched_task.cpu = if self.opts.percpu_local {
             task.qtask.cpu
         } else {
-            match self
-                .bpf
-                .select_cpu(task.qtask.pid, task.qtask.cpu, task.qtask.flags)
-            {
+            match self.bpf.select_cpu(
+                task.qtask.pid,
+                task.qtask.cpu,
+                task.qtask.numa_node,
+                task.qtask.flags,
+            ) {
                 cpu if cpu >= 0 => cpu,
                 _ => RL_CPU_ANY,
             }


### PR DESCRIPTION
Expose p->numa_preferred_nid to the user-space scheduler and then pass the node id to BpfScheduler::select_cpu(), in this way the user-space part has more control on the node selection.

Suggested-by: Andrea Righi <arighi@nvidia.com>

Follow up #3381 