### PR TITLE
mitosis: fix lsp config and warnings

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,22 +1,51 @@
 #!/bin/sh
 
+# Mirror CI lint checks locally.
+# CI reference: .github/workflows/ci.yml (lint job)
+
+# Run all formatting first so clippy caches the post-formatted state.
+# If formatting runs after clippy, the file mutations invalidate
+# clippy's fingerprints for the next run.
+
+if command -v clang-format >/dev/null 2>&1; then
+    echo "Running clang-format..."
+    # Same dirs as CI
+    find tools/scxtop scheds/rust/scx_chaos scheds/rust/scx_mitosis \
+        \( -name '*.c' -o -name '*.h' \) 2>/dev/null | while read -r file; do
+        clang-format -i "$file"
+    done
+else
+    echo "Warning: clang-format not found, skipping C formatting"
+fi
+
 if command -v cargo >/dev/null 2>&1; then
     echo "Running cargo fmt..."
     cargo fmt --all
+
+    echo "Running clippy..."
+    if command -v jq >/dev/null 2>&1; then
+        clippy_args=""
+        for pkg in $(cargo metadata --format-version 1 | \
+            jq -r '.packages[] | select(.metadata.scx.ci.use_clippy == true) | .name'); do
+            clippy_args="$clippy_args -p $pkg"
+        done
+        if [ -n "$clippy_args" ]; then
+            if ! cargo clippy --no-deps --locked $clippy_args -- -Dwarnings; then
+                echo "Error: clippy failed, commit aborted"
+                exit 1
+            fi
+        fi
+    else
+        echo "Warning: jq not found, skipping clippy"
+    fi
 else
-    echo "Warning: cargo not found, skipping Rust formatting"
+    echo "Warning: cargo not found, skipping Rust formatting and clippy"
 fi
 
-if command -v clang-format >/dev/null 2>&1; then
-    echo "Running clang-format on scx_mitosis"
-    for file in scheds/rust/scx_mitosis/src/bpf/*.c scheds/rust/scx_mitosis/src/bpf/*.h; do
-        [ -f "$file" ] && clang-format -i "$file"
-    done
-else
-    echo "Warning: clang-format not found, skipping formatting"
+# Stage any formatting changes
+changed=$(git diff --name-only)
+if [ -n "$changed" ]; then
+    git add $changed
 fi
-
-git add $(git diff --name-only)
 
 exit 0
-

--- a/scheds/rust/scx_mitosis/Cargo.toml
+++ b/scheds/rust/scx_mitosis/Cargo.toml
@@ -8,6 +8,9 @@ license = "GPL-2.0-only"
 
 publish = false
 
+[package.metadata.scx]
+ci.use_clippy = true
+
 [dependencies]
 anyhow = "1"
 bitvec = "1"

--- a/scheds/rust/scx_mitosis/src/bpf/cell_cpumask.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/cell_cpumask.bpf.h
@@ -25,12 +25,13 @@
 #ifdef LSP
 #define __bpf__
 #include "../../../../include/scx/common.bpf.h"
+#include "../../../../include/lib/cleanup.bpf.h"
 #else
 #include <scx/common.bpf.h>
+#include <lib/cleanup.bpf.h>
 #endif
 
 #include "intf.h"
-#include <lib/cleanup.bpf.h>
 
 /*
  * One publishable cell cpumask slot.

--- a/scheds/rust/scx_mitosis/src/bpf/dsq.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/dsq.bpf.h
@@ -10,6 +10,15 @@
  */
 #pragma once
 
+#ifdef LSP
+#define __bpf__
+#include "../../../../include/scx/common.bpf.h"
+#include "../../../../include/lib/cleanup.bpf.h"
+#else
+#include <scx/common.bpf.h>
+#include <lib/cleanup.bpf.h>
+#endif
+
 #include "intf.h"
 
 /*

--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -12,6 +12,13 @@ typedef unsigned int u32;
 typedef _Bool bool;
 #endif
 
+#ifdef LSP
+#define __bpf__
+typedef unsigned long long u64;
+typedef unsigned int u32;
+typedef _Bool bool;
+#endif
+
 enum consts {
 	CACHELINE_SIZE = 64,
 	MAX_CPUS_SHIFT = 9,

--- a/scheds/rust/scx_mitosis/src/bpf/llc_aware.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/llc_aware.bpf.h
@@ -11,6 +11,10 @@
  */
 #pragma once
 
+#ifdef LSP
+#define __bpf__
+#endif
+
 #include "mitosis.bpf.h"
 #include "intf.h"
 
@@ -190,10 +194,10 @@ static void zero_cell_vtimes(struct cell *cell)
 		u32 llc_idx;
 		bpf_for(llc_idx, 0, MAX_LLCS)
 		{
-			WRITE_ONCE(cell->llcs[llc_idx].vtime_now, 0);
+			(void)WRITE_ONCE(cell->llcs[llc_idx].vtime_now, 0);
 		}
 	} else {
-		WRITE_ONCE(cell->llcs[FAKE_FLAT_CELL_LLC].vtime_now, 0);
+		(void)WRITE_ONCE(cell->llcs[FAKE_FLAT_CELL_LLC].vtime_now, 0);
 	}
 }
 

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -251,7 +251,7 @@ static inline int free_cell(int cell_idx)
 	if (!(c = lookup_cell(cell_idx)))
 		return -1;
 
-	WRITE_ONCE(c->in_use, 0);
+	(void)WRITE_ONCE(c->in_use, 0);
 	return 0;
 }
 
@@ -907,7 +907,7 @@ static inline struct cpumask_entry *allocate_cpumask_entry()
 
 static inline void free_cpumask_entry(struct cpumask_entry *entry)
 {
-	WRITE_ONCE(entry->used, 0);
+	(void)WRITE_ONCE(entry->used, 0);
 }
 
 /* Cpumask entry — uses RAII framework from mitosis.bpf.h */
@@ -1109,7 +1109,7 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 				 * cgroup's ancestor's cells in level_cells.
 				 */
 				u32 parent_cell = level_cells[level - 1];
-				WRITE_ONCE(cgrp_ctx->cell, parent_cell);
+				(void)WRITE_ONCE(cgrp_ctx->cell, parent_cell);
 				level_cells[level] = parent_cell;
 			}
 			continue;
@@ -1168,7 +1168,7 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 		}
 
 		barrier();
-		WRITE_ONCE(cgrp_ctx->cell, cell_idx);
+		(void)WRITE_ONCE(cgrp_ctx->cell, cell_idx);
 		u32 level = cur_cgrp->level;
 		if (level <= 0 || level >= MAX_CG_DEPTH) {
 			scx_bpf_error("Cgroup hierarchy is too deep: %d", level);
@@ -1210,7 +1210,7 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 	}
 
 	barrier();
-	WRITE_ONCE(applied_configuration_seq, local_configuration_seq);
+	(void)WRITE_ONCE(applied_configuration_seq, local_configuration_seq);
 
 	return 0;
 }
@@ -1221,7 +1221,7 @@ static inline void advance_cell_llc_vtime(struct cell *cell, struct task_ctx *tc
 									FAKE_FLAT_CELL_LLC;
 
 	if (time_before(READ_ONCE(cell->llcs[llc_idx].vtime_now), task_vtime))
-		WRITE_ONCE(cell->llcs[llc_idx].vtime_now, task_vtime);
+		(void)WRITE_ONCE(cell->llcs[llc_idx].vtime_now, task_vtime);
 }
 
 void BPF_STRUCT_OPS(mitosis_running, struct task_struct *p)
@@ -1290,7 +1290,7 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 	 */
 	if (!tctx->borrowed) {
 		if (time_before(READ_ONCE(cctx->vtime_now), p->scx.dsq_vtime))
-			WRITE_ONCE(cctx->vtime_now, p->scx.dsq_vtime);
+			(void)WRITE_ONCE(cctx->vtime_now, p->scx.dsq_vtime);
 	}
 
 	/* Clear the borrowed flag — it is one-shot, consumed above */
@@ -1365,7 +1365,7 @@ static int init_cgrp_ctx(struct cgroup *cgrp)
 	}
 
 	if (cgrp->kn->id == root_cgid) {
-		WRITE_ONCE(cgc->cell, 0);
+		(void)WRITE_ONCE(cgc->cell, 0);
 		return 0;
 	}
 
@@ -2046,7 +2046,7 @@ int apply_cell_config(void *ctx)
 		if (!cell)
 			return -EINVAL;
 
-		WRITE_ONCE(cell->in_use, 0);
+		(void)WRITE_ONCE(cell->in_use, 0);
 		cell->owner_cgid = 0;
 	}
 
@@ -2125,7 +2125,7 @@ int apply_cell_config(void *ctx)
 						      FAKE_FLAT_CELL_LLC;
 				if (time_before(READ_ONCE(cell->llcs[llc_idx].vtime_now),
 						cctx->vtime_now))
-					WRITE_ONCE(cell->llcs[llc_idx].vtime_now, cctx->vtime_now);
+					(void)WRITE_ONCE(cell->llcs[llc_idx].vtime_now, cctx->vtime_now);
 			}
 			cctx->cell = cell_id;
 		}
@@ -2286,7 +2286,7 @@ int apply_cell_config(void *ctx)
 			else
 				parent_cell = 0;
 
-			WRITE_ONCE(cgrp_ctx->cell, parent_cell);
+			(void)WRITE_ONCE(cgrp_ctx->cell, parent_cell);
 			level_cells[level] = parent_cell;
 		}
 	}

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -2125,7 +2125,8 @@ int apply_cell_config(void *ctx)
 						      FAKE_FLAT_CELL_LLC;
 				if (time_before(READ_ONCE(cell->llcs[llc_idx].vtime_now),
 						cctx->vtime_now))
-					(void)WRITE_ONCE(cell->llcs[llc_idx].vtime_now, cctx->vtime_now);
+					(void)WRITE_ONCE(cell->llcs[llc_idx].vtime_now,
+							 cctx->vtime_now);
 			}
 			cctx->cell = cell_id;
 		}

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.h
@@ -13,15 +13,15 @@
 #ifdef LSP
 #define __bpf__
 #include "../../../../include/scx/common.bpf.h"
-#include "../../../../include/scx/ravg_impl.bpf.h"
+#include "../../../../include/lib/cleanup.bpf.h"
 #else
 #include <scx/common.bpf.h>
+#include <lib/cleanup.bpf.h>
 #endif
 
 #include "intf.h"
 #include "cell_cpumask.bpf.h"
 #include "dsq.bpf.h"
-#include <lib/cleanup.bpf.h>
 
 extern const volatile u32 nr_llc;
 

--- a/scheds/rust/scx_mitosis/src/cell_manager.rs
+++ b/scheds/rust/scx_mitosis/src/cell_manager.rs
@@ -19,6 +19,10 @@ use inotify::{Inotify, WatchMask};
 use scx_utils::Cpumask;
 use tracing::{debug, info};
 
+/// (new_cells, destroyed_cells) returned by event processing.
+/// Each new cell is a (cgid, cell_id) pair.
+pub type CellEventResult = (Vec<(u64, u32)>, Vec<u32>);
+
 /// Information about a cell created for a cgroup
 #[derive(Debug)]
 pub struct CellInfo {
@@ -326,7 +330,7 @@ impl CellManager {
     /// Rather than processing individual events, we simply check if any events occurred
     /// and then rescan the directory to reconcile state. This is simpler and handles
     /// edge cases like inotify queue overflow gracefully.
-    pub fn process_events(&mut self) -> Result<(Vec<(u64, u32)>, Vec<u32>)> {
+    pub fn process_events(&mut self) -> Result<CellEventResult> {
         let mut buffer = [0; 1024];
         let mut has_events = false;
 
@@ -357,7 +361,7 @@ impl CellManager {
 
     /// Reconcile our tracked cells with the actual cgroup directory contents.
     /// Returns (new_cells, destroyed_cells).
-    fn reconcile_cells(&mut self) -> Result<(Vec<(u64, u32)>, Vec<u32>)> {
+    fn reconcile_cells(&mut self) -> Result<CellEventResult> {
         let mut new_cells = Vec::new();
 
         // Find current cgroups on disk
@@ -729,9 +733,7 @@ impl CellManager {
         // Phase 5: Verify all cells have at least one CPU assigned
         for info in self.cells.values() {
             if !cell_cpus.contains_key(&info.cell_id)
-                || cell_cpus
-                    .get(&info.cell_id)
-                    .map_or(true, |m| m.weight() == 0)
+                || cell_cpus.get(&info.cell_id).is_none_or(|m| m.weight() == 0)
             {
                 bail!(
                     "Cell {} has no CPUs assigned (nr_cpus={}, num_cells={})",

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -675,7 +675,7 @@ impl<'a> Scheduler<'a> {
             let changed = cpu_assignments.iter().any(|a| {
                 self.cells
                     .get(&a.cell_id)
-                    .map_or(true, |cell| cell.cpus != a.primary)
+                    .is_none_or(|cell| cell.cpus != a.primary)
             });
 
             if !changed {
@@ -838,7 +838,7 @@ impl<'a> Scheduler<'a> {
             );
         }
 
-        return Ok(DistributionStats {
+        Ok(DistributionStats {
             total_decisions: scope_queue_decisions,
             share_of_decisions_pct: share_of_global,
             local_q_pct: queue_pct[0],
@@ -848,7 +848,7 @@ impl<'a> Scheduler<'a> {
             affn_viol_pct: affinity_violations_percent,
             steal_pct,
             global_queue_decisions,
-        });
+        })
     }
 
     // Queue stats for the whole node
@@ -859,9 +859,9 @@ impl<'a> Scheduler<'a> {
     ) -> Result<()> {
         // Get total of each queue summed over all cells
         let mut queue_counts = [0; QUEUE_STATS_IDX.len()];
-        for cells in 0..MAX_CELLS {
+        for cell in cell_stats_delta.iter().take(MAX_CELLS) {
             for (i, stat) in QUEUE_STATS_IDX.iter().enumerate() {
-                queue_counts[i] += cell_stats_delta[cells][*stat as usize];
+                queue_counts[i] += cell[*stat as usize];
             }
         }
 
@@ -901,10 +901,10 @@ impl<'a> Scheduler<'a> {
         global_queue_decisions: u64,
         cell_stats_delta: &[[u64; NR_CSTATS]; MAX_CELLS],
     ) -> Result<()> {
-        for cell in 0..MAX_CELLS {
+        for (cell_idx, cell) in cell_stats_delta.iter().enumerate().take(MAX_CELLS) {
             let cell_queue_decisions = QUEUE_STATS_IDX
                 .iter()
-                .map(|&stat| cell_stats_delta[cell][stat as usize])
+                .map(|&stat| cell[stat as usize])
                 .sum::<u64>();
 
             // FIXME: This should really query if the cell is enabled or not.
@@ -914,21 +914,19 @@ impl<'a> Scheduler<'a> {
 
             let mut queue_counts = [0; QUEUE_STATS_IDX.len()];
             for (i, &stat) in QUEUE_STATS_IDX.iter().enumerate() {
-                queue_counts[i] = cell_stats_delta[cell][stat as usize];
+                queue_counts[i] = cell[stat as usize];
             }
 
             const MIN_CELL_WIDTH: usize = 2;
             let cell_width: usize = max(MIN_CELL_WIDTH, (MAX_CELLS as f64).log10().ceil() as usize);
 
-            let prefix = format!("        Cell {:width$}:", cell, width = cell_width);
+            let prefix = format!("        Cell {:width$}:", cell_idx, width = cell_width);
 
             // Sum affinity violations for this cell
-            let scope_affn_viols: u64 =
-                cell_stats_delta[cell][bpf_intf::cell_stat_idx_CSTAT_AFFN_VIOL as usize];
+            let scope_affn_viols: u64 = cell[bpf_intf::cell_stat_idx_CSTAT_AFFN_VIOL as usize];
 
             // Steals for this cell
-            let scope_steals: u64 =
-                cell_stats_delta[cell][bpf_intf::cell_stat_idx_CSTAT_STEAL as usize];
+            let scope_steals: u64 = cell[bpf_intf::cell_stat_idx_CSTAT_STEAL as usize];
 
             let stats = self.calculate_distribution_stats(
                 &queue_counts,
@@ -940,7 +938,7 @@ impl<'a> Scheduler<'a> {
 
             self.metrics
                 .cells
-                .entry(cell as u32)
+                .entry(cell_idx as u32)
                 .or_default()
                 .update(&stats);
 
@@ -964,9 +962,9 @@ impl<'a> Scheduler<'a> {
             bail!("Error: No queueing decisions made globally");
         }
 
-        self.update_and_log_global_queue_stats(global_queue_decisions, &cell_stats_delta)?;
+        self.update_and_log_global_queue_stats(global_queue_decisions, cell_stats_delta)?;
 
-        self.update_and_log_cell_queue_stats(global_queue_decisions, &cell_stats_delta)?;
+        self.update_and_log_cell_queue_stats(global_queue_decisions, cell_stats_delta)?;
 
         Ok(())
     }
@@ -975,22 +973,22 @@ impl<'a> Scheduler<'a> {
         &mut self,
         cpu_ctxs: &[bpf_intf::cpu_ctx],
     ) -> Result<[[u64; NR_CSTATS]; MAX_CELLS]> {
-        let mut cell_stats_delta = [[0 as u64; NR_CSTATS]; MAX_CELLS];
+        let mut cell_stats_delta = [[0_u64; NR_CSTATS]; MAX_CELLS];
 
         // Loop over cells and stats first, then CPU contexts
         // TODO: We should loop over the in_use cells only.
-        for cell in 0..MAX_CELLS {
-            for stat in 0..NR_CSTATS {
+        for (cell_idx, cell_delta) in cell_stats_delta.iter_mut().enumerate().take(MAX_CELLS) {
+            for (stat_idx, delta) in cell_delta.iter_mut().enumerate().take(NR_CSTATS) {
                 let mut cur_cell_stat = 0;
 
                 // Accumulate stats from all CPUs
                 for cpu_ctx in cpu_ctxs.iter() {
-                    cur_cell_stat += cpu_ctx.cstats[cell][stat];
+                    cur_cell_stat += cpu_ctx.cstats[cell_idx][stat_idx];
                 }
 
                 // Calculate delta and update previous stat
-                cell_stats_delta[cell][stat] = cur_cell_stat - self.prev_cell_stats[cell][stat];
-                self.prev_cell_stats[cell][stat] = cur_cell_stat;
+                *delta = cur_cell_stat - self.prev_cell_stats[cell_idx][stat_idx];
+                self.prev_cell_stats[cell_idx][stat_idx] = cur_cell_stat;
             }
         }
         Ok(cell_stats_delta)
@@ -1212,7 +1210,7 @@ impl<'a> Scheduler<'a> {
         for (i, cpu_ctx) in cpu_ctxs.iter().enumerate() {
             cell_to_cpus
                 .entry(cpu_ctx.cell)
-                .or_insert_with(|| Cpumask::new())
+                .or_insert_with(Cpumask::new)
                 .set_cpu(i)
                 .expect("set cpu in existing mask");
         }
@@ -1235,7 +1233,7 @@ impl<'a> Scheduler<'a> {
             let cpus = cell_to_cpus
                 .get(cell_idx)
                 .cloned()
-                .unwrap_or_else(|| Cpumask::new());
+                .unwrap_or_else(Cpumask::new);
             self.cells
                 .entry(*cell_idx)
                 .or_insert_with(|| Cell {
@@ -1284,10 +1282,8 @@ fn read_cpu_ctxs(skel: &BpfSkel) -> Result<Vec<bpf_intf::cpu_ctx>> {
             *NR_CPUS_POSSIBLE
         );
     }
-    for cpu in 0..*NR_CPUS_POSSIBLE {
-        cpu_ctxs.push(*unsafe {
-            &*(cpu_ctxs_vec[cpu].as_slice().as_ptr() as *const bpf_intf::cpu_ctx)
-        });
+    for entry in cpu_ctxs_vec.iter().take(*NR_CPUS_POSSIBLE) {
+        cpu_ctxs.push(*unsafe { &*(entry.as_slice().as_ptr() as *const bpf_intf::cpu_ctx) });
     }
     Ok(cpu_ctxs)
 }


### PR DESCRIPTION
fix lsp config for mitosis (scx repo has a config enabling lsp for bpf c).

address warnings in mitosis build by casting WRITE_ONCE return to void.

builds, runs and readable/navigable:

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/3f97f788-c9a4-4707-b026-4c3ede63b9ff" />
