### PR TITLE
scheds: add --completions flag for shell completion generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,6 +3621,7 @@ version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "crossbeam",
  "ctrlc",
  "libbpf-rs",
@@ -3661,6 +3662,7 @@ version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "crossbeam",
  "ctrlc",
  "libbpf-rs",
@@ -3680,6 +3682,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "clap",
+ "clap_complete",
  "core_affinity",
  "crossbeam-utils",
  "crossterm 0.29.0",
@@ -3725,6 +3728,7 @@ version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "crossbeam",
  "ctrlc",
  "libbpf-rs",
@@ -3748,6 +3752,7 @@ version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "crossbeam",
  "ctrlc",
  "libbpf-rs",
@@ -3769,6 +3774,7 @@ version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "crossbeam",
  "ctrlc",
  "libbpf-rs",
@@ -3789,6 +3795,7 @@ dependencies = [
  "bitvec",
  "clap",
  "clap-num",
+ "clap_complete",
  "clap_main",
  "combinations",
  "crossbeam",
@@ -3821,6 +3828,7 @@ dependencies = [
  "bitvec",
  "chrono",
  "clap",
+ "clap_complete",
  "clap_main",
  "crossbeam",
  "ctrlc",
@@ -3857,6 +3865,7 @@ dependencies = [
  "bitvec",
  "cgroupfs",
  "clap",
+ "clap_complete",
  "clap_main",
  "crossbeam",
  "ctrlc",
@@ -3885,6 +3894,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "clap_main",
  "crossbeam",
  "ctrlc",
@@ -3910,6 +3920,7 @@ version = "5.5.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "ctrlc",
  "flate2",
  "libbpf-rs",
@@ -3954,6 +3965,7 @@ version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "ctrlc",
  "libbpf-rs",
  "libc",
@@ -3989,6 +4001,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "crossbeam",
  "ctrlc",
  "fb_procfs",
@@ -4041,6 +4054,26 @@ dependencies = [
  "affinity",
  "anyhow",
  "clap",
+ "clap_complete",
+ "crossbeam",
+ "ctrlc",
+ "libbpf-rs",
+ "log",
+ "scx_cargo",
+ "scx_stats",
+ "scx_stats_derive",
+ "scx_utils",
+ "serde",
+ "simplelog",
+]
+
+[[package]]
+name = "scx_timely"
+version = "1.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "clap_complete",
  "crossbeam",
  "ctrlc",
  "libbpf-rs",
@@ -4106,6 +4139,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "crossbeam",
  "ctrlc",
  "fb_procfs",
@@ -4130,6 +4164,7 @@ version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "ctrlc",
  "libbpf-rs",
  "libc",

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -66,6 +66,27 @@ have `rustup` installed this will use the version in `rust-toolchain.toml`.
 
     $ cargo fmt
 
+## Shell Completions
+
+All Rust schedulers and `scxcash` support a hidden `--completions <SHELL>` flag
+to generate shell completions for `bash`, `zsh`, `fish`, `elvish`, and `powershell`.
+This is intended for distro packaging — completions can be generated at install time:
+
+    scx_bpfland --completions bash > /usr/share/bash-completion/completions/scx_bpfland
+    scx_bpfland --completions zsh > /usr/share/zsh/site-functions/_scx_bpfland
+    scx_bpfland --completions fish > /usr/share/fish/vendor_completions.d/scx_bpfland.fish
+
+To generate and install completions for all schedulers at once (bash example):
+
+```bash
+for bin in scx_beerland scx_bpfland scx_cake scx_chaos scx_cosmos \
+           scx_flash scx_lavd scx_layered scx_mitosis scx_p2dq \
+           scx_pandemonium scx_rustland scx_rusty scx_tickless \
+           scx_wd40 scxcash; do
+    $bin --completions bash > /usr/share/bash-completion/completions/$bin
+done
+```
+
 ## Useful Tools
 
 ## [systing](https://github.com/josefbacik/systing)

--- a/scheds/rust/scx_beerland/Cargo.toml
+++ b/scheds/rust/scx_beerland/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-2.0-only"
 anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 crossbeam = "0.8"
 libbpf-rs = "=0.26.1"
 log = "0.4"

--- a/scheds/rust/scx_beerland/src/main.rs
+++ b/scheds/rust/scx_beerland/src/main.rs
@@ -24,7 +24,10 @@ use std::time::{Duration, Instant};
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use crossbeam::channel::RecvTimeoutError;
 use libbpf_rs::OpenObject;
 use libbpf_rs::ProgramInput;
@@ -132,6 +135,9 @@ struct Opts {
 
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 #[derive(PartialEq)]
@@ -526,6 +532,16 @@ impl Drop for Scheduler<'_> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            "scx_beerland",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     if opts.version {
         println!(

--- a/scheds/rust/scx_bpfland/Cargo.toml
+++ b/scheds/rust/scx_bpfland/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-2.0-only"
 anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 crossbeam = "0.8"
 libbpf-rs = "=0.26.1"
 log = "0.4"

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -23,7 +23,10 @@ use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use crossbeam::channel::RecvTimeoutError;
 use libbpf_rs::OpenObject;
 use libbpf_rs::ProgramInput;
@@ -297,6 +300,10 @@ struct Opts {
 
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
+
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 struct Scheduler<'a> {
@@ -726,6 +733,16 @@ impl Drop for Scheduler<'_> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            "scx_bpfland",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     if opts.version {
         println!(

--- a/scheds/rust/scx_cake/Cargo.toml
+++ b/scheds/rust/scx_cake/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-2.0-only"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 ctrlc = { version = "3", features = ["termination"] }
 libbpf-rs = "=0.26.1"
 libc = "0.2"

--- a/scheds/rust/scx_cake/src/main.rs
+++ b/scheds/rust/scx_cake/src/main.rs
@@ -11,7 +11,10 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use clap::CommandFactory;
 use clap::{Parser, ValueEnum};
+use clap_complete::generate;
+use clap_complete::Shell;
 use log::{info, warn};
 
 use scx_arena::ArenaLib;
@@ -176,6 +179,10 @@ struct Args {
     /// Print scheduler version and exit.
     #[arg(short = 'V', long, action = clap::ArgAction::SetTrue)]
     version: bool,
+
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 impl Args {
@@ -788,6 +795,16 @@ fn main() -> Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     let args = Args::parse();
+
+    if let Some(shell) = args.completions {
+        generate(
+            shell,
+            &mut Args::command(),
+            "scx_cake",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     // Handle --version before anything else (matches cosmos/bpfland)
     if args.version {

--- a/scheds/rust/scx_chaos/Cargo.toml
+++ b/scheds/rust/scx_chaos/Cargo.toml
@@ -19,6 +19,7 @@ scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version 
 
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 crossbeam = "0.8"
 ctrlc = { version = "3", features = ["termination"] }
 libbpf-rs = "=0.26.1"

--- a/scheds/rust/scx_chaos/src/lib.rs
+++ b/scheds/rust/scx_chaos/src/lib.rs
@@ -35,6 +35,7 @@ use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use clap::Parser;
+use clap_complete::Shell;
 use crossbeam::channel::RecvTimeoutError;
 use libbpf_rs::libbpf_sys::bpf_program__set_autoattach;
 use libbpf_rs::AsRawLibbpf;
@@ -596,6 +597,10 @@ pub struct Args {
         conflicts_with = "args"
     )]
     pub pid: Option<libc::pid_t>,
+
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    pub completions: Option<Shell>,
 
     /// Program to run under the chaos scheduler
     ///

--- a/scheds/rust/scx_chaos/src/main.rs
+++ b/scheds/rust/scx_chaos/src/main.rs
@@ -6,10 +6,22 @@ use anyhow::bail;
 use scx_chaos::run;
 use scx_chaos::Args;
 
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+
+    if let Some(shell) = args.completions {
+        generate(
+            shell,
+            &mut Args::command(),
+            "scx_chaos",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     let llv = match &args.verbose {
         0 => simplelog::LevelFilter::Info,

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-2.0-only"
 anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 crossbeam = "0.8"
 libbpf-rs = "=0.26.1"
 log = "0.4"

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -26,7 +26,10 @@ use std::time::{Duration, Instant};
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use crossbeam::channel::RecvTimeoutError;
 use libbpf_rs::MapCore;
 use libbpf_rs::MapFlags;
@@ -438,6 +441,9 @@ struct Opts {
 
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 #[derive(PartialEq)]
@@ -1386,6 +1392,16 @@ impl Drop for Scheduler<'_> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            "scx_cosmos",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     if opts.version {
         println!(

--- a/scheds/rust/scx_flash/Cargo.toml
+++ b/scheds/rust/scx_flash/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-2.0-only"
 anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 crossbeam = "0.8"
 libbpf-rs = "=0.26.1"
 log = "0.4"

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -23,7 +23,10 @@ use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use crossbeam::channel::RecvTimeoutError;
 use libbpf_rs::OpenObject;
 use libbpf_rs::ProgramInput;
@@ -249,6 +252,9 @@ struct Opts {
 
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 struct Scheduler<'a> {
@@ -620,6 +626,16 @@ impl Drop for Scheduler<'_> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            "scx_flash",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     if opts.version {
         println!(

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -16,6 +16,7 @@ scx_arena = { path = "../../../rust/scx_arena/scx_arena", version = "1.1.0" }
 anyhow = "1"
 bitvec = { version = "1", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 clap_main = "0.2"
 clap-num = { version = "1" }
 crossbeam = "0.8"

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -27,7 +27,10 @@ use std::time::Duration;
 
 use anyhow::Context;
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use clap_num::number_range;
 use cpu_order::CpuOrder;
 use cpu_order::PerfCpuOrder;
@@ -268,6 +271,10 @@ struct Opts {
     /// Topology configuration options
     #[clap(flatten)]
     topology: Option<TopologyArgs>,
+
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 impl Opts {
@@ -1004,6 +1011,16 @@ fn init_log(opts: &Opts) {
 
 #[clap_main::clap_main]
 fn main(mut opts: Opts) -> Result<()> {
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            "scx_lavd",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
+
     if opts.version {
         println!(
             "scx_lavd {}",

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1"
 bitvec = "1"
 chrono = "0.4"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 clap_main = "0.2"
 crossbeam = "0.8"
 ctrlc = { version = "3", features = ["termination"] }

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -32,7 +32,10 @@ use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 pub use bpf_skel::*;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use crossbeam::channel::Receiver;
 use crossbeam::select;
 use lazy_static::lazy_static;
@@ -650,6 +653,9 @@ struct Opts {
 
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 // Cgroup event types for inter-thread communication
@@ -4795,6 +4801,16 @@ fn setup_membw_tracking(skel: &mut OpenBpfSkel) -> Result<u64> {
 
 #[clap_main::clap_main]
 fn main(opts: Opts) -> Result<()> {
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            "scx_layered",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
+
     if opts.version {
         println!(
             "scx_layered {}",

--- a/scheds/rust/scx_mitosis/Cargo.toml
+++ b/scheds/rust/scx_mitosis/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1"
 bitvec = "1"
 cgroupfs = "0.9"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 clap_main = "0.2"
 ctrlc = { version = "3", features = ["termination"] }
 itertools = "0.14"

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -27,7 +27,10 @@ use std::time::Instant;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use libbpf_rs::MapCore as _;
 use libbpf_rs::OpenObject;
 use libbpf_rs::ProgramInput;
@@ -187,6 +190,9 @@ struct Opts {
 
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 // The subset of cstats we care about.
@@ -1294,6 +1300,16 @@ fn read_cpu_ctxs(skel: &BpfSkel) -> Result<Vec<bpf_intf::cpu_ctx>> {
 
 #[clap_main::clap_main]
 fn main(opts: Opts) -> Result<()> {
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            "scx_mitosis",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
+
     if opts.version {
         println!(
             "scx_mitosis {}",

--- a/scheds/rust/scx_p2dq/Cargo.toml
+++ b/scheds/rust/scx_p2dq/Cargo.toml
@@ -19,6 +19,7 @@ scx_arena = { path = "../../../rust/scx_arena/scx_arena", version = "1.1.0" }
 anyhow = "1"
 chrono = "0.4"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 clap_main = "0.2"
 crossbeam = "0.8"
 ctrlc = { version = "3", features = ["termination"] }

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -14,7 +14,10 @@ use std::time::Duration;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use crossbeam::channel::RecvTimeoutError;
 use libbpf_rs::skel::Skel;
 use libbpf_rs::AsRawLibbpf;
@@ -116,6 +119,10 @@ struct CliOpts {
 
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
+
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    pub completions: Option<Shell>,
 }
 
 struct Scheduler<'a> {
@@ -352,6 +359,16 @@ impl Drop for Scheduler<'_> {
 
 #[clap_main::clap_main]
 fn main(opts: CliOpts) -> Result<()> {
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut CliOpts::command(),
+            "scx_p2dq",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
+
     if opts.version {
         println!(
             "scx_p2dq: {}",

--- a/scheds/rust/scx_pandemonium/Cargo.toml
+++ b/scheds/rust/scx_pandemonium/Cargo.toml
@@ -10,6 +10,7 @@ libbpf-rs = { version = "=0.26.1" }
 libc = "0.2"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 ctrlc = { version = "3", features = ["termination"] }
 flate2 = "1"
 regex = "1"

--- a/scheds/rust/scx_pandemonium/src/main.rs
+++ b/scheds/rust/scx_pandemonium/src/main.rs
@@ -24,7 +24,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::{Parser, Subcommand};
+use clap_complete::generate;
+use clap_complete::Shell;
 
 use scheduler::Scheduler;
 
@@ -55,6 +58,10 @@ struct Cli {
     /// Additional compositor process names to boost to LAT_CRITICAL
     #[arg(long)]
     compositor: Vec<String>,
+
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 #[derive(Subcommand)]
@@ -157,6 +164,16 @@ struct BenchRunArgs {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    if let Some(shell) = cli.completions {
+        generate(
+            shell,
+            &mut Cli::command(),
+            "scx_pandemonium",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     let verbose = cli.verbose;
     let dump_log = cli.dump_log;

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-2.0-only"
 anyhow = "1"
 plain = "0.2"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 ctrlc = { version = "3", features = ["termination"] }
 libbpf-rs = "=0.26.1"
 libc = "0.2"

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -18,7 +18,10 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use libbpf_rs::OpenObject;
 use log::info;
 use log::warn;
@@ -123,6 +126,9 @@ struct Opts {
 
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 // Time constants.
@@ -388,6 +394,16 @@ impl Drop for Scheduler<'_> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            "scx_rustland",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     if opts.version {
         println!(

--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-2.0-only"
 anyhow = "1"
 chrono = "0.4"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 crossbeam = "0.8"
 ctrlc = { version = "3", features = ["termination"] }
 fb_procfs = "0.9"

--- a/scheds/rust/scx_rusty/src/main.rs
+++ b/scheds/rust/scx_rusty/src/main.rs
@@ -37,7 +37,10 @@ use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use crossbeam::channel::RecvTimeoutError;
 use libbpf_rs::MapCore as _;
 use libbpf_rs::OpenObject;
@@ -232,6 +235,9 @@ struct Opts {
 
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 fn read_cpu_busy_and_total(reader: &procfs::ProcReader) -> Result<(u64, u64)> {
@@ -634,6 +640,16 @@ impl Drop for Scheduler<'_> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            "scx_rusty",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     if opts.version {
         println!(

--- a/scheds/rust/scx_tickless/Cargo.toml
+++ b/scheds/rust/scx_tickless/Cargo.toml
@@ -11,6 +11,7 @@ affinity = "0.1"
 anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 crossbeam = "0.8"
 libbpf-rs = "=0.26.1"
 log = "0.4"

--- a/scheds/rust/scx_tickless/src/main.rs
+++ b/scheds/rust/scx_tickless/src/main.rs
@@ -23,7 +23,10 @@ use affinity::set_thread_affinity;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use crossbeam::channel::RecvTimeoutError;
 use libbpf_rs::OpenObject;
 use libbpf_rs::ProgramInput;
@@ -100,6 +103,9 @@ struct Opts {
 
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 pub fn is_nohz_enabled() -> bool {
@@ -288,6 +294,16 @@ impl Drop for Scheduler<'_> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            "scx_tickless",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     if opts.version {
         println!(

--- a/scheds/rust/scx_wd40/Cargo.toml
+++ b/scheds/rust/scx_wd40/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1"
 scx_arena = { path = "../../../rust/scx_arena/scx_arena", version = "1.1.0" }
 chrono = "0.4"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 crossbeam = "0.8"
 ctrlc = { version = "3", features = ["termination"] }
 fb_procfs = "0.9"

--- a/scheds/rust/scx_wd40/src/main.rs
+++ b/scheds/rust/scx_wd40/src/main.rs
@@ -37,7 +37,10 @@ use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use crossbeam::channel::RecvTimeoutError;
 use libbpf_rs::skel::Skel;
 use libbpf_rs::MapCore as _;
@@ -234,6 +237,9 @@ struct Opts {
 
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     pub libbpf: LibbpfOpts,
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 fn read_cpu_busy_and_total(reader: &procfs::ProcReader) -> Result<(u64, u64)> {
@@ -679,6 +685,16 @@ impl Drop for Scheduler<'_> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            "scx_wd40",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     if opts.version {
         println!(

--- a/scripts/test_completions.sh
+++ b/scripts/test_completions.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BINDIR="${1:-./target/debug}"
+PASS=0
+FAIL=0
+SHELLS=(bash zsh fish)
+
+BINS=(
+    scx_beerland scx_bpfland scx_cake scx_chaos scx_cosmos
+    scx_flash scx_lavd scx_layered scx_mitosis scx_p2dq
+    scx_pandemonium scx_rustland scx_rusty scx_tickless
+    scx_wd40 scxcash
+)
+
+pass() { PASS=$((PASS + 1)); echo "  PASS  $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL  $1"; }
+
+for bin in "${BINS[@]}"; do
+    exe="$BINDIR/$bin"
+    if [[ ! -x "$exe" ]]; then
+        fail "$bin: binary not found at $exe"
+        continue
+    fi
+
+    echo "=== $bin ==="
+
+    # 1) --completions exits 0 and produces output for each shell
+    for sh in "${SHELLS[@]}"; do
+        output=$("$exe" --completions "$sh" 2>&1) || true
+        if [[ -z "$output" ]]; then
+            fail "$bin --completions $sh: empty output"
+        else
+            pass "$bin --completions $sh: produces output"
+        fi
+    done
+
+    # 2) Bash completions reference the correct binary name
+    bash_output=$("$exe" --completions bash 2>&1)
+    if echo "$bash_output" | grep -q "$bin"; then
+        pass "$bin: binary name found in bash completions"
+    else
+        fail "$bin: binary name NOT found in bash completions"
+    fi
+
+    # 3) --completions is hidden from --help
+    help_output=$("$exe" --help 2>&1) || true
+    if echo "$help_output" | grep -q "\-\-completions"; then
+        fail "$bin: --completions visible in --help (should be hidden)"
+    else
+        pass "$bin: --completions hidden from --help"
+    fi
+
+    # 4) Completions contain at least some real options (not an empty stub)
+    line_count=$(echo "$bash_output" | wc -l)
+    if (( line_count > 20 )); then
+        pass "$bin: bash completions have $line_count lines"
+    else
+        fail "$bin: bash completions suspiciously short ($line_count lines)"
+    fi
+done
+
+# 5) Scheduler-specific: ValueEnum variants appear in completions
+echo ""
+echo "=== ValueEnum checks ==="
+
+cake_output=$("$BINDIR/scx_cake" --completions bash 2>&1)
+for val in esports gaming battery legacy default; do
+    if echo "$cake_output" | grep -qi "$val"; then
+        pass "scx_cake: ValueEnum '$val' in completions"
+    else
+        fail "scx_cake: ValueEnum '$val' NOT in completions"
+    fi
+done
+
+echo ""
+echo "==============================="
+echo "Results: $PASS passed, $FAIL failed"
+(( FAIL == 0 )) && echo "ALL TESTS PASSED" || echo "SOME TESTS FAILED"
+exit $FAIL

--- a/tools/scxcash/Cargo.toml
+++ b/tools/scxcash/Cargo.toml
@@ -14,6 +14,7 @@ disable = true
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 log = "0.4"
 libc = "0.2"
 libbpf-rs = "=0.26.1"

--- a/tools/scxcash/src/main.rs
+++ b/tools/scxcash/src/main.rs
@@ -4,7 +4,10 @@
 // GNU General Public License version 2.
 
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use log::*;
 
 mod monitors;
@@ -61,10 +64,24 @@ struct Opts {
     /// Pin path of the task hint TLS map (mandatory with --hints).
     #[clap(long = "hints-map")]
     hints_map: Option<String>,
+
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
 }
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            "scxcash",
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
 
     let llv = match opts.verbose {
         0 => simplelog::LevelFilter::Info,


### PR DESCRIPTION
## Summary

- Add a hidden `--completions <SHELL>` flag to all 16 Rust schedulers and `scxcash` for distro packaging of shell completions (bash, zsh, fish, elvish, powershell) via `clap_complete`
- Document the feature in `DEVELOPER_GUIDE.md` with batch install example
- Include `scripts/test_completions.sh` to validate completions output across all targets

## Details

The flag is hidden from `--help` (intended for distro packagers, not end users) and exits immediately after printing — no kernel, BPF, or root required.

```bash
# Distro packaging: generate at install time
scx_bpfland --completions bash > /usr/share/bash-completion/completions/scx_bpfland
```

Reference: `scxtop` already has this via a `GenerateCompletions` subcommand. The schedulers use a simpler hidden flag approach — less invasive, no `main()` refactor needed.

### Targets (16 schedulers + 1 tool)

scx_beerland, scx_bpfland, scx_cake, scx_chaos, scx_cosmos, scx_flash,
scx_lavd, scx_layered, scx_mitosis, scx_p2dq, scx_pandemonium,
scx_rustland, scx_rusty, scx_tickless, scx_wd40, scxcash

Skipped: `scx_rlfifo` (no clap dependency), `scxtop` (already done), `xtask`/`vmlinux_docify` (internal build tools)

## Test plan

- [x] All 16 targets build cleanly
- [x] `--completions bash/zsh/fish` produces valid output and exits 0 on all targets
- [x] `--completions` is hidden from `--help`
- [x] Binary name is correct in generated output (no copy-paste errors)
- [x] ValueEnum variants appear in completions (scx_cake profiles)
- [x] `scripts/test_completions.sh` passes (110 checks, 0 failures)

Fixes: #1572
