### PR TITLE
scxtop: refactor scheduler view with rsched-style aggregations

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -18,7 +18,7 @@ use crate::config::get_config_path;
 use crate::config::Config;
 use crate::get_default_events;
 use crate::render::bpf_programs::{ProgramDetailParams, ProgramsListParams};
-use crate::render::scheduler::{SchedulerStatsParams, SchedulerViewParams};
+use crate::render::scheduler::{DsqSummaryParams, ProcessLatencyParams, SchedulerViewParams};
 use crate::render::{
     BpfProgramRenderer, MemoryRenderer, NetworkRenderer, ProcessRenderer, SchedulerRenderer,
 };
@@ -187,6 +187,13 @@ pub struct App<'a> {
     // power monitoring
     power_snapshot: crate::PowerSnapshot,
     power_collector: crate::PowerDataCollector,
+
+    // scheduler DSQ filter (hex string match)
+    dsq_filter_text: String,
+    dsq_summary_table_state: TableState,
+    dsq_summary_row_count: usize,
+    proc_latency_table_state: TableState,
+    proc_latency_row_count: usize,
 
     // layout related
     events_list_size: u16,
@@ -433,6 +440,11 @@ impl<'a> App<'a> {
             kprobe_links: Vec::new(),
             filtered_state,
             filtering: false,
+            dsq_filter_text: String::new(),
+            dsq_summary_table_state: TableState::default(),
+            dsq_summary_row_count: 0,
+            proc_latency_table_state: TableState::default(),
+            proc_latency_row_count: 0,
             events_list_size: 1,
             prev_bpf_sample_rate: sample_rate,
             trace_start: 0,
@@ -691,6 +703,11 @@ impl<'a> App<'a> {
             kprobe_links: Vec::new(),
             filtered_state,
             filtering: false,
+            dsq_filter_text: String::new(),
+            dsq_summary_table_state: TableState::default(),
+            dsq_summary_row_count: 0,
+            proc_latency_table_state: TableState::default(),
+            proc_latency_row_count: 0,
             events_list_size: 1,
             prev_bpf_sample_rate: sample_rate,
             trace_start: 0,
@@ -2545,16 +2562,13 @@ impl<'a> App<'a> {
                     self.render_capability_warnings(frame, area)?;
                     return Ok(());
                 }
-                let [left, right] = Layout::horizontal([Constraint::Fill(1); 2]).areas(area);
-                let [left_top, left_center, left_bottom] = Layout::vertical([
+
+                let [top, middle, bottom] = Layout::vertical([
                     Constraint::Ratio(1, 3),
-                    Constraint::Ratio(1, 3),
-                    Constraint::Ratio(1, 3),
+                    Constraint::Ratio(1, 4),
+                    Constraint::Fill(1),
                 ])
-                .areas(left);
-                let [right_top, right_bottom] =
-                    Layout::vertical(vec![Constraint::Ratio(2, 3), Constraint::Ratio(1, 3)])
-                        .areas(right);
+                .areas(area);
 
                 let sample_rate = self
                     .skel
@@ -2562,7 +2576,8 @@ impl<'a> App<'a> {
                     .map(|s| s.maps.data_data.as_ref().unwrap().sample_rate)
                     .unwrap_or(0);
 
-                let params1 = SchedulerViewParams {
+                // Top: DSQ latency sparklines/barchart
+                let sparkline_params = SchedulerViewParams {
                     event: "dsq_lat_us",
                     scheduler_name: &self.scheduler,
                     dsq_data: &self.dsq_data,
@@ -2570,83 +2585,55 @@ impl<'a> App<'a> {
                     localize: self.localize,
                     locale: &self.locale,
                     theme: self.theme(),
-                    render_title: false,
+                    render_title: true,
                     render_sample_rate: true,
                 };
                 let new_max = SchedulerRenderer::render_scheduler_view(
                     frame,
-                    left_top,
+                    top,
                     &self.view_state,
                     self.max_sched_events,
-                    &params1,
+                    &sparkline_params,
                 )?;
-                self.max_sched_events = new_max;
+                if new_max != self.max_sched_events {
+                    self.max_sched_events = new_max;
+                    for dsq_event_data in self.dsq_data.values_mut() {
+                        dsq_event_data.set_max_size(new_max);
+                    }
+                }
 
-                let params2 = SchedulerViewParams {
-                    event: "dsq_slice_consumed",
+                // Middle: DSQ summary table with percentile aggregations
+                let theme = self.config.theme().clone();
+                let summary_params = DsqSummaryParams {
                     scheduler_name: &self.scheduler,
                     dsq_data: &self.dsq_data,
                     sample_rate,
-                    localize: self.localize,
-                    locale: &self.locale,
-                    theme: self.theme(),
-                    render_title: false,
-                    render_sample_rate: false,
+                    dsq_filter_text: &self.dsq_filter_text,
+                    filtering: self.filtering,
+                    filter_input: &self.event_input_buffer,
+                    theme: &theme,
                 };
-                SchedulerRenderer::render_scheduler_view(
+                self.dsq_summary_row_count = SchedulerRenderer::render_dsq_summary_table(
                     frame,
-                    left_center,
-                    &self.view_state,
-                    self.max_sched_events,
-                    &params2,
+                    middle,
+                    &summary_params,
+                    &mut self.dsq_summary_table_state,
                 )?;
 
-                let params3 = SchedulerViewParams {
-                    event: "dsq_vtime",
-                    scheduler_name: &self.scheduler,
-                    dsq_data: &self.dsq_data,
-                    sample_rate,
-                    localize: self.localize,
-                    locale: &self.locale,
-                    theme: self.theme(),
-                    render_title: false,
-                    render_sample_rate: false,
+                // Bottom: Per-process scheduling latency table
+                let proc_params = ProcessLatencyParams {
+                    proc_data: &self.proc_data,
+                    dsq_filter_text: &self.dsq_filter_text,
+                    theme: &theme,
                 };
-                SchedulerRenderer::render_scheduler_view(
+                self.proc_latency_row_count = SchedulerRenderer::render_process_latency_table(
                     frame,
-                    left_bottom,
-                    &self.view_state,
-                    self.max_sched_events,
-                    &params3,
+                    bottom,
+                    &proc_params,
+                    &mut self.proc_latency_table_state,
                 )?;
 
-                let params4 = SchedulerViewParams {
-                    event: "dsq_nr_queued",
-                    scheduler_name: &self.scheduler,
-                    dsq_data: &self.dsq_data,
-                    sample_rate,
-                    localize: self.localize,
-                    locale: &self.locale,
-                    theme: self.theme(),
-                    render_title: false,
-                    render_sample_rate: false,
-                };
-                SchedulerRenderer::render_scheduler_view(
-                    frame,
-                    right_bottom,
-                    &self.view_state,
-                    self.max_sched_events,
-                    &params4,
-                )?;
-                let stats_params = SchedulerStatsParams {
-                    scheduler_name: &self.scheduler,
-                    sched_stats_raw: &self.sched_stats_raw,
-                    tick_rate_ms: self.config.tick_rate_ms(),
-                    dispatch_keep_last: self.scx_stats.dispatch_keep_last,
-                    select_cpu_fallback: self.scx_stats.select_cpu_fallback,
-                    theme: self.theme(),
-                };
-                SchedulerRenderer::render_scheduler_stats(frame, right_top, &stats_params)
+                Ok(())
             }
             AppState::Tracing => self.render_tracing(frame),
             _ => self.render_default(frame),
@@ -3959,6 +3946,12 @@ impl<'a> App<'a> {
                 self.perf_top_table_state
                     .select(Some(self.selected_symbol_index));
             }
+        } else if self.state == AppState::Scheduler {
+            // Scroll the process latency table (bottom pane)
+            let max_index = self.proc_latency_row_count.saturating_sub(1);
+            let current = self.proc_latency_table_state.selected().unwrap_or(0);
+            let new_selected = if current < max_index { current + 1 } else { 0 };
+            self.proc_latency_table_state.select(Some(new_selected));
         } else {
             let mut filtered_state = self.filtered_state.lock().unwrap();
             if (self.state == AppState::PerfEvent
@@ -4031,6 +4024,14 @@ impl<'a> App<'a> {
             }
             self.perf_top_table_state
                 .select(Some(self.selected_symbol_index));
+        } else if self.state == AppState::Scheduler {
+            let current = self.proc_latency_table_state.selected().unwrap_or(0);
+            let new_selected = if current > 0 {
+                current - 1
+            } else {
+                self.proc_latency_row_count.saturating_sub(1)
+            };
+            self.proc_latency_table_state.select(Some(new_selected));
         } else if self.state == AppState::Help {
         } else {
             let mut filtered_state = self.filtered_state.lock().unwrap();
@@ -4100,6 +4101,16 @@ impl<'a> App<'a> {
             }
             self.perf_top_table_state
                 .select(Some(self.selected_symbol_index));
+        } else if self.state == AppState::Scheduler {
+            let page_size = 10;
+            let max_index = self.proc_latency_row_count.saturating_sub(1);
+            let current = self.proc_latency_table_state.selected().unwrap_or(0);
+            let new_selected = if current + page_size <= max_index {
+                current + page_size
+            } else {
+                max_index
+            };
+            self.proc_latency_table_state.select(Some(new_selected));
         } else {
             let mut filtered_state = self.filtered_state.lock().unwrap();
             if (self.state == AppState::PerfEvent
@@ -4161,6 +4172,11 @@ impl<'a> App<'a> {
             }
             self.perf_top_table_state
                 .select(Some(self.selected_symbol_index));
+        } else if self.state == AppState::Scheduler {
+            let page_size = 10;
+            let current = self.proc_latency_table_state.selected().unwrap_or(0);
+            let new_selected = current.saturating_sub(page_size);
+            self.proc_latency_table_state.select(Some(new_selected));
         } else {
             let mut filtered_state = self.filtered_state.lock().unwrap();
             if (self.state == AppState::PerfEvent
@@ -4306,6 +4322,11 @@ impl<'a> App<'a> {
 
                 self.filter_events();
             }
+            AppState::Scheduler => {
+                // Confirm DSQ filter
+                self.apply_dsq_filter();
+                self.filtering = false;
+            }
             _ => {
                 // Handle other states (Help, MangoApp, Memory, Pause, Scheduler, etc.)
                 // For these states, do nothing on Enter
@@ -4315,8 +4336,20 @@ impl<'a> App<'a> {
         Ok(())
     }
 
+    /// Updates dsq_filter_text from event_input_buffer for string-based DSQ matching
+    fn apply_dsq_filter(&mut self) {
+        self.dsq_filter_text = self.event_input_buffer.trim().to_string();
+    }
+
     fn on_escape(&mut self) -> Result<()> {
         match self.state() {
+            AppState::Scheduler => {
+                if self.filtering {
+                    self.filtering = false;
+                    self.event_input_buffer.clear();
+                    self.dsq_filter_text.clear();
+                }
+            }
             AppState::BpfPrograms => {
                 if self.filtering {
                     // Clear filter and exit filtering mode
@@ -4812,7 +4845,7 @@ impl<'a> App<'a> {
             let next_dsq_data = self
                 .dsq_data
                 .entry(next_dsq_id)
-                .or_insert(EventData::new(self.max_cpu_events));
+                .or_insert(EventData::new(self.max_sched_events));
 
             if self.state == AppState::MangoApp {
                 if self.process_id > 0 && action.next_tgid == self.process_id as u32 {
@@ -4835,7 +4868,7 @@ impl<'a> App<'a> {
             let prev_dsq_data = self
                 .dsq_data
                 .entry(prev_dsq_id)
-                .or_insert(EventData::new(self.max_cpu_events));
+                .or_insert(EventData::new(self.max_sched_events));
             if self.state == AppState::MangoApp {
                 if self.process_id > 0 && action.prev_tgid == self.process_id as u32 {
                     prev_dsq_data.add_event_data("dsq_slice_consumed", *prev_used_slice_ns);
@@ -5704,6 +5737,9 @@ impl<'a> App<'a> {
                     self.filtering = true;
                     self.filter_symbols();
                 }
+                AppState::Scheduler => {
+                    self.filtering = true;
+                }
                 _ => {}
             },
             Action::InputEntry(input) => {
@@ -5714,6 +5750,10 @@ impl<'a> App<'a> {
                     }
                     AppState::PerfTop => {
                         self.filter_symbols();
+                    }
+                    AppState::Scheduler => {
+                        // Live-update DSQ filter as user types
+                        self.apply_dsq_filter();
                     }
                     _ => {
                         self.filter_events();
@@ -5728,6 +5768,9 @@ impl<'a> App<'a> {
                     }
                     AppState::PerfTop => {
                         self.filter_symbols();
+                    }
+                    AppState::Scheduler => {
+                        self.apply_dsq_filter();
                     }
                     _ => {
                         self.filter_events();

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -124,6 +124,7 @@ fn handle_input_entry(app: &App, s: String) -> Option<Action> {
         | AppState::Memory
         | AppState::PerfTop
         | AppState::BpfPrograms
+        | AppState::Scheduler
             if app.filtering() =>
         {
             Some(Action::InputEntry(s))

--- a/tools/scxtop/src/render/scheduler.rs
+++ b/tools/scxtop/src/render/scheduler.rs
@@ -4,18 +4,19 @@
 // GNU General Public License version 2.
 
 use crate::util::sanitize_nbsp;
-use crate::{AppTheme, EventData, VecStats, ViewState};
+use crate::{AppTheme, EventData, ProcData, StatAggregation, VecStats, ViewState};
 use anyhow::Result;
 use num_format::{SystemLocale, ToFormattedString};
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::prelude::Stylize;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{
-    Bar, BarChart, BarGroup, Block, BorderType, Borders, Clear, Paragraph, RenderDirection,
-    Sparkline,
+    Bar, BarChart, BarGroup, Block, BorderType, Borders, Cell, Clear, Paragraph, RenderDirection,
+    Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Sparkline, Table, TableState,
 };
 use ratatui::Frame;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 /// Parameters for rendering scheduler views
 pub struct SchedulerViewParams<'a> {
@@ -42,13 +43,21 @@ pub struct DsqRenderParams<'a> {
     pub render_sample_rate: bool,
 }
 
-/// Parameters for scheduler statistics
-pub struct SchedulerStatsParams<'a> {
+/// Parameters for DSQ summary table
+pub struct DsqSummaryParams<'a> {
     pub scheduler_name: &'a str,
-    pub sched_stats_raw: &'a str,
-    pub tick_rate_ms: usize,
-    pub dispatch_keep_last: i64,
-    pub select_cpu_fallback: i64,
+    pub dsq_data: &'a BTreeMap<u64, EventData>,
+    pub sample_rate: u32,
+    pub dsq_filter_text: &'a str,
+    pub filtering: bool,
+    pub filter_input: &'a str,
+    pub theme: &'a AppTheme,
+}
+
+/// Parameters for process latency table
+pub struct ProcessLatencyParams<'a> {
+    pub proc_data: &'a BTreeMap<i32, ProcData>,
+    pub dsq_filter_text: &'a str,
     pub theme: &'a AppTheme,
 }
 
@@ -82,41 +91,362 @@ impl SchedulerRenderer {
         }
     }
 
-    /// Renders scheduler statistics panel
-    #[allow(clippy::too_many_arguments)]
-    pub fn render_scheduler_stats(
+    /// Renders DSQ latency summary table with percentile aggregations.
+    /// Returns the number of rows for scroll state management.
+    pub fn render_dsq_summary_table(
         frame: &mut Frame,
         area: Rect,
-        params: &SchedulerStatsParams,
-    ) -> Result<()> {
-        let paragraph = Paragraph::new(params.sched_stats_raw.to_string());
+        params: &DsqSummaryParams,
+        table_state: &mut TableState,
+    ) -> Result<usize> {
+        let percentile_set: HashSet<StatAggregation> = [
+            StatAggregation::P50,
+            StatAggregation::P90,
+            StatAggregation::P99,
+        ]
+        .into_iter()
+        .collect();
+
+        struct DsqEntry {
+            dsq_id: u64,
+            p50: u64,
+            p90: u64,
+            p99: u64,
+            avg: u64,
+            max: u64,
+            q_max: u64,
+            count: usize,
+        }
+
+        let mut entries: Vec<DsqEntry> = Vec::new();
+        for (dsq_id, event_data) in params.dsq_data.iter() {
+            if !params.dsq_filter_text.is_empty() {
+                let dsq_hex = format!("{:#X}", dsq_id);
+                let filter_upper = params.dsq_filter_text.to_uppercase();
+                if !dsq_hex.to_uppercase().contains(&filter_upper) {
+                    continue;
+                }
+            }
+            let lat_data = event_data.event_data_immut("dsq_lat_us");
+            let non_zero: Vec<u64> = lat_data.into_iter().filter(|&v| v > 0).collect();
+            if non_zero.is_empty() {
+                continue;
+            }
+            let lat_stats = VecStats::new(&non_zero, Some(percentile_set.clone()));
+            let nr_queued_data = event_data.event_data_immut("dsq_nr_queued");
+            let nr_non_zero: Vec<u64> = nr_queued_data.into_iter().filter(|&v| v > 0).collect();
+            let nr_stats = VecStats::new(&nr_non_zero, None);
+
+            let pmap = lat_stats.percentiles.as_ref();
+            entries.push(DsqEntry {
+                dsq_id: *dsq_id,
+                p50: pmap
+                    .and_then(|m| m.get(&StatAggregation::P50))
+                    .copied()
+                    .unwrap_or(0),
+                p90: pmap
+                    .and_then(|m| m.get(&StatAggregation::P90))
+                    .copied()
+                    .unwrap_or(0),
+                p99: pmap
+                    .and_then(|m| m.get(&StatAggregation::P99))
+                    .copied()
+                    .unwrap_or(0),
+                avg: lat_stats.avg,
+                max: lat_stats.max,
+                q_max: nr_stats.max,
+                count: non_zero.len(),
+            });
+        }
+
+        // Sort by avg desc, then p99 desc, then q_max desc
+        entries.sort_by(|a, b| {
+            b.avg
+                .cmp(&a.avg)
+                .then(b.p99.cmp(&a.p99))
+                .then(b.q_max.cmp(&a.q_max))
+        });
+
+        let row_count = entries.len();
+
+        let rows: Vec<Row> = entries
+            .iter()
+            .map(|e| {
+                let color = Self::latency_group_color(e.p90, params.theme);
+                Row::new(vec![
+                    Cell::from(format!("{:#X}", e.dsq_id)),
+                    Cell::from(format!("{}", e.p50)),
+                    Cell::from(format!("{}", e.p90)),
+                    Cell::from(format!("{}", e.p99)),
+                    Cell::from(format!("{}", e.avg)),
+                    Cell::from(format!("{}", e.max)),
+                    Cell::from(format!("{}", e.q_max)),
+                    Cell::from(format!("{}", e.count)),
+                ])
+                .style(Style::default().fg(color))
+            })
+            .collect();
+
+        let header = Row::new(vec![
+            Cell::from("DSQ"),
+            Cell::from("p50"),
+            Cell::from("p90"),
+            Cell::from("p99"),
+            Cell::from("avg ▼"),
+            Cell::from("max"),
+            Cell::from("q_max"),
+            Cell::from("count"),
+        ])
+        .style(params.theme.text_color())
+        .bold()
+        .underlined();
+
+        let constraints = vec![
+            Constraint::Min(14),
+            Constraint::Min(8),
+            Constraint::Min(8),
+            Constraint::Min(8),
+            Constraint::Min(8),
+            Constraint::Min(8),
+            Constraint::Min(8),
+            Constraint::Min(8),
+        ];
+
         let block = Block::bordered()
+            .border_type(BorderType::Rounded)
+            .border_style(params.theme.border_style())
             .title_top(
-                Line::from(params.scheduler_name.to_string())
-                    .style(params.theme.title_style())
-                    .centered(),
+                Line::from(format!(
+                    "{} DSQ Latency Summary (μs)",
+                    params.scheduler_name
+                ))
+                .style(params.theme.title_style())
+                .centered(),
             )
             .title_top(
-                Line::from(format!("{}ms", params.tick_rate_ms))
+                Line::from(vec![
+                    Span::styled("f", params.theme.text_important_color()),
+                    Span::styled(
+                        if params.filtering {
+                            format!("ilter DSQ: {}_", params.filter_input)
+                        } else if !params.dsq_filter_text.is_empty() {
+                            format!("ilter DSQ: {}", params.dsq_filter_text)
+                        } else {
+                            "ilter".to_string()
+                        },
+                        params.theme.text_color(),
+                    ),
+                ])
+                .left_aligned(),
+            )
+            .title_top(
+                Line::from(format!("sample rate {}", params.sample_rate))
                     .style(params.theme.text_important_color())
                     .right_aligned(),
-            )
-            .title_bottom(
-                Line::from(format!("keep_last {}", params.dispatch_keep_last))
-                    .style(params.theme.text_important_color())
-                    .right_aligned(),
-            )
-            .title_bottom(
-                Line::from(format!("select_fall {}", params.select_cpu_fallback))
-                    .style(params.theme.text_important_color())
-                    .left_aligned(),
-            )
-            .style(params.theme.border_style())
-            .border_type(BorderType::Rounded);
+            );
 
-        frame.render_widget(paragraph.block(block), area);
+        let table = Table::new(rows, constraints)
+            .header(header)
+            .block(block)
+            .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+        frame.render_stateful_widget(table, area, table_state);
 
-        Ok(())
+        // Scrollbar
+        let visible_rows = area.height.saturating_sub(4) as usize;
+        if row_count > visible_rows {
+            let scrollbar = Scrollbar::default()
+                .orientation(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(Some("↑"))
+                .end_symbol(Some("↓"));
+            let scroll_pos = table_state.selected().unwrap_or(0);
+            let mut scrollbar_state = ScrollbarState::new(row_count).position(scroll_pos);
+            frame.render_stateful_widget(
+                scrollbar,
+                area.inner(ratatui::layout::Margin {
+                    vertical: 1,
+                    horizontal: 0,
+                }),
+                &mut scrollbar_state,
+            );
+        }
+
+        Ok(row_count)
+    }
+
+    /// Renders per-process scheduling latency table.
+    /// Returns the number of rows for scroll state management.
+    pub fn render_process_latency_table(
+        frame: &mut Frame,
+        area: Rect,
+        params: &ProcessLatencyParams,
+        table_state: &mut TableState,
+    ) -> Result<usize> {
+        let percentile_set: HashSet<StatAggregation> = [
+            StatAggregation::P50,
+            StatAggregation::P90,
+            StatAggregation::P99,
+        ]
+        .into_iter()
+        .collect();
+
+        struct ProcEntry {
+            pid: i32,
+            comm: String,
+            dsq: String,
+            cpu: i32,
+            p50: u64,
+            p90: u64,
+            p99: u64,
+            slice_avg_us: u64,
+            count: usize,
+        }
+
+        let mut entries: Vec<ProcEntry> = Vec::new();
+
+        for (pid, proc_data) in params.proc_data.iter() {
+            if !params.dsq_filter_text.is_empty() {
+                let proc_dsq_hex = proc_data
+                    .dsq
+                    .map(|d| format!("{:#X}", d))
+                    .unwrap_or_default();
+                let filter_upper = params.dsq_filter_text.to_uppercase();
+                if !proc_dsq_hex.to_uppercase().contains(&filter_upper) {
+                    continue;
+                }
+            }
+            let lat_data = proc_data.event_data_immut("lat_us");
+            let non_zero: Vec<u64> = lat_data.into_iter().filter(|&v| v > 0).collect();
+            if non_zero.is_empty() {
+                continue;
+            }
+            let lat_stats = VecStats::new(&non_zero, Some(percentile_set.clone()));
+            let pmap = lat_stats.percentiles.as_ref();
+
+            let slice_data = proc_data.event_data_immut("slice_consumed");
+            let slice_non_zero: Vec<u64> = slice_data.into_iter().filter(|&v| v > 0).collect();
+            let slice_stats = VecStats::new(&slice_non_zero, None);
+
+            entries.push(ProcEntry {
+                pid: *pid,
+                comm: proc_data.process_name.clone(),
+                dsq: proc_data
+                    .dsq
+                    .map(|d| format!("{:#X}", d))
+                    .unwrap_or_default(),
+                cpu: proc_data.cpu,
+                p50: pmap
+                    .and_then(|m| m.get(&StatAggregation::P50))
+                    .copied()
+                    .unwrap_or(0),
+                p90: pmap
+                    .and_then(|m| m.get(&StatAggregation::P90))
+                    .copied()
+                    .unwrap_or(0),
+                p99: pmap
+                    .and_then(|m| m.get(&StatAggregation::P99))
+                    .copied()
+                    .unwrap_or(0),
+                slice_avg_us: slice_stats.avg / 1000, // ns to μs
+                count: non_zero.len(),
+            });
+        }
+
+        // Sort by p90 descending (highest latency first)
+        entries.sort_by(|a, b| b.p90.cmp(&a.p90));
+
+        let header = Row::new(vec![
+            Cell::from("PID"),
+            Cell::from("COMM"),
+            Cell::from("DSQ"),
+            Cell::from("CPU"),
+            Cell::from("lat p50"),
+            Cell::from("lat p90"),
+            Cell::from("lat p99"),
+            Cell::from("slice(μs)"),
+            Cell::from("count"),
+        ])
+        .style(params.theme.text_color())
+        .bold()
+        .underlined();
+
+        let constraints = vec![
+            Constraint::Min(8),
+            Constraint::Min(16),
+            Constraint::Min(14),
+            Constraint::Min(5),
+            Constraint::Min(8),
+            Constraint::Min(8),
+            Constraint::Min(8),
+            Constraint::Min(10),
+            Constraint::Min(8),
+        ];
+
+        let rows: Vec<Row> = entries
+            .iter()
+            .map(|e| {
+                let color = Self::latency_group_color(e.p90, params.theme);
+                Row::new(vec![
+                    Cell::from(format!("{}", e.pid)),
+                    Cell::from(e.comm.clone()),
+                    Cell::from(e.dsq.clone()),
+                    Cell::from(format!("{}", e.cpu)),
+                    Cell::from(format!("{}", e.p50)),
+                    Cell::from(format!("{}", e.p90)),
+                    Cell::from(format!("{}", e.p99)),
+                    Cell::from(format!("{}", e.slice_avg_us)),
+                    Cell::from(format!("{}", e.count)),
+                ])
+                .style(Style::default().fg(color))
+            })
+            .collect();
+
+        let block = Block::bordered()
+            .border_type(BorderType::Rounded)
+            .border_style(params.theme.border_style())
+            .title_top(
+                Line::from(format!(
+                    "Process Scheduling Latency (μs) ({} procs)",
+                    entries.len()
+                ))
+                .style(params.theme.title_style())
+                .centered(),
+            );
+
+        let row_count = entries.len();
+
+        let table = Table::new(rows, constraints)
+            .header(header)
+            .block(block)
+            .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+        frame.render_stateful_widget(table, area, table_state);
+
+        // Scrollbar
+        let visible_rows = area.height.saturating_sub(4) as usize;
+        if row_count > visible_rows {
+            let scrollbar = Scrollbar::default()
+                .orientation(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(Some("↑"))
+                .end_symbol(Some("↓"));
+            let scroll_pos = table_state.selected().unwrap_or(0);
+            let mut scrollbar_state = ScrollbarState::new(row_count).position(scroll_pos);
+            frame.render_stateful_widget(
+                scrollbar,
+                area.inner(ratatui::layout::Margin {
+                    vertical: 1,
+                    horizontal: 0,
+                }),
+                &mut scrollbar_state,
+            );
+        }
+
+        Ok(row_count)
+    }
+
+    /// Returns color based on latency group thresholds (similar to rsched)
+    fn latency_group_color(p90_us: u64, theme: &AppTheme) -> Color {
+        // Latency groups matching rsched:
+        // <10μs green, 10-100μs light green, 100-1000μs yellow, 1-10ms orange, >10ms red
+        theme.gradient_5(p90_us as f64, 10.0, 100.0, 1000.0, 10000.0, false)
     }
 
     /// Renders the scheduler state as sparklines.
@@ -256,7 +586,6 @@ impl SchedulerRenderer {
         let barchart = BarChart::default()
             .data(BarGroup::default().bars(&dsq_bars))
             .block(bar_block)
-            .max(stats.max)
             .direction(Direction::Horizontal)
             .bar_gap(0)
             .bar_width(1);
@@ -347,11 +676,9 @@ impl SchedulerRenderer {
     }
 
     /// Generates a DSQ bar chart.
-    #[allow(clippy::too_many_arguments)]
     fn dsq_bar(
         dsq: u64,
         value: u64,
-        avg: u64,
         max: u64,
         min: u64,
         localize: bool,
@@ -363,17 +690,7 @@ impl SchedulerRenderer {
         Bar::default()
             .value(value)
             .style(Style::default().fg(gradient_color))
-            .label(Line::from(if localize {
-                format!(
-                    "{:#X} avg {} max {} min {}",
-                    dsq,
-                    sanitize_nbsp(avg.to_formatted_string(locale)),
-                    sanitize_nbsp(max.to_formatted_string(locale)),
-                    sanitize_nbsp(min.to_formatted_string(locale))
-                )
-            } else {
-                format!("{dsq:#X} avg {avg} max {max} min {min}",)
-            }))
+            .label(Line::from(format!("{dsq:#X}")))
             .text_value(if localize {
                 sanitize_nbsp(value.to_formatted_string(locale))
             } else {
@@ -397,7 +714,7 @@ impl SchedulerRenderer {
                 let value = values.last().copied().unwrap_or(0_u64);
                 let stats = VecStats::new(&values, None);
                 Self::dsq_bar(
-                    *dsq_id, value, stats.avg, stats.max, stats.min, localize, locale, theme,
+                    *dsq_id, value, stats.max, stats.min, localize, locale, theme,
                 )
             })
             .collect()

--- a/tools/scxtop/tests/render_scheduler_tests.rs
+++ b/tools/scxtop/tests/render_scheduler_tests.rs
@@ -5,9 +5,10 @@
 
 use num_format::SystemLocale;
 use ratatui::backend::TestBackend;
+use ratatui::widgets::TableState;
 use ratatui::Terminal;
-use scxtop::render::scheduler::{SchedulerStatsParams, SchedulerViewParams};
-use scxtop::{render::SchedulerRenderer, AppTheme, EventData, ViewState};
+use scxtop::render::scheduler::{DsqSummaryParams, ProcessLatencyParams, SchedulerViewParams};
+use scxtop::{render::SchedulerRenderer, AppTheme, EventData, ProcData, ViewState};
 use std::collections::BTreeMap;
 
 // Helper function to create test DSQ data
@@ -221,31 +222,72 @@ fn test_render_scheduler_view_with_localization() {
 }
 
 #[test]
-fn test_render_scheduler_stats() {
-    let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
+fn test_render_dsq_summary_table() {
+    let mut terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    let dsq_data = create_test_dsq_data();
     let theme = AppTheme::Default;
 
     terminal
         .draw(|frame| {
             let area = frame.area();
-            let params = SchedulerStatsParams {
+            let params = DsqSummaryParams {
                 scheduler_name: "scx_rustland",
-                sched_stats_raw: "dispatch_count: 12345\nlocal: 98%\nglobal: 2%",
-                tick_rate_ms: 1000,
-                dispatch_keep_last: 100,
-                select_cpu_fallback: 50,
+                dsq_data: &dsq_data,
+                sample_rate: 1000,
+                dsq_filter_text: "",
+                filtering: false,
+                filter_input: "",
                 theme: &theme,
             };
-            let result = SchedulerRenderer::render_scheduler_stats(frame, area, &params);
+            let result = SchedulerRenderer::render_dsq_summary_table(
+                frame,
+                area,
+                &params,
+                &mut TableState::default(),
+            );
 
-            assert!(result.is_ok(), "render_scheduler_stats should succeed");
+            assert!(result.is_ok(), "render_dsq_summary_table should succeed");
         })
         .unwrap();
 }
 
 #[test]
-fn test_render_scheduler_stats_different_themes() {
-    let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
+fn test_render_dsq_summary_table_empty() {
+    let mut terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    let dsq_data = BTreeMap::new();
+    let theme = AppTheme::Default;
+
+    terminal
+        .draw(|frame| {
+            let area = frame.area();
+            let params = DsqSummaryParams {
+                scheduler_name: "scx_rustland",
+                dsq_data: &dsq_data,
+                sample_rate: 1000,
+                dsq_filter_text: "",
+                filtering: false,
+                filter_input: "",
+                theme: &theme,
+            };
+            let result = SchedulerRenderer::render_dsq_summary_table(
+                frame,
+                area,
+                &params,
+                &mut TableState::default(),
+            );
+
+            assert!(
+                result.is_ok(),
+                "render_dsq_summary_table with empty data should succeed"
+            );
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_render_dsq_summary_table_different_themes() {
+    let mut terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    let dsq_data = create_test_dsq_data();
 
     for theme in [
         AppTheme::Default,
@@ -255,24 +297,61 @@ fn test_render_scheduler_stats_different_themes() {
         terminal
             .draw(|frame| {
                 let area = frame.area();
-                let params = SchedulerStatsParams {
+                let params = DsqSummaryParams {
                     scheduler_name: "scx_rustland",
-                    sched_stats_raw: "test stats",
-                    tick_rate_ms: 1000,
-                    dispatch_keep_last: 100,
-                    select_cpu_fallback: 50,
+                    dsq_data: &dsq_data,
+                    sample_rate: 1000,
+                    dsq_filter_text: "",
+                    filtering: false,
+                    filter_input: "",
                     theme: &theme,
                 };
-                let result = SchedulerRenderer::render_scheduler_stats(frame, area, &params);
+                let result = SchedulerRenderer::render_dsq_summary_table(
+                    frame,
+                    area,
+                    &params,
+                    &mut TableState::default(),
+                );
 
                 assert!(
                     result.is_ok(),
-                    "render_scheduler_stats with {:?} theme should succeed",
+                    "render_dsq_summary_table with {:?} theme should succeed",
                     theme
                 );
             })
             .unwrap();
     }
+}
+
+#[test]
+fn test_render_process_latency_table() {
+    let mut terminal = Terminal::new(TestBackend::new(160, 40)).unwrap();
+    let theme = AppTheme::Default;
+
+    // Use empty proc_data since we can't easily create ProcData without /proc
+    let proc_data: BTreeMap<i32, ProcData> = BTreeMap::new();
+
+    terminal
+        .draw(|frame| {
+            let area = frame.area();
+            let params = ProcessLatencyParams {
+                proc_data: &proc_data,
+                dsq_filter_text: "",
+                theme: &theme,
+            };
+            let result = SchedulerRenderer::render_process_latency_table(
+                frame,
+                area,
+                &params,
+                &mut TableState::default(),
+            );
+
+            assert!(
+                result.is_ok(),
+                "render_process_latency_table should succeed"
+            );
+        })
+        .unwrap();
 }
 
 #[test]


### PR DESCRIPTION
- Replace scheduler stats panel with DSQ latency summary table showing p50/p90/p99/avg/max percentiles with rsched-style color coding
- Add per-process scheduling latency table with pid, comm, dsq, cpu, latency percentiles, slice consumption, and event count
- Add DSQ sparkline/barchart view sized to terminal width
- Add string-based DSQ filter (f key) with case-insensitive hex matching
- Add scrollbars and keyboard navigation (up/down/pgup/pgdn) for tables
- Default sort DSQ summary by avg desc, p99 desc, q_max desc
- Fix barchart horizontal bars not spanning full width
- Route filter key input for Scheduler state in main.rs

Example view of running `scx_cosmos`, where you can see kthreads being queued:
<img width="3456" height="1774" alt="image" src="https://github.com/user-attachments/assets/811ef701-5277-416f-adb7-262da858c563" />
