### PR TITLE
scx_layered: Force minimum of 1 CPU as upper bound when using cpus_range_frac

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1346,7 +1346,7 @@ fn resolve_cpus_pct_range(
             let cpus_max_count = ((max_cpus as f64) * cpus_frac_max).round_ties_even() as usize;
             Ok((
                 std::cmp::max(cpus_min_count, 1),
-                std::cmp::min(cpus_max_count, max_cpus),
+                std::cmp::min(std::cmp::max(cpus_max_count, 1), max_cpus),
             ))
         }
         (None, None) => Ok((0, max_cpus)),


### PR DESCRIPTION
The cpus_range_frac layer sizing option currently clamps the minimum layer size, but not the maximum. This causes edge the edge case that a small enough maximum CPU bound gets rounded down to 0, while the minimum is clamped down to 1. Consistently enforce the minimum CPU size of 1 for both the minimum and the maximum.