### PR TITLE
scheds/experimental: add scx_flow v2.2.0 scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,10 +3788,11 @@ dependencies = [
 
 [[package]]
 name = "scx_flow"
-version = "1.0.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "crossbeam",
  "ctrlc",
  "libbpf-rs",

--- a/scheds/experimental/scx_flow/Cargo.toml
+++ b/scheds/experimental/scx_flow/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "scx_flow"
-version = "1.0.0"
+version = "2.2.0"
 authors = ["Galih Tama <galpt@v.recipes>"]
 edition = "2021"
-description = "A budget-based sched_ext CPU scheduler with reserved wakeup paths, shared fallback dispatch, and bounded adaptive tuning. https://github.com/sched-ext/scx"
+description = "A multi-lane budget-based sched_ext scheduler for interactive responsiveness and general-purpose throughput. https://github.com/sched-ext/scx/tree/main"
 license = "GPL-2.0-only"
 
 [dependencies]
 anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
+clap_complete = "4"
 crossbeam = "0.8"
 libbpf-rs = "=0.26.2"
 log = "0.4"

--- a/scheds/experimental/scx_flow/README.md
+++ b/scheds/experimental/scx_flow/README.md
@@ -8,46 +8,58 @@ dynamically loading them. [Read more about
 
 ## Overview
 
-`scx_flow` is a budget-based `sched_ext` scheduler focused on balancing
-interactive wakeup responsiveness with general-purpose throughput.
+`scx_flow` is a budget-based `sched_ext` scheduler built around a small number
+of bounded service lanes. It aims to keep interactive wakeups responsive
+without abandoning general-purpose throughput or turning the policy into a
+large collection of special cases.
 
-Tasks earn wakeup budget while sleeping and spend that budget while running.
-Positive-budget tasks are favored through a reserved path ahead of the shared
-fallback queue. The scheduler also includes a bounded adaptive controller so it
-can move between balanced, latency-guarded, and throughput-oriented settings
-without relying on manual tuning.
-
-Current implementation includes:
-
-- a reserved vs shared queue split
-- wakeup-budget accounting in `runnable()`
-- lifecycle cleanup through `enable()` and `exit_task()`
-- `cpu_release()` rescue handling
-- a narrow RT-sensitive wakeup lane for pinned positive-budget wakeups
+Tasks accumulate wakeup budget while sleeping and spend that budget while
+running. Positive-budget work is favored ahead of the shared fallback path,
+while bounded adaptive tuning lets the scheduler move between balanced,
+latency-oriented, and throughput-oriented behavior without requiring constant
+manual retuning. The implementation combines reserved, latency, shared, and
+contained paths with bounded urgency, fairness, locality, and confidence
+signals so the scheduler stays explainable and measurable instead of depending
+on large, open-ended heuristics.
 
 ## Typical Use Case
 
-General-purpose workloads where interactive sleepers and background CPU work
-need to coexist reasonably well without per-machine hand tuning.
+General-purpose desktop and workstation use where foreground responsiveness and
+background CPU work both matter.
+
+In plain terms, `scx_flow` is aimed at machines that do several things at once:
+
+- gaming while browsers, chat apps, or launchers stay open
+- coding or office work while builds, downloads, or background jobs keep running
+- everyday multitasking where short interactive work should feel quick instead
+  of getting buried behind heavier CPU activity
+
+What users should usually notice is not "maximum benchmark throughput at all
+costs", but a machine that feels more consistently responsive, with fewer
+obvious hiccups when interactive tasks and background load need to coexist.
 
 ## Production Ready?
 
-Yes, for practical general-purpose use, with caveats.
+Yes, for everyday general-purpose use.
 
-`scx_flow` is stable enough to run as an everyday `sched_ext` scheduler and has
-been exercised across normal workload, lifecycle, and stress scenarios. Its
-core behavior, adaptive tuning loop, and task lifecycle paths are all intended
-to be production-capable rather than experimental scaffolding.
-
-That said, `scx_flow` should still be described conservatively. It does not yet
-justify hard wakeup-latency guarantees, and its implementation surface is still
-smaller and less feature-rich than the most mature schedulers in the tree.
+`scx_flow` has been exercised across broad workload, lifecycle, and adversarial
+stress validation, and its core paths are intended to be robust rather than
+experimental scaffolding. It should still be described conservatively for hard
+latency guarantees under extreme interference, but it is suitable for daily use
+as a general-purpose `sched_ext` scheduler.
 
 ## Validation
 
 Benchmark scripts, validation helpers, and archived result bundles used during
 development are available at:
 https://github.com/galpt/testing-scx_flow
+
+Direct `v2.2.0` benchmark snapshot:
+https://github.com/galpt/testing-scx_flow/tree/benchmark-archives/20260409_scx_flow_v2.2.0_release
+
+In practice, the stronger results there usually translate to better foreground
+responsiveness, steadier behavior under background load, and fewer obvious
+hiccups when interactive and CPU-heavy work happen at the same time.
 
 These artifacts are provided as supplementary validation material and are not
 required to use `scx_flow` itself.

--- a/scheds/experimental/scx_flow/src/bpf/intf.h
+++ b/scheds/experimental/scx_flow/src/bpf/intf.h
@@ -21,6 +21,7 @@ enum consts {
 	FLOW_SLICE_SHARED_NS = (1ULL * NSEC_PER_MSEC),
 	FLOW_SLICE_SHARED_MIN_NS = (750ULL * NSEC_PER_USEC),
 	FLOW_SLICE_SHARED_MAX_NS = (1500ULL * NSEC_PER_USEC),
+	FLOW_SLICE_CONTAINED_MIN_NS = (1200ULL * NSEC_PER_USEC),
 	FLOW_BUDGET_MAX_NS = (2ULL * NSEC_PER_MSEC),
 	FLOW_BUDGET_MIN_NS = (500ULL * NSEC_PER_USEC),
 	FLOW_SLEEP_MAX_NS = (250ULL * NSEC_PER_MSEC),
@@ -33,6 +34,66 @@ enum consts {
 	FLOW_PREEMPT_REFILL_MIN_NS = (200ULL * NSEC_PER_USEC),
 	FLOW_PREEMPT_REFILL_MAX_NS = (350ULL * NSEC_PER_USEC),
 	FLOW_RT_WAKE_SLICE_NS = (50ULL * NSEC_PER_USEC),
+	FLOW_LATENCY_LANE_REFILL_MIN_NS = (60ULL * NSEC_PER_USEC),
+	FLOW_LATENCY_LANE_BUDGET_MIN_NS = (80ULL * NSEC_PER_USEC),
+	FLOW_LATENCY_CREDIT_GRANT_MIN = 1ULL,
+	FLOW_LATENCY_CREDIT_GRANT_MAX = 4ULL,
+	FLOW_LATENCY_CREDIT_MAX = 4ULL,
+	FLOW_LATENCY_CREDIT_GRANT = 2ULL,
+	FLOW_LATENCY_CREDIT_DECAY_MIN = 1ULL,
+	FLOW_LATENCY_CREDIT_DECAY_MAX = 4ULL,
+	FLOW_LATENCY_CREDIT_DECAY = 1ULL,
+	FLOW_LATENCY_CREDIT_DECAY_SHIFT = 1ULL,
+	FLOW_LATENCY_DEBT_MAX = 4ULL,
+	FLOW_LATENCY_DEBT_URGENT_MIN_MIN = 1ULL,
+	FLOW_LATENCY_DEBT_URGENT_MIN_MAX = 3ULL,
+	FLOW_LATENCY_DEBT_URGENT_MIN = 1ULL,
+	FLOW_LATENCY_DEBT_RAISE_STEP = 1ULL,
+	FLOW_LATENCY_DEBT_DECAY_STEP = 1ULL,
+	FLOW_LATENCY_DEBT_DECAY_SHIFT = 1ULL,
+	FLOW_URGENT_LATENCY_BURST_MIN = 1ULL,
+	FLOW_URGENT_LATENCY_BURST_MAX_TUNE = 4ULL,
+	FLOW_URGENT_LATENCY_BURST_MAX = 2ULL,
+	FLOW_RESERVED_QUOTA_BURST_MIN = 2ULL,
+	FLOW_RESERVED_QUOTA_BURST_MAX_TUNE = 8ULL,
+	FLOW_RESERVED_QUOTA_BURST_MAX = 4ULL,
+	FLOW_RESERVED_LANE_BURST_MIN = 2ULL,
+	FLOW_RESERVED_LANE_BURST_MAX_TUNE = 10ULL,
+	FLOW_RESERVED_LANE_BURST_MAX = 5ULL,
+	FLOW_DIRECT_LOCAL_SCORE_MAX = 8ULL,
+	FLOW_DIRECT_LOCAL_SCORE_MIN = 3ULL,
+	FLOW_DIRECT_LOCAL_SCORE_GAIN = 1ULL,
+	FLOW_DIRECT_LOCAL_SCORE_DECAY = 2ULL,
+	FLOW_DIRECT_LOCAL_SCORE_DECAY_SHIFT = 1ULL,
+	FLOW_DIRECT_LOCAL_MISMATCH_DECAY = 1ULL,
+	FLOW_DIRECT_LOCAL_SLICE_NS = (150ULL * NSEC_PER_USEC),
+	FLOW_IPC_SCORE_MAX = 16ULL,
+	FLOW_IPC_SCORE_ACTIVATE = 4ULL,
+	FLOW_IPC_SCORE_GAIN = 4ULL,
+	FLOW_IPC_SCORE_DECAY_SHIFT = 1ULL,
+	FLOW_IPC_CPUS_MAX = 2ULL,
+	FLOW_IPC_SLEEP_MAX_NS = (2ULL * NSEC_PER_MSEC),
+	FLOW_IPC_RUNTIME_MAX_NS = (120ULL * NSEC_PER_USEC),
+	FLOW_IPC_REFILL_MIN_NS = (80ULL * NSEC_PER_USEC),
+	FLOW_IPC_SLICE_NS = (120ULL * NSEC_PER_USEC),
+	FLOW_LOCAL_FAST_NR_RUNNING_MIN = 1ULL,
+	FLOW_LOCAL_FAST_NR_RUNNING_MAX_TUNE = 6ULL,
+	FLOW_LOCAL_FAST_NR_RUNNING_MAX = 4ULL,
+	FLOW_LOCAL_RESERVED_BURST_MIN = 2ULL,
+	FLOW_LOCAL_RESERVED_BURST_MAX_TUNE = 8ULL,
+	FLOW_LOCAL_RESERVED_BURST_MAX = 5ULL,
+	FLOW_CONTAINED_STARVATION_MIN = 3ULL,
+	FLOW_CONTAINED_STARVATION_MAX_TUNE = 12ULL,
+	FLOW_CONTAINED_STARVATION_MAX = 6ULL,
+	FLOW_SHARED_STARVATION_MIN = 6ULL,
+	FLOW_SHARED_STARVATION_MAX_TUNE = 20ULL,
+	FLOW_SHARED_STARVATION_MAX = 12ULL,
+	FLOW_HOG_SCORE_MAX = 8ULL,
+	FLOW_HOG_SCORE_CONTAIN = 3ULL,
+	FLOW_HOG_SCORE_EXHAUST_STEP = 2ULL,
+	FLOW_HOG_SCORE_DECAY_STEP = 1ULL,
+	FLOW_HOG_SCORE_DECAY_SHIFT = 1ULL,
+	FLOW_HOG_RECOVERY_MARGIN_NS = (50ULL * NSEC_PER_USEC),
 	FLOW_REFILL_DIV = 100ULL,
 };
 
@@ -49,5 +110,73 @@ typedef signed long s64;
 
 typedef int pid_t;
 #endif /* __VMLINUX_H__ */
+
+struct flow_cpu_state {
+	u64 urgent_latency_burst_rounds;
+	u64 high_priority_burst_rounds;
+	u64 local_reserved_burst_rounds;
+	u64 local_reserved_fast_grants;
+	u64 local_reserved_burst_continuations;
+	u64 reserved_lane_burst_rounds;
+	u64 contained_starvation_rounds;
+	u64 shared_starvation_rounds;
+	u64 budget_refill_events;
+	u64 budget_exhaustions;
+	u64 runnable_wakeups;
+	u64 urgent_latency_dispatches;
+	u64 urgent_latency_burst_grants;
+	u64 urgent_latency_burst_continuations;
+	u64 urgent_latency_enqueues;
+	u64 urgent_latency_misses;
+	u64 latency_dispatches;
+	u64 latency_debt_raises;
+	u64 latency_debt_decays;
+	u64 latency_debt_urgent_enqueues;
+	u64 reserved_dispatches;
+	u64 shared_dispatches;
+	u64 contained_dispatches;
+	u64 contained_rescue_dispatches;
+	u64 shared_rescue_dispatches;
+	u64 local_fast_dispatches;
+	u64 wake_preempt_dispatches;
+	u64 cpu_stability_biases;
+	u64 last_cpu_matches;
+	u64 latency_lane_candidates;
+	u64 latency_lane_enqueues;
+	u64 latency_candidate_local_enqueues;
+	u64 latency_candidate_hog_blocks;
+	u64 positive_budget_wakeups;
+	u64 rt_sensitive_wakeups;
+	u64 reserved_local_enqueues;
+	u64 reserved_global_enqueues;
+	u64 reserved_quota_skips;
+	u64 quota_shared_forces;
+	u64 quota_contained_forces;
+	u64 reserved_lane_grants;
+	u64 reserved_lane_burst_continuations;
+	u64 reserved_lane_skips;
+	u64 reserved_lane_shared_forces;
+	u64 reserved_lane_contained_forces;
+	u64 reserved_lane_shared_misses;
+	u64 reserved_lane_contained_misses;
+	u64 shared_wakeup_enqueues;
+	u64 shared_starved_head_enqueues;
+	u64 local_quota_skips;
+	u64 rt_sensitive_local_enqueues;
+	u64 rt_sensitive_preempts;
+	u64 direct_local_candidates;
+	u64 direct_local_enqueues;
+	u64 direct_local_rejections;
+	u64 direct_local_mismatches;
+	u64 ipc_wake_candidates;
+	u64 ipc_local_enqueues;
+	u64 ipc_score_raises;
+	u64 ipc_boosts;
+	u64 contained_enqueues;
+	u64 contained_starved_head_enqueues;
+	u64 hog_containment_enqueues;
+	u64 hog_recoveries;
+	u64 cpu_migrations;
+};
 
 #endif /* __INTF_H */

--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -16,7 +16,15 @@ struct task_ctx {
 	s64 budget_ns;
 	s64 last_refill_ns;
 	u64 last_run_at;
+	u64 last_sleep_ns;
 	u64 sleep_started_at;
+	u32 latency_allowance;
+	u32 latency_pressure;
+	u32 containment_score;
+	u32 locality_score;
+	u32 ipc_confidence;
+	u32 wake_profile;
+	s32 last_cpu;
 	s32 wake_cpu;
 	bool wake_cpu_idle;
 	bool wake_cpu_valid;
@@ -29,36 +37,121 @@ struct {
 	__type(value, struct task_ctx);
 } task_ctx_stor SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, struct flow_cpu_state);
+} cpu_state SEC(".maps");
+
 volatile u64 nr_running;
 volatile u64 total_runtime;
 volatile u64 reserved_dispatches;
+volatile u64 urgent_latency_dispatches;
+volatile u64 urgent_latency_burst_grants;
+volatile u64 urgent_latency_burst_continuations;
+volatile u64 latency_dispatches;
 volatile u64 shared_dispatches;
+volatile u64 contained_dispatches;
 volatile u64 local_fast_dispatches;
 volatile u64 wake_preempt_dispatches;
 volatile u64 budget_refill_events;
 volatile u64 budget_exhaustions;
 volatile u64 positive_budget_wakeups;
+volatile u64 urgent_latency_enqueues;
+volatile u64 latency_lane_enqueues;
+volatile u64 latency_lane_candidates;
+volatile u64 latency_candidate_local_enqueues;
+volatile u64 latency_candidate_hog_blocks;
+volatile u64 latency_debt_raises;
+volatile u64 latency_debt_decays;
+volatile u64 latency_debt_urgent_enqueues;
+volatile u64 urgent_latency_misses;
 volatile u64 reserved_local_enqueues;
 volatile u64 reserved_global_enqueues;
 volatile u64 shared_wakeup_enqueues;
 volatile u64 runnable_wakeups;
 volatile u64 cpu_release_reenqueues;
+volatile u64 local_reserved_fast_grants;
+volatile u64 local_reserved_burst_continuations;
+volatile u64 local_quota_skips;
+volatile u64 reserved_quota_skips;
+volatile u64 quota_shared_forces;
+volatile u64 quota_contained_forces;
 volatile u64 init_task_events;
 volatile u64 enable_events;
 volatile u64 exit_task_events;
+volatile u64 cpu_stability_biases;
+volatile u64 last_cpu_matches;
+volatile u64 cpu_migrations;
 volatile u64 rt_sensitive_wakeups;
 volatile u64 rt_sensitive_local_enqueues;
 volatile u64 rt_sensitive_preempts;
+volatile u64 reserved_lane_grants;
+volatile u64 reserved_lane_burst_continuations;
+volatile u64 reserved_lane_skips;
+volatile u64 reserved_lane_shared_forces;
+volatile u64 reserved_lane_contained_forces;
+volatile u64 reserved_lane_shared_misses;
+volatile u64 reserved_lane_contained_misses;
+volatile u64 contained_starved_head_enqueues;
+volatile u64 shared_starved_head_enqueues;
+volatile u64 direct_local_candidates;
+volatile u64 direct_local_enqueues;
+volatile u64 direct_local_rejections;
+volatile u64 direct_local_mismatches;
+volatile u64 ipc_wake_candidates;
+volatile u64 ipc_local_enqueues;
+volatile u64 ipc_score_raises;
+volatile u64 ipc_boosts;
+volatile u64 contained_enqueues;
+volatile u64 hog_containment_enqueues;
+volatile u64 hog_recoveries;
+volatile u64 contained_rescue_dispatches;
+volatile u64 shared_rescue_dispatches;
 volatile u64 tune_reserved_max_ns = FLOW_SLICE_RESERVED_MAX_NS;
 volatile u64 tune_shared_slice_ns = FLOW_SLICE_SHARED_NS;
 volatile u64 tune_interactive_floor_ns = FLOW_INTERACTIVE_FLOOR_NS;
 volatile u64 tune_preempt_budget_min_ns = FLOW_PREEMPT_BUDGET_MIN_NS;
 volatile u64 tune_preempt_refill_min_ns = FLOW_PREEMPT_REFILL_MIN_NS;
+volatile u64 tune_latency_credit_grant = FLOW_LATENCY_CREDIT_GRANT;
+volatile u64 tune_latency_credit_decay = FLOW_LATENCY_CREDIT_DECAY;
+volatile u64 tune_latency_debt_urgent_min = FLOW_LATENCY_DEBT_URGENT_MIN;
+volatile u64 tune_urgent_latency_burst_max = FLOW_URGENT_LATENCY_BURST_MAX;
+volatile u64 tune_reserved_quota_burst_max = FLOW_RESERVED_QUOTA_BURST_MAX;
+volatile u64 tune_reserved_lane_burst_max = FLOW_RESERVED_LANE_BURST_MAX;
+volatile u64 tune_contained_starvation_max = FLOW_CONTAINED_STARVATION_MAX;
+volatile u64 tune_shared_starvation_max = FLOW_SHARED_STARVATION_MAX;
+volatile u64 tune_local_fast_nr_running_max = FLOW_LOCAL_FAST_NR_RUNNING_MAX;
+volatile u64 tune_local_reserved_burst_max = FLOW_LOCAL_RESERVED_BURST_MAX;
 volatile u64 autotune_generation;
 volatile u64 autotune_mode;
 
+static u64 nr_cpu_ids;
+
+#define URGENT_LATENCY_DSQ 1022
+#define LATENCY_DSQ 1023
 #define RESERVED_DSQ 1024
-#define SHARED_DSQ 1025
+#define CONTAINED_DSQ 1025
+#define SHARED_DSQ 1026
+#define RESERVED_CPU_DSQ_BASE 0x40000000ULL
+#define SHARED_CPU_DSQ_BASE 0x50000000ULL
+
+enum wake_profile_bits {
+	WAKE_PROFILE_POSITIVE_BUDGET = 1U << 0,
+	WAKE_PROFILE_CONTAINMENT_ACTIVE = 1U << 1,
+	WAKE_PROFILE_LATENCY_ALLOWANCE = 1U << 2,
+	WAKE_PROFILE_LATENCY_PRESSURE = 1U << 3,
+	WAKE_PROFILE_LATENCY_LANE = 1U << 4,
+	WAKE_PROFILE_URGENT_LATENCY = 1U << 5,
+	WAKE_PROFILE_RT_SENSITIVE = 1U << 6,
+	WAKE_PROFILE_LOCALITY = 1U << 7,
+	WAKE_PROFILE_LOCALITY_FAST = 1U << 8,
+	WAKE_PROFILE_IPC = 1U << 9,
+	WAKE_PROFILE_IPC_STRONG = 1U << 10,
+	WAKE_PROFILE_PREEMPT_READY = 1U << 11,
+	WAKE_PROFILE_RESERVED_HEAD = 1U << 12,
+};
 
 static inline struct task_ctx *lookup_task_ctx(const struct task_struct *p)
 {
@@ -73,6 +166,22 @@ static inline struct task_ctx *alloc_task_ctx(struct task_struct *p)
 				    BPF_LOCAL_STORAGE_GET_F_CREATE);
 }
 
+static __always_inline struct flow_cpu_state *lookup_cpu_state(void)
+{
+	u32 key = 0;
+
+	return bpf_map_lookup_elem(&cpu_state, &key);
+}
+
+#define FLOW_CPUSTAT_INC(_cstate, _field)					\
+	do {									\
+		typeof(_cstate) __cstate = (_cstate);				\
+		if (__cstate)							\
+			__cstate->_field++;					\
+		else								\
+			__sync_fetch_and_add(&_field, 1);			\
+	} while (0)
+
 static __always_inline bool is_kthread(const struct task_struct *p)
 {
 	return p->flags & PF_KTHREAD;
@@ -81,6 +190,11 @@ static __always_inline bool is_kthread(const struct task_struct *p)
 static __always_inline bool is_pinned_kthread(const struct task_struct *p)
 {
 	return is_kthread(p) && p->nr_cpus_allowed == 1;
+}
+
+static __always_inline bool is_non_migratable(const struct task_struct *p)
+{
+	return p->nr_cpus_allowed == 1 || is_migration_disabled(p);
 }
 
 static __always_inline s64 clamp_budget(s64 budget_ns)
@@ -117,6 +231,50 @@ static __always_inline u64 task_slice_ns(const struct task_ctx *tctx)
 	return tune_shared_slice_ns;
 }
 
+static __always_inline u64 contained_slice_ns(void)
+{
+	u64 slice_ns = tune_shared_slice_ns;
+
+	if (slice_ns < FLOW_SLICE_CONTAINED_MIN_NS)
+		slice_ns = FLOW_SLICE_CONTAINED_MIN_NS;
+	if (slice_ns > FLOW_SLICE_SHARED_MAX_NS)
+		slice_ns = FLOW_SLICE_SHARED_MAX_NS;
+	return slice_ns;
+}
+
+static __always_inline bool valid_sched_cpu(s32 cpu)
+{
+	return cpu >= 0 && (u64)cpu < nr_cpu_ids;
+}
+
+static __always_inline u64 reserved_cpu_dsq_id(s32 cpu)
+{
+	return RESERVED_CPU_DSQ_BASE | (u32)cpu;
+}
+
+static __always_inline u64 shared_cpu_dsq_id(s32 cpu)
+{
+	return SHARED_CPU_DSQ_BASE | (u32)cpu;
+}
+
+static __always_inline bool move_reserved_lane_to_local(s32 cpu)
+{
+	if (valid_sched_cpu(cpu) &&
+	    scx_bpf_dsq_move_to_local(reserved_cpu_dsq_id(cpu), 0))
+		return true;
+
+	return scx_bpf_dsq_move_to_local(RESERVED_DSQ, 0);
+}
+
+static __always_inline bool move_shared_lane_to_local(s32 cpu)
+{
+	if (valid_sched_cpu(cpu) &&
+	    scx_bpf_dsq_move_to_local(shared_cpu_dsq_id(cpu), 0))
+		return true;
+
+	return scx_bpf_dsq_move_to_local(SHARED_DSQ, 0);
+}
+
 static __always_inline void clear_wake_target(struct task_ctx *tctx)
 {
 	if (!tctx)
@@ -135,7 +293,15 @@ static __always_inline void reset_task_ctx(struct task_ctx *tctx, u64 now, bool 
 	tctx->budget_ns = 0;
 	tctx->last_refill_ns = 0;
 	tctx->last_run_at = 0;
+	tctx->last_sleep_ns = 0;
 	tctx->sleep_started_at = sleeping ? now : 0;
+	tctx->latency_allowance = 0;
+	tctx->latency_pressure = 0;
+	tctx->containment_score = 0;
+	tctx->locality_score = 0;
+	tctx->ipc_confidence = 0;
+	tctx->wake_profile = 0;
+	tctx->last_cpu = -1;
 	clear_wake_target(tctx);
 }
 
@@ -170,52 +336,829 @@ static __always_inline s64 calc_budget_refill(const struct task_struct *p, u64 s
 	return refill_ns;
 }
 
+/*
+ * Keep small scheduler signals bounded and decayed consistently so policy
+ * gates can stay simple while the evidence underneath remains recency-aware.
+ */
+static __always_inline u32 clamp_bounded_signal(u32 signal, u32 signal_max)
+{
+	if (signal > signal_max)
+		return signal_max;
+	return signal;
+}
+
+static __always_inline u32 raise_bounded_signal(u32 signal, u32 delta,
+						       u32 signal_max)
+{
+	if (!delta)
+		return signal;
+	return clamp_bounded_signal(signal + delta, signal_max);
+}
+
+static __always_inline u32 decay_bounded_signal(u32 signal, u32 delta)
+{
+	if (!delta || !signal)
+		return signal;
+	if (signal <= delta)
+		return 0;
+	return signal - delta;
+}
+
+static __always_inline u32 decay_geometric_signal(u32 signal, u32 shift)
+{
+	u32 delta;
+
+	if (!signal)
+		return 0;
+
+	delta = shift ? signal >> shift : signal;
+	if (!delta)
+		delta = 1;
+
+	return decay_bounded_signal(signal, delta);
+}
+
+static __always_inline u32 decay_confidence_signal(u32 signal, u32 delta,
+						   u32 shift)
+{
+	u32 decayed_signal;
+
+	if (!signal)
+		return 0;
+
+	decayed_signal = decay_geometric_signal(signal, shift);
+	if (delta > 1)
+		decayed_signal = decay_bounded_signal(decayed_signal, delta - 1);
+
+	return decayed_signal;
+}
+
+static __always_inline bool is_containment_active(const struct task_ctx *tctx)
+{
+	return tctx && tctx->containment_score >= FLOW_HOG_SCORE_CONTAIN;
+}
+
+static __always_inline u32 tuned_latency_credit_grant(void)
+{
+	u64 grant = tune_latency_credit_grant;
+
+	if (grant < FLOW_LATENCY_CREDIT_GRANT_MIN)
+		grant = FLOW_LATENCY_CREDIT_GRANT_MIN;
+	else if (grant > FLOW_LATENCY_CREDIT_GRANT_MAX)
+		grant = FLOW_LATENCY_CREDIT_GRANT_MAX;
+
+	return grant;
+}
+
+static __always_inline u32 tuned_latency_credit_decay(void)
+{
+	u64 decay = tune_latency_credit_decay;
+
+	if (decay < FLOW_LATENCY_CREDIT_DECAY_MIN)
+		decay = FLOW_LATENCY_CREDIT_DECAY_MIN;
+	else if (decay > FLOW_LATENCY_CREDIT_DECAY_MAX)
+		decay = FLOW_LATENCY_CREDIT_DECAY_MAX;
+
+	return decay;
+}
+
+static __always_inline u32 tuned_latency_debt_urgent_min(void)
+{
+	u64 urgent_min = tune_latency_debt_urgent_min;
+
+	if (urgent_min < FLOW_LATENCY_DEBT_URGENT_MIN_MIN)
+		urgent_min = FLOW_LATENCY_DEBT_URGENT_MIN_MIN;
+	else if (urgent_min > FLOW_LATENCY_DEBT_URGENT_MIN_MAX)
+		urgent_min = FLOW_LATENCY_DEBT_URGENT_MIN_MAX;
+
+	return urgent_min;
+}
+
+static __always_inline u32 tuned_urgent_latency_burst_max(void)
+{
+	u64 burst_max = tune_urgent_latency_burst_max;
+
+	if (burst_max < FLOW_URGENT_LATENCY_BURST_MIN)
+		burst_max = FLOW_URGENT_LATENCY_BURST_MIN;
+	else if (burst_max > FLOW_URGENT_LATENCY_BURST_MAX_TUNE)
+		burst_max = FLOW_URGENT_LATENCY_BURST_MAX_TUNE;
+
+	return burst_max;
+}
+
+static __always_inline u32 tuned_reserved_quota_burst_max(void)
+{
+	u64 burst_max = tune_reserved_quota_burst_max;
+
+	if (burst_max < FLOW_RESERVED_QUOTA_BURST_MIN)
+		burst_max = FLOW_RESERVED_QUOTA_BURST_MIN;
+	else if (burst_max > FLOW_RESERVED_QUOTA_BURST_MAX_TUNE)
+		burst_max = FLOW_RESERVED_QUOTA_BURST_MAX_TUNE;
+
+	return burst_max;
+}
+
+static __always_inline u32 tuned_reserved_lane_burst_max(void)
+{
+	u64 burst_max = tune_reserved_lane_burst_max;
+
+	if (burst_max < FLOW_RESERVED_LANE_BURST_MIN)
+		burst_max = FLOW_RESERVED_LANE_BURST_MIN;
+	else if (burst_max > FLOW_RESERVED_LANE_BURST_MAX_TUNE)
+		burst_max = FLOW_RESERVED_LANE_BURST_MAX_TUNE;
+
+	return burst_max;
+}
+
+static __always_inline u32 tuned_local_reserved_burst_max(void)
+{
+	u64 burst_max = tune_local_reserved_burst_max;
+
+	if (burst_max < FLOW_LOCAL_RESERVED_BURST_MIN)
+		burst_max = FLOW_LOCAL_RESERVED_BURST_MIN;
+	else if (burst_max > FLOW_LOCAL_RESERVED_BURST_MAX_TUNE)
+		burst_max = FLOW_LOCAL_RESERVED_BURST_MAX_TUNE;
+
+	return burst_max;
+}
+
+static __always_inline void raise_latency_allowance(struct task_ctx *tctx, u32 delta)
+{
+	if (!tctx || !delta)
+		return;
+
+	tctx->latency_allowance = raise_bounded_signal(tctx->latency_allowance, delta,
+							FLOW_LATENCY_CREDIT_MAX);
+}
+
+static __always_inline void decay_latency_allowance(struct task_ctx *tctx, u32 delta)
+{
+	if (!tctx || !delta)
+		return;
+
+	tctx->latency_allowance =
+		decay_confidence_signal(tctx->latency_allowance, delta,
+					FLOW_LATENCY_CREDIT_DECAY_SHIFT);
+}
+
+static __always_inline bool has_urgent_latency_pressure(const struct task_ctx *tctx)
+{
+	return tctx && tctx->latency_pressure >= tuned_latency_debt_urgent_min();
+}
+
+static __always_inline bool is_latency_allowance_candidate(const struct task_ctx *tctx)
+{
+	if (!tctx || tctx->budget_ns <= 0 || !tctx->latency_allowance)
+		return false;
+	return tctx->budget_ns >= (s64)FLOW_LATENCY_LANE_BUDGET_MIN_NS;
+}
+
+static __always_inline bool raise_latency_pressure(struct task_ctx *tctx, u32 delta)
+{
+	u32 old_pressure;
+	u32 new_pressure;
+
+	if (!tctx || !delta)
+		return false;
+
+	old_pressure = tctx->latency_pressure;
+	new_pressure = raise_bounded_signal(old_pressure, delta, FLOW_LATENCY_DEBT_MAX);
+	if (new_pressure == old_pressure)
+		return false;
+
+	tctx->latency_pressure = new_pressure;
+	return true;
+}
+
+static __always_inline bool decay_latency_pressure(struct task_ctx *tctx, u32 delta)
+{
+	u32 old_pressure;
+
+	if (!tctx || !delta)
+		return false;
+
+	old_pressure = tctx->latency_pressure;
+	if (!old_pressure)
+		return false;
+
+	tctx->latency_pressure =
+		decay_confidence_signal(old_pressure, delta,
+					FLOW_LATENCY_DEBT_DECAY_SHIFT);
+
+	return tctx->latency_pressure != old_pressure;
+}
+
+static __always_inline bool has_locality_confidence(const struct task_ctx *tctx, u32 min_score)
+{
+	return tctx && tctx->locality_score >= min_score;
+}
+
+static __always_inline bool locality_hits_last_cpu(const struct task_ctx *tctx,
+						   s32 target_cpu)
+{
+	return tctx && target_cpu >= 0 && tctx->last_cpu >= 0 &&
+		target_cpu == tctx->last_cpu;
+}
+
+static __always_inline void raise_locality_score(struct task_ctx *tctx, u32 delta)
+{
+	if (!tctx || !delta)
+		return;
+
+	tctx->locality_score =
+		raise_bounded_signal(tctx->locality_score, delta,
+				   FLOW_DIRECT_LOCAL_SCORE_MAX);
+}
+
+static __always_inline void decay_locality_score(struct task_ctx *tctx, u32 delta)
+{
+	if (!tctx || !delta)
+		return;
+
+	tctx->locality_score =
+		decay_confidence_signal(tctx->locality_score, delta,
+					FLOW_DIRECT_LOCAL_SCORE_DECAY_SHIFT);
+}
+
+static __always_inline bool has_ipc_confidence(const struct task_ctx *tctx, u32 min_score)
+{
+	return tctx && tctx->ipc_confidence >= min_score;
+}
+
+static __always_inline bool has_ipc_continuity_confidence(const struct task_ctx *tctx,
+							  u32 ipc_min_score,
+							  u32 locality_min_score)
+{
+	return has_ipc_confidence(tctx, ipc_min_score) &&
+		has_locality_confidence(tctx, locality_min_score);
+}
+
+static __always_inline bool has_wake_profile(const struct task_ctx *tctx, u32 bit)
+{
+	return tctx && (tctx->wake_profile & bit);
+}
+
+static __always_inline void decay_ipc_confidence(struct task_ctx *tctx)
+{
+	if (!tctx || !tctx->ipc_confidence)
+		return;
+
+	tctx->ipc_confidence =
+		decay_geometric_signal(tctx->ipc_confidence, FLOW_IPC_SCORE_DECAY_SHIFT);
+}
+
+static __always_inline void raise_ipc_confidence(struct task_ctx *tctx)
+{
+	struct flow_cpu_state *cstate = lookup_cpu_state();
+
+	if (!tctx)
+		return;
+
+	decay_ipc_confidence(tctx);
+	tctx->ipc_confidence = raise_bounded_signal(tctx->ipc_confidence,
+						      FLOW_IPC_SCORE_GAIN,
+						      FLOW_IPC_SCORE_MAX);
+	FLOW_CPUSTAT_INC(cstate, ipc_score_raises);
+}
+
+static __always_inline void decay_containment_score(struct task_ctx *tctx, u32 delta)
+{
+	struct flow_cpu_state *cstate = lookup_cpu_state();
+	u32 old_score;
+
+	if (!tctx || !delta)
+		return;
+
+	old_score = tctx->containment_score;
+	tctx->containment_score =
+		decay_confidence_signal(old_score, delta,
+					FLOW_HOG_SCORE_DECAY_SHIFT);
+
+	if (old_score >= FLOW_HOG_SCORE_CONTAIN &&
+	    tctx->containment_score < FLOW_HOG_SCORE_CONTAIN)
+		FLOW_CPUSTAT_INC(cstate, hog_recoveries);
+}
+
+static __always_inline void raise_containment_score(struct task_ctx *tctx, u32 delta)
+{
+	if (!tctx || !delta)
+		return;
+
+	tctx->containment_score =
+		raise_bounded_signal(tctx->containment_score, delta,
+				   FLOW_HOG_SCORE_MAX);
+}
+
+static __always_inline void recompute_wake_profile(const struct task_struct *p,
+						   struct task_ctx *tctx)
+{
+	u32 wake_profile = 0;
+	bool allowance_ready = false;
+	bool pressure_ready = false;
+	bool latency_lane_ready = false;
+	bool rt_sensitive_ready = false;
+	bool preempt_ready = false;
+	bool containment_active;
+	bool positive_budget;
+	u64 preempt_refill_min_ns = tune_preempt_refill_min_ns;
+	u64 preempt_budget_min_ns = tune_preempt_budget_min_ns;
+
+	if (!tctx)
+		return;
+
+	containment_active = is_containment_active(tctx);
+	positive_budget = tctx->budget_ns > 0;
+
+	if (positive_budget)
+		wake_profile |= WAKE_PROFILE_POSITIVE_BUDGET;
+	if (containment_active)
+		wake_profile |= WAKE_PROFILE_CONTAINMENT_ACTIVE;
+
+	if (!positive_budget) {
+		tctx->wake_profile = wake_profile;
+		return;
+	}
+
+	if (preempt_refill_min_ns < FLOW_PREEMPT_REFILL_MIN_NS)
+		preempt_refill_min_ns = FLOW_PREEMPT_REFILL_MIN_NS;
+	else if (preempt_refill_min_ns > FLOW_PREEMPT_REFILL_MAX_NS)
+		preempt_refill_min_ns = FLOW_PREEMPT_REFILL_MAX_NS;
+
+	if (preempt_budget_min_ns < FLOW_PREEMPT_BUDGET_MIN_NS)
+		preempt_budget_min_ns = FLOW_PREEMPT_BUDGET_MIN_NS;
+	else if (preempt_budget_min_ns > FLOW_PREEMPT_BUDGET_MAX_NS)
+		preempt_budget_min_ns = FLOW_PREEMPT_BUDGET_MAX_NS;
+
+	allowance_ready = !containment_active &&
+		is_latency_allowance_candidate(tctx);
+	pressure_ready = !containment_active &&
+		has_urgent_latency_pressure(tctx);
+	rt_sensitive_ready = !containment_active &&
+		p->nr_cpus_allowed == 1 &&
+		tctx->last_refill_ns > 0 &&
+		tctx->last_refill_ns >= (s64)FLOW_INTERACTIVE_FLOOR_MIN_NS;
+	preempt_ready = !containment_active &&
+		(p->nr_cpus_allowed == 1 ||
+		 (tctx->last_refill_ns >= (s64)preempt_refill_min_ns &&
+		  tctx->budget_ns >= (s64)preempt_budget_min_ns));
+	latency_lane_ready = (allowance_ready || pressure_ready) &&
+		!rt_sensitive_ready;
+
+	if (allowance_ready)
+		wake_profile |= WAKE_PROFILE_LATENCY_ALLOWANCE;
+	if (pressure_ready)
+		wake_profile |= WAKE_PROFILE_LATENCY_PRESSURE;
+	if (latency_lane_ready)
+		wake_profile |= WAKE_PROFILE_LATENCY_LANE;
+	if (pressure_ready && latency_lane_ready)
+		wake_profile |= WAKE_PROFILE_URGENT_LATENCY;
+	if (rt_sensitive_ready)
+		wake_profile |= WAKE_PROFILE_RT_SENSITIVE;
+	if (preempt_ready)
+		wake_profile |= WAKE_PROFILE_PREEMPT_READY;
+
+	if (!containment_active &&
+	    has_locality_confidence(tctx, FLOW_DIRECT_LOCAL_SCORE_MIN))
+		wake_profile |= WAKE_PROFILE_LOCALITY;
+
+	if (!containment_active &&
+	    !rt_sensitive_ready &&
+	    !latency_lane_ready &&
+	    has_locality_confidence(tctx, FLOW_DIRECT_LOCAL_SCORE_MIN))
+		wake_profile |= WAKE_PROFILE_LOCALITY_FAST;
+
+	if (!containment_active &&
+	    p->nr_cpus_allowed <= FLOW_IPC_CPUS_MAX &&
+	    tctx->last_sleep_ns > 0 &&
+	    tctx->last_sleep_ns <= FLOW_IPC_SLEEP_MAX_NS &&
+	    tctx->budget_ns >= (s64)FLOW_IPC_REFILL_MIN_NS &&
+	    tctx->last_refill_ns >= (s64)FLOW_IPC_REFILL_MIN_NS &&
+	    has_ipc_continuity_confidence(tctx, FLOW_IPC_SCORE_ACTIVATE,
+					      FLOW_DIRECT_LOCAL_SCORE_GAIN))
+		wake_profile |= WAKE_PROFILE_IPC;
+
+	if (!containment_active &&
+	    p->nr_cpus_allowed == FLOW_IPC_CPUS_MAX &&
+	    tctx->last_sleep_ns > 0 &&
+	    tctx->last_sleep_ns <= FLOW_IPC_SLEEP_MAX_NS &&
+	    tctx->budget_ns >= (s64)FLOW_IPC_REFILL_MIN_NS &&
+	    tctx->last_refill_ns >= (s64)FLOW_IPC_REFILL_MIN_NS &&
+	    has_ipc_continuity_confidence(tctx,
+					      FLOW_IPC_SCORE_ACTIVATE + FLOW_IPC_SCORE_GAIN,
+					      FLOW_DIRECT_LOCAL_SCORE_MIN))
+		wake_profile |= WAKE_PROFILE_IPC_STRONG;
+
+	if (!containment_active &&
+	    !latency_lane_ready &&
+	    (rt_sensitive_ready ||
+	     (wake_profile & WAKE_PROFILE_LOCALITY_FAST) ||
+	     (wake_profile & WAKE_PROFILE_IPC)))
+		wake_profile |= WAKE_PROFILE_RESERVED_HEAD;
+
+	tctx->wake_profile = wake_profile;
+}
+
 static __always_inline void update_budget_on_wakeup(const struct task_struct *p,
 						    struct task_ctx *tctx,
 						    u64 now)
 {
 	s64 refill_ns;
+	u64 sleep_ns;
+	u64 interactive_floor_ns = tune_interactive_floor_ns;
+	u64 recovery_refill_min_ns;
 
 	if (!tctx)
 		return;
 
 	tctx->last_refill_ns = 0;
 
-	if (!tctx->sleep_started_at || now <= tctx->sleep_started_at)
+	if (!tctx->sleep_started_at || now <= tctx->sleep_started_at) {
+		tctx->last_sleep_ns = 0;
 		return;
+	}
 
-	refill_ns = calc_budget_refill(p, now - tctx->sleep_started_at);
+	sleep_ns = now - tctx->sleep_started_at;
+	refill_ns = calc_budget_refill(p, sleep_ns);
 	tctx->budget_ns = clamp_budget(tctx->budget_ns + refill_ns);
 	tctx->last_refill_ns = refill_ns;
+	tctx->last_sleep_ns = sleep_ns;
 	tctx->sleep_started_at = 0;
 
-	if (refill_ns > 0)
-		__sync_fetch_and_add(&budget_refill_events, 1);
+	if (refill_ns > 0) {
+		if (interactive_floor_ns < FLOW_INTERACTIVE_FLOOR_MIN_NS)
+			interactive_floor_ns = FLOW_INTERACTIVE_FLOOR_MIN_NS;
+		else if (interactive_floor_ns > FLOW_INTERACTIVE_FLOOR_MAX_NS)
+			interactive_floor_ns = FLOW_INTERACTIVE_FLOOR_MAX_NS;
+
+		recovery_refill_min_ns = interactive_floor_ns + FLOW_HOG_RECOVERY_MARGIN_NS;
+		if (refill_ns >= (s64)recovery_refill_min_ns)
+			decay_containment_score(tctx, FLOW_HOG_SCORE_DECAY_STEP);
+		if (refill_ns >= (s64)FLOW_LATENCY_LANE_REFILL_MIN_NS &&
+		    tctx->budget_ns >= (s64)FLOW_LATENCY_LANE_BUDGET_MIN_NS)
+			raise_latency_allowance(tctx, tuned_latency_credit_grant());
+		/* Count every positive budget refill event, not only lane grants. */
+		FLOW_CPUSTAT_INC(lookup_cpu_state(), budget_refill_events);
+	}
+
+	if (p->nr_cpus_allowed > FLOW_IPC_CPUS_MAX ||
+	    !tctx->last_sleep_ns ||
+	    tctx->last_sleep_ns > FLOW_IPC_SLEEP_MAX_NS ||
+	    refill_ns < (s64)FLOW_IPC_REFILL_MIN_NS)
+		decay_ipc_confidence(tctx);
+
+	recompute_wake_profile(p, tctx);
 }
 
-static __always_inline bool is_rt_sensitive_wakeup(const struct task_struct *p,
-						    const struct task_ctx *tctx,
-						    bool is_wakeup)
+static __always_inline bool is_ipc_confidence_candidate(const struct task_struct *p,
+							const struct task_ctx *tctx,
+							s32 target_cpu,
+							bool wake_cpu_idle,
+							bool is_wakeup,
+							bool latency_lane_wakeup,
+							bool containment_active)
+{
+	s32 task_cpu;
+
+	if (!tctx || !is_wakeup)
+		return false;
+	if (containment_active || latency_lane_wakeup)
+		return false;
+	if (!has_wake_profile(tctx, WAKE_PROFILE_IPC))
+		return false;
+	if (target_cpu < 0 || tctx->last_cpu < 0)
+		return false;
+
+	if (locality_hits_last_cpu(tctx, target_cpu))
+		return true;
+
+	if (!has_wake_profile(tctx, WAKE_PROFILE_IPC_STRONG))
+		return false;
+
+	task_cpu = scx_bpf_task_cpu(p);
+	if (task_cpu >= 0 && target_cpu == task_cpu)
+		return true;
+
+	return wake_cpu_idle;
+}
+
+static __always_inline bool is_locality_candidate(const struct task_ctx *tctx,
+						  s32 target_cpu,
+						  bool wake_cpu_idle,
+						  bool is_wakeup,
+						  bool rt_sensitive_wakeup,
+						  bool latency_lane_wakeup,
+						  bool containment_active)
 {
 	if (!tctx || !is_wakeup)
 		return false;
-	if (p->nr_cpus_allowed != 1)
+	if (target_cpu < 0)
 		return false;
-	if (tctx->budget_ns <= 0)
+	if (containment_active || rt_sensitive_wakeup || latency_lane_wakeup)
 		return false;
-	if (tctx->last_refill_ns <= 0)
+	if (!has_wake_profile(tctx, WAKE_PROFILE_LOCALITY_FAST))
 		return false;
 
-	return tctx->last_refill_ns >= (s64)FLOW_INTERACTIVE_FLOOR_MIN_NS;
+	if (locality_hits_last_cpu(tctx, target_cpu))
+		return true;
+
+	return wake_cpu_idle;
+}
+
+static __always_inline bool should_prioritize_reserved_enqueue(
+	const struct task_ctx *tctx, bool is_wakeup, bool containment_active,
+	bool latency_lane_wakeup, bool rt_sensitive_wakeup,
+	bool direct_local_wakeup, bool ipc_confidence_wakeup)
+{
+	if (!tctx || !is_wakeup)
+		return false;
+	if (containment_active || latency_lane_wakeup)
+		return false;
+	if (!has_wake_profile(tctx, WAKE_PROFILE_RESERVED_HEAD))
+		return false;
+	if (rt_sensitive_wakeup || direct_local_wakeup || ipc_confidence_wakeup)
+		return true;
+
+	return has_wake_profile(tctx, WAKE_PROFILE_LOCALITY_FAST);
+}
+
+static __always_inline bool allow_direct_local_fast_path(void)
+{
+	u64 max_running = tune_local_fast_nr_running_max;
+
+	if (max_running < FLOW_LOCAL_FAST_NR_RUNNING_MIN)
+		max_running = FLOW_LOCAL_FAST_NR_RUNNING_MIN;
+	else if (max_running > FLOW_LOCAL_FAST_NR_RUNNING_MAX_TUNE)
+		max_running = FLOW_LOCAL_FAST_NR_RUNNING_MAX_TUNE;
+
+	if (nr_running > max_running)
+		return false;
+	return true;
+}
+
+static __always_inline u64 direct_local_slice_ns(u64 slice_ns)
+{
+	if (slice_ns < FLOW_SLICE_MIN_NS)
+		return FLOW_SLICE_MIN_NS;
+	if (slice_ns > FLOW_DIRECT_LOCAL_SLICE_NS)
+		return FLOW_DIRECT_LOCAL_SLICE_NS;
+	return slice_ns;
+}
+
+static __always_inline void bump_starvation_round(u64 *counter, u64 max_rounds)
+{
+	if (counter && *counter < max_rounds)
+		*counter += 1;
+}
+
+static __always_inline void backoff_starvation_round(u64 *counter, u64 max_rounds)
+{
+	if (!counter || !max_rounds)
+		return;
+
+	if (*counter >= max_rounds)
+		*counter = max_rounds - 1;
+}
+
+static __always_inline void note_high_priority_dispatch(struct flow_cpu_state *cstate)
+{
+	u64 contained_max = tune_contained_starvation_max;
+	u64 shared_max = tune_shared_starvation_max;
+	u64 quota_max = tuned_reserved_quota_burst_max();
+
+	if (contained_max < FLOW_CONTAINED_STARVATION_MIN)
+		contained_max = FLOW_CONTAINED_STARVATION_MIN;
+	else if (contained_max > FLOW_CONTAINED_STARVATION_MAX_TUNE)
+		contained_max = FLOW_CONTAINED_STARVATION_MAX_TUNE;
+
+	if (shared_max < FLOW_SHARED_STARVATION_MIN)
+		shared_max = FLOW_SHARED_STARVATION_MIN;
+	else if (shared_max > FLOW_SHARED_STARVATION_MAX_TUNE)
+		shared_max = FLOW_SHARED_STARVATION_MAX_TUNE;
+
+	bump_starvation_round(cstate ? &cstate->contained_starvation_rounds : NULL,
+			      contained_max);
+	bump_starvation_round(cstate ? &cstate->shared_starvation_rounds : NULL,
+			      shared_max);
+	if (cstate && cstate->high_priority_burst_rounds < quota_max)
+		cstate->high_priority_burst_rounds++;
+}
+
+static __always_inline void reset_urgent_latency_burst(struct flow_cpu_state *cstate)
+{
+	if (cstate)
+		cstate->urgent_latency_burst_rounds = 0;
+}
+
+static __always_inline void reset_reserved_lane_burst(struct flow_cpu_state *cstate)
+{
+	if (cstate)
+		cstate->reserved_lane_burst_rounds = 0;
+}
+
+static __always_inline void reset_local_reserved_burst(struct flow_cpu_state *cstate)
+{
+	if (cstate)
+		cstate->local_reserved_burst_rounds = 0;
+}
+
+static __always_inline void note_local_reserved_fast(struct flow_cpu_state *cstate)
+{
+	u64 burst_max = tuned_local_reserved_burst_max();
+
+	FLOW_CPUSTAT_INC(cstate, local_reserved_fast_grants);
+	if (cstate && cstate->local_reserved_burst_rounds > 0)
+		FLOW_CPUSTAT_INC(cstate, local_reserved_burst_continuations);
+	if (cstate && cstate->local_reserved_burst_rounds < burst_max)
+		cstate->local_reserved_burst_rounds++;
+}
+
+static __always_inline void note_urgent_latency_dispatch(struct flow_cpu_state *cstate)
+{
+	if (cstate && cstate->urgent_latency_burst_rounds > 0)
+		FLOW_CPUSTAT_INC(cstate, urgent_latency_burst_continuations);
+	if (cstate &&
+	    cstate->urgent_latency_burst_rounds < tuned_urgent_latency_burst_max())
+		cstate->urgent_latency_burst_rounds++;
+	FLOW_CPUSTAT_INC(cstate, urgent_latency_dispatches);
+	FLOW_CPUSTAT_INC(cstate, urgent_latency_burst_grants);
+	reset_reserved_lane_burst(cstate);
+	note_high_priority_dispatch(cstate);
+}
+
+static __always_inline void note_reserved_dispatch(struct flow_cpu_state *cstate)
+{
+	u64 burst_max = tuned_reserved_lane_burst_max();
+
+	FLOW_CPUSTAT_INC(cstate, reserved_dispatches);
+	FLOW_CPUSTAT_INC(cstate, reserved_lane_grants);
+	if (cstate && cstate->reserved_lane_burst_rounds > 0)
+		FLOW_CPUSTAT_INC(cstate, reserved_lane_burst_continuations);
+	if (cstate && cstate->reserved_lane_burst_rounds < burst_max)
+		cstate->reserved_lane_burst_rounds++;
+	reset_urgent_latency_burst(cstate);
+	reset_local_reserved_burst(cstate);
+	note_high_priority_dispatch(cstate);
+}
+
+static __always_inline void note_contained_dispatch(struct flow_cpu_state *cstate,
+						    bool rescued)
+{
+	u64 shared_max = tune_shared_starvation_max;
+
+	if (shared_max < FLOW_SHARED_STARVATION_MIN)
+		shared_max = FLOW_SHARED_STARVATION_MIN;
+	else if (shared_max > FLOW_SHARED_STARVATION_MAX_TUNE)
+		shared_max = FLOW_SHARED_STARVATION_MAX_TUNE;
+
+	if (cstate) {
+		cstate->contained_starvation_rounds = 0;
+		cstate->high_priority_burst_rounds = 0;
+	}
+	bump_starvation_round(cstate ? &cstate->shared_starvation_rounds : NULL,
+			      shared_max);
+	reset_urgent_latency_burst(cstate);
+	reset_reserved_lane_burst(cstate);
+	reset_local_reserved_burst(cstate);
+	if (rescued)
+		FLOW_CPUSTAT_INC(cstate, contained_rescue_dispatches);
+}
+
+static __always_inline void note_shared_dispatch(struct flow_cpu_state *cstate,
+						 bool rescued)
+{
+	u64 contained_max = tune_contained_starvation_max;
+
+	if (contained_max < FLOW_CONTAINED_STARVATION_MIN)
+		contained_max = FLOW_CONTAINED_STARVATION_MIN;
+	else if (contained_max > FLOW_CONTAINED_STARVATION_MAX_TUNE)
+		contained_max = FLOW_CONTAINED_STARVATION_MAX_TUNE;
+
+	if (cstate) {
+		cstate->shared_starvation_rounds = 0;
+		cstate->high_priority_burst_rounds = 0;
+	}
+	bump_starvation_round(cstate ? &cstate->contained_starvation_rounds : NULL,
+			      contained_max);
+	reset_urgent_latency_burst(cstate);
+	reset_reserved_lane_burst(cstate);
+	reset_local_reserved_burst(cstate);
+	if (rescued)
+		FLOW_CPUSTAT_INC(cstate, shared_rescue_dispatches);
+}
+
+static __always_inline bool local_reserved_quota_active(struct flow_cpu_state *cstate)
+{
+	u64 max_running = tune_local_fast_nr_running_max;
+
+	if (max_running < FLOW_LOCAL_FAST_NR_RUNNING_MIN)
+		max_running = FLOW_LOCAL_FAST_NR_RUNNING_MIN;
+	else if (max_running > FLOW_LOCAL_FAST_NR_RUNNING_MAX_TUNE)
+		max_running = FLOW_LOCAL_FAST_NR_RUNNING_MAX_TUNE;
+
+	return nr_running > max_running ||
+		(cstate && cstate->contained_starvation_rounds > 0) ||
+		(cstate && cstate->shared_starvation_rounds > 0);
+}
+
+static __always_inline void note_locality_mismatch(const struct task_struct *p,
+						   struct task_ctx *tctx)
+{
+	struct flow_cpu_state *cstate = lookup_cpu_state();
+
+	if (!tctx)
+		return;
+
+	FLOW_CPUSTAT_INC(cstate, direct_local_mismatches);
+	decay_locality_score(tctx, FLOW_DIRECT_LOCAL_MISMATCH_DECAY);
+	recompute_wake_profile(p, tctx);
+}
+
+static __always_inline void note_locality_rejection(const struct task_struct *p,
+						    struct task_ctx *tctx)
+{
+	struct flow_cpu_state *cstate = lookup_cpu_state();
+
+	if (!tctx)
+		return;
+
+	FLOW_CPUSTAT_INC(cstate, direct_local_rejections);
+	decay_locality_score(tctx, FLOW_DIRECT_LOCAL_MISMATCH_DECAY);
+	recompute_wake_profile(p, tctx);
+}
+
+static __always_inline bool should_promote_shared_enqueue(struct flow_cpu_state *cstate)
+{
+	u64 shared_max = tune_shared_starvation_max;
+
+	if (shared_max < FLOW_SHARED_STARVATION_MIN)
+		shared_max = FLOW_SHARED_STARVATION_MIN;
+	else if (shared_max > FLOW_SHARED_STARVATION_MAX_TUNE)
+		shared_max = FLOW_SHARED_STARVATION_MAX_TUNE;
+
+	return cstate && cstate->shared_starvation_rounds * 2 >= shared_max;
+}
+
+static __always_inline bool should_promote_contained_enqueue(struct flow_cpu_state *cstate)
+{
+	u64 contained_max = tune_contained_starvation_max;
+
+	if (contained_max < FLOW_CONTAINED_STARVATION_MIN)
+		contained_max = FLOW_CONTAINED_STARVATION_MIN;
+	else if (contained_max > FLOW_CONTAINED_STARVATION_MAX_TUNE)
+		contained_max = FLOW_CONTAINED_STARVATION_MAX_TUNE;
+
+	return cstate && cstate->contained_starvation_rounds * 2 >= contained_max;
 }
 
 s32 BPF_STRUCT_OPS_SLEEPABLE(flow_init)
 {
+	s32 cpu;
 	s32 ret;
+
+	ret = scx_lib_init();
+	if (ret)
+		return ret;
+
+	nr_cpu_ids = scx_bpf_nr_cpu_ids();
+
+	bpf_for(cpu, 0, nr_cpu_ids) {
+		ret = scx_bpf_create_dsq(reserved_cpu_dsq_id(cpu), -1);
+		if (ret < 0 && ret != -EEXIST) {
+			scx_bpf_error("failed to create reserved cpu DSQ %d: %d",
+				      cpu, ret);
+			return ret;
+		}
+
+		ret = scx_bpf_create_dsq(shared_cpu_dsq_id(cpu), -1);
+		if (ret < 0 && ret != -EEXIST) {
+			scx_bpf_error("failed to create shared cpu DSQ %d: %d",
+				      cpu, ret);
+			return ret;
+		}
+	}
+
+	ret = scx_bpf_create_dsq(LATENCY_DSQ, -1);
+	if (ret < 0 && ret != -EEXIST) {
+		scx_bpf_error("failed to create latency DSQ %d: %d", LATENCY_DSQ, ret);
+		return ret;
+	}
+
+	ret = scx_bpf_create_dsq(URGENT_LATENCY_DSQ, -1);
+	if (ret < 0 && ret != -EEXIST) {
+		scx_bpf_error("failed to create urgent latency DSQ %d: %d",
+			     URGENT_LATENCY_DSQ, ret);
+		return ret;
+	}
 
 	ret = scx_bpf_create_dsq(RESERVED_DSQ, -1);
 	if (ret < 0 && ret != -EEXIST) {
 		scx_bpf_error("failed to create reserved DSQ %d: %d", RESERVED_DSQ, ret);
+		return ret;
+	}
+
+	ret = scx_bpf_create_dsq(CONTAINED_DSQ, -1);
+	if (ret < 0 && ret != -EEXIST) {
+		scx_bpf_error("failed to create contained DSQ %d: %d", CONTAINED_DSQ, ret);
 		return ret;
 	}
 
@@ -264,7 +1207,9 @@ s32 BPF_STRUCT_OPS(flow_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wak
 	struct task_ctx *tctx;
 	bool is_idle = false;
 	s32 cpu;
+	s32 preferred_cpu;
 	s32 this_cpu = bpf_get_smp_processor_id();
+	bool non_migratable = is_non_migratable(p);
 	bool is_this_cpu_allowed = bpf_cpumask_test_cpu(this_cpu, p->cpus_ptr);
 
 	tctx = lookup_task_ctx(p);
@@ -277,16 +1222,33 @@ s32 BPF_STRUCT_OPS(flow_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wak
 	if (!bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr))
 		prev_cpu = is_this_cpu_allowed ? this_cpu : bpf_cpumask_first(p->cpus_ptr);
 
-	cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
+	preferred_cpu = prev_cpu;
+	if (!non_migratable && tctx && tctx->last_cpu >= 0 &&
+	    bpf_cpumask_test_cpu(tctx->last_cpu, p->cpus_ptr)) {
+		preferred_cpu = tctx->last_cpu;
+		FLOW_CPUSTAT_INC(lookup_cpu_state(), cpu_stability_biases);
+	}
+
+	if (non_migratable) {
+		cpu = preferred_cpu;
+		is_idle = scx_bpf_test_and_clear_cpu_idle(preferred_cpu);
+	} else {
+		cpu = scx_bpf_select_cpu_dfl(p, preferred_cpu, wake_flags, &is_idle);
+	}
+
 	if (tctx) {
-		tctx->wake_cpu = cpu >= 0 ? cpu : prev_cpu;
+		tctx->wake_cpu = cpu >= 0 ? cpu : preferred_cpu;
 		tctx->wake_cpu_idle = is_idle;
 		tctx->wake_cpu_valid =
 			tctx->wake_cpu >= 0 &&
 			bpf_cpumask_test_cpu(tctx->wake_cpu, p->cpus_ptr);
+		if (tctx->last_cpu >= 0 && tctx->wake_cpu == tctx->last_cpu)
+			FLOW_CPUSTAT_INC(lookup_cpu_state(), last_cpu_matches);
+		else if (tctx->last_cpu >= 0)
+			note_locality_mismatch(p, tctx);
 	}
 
-	return cpu >= 0 ? cpu : prev_cpu;
+	return cpu >= 0 ? cpu : preferred_cpu;
 }
 
 void BPF_STRUCT_OPS(flow_runnable, struct task_struct *p, u64 enq_flags)
@@ -300,21 +1262,34 @@ void BPF_STRUCT_OPS(flow_runnable, struct task_struct *p, u64 enq_flags)
 
 	now = bpf_ktime_get_ns();
 	if (tctx->sleep_started_at && now > tctx->sleep_started_at)
-		__sync_fetch_and_add(&runnable_wakeups, 1);
+		FLOW_CPUSTAT_INC(lookup_cpu_state(), runnable_wakeups);
 	update_budget_on_wakeup(p, tctx, now);
 }
 
 void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 {
 	struct task_ctx *tctx;
+	struct flow_cpu_state *cstate;
 	s32 target_cpu = -1;
+	s32 task_cpu;
 	u64 slice_ns;
 	bool is_wakeup;
 	bool has_wake_target = false;
+	bool non_migratable = is_non_migratable(p);
 	bool rt_sensitive_wakeup = false;
+	bool allowance_latency_wakeup = false;
+	bool pressure_latency_wakeup = false;
+	bool latency_lane_wakeup = false;
+	bool urgent_latency_wakeup = false;
+	bool direct_local_wakeup = false;
+	bool ipc_confidence_wakeup = false;
+	bool containment_active = false;
+	bool reserved_priority_wakeup = false;
 	bool use_local_reserved = false;
+	bool ordinary_local_reserved = false;
 
 	tctx = lookup_task_ctx(p);
+	cstate = lookup_cpu_state();
 	slice_ns = task_slice_ns(tctx);
 	is_wakeup = enq_flags & SCX_ENQ_WAKEUP;
 
@@ -325,102 +1300,387 @@ void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 		target_cpu = scx_bpf_task_cpu(p);
 	}
 
+	task_cpu = scx_bpf_task_cpu(p);
+	if (non_migratable && task_cpu >= 0 &&
+	    bpf_cpumask_test_cpu(task_cpu, p->cpus_ptr)) {
+		if (!has_wake_target || target_cpu != task_cpu) {
+			target_cpu = task_cpu;
+			has_wake_target = true;
+			if (tctx) {
+				tctx->wake_cpu = task_cpu;
+				tctx->wake_cpu_idle = false;
+				tctx->wake_cpu_valid = true;
+			}
+		}
+	}
+
 	if (is_pinned_kthread(p)) {
 		clear_wake_target(tctx);
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice_ns(NULL), enq_flags);
-		__sync_fetch_and_add(&local_fast_dispatches, 1);
+		FLOW_CPUSTAT_INC(cstate, local_fast_dispatches);
 		return;
 	}
 
-	if (tctx) {
-		if (tctx->budget_ns > 0) {
-			if (is_wakeup)
-				__sync_fetch_and_add(&positive_budget_wakeups, 1);
+	if (tctx && tctx->budget_ns > 0) {
+		containment_active = has_wake_profile(tctx, WAKE_PROFILE_CONTAINMENT_ACTIVE);
+		pressure_latency_wakeup =
+			is_wakeup && has_wake_profile(tctx, WAKE_PROFILE_LATENCY_PRESSURE);
+		allowance_latency_wakeup =
+			is_wakeup && has_wake_profile(tctx, WAKE_PROFILE_LATENCY_ALLOWANCE);
+		if (allowance_latency_wakeup || pressure_latency_wakeup)
+			FLOW_CPUSTAT_INC(cstate, latency_lane_candidates);
+		if (is_wakeup && containment_active && tctx->latency_allowance > 0)
+			FLOW_CPUSTAT_INC(cstate, latency_candidate_hog_blocks);
+		if (is_wakeup)
+			FLOW_CPUSTAT_INC(cstate, positive_budget_wakeups);
 
-			rt_sensitive_wakeup = is_rt_sensitive_wakeup(p, tctx, is_wakeup);
-			if (rt_sensitive_wakeup)
-				__sync_fetch_and_add(&rt_sensitive_wakeups, 1);
+		rt_sensitive_wakeup =
+			is_wakeup && has_wake_profile(tctx, WAKE_PROFILE_RT_SENSITIVE);
+		if (rt_sensitive_wakeup)
+			FLOW_CPUSTAT_INC(cstate, rt_sensitive_wakeups);
 
-			if (is_wakeup)
-				enq_flags |= SCX_ENQ_HEAD;
+		latency_lane_wakeup =
+			is_wakeup && has_wake_profile(tctx, WAKE_PROFILE_LATENCY_LANE);
+		urgent_latency_wakeup =
+			is_wakeup && has_wake_profile(tctx, WAKE_PROFILE_URGENT_LATENCY);
+		ipc_confidence_wakeup = is_ipc_confidence_candidate(
+			p, tctx, target_cpu, tctx->wake_cpu_idle, is_wakeup,
+			latency_lane_wakeup, containment_active);
+		if (ipc_confidence_wakeup)
+			FLOW_CPUSTAT_INC(cstate, ipc_wake_candidates);
 
-			if (has_wake_target ||
-			    bpf_cpumask_test_cpu(target_cpu, p->cpus_ptr)) {
-				u64 preempt_refill_min_ns = tune_preempt_refill_min_ns;
-				u64 preempt_budget_min_ns = tune_preempt_budget_min_ns;
-				bool single_cpu_task = p->nr_cpus_allowed == 1;
-				bool should_preempt;
+		direct_local_wakeup = is_locality_candidate(
+			tctx, target_cpu, tctx->wake_cpu_idle, is_wakeup,
+			rt_sensitive_wakeup, latency_lane_wakeup, containment_active);
+		if (direct_local_wakeup && !allow_direct_local_fast_path()) {
+			direct_local_wakeup = false;
+			note_locality_rejection(p, tctx);
+		}
+		if (direct_local_wakeup)
+			FLOW_CPUSTAT_INC(cstate, direct_local_candidates);
 
-				if (preempt_refill_min_ns < FLOW_PREEMPT_REFILL_MIN_NS)
-					preempt_refill_min_ns = FLOW_PREEMPT_REFILL_MIN_NS;
-				else if (preempt_refill_min_ns > FLOW_PREEMPT_REFILL_MAX_NS)
-					preempt_refill_min_ns = FLOW_PREEMPT_REFILL_MAX_NS;
+		if (is_wakeup && !containment_active)
+			enq_flags |= SCX_ENQ_HEAD;
 
-				if (preempt_budget_min_ns < FLOW_PREEMPT_BUDGET_MIN_NS)
-					preempt_budget_min_ns = FLOW_PREEMPT_BUDGET_MIN_NS;
-				else if (preempt_budget_min_ns > FLOW_PREEMPT_BUDGET_MAX_NS)
-					preempt_budget_min_ns = FLOW_PREEMPT_BUDGET_MAX_NS;
+		if (has_wake_target ||
+		    (target_cpu >= 0 && bpf_cpumask_test_cpu(target_cpu, p->cpus_ptr))) {
+			bool should_preempt;
 
-				should_preempt = rt_sensitive_wakeup ||
-					(is_wakeup &&
-					 !tctx->wake_cpu_idle &&
-					 (single_cpu_task ||
-					  (tctx->last_refill_ns >= (s64)preempt_refill_min_ns &&
-					   tctx->budget_ns >= (s64)preempt_budget_min_ns)));
+			should_preempt = rt_sensitive_wakeup || ipc_confidence_wakeup ||
+				(is_wakeup && !containment_active && !tctx->wake_cpu_idle &&
+				 has_wake_profile(tctx, WAKE_PROFILE_PREEMPT_READY));
 
-				if (should_preempt) {
-					use_local_reserved = true;
-					enq_flags |= SCX_ENQ_PREEMPT;
-					__sync_fetch_and_add(&wake_preempt_dispatches, 1);
-					if (rt_sensitive_wakeup)
-						__sync_fetch_and_add(&rt_sensitive_preempts, 1);
-				} else if (tctx->wake_cpu_idle && is_wakeup) {
-					use_local_reserved = true;
-				}
+			use_local_reserved = should_preempt || direct_local_wakeup ||
+				ipc_confidence_wakeup;
+			ordinary_local_reserved = use_local_reserved && !should_preempt;
 
-				if (use_local_reserved) {
-					u64 local_slice_ns = rt_sensitive_wakeup ?
-						FLOW_RT_WAKE_SLICE_NS : slice_ns;
-
-					scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | target_cpu,
-							   local_slice_ns, enq_flags);
-					__sync_fetch_and_add(&reserved_local_enqueues, 1);
-					if (rt_sensitive_wakeup)
-						__sync_fetch_and_add(&rt_sensitive_local_enqueues, 1);
-					if (tctx->wake_cpu_idle)
-						__sync_fetch_and_add(&local_fast_dispatches, 1);
-					clear_wake_target(tctx);
-					return;
-				}
+			if (ordinary_local_reserved &&
+			    local_reserved_quota_active(cstate) &&
+			    cstate &&
+			    cstate->local_reserved_burst_rounds >=
+				    tuned_local_reserved_burst_max()) {
+				use_local_reserved = false;
+				ordinary_local_reserved = false;
+				FLOW_CPUSTAT_INC(cstate, local_quota_skips);
 			}
 
-			scx_bpf_dsq_insert(p, RESERVED_DSQ, slice_ns, enq_flags);
-			__sync_fetch_and_add(&reserved_global_enqueues, 1);
+			if (should_preempt) {
+				enq_flags |= SCX_ENQ_PREEMPT;
+				scx_bpf_kick_cpu(target_cpu, SCX_KICK_PREEMPT);
+				FLOW_CPUSTAT_INC(cstate, wake_preempt_dispatches);
+				if (rt_sensitive_wakeup)
+					FLOW_CPUSTAT_INC(cstate, rt_sensitive_preempts);
+			} else if (tctx->wake_cpu_idle &&
+				   (is_wakeup || !scx_bpf_task_running(p))) {
+				scx_bpf_kick_cpu(target_cpu, SCX_KICK_IDLE);
+			}
+
+			if (use_local_reserved) {
+				u64 local_slice_ns;
+
+				if (ipc_confidence_wakeup) {
+					local_slice_ns = FLOW_IPC_SLICE_NS;
+					FLOW_CPUSTAT_INC(cstate, ipc_boosts);
+				} else if (rt_sensitive_wakeup) {
+					local_slice_ns = FLOW_RT_WAKE_SLICE_NS;
+				} else {
+					local_slice_ns = direct_local_slice_ns(slice_ns);
+				}
+
+				if (urgent_latency_wakeup)
+					FLOW_CPUSTAT_INC(cstate, urgent_latency_misses);
+				scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | target_cpu,
+						   local_slice_ns, enq_flags);
+				if (latency_lane_wakeup)
+					FLOW_CPUSTAT_INC(cstate, latency_candidate_local_enqueues);
+				FLOW_CPUSTAT_INC(cstate, reserved_local_enqueues);
+				if (rt_sensitive_wakeup)
+					FLOW_CPUSTAT_INC(cstate, rt_sensitive_local_enqueues);
+				if (direct_local_wakeup)
+					FLOW_CPUSTAT_INC(cstate, direct_local_enqueues);
+				if (ipc_confidence_wakeup)
+					FLOW_CPUSTAT_INC(cstate, ipc_local_enqueues);
+				if (tctx->wake_cpu_idle)
+					FLOW_CPUSTAT_INC(cstate, local_fast_dispatches);
+				if (ordinary_local_reserved)
+					note_local_reserved_fast(cstate);
+				clear_wake_target(tctx);
+				return;
+			}
+		}
+
+		if (direct_local_wakeup)
+			note_locality_rejection(p, tctx);
+
+		if (containment_active) {
+			if (should_promote_contained_enqueue(cstate)) {
+				enq_flags |= SCX_ENQ_HEAD;
+				FLOW_CPUSTAT_INC(cstate, contained_starved_head_enqueues);
+			}
+			scx_bpf_dsq_insert(p, CONTAINED_DSQ, contained_slice_ns(), enq_flags);
+			reset_local_reserved_burst(cstate);
+			FLOW_CPUSTAT_INC(cstate, contained_enqueues);
+			FLOW_CPUSTAT_INC(cstate, hog_containment_enqueues);
+			clear_wake_target(tctx);
+			return;
+		}
+
+		if (latency_lane_wakeup) {
+			u64 latency_dsq = urgent_latency_wakeup ?
+				URGENT_LATENCY_DSQ : LATENCY_DSQ;
+
+			scx_bpf_dsq_insert(p, latency_dsq, slice_ns, enq_flags);
+			reset_local_reserved_burst(cstate);
+			decay_latency_allowance(tctx, tuned_latency_credit_decay());
+			if (urgent_latency_wakeup)
+				FLOW_CPUSTAT_INC(cstate, urgent_latency_enqueues);
+			if (has_urgent_latency_pressure(tctx))
+				FLOW_CPUSTAT_INC(cstate, latency_debt_urgent_enqueues);
+			if (decay_latency_pressure(tctx, FLOW_LATENCY_DEBT_DECAY_STEP))
+				FLOW_CPUSTAT_INC(cstate, latency_debt_decays);
+			FLOW_CPUSTAT_INC(cstate, latency_lane_enqueues);
 			if (has_wake_target && (is_wakeup || !scx_bpf_task_running(p)))
 				scx_bpf_kick_cpu(target_cpu, SCX_KICK_IDLE);
 			clear_wake_target(tctx);
 			return;
 		}
+
+		reserved_priority_wakeup = should_prioritize_reserved_enqueue(
+			tctx, is_wakeup, containment_active, latency_lane_wakeup,
+			rt_sensitive_wakeup, direct_local_wakeup, ipc_confidence_wakeup);
+		if (reserved_priority_wakeup)
+			enq_flags |= SCX_ENQ_HEAD;
+
+		if (has_wake_target && is_wakeup && valid_sched_cpu(target_cpu)) {
+			scx_bpf_dsq_insert(p, reserved_cpu_dsq_id(target_cpu), slice_ns, enq_flags);
+			reset_local_reserved_burst(cstate);
+			FLOW_CPUSTAT_INC(cstate, reserved_global_enqueues);
+			if (tctx->wake_cpu_idle)
+				scx_bpf_kick_cpu(target_cpu, SCX_KICK_IDLE);
+			clear_wake_target(tctx);
+			return;
+		}
+
+		scx_bpf_dsq_insert(p, RESERVED_DSQ, slice_ns, enq_flags);
+		reset_local_reserved_burst(cstate);
+		FLOW_CPUSTAT_INC(cstate, reserved_global_enqueues);
+		if (has_wake_target && (is_wakeup || !scx_bpf_task_running(p)))
+			scx_bpf_kick_cpu(target_cpu, SCX_KICK_IDLE);
+		clear_wake_target(tctx);
+		return;
+	}
+
+	if (tctx && is_containment_active(tctx)) {
+		if (should_promote_contained_enqueue(cstate)) {
+			enq_flags |= SCX_ENQ_HEAD;
+			FLOW_CPUSTAT_INC(cstate, contained_starved_head_enqueues);
+		}
+		scx_bpf_dsq_insert(p, CONTAINED_DSQ, contained_slice_ns(), enq_flags);
+		reset_local_reserved_burst(cstate);
+		FLOW_CPUSTAT_INC(cstate, contained_enqueues);
+		FLOW_CPUSTAT_INC(cstate, hog_containment_enqueues);
+		clear_wake_target(tctx);
+		return;
 	}
 
 	if (is_wakeup)
-		__sync_fetch_and_add(&shared_wakeup_enqueues, 1);
+		FLOW_CPUSTAT_INC(cstate, shared_wakeup_enqueues);
+
+	if (should_promote_shared_enqueue(cstate)) {
+		enq_flags |= SCX_ENQ_HEAD;
+		FLOW_CPUSTAT_INC(cstate, shared_starved_head_enqueues);
+	}
+
+	if (is_wakeup && has_wake_target && valid_sched_cpu(target_cpu)) {
+		scx_bpf_dsq_insert(p, shared_cpu_dsq_id(target_cpu), slice_ns, enq_flags);
+		reset_local_reserved_burst(cstate);
+		if (tctx && tctx->wake_cpu_idle)
+			scx_bpf_kick_cpu(target_cpu, SCX_KICK_IDLE);
+		clear_wake_target(tctx);
+		return;
+	}
 
 	scx_bpf_dsq_insert(p, SHARED_DSQ, slice_ns, enq_flags);
+	reset_local_reserved_burst(cstate);
 	clear_wake_target(tctx);
 }
 
 void BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
 {
 	struct task_ctx *tctx;
+	struct flow_cpu_state *cstate;
+	u64 shared_max = tune_shared_starvation_max;
+	u64 contained_max = tune_contained_starvation_max;
+	u64 reserved_lane_max = tuned_reserved_lane_burst_max();
+	bool force_shared;
+	bool force_contained;
+	u64 quota_max = tuned_reserved_quota_burst_max();
+	bool quota_force_shared;
+	bool quota_force_contained;
+	bool shared_more_starved;
+	u64 shared_rounds;
+	u64 contained_rounds;
+	u64 high_priority_rounds;
+	u64 urgent_burst_rounds;
+	u64 reserved_lane_rounds;
 
-	if (scx_bpf_dsq_move_to_local(RESERVED_DSQ, 0)) {
-		__sync_fetch_and_add(&reserved_dispatches, 1);
+	if (shared_max < FLOW_SHARED_STARVATION_MIN)
+		shared_max = FLOW_SHARED_STARVATION_MIN;
+	else if (shared_max > FLOW_SHARED_STARVATION_MAX_TUNE)
+		shared_max = FLOW_SHARED_STARVATION_MAX_TUNE;
+
+	if (contained_max < FLOW_CONTAINED_STARVATION_MIN)
+		contained_max = FLOW_CONTAINED_STARVATION_MIN;
+	else if (contained_max > FLOW_CONTAINED_STARVATION_MAX_TUNE)
+		contained_max = FLOW_CONTAINED_STARVATION_MAX_TUNE;
+
+	cstate = lookup_cpu_state();
+	shared_rounds = cstate ? cstate->shared_starvation_rounds : 0;
+	contained_rounds = cstate ? cstate->contained_starvation_rounds : 0;
+	high_priority_rounds = cstate ? cstate->high_priority_burst_rounds : 0;
+	urgent_burst_rounds = cstate ? cstate->urgent_latency_burst_rounds : 0;
+	reserved_lane_rounds = cstate ? cstate->reserved_lane_burst_rounds : 0;
+
+	force_shared = shared_rounds >= shared_max;
+	force_contained = contained_rounds >= contained_max;
+	quota_force_shared = !force_shared &&
+		high_priority_rounds >= quota_max &&
+		shared_rounds > 0;
+	quota_force_contained = !force_contained &&
+		high_priority_rounds >= quota_max &&
+		contained_rounds > 0;
+	shared_more_starved =
+		shared_rounds * contained_max >=
+		contained_rounds * shared_max;
+
+	if (quota_force_shared || quota_force_contained)
+		FLOW_CPUSTAT_INC(cstate, reserved_quota_skips);
+
+	if (quota_force_shared &&
+	    (!quota_force_contained || shared_more_starved)) {
+		if (move_shared_lane_to_local(cpu)) {
+			FLOW_CPUSTAT_INC(cstate, shared_dispatches);
+			FLOW_CPUSTAT_INC(cstate, quota_shared_forces);
+			note_shared_dispatch(cstate, true);
+			return;
+		}
+	}
+
+	if (quota_force_contained &&
+	    (!quota_force_shared || !shared_more_starved)) {
+		if (scx_bpf_dsq_move_to_local(CONTAINED_DSQ, 0)) {
+			FLOW_CPUSTAT_INC(cstate, contained_dispatches);
+			FLOW_CPUSTAT_INC(cstate, quota_contained_forces);
+			note_contained_dispatch(cstate, true);
+			return;
+		}
+	}
+
+	if (force_shared) {
+		if (move_shared_lane_to_local(cpu)) {
+			FLOW_CPUSTAT_INC(cstate, shared_dispatches);
+			note_shared_dispatch(cstate, true);
+			return;
+		}
+		backoff_starvation_round(cstate ? &cstate->shared_starvation_rounds : NULL,
+					 shared_max);
+	}
+
+	if (force_contained) {
+		if (scx_bpf_dsq_move_to_local(CONTAINED_DSQ, 0)) {
+			FLOW_CPUSTAT_INC(cstate, contained_dispatches);
+			note_contained_dispatch(cstate, true);
+			return;
+		}
+		backoff_starvation_round(cstate ? &cstate->contained_starvation_rounds : NULL,
+					 contained_max);
+	}
+
+	if (urgent_burst_rounds < tuned_urgent_latency_burst_max() &&
+	    scx_bpf_dsq_move_to_local(URGENT_LATENCY_DSQ, 0)) {
+		reset_local_reserved_burst(cstate);
+		note_urgent_latency_dispatch(cstate);
 		return;
 	}
 
-	if (scx_bpf_dsq_move_to_local(SHARED_DSQ, 0)) {
-		__sync_fetch_and_add(&shared_dispatches, 1);
+	if (scx_bpf_dsq_move_to_local(LATENCY_DSQ, 0)) {
+		reset_urgent_latency_burst(cstate);
+		reset_reserved_lane_burst(cstate);
+		reset_local_reserved_burst(cstate);
+		FLOW_CPUSTAT_INC(cstate, latency_dispatches);
+		note_high_priority_dispatch(cstate);
+		return;
+	}
+
+	if (reserved_lane_rounds >= reserved_lane_max) {
+		FLOW_CPUSTAT_INC(cstate, reserved_lane_skips);
+		if (shared_more_starved) {
+			if (move_shared_lane_to_local(cpu)) {
+				FLOW_CPUSTAT_INC(cstate, shared_dispatches);
+				FLOW_CPUSTAT_INC(cstate, reserved_lane_shared_forces);
+				note_shared_dispatch(cstate, true);
+				return;
+			}
+			FLOW_CPUSTAT_INC(cstate, reserved_lane_shared_misses);
+			if (scx_bpf_dsq_move_to_local(CONTAINED_DSQ, 0)) {
+				FLOW_CPUSTAT_INC(cstate, contained_dispatches);
+				FLOW_CPUSTAT_INC(cstate, reserved_lane_contained_forces);
+				note_contained_dispatch(cstate, true);
+				return;
+			}
+			FLOW_CPUSTAT_INC(cstate, reserved_lane_contained_misses);
+		} else {
+			if (scx_bpf_dsq_move_to_local(CONTAINED_DSQ, 0)) {
+				FLOW_CPUSTAT_INC(cstate, contained_dispatches);
+				FLOW_CPUSTAT_INC(cstate, reserved_lane_contained_forces);
+				note_contained_dispatch(cstate, true);
+				return;
+			}
+			FLOW_CPUSTAT_INC(cstate, reserved_lane_contained_misses);
+			if (move_shared_lane_to_local(cpu)) {
+				FLOW_CPUSTAT_INC(cstate, shared_dispatches);
+				FLOW_CPUSTAT_INC(cstate, reserved_lane_shared_forces);
+				note_shared_dispatch(cstate, true);
+				return;
+			}
+			FLOW_CPUSTAT_INC(cstate, reserved_lane_shared_misses);
+		}
+	}
+
+	if (move_reserved_lane_to_local(cpu)) {
+		note_reserved_dispatch(cstate);
+		return;
+	}
+
+	if (scx_bpf_dsq_move_to_local(CONTAINED_DSQ, 0)) {
+		FLOW_CPUSTAT_INC(cstate, contained_dispatches);
+		note_contained_dispatch(cstate, false);
+		return;
+	}
+
+	if (move_shared_lane_to_local(cpu)) {
+		FLOW_CPUSTAT_INC(cstate, shared_dispatches);
+		note_shared_dispatch(cstate, false);
 		return;
 	}
 
@@ -434,10 +1694,22 @@ void BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
 void BPF_STRUCT_OPS(flow_running, struct task_struct *p)
 {
 	struct task_ctx *tctx;
+	s32 current_cpu;
+	u64 now;
 
 	tctx = lookup_task_ctx(p);
-	if (tctx)
-		tctx->last_run_at = bpf_ktime_get_ns();
+	current_cpu = bpf_get_smp_processor_id();
+	now = bpf_ktime_get_ns();
+	if (tctx) {
+		if (tctx->last_cpu >= 0 && tctx->last_cpu != current_cpu) {
+			FLOW_CPUSTAT_INC(lookup_cpu_state(), cpu_migrations);
+			decay_locality_score(tctx, FLOW_DIRECT_LOCAL_SCORE_DECAY);
+			decay_ipc_confidence(tctx);
+		}
+		tctx->last_cpu = current_cpu;
+		tctx->last_run_at = now;
+		recompute_wake_profile(p, tctx);
+	}
 
 	__sync_fetch_and_add(&nr_running, 1);
 }
@@ -447,6 +1719,7 @@ void BPF_STRUCT_OPS(flow_stopping, struct task_struct *p, bool runnable)
 	struct task_ctx *tctx;
 	u64 now;
 	u64 runtime_ns = 0;
+	bool exhausted_budget = false;
 
 	tctx = lookup_task_ctx(p);
 	now = bpf_ktime_get_ns();
@@ -455,15 +1728,47 @@ void BPF_STRUCT_OPS(flow_stopping, struct task_struct *p, bool runnable)
 		if (tctx->last_run_at && now > tctx->last_run_at)
 			runtime_ns = now - tctx->last_run_at;
 
-		if (tctx->budget_ns > 0 &&
-		    tctx->budget_ns - (s64)runtime_ns <= 0)
-			__sync_fetch_and_add(&budget_exhaustions, 1);
+		exhausted_budget = tctx->budget_ns > 0 &&
+			tctx->budget_ns - (s64)runtime_ns <= 0;
+
+		if (exhausted_budget)
+			FLOW_CPUSTAT_INC(lookup_cpu_state(), budget_exhaustions);
+		if (exhausted_budget)
+			raise_containment_score(tctx, FLOW_HOG_SCORE_EXHAUST_STEP);
+		if (exhausted_budget)
+			decay_latency_allowance(tctx, tuned_latency_credit_decay());
+		if (exhausted_budget)
+			decay_locality_score(tctx, FLOW_DIRECT_LOCAL_SCORE_DECAY);
+		if (exhausted_budget)
+			decay_ipc_confidence(tctx);
+		if (exhausted_budget && runnable &&
+		    !is_containment_active(tctx) &&
+		    (tctx->last_refill_ns >= (s64)FLOW_LATENCY_LANE_REFILL_MIN_NS ||
+		     tctx->latency_allowance > 0) &&
+		    raise_latency_pressure(tctx, FLOW_LATENCY_DEBT_RAISE_STEP))
+			FLOW_CPUSTAT_INC(lookup_cpu_state(), latency_debt_raises);
 
 		tctx->budget_ns = clamp_budget(tctx->budget_ns - (s64)runtime_ns);
+		if (!runnable && !exhausted_budget &&
+		    !is_containment_active(tctx) &&
+		    runtime_ns > 0 && runtime_ns <= FLOW_DIRECT_LOCAL_SLICE_NS &&
+		    tctx->last_cpu >= 0)
+			raise_locality_score(tctx, FLOW_DIRECT_LOCAL_SCORE_GAIN);
+		if (!runnable && !exhausted_budget &&
+		    !is_containment_active(tctx) &&
+		    p->nr_cpus_allowed <= FLOW_IPC_CPUS_MAX &&
+		    runtime_ns > 0 &&
+		    runtime_ns <= FLOW_IPC_RUNTIME_MAX_NS &&
+		    tctx->budget_ns > (s64)FLOW_IPC_REFILL_MIN_NS)
+			raise_ipc_confidence(tctx);
+		else if (runtime_ns > FLOW_IPC_RUNTIME_MAX_NS ||
+			 p->nr_cpus_allowed > FLOW_IPC_CPUS_MAX)
+			decay_ipc_confidence(tctx);
 		tctx->last_run_at = 0;
 		tctx->sleep_started_at = runnable ? 0 : now;
 		if (!runnable)
 			clear_wake_target(tctx);
+		recompute_wake_profile(p, tctx);
 	}
 
 	__sync_fetch_and_add(&total_runtime, runtime_ns);

--- a/scheds/experimental/scx_flow/src/main.rs
+++ b/scheds/experimental/scx_flow/src/main.rs
@@ -19,8 +19,12 @@ use std::time::Duration;
 use std::time::Instant;
 
 use anyhow::Result;
+use clap::CommandFactory;
 use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
 use crossbeam::channel::RecvTimeoutError;
+use libbpf_rs::MapCore;
 use log::info;
 use scx_stats::prelude::*;
 use scx_utils::build_id;
@@ -65,6 +69,10 @@ struct Opts {
     #[clap(long, action = clap::ArgAction::SetTrue)]
     no_autotune: bool,
 
+    /// Generate shell completions for the given shell and exit.
+    #[clap(long, value_name = "SHELL", hide = true)]
+    completions: Option<Shell>,
+
     #[clap(flatten, next_help_heading = "Libbpf Options")]
     libbpf: LibbpfOpts,
 }
@@ -107,6 +115,16 @@ struct RuntimeTunables {
     interactive_floor_ns: u64,
     preempt_budget_min_ns: u64,
     preempt_refill_min_ns: u64,
+    latency_credit_grant: u64,
+    latency_credit_decay: u64,
+    latency_debt_urgent_min: u64,
+    urgent_latency_burst_max: u64,
+    reserved_quota_burst_max: u64,
+    reserved_lane_burst_max: u64,
+    contained_starvation_max: u64,
+    shared_starvation_max: u64,
+    local_fast_nr_running_max: u64,
+    local_reserved_burst_max: u64,
 }
 
 impl Default for RuntimeTunables {
@@ -117,6 +135,16 @@ impl Default for RuntimeTunables {
             interactive_floor_ns: u64::from(consts_FLOW_INTERACTIVE_FLOOR_NS),
             preempt_budget_min_ns: u64::from(consts_FLOW_PREEMPT_BUDGET_MIN_NS),
             preempt_refill_min_ns: u64::from(consts_FLOW_PREEMPT_REFILL_MIN_NS),
+            latency_credit_grant: u64::from(consts_FLOW_LATENCY_CREDIT_GRANT),
+            latency_credit_decay: u64::from(consts_FLOW_LATENCY_CREDIT_DECAY),
+            latency_debt_urgent_min: u64::from(consts_FLOW_LATENCY_DEBT_URGENT_MIN),
+            urgent_latency_burst_max: u64::from(consts_FLOW_URGENT_LATENCY_BURST_MAX),
+            reserved_quota_burst_max: u64::from(consts_FLOW_RESERVED_QUOTA_BURST_MAX),
+            reserved_lane_burst_max: u64::from(consts_FLOW_RESERVED_LANE_BURST_MAX),
+            contained_starvation_max: u64::from(consts_FLOW_CONTAINED_STARVATION_MAX),
+            shared_starvation_max: u64::from(consts_FLOW_SHARED_STARVATION_MAX),
+            local_fast_nr_running_max: u64::from(consts_FLOW_LOCAL_FAST_NR_RUNNING_MAX),
+            local_reserved_burst_max: u64::from(consts_FLOW_LOCAL_RESERVED_BURST_MAX),
         }
     }
 }
@@ -144,6 +172,46 @@ impl RuntimeTunables {
                 u64::from(consts_FLOW_PREEMPT_REFILL_MIN_NS),
                 u64::from(consts_FLOW_PREEMPT_REFILL_MAX_NS),
             ),
+            latency_credit_grant: self.latency_credit_grant.clamp(
+                u64::from(consts_FLOW_LATENCY_CREDIT_GRANT_MIN),
+                u64::from(consts_FLOW_LATENCY_CREDIT_GRANT_MAX),
+            ),
+            latency_credit_decay: self.latency_credit_decay.clamp(
+                u64::from(consts_FLOW_LATENCY_CREDIT_DECAY_MIN),
+                u64::from(consts_FLOW_LATENCY_CREDIT_DECAY_MAX),
+            ),
+            latency_debt_urgent_min: self.latency_debt_urgent_min.clamp(
+                u64::from(consts_FLOW_LATENCY_DEBT_URGENT_MIN_MIN),
+                u64::from(consts_FLOW_LATENCY_DEBT_URGENT_MIN_MAX),
+            ),
+            urgent_latency_burst_max: self.urgent_latency_burst_max.clamp(
+                u64::from(consts_FLOW_URGENT_LATENCY_BURST_MIN),
+                u64::from(consts_FLOW_URGENT_LATENCY_BURST_MAX_TUNE),
+            ),
+            reserved_quota_burst_max: self.reserved_quota_burst_max.clamp(
+                u64::from(consts_FLOW_RESERVED_QUOTA_BURST_MIN),
+                u64::from(consts_FLOW_RESERVED_QUOTA_BURST_MAX_TUNE),
+            ),
+            reserved_lane_burst_max: self.reserved_lane_burst_max.clamp(
+                u64::from(consts_FLOW_RESERVED_LANE_BURST_MIN),
+                u64::from(consts_FLOW_RESERVED_LANE_BURST_MAX_TUNE),
+            ),
+            contained_starvation_max: self.contained_starvation_max.clamp(
+                u64::from(consts_FLOW_CONTAINED_STARVATION_MIN),
+                u64::from(consts_FLOW_CONTAINED_STARVATION_MAX_TUNE),
+            ),
+            shared_starvation_max: self.shared_starvation_max.clamp(
+                u64::from(consts_FLOW_SHARED_STARVATION_MIN),
+                u64::from(consts_FLOW_SHARED_STARVATION_MAX_TUNE),
+            ),
+            local_fast_nr_running_max: self.local_fast_nr_running_max.clamp(
+                u64::from(consts_FLOW_LOCAL_FAST_NR_RUNNING_MIN),
+                u64::from(consts_FLOW_LOCAL_FAST_NR_RUNNING_MAX_TUNE),
+            ),
+            local_reserved_burst_max: self.local_reserved_burst_max.clamp(
+                u64::from(consts_FLOW_LOCAL_RESERVED_BURST_MIN),
+                u64::from(consts_FLOW_LOCAL_RESERVED_BURST_MAX_TUNE),
+            ),
         }
     }
 
@@ -156,6 +224,16 @@ impl RuntimeTunables {
                 interactive_floor_ns: 140 * 1000,
                 preempt_budget_min_ns: 225 * 1000,
                 preempt_refill_min_ns: 250 * 1000,
+                latency_credit_grant: u64::from(consts_FLOW_LATENCY_CREDIT_GRANT),
+                latency_credit_decay: u64::from(consts_FLOW_LATENCY_CREDIT_DECAY),
+                latency_debt_urgent_min: u64::from(consts_FLOW_LATENCY_DEBT_URGENT_MIN),
+                urgent_latency_burst_max: 3,
+                reserved_quota_burst_max: u64::from(consts_FLOW_RESERVED_QUOTA_BURST_MAX),
+                reserved_lane_burst_max: 4,
+                contained_starvation_max: u64::from(consts_FLOW_CONTAINED_STARVATION_MAX),
+                shared_starvation_max: 10,
+                local_fast_nr_running_max: u64::from(consts_FLOW_LOCAL_FAST_NR_RUNNING_MAX),
+                local_reserved_burst_max: 3,
             }
             .clamp(),
             AutoTuneMode::Throughput => Self {
@@ -164,6 +242,16 @@ impl RuntimeTunables {
                 interactive_floor_ns: 80 * 1000,
                 preempt_budget_min_ns: 300 * 1000,
                 preempt_refill_min_ns: 325 * 1000,
+                latency_credit_grant: u64::from(consts_FLOW_LATENCY_CREDIT_GRANT),
+                latency_credit_decay: u64::from(consts_FLOW_LATENCY_CREDIT_DECAY),
+                latency_debt_urgent_min: 2,
+                urgent_latency_burst_max: 1,
+                reserved_quota_burst_max: 3,
+                reserved_lane_burst_max: 6,
+                contained_starvation_max: u64::from(consts_FLOW_CONTAINED_STARVATION_MAX),
+                shared_starvation_max: u64::from(consts_FLOW_SHARED_STARVATION_MAX),
+                local_fast_nr_running_max: u64::from(consts_FLOW_LOCAL_FAST_NR_RUNNING_MAX),
+                local_reserved_burst_max: 3,
             }
             .clamp(),
         }
@@ -193,6 +281,56 @@ impl RuntimeTunables {
             target.preempt_refill_min_ns,
             25 * 1000,
         );
+        changed |= step_u64(
+            &mut self.latency_credit_grant,
+            target.latency_credit_grant,
+            1,
+        );
+        changed |= step_u64(
+            &mut self.latency_credit_decay,
+            target.latency_credit_decay,
+            1,
+        );
+        changed |= step_u64(
+            &mut self.latency_debt_urgent_min,
+            target.latency_debt_urgent_min,
+            1,
+        );
+        changed |= step_u64(
+            &mut self.urgent_latency_burst_max,
+            target.urgent_latency_burst_max,
+            1,
+        );
+        changed |= step_u64(
+            &mut self.reserved_quota_burst_max,
+            target.reserved_quota_burst_max,
+            1,
+        );
+        changed |= step_u64(
+            &mut self.reserved_lane_burst_max,
+            target.reserved_lane_burst_max,
+            1,
+        );
+        changed |= step_u64(
+            &mut self.contained_starvation_max,
+            target.contained_starvation_max,
+            1,
+        );
+        changed |= step_u64(
+            &mut self.shared_starvation_max,
+            target.shared_starvation_max,
+            1,
+        );
+        changed |= step_u64(
+            &mut self.local_fast_nr_running_max,
+            target.local_fast_nr_running_max,
+            1,
+        );
+        changed |= step_u64(
+            &mut self.local_reserved_burst_max,
+            target.local_reserved_burst_max,
+            1,
+        );
 
         *self = self.clamp();
         changed
@@ -211,6 +349,75 @@ fn step_u64(value: &mut u64, target: u64, step: u64) -> bool {
     }
 
     true
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CpuPolicyStateAgg {
+    urgent_latency_burst_rounds: u64,
+    high_priority_burst_rounds: u64,
+    local_reserved_burst_rounds: u64,
+    local_reserved_fast_grants: u64,
+    local_reserved_burst_continuations: u64,
+    reserved_lane_burst_rounds: u64,
+    contained_starvation_rounds: u64,
+    shared_starvation_rounds: u64,
+    budget_refill_events: u64,
+    budget_exhaustions: u64,
+    runnable_wakeups: u64,
+    urgent_latency_dispatches: u64,
+    urgent_latency_burst_grants: u64,
+    urgent_latency_burst_continuations: u64,
+    urgent_latency_enqueues: u64,
+    urgent_latency_misses: u64,
+    latency_dispatches: u64,
+    latency_debt_raises: u64,
+    latency_debt_decays: u64,
+    latency_debt_urgent_enqueues: u64,
+    reserved_dispatches: u64,
+    shared_dispatches: u64,
+    contained_dispatches: u64,
+    contained_rescue_dispatches: u64,
+    shared_rescue_dispatches: u64,
+    local_fast_dispatches: u64,
+    wake_preempt_dispatches: u64,
+    cpu_stability_biases: u64,
+    last_cpu_matches: u64,
+    latency_lane_candidates: u64,
+    latency_lane_enqueues: u64,
+    latency_candidate_local_enqueues: u64,
+    latency_candidate_hog_blocks: u64,
+    positive_budget_wakeups: u64,
+    rt_sensitive_wakeups: u64,
+    reserved_local_enqueues: u64,
+    reserved_global_enqueues: u64,
+    reserved_quota_skips: u64,
+    quota_shared_forces: u64,
+    quota_contained_forces: u64,
+    reserved_lane_grants: u64,
+    reserved_lane_burst_continuations: u64,
+    reserved_lane_skips: u64,
+    reserved_lane_shared_forces: u64,
+    reserved_lane_contained_forces: u64,
+    reserved_lane_shared_misses: u64,
+    reserved_lane_contained_misses: u64,
+    shared_wakeup_enqueues: u64,
+    shared_starved_head_enqueues: u64,
+    local_quota_skips: u64,
+    rt_sensitive_local_enqueues: u64,
+    rt_sensitive_preempts: u64,
+    direct_local_candidates: u64,
+    direct_local_enqueues: u64,
+    direct_local_rejections: u64,
+    direct_local_mismatches: u64,
+    ipc_wake_candidates: u64,
+    ipc_local_enqueues: u64,
+    ipc_score_raises: u64,
+    ipc_boosts: u64,
+    contained_enqueues: u64,
+    contained_starved_head_enqueues: u64,
+    hog_containment_enqueues: u64,
+    hog_recoveries: u64,
+    cpu_migrations: u64,
 }
 
 #[derive(Debug)]
@@ -243,12 +450,28 @@ impl AutoTuner {
         let reserved_local = delta.reserved_local_enqueues;
         let reserved_global = delta.reserved_global_enqueues;
         let reserved_dispatches = delta.reserved_dispatches;
+        let latency_dispatches = delta.latency_dispatches;
+        let contained_enqueues = delta.contained_enqueues;
+        let contained_dispatches = delta.contained_dispatches;
+        let contained_rescues = delta.contained_rescue_dispatches;
+        let shared_rescues = delta.shared_rescue_dispatches;
         let wake_preempt = delta.wake_preempt_dispatches;
         let exhaustions = delta.budget_exhaustions;
         let runnable = delta.runnable_wakeups;
+        let direct_candidates = delta.direct_local_candidates;
+        let direct_rejections = delta.direct_local_rejections;
+        let direct_mismatches = delta.direct_local_mismatches;
+        let cpu_biases = delta.cpu_stability_biases;
         let reserved_total = reserved_local + reserved_global;
+        let lane_events = positive + shared_wake + contained_enqueues;
+        let urgent_latency_dispatches = delta.urgent_latency_dispatches;
+        let total_latency_dispatches = latency_dispatches + urgent_latency_dispatches;
+        let dispatch_total = total_latency_dispatches
+            + reserved_dispatches
+            + contained_dispatches
+            + delta.shared_dispatches;
 
-        if positive + shared_wake < 3 && reserved_total < 2 {
+        if lane_events < 3 && reserved_total + contained_dispatches < 2 {
             return self.mode;
         }
 
@@ -256,23 +479,56 @@ impl AutoTuner {
         let global_ratio = reserved_global as f64 / reserved_total.max(1) as f64;
         let preempt_ratio = wake_preempt as f64 / reserved_local.max(1) as f64;
         let exhaustion_ratio = exhaustions as f64 / positive.max(1) as f64;
+        let contained_ratio = contained_enqueues as f64 / positive.max(1) as f64;
+        let direct_reject_ratio = direct_rejections as f64 / direct_candidates.max(1) as f64;
+        let direct_mismatch_attempts = cpu_biases.saturating_add(direct_mismatches);
+        let direct_mismatch_ratio =
+            direct_mismatches as f64 / direct_mismatch_attempts.max(1) as f64;
+        let rescue_total = contained_rescues + shared_rescues;
+        let rescue_ratio = rescue_total as f64 / dispatch_total.max(1) as f64;
+        let latency_dispatch_ratio = total_latency_dispatches as f64 / dispatch_total.max(1) as f64;
+        let rescue_pressure = rescue_total >= 8 && rescue_ratio > 0.08;
         let keep_latency_mode = self.mode == AutoTuneMode::Latency
             && current.nr_running >= 1
+            && !rescue_pressure
             && (wake_preempt > 0
-                || reserved_dispatches > 0
-                || reserved_global > 0
+                || latency_dispatch_ratio > 0.45
+                || shared_ratio > 0.45
+                || global_ratio > 0.35
+                || exhaustion_ratio > 0.30
                 || runnable > 64);
-        let should_enter_latency_mode =
-            shared_ratio > 0.45 || global_ratio > 0.35 || exhaustion_ratio > 0.30;
+        let keep_throughput_mode = self.mode == AutoTuneMode::Throughput
+            && current.nr_running >= 2
+            && (contained_enqueues > 0 || contained_dispatches > 0)
+            && shared_ratio < 0.45
+            && global_ratio < 0.30;
+        let should_enter_throughput_mode = current.nr_running >= 3
+            && ((shared_ratio < 0.45
+                && global_ratio < 0.30
+                && ((contained_dispatches > 0 && contained_ratio > 0.12)
+                    || (direct_candidates > 0
+                        && direct_reject_ratio > 0.20
+                        && direct_mismatch_ratio > 0.20)))
+                || (reserved_local >= 2
+                    && preempt_ratio > 0.65
+                    && shared_ratio < 0.35
+                    && global_ratio < 0.20));
+        let should_enter_latency_mode = latency_dispatch_ratio > 0.40
+            || wake_preempt > 0
+            || shared_ratio > 0.45
+            || global_ratio > 0.35
+            || exhaustion_ratio > 0.30;
+        let should_rebalance_mode = rescue_pressure
+            && latency_dispatch_ratio < 0.40
+            && shared_ratio < 0.45
+            && global_ratio < 0.35
+            && exhaustion_ratio < 0.30;
 
-        if keep_latency_mode || should_enter_latency_mode {
+        if keep_latency_mode || (should_enter_latency_mode && !should_rebalance_mode) {
             AutoTuneMode::Latency
-        } else if current.nr_running >= 3
-            && reserved_local >= 2
-            && preempt_ratio > 0.65
-            && shared_ratio < 0.35
-            && global_ratio < 0.20
-        {
+        } else if should_rebalance_mode {
+            AutoTuneMode::Balanced
+        } else if keep_throughput_mode || should_enter_throughput_mode {
             AutoTuneMode::Throughput
         } else {
             AutoTuneMode::Balanced
@@ -333,6 +589,217 @@ impl AutoTuner {
 }
 
 impl<'a> Scheduler<'a> {
+    fn read_cpu_policy_state(&self) -> CpuPolicyStateAgg {
+        let key = 0u32.to_ne_bytes();
+        let mut agg = CpuPolicyStateAgg::default();
+
+        let percpu_vals: Vec<Vec<u8>> = match self
+            .skel
+            .maps
+            .cpu_state
+            .lookup_percpu(&key, libbpf_rs::MapFlags::ANY)
+        {
+            Ok(Some(vals)) => vals,
+            _ => return agg,
+        };
+
+        for cpu_val in percpu_vals.iter() {
+            if cpu_val.len() < std::mem::size_of::<bpf_intf::flow_cpu_state>() {
+                continue;
+            }
+
+            let state = unsafe {
+                std::ptr::read_unaligned(cpu_val.as_ptr() as *const bpf_intf::flow_cpu_state)
+            };
+
+            agg.urgent_latency_burst_rounds = agg
+                .urgent_latency_burst_rounds
+                .max(state.urgent_latency_burst_rounds);
+            agg.high_priority_burst_rounds = agg
+                .high_priority_burst_rounds
+                .max(state.high_priority_burst_rounds);
+            agg.local_reserved_burst_rounds = agg
+                .local_reserved_burst_rounds
+                .max(state.local_reserved_burst_rounds);
+            agg.local_reserved_fast_grants = agg
+                .local_reserved_fast_grants
+                .saturating_add(state.local_reserved_fast_grants);
+            agg.local_reserved_burst_continuations = agg
+                .local_reserved_burst_continuations
+                .saturating_add(state.local_reserved_burst_continuations);
+            agg.reserved_lane_burst_rounds = agg
+                .reserved_lane_burst_rounds
+                .max(state.reserved_lane_burst_rounds);
+            agg.contained_starvation_rounds = agg
+                .contained_starvation_rounds
+                .max(state.contained_starvation_rounds);
+            agg.shared_starvation_rounds = agg
+                .shared_starvation_rounds
+                .max(state.shared_starvation_rounds);
+            agg.budget_refill_events = agg
+                .budget_refill_events
+                .saturating_add(state.budget_refill_events);
+            agg.budget_exhaustions = agg
+                .budget_exhaustions
+                .saturating_add(state.budget_exhaustions);
+            agg.runnable_wakeups = agg.runnable_wakeups.saturating_add(state.runnable_wakeups);
+            agg.urgent_latency_dispatches = agg
+                .urgent_latency_dispatches
+                .saturating_add(state.urgent_latency_dispatches);
+            agg.urgent_latency_burst_grants = agg
+                .urgent_latency_burst_grants
+                .saturating_add(state.urgent_latency_burst_grants);
+            agg.urgent_latency_burst_continuations = agg
+                .urgent_latency_burst_continuations
+                .saturating_add(state.urgent_latency_burst_continuations);
+            agg.urgent_latency_enqueues = agg
+                .urgent_latency_enqueues
+                .saturating_add(state.urgent_latency_enqueues);
+            agg.urgent_latency_misses = agg
+                .urgent_latency_misses
+                .saturating_add(state.urgent_latency_misses);
+            agg.latency_dispatches = agg
+                .latency_dispatches
+                .saturating_add(state.latency_dispatches);
+            agg.latency_debt_raises = agg
+                .latency_debt_raises
+                .saturating_add(state.latency_debt_raises);
+            agg.latency_debt_decays = agg
+                .latency_debt_decays
+                .saturating_add(state.latency_debt_decays);
+            agg.latency_debt_urgent_enqueues = agg
+                .latency_debt_urgent_enqueues
+                .saturating_add(state.latency_debt_urgent_enqueues);
+            agg.reserved_dispatches = agg
+                .reserved_dispatches
+                .saturating_add(state.reserved_dispatches);
+            agg.shared_dispatches = agg
+                .shared_dispatches
+                .saturating_add(state.shared_dispatches);
+            agg.contained_dispatches = agg
+                .contained_dispatches
+                .saturating_add(state.contained_dispatches);
+            agg.contained_rescue_dispatches = agg
+                .contained_rescue_dispatches
+                .saturating_add(state.contained_rescue_dispatches);
+            agg.shared_rescue_dispatches = agg
+                .shared_rescue_dispatches
+                .saturating_add(state.shared_rescue_dispatches);
+            agg.local_fast_dispatches = agg
+                .local_fast_dispatches
+                .saturating_add(state.local_fast_dispatches);
+            agg.wake_preempt_dispatches = agg
+                .wake_preempt_dispatches
+                .saturating_add(state.wake_preempt_dispatches);
+            agg.cpu_stability_biases = agg
+                .cpu_stability_biases
+                .saturating_add(state.cpu_stability_biases);
+            agg.last_cpu_matches = agg.last_cpu_matches.saturating_add(state.last_cpu_matches);
+            agg.latency_lane_candidates = agg
+                .latency_lane_candidates
+                .saturating_add(state.latency_lane_candidates);
+            agg.latency_lane_enqueues = agg
+                .latency_lane_enqueues
+                .saturating_add(state.latency_lane_enqueues);
+            agg.latency_candidate_local_enqueues = agg
+                .latency_candidate_local_enqueues
+                .saturating_add(state.latency_candidate_local_enqueues);
+            agg.latency_candidate_hog_blocks = agg
+                .latency_candidate_hog_blocks
+                .saturating_add(state.latency_candidate_hog_blocks);
+            agg.positive_budget_wakeups = agg
+                .positive_budget_wakeups
+                .saturating_add(state.positive_budget_wakeups);
+            agg.rt_sensitive_wakeups = agg
+                .rt_sensitive_wakeups
+                .saturating_add(state.rt_sensitive_wakeups);
+            agg.reserved_local_enqueues = agg
+                .reserved_local_enqueues
+                .saturating_add(state.reserved_local_enqueues);
+            agg.reserved_global_enqueues = agg
+                .reserved_global_enqueues
+                .saturating_add(state.reserved_global_enqueues);
+            agg.reserved_quota_skips = agg
+                .reserved_quota_skips
+                .saturating_add(state.reserved_quota_skips);
+            agg.quota_shared_forces = agg
+                .quota_shared_forces
+                .saturating_add(state.quota_shared_forces);
+            agg.quota_contained_forces = agg
+                .quota_contained_forces
+                .saturating_add(state.quota_contained_forces);
+            agg.reserved_lane_grants = agg
+                .reserved_lane_grants
+                .saturating_add(state.reserved_lane_grants);
+            agg.reserved_lane_burst_continuations = agg
+                .reserved_lane_burst_continuations
+                .saturating_add(state.reserved_lane_burst_continuations);
+            agg.reserved_lane_skips = agg
+                .reserved_lane_skips
+                .saturating_add(state.reserved_lane_skips);
+            agg.reserved_lane_shared_forces = agg
+                .reserved_lane_shared_forces
+                .saturating_add(state.reserved_lane_shared_forces);
+            agg.reserved_lane_contained_forces = agg
+                .reserved_lane_contained_forces
+                .saturating_add(state.reserved_lane_contained_forces);
+            agg.reserved_lane_shared_misses = agg
+                .reserved_lane_shared_misses
+                .saturating_add(state.reserved_lane_shared_misses);
+            agg.reserved_lane_contained_misses = agg
+                .reserved_lane_contained_misses
+                .saturating_add(state.reserved_lane_contained_misses);
+            agg.shared_wakeup_enqueues = agg
+                .shared_wakeup_enqueues
+                .saturating_add(state.shared_wakeup_enqueues);
+            agg.shared_starved_head_enqueues = agg
+                .shared_starved_head_enqueues
+                .saturating_add(state.shared_starved_head_enqueues);
+            agg.local_quota_skips = agg
+                .local_quota_skips
+                .saturating_add(state.local_quota_skips);
+            agg.rt_sensitive_local_enqueues = agg
+                .rt_sensitive_local_enqueues
+                .saturating_add(state.rt_sensitive_local_enqueues);
+            agg.rt_sensitive_preempts = agg
+                .rt_sensitive_preempts
+                .saturating_add(state.rt_sensitive_preempts);
+            agg.direct_local_candidates = agg
+                .direct_local_candidates
+                .saturating_add(state.direct_local_candidates);
+            agg.direct_local_enqueues = agg
+                .direct_local_enqueues
+                .saturating_add(state.direct_local_enqueues);
+            agg.direct_local_rejections = agg
+                .direct_local_rejections
+                .saturating_add(state.direct_local_rejections);
+            agg.direct_local_mismatches = agg
+                .direct_local_mismatches
+                .saturating_add(state.direct_local_mismatches);
+            agg.ipc_wake_candidates = agg
+                .ipc_wake_candidates
+                .saturating_add(state.ipc_wake_candidates);
+            agg.ipc_local_enqueues = agg
+                .ipc_local_enqueues
+                .saturating_add(state.ipc_local_enqueues);
+            agg.ipc_score_raises = agg.ipc_score_raises.saturating_add(state.ipc_score_raises);
+            agg.ipc_boosts = agg.ipc_boosts.saturating_add(state.ipc_boosts);
+            agg.contained_enqueues = agg
+                .contained_enqueues
+                .saturating_add(state.contained_enqueues);
+            agg.contained_starved_head_enqueues = agg
+                .contained_starved_head_enqueues
+                .saturating_add(state.contained_starved_head_enqueues);
+            agg.hog_containment_enqueues = agg
+                .hog_containment_enqueues
+                .saturating_add(state.hog_containment_enqueues);
+            agg.hog_recoveries = agg.hog_recoveries.saturating_add(state.hog_recoveries);
+            agg.cpu_migrations = agg.cpu_migrations.saturating_add(state.cpu_migrations);
+        }
+
+        agg
+    }
+
     fn init(
         opts: &'a Opts,
         open_object: &'a mut MaybeUninit<libbpf_rs::OpenObject>,
@@ -350,7 +817,6 @@ impl<'a> Scheduler<'a> {
             | *compat::SCX_OPS_ENQ_MIGRATION_DISABLED
             | *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP;
 
-        // Load BPF program
         let mut skel = scx_ops_load!(skel, flow_ops, uei)?;
         Self::write_runtime_tunables(
             &mut skel,
@@ -359,10 +825,9 @@ impl<'a> Scheduler<'a> {
             0,
         );
 
-        // Attach scheduler
         let struct_ops = scx_ops_attach!(skel, flow_ops)?;
 
-        // Launch stats server for scx_top
+        // Expose live metrics for monitor and stats clients.
         let stats_server = StatsServer::new(stats::server_data()).launch()?;
 
         Ok(Self {
@@ -375,27 +840,136 @@ impl<'a> Scheduler<'a> {
     fn get_metrics(&self) -> Metrics {
         let bss_data = self.skel.maps.bss_data.as_ref().unwrap();
         let data = self.skel.maps.data_data.as_ref().unwrap();
+        let cpu_policy_state = self.read_cpu_policy_state();
         Metrics {
             nr_running: bss_data.nr_running,
             total_runtime: bss_data.total_runtime,
-            reserved_dispatches: bss_data.reserved_dispatches,
-            shared_dispatches: bss_data.shared_dispatches,
-            local_fast_dispatches: bss_data.local_fast_dispatches,
-            wake_preempt_dispatches: bss_data.wake_preempt_dispatches,
-            budget_refill_events: bss_data.budget_refill_events,
-            budget_exhaustions: bss_data.budget_exhaustions,
-            positive_budget_wakeups: bss_data.positive_budget_wakeups,
-            reserved_local_enqueues: bss_data.reserved_local_enqueues,
-            reserved_global_enqueues: bss_data.reserved_global_enqueues,
-            shared_wakeup_enqueues: bss_data.shared_wakeup_enqueues,
-            runnable_wakeups: bss_data.runnable_wakeups,
+            reserved_dispatches: bss_data.reserved_dispatches
+                + cpu_policy_state.reserved_dispatches,
+            urgent_latency_dispatches: bss_data.urgent_latency_dispatches
+                + cpu_policy_state.urgent_latency_dispatches,
+            urgent_latency_burst_grants: bss_data.urgent_latency_burst_grants
+                + cpu_policy_state.urgent_latency_burst_grants,
+            urgent_latency_burst_continuations: bss_data.urgent_latency_burst_continuations
+                + cpu_policy_state.urgent_latency_burst_continuations,
+            latency_dispatches: bss_data.latency_dispatches + cpu_policy_state.latency_dispatches,
+            shared_dispatches: bss_data.shared_dispatches + cpu_policy_state.shared_dispatches,
+            contained_dispatches: bss_data.contained_dispatches
+                + cpu_policy_state.contained_dispatches,
+            local_fast_dispatches: bss_data.local_fast_dispatches
+                + cpu_policy_state.local_fast_dispatches,
+            wake_preempt_dispatches: bss_data.wake_preempt_dispatches
+                + cpu_policy_state.wake_preempt_dispatches,
+            budget_refill_events: bss_data.budget_refill_events
+                + cpu_policy_state.budget_refill_events,
+            budget_exhaustions: bss_data.budget_exhaustions + cpu_policy_state.budget_exhaustions,
+            positive_budget_wakeups: bss_data.positive_budget_wakeups
+                + cpu_policy_state.positive_budget_wakeups,
+            urgent_latency_enqueues: bss_data.urgent_latency_enqueues
+                + cpu_policy_state.urgent_latency_enqueues,
+            latency_lane_enqueues: bss_data.latency_lane_enqueues
+                + cpu_policy_state.latency_lane_enqueues,
+            latency_lane_candidates: bss_data.latency_lane_candidates
+                + cpu_policy_state.latency_lane_candidates,
+            latency_candidate_local_enqueues: bss_data.latency_candidate_local_enqueues
+                + cpu_policy_state.latency_candidate_local_enqueues,
+            latency_candidate_hog_blocks: bss_data.latency_candidate_hog_blocks
+                + cpu_policy_state.latency_candidate_hog_blocks,
+            latency_debt_raises: bss_data.latency_debt_raises
+                + cpu_policy_state.latency_debt_raises,
+            latency_debt_decays: bss_data.latency_debt_decays
+                + cpu_policy_state.latency_debt_decays,
+            latency_debt_urgent_enqueues: bss_data.latency_debt_urgent_enqueues
+                + cpu_policy_state.latency_debt_urgent_enqueues,
+            urgent_latency_misses: bss_data.urgent_latency_misses
+                + cpu_policy_state.urgent_latency_misses,
+            reserved_local_enqueues: bss_data.reserved_local_enqueues
+                + cpu_policy_state.reserved_local_enqueues,
+            reserved_global_enqueues: bss_data.reserved_global_enqueues
+                + cpu_policy_state.reserved_global_enqueues,
+            shared_wakeup_enqueues: bss_data.shared_wakeup_enqueues
+                + cpu_policy_state.shared_wakeup_enqueues,
+            runnable_wakeups: bss_data.runnable_wakeups + cpu_policy_state.runnable_wakeups,
             cpu_release_reenqueues: bss_data.cpu_release_reenqueues,
+            urgent_latency_burst_rounds: cpu_policy_state.urgent_latency_burst_rounds,
+            high_priority_burst_rounds: cpu_policy_state.high_priority_burst_rounds,
+            local_reserved_burst_rounds: cpu_policy_state.local_reserved_burst_rounds,
+            local_reserved_fast_grants: bss_data.local_reserved_fast_grants
+                + cpu_policy_state.local_reserved_fast_grants,
+            local_reserved_burst_continuations: bss_data.local_reserved_burst_continuations
+                + cpu_policy_state.local_reserved_burst_continuations,
+            local_quota_skips: bss_data.local_quota_skips + cpu_policy_state.local_quota_skips,
+            reserved_quota_skips: bss_data.reserved_quota_skips
+                + cpu_policy_state.reserved_quota_skips,
+            quota_shared_forces: bss_data.quota_shared_forces
+                + cpu_policy_state.quota_shared_forces,
+            quota_contained_forces: bss_data.quota_contained_forces
+                + cpu_policy_state.quota_contained_forces,
             init_task_events: bss_data.init_task_events,
             enable_events: bss_data.enable_events,
             exit_task_events: bss_data.exit_task_events,
-            rt_sensitive_wakeups: bss_data.rt_sensitive_wakeups,
-            rt_sensitive_local_enqueues: bss_data.rt_sensitive_local_enqueues,
-            rt_sensitive_preempts: bss_data.rt_sensitive_preempts,
+            cpu_stability_biases: bss_data.cpu_stability_biases
+                + cpu_policy_state.cpu_stability_biases,
+            last_cpu_matches: bss_data.last_cpu_matches + cpu_policy_state.last_cpu_matches,
+            cpu_migrations: bss_data.cpu_migrations + cpu_policy_state.cpu_migrations,
+            rt_sensitive_wakeups: bss_data.rt_sensitive_wakeups
+                + cpu_policy_state.rt_sensitive_wakeups,
+            rt_sensitive_local_enqueues: bss_data.rt_sensitive_local_enqueues
+                + cpu_policy_state.rt_sensitive_local_enqueues,
+            rt_sensitive_preempts: bss_data.rt_sensitive_preempts
+                + cpu_policy_state.rt_sensitive_preempts,
+            reserved_lane_burst_rounds: cpu_policy_state.reserved_lane_burst_rounds,
+            reserved_lane_grants: bss_data.reserved_lane_grants
+                + cpu_policy_state.reserved_lane_grants,
+            reserved_lane_burst_continuations: bss_data.reserved_lane_burst_continuations
+                + cpu_policy_state.reserved_lane_burst_continuations,
+            reserved_lane_skips: bss_data.reserved_lane_skips
+                + cpu_policy_state.reserved_lane_skips,
+            reserved_lane_shared_forces: bss_data.reserved_lane_shared_forces
+                + cpu_policy_state.reserved_lane_shared_forces,
+            reserved_lane_contained_forces: bss_data.reserved_lane_contained_forces
+                + cpu_policy_state.reserved_lane_contained_forces,
+            reserved_lane_shared_misses: bss_data.reserved_lane_shared_misses
+                + cpu_policy_state.reserved_lane_shared_misses,
+            reserved_lane_contained_misses: bss_data.reserved_lane_contained_misses
+                + cpu_policy_state.reserved_lane_contained_misses,
+            contained_starved_head_enqueues: bss_data.contained_starved_head_enqueues
+                + cpu_policy_state.contained_starved_head_enqueues,
+            shared_starved_head_enqueues: bss_data.shared_starved_head_enqueues
+                + cpu_policy_state.shared_starved_head_enqueues,
+            direct_local_candidates: bss_data.direct_local_candidates
+                + cpu_policy_state.direct_local_candidates,
+            direct_local_enqueues: bss_data.direct_local_enqueues
+                + cpu_policy_state.direct_local_enqueues,
+            direct_local_rejections: bss_data.direct_local_rejections
+                + cpu_policy_state.direct_local_rejections,
+            direct_local_mismatches: bss_data.direct_local_mismatches
+                + cpu_policy_state.direct_local_mismatches,
+            ipc_wake_candidates: bss_data.ipc_wake_candidates
+                + cpu_policy_state.ipc_wake_candidates,
+            ipc_local_enqueues: bss_data.ipc_local_enqueues + cpu_policy_state.ipc_local_enqueues,
+            ipc_score_raises: bss_data.ipc_score_raises + cpu_policy_state.ipc_score_raises,
+            ipc_boosts: bss_data.ipc_boosts + cpu_policy_state.ipc_boosts,
+            contained_enqueues: bss_data.contained_enqueues + cpu_policy_state.contained_enqueues,
+            hog_containment_enqueues: bss_data.hog_containment_enqueues
+                + cpu_policy_state.hog_containment_enqueues,
+            hog_recoveries: bss_data.hog_recoveries + cpu_policy_state.hog_recoveries,
+            contained_starvation_rounds: cpu_policy_state.contained_starvation_rounds,
+            shared_starvation_rounds: cpu_policy_state.shared_starvation_rounds,
+            contained_rescue_dispatches: bss_data.contained_rescue_dispatches
+                + cpu_policy_state.contained_rescue_dispatches,
+            shared_rescue_dispatches: bss_data.shared_rescue_dispatches
+                + cpu_policy_state.shared_rescue_dispatches,
+            tune_latency_credit_grant: data.tune_latency_credit_grant,
+            tune_latency_credit_decay: data.tune_latency_credit_decay,
+            tune_latency_debt_urgent_min: data.tune_latency_debt_urgent_min,
+            tune_urgent_latency_burst_max: data.tune_urgent_latency_burst_max,
+            tune_reserved_quota_burst_max: data.tune_reserved_quota_burst_max,
+            tune_contained_starvation_max: data.tune_contained_starvation_max,
+            tune_shared_starvation_max: data.tune_shared_starvation_max,
+            tune_local_fast_nr_running_max: data.tune_local_fast_nr_running_max,
+            tune_local_reserved_burst_max: data.tune_local_reserved_burst_max,
+            tune_reserved_lane_burst_max: data.tune_reserved_lane_burst_max,
             autotune_generation: bss_data.autotune_generation,
             autotune_mode: bss_data.autotune_mode,
             tune_reserved_max_ns: data.tune_reserved_max_ns,
@@ -418,6 +992,16 @@ impl<'a> Scheduler<'a> {
         data.tune_interactive_floor_ns = tunables.interactive_floor_ns;
         data.tune_preempt_budget_min_ns = tunables.preempt_budget_min_ns;
         data.tune_preempt_refill_min_ns = tunables.preempt_refill_min_ns;
+        data.tune_latency_credit_grant = tunables.latency_credit_grant;
+        data.tune_latency_credit_decay = tunables.latency_credit_decay;
+        data.tune_latency_debt_urgent_min = tunables.latency_debt_urgent_min;
+        data.tune_urgent_latency_burst_max = tunables.urgent_latency_burst_max;
+        data.tune_reserved_quota_burst_max = tunables.reserved_quota_burst_max;
+        data.tune_contained_starvation_max = tunables.contained_starvation_max;
+        data.tune_shared_starvation_max = tunables.shared_starvation_max;
+        data.tune_local_fast_nr_running_max = tunables.local_fast_nr_running_max;
+        data.tune_local_reserved_burst_max = tunables.local_reserved_burst_max;
+        data.tune_reserved_lane_burst_max = tunables.reserved_lane_burst_max;
 
         let bss_data = skel.maps.bss_data.as_mut().unwrap();
         bss_data.autotune_mode = mode.as_u64();
@@ -455,7 +1039,7 @@ impl<'a> Scheduler<'a> {
                     if let Some((mode, tunables, generation)) = autotuner.update(&current) {
                         self.apply_runtime_tunables(tunables, mode, generation);
                         info!(
-                            "autotune={} gen={} reserve_cap={}us shared_slice={}us refill_floor={}us preempt_budget={}us preempt_refill={}us",
+                            "autotune={} gen={} reserve_cap={}us shared_slice={}us refill_floor={}us preempt_budget={}us preempt_refill={}us debt_min={} urgent_burst_max={} reserved_quota_max={} reserved_lane_max={} local_burst_max={}",
                             mode.as_str(),
                             generation,
                             tunables.reserved_max_ns / 1000,
@@ -463,6 +1047,11 @@ impl<'a> Scheduler<'a> {
                             tunables.interactive_floor_ns / 1000,
                             tunables.preempt_budget_min_ns / 1000,
                             tunables.preempt_refill_min_ns / 1000,
+                            tunables.latency_debt_urgent_min,
+                            tunables.urgent_latency_burst_max,
+                            tunables.reserved_quota_burst_max,
+                            tunables.reserved_lane_burst_max,
+                            tunables.local_reserved_burst_max,
                         );
                     }
                     next_tune_at = Instant::now() + Duration::from_secs(1);
@@ -477,6 +1066,17 @@ impl<'a> Scheduler<'a> {
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
+
+    if let Some(shell) = opts.completions {
+        generate(
+            shell,
+            &mut Opts::command(),
+            SCHEDULER_NAME,
+            &mut std::io::stdout(),
+        );
+        return Ok(());
+    }
+
     let monitor_only = opts.monitor.is_some();
 
     if opts.version {
@@ -501,15 +1101,14 @@ fn main() -> Result<()> {
     let shutdown = Arc::new(AtomicBool::new(false));
     let shutdown_clone = shutdown.clone();
 
-    // Handle Ctrl+C
     ctrlc::set_handler(move || {
         shutdown_clone.store(true, Ordering::Relaxed);
     })?;
 
     if let Some(intv) = opts.monitor.or(opts.stats) {
-        let shutdown_copy = shutdown.clone();
+        let monitor_shutdown = shutdown.clone();
         let jh = std::thread::spawn(move || {
-            if let Err(err) = stats::monitor(Duration::from_secs_f64(intv), shutdown_copy) {
+            if let Err(err) = stats::monitor(Duration::from_secs_f64(intv), monitor_shutdown) {
                 log::warn!("stats monitor thread finished with error: {err}");
             }
         });

--- a/scheds/experimental/scx_flow/src/stats.rs
+++ b/scheds/experimental/scx_flow/src/stats.rs
@@ -26,8 +26,18 @@ pub struct Metrics {
     pub total_runtime: u64,
     #[stat(desc = "Tasks dispatched from the reserved positive-budget DSQ")]
     pub reserved_dispatches: u64,
+    #[stat(desc = "Tasks dispatched from the urgent latency lane DSQ")]
+    pub urgent_latency_dispatches: u64,
+    #[stat(desc = "Urgent-latency dispatches granted through the bounded burst path")]
+    pub urgent_latency_burst_grants: u64,
+    #[stat(desc = "Urgent-latency dispatches that continued an already-active burst window")]
+    pub urgent_latency_burst_continuations: u64,
+    #[stat(desc = "Tasks dispatched from the dedicated latency lane DSQ")]
+    pub latency_dispatches: u64,
     #[stat(desc = "Tasks dispatched from the shared DSQ")]
     pub shared_dispatches: u64,
+    #[stat(desc = "Tasks dispatched from the contained throughput/background DSQ")]
+    pub contained_dispatches: u64,
     #[stat(desc = "Tasks fast-dispatched to local DSQs")]
     pub local_fast_dispatches: u64,
     #[stat(desc = "Positive-budget wakeups sent to local DSQs with preempt kicks")]
@@ -38,6 +48,30 @@ pub struct Metrics {
     pub budget_exhaustions: u64,
     #[stat(desc = "Wakeups that still had positive budget at enqueue time")]
     pub positive_budget_wakeups: u64,
+    #[stat(desc = "Latency-debt wakeups inserted into the urgent latency lane")]
+    pub urgent_latency_enqueues: u64,
+    #[stat(desc = "Interactive wakeups inserted into the dedicated latency lane")]
+    pub latency_lane_enqueues: u64,
+    #[stat(desc = "Soft latency-lane candidates observed before final routing decisions")]
+    pub latency_lane_candidates: u64,
+    #[stat(desc = "Latency-lane candidates that were consumed by the local reserved fast path")]
+    pub latency_candidate_local_enqueues: u64,
+    #[stat(desc = "Soft latency-lane candidates blocked because they were already contained hogs")]
+    pub latency_candidate_hog_blocks: u64,
+    #[stat(desc = "Interactive budget exhaustions that raised per-task latency debt")]
+    pub latency_debt_raises: u64,
+    #[stat(
+        desc = "Times latency debt decayed after the scheduler gave a debt-bearing task latency service"
+    )]
+    pub latency_debt_decays: u64,
+    #[stat(
+        desc = "Latency-lane enqueues driven by accumulated latency debt rather than fresh wake credit alone"
+    )]
+    pub latency_debt_urgent_enqueues: u64,
+    #[stat(
+        desc = "Urgent-debt wakeups that still missed the urgent lane and fell back to ordinary routing"
+    )]
+    pub urgent_latency_misses: u64,
     #[stat(desc = "Positive-budget tasks inserted directly into selected local DSQs")]
     pub reserved_local_enqueues: u64,
     #[stat(desc = "Positive-budget tasks enqueued to the reserved global DSQ")]
@@ -48,18 +82,162 @@ pub struct Metrics {
     pub runnable_wakeups: u64,
     #[stat(desc = "Local DSQ tasks rescued during cpu_release")]
     pub cpu_release_reenqueues: u64,
+    #[stat(
+        desc = "Maximum current consecutive urgent-latency dispatches within the bounded burst window across CPUs"
+    )]
+    pub urgent_latency_burst_rounds: u64,
+    #[stat(
+        desc = "Maximum current consecutive high-priority dispatches since shared or contained service last ran across CPUs"
+    )]
+    pub high_priority_burst_rounds: u64,
+    #[stat(
+        desc = "Maximum current consecutive ordinary local-reserved fast-path enqueues under pressure across CPUs"
+    )]
+    pub local_reserved_burst_rounds: u64,
+    #[stat(
+        desc = "Ordinary local-reserved fast-path grants that counted toward the local burst window"
+    )]
+    pub local_reserved_fast_grants: u64,
+    #[stat(
+        desc = "Ordinary local-reserved fast-path grants that continued an already-active local burst window"
+    )]
+    pub local_reserved_burst_continuations: u64,
+    #[stat(desc = "Ordinary local-reserved fast-path enqueues skipped by the local burst cap")]
+    pub local_quota_skips: u64,
+    #[stat(
+        desc = "Dispatch rounds where a lower-lane quota check skipped the normal reserved/high-priority order"
+    )]
+    pub reserved_quota_skips: u64,
+    #[stat(desc = "Shared-lane dispatches forced early by the bounded quota")]
+    pub quota_shared_forces: u64,
+    #[stat(desc = "Contained-lane dispatches forced early by the bounded quota")]
+    pub quota_contained_forces: u64,
     #[stat(desc = "Tasks initialized through init_task task storage setup")]
     pub init_task_events: u64,
     #[stat(desc = "Tasks explicitly initialized on entry into scx_flow")]
     pub enable_events: u64,
     #[stat(desc = "Tasks explicitly cleaned up on exit from scx_flow")]
     pub exit_task_events: u64,
+    #[stat(desc = "Wakeups where select_cpu() biased toward the task's last CPU")]
+    pub cpu_stability_biases: u64,
+    #[stat(desc = "Wakeups where the chosen target CPU matched the task's last CPU")]
+    pub last_cpu_matches: u64,
+    #[stat(desc = "Observed task migrations between successive runs")]
+    pub cpu_migrations: u64,
     #[stat(desc = "Pinned positive-budget wakeups classified into the RT-sensitive lane")]
     pub rt_sensitive_wakeups: u64,
     #[stat(desc = "RT-sensitive wakeups inserted directly into selected local DSQs")]
     pub rt_sensitive_local_enqueues: u64,
     #[stat(desc = "RT-sensitive wakeups that used the preempt path")]
     pub rt_sensitive_preempts: u64,
+    #[stat(
+        desc = "Maximum current consecutive dispatches from the reserved global DSQ across CPUs"
+    )]
+    pub reserved_lane_burst_rounds: u64,
+    #[stat(
+        desc = "Dispatches granted from the reserved global DSQ while reserved-lane shaping was active"
+    )]
+    pub reserved_lane_grants: u64,
+    #[stat(
+        desc = "Reserved global dispatches that continued an already-active reserved-lane burst window"
+    )]
+    pub reserved_lane_burst_continuations: u64,
+    #[stat(
+        desc = "Reserved global dispatches skipped because the reserved-lane burst cap engaged"
+    )]
+    pub reserved_lane_skips: u64,
+    #[stat(desc = "Shared-lane dispatches forced by the reserved-lane burst cap")]
+    pub reserved_lane_shared_forces: u64,
+    #[stat(desc = "Contained-lane dispatches forced by the reserved-lane burst cap")]
+    pub reserved_lane_contained_forces: u64,
+    #[stat(
+        desc = "Reserved-lane cap attempts that wanted shared service but found no immediately dispatchable shared work"
+    )]
+    pub reserved_lane_shared_misses: u64,
+    #[stat(
+        desc = "Reserved-lane cap attempts that wanted contained service but found no immediately dispatchable contained work"
+    )]
+    pub reserved_lane_contained_misses: u64,
+    #[stat(
+        desc = "Contained-lane enqueues promoted to the head because the contained lane was already meaningfully starved"
+    )]
+    pub contained_starved_head_enqueues: u64,
+    #[stat(
+        desc = "Shared-lane enqueues promoted to the head because the shared lane was already meaningfully starved"
+    )]
+    pub shared_starved_head_enqueues: u64,
+    #[stat(
+        desc = "Direct-local wakeups that were eligible for the bounded front-door before final fast-path checks"
+    )]
+    pub direct_local_candidates: u64,
+    #[stat(
+        desc = "Positive-budget wakeups routed through the bounded direct-local front-door without using the RT-sensitive path"
+    )]
+    pub direct_local_enqueues: u64,
+    #[stat(
+        desc = "Direct-local candidates that lost the front-door and decayed back toward ordinary routing"
+    )]
+    pub direct_local_rejections: u64,
+    #[stat(
+        desc = "Wakeups where the chosen target CPU did not match the remembered last CPU continuity hint"
+    )]
+    pub direct_local_mismatches: u64,
+    #[stat(desc = "Wakeups that qualified for the decayed IPC-confidence path")]
+    pub ipc_wake_candidates: u64,
+    #[stat(desc = "IPC-confidence wakeups inserted directly into selected local DSQs")]
+    pub ipc_local_enqueues: u64,
+    #[stat(
+        desc = "Times the decayed IPC-confidence score strengthened after a short blocking run"
+    )]
+    pub ipc_score_raises: u64,
+    #[stat(desc = "Local slice boosts granted through the IPC-confidence path")]
+    pub ipc_boosts: u64,
+    #[stat(desc = "Tasks routed into the dedicated contained throughput/background DSQ")]
+    pub contained_enqueues: u64,
+    #[stat(desc = "Enqueues where a persistent hog-like task had latency privileges reduced")]
+    pub hog_containment_enqueues: u64,
+    #[stat(desc = "Times a previously contained hog-like task decayed back below containment")]
+    pub hog_recoveries: u64,
+    #[stat(
+        desc = "Maximum current consecutive dispatch rounds since a contained/background task last ran across CPUs"
+    )]
+    pub contained_starvation_rounds: u64,
+    #[stat(
+        desc = "Maximum current consecutive dispatch rounds since a shared-fallback task last ran across CPUs"
+    )]
+    pub shared_starvation_rounds: u64,
+    #[stat(desc = "Contained/background tasks rescued early by the fairness floor")]
+    pub contained_rescue_dispatches: u64,
+    #[stat(desc = "Shared-fallback tasks rescued early by the fairness floor")]
+    pub shared_rescue_dispatches: u64,
+    #[stat(desc = "Current latency-credit grant per strong interactive refill")]
+    pub tune_latency_credit_grant: u64,
+    #[stat(desc = "Current latency-credit decay applied when credit is consumed or exhausted")]
+    pub tune_latency_credit_decay: u64,
+    #[stat(
+        desc = "Current debt threshold required before a wakeup qualifies for the urgent latency lane"
+    )]
+    pub tune_latency_debt_urgent_min: u64,
+    #[stat(desc = "Current maximum consecutive urgent-latency dispatches allowed in one burst")]
+    pub tune_urgent_latency_burst_max: u64,
+    #[stat(
+        desc = "Current maximum consecutive high-priority dispatches before lower-lane quota checks engage"
+    )]
+    pub tune_reserved_quota_burst_max: u64,
+    #[stat(desc = "Current contained-lane fairness-floor threshold")]
+    pub tune_contained_starvation_max: u64,
+    #[stat(desc = "Current shared-lane fairness-floor threshold")]
+    pub tune_shared_starvation_max: u64,
+    #[stat(desc = "Current runnable-pressure cap for the ordinary local fast path")]
+    pub tune_local_fast_nr_running_max: u64,
+    #[stat(
+        desc = "Current maximum consecutive ordinary local-reserved fast-path enqueues allowed under pressure"
+    )]
+    pub tune_local_reserved_burst_max: u64,
+    #[stat(
+        desc = "Current maximum consecutive dispatches allowed from the reserved global DSQ before forcing a lower-lane rotation"
+    )]
+    pub tune_reserved_lane_burst_max: u64,
     #[stat(desc = "Adaptive tuning generation counter")]
     pub autotune_generation: u64,
     #[stat(desc = "Adaptive tuning mode (0=balanced, 1=latency, 2=throughput)")]
@@ -88,34 +266,95 @@ impl Metrics {
     fn format<W: Write>(&self, w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "[{}] mode={} gen={} run={} reserve_disp={} shared_disp={} local_fast={} wake_preempt={} refill={} exhaust={} pos_wake={} reserve_local={} reserve_global={} shared_wake={} runnable={} cpu_release={} init_task={} enable={} exit_task={} rt_wake={} rt_local={} rt_preempt={} reserve_cap_us={} shared_slice_us={} refill_floor_us={} preempt_budget_us={} preempt_refill_us={}",
+            "[{}] mode={} gen={} run={} urgent_lat_disp={} urgent_grant={} urgent_cont={} latency_disp={} reserve_disp={} contained_disp={} shared_disp={} local_fast={} wake_preempt={} refill={} exhaust={} pos_wake={} urgent_lat_enq={} latency_enq={} latency_cand={} latency_local={} latency_hog_block={} debt_raise={} debt_decay={} debt_urgent={} urgent_miss={} reserve_local={} reserve_global={} shared_wake={} runnable={} cpu_release={} urgent_burst={} high_prio_burst={} reserved_burst={} reserved_grant={} reserved_cont={} reserved_skip={} reserved_shared={} reserved_contained={} reserved_miss_shared={} reserved_miss_contained={} contained_head={} shared_head={} local_burst={} local_grant={} local_cont={} local_quota_skip={} quota_skip={} quota_shared={} quota_contained={} init_task={} enable={} exit_task={} cpu_bias={} last_cpu_hit={} migrations={} rt_wake={} rt_local={} rt_preempt={} direct_cand={} direct_local={} direct_reject={} direct_mismatch={} ipc_wake={} ipc_local={} ipc_raise={} ipc_boost={} contained_enq={} hog_contain={} hog_recover={} contained_starve={} shared_starve={} contained_rescue={} shared_rescue={} reserve_cap_us={} shared_slice_us={} refill_floor_us={} preempt_budget_us={} preempt_refill_us={} credit_grant={} credit_decay={} debt_min={} urgent_burst_max={} reserved_quota_max={} reserved_lane_max={} contained_floor={} shared_floor={} local_fast_cap={} local_burst_max={}",
             crate::SCHEDULER_NAME,
             self.autotune_mode_name(),
             self.autotune_generation,
             self.nr_running,
+            self.urgent_latency_dispatches,
+            self.urgent_latency_burst_grants,
+            self.urgent_latency_burst_continuations,
+            self.latency_dispatches,
             self.reserved_dispatches,
+            self.contained_dispatches,
             self.shared_dispatches,
             self.local_fast_dispatches,
             self.wake_preempt_dispatches,
             self.budget_refill_events,
             self.budget_exhaustions,
             self.positive_budget_wakeups,
+            self.urgent_latency_enqueues,
+            self.latency_lane_enqueues,
+            self.latency_lane_candidates,
+            self.latency_candidate_local_enqueues,
+            self.latency_candidate_hog_blocks,
+            self.latency_debt_raises,
+            self.latency_debt_decays,
+            self.latency_debt_urgent_enqueues,
+            self.urgent_latency_misses,
             self.reserved_local_enqueues,
             self.reserved_global_enqueues,
             self.shared_wakeup_enqueues,
             self.runnable_wakeups,
             self.cpu_release_reenqueues,
+            self.urgent_latency_burst_rounds,
+            self.high_priority_burst_rounds,
+            self.reserved_lane_burst_rounds,
+            self.reserved_lane_grants,
+            self.reserved_lane_burst_continuations,
+            self.reserved_lane_skips,
+            self.reserved_lane_shared_forces,
+            self.reserved_lane_contained_forces,
+            self.reserved_lane_shared_misses,
+            self.reserved_lane_contained_misses,
+            self.contained_starved_head_enqueues,
+            self.shared_starved_head_enqueues,
+            self.local_reserved_burst_rounds,
+            self.local_reserved_fast_grants,
+            self.local_reserved_burst_continuations,
+            self.local_quota_skips,
+            self.reserved_quota_skips,
+            self.quota_shared_forces,
+            self.quota_contained_forces,
             self.init_task_events,
             self.enable_events,
             self.exit_task_events,
+            self.cpu_stability_biases,
+            self.last_cpu_matches,
+            self.cpu_migrations,
             self.rt_sensitive_wakeups,
             self.rt_sensitive_local_enqueues,
             self.rt_sensitive_preempts,
+            self.direct_local_candidates,
+            self.direct_local_enqueues,
+            self.direct_local_rejections,
+            self.direct_local_mismatches,
+            self.ipc_wake_candidates,
+            self.ipc_local_enqueues,
+            self.ipc_score_raises,
+            self.ipc_boosts,
+            self.contained_enqueues,
+            self.hog_containment_enqueues,
+            self.hog_recoveries,
+            self.contained_starvation_rounds,
+            self.shared_starvation_rounds,
+            self.contained_rescue_dispatches,
+            self.shared_rescue_dispatches,
             self.tune_reserved_max_ns / 1000,
             self.tune_shared_slice_ns / 1000,
             self.tune_interactive_floor_ns / 1000,
             self.tune_preempt_budget_min_ns / 1000,
             self.tune_preempt_refill_min_ns / 1000,
+            self.tune_latency_credit_grant,
+            self.tune_latency_credit_decay,
+            self.tune_latency_debt_urgent_min,
+            self.tune_urgent_latency_burst_max,
+            self.tune_reserved_quota_burst_max,
+            self.tune_reserved_lane_burst_max,
+            self.tune_contained_starvation_max,
+            self.tune_shared_starvation_max,
+            self.tune_local_fast_nr_running_max,
+            self.tune_local_reserved_burst_max,
         )?;
         Ok(())
     }
@@ -127,6 +366,19 @@ impl Metrics {
             reserved_dispatches: self
                 .reserved_dispatches
                 .wrapping_sub(rhs.reserved_dispatches),
+            urgent_latency_dispatches: self
+                .urgent_latency_dispatches
+                .wrapping_sub(rhs.urgent_latency_dispatches),
+            urgent_latency_burst_grants: self
+                .urgent_latency_burst_grants
+                .wrapping_sub(rhs.urgent_latency_burst_grants),
+            urgent_latency_burst_continuations: self
+                .urgent_latency_burst_continuations
+                .wrapping_sub(rhs.urgent_latency_burst_continuations),
+            latency_dispatches: self.latency_dispatches.wrapping_sub(rhs.latency_dispatches),
+            contained_dispatches: self
+                .contained_dispatches
+                .wrapping_sub(rhs.contained_dispatches),
             shared_dispatches: self.shared_dispatches.wrapping_sub(rhs.shared_dispatches),
             local_fast_dispatches: self
                 .local_fast_dispatches
@@ -141,6 +393,33 @@ impl Metrics {
             positive_budget_wakeups: self
                 .positive_budget_wakeups
                 .wrapping_sub(rhs.positive_budget_wakeups),
+            urgent_latency_enqueues: self
+                .urgent_latency_enqueues
+                .wrapping_sub(rhs.urgent_latency_enqueues),
+            latency_lane_enqueues: self
+                .latency_lane_enqueues
+                .wrapping_sub(rhs.latency_lane_enqueues),
+            latency_lane_candidates: self
+                .latency_lane_candidates
+                .wrapping_sub(rhs.latency_lane_candidates),
+            latency_candidate_local_enqueues: self
+                .latency_candidate_local_enqueues
+                .wrapping_sub(rhs.latency_candidate_local_enqueues),
+            latency_candidate_hog_blocks: self
+                .latency_candidate_hog_blocks
+                .wrapping_sub(rhs.latency_candidate_hog_blocks),
+            latency_debt_raises: self
+                .latency_debt_raises
+                .wrapping_sub(rhs.latency_debt_raises),
+            latency_debt_decays: self
+                .latency_debt_decays
+                .wrapping_sub(rhs.latency_debt_decays),
+            latency_debt_urgent_enqueues: self
+                .latency_debt_urgent_enqueues
+                .wrapping_sub(rhs.latency_debt_urgent_enqueues),
+            urgent_latency_misses: self
+                .urgent_latency_misses
+                .wrapping_sub(rhs.urgent_latency_misses),
             reserved_local_enqueues: self
                 .reserved_local_enqueues
                 .wrapping_sub(rhs.reserved_local_enqueues),
@@ -154,9 +433,33 @@ impl Metrics {
             cpu_release_reenqueues: self
                 .cpu_release_reenqueues
                 .wrapping_sub(rhs.cpu_release_reenqueues),
+            urgent_latency_burst_rounds: self.urgent_latency_burst_rounds,
+            high_priority_burst_rounds: self.high_priority_burst_rounds,
+            local_reserved_burst_rounds: self.local_reserved_burst_rounds,
+            local_reserved_fast_grants: self
+                .local_reserved_fast_grants
+                .wrapping_sub(rhs.local_reserved_fast_grants),
+            local_reserved_burst_continuations: self
+                .local_reserved_burst_continuations
+                .wrapping_sub(rhs.local_reserved_burst_continuations),
+            local_quota_skips: self.local_quota_skips.wrapping_sub(rhs.local_quota_skips),
+            reserved_quota_skips: self
+                .reserved_quota_skips
+                .wrapping_sub(rhs.reserved_quota_skips),
+            quota_shared_forces: self
+                .quota_shared_forces
+                .wrapping_sub(rhs.quota_shared_forces),
+            quota_contained_forces: self
+                .quota_contained_forces
+                .wrapping_sub(rhs.quota_contained_forces),
             init_task_events: self.init_task_events.wrapping_sub(rhs.init_task_events),
             enable_events: self.enable_events.wrapping_sub(rhs.enable_events),
             exit_task_events: self.exit_task_events.wrapping_sub(rhs.exit_task_events),
+            cpu_stability_biases: self
+                .cpu_stability_biases
+                .wrapping_sub(rhs.cpu_stability_biases),
+            last_cpu_matches: self.last_cpu_matches.wrapping_sub(rhs.last_cpu_matches),
+            cpu_migrations: self.cpu_migrations.wrapping_sub(rhs.cpu_migrations),
             rt_sensitive_wakeups: self
                 .rt_sensitive_wakeups
                 .wrapping_sub(rhs.rt_sensitive_wakeups),
@@ -166,6 +469,75 @@ impl Metrics {
             rt_sensitive_preempts: self
                 .rt_sensitive_preempts
                 .wrapping_sub(rhs.rt_sensitive_preempts),
+            reserved_lane_burst_rounds: self.reserved_lane_burst_rounds,
+            reserved_lane_grants: self
+                .reserved_lane_grants
+                .wrapping_sub(rhs.reserved_lane_grants),
+            reserved_lane_burst_continuations: self
+                .reserved_lane_burst_continuations
+                .wrapping_sub(rhs.reserved_lane_burst_continuations),
+            reserved_lane_skips: self
+                .reserved_lane_skips
+                .wrapping_sub(rhs.reserved_lane_skips),
+            reserved_lane_shared_forces: self
+                .reserved_lane_shared_forces
+                .wrapping_sub(rhs.reserved_lane_shared_forces),
+            reserved_lane_contained_forces: self
+                .reserved_lane_contained_forces
+                .wrapping_sub(rhs.reserved_lane_contained_forces),
+            reserved_lane_shared_misses: self
+                .reserved_lane_shared_misses
+                .wrapping_sub(rhs.reserved_lane_shared_misses),
+            reserved_lane_contained_misses: self
+                .reserved_lane_contained_misses
+                .wrapping_sub(rhs.reserved_lane_contained_misses),
+            contained_starved_head_enqueues: self
+                .contained_starved_head_enqueues
+                .wrapping_sub(rhs.contained_starved_head_enqueues),
+            shared_starved_head_enqueues: self
+                .shared_starved_head_enqueues
+                .wrapping_sub(rhs.shared_starved_head_enqueues),
+            direct_local_candidates: self
+                .direct_local_candidates
+                .wrapping_sub(rhs.direct_local_candidates),
+            direct_local_enqueues: self
+                .direct_local_enqueues
+                .wrapping_sub(rhs.direct_local_enqueues),
+            direct_local_rejections: self
+                .direct_local_rejections
+                .wrapping_sub(rhs.direct_local_rejections),
+            direct_local_mismatches: self
+                .direct_local_mismatches
+                .wrapping_sub(rhs.direct_local_mismatches),
+            ipc_wake_candidates: self
+                .ipc_wake_candidates
+                .wrapping_sub(rhs.ipc_wake_candidates),
+            ipc_local_enqueues: self.ipc_local_enqueues.wrapping_sub(rhs.ipc_local_enqueues),
+            ipc_score_raises: self.ipc_score_raises.wrapping_sub(rhs.ipc_score_raises),
+            ipc_boosts: self.ipc_boosts.wrapping_sub(rhs.ipc_boosts),
+            contained_enqueues: self.contained_enqueues.wrapping_sub(rhs.contained_enqueues),
+            hog_containment_enqueues: self
+                .hog_containment_enqueues
+                .wrapping_sub(rhs.hog_containment_enqueues),
+            hog_recoveries: self.hog_recoveries.wrapping_sub(rhs.hog_recoveries),
+            contained_starvation_rounds: self.contained_starvation_rounds,
+            shared_starvation_rounds: self.shared_starvation_rounds,
+            contained_rescue_dispatches: self
+                .contained_rescue_dispatches
+                .wrapping_sub(rhs.contained_rescue_dispatches),
+            shared_rescue_dispatches: self
+                .shared_rescue_dispatches
+                .wrapping_sub(rhs.shared_rescue_dispatches),
+            tune_latency_credit_grant: self.tune_latency_credit_grant,
+            tune_latency_credit_decay: self.tune_latency_credit_decay,
+            tune_latency_debt_urgent_min: self.tune_latency_debt_urgent_min,
+            tune_urgent_latency_burst_max: self.tune_urgent_latency_burst_max,
+            tune_reserved_quota_burst_max: self.tune_reserved_quota_burst_max,
+            tune_contained_starvation_max: self.tune_contained_starvation_max,
+            tune_shared_starvation_max: self.tune_shared_starvation_max,
+            tune_local_fast_nr_running_max: self.tune_local_fast_nr_running_max,
+            tune_local_reserved_burst_max: self.tune_local_reserved_burst_max,
+            tune_reserved_lane_burst_max: self.tune_reserved_lane_burst_max,
             autotune_generation: self.autotune_generation,
             autotune_mode: self.autotune_mode,
             tune_reserved_max_ns: self.tune_reserved_max_ns,


### PR DESCRIPTION
## Summary

This is the `scx_flow` v2 line for upstream review. It supersedes the earlier v1 submission in #3493 rather than trying to extend that branch in place.

Compared to the v1 PR, this branch carries the later `v2.0.x -> v2.2.0` scheduler work:

- broader `v2` wake classification and bounded service-lane model
- hot-path cleanup and more cached task-local wake readiness
- more local-first dispatch behavior, including per-CPU reserved handling and reduced shared hot-path accounting pressure
- hidden `--completions <SHELL>` support so the scheduler already cooperates with the CLI-completions work in #3495
- updated `scx_flow` documentation and public validation links for the current `v2.2.0` release snapshot

## What Changed Relative to #3493

The earlier PR introduced the first `scx_flow` version and drew a few clear requests from review. This branch already folds those expectations in:

- `scx_flow` lives under `scheds/experimental/scx_flow`
- the workspace entry follows the current `scheds/experimental` layout and ordering
- the current line is based on the later `v2` scheduler work, not the older `v1` implementation
- the release snapshot and benchmark history are documented publicly in the testing repo instead of only living in local notes

The goal here is not to argue with the original review, but to present the newer line in the shape that review was asking for.

## Validation

Local checks:

- `cargo fmt -p scx_flow`
- `cargo check -p scx_flow`
- `cargo clippy -p scx_flow --no-deps -- -D warnings`
- `cargo run -q -p scx_flow -- --completions bash`

Benchmarks and public artifacts:

- testing repo: https://github.com/galpt/testing-scx_flow
- archived `v2.2.0` snapshot: https://github.com/galpt/testing-scx_flow/tree/benchmark-archives/20260409_scx_flow_v2.2.0_release

The `v2.2.0` line was also checked manually with Aquarium runs outside the noisy browser harness:

- `20000` fish at roughly `100-120 FPS`
- `30000` fish at roughly `70-80 FPS`

## Notes

I kept this PR scoped to the scheduler addition plus the small shared-header change it needs. The completions support is intentionally hidden and is there so this branch does not trip over #3495 once that lands.
