### PR TITLE
build: fix cargo cache invalidation for BPF builds

### DIFF
--- a/rust/scx_cargo/build.rs
+++ b/rust/scx_cargo/build.rs
@@ -34,6 +34,8 @@ fn gen_bpf_h() {
             println!("cargo:rerun-if-changed={}", ent.path().to_string_lossy());
         }
     }
+    println!("cargo:rerun-if-changed=vmlinux.tar.zst");
+    println!("cargo:rerun-if-changed=build.rs");
 }
 
 fn main() {

--- a/rust/scx_cargo/src/bpf_builder.rs
+++ b/rust/scx_cargo/src/bpf_builder.rs
@@ -337,10 +337,9 @@ impl BpfBuilder {
     }
 
     pub fn compile_link_gen(&mut self) -> Result<()> {
-        let input = match &self.skel_input_name {
-            Some((name, _)) => name,
-            None => return Ok(()),
-        };
+        if self.skel_input_name.is_none() {
+            return Ok(());
+        }
 
         // Better to hardcode the name because it gets embedded in
         // all the skeleton struct/member definitions.
@@ -379,9 +378,9 @@ impl BpfBuilder {
             .generate(&skel_path)?;
 
         let mut deps = BTreeSet::new();
-        self.add_src_deps(&mut deps, input)?;
         for filename in self.sources.iter() {
             deps.insert(filename.to_string());
+            self.add_src_deps(&mut deps, filename)?;
         }
 
         self.gen_cargo_reruns(Some(&deps))?;

--- a/rust/scx_utils/build.rs
+++ b/rust/scx_utils/build.rs
@@ -83,4 +83,8 @@ fn main() {
     bindings
         .write_to_file(out_path.join("perf_bindings.rs"))
         .expect("Couldn't write bindings!");
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=vmlinux.tar.zst");
+    println!("cargo:rerun-if-changed=perf_wrapper.h");
 }


### PR DESCRIPTION
BpfBuilder::compile_link_gen only called add_src_deps on the skel input, missing sibling files for add_source() paths (e.g. shared lib/ sources reached via symlink in lavd, p2dq, layered, etc.).

Add rerun-if-changed for actual dependencies in scx_utils and scx_cargo, and glob sibling files for every source, not just the skel input.

This makes builds cache better (12s per clippy/lint git hook run to 7s) while also reducing the need for random cargo clean's when improperly tracked deps are edited and cache isn't invalidated.