### PR TITLE
scxtop: pass wakeup timestamp in BPF event and add v2 dsq insert probes

### DIFF
--- a/tools/scxtop/src/bpf/intf.h
+++ b/tools/scxtop/src/bpf/intf.h
@@ -76,6 +76,7 @@ struct sched_switch_event {
 	u32  next_dsq_nr;
 	u64  next_dsq_vtime;
 	u64  next_slice_ns;
+	u64  next_wakeup_ts;
 	u32  next_pid;
 	u32  next_tgid;
 	int  next_prio;

--- a/tools/scxtop/src/bpf/main.bpf.c
+++ b/tools/scxtop/src/bpf/main.bpf.c
@@ -332,6 +332,36 @@ int BPF_KPROBE(scx_insert_vtime, struct task_struct *p, u64 dsq, u64 slice_ns,
 	return update_task_ctx(p, dsq, vtime, slice_ns);
 }
 
+/*
+ * __scx_bpf_dsq_insert_vtime takes a struct pointer as the second arg:
+ * struct scx_bpf_dsq_insert_vtime_args { u64 dsq_id, slice, vtime, enq_flags; }
+ * This is the current canonical vtime insert on 6.19+ kernels.
+ */
+SEC("kprobe/__scx_bpf_dsq_insert_vtime")
+int BPF_KPROBE(scx_insert_vtime_args, struct task_struct *p, void *args)
+{
+	if (!enable_bpf_events)
+		return 0;
+
+	struct task_ctx *tctx;
+
+	if (!(tctx = try_lookup_task_ctx(p)))
+		return -ENOENT;
+
+	u64 dsq_id = 0, slice = 0, vtime = 0;
+
+	bpf_probe_read_kernel(&dsq_id, sizeof(dsq_id), args);
+	bpf_probe_read_kernel(&slice, sizeof(slice), args + sizeof(u64));
+	bpf_probe_read_kernel(&vtime, sizeof(vtime), args + 2 * sizeof(u64));
+
+	tctx->dsq_insert_time = bpf_ktime_get_ns();
+	tctx->dsq_id	      = dsq_id;
+	tctx->dsq_vtime	      = vtime;
+	tctx->slice_ns	      = slice;
+
+	return 0;
+}
+
 SEC("kprobe/scx_bpf_dispatch_vtime")
 int BPF_KPROBE(scx_dispatch_vtime, struct task_struct *p, u64 dsq, u64 slice_ns,
 	       u64 vtime)
@@ -358,6 +388,12 @@ static int on_insert(struct task_struct *p, u64 dsq)
 
 SEC("kprobe/scx_bpf_dsq_insert")
 int BPF_KPROBE(scx_insert, struct task_struct *p, u64 dsq)
+{
+	return on_insert(p, dsq);
+}
+
+SEC("kprobe/scx_bpf_dsq_insert___v2")
+int BPF_KPROBE(scx_insert_v2, struct task_struct *p, u64 dsq)
 {
 	return on_insert(p, dsq);
 }
@@ -749,6 +785,10 @@ int BPF_PROG(on_sched_switch, bool preempt, struct task_struct *prev,
 			event->event.sched_switch.next_pid  = next->pid;
 			event->event.sched_switch.next_tgid = next->tgid;
 			event->event.sched_switch.next_prio = (int)next->prio;
+			// Pass wakeup timestamp directly so userspace doesn't
+			// need to correlate across ring buffers
+			event->event.sched_switch.next_wakeup_ts =
+				next_tctx ? next_tctx->wakeup_ts : 0;
 			record_real_comm(event->event.sched_switch.next_comm,
 					 next);
 
@@ -785,6 +825,7 @@ int BPF_PROG(on_sched_switch, bool preempt, struct task_struct *prev,
 			}
 		} else {
 			event->event.sched_switch.next_dsq_lat_us = 0;
+			event->event.sched_switch.next_wakeup_ts  = 0;
 			event->event.sched_switch.next_pid	  = 0;
 			event->event.sched_switch.next_tgid	  = 0;
 		}

--- a/tools/scxtop/src/main.rs
+++ b/tools/scxtop/src/main.rs
@@ -205,8 +205,16 @@ fn attach_progs_selective(
         safe_attach!(skel.progs.scx_insert_vtime, "scx_insert_vtime");
         safe_attach!(skel.progs.scx_insert, "scx_insert");
         safe_attach!(skel.progs.scx_dsq_move, "scx_dsq_move");
+        safe_attach!(skel.progs.scx_dsq_move_vtime, "scx_dsq_move_vtime");
         safe_attach!(skel.progs.scx_dsq_move_set_vtime, "scx_dsq_move_set_vtime");
         safe_attach!(skel.progs.scx_dsq_move_set_slice, "scx_dsq_move_set_slice");
+        // v2 API variants (6.19+) - schedulers call these directly via compat macros
+        if compat::ksym_exists("scx_bpf_dsq_insert___v2")? {
+            safe_attach!(skel.progs.scx_insert_v2, "scx_insert_v2");
+        }
+        if compat::ksym_exists("__scx_bpf_dsq_insert_vtime")? {
+            safe_attach!(skel.progs.scx_insert_vtime_args, "scx_insert_vtime_args");
+        }
     } else {
         safe_attach!(skel.progs.scx_dispatch, "scx_dispatch");
         safe_attach!(skel.progs.scx_dispatch_vtime, "scx_dispatch_vtime");
@@ -219,6 +227,10 @@ fn attach_progs_selective(
             "scx_dispatch_from_dsq_set_slice"
         );
         safe_attach!(skel.progs.scx_dispatch_from_dsq, "scx_dispatch_from_dsq");
+        safe_attach!(
+            skel.progs.scx_dispatch_vtime_from_dsq,
+            "scx_dispatch_vtime_from_dsq"
+        );
     }
 
     // Optional probes
@@ -358,11 +370,25 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
                 if let Ok(link) = skel.progs.scx_dsq_move.attach() {
                     links.push(link);
                 }
+                if let Ok(link) = skel.progs.scx_dsq_move_vtime.attach() {
+                    links.push(link);
+                }
                 if let Ok(link) = skel.progs.scx_dsq_move_set_vtime.attach() {
                     links.push(link);
                 }
                 if let Ok(link) = skel.progs.scx_dsq_move_set_slice.attach() {
                     links.push(link);
+                }
+                // v2 API variants (6.19+)
+                if compat::ksym_exists("scx_bpf_dsq_insert___v2")? {
+                    if let Ok(link) = skel.progs.scx_insert_v2.attach() {
+                        links.push(link);
+                    }
+                }
+                if compat::ksym_exists("__scx_bpf_dsq_insert_vtime")? {
+                    if let Ok(link) = skel.progs.scx_insert_vtime_args.attach() {
+                        links.push(link);
+                    }
                 }
             } else {
                 if let Ok(link) = skel.progs.scx_dispatch.attach() {
@@ -378,6 +404,9 @@ fn run_trace(trace_args: &TraceArgs) -> Result<()> {
                     links.push(link);
                 }
                 if let Ok(link) = skel.progs.scx_dispatch_from_dsq.attach() {
+                    links.push(link);
+                }
+                if let Ok(link) = skel.progs.scx_dispatch_vtime_from_dsq.attach() {
                     links.push(link);
                 }
             }

--- a/tools/scxtop/src/mcp/shared_state.rs
+++ b/tools/scxtop/src/mcp/shared_state.rs
@@ -69,10 +69,6 @@ pub struct SharedStats {
     pub cpu_stats: BTreeMap<usize, CpuStats>,
     pub process_stats: BTreeMap<i32, ProcessStats>,
     pub dsq_stats: BTreeMap<u64, DsqStats>,
-    /// Track pending wakeups per-thread (TID) to avoid overwriting when multiple
-    /// threads from the same process wake up before being scheduled.
-    /// Note: In Linux kernel scheduling events, the "pid" field is actually the TID.
-    pub pending_wakeups: BTreeMap<i32, u64>, // tid -> wakeup_timestamp_ns
     pub start_time_ns: u64,
     /// Flag to control whether stat tracking is enabled. When false, update_from_event
     /// does no work, providing significant performance improvement when stats aren't needed.
@@ -85,7 +81,6 @@ impl Default for SharedStats {
             cpu_stats: BTreeMap::new(),
             process_stats: BTreeMap::new(),
             dsq_stats: BTreeMap::new(),
-            pending_wakeups: BTreeMap::new(),
             start_time_ns: crate::util::get_clock_value(libc::CLOCK_BOOTTIME),
             tracking_enabled: false, // Disabled by default for performance
         }
@@ -125,8 +120,6 @@ impl SharedStats {
                 self.handle_sched_wakeup(event)
             }
             bpf_intf::event_type_SCHED_MIGRATE => self.handle_sched_migrate(event),
-            bpf_intf::event_type_EXIT => self.handle_exit(event),
-            bpf_intf::event_type_EXEC => self.handle_exec(event),
             _ => {}
         }
     }
@@ -144,10 +137,13 @@ impl SharedStats {
         cpu_stats.cpu_id = cpu_id;
         cpu_stats.nr_switches += 1;
 
-        // Check if this thread was previously woken up (tracks per-TID to avoid
-        // losing wakeup events when multiple threads in same process wake up)
-        if let Some(wakeup_ts) = self.pending_wakeups.remove(&next_tid) {
-            let latency_ns = timestamp_ns.saturating_sub(wakeup_ts);
+        // Use wakeup timestamp from the BPF event directly rather than
+        // correlating wakeup/switch events in userspace. Multi-ringbuffer
+        // delivery can reorder events across CPUs, causing stale entries
+        // in pending_wakeups and massively inflated latency measurements.
+        let wakeup_ts = sched_switch.next_wakeup_ts;
+        if wakeup_ts > 0 && timestamp_ns > wakeup_ts {
+            let latency_ns = timestamp_ns - wakeup_ts;
 
             // Update CPU latency stats
             cpu_stats.total_latency_ns = cpu_stats.total_latency_ns.saturating_add(latency_ns);
@@ -209,11 +205,6 @@ impl SharedStats {
         // Note: wakeup.pid is actually the TID (Thread ID) in kernel scheduling events
         let tid = wakeup.pid as i32;
         let tgid = wakeup.tgid as i32; // Actual process ID
-        let timestamp_ns = event.ts;
-
-        // Store wakeup timestamp per-thread (TID) for accurate latency calculation
-        // This prevents losing wakeup events when multiple threads wake up before scheduling
-        self.pending_wakeups.insert(tid, timestamp_ns);
 
         // Update CPU wakeup count
         let cpu_stats = self.cpu_stats.entry(cpu_id).or_default();
@@ -239,24 +230,6 @@ impl SharedStats {
         let cpu_stats = self.cpu_stats.entry(cpu_id).or_default();
         cpu_stats.cpu_id = cpu_id;
         cpu_stats.nr_migrations += 1;
-    }
-
-    fn handle_exit(&mut self, event: &bpf_event) {
-        let exit = unsafe { &event.event.exit };
-        let tid = exit.pid as i32;
-
-        // Clean up stale wakeup timestamp to prevent TID reuse from causing
-        // inflated latency measurements
-        self.pending_wakeups.remove(&tid);
-    }
-
-    fn handle_exec(&mut self, event: &bpf_event) {
-        let exec = unsafe { &event.event.exec };
-        let tid = exec.pid as i32;
-
-        // Clean up wakeup timestamp on exec since the thread identity has changed
-        // Latency measurements from before exec() are not meaningful for the new program
-        self.pending_wakeups.remove(&tid);
     }
 
     /// Get CPU stats as JSON

--- a/tools/scxtop/tests/mcp_shared_state_tests.rs
+++ b/tools/scxtop/tests/mcp_shared_state_tests.rs
@@ -26,6 +26,28 @@ fn create_sched_switch_event(
     next_dsq_id: u64,
     prev_dsq_id: u64,
 ) -> bpf_event {
+    create_sched_switch_event_with_wakeup(
+        cpu,
+        timestamp_ns,
+        prev_pid,
+        next_pid,
+        next_comm,
+        next_dsq_id,
+        prev_dsq_id,
+        0,
+    )
+}
+
+fn create_sched_switch_event_with_wakeup(
+    cpu: u32,
+    timestamp_ns: u64,
+    prev_pid: u32,
+    next_pid: u32,
+    next_comm: &str,
+    next_dsq_id: u64,
+    prev_dsq_id: u64,
+    next_wakeup_ts: u64,
+) -> bpf_event {
     let mut event: bpf_event = unsafe { MaybeUninit::zeroed().assume_init() };
     event.r#type = bpf_intf::event_type_SCHED_SWITCH as i32;
     event.cpu = cpu;
@@ -36,6 +58,7 @@ fn create_sched_switch_event(
         event.event.sched_switch.next_pid = next_pid;
         event.event.sched_switch.next_dsq_id = next_dsq_id;
         event.event.sched_switch.prev_dsq_id = prev_dsq_id;
+        event.event.sched_switch.next_wakeup_ts = next_wakeup_ts;
 
         // Copy command name
         let comm_bytes = next_comm.as_bytes();
@@ -163,7 +186,6 @@ fn test_sched_wakeup_updates_stats() {
     assert_eq!(stats.cpu_stats.len(), 1);
     let cpu_stats = stats.cpu_stats.get(&0).unwrap();
     assert_eq!(cpu_stats.nr_wakeups, 1);
-    assert!(stats.pending_wakeups.contains_key(&200));
 
     // Verify process stats
     assert_eq!(stats.process_stats.len(), 1);
@@ -177,12 +199,17 @@ fn test_wakeup_latency_calculation() {
     let mut stats = SharedStats::new();
     stats.enable_tracking();
 
-    // Wakeup at t=1000000
-    let wakeup = create_sched_wakeup_event(0, 1000000, 200, "test_proc");
-    stats.update_from_event(&wakeup);
-
-    // Switch at t=1500000 (latency = 500000)
-    let switch = create_sched_switch_event(0, 1500000, 100, 200, "test_proc", u64::MAX, u64::MAX);
+    // Switch at t=1500000 with wakeup_ts=1000000 (latency = 500000)
+    let switch = create_sched_switch_event_with_wakeup(
+        0,
+        1500000,
+        100,
+        200,
+        "test_proc",
+        u64::MAX,
+        u64::MAX,
+        1000000,
+    );
     stats.update_from_event(&switch);
 
     // Verify CPU latency stats
@@ -198,9 +225,6 @@ fn test_wakeup_latency_calculation() {
     assert_eq!(proc_stats.min_latency_ns, 500000);
     assert_eq!(proc_stats.max_latency_ns, 500000);
     assert_eq!(proc_stats.latency_samples, 1);
-
-    // Pending wakeup should be removed
-    assert!(!stats.pending_wakeups.contains_key(&200));
 }
 
 #[test]
@@ -208,22 +232,43 @@ fn test_multiple_latency_samples() {
     let mut stats = SharedStats::new();
     stats.enable_tracking();
 
-    // First wakeup/switch pair (latency = 500000)
-    let wakeup1 = create_sched_wakeup_event(0, 1000000, 200, "test_proc");
-    stats.update_from_event(&wakeup1);
-    let switch1 = create_sched_switch_event(0, 1500000, 100, 200, "test_proc", u64::MAX, u64::MAX);
+    // First switch with wakeup_ts (latency = 500000)
+    let switch1 = create_sched_switch_event_with_wakeup(
+        0,
+        1500000,
+        100,
+        200,
+        "test_proc",
+        u64::MAX,
+        u64::MAX,
+        1000000,
+    );
     stats.update_from_event(&switch1);
 
-    // Second wakeup/switch pair (latency = 300000)
-    let wakeup2 = create_sched_wakeup_event(0, 2000000, 200, "test_proc");
-    stats.update_from_event(&wakeup2);
-    let switch2 = create_sched_switch_event(0, 2300000, 100, 200, "test_proc", u64::MAX, u64::MAX);
+    // Second switch with wakeup_ts (latency = 300000)
+    let switch2 = create_sched_switch_event_with_wakeup(
+        0,
+        2300000,
+        100,
+        200,
+        "test_proc",
+        u64::MAX,
+        u64::MAX,
+        2000000,
+    );
     stats.update_from_event(&switch2);
 
-    // Third wakeup/switch pair (latency = 700000)
-    let wakeup3 = create_sched_wakeup_event(0, 3000000, 200, "test_proc");
-    stats.update_from_event(&wakeup3);
-    let switch3 = create_sched_switch_event(0, 3700000, 100, 200, "test_proc", u64::MAX, u64::MAX);
+    // Third switch with wakeup_ts (latency = 700000)
+    let switch3 = create_sched_switch_event_with_wakeup(
+        0,
+        3700000,
+        100,
+        200,
+        "test_proc",
+        u64::MAX,
+        u64::MAX,
+        3000000,
+    );
     stats.update_from_event(&switch3);
 
     let proc_stats = stats.process_stats.get(&200).unwrap();
@@ -299,7 +344,16 @@ fn test_get_cpu_stats_json() {
     let wakeup = create_sched_wakeup_event(0, 1000000, 200, "test");
     stats.update_from_event(&wakeup);
 
-    let switch = create_sched_switch_event(0, 1500000, 100, 200, "test", u64::MAX, u64::MAX);
+    let switch = create_sched_switch_event_with_wakeup(
+        0,
+        1500000,
+        100,
+        200,
+        "test",
+        u64::MAX,
+        u64::MAX,
+        1000000,
+    );
     stats.update_from_event(&switch);
 
     let json = stats.get_cpu_stats_json();


### PR DESCRIPTION
Pass wakeup_ts directly in the sched_switch BPF event instead of correlating wakeup/switch events in userspace via pending_wakeups. Multi-ringbuffer delivery can reorder events across CPUs, causing stale entries and inflated latency measurements. By embedding the timestamp from the BPF task_ctx, latency calculation becomes self-contained per event.

Also add kprobe handlers for the v2 dsq insert API variants (__scx_bpf_dsq_insert_vtime and scx_bpf_dsq_insert___v2) used on 6.19+ kernels, and attach scx_dsq_move_vtime and scx_dispatch_vtime_from_dsq.