### PR TITLE
Cargo: update libbpf to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1552,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -1882,6 +1882,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,12 +1991,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2076,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -2151,15 +2157,14 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd59674b82a31cb53e512cee97e3d5143737b40feda35f89b5b7f5c439e51e8"
+checksum = "67e63283df9689af55b85f91e99dc8b213ae89fc3e1d9bb29ab7f75eb8a8a783"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
  "clap",
  "libbpf-rs",
- "libbpf-sys",
  "memmap2",
  "serde",
  "serde_json",
@@ -2170,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6af29f679fd713ba4466b0296436268f573f6c5a8ef2f316d237eb3019c3c6f"
+checksum = "fd8e8db46a2d5967b5b3dba7aba32a875dc38f222395040607045635ec1f9b63"
 dependencies = [
  "bitflags 2.11.0",
  "libbpf-sys",
@@ -2182,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-sys"
-version = "1.6.3+v1.6.3"
+version = "1.7.0+v1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f55336f7dbde4fbbaae7b5e271f9efc65bf1d0b69c6fcb1e5026a385e95f70"
+checksum = "a109478760b2900aa2a6f2087e9d0de1d9c535b1758602af2845d5d2ccfaed7c"
 dependencies = [
  "cc",
  "nix 0.31.2",
@@ -2193,9 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -4199,9 +4204,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -4605,12 +4610,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5471,15 +5476,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5511,28 +5507,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5557,12 +5536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5573,12 +5546,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5593,22 +5560,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5623,12 +5578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5639,12 +5588,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5659,12 +5602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5675,12 +5612,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/rust/scx_arena/scx_arena/Cargo.toml
+++ b/rust/scx_arena/scx_arena/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPL-2.0-only"
 
 [dependencies]
 anyhow = "1"
-libbpf-rs = "=0.26.1"
-libbpf-sys = "=1.6.3"
+libbpf-rs = "=0.26.2"
+libbpf-sys = "=1.7.0"
 simplelog = "0.12"
 scx_utils = { path = "../../scx_utils", version = "1.1.0" }
 

--- a/rust/scx_arena/selftests/Cargo.toml
+++ b/rust/scx_arena/selftests/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 simplelog = "0.12"
 scx_utils = { path = "../../scx_utils", version = "1.1.0" }
 

--- a/rust/scx_bpf_compat/Cargo.toml
+++ b/rust/scx_bpf_compat/Cargo.toml
@@ -15,7 +15,7 @@ ci.use_clippy = true
 scx_utils = { path = "../scx_utils", version = "1.1.0" }
 
 anyhow = "1"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 log = "0.4"
 once_cell = "1"
 

--- a/rust/scx_bpf_unittests/Cargo.toml
+++ b/rust/scx_bpf_unittests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-libbpf-sys = "=1.6.3"  # need the includes and can't use libbpf_rs instead
+libbpf-sys = "=1.7.0"  # need the includes and can't use libbpf_rs instead
 
 [build-dependencies]
 cc = "1"

--- a/rust/scx_cargo/Cargo.toml
+++ b/rust/scx_cargo/Cargo.toml
@@ -15,9 +15,9 @@ version-compare = "0.2"
 glob = "0.3"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-libbpf-cargo = "=0.26.1"
+libbpf-cargo = "=0.26.2"
 tar = "0.4"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 bindgen = ">=0.69"
 
 [build-dependencies]

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -10,7 +10,7 @@ description = "Framework to implement sched_ext schedulers running in user space
 [dependencies]
 anyhow = "1"
 plain = "0.2"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 libc = "0.2"
 seccomp = "0.1"
 scx_cargo = { path = "../scx_cargo", version = "1.1.0" }

--- a/rust/scx_userspace_arena/Cargo.toml
+++ b/rust/scx_userspace_arena/Cargo.toml
@@ -15,7 +15,7 @@ scx_utils = { path = "../scx_utils", version = "1.1.0" }
 
 anyhow = "1"
 buddy_system_allocator = { version = "0.12", default-features = false }
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 
 [build-dependencies]
 scx_cargo = { path = "../scx_cargo", version = "1.1.0" }

--- a/rust/scx_utils/Cargo.toml
+++ b/rust/scx_utils/Cargo.toml
@@ -15,8 +15,8 @@ clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 glob = "0.3"
 hex = "0.4"
 lazy_static = "1"
-libbpf-cargo = "=0.26.1"
-libbpf-rs = "=0.26.1"
+libbpf-cargo = "=0.26.2"
+libbpf-rs = "=0.26.2"
 log = "0.4"
 nvml-wrapper = { version = "0.12", optional = true }
 nvml-wrapper-sys = { version = "0.9", optional = true }
@@ -44,7 +44,7 @@ anyhow = "1"
 bindgen = ">=0.69"
 glob = "0.3"
 lazy_static = "1"
-libbpf-cargo = "=0.26.1"
+libbpf-cargo = "=0.26.2"
 ruzstd = "0.8"
 scx_cargo = { path = "../scx_cargo", version = "1.1.0" }
 sscanf = "0.5"

--- a/scheds/experimental/scx_flow/Cargo.toml
+++ b/scheds/experimental/scx_flow/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 log = "0.4"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.1.0" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.1.0" }

--- a/scheds/experimental/scx_rlfifo/Cargo.toml
+++ b/scheds/experimental/scx_rlfifo/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 plain = "0.2"
 procfs = "0.18"
 ctrlc = { version = "3", features = ["termination"] }
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 libc = "0.2"
 scx_utils = { path = "../../../rust/scx_utils", version = "1.1.0" }
 scx_rustland_core = { path = "../../../rust/scx_rustland_core", version = "2.4.11" }

--- a/scheds/rust/scx_beerland/Cargo.toml
+++ b/scheds/rust/scx_beerland/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 log = "0.4"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.1.0" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.1.0" }

--- a/scheds/rust/scx_bpfland/Cargo.toml
+++ b/scheds/rust/scx_bpfland/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 log = "0.4"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.1.0" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.1.0" }

--- a/scheds/rust/scx_cake/Cargo.toml
+++ b/scheds/rust/scx_cake/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-2.0-only"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 ctrlc = { version = "3", features = ["termination"] }
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 libc = "0.2"
 log = "0.4"
 env_logger = "0.11"

--- a/scheds/rust/scx_chaos/Cargo.toml
+++ b/scheds/rust/scx_chaos/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8"
 ctrlc = { version = "3", features = ["termination"] }
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 libc = "0.2"
 log = "0.4"
 nix = { version = "0.31", features = ["process"] }

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 log = "0.4"
 nvml-wrapper = "0.12"
 nvml-wrapper-sys = "0.9"

--- a/scheds/rust/scx_flash/Cargo.toml
+++ b/scheds/rust/scx_flash/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 log = "0.4"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.1.0" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.1.0" }

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -22,7 +22,7 @@ crossbeam = "0.8"
 ctrlc = { version = "3", features = ["termination"] }
 hex = "0.4"
 itertools = "0.14"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 libc = "0.2"
 ordered-float = "5"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.1.0" }

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -18,7 +18,7 @@ fastrand = "2"
 fb_procfs = "0.9"
 inotify = "0.11"
 lazy_static = "1"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 libc = "0.2"
 regex = "1"
 scx_bpf_compat = { path = "../../../rust/scx_bpf_compat", version = "1.1.0" }

--- a/scheds/rust/scx_mitosis/Cargo.toml
+++ b/scheds/rust/scx_mitosis/Cargo.toml
@@ -17,7 +17,7 @@ clap_main = "0.2"
 ctrlc = { version = "3", features = ["termination"] }
 itertools = "0.14"
 lazy_static = "1"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 libc = "0.2"
 inotify = "0.11"
 nix = { version = "0.31", features = ["event"] }

--- a/scheds/rust/scx_p2dq/Cargo.toml
+++ b/scheds/rust/scx_p2dq/Cargo.toml
@@ -23,7 +23,7 @@ clap_main = "0.2"
 crossbeam = "0.8"
 ctrlc = { version = "3", features = ["termination"] }
 lazy_static = "1"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 libc = "0.2"
 ordered-float = "5"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.1.0" }

--- a/scheds/rust/scx_pandemonium/Cargo.toml
+++ b/scheds/rust/scx_pandemonium/Cargo.toml
@@ -6,7 +6,7 @@ description = "A behavioral, adaptive sched_ext scheduler with three-tier classi
 license = "GPL-2.0-only"
 
 [dependencies]
-libbpf-rs = { version = "=0.26.1" }
+libbpf-rs = { version = "=0.26.2" }
 libc = "0.2"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/scheds/rust/scx_rustland/Cargo.toml
+++ b/scheds/rust/scx_rustland/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 plain = "0.2"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 ctrlc = { version = "3", features = ["termination"] }
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 libc = "0.2"
 log = "0.4"
 ordered-float = "5"

--- a/scheds/rust/scx_rusty/Cargo.toml
+++ b/scheds/rust/scx_rusty/Cargo.toml
@@ -13,7 +13,7 @@ clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8"
 ctrlc = { version = "3", features = ["termination"] }
 fb_procfs = "0.9"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 libc = "0.2"
 log = "0.4"
 ordered-float = "5"

--- a/scheds/rust/scx_tickless/Cargo.toml
+++ b/scheds/rust/scx_tickless/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 crossbeam = "0.8"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 log = "0.4"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.1.0" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.1.0" }

--- a/tools/scxcash/Cargo.toml
+++ b/tools/scxcash/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 log = "0.4"
 libc = "0.2"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 scx_utils = { path = "../../rust/scx_utils", version = "1.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -27,7 +27,7 @@ clap_complete = "4"
 crossterm = { version = "0.29", features = ["serde", "event-stream"] }
 futures = "0.3"
 glob = "0.3"
-libbpf-rs = "=0.26.1"
+libbpf-rs = "=0.26.2"
 libc = "0.2"
 log = "0.4"
 num-format = { version = "0.4", features = ["with-serde", "with-system-locale"] }


### PR DESCRIPTION
New versions of libbpf are available. 

**Log:**

```
❯ cargo build --workspace --exclude scx_wd40                                       
warning: /home/lucjan/Patchownia/other/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.45
   Compiling unicode-ident v1.0.24
   Compiling libc v0.2.184
   Compiling cfg-if v1.0.4
   Compiling autocfg v1.5.0
   Compiling log v0.4.29
   Compiling bitflags v2.11.0
   Compiling strsim v0.11.1
   Compiling itoa v1.0.18
   Compiling once_cell v1.21.4
   Compiling serde_core v1.0.228
   Compiling cfg_aliases v0.2.1
   Compiling pin-project-lite v0.2.17
   Compiling regex-syntax v0.8.10
   Compiling unicode-segmentation v1.12.0
   Compiling fastrand v2.4.1
   Compiling shlex v1.3.0
   Compiling unicode-width v0.2.2
   Compiling memchr v2.8.0
   Compiling smallvec v1.15.1
   Compiling thiserror v2.0.18
   Compiling find-msvc-tools v0.1.9
   Compiling heck v0.5.0
   Compiling anyhow v1.0.102
   Compiling rustix v1.1.4
   Compiling linux-raw-sys v0.12.1
   Compiling cc v1.2.59
   Compiling nix v0.31.2
   Compiling utf8parse v0.2.2
   Compiling serde v1.0.228
   Compiling zmij v1.0.21
   Compiling colorchoice v1.0.5
   Compiling anstyle v1.0.14
   Compiling pkg-config v0.3.32
   Compiling iana-time-zone v0.1.65
   Compiling is_terminal_polyfill v1.70.2
   Compiling serde_json v1.0.149
   Compiling anstyle-query v1.1.5
   Compiling lazy_static v1.5.0
   Compiling getrandom v0.4.2
   Compiling anstyle-parse v1.0.0
   Compiling unicase v2.9.0
   Compiling prettyplease v0.2.37
   Compiling camino v1.2.2
   Compiling anstream v1.0.0
   Compiling clap_lex v1.1.0
   Compiling thread_local v1.1.9
   Compiling tracing-core v0.1.36
   Compiling twox-hash v2.1.2
   Compiling same-file v1.0.6
   Compiling ruzstd v0.8.2
   Compiling aho-corasick v1.1.4
   Compiling syn v2.0.117
   Compiling walkdir v2.5.0
   Compiling either v1.15.0
   Compiling glob v0.3.3
   Compiling minimal-lexical v0.2.1
   Compiling libloading v0.8.9
   Compiling sharded-slab v0.1.7
   Compiling nu-ansi-term v0.50.3
   Compiling tracing-log v0.2.0
   Compiling num-traits v0.2.19
   Compiling convert_case v0.11.0
   Compiling bindgen v0.72.1
   Compiling rustc-hash v2.1.1
   Compiling nom v7.1.3
   Compiling clang-sys v1.8.1
   Compiling version-compare v0.2.1
   Compiling itertools v0.13.0
   Compiling vsprintf v2.0.0
   Compiling filetime v0.2.27
   Compiling memmap2 v0.9.10
   Compiling regex-automata v0.4.14
   Compiling equivalent v1.0.2
   Compiling crossbeam-utils v0.8.21
   Compiling chrono v0.4.44
   Compiling tempfile v3.27.0
   Compiling xattr v1.6.1
   Compiling terminal_size v0.4.4
   Compiling tar v0.4.44
   Compiling semver v1.0.28
   Compiling clap_builder v4.6.0
   Compiling libbpf-sys v1.7.0+v1.7.0
   Compiling ident_case v1.0.1
   Compiling errno v0.3.14
   Compiling futures-core v0.3.32
   Compiling cexpr v0.6.0
   Compiling parking_lot_core v0.9.12
   Compiling scopeguard v1.2.0
   Compiling lock_api v0.4.14
   Compiling signal-hook-registry v1.4.8
   Compiling tracing-subscriber v0.3.23
   Compiling winnow v0.7.15
   Compiling parking_lot v0.12.5
   Compiling hashbrown v0.16.1
   Compiling fnv v1.0.7
   Compiling parking v2.2.1
   Compiling concurrent-queue v2.5.0
   Compiling scx_cargo v1.1.0 (/home/lucjan/Patchownia/other/scx/rust/scx_cargo)
   Compiling futures-io v0.3.32
   Compiling thiserror v1.0.69
   Compiling num-integer v0.1.46
   Compiling toml_datetime v1.0.0+spec-1.1.0
   Compiling static_assertions v1.1.0
   Compiling time-core v0.1.8
   Compiling powerfmt v0.2.0
   Compiling indexmap v2.13.1
   Compiling num-conv v0.2.0
   Compiling slab v0.4.12
   Compiling time-macros v0.2.27
   Compiling deranged v0.5.8
   Compiling libbpf-rs v0.26.2
   Compiling num-bigint v0.4.6
   Compiling regex v1.12.3
   Compiling toml_parser v1.0.9+spec-1.1.0
   Compiling event-listener v5.4.1
   Compiling toml_edit v0.25.4+spec-1.1.0
   Compiling crossbeam-channel v0.5.15
   Compiling num_threads v0.1.7
   Compiling rand_core v0.10.0
   Compiling serde_derive v1.0.228
   Compiling thiserror-impl v2.0.18
   Compiling clap_derive v4.6.0
   Compiling tracing-attributes v0.1.31
   Compiling sscanf_macro v0.5.0
   Compiling thiserror-impl v1.0.69
   Compiling enumflags2_derive v0.7.12
   Compiling proc-macro-crate v3.5.0
   Compiling time v0.3.47
   Compiling num-rational v0.4.2
   Compiling event-listener-strategy v0.5.4
   Compiling num-iter v0.1.45
   Compiling futures-lite v2.6.1
   Compiling num-complex v0.4.6
   Compiling tracing v0.1.44
   Compiling endi v1.1.1
   Compiling crossbeam-epoch v0.9.18
   Compiling num v0.4.3
   Compiling async-io v2.6.0
   Compiling matchers v0.2.0
   Compiling darling_core v0.20.11
   Compiling clap v4.6.0
   Compiling sscanf v0.5.0
   Compiling polling v3.11.0
   Compiling crossbeam-deque v0.8.6
   Compiling async-task v4.7.1
   Compiling async-channel v2.5.0
   Compiling atomic-waker v1.1.2
   Compiling radium v0.7.0
   Compiling hex v0.4.3
   Compiling async-signal v0.2.13
   Compiling piper v0.2.5
   Compiling async-lock v3.4.2
   Compiling crossbeam-queue v0.3.12
   Compiling paste v1.0.15
   Compiling tap v1.0.1
   Compiling async-process v2.5.0
   Compiling wyz v0.5.1
   Compiling crossbeam v0.8.4
   Compiling blocking v1.6.2
   Compiling async-executor v1.14.0
   Compiling async-broadcast v0.7.2
   Compiling cargo-platform v0.1.9
   Compiling zvariant_utils v3.3.0
   Compiling enumflags2 v0.7.12
   Compiling cargo_metadata v0.19.2
   Compiling async-recursion v1.1.1
   Compiling async-trait v0.1.89
   Compiling serde_repr v0.1.20
   Compiling ordered-stream v0.2.0
   Compiling uuid v1.22.0
   Compiling nvml-wrapper-sys v0.9.0
   Compiling funty v2.0.0
   Compiling zvariant_derive v5.10.0
   Compiling scx_stats v1.1.0 (/home/lucjan/Patchownia/other/scx/rust/scx_stats)
   Compiling darling_macro v0.20.11
   Compiling rustversion v1.0.22
   Compiling adler2 v2.0.1
   Compiling crc32fast v1.5.0
   Compiling darling v0.20.11
   Compiling bitvec v1.0.1
   Compiling wrapcenum-derive v0.4.1
   Compiling ctrlc v3.5.2
   Compiling libbpf-cargo v0.26.2
   Compiling termcolor v1.4.1
   Compiling simd-adler32 v0.3.8
   Compiling zvariant v5.10.0
   Compiling simplelog v0.12.2
   Compiling nvml-wrapper v0.12.0
   Compiling mio v1.1.1
   Compiling signal-hook v0.3.18
   Compiling allocator-api2 v0.2.21
   Compiling foldhash v0.2.0
   Compiling miniz_oxide v0.8.9
   Compiling stable_deref_trait v1.2.1
   Compiling version_check v0.9.5
   Compiling mio v0.8.11
   Compiling ryu v1.0.23
   Compiling flate2 v1.1.9
   Compiling signal-hook-mio v0.2.5
   Compiling darling_core v0.23.0
   Compiling darling_core v0.21.3
   Compiling plain v0.2.3
   Compiling indoc v2.0.7
   Compiling itertools v0.14.0
   Compiling zerocopy v0.8.42
   Compiling getrandom v0.3.4
   Compiling scx_stats_derive v1.1.0 (/home/lucjan/Patchownia/other/scx/rust/scx_stats/scx_stats_derive)
   Compiling ahash v0.8.12
   Compiling seccomp-sys v0.1.3
   Compiling slog v2.8.2
   Compiling castaway v0.2.4
   Compiling zbus_names v4.3.1
   Compiling enum-map-derive v0.17.0
   Compiling strum_macros v0.27.2
   Compiling num_cpus v1.17.0
   Compiling rustix v0.38.44
   Compiling enum-map v2.7.3
   Compiling compact_str v0.9.0
   Compiling lru v0.16.3
   Compiling kasuari v0.4.12
   Compiling owning_ref v0.4.1
   Compiling zbus_macros v5.14.0
   Compiling erased-serde v0.3.31
   Compiling memoffset v0.9.1
   Compiling unicode-width v0.1.14
   Compiling scx_utils v1.1.0 (/home/lucjan/Patchownia/other/scx/rust/scx_utils)
   Compiling linux-raw-sys v0.4.15
   Compiling procfs v0.18.0
   Compiling unicode-truncate v2.0.1
   Compiling protobuf v3.7.2
   Compiling xi-unicode v0.3.0
   Compiling instability v0.3.12
   Compiling bitflags v1.3.2
   Compiling crossterm v0.25.0
   Compiling scx_arena v1.1.0 (/home/lucjan/Patchownia/other/scx/rust/scx_arena/scx_arena)
   Compiling seccomp v0.1.2
   Compiling procfs-core v0.18.0
   Compiling protobuf-support v3.7.2
   Compiling clap_main v0.2.9
   Compiling tokio-macros v2.6.1
   Compiling is-terminal v0.4.17
   Compiling socket2 v0.6.3
   Compiling convert_case v0.10.0
   Compiling nix v0.29.0
   Compiling bytes v1.11.1
   Compiling term v1.2.1
   Compiling home v0.5.12
   Compiling derive_more-impl v2.1.1
   Compiling darling_macro v0.23.0
   Compiling darling_macro v0.21.3
   Compiling ordered-float v5.1.0
   Compiling darling v0.23.0
   Compiling darling v0.21.3
   Compiling strum v0.27.2
   Compiling enumset_derive v0.14.0
   Compiling ratatui-core v0.1.0
   Compiling tokio v1.50.0
   Compiling slog-term v2.9.2
   Compiling futures-sink v0.3.32
   Compiling humantime v2.3.0
   Compiling litrs v1.0.0
   Compiling fallible-iterator v0.3.0
   Compiling which v4.4.2
   Compiling derive_more v2.1.1
   Compiling gimli v0.32.3
   Compiling scx_rustland_core v2.4.11 (/home/lucjan/Patchownia/other/scx/rust/scx_rustland_core)
   Compiling line-clipping v0.3.5
   Compiling document-features v0.2.12
   Compiling openat v0.1.21
   Compiling object v0.37.3
   Compiling protoc-bin-vendored-linux-aarch_64 v3.2.0
   Compiling protoc-bin-vendored-macos-aarch_64 v3.2.0
   Compiling enumset v1.1.10
   Compiling zbus v5.14.0
   Compiling protoc-bin-vendored-win32 v3.2.0
   Compiling protoc-bin-vendored-linux-x86_64 v3.2.0
   Compiling protoc-bin-vendored-macos-x86_64 v3.2.0
   Compiling protoc-bin-vendored-linux-x86_32 v3.2.0
   Compiling protoc-bin-vendored-linux-ppcle_64 v3.2.0
   Compiling protoc-bin-vendored-linux-s390_64 v3.2.0
   Compiling cursive_core v0.3.7
   Compiling crossterm v0.29.0
   Compiling futures-channel v0.3.32
   Compiling protoc-bin-vendored v3.2.0
   Compiling scx_p2dq v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_p2dq)
   Compiling futures-macro v0.3.32
   Compiling ratatui-widgets v0.3.0
   Compiling sysinfo v0.38.4
   Compiling rayon-core v1.13.0
   Compiling sorted-vec v0.8.10
   Compiling rustc-demangle v0.1.27
   Compiling object v0.38.1
   Compiling futures-task v0.3.32
   Compiling cpp_demangle v0.5.1
   Compiling futures-util v0.3.32
   Compiling ratatui-crossterm v0.1.0
   Compiling protobuf-parse v3.7.2
   Compiling ratatui-macros v0.7.0
   Compiling cursive v0.20.0
   Compiling below-common v0.9.0
   Compiling protobuf-codegen v3.7.2
   Compiling addr2line v0.25.1
   Compiling scx_bpf_compat v1.1.0 (/home/lucjan/Patchownia/other/scx/rust/scx_bpf_compat)
   Compiling scx_userspace_arena v1.1.0 (/home/lucjan/Patchownia/other/scx/rust/scx_userspace_arena)
   Compiling threadpool v1.8.1
   Compiling smartstring v1.0.1
   Compiling fdeflate v0.3.7
   Compiling serde_spanned v1.0.4
   Compiling csv-core v0.1.13
   Compiling inotify-sys v0.1.5
   Compiling include_dir_macros v0.7.4
   Compiling toml_writer v1.0.6+spec-1.1.0
   Compiling cpufeatures v0.3.0
   Compiling signal-hook v0.4.3
   Compiling pxfm v0.1.28
   Compiling blazesym v0.2.3
   Compiling chacha20 v0.10.0
   Compiling include_dir v0.7.4
   Compiling toml v1.0.6+spec-1.1.0
   Compiling csv v1.4.0
   Compiling futures-executor v0.3.32
   Compiling png v0.18.1
   Compiling inotify v0.11.1
   Compiling fb_procfs v0.9.0
   Compiling ratatui v0.30.0
   Compiling bon-macros v3.9.1
   Compiling scxtop v1.1.0 (/home/lucjan/Patchownia/other/scx/tools/scxtop)
   Compiling scx_pandemonium v5.5.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_pandemonium)
   Compiling scx_layered v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_layered)
   Compiling backtrace v0.3.76
   Compiling scx_chaos v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_chaos)
   Compiling miniz_oxide v0.9.1
   Compiling arrayvec v0.7.6
   Compiling gethostname v1.1.0
   Compiling anstyle-parse v0.2.7
   Compiling encoding_rs v0.8.35
   Compiling x11rb-protocol v0.13.2
   Compiling buddy_system_allocator v0.12.0
   Compiling rlimit v0.11.0
   Compiling byteorder-lite v0.1.0
   Compiling moxcms v0.8.1
   Compiling bytemuck v1.25.0
   Compiling perfetto_protos v0.51.1
   Compiling num-format v0.4.4
   Compiling anstream v0.6.21
   Compiling log-panics v2.1.0
   Compiling rayon v1.11.0
   Compiling scx_bpf_unittests v1.1.0 (/home/lucjan/Patchownia/other/scx/rust/scx_bpf_unittests)
   Compiling bon v3.9.1
   Compiling scx_raw_pmu v1.1.0 (/home/lucjan/Patchownia/other/scx/rust/scx_raw_pmu)
   Compiling futures v0.3.32
   Compiling rand v0.10.0
   Compiling tokio-util v0.7.18
   Compiling x11rb v0.13.2
   Compiling scx_rlfifo v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/experimental/scx_rlfifo)
   Compiling scx_rustland v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_rustland)
   Compiling scx_rusty v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_rusty)
   Compiling image v0.25.10
   Compiling scx_bpfland v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_bpfland)
   Compiling scx_mitosis v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_mitosis)
   Compiling scxcash v1.1.0 (/home/lucjan/Patchownia/other/scx/tools/scxcash)
   Compiling scx_tickless v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_tickless)
   Compiling scx_cosmos v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_cosmos)
   Compiling scx_cake v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_cake)
   Compiling scx_flash v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_flash)
   Compiling scx_flow v1.0.0 (/home/lucjan/Patchownia/other/scx/scheds/experimental/scx_flow)
   Compiling scx_arena_selftests v1.1.0 (/home/lucjan/Patchownia/other/scx/rust/scx_arena/selftests)
   Compiling scx_lavd v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_lavd)
   Compiling scx_beerland v1.1.0 (/home/lucjan/Patchownia/other/scx/scheds/rust/scx_beerland)
   Compiling clap_complete v4.6.0
   Compiling env_filter v1.0.0
   Compiling raw-cpuid v11.6.0
   Compiling cargo-platform v0.3.2
   Compiling anpa v0.10.0
   Compiling micromath v2.1.0
   Compiling jiff v0.2.23
   Compiling percent-encoding v2.3.2
   Compiling xdg v3.0.0
   Compiling tachyonfx v0.25.0
   Compiling cargo_metadata v0.23.1
   Compiling arboard v3.6.1
   Compiling quanta v0.12.6
   Compiling env_logger v0.11.9
   Compiling cgroupfs v0.9.0
   Compiling core_affinity v0.8.3
   Compiling affinity v0.1.2
   Compiling clap-num v1.2.0
   Compiling gpoint v0.2.1
   Compiling perf-event-open-sys v6.0.0
   Compiling maplit v1.0.2
   Compiling combinations v0.1.0
   Compiling xtask v1.1.0 (/home/lucjan/Patchownia/other/scx/tools/xtask)
   Compiling vmlinux_docify v1.1.0 (/home/lucjan/Patchownia/other/scx/tools/vmlinux_docify)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 10s
'cargo build --workspace --exclude scx_wd40' time: 1:10,24s, cpu: 996%
```

**Quick test:**

```
lucjan at cachyos ~/Patchownia/other/scx/target/debug 16:56:09 17ed86e3 libbpf-update    
❯ sudo scx_bpfland                                                          
[sudo] hasło użytkownika lucjan: 
16:56:24 [INFO] NUMA nodes: 1
16:56:24 [INFO] Disabling NUMA optimizations
16:56:24 [INFO] scx_bpfland 1.1.0 x86_64-unknown-linux-gnu SMT on
16:56:24 [INFO] scheduler options: scx_bpfland
16:56:24 [INFO] scheduler flags: 0x36
16:56:24 [INFO] primary CPU domain = 0xffff
16:56:24 [INFO] cpufreq performance level: max
16:56:24 [INFO] SMT sibling CPUs: [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7]
^CEXIT: unregistered from user space
16:56:25 [INFO] Unregister scx_bpfland scheduler
lucjan at cachyos ~/Patchownia/other/scx/target/debug 16:56:25 17ed86e3 libbpf-update    
❯ sudo scx_bpfland
16:56:27 [INFO] NUMA nodes: 1
16:56:27 [INFO] Disabling NUMA optimizations
16:56:27 [INFO] scx_bpfland 1.1.0 x86_64-unknown-linux-gnu SMT on
16:56:27 [INFO] scheduler options: scx_bpfland
16:56:27 [INFO] scheduler flags: 0x36
16:56:27 [INFO] primary CPU domain = 0xffff
16:56:27 [INFO] cpufreq performance level: max
16:56:27 [INFO] SMT sibling CPUs: [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7]
^CEXIT: unregistered from user space
16:56:33 [INFO] Unregister scx_bpfland scheduler
lucjan at cachyos ~/Patchownia/other/scx/target/debug 16:56:33 17ed86e3 libbpf-update    
❯ sudo scx_beerland 
16:56:37 [INFO] scx_beerland 1.1.0 x86_64-unknown-linux-gnu SMT on
16:56:37 [INFO] scheduler options: scx_beerland
16:56:37 [INFO] scheduler flags: 0x36
16:56:37 [INFO] SMT sibling CPUs: [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7]
^CEXIT: unregistered from user space
16:56:39 [INFO] Unregister scx_beerland scheduler
lucjan at cachyos ~/Patchownia/other/scx/target/debug 16:56:39 17ed86e3 libbpf-update    
❯ sudo scx_flash 
16:56:45 [INFO] scx_flash 1.1.0 x86_64-unknown-linux-gnu SMT on
16:56:45 [INFO] scheduler options: scx_flash
16:56:45 [INFO] Setting idle QoS to 32 us
16:56:45 [INFO] NUMA nodes: 1
16:56:45 [INFO] Disabling NUMA optimizations
16:56:45 [INFO] scheduler flags: 0x36
16:56:45 [INFO] primary CPU domain = 0xffff
16:56:45 [INFO] cpufreq performance level: max
16:56:45 [INFO] SMT sibling CPUs: [8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7]
^CEXIT: unregistered from user space
16:56:46 [INFO] Unregister scx_flash scheduler
lucjan at cachyos ~/Patchownia/other/scx/target/debug 16:56:46 17ed86e3 libbpf-update    
❯ sudo scx_p2dq 
2026-04-09T14:56:56.709816Z  INFO ThreadId(01) scx_p2dq: scheds/rust/scx_p2dq/src/main.rs:147: Running scx_p2dq (build ID: 1.1.0 x86_64-unknown-linux-gnu)
2026-04-09T14:56:56.726898Z  INFO ThreadId(01) scx_p2dq: scheds/rust/scx_p2dq/src/lib.rs:124: Single LLC detected - disabling multi-LLC optimizations
2026-04-09T14:56:56.726913Z  INFO ThreadId(01) scx_p2dq: scheds/rust/scx_p2dq/src/main.rs:179: DSQ[0] slice_ns 500000
2026-04-09T14:56:56.726922Z  INFO ThreadId(01) scx_p2dq: scheds/rust/scx_p2dq/src/main.rs:179: DSQ[1] slice_ns 2500000
2026-04-09T14:56:56.726924Z  INFO ThreadId(01) scx_p2dq: scheds/rust/scx_p2dq/src/main.rs:179: DSQ[2] slice_ns 5000000
2026-04-09T14:56:56.778845Z  INFO ThreadId(01) scx_utils::libbpf_logger: rust/scx_utils/src/libbpf_logger.rs:11: libbpf: struct_ops p2dq: member sub_attach not found in kernel, skipping it as it's set to zero

2026-04-09T14:56:56.778860Z  INFO ThreadId(01) scx_utils::libbpf_logger: rust/scx_utils/src/libbpf_logger.rs:11: libbpf: struct_ops p2dq: member sub_detach not found in kernel, skipping it as it's set to zero

2026-04-09T14:56:56.778868Z  INFO ThreadId(01) scx_utils::libbpf_logger: rust/scx_utils/src/libbpf_logger.rs:11: libbpf: struct_ops p2dq: member sub_cgroup_id not found in kernel, skipping it as it's set to zero

2026-04-09T14:56:56.891434Z  INFO ThreadId(01) scx_p2dq::energy: scheds/rust/scx_p2dq/src/energy.rs:50: Kernel energy model not available, using frequency-based estimates
2026-04-09T14:56:56.928430Z  INFO ThreadId(01) scx_p2dq: scheds/rust/scx_p2dq/src/main.rs:337: P2DQ scheduler started! Run `scx_p2dq --monitor` for metrics.
^CEXIT: unregistered from user space
2026-04-09T14:56:59.945464Z  INFO ThreadId(01) scx_p2dq: scheds/rust/scx_p2dq/src/main.rs:345: Unregister scx_p2dq scheduler
lucjan at cachyos ~/Patchownia/other/scx/target/debug 16:56:59 17ed86e3 libbpf-update    
❯ sudo scx_lavd 
2026-04-09T14:57:07.129252Z  INFO ThreadId(01) scx_lavd: scheds/rust/scx_lavd/src/main.rs:331: Autopilot mode is enabled.
2026-04-09T14:57:07.129437Z  INFO ThreadId(01) scx_lavd: scheds/rust/scx_lavd/src/main.rs:371: Energy model won't be used for CPU preference order.
2026-04-09T14:57:07.129442Z  INFO ThreadId(01) scx_lavd: scheds/rust/scx_lavd/src/main.rs:384: Pinned task slice mode is enabled (5000 us). Pinned tasks will use per-CPU DSQs.
2026-04-09T14:57:07.129447Z  INFO ThreadId(01) scx_lavd: scheds/rust/scx_lavd/src/main.rs:1055: Opts {
    verbose: 0,
    autopilot: true,
    autopower: false,
    performance: false,
    powersave: false,
    balanced: false,
    slice_max_us: 5000,
    slice_min_us: 500,
    lat_load_target_pct: 100,
    mig_delta_pct: 0,
    lb_low_util_pct: 25,
    lb_local_dsq_util_pct: 10,
    pinned_slice_us: Some(
        5000,
    ),
    preempt_shift: 6,
    cpu_pref_order: "",
    no_use_em: true,
    no_futex_boost: false,
    no_preemption: false,
    no_wake_sync: false,
    no_slice_boost: false,
    per_cpu_dsq: false,
    enable_cpu_bw: false,
    partial: false,
    no_core_compaction: false,
    no_freq_scaling: false,
    stats: None,
    monitor: None,
    monitor_sched_samples: None,
    log_level: "info",
    version: false,
    run_id: None,
    help_stats: false,
    libbpf: LibbpfOpts {
        relaxed_maps: None,
        pin_root_path: None,
        kconfig: None,
        btf_custom_path: None,
        bpf_token_path: None,
    },
    topology: None,
}
2026-04-09T14:57:07.184030Z  INFO ThreadId(01) scx_lavd: scheds/rust/scx_lavd/src/main.rs:604: capacity bound:  1024 (6.7068377%)
  primary CPUs:  [1]
  overflow CPUs: [9, 5, 13, 7, 15, 4, 12, 3, 11, 6, 14, 2, 10, 0, 8]
2026-04-09T14:57:07.184044Z  INFO ThreadId(01) scx_lavd: scheds/rust/scx_lavd/src/main.rs:604: capacity bound:  15268 (100%)
  primary CPUs:  [1]
  overflow CPUs: [5, 7, 4, 3, 6, 2, 0, 9, 13, 15, 12, 11, 14, 10, 8]
2026-04-09T14:57:07.244271Z  INFO ThreadId(01) scx_utils::libbpf_logger: rust/scx_utils/src/libbpf_logger.rs:11: libbpf: struct_ops lavd_ops: member sub_attach not found in kernel, skipping it as it's set to zero

2026-04-09T14:57:07.244286Z  INFO ThreadId(01) scx_utils::libbpf_logger: rust/scx_utils/src/libbpf_logger.rs:11: libbpf: struct_ops lavd_ops: member sub_detach not found in kernel, skipping it as it's set to zero

2026-04-09T14:57:07.244294Z  INFO ThreadId(01) scx_utils::libbpf_logger: rust/scx_utils/src/libbpf_logger.rs:11: libbpf: struct_ops lavd_ops: member sub_cgroup_id not found in kernel, skipping it as it's set to zero

^C2026-04-09T14:57:10.249771Z  WARN ThreadId(01) scx_utils::libbpf_logger: rust/scx_utils/src/libbpf_logger.rs:12: libbpf: map 'lavd_ops': BPF map skeleton link is uninitialized

2026-04-09T14:57:10.268928Z  INFO ThreadId(01) scx_lavd: scheds/rust/scx_lavd/src/main.rs:1088: scx_lavd scheduler is initialized (build ID: 1.1.0 x86_64-unknown-linux-gnu)
2026-04-09T14:57:10.268944Z  INFO ThreadId(01) scx_lavd: scheds/rust/scx_lavd/src/main.rs:1092: scx_lavd scheduler starts running.
EXIT: unregistered from user space
2026-04-09T14:57:10.279222Z  INFO ThreadId(01) scx_lavd: scheds/rust/scx_lavd/src/main.rs:987: Unregister scx_lavd scheduler
```

@EricccTaiwan Could you check Ubuntu ARM?