### PR TITLE
mitosis: Fix cgroup namespace support

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -147,6 +147,18 @@ static inline struct cgrp_ctx *lookup_cgrp_ctx(struct cgroup *cgrp)
 	return cgc;
 }
 
+/*
+ * Check whether a cgroup should be treated as the scheduling root. Matches
+ * both the root_cgid set by userspace (which is the cgroup namespace root
+ * when running inside a container) and the global root at level 0 (which
+ * is unreachable from a non-init cgroup namespace but may appear when
+ * init_task runs for host-level processes like kthreads or systemd).
+ */
+static inline bool is_root_cgroup(struct cgroup *cgrp)
+{
+	return cgrp->kn->id == root_cgid || cgrp->level == 0;
+}
+
 static inline struct cgroup *task_cgroup(struct task_struct *p)
 {
 	struct cgroup *cgrp;
@@ -433,21 +445,17 @@ static inline int update_task_cell(struct task_struct *p, struct task_ctx *tctx,
 
 	if (!cgc) {
 		/*
-		 * Cgroup lookup failed - this can happen during scheduler load
-		 * for tasks that were forked before the scheduler was loaded,
-		 * whose cgroups went offline before scx_cgroup_init() ran.
-		 * Only fall back to root cgroup if the workaround is enabled
-		 * and the task is exiting.
+		 * Cgroup lookup failed. This can happen when:
+		 * - Tasks were forked before the scheduler loaded and their
+		 *   cgroups went offline before scx_cgroup_init() ran.
+		 * - The scheduler runs inside a cgroup namespace and the
+		 *   task belongs to a host cgroup outside the namespace
+		 *   that was never initialized.
+		 * Fall back to the root cgroup's context (cell 0).
 		 */
-		if (exiting_task_workaround_enabled && (p->flags & PF_EXITING)) {
-			struct cgroup *rootcg = READ_ONCE(root_cgrp);
-			if (!rootcg) {
-				scx_bpf_error("Unexpected uninitialized rootcg");
-				return -ENOENT;
-			}
-
-			cgc = lookup_cgrp_ctx(rootcg);
-		}
+		struct cgroup *rootcg = READ_ONCE(root_cgrp);
+		if (rootcg)
+			cgc = lookup_cgrp_ctx_fallible(rootcg);
 
 		if (!cgc) {
 			scx_bpf_error(
@@ -1088,7 +1096,7 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 			 * in-flight tasks scheduled to the dsq.
 			 */
 			/* No cpuset, assign to parent cell and continue */
-			if (cur_cgrp->kn->id != root_cgid) {
+			if (!is_root_cgroup(cur_cgrp)) {
 				u32 level = cur_cgrp->level;
 				if (level <= 0 || level >= MAX_CG_DEPTH) {
 					scx_bpf_error("Cgroup hierarchy is too deep: %d", level);
@@ -1364,7 +1372,7 @@ static int init_cgrp_ctx(struct cgroup *cgrp)
 		return -ENOENT;
 	}
 
-	if (cgrp->kn->id == root_cgid) {
+	if (is_root_cgroup(cgrp)) {
 		WRITE_ONCE(cgc->cell, 0);
 		return 0;
 	}
@@ -1383,16 +1391,13 @@ static int init_cgrp_ctx(struct cgroup *cgrp)
 		__atomic_add_fetch(&configuration_seq, 1, __ATOMIC_RELEASE);
 	}
 
-	/* Initialize to parent's cell */
+	/* Initialize to parent's cell, defaulting to cell 0 (root's cell) */
 	struct cgroup *parent_cg __free(cgroup) = lookup_cgrp_ancestor(cgrp, cgrp->level - 1);
 	if (!parent_cg)
 		return -ENOENT;
 
-	struct cgrp_ctx *parent_cgc;
-	if (!(parent_cgc = lookup_cgrp_ctx(parent_cg)))
-		return -ENOENT;
-
-	cgc->cell = parent_cgc->cell;
+	struct cgrp_ctx *parent_cgc = lookup_cgrp_ctx_fallible(parent_cg);
+	cgc->cell = parent_cgc ? parent_cgc->cell : 0;
 	return 0;
 }
 
@@ -1410,12 +1415,30 @@ static int init_cgrp_ctx_with_ancestors(struct cgroup *cgrp)
 	if (cgrp_is_dying(cgrp))
 		return 0;
 
-	/* Initialize ancestors first (replicates SCX cgroup_init order) */
+	/*
+	 * Initialize ancestors first (replicates SCX cgroup_init order).
+	 *
+	 * When the scheduler runs inside a cgroup namespace, root_cgid is
+	 * the namespace root (not the global root). Ancestors above it are
+	 * outside the namespace — their cgrp_ctx was never initialized and
+	 * bpf_cgroup_from_id() can't resolve them. The root's own context
+	 * is initialized in mitosis_init(), so we skip it and everything
+	 * above it and only initialize ancestors below the root.
+	 */
+	bool below_root = false;
 	bpf_for(level, 1, target_level)
 	{
 		struct cgroup *ancestor __free(cgroup) = lookup_cgrp_ancestor(cgrp, level);
 		if (!ancestor)
 			return -ENOENT;
+
+		if (is_root_cgroup(ancestor)) {
+			below_root = true;
+			continue;
+		}
+
+		if (!below_root)
+			continue;
 
 		/* Skip if dying or already initialized */
 		if (!cgrp_is_dying(ancestor) && !lookup_cgrp_ctx_fallible(ancestor)) {

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -17,6 +17,7 @@ use std::fmt;
 use std::fmt::Display;
 use std::mem::MaybeUninit;
 use std::os::fd::AsFd;
+use std::os::unix::fs::MetadataExt;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
@@ -322,6 +323,14 @@ impl<'a> Scheduler<'a> {
         skel.struct_ops.mitosis_mut().exit_dump_len = opts.exit_dump_len;
 
         let rodata = skel.maps.rodata_data.as_mut().unwrap();
+
+        // Set root_cgid to the kernfs node ID of the cgroup root visible
+        // to this process. On the host this is 1; inside a cgroup namespace
+        // it's the namespace root's ID, which is what bpf_cgroup_from_id()
+        // expects given its namespace visibility check.
+        rodata.root_cgid = std::fs::metadata("/sys/fs/cgroup/")
+            .map(|metadata| metadata.ino())
+            .unwrap_or(1);
 
         rodata.slice_ns = scx_enums.SCX_SLICE_DFL;
         rodata.debug_events_enabled = opts.debug_events;


### PR DESCRIPTION
# Summary
Fix scx_mitosis to work when loaded from inside a cgroup namespace (e.g., from within a container). The kernel's bpf_cgroup_from_id() enforces namespace visibility, so the hardcoded root_cgid of 1 is not visible from a non-init namespace, causing ops.init() to fail with ENOENT. Additional crashes occur because BPF callbacks like init_task and select_cpu run for all tasks on the system, including host processes whose cgroups are outside the namespace.

# Details
**Userspace (main.rs)**:
Set root_cgid by reading the inode of /sys/fs/cgroup/, which returns the kernfs node ID of the cgroup root visible to the process. On the host this is 1 (no behavior change); inside a cgroup namespace it returns the namespace root's ID. This follows the same pattern used by scx_layered, which reads cgroup IDs via std::fs::metadata(path).ino() rather than
  hardcoding them.

**BPF (mitosis.bpf.c)**:
- Add is_root_cgroup() helper that matches both root_cgid and the global root at level 0, which appears when init_task runs for kthreads and systemd but is not the namespace root.
- init_cgrp_ctx_with_ancestors: skip ancestors at or above the namespace root. Their cgrp_ctx was never initialized and bpf_cgroup_from_id() cannot resolve them.
- init_cgrp_ctx: use fallible parent context lookup with cell 0 default instead of fatal scx_bpf_error, handling parents that are outside the namespace or were skipped during initialization.
- update_task_cell: fall back to root cgroup context unconditionally when a task's cgroup context is missing, rather than only for exiting tasks. This handles host tasks whose cgroups are outside the namespace.

# Test Plan
Loaded scx_mitosis with --cpu-controller-disabled from inside a container's cgroup namespace on a multi-container host. 
Verified:
  - Scheduler attaches successfully (no ops.init() failed error)
  - Host tasks (kthreads, systemd) are handled gracefully with cell 0 assignment
  - Container tasks are initialized and scheduled correctly
  - tick() runs without errors across multiple cycles
  - No scx_bpf_error messages in dmesg