### PR TITLE
arena/p2dq: address warnings

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -1222,7 +1222,8 @@ u64 scx_buddy_chunk_alloc(scx_buddy_chunk_t *chunk, int order_req)
 	address = (u64)chunk_idx_to_mem(chunk, idx);
 
 	/* If we allocated from a larger-order chunk, split the buddies. */
-	bpf_for(order, order_req, order) {
+	int order_end = order;
+	bpf_for(order, order_req, order_end) {
 		/* Flip the bit for the current order. */
 		idx ^= 1 << order;
 

--- a/scheds/include/bpf_arena_spin_lock.h
+++ b/scheds/include/bpf_arena_spin_lock.h
@@ -186,7 +186,7 @@ out:
  */
 static __always_inline void clear_pending(arena_spinlock_t __arena *lock)
 {
-	WRITE_ONCE(lock->pending, 0);
+	(void)WRITE_ONCE(lock->pending, 0);
 }
 
 /**
@@ -199,7 +199,7 @@ static __always_inline void clear_pending(arena_spinlock_t __arena *lock)
  */
 static __always_inline void clear_pending_set_locked(arena_spinlock_t __arena *lock)
 {
-	WRITE_ONCE(lock->locked_pending, _Q_LOCKED_VAL);
+	(void)WRITE_ONCE(lock->locked_pending, _Q_LOCKED_VAL);
 }
 
 /**
@@ -210,7 +210,7 @@ static __always_inline void clear_pending_set_locked(arena_spinlock_t __arena *l
  */
 static __always_inline void set_locked(arena_spinlock_t __arena *lock)
 {
-	WRITE_ONCE(lock->locked, _Q_LOCKED_VAL);
+	(void)WRITE_ONCE(lock->locked, _Q_LOCKED_VAL);
 }
 
 static __always_inline
@@ -311,7 +311,7 @@ int arena_spin_lock_slowpath(arena_spinlock_t __arena __arg_arena *lock, u32 val
 	 * barriers.
 	 */
 	if (val & _Q_LOCKED_MASK)
-		smp_cond_load_acquire_label(&lock->locked, !VAL, release_err);
+		(void)smp_cond_load_acquire_label(&lock->locked, !VAL, release_err);
 
 	/*
 	 * take ownership and clear the pending bit.
@@ -387,9 +387,9 @@ queue:
 		prev = decode_tail(old);
 
 		/* Link @node into the waitqueue. */
-		WRITE_ONCE(prev->next, node);
+		(void)WRITE_ONCE(prev->next, node);
 
-		arch_mcs_spin_lock_contended_label(&node->locked, release_node_err);
+		(void)arch_mcs_spin_lock_contended_label(&node->locked, release_node_err);
 
 		/*
 		 * While waiting for the MCS lock, the next pointer may have

--- a/scheds/include/bpf_atomic.h
+++ b/scheds/include/bpf_atomic.h
@@ -102,7 +102,7 @@ extern bool CONFIG_X86_64 __kconfig __weak;
 		if (!CONFIG_X86_64)    \
 			smp_mb();      \
 		barrier();             \
-		WRITE_ONCE(*(p), val); \
+		(void)WRITE_ONCE(*(p), val); \
 	})
 
 #define smp_cond_load_relaxed_label(p, cond_expr, label)                \


### PR DESCRIPTION
p2dq emits a bunch of warnings, fix them in arena lib.
  - scheds/include/bpf_arena_spin_lock.h — (void) cast on 6 unused WRITE_ONCE/smp_cond_load_acquire_label/arch_mcs_spin_lock_contended_label results
  - scheds/include/bpf_atomic.h — (void) cast on WRITE_ONCE inside smp_store_release macro
  - lib/sdt_alloc.bpf.c — save order to order_end before bpf_for() to fix self-comparison warning (order < order)

p2dq lint runs on ci and i'm updating shared git hook to match ci so no more commit -> push -> figure out lint command -> get lint cmd wrong -> figure out lint cmd for real -> lint -> amend -> push -f cycle.

once the shared git hook is updated, the following cmd will enable lint to just work always:
`git config core.hooksPath .githooks`