### PR TITLE
Cargo: drop scx_wd40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4118,31 +4118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scx_wd40"
-version = "1.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "clap",
- "crossbeam",
- "ctrlc",
- "fb_procfs",
- "libbpf-rs",
- "log",
- "nix 0.31.2",
- "ordered-float 5.1.0",
- "scx_arena",
- "scx_cargo",
- "scx_stats",
- "scx_stats_derive",
- "scx_utils",
- "serde",
- "simplelog",
- "sorted-vec",
- "static_assertions",
-]
-
-[[package]]
 name = "scxcash"
 version = "1.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ members = [
     "scheds/rust/scx_tickless",
     "scheds/experimental/scx_flow",
     "scheds/experimental/scx_rlfifo",
-    "scheds/experimental/scx_wd40",
     "tools/scxcash",
     "tools/scxtop",
     "tools/vmlinux_docify",


### PR DESCRIPTION
As mentioned here https://github.com/sched-ext/scx/pull/3526, scx_wd40 has not been working for quite some time. The best solution is to temporarily remove it from the workspace. 

```
lucjan at cachyos ~/Pobrane/scx/target/debug 17:30:24 14dda766 main    
❯ sudo ./scx_wd40
17:30:32 [INFO] Running scx_wd40 (build ID: 1.1.0 x86_64-unknown-linux-gnu/debug)
17:30:32 [INFO] libbpf: struct_ops wd40: member sub_attach not found in kernel, skipping it as it's set to zero

17:30:32 [INFO] libbpf: struct_ops wd40: member sub_detach not found in kernel, skipping it as it's set to zero

17:30:32 [INFO] libbpf: struct_ops wd40: member sub_cgroup_id not found in kernel, skipping it as it's set to zero

17:30:32 [WARN] libbpf: prog 'wd40_enqueue': BPF program load failed: -EINVAL

17:30:32 [WARN] libbpf: prog 'wd40_enqueue': -- BEGIN PROG LOAD LOG --
Func#9 ('scx_bitmap_intersects') is safe for any args that match its prototype
Validating dom_xfer_task() func#10...
393: R1=trusted_ptr_task_struct(id=700) R2=scalar() R3=scalar() R10=fp0
; int dom_xfer_task(struct task_struct *p __arg_trusted, u32 new_dom_id, u64 now) @ lb_domain.bpf.c:282
393: (bf) r6 = r3                     ; R3=scalar(id=701) R6=scalar(id=701)
394: (bc) w7 = w2                     ; R2=scalar() R7=scalar(smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff))
; taskc = (task_ptr)scx_task_data(p); @ lb_domain.bpf.c:287
395: (85) call pc-253
caller:
 R6=scalar(id=701) R7=scalar(smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) R10=fp0
callee:
 frame1: R1=trusted_ptr_task_struct(id=700) R2=scalar() R3=scalar(id=701) R10=fp0
143: frame1: R1=trusted_ptr_task_struct(id=700) R2=scalar() R3=scalar(id=701) R10=fp0
; void __arena *scx_task_data(struct task_struct *p) @ sdt_task.bpf.c:64
143: (bf) r7 = r1                     ; frame1: R1=trusted_ptr_task_struct(id=700) R7=trusted_ptr_task_struct(id=700)
; scx_arena_subprog_init(); @ sdt_task.bpf.c:69
144: (85) call pc+12
caller:
 frame1: R7=trusted_ptr_task_struct(id=700) R10=fp0
callee:
 frame2: R1=trusted_ptr_task_struct(id=700) R2=scalar() R3=scalar(id=701) R10=fp0
157: frame2: R1=trusted_ptr_task_struct(id=700) R2=scalar() R3=scalar(id=701) R10=fp0
; if (scx_arena_verify_once) @ sdt_alloc.bpf.c:41
157: (18) r6 = 0xffffd1536a00e0a8     ; frame2: R6=map_value(map=bpf_bpf.bss,ks=4,vs=75072,off=168)
159: (71) r1 = *(u8 *)(r6 +0)         ; frame2: R1=scalar(smin=smin32=0,smax=umax=smax32=umax32=255,var_off=(0x0; 0xff)) R6=map_value(map=bpf_bpf.bss,ks=4,vs=75072,off=168)
160: (56) if w1 != 0x0 goto pc+10     ; frame2: R1=0
; bpf_printk("%s: arena pointer %p", __func__, &arena); @ sdt_alloc.bpf.c:44
161: (18) r1 = 0xffffd1534d4f62e0     ; frame2: R1=map_value(map=bpf_bpf.rodata,ks=4,vs=10577,off=4832)
163: (b4) w2 = 21                     ; frame2: R2=21
164: (18) r3 = 0xffff8c6452140a6c     ; frame2: R3=map_value(map=.rodata.str1.1,ks=4,vs=742,off=316)
166: (18) r4 = 0xffff8c606c21ee00     ; frame2: R4=map_ptr(map=arena,ks=0,vs=0)
168: (85) call bpf_trace_printk#6     ; frame2: R0=scalar()
169: (b4) w1 = 1                      ; frame2: R1=1
; scx_arena_verify_once = true; @ sdt_alloc.bpf.c:45
170: (73) *(u8 *)(r6 +0) = r1         ; frame2: R1=1 R6=map_value(map=bpf_bpf.bss,ks=4,vs=75072,off=168)
; } @ sdt_alloc.bpf.c:46
171: (95) exit
returning from callee:
 frame2: R0=scalar() R1=1 R6=map_value(map=bpf_bpf.bss,ks=4,vs=75072,off=168) R10=fp0
to caller at 145:
 frame1: R0=scalar() R7=trusted_ptr_task_struct(id=700) R10=fp0
; scx_arena_subprog_init(); @ sdt_task.bpf.c:69
145: (b7) r6 = 0                      ; frame1: R6=0
; mval = bpf_task_storage_get(&scx_task_map, p, 0, 0); @ sdt_task.bpf.c:71
146: (18) r1 = 0xffff8c606c21de00     ; frame1: R1=map_ptr(map=scx_task_map,ks=4,vs=24)
148: (bf) r2 = r7                     ; frame1: R2=trusted_ptr_task_struct(id=700) R7=trusted_ptr_task_struct(id=700)
149: (b7) r3 = 0                      ; frame1: R3=0
150: (b7) r4 = 0                      ; frame1: R4=0
151: (85) call bpf_task_storage_get#156       ; frame1: R0=map_value_or_null(id=702,map=scx_task_map,ks=4,vs=24)
; if (!mval) @ sdt_task.bpf.c:72
152: (15) if r0 == 0x0 goto pc+2      ; frame1: R0=map_value(map=scx_task_map,ks=4,vs=24)
; data = mval->data; @ sdt_task.bpf.c:75
153: (79) r6 = *(u64 *)(r0 +16)       ; frame1: R0=map_value(map=scx_task_map,ks=4,vs=24) R6=scalar()
; return (void __arena *)data->payload; @ sdt_task.bpf.c:77
154: (07) r6 += 8                     ; frame1: R6=scalar()
; } @ sdt_task.bpf.c:78
155: (bf) r0 = r6                     ; frame1: R0=scalar(id=703) R6=scalar(id=703)
156: (95) exit
returning from callee:
 frame1: R0=scalar(id=703) R6=scalar(id=703) R7=trusted_ptr_task_struct(id=700) R10=fp0
to caller at 396:
 R0=scalar(id=703) R6=scalar(id=701) R7=scalar(smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) R10=fp0
; if (!taskc) @ lb_domain.bpf.c:288
396: (15) if r0 == 0x0 goto pc+101    ; R0=scalar(id=703,umin=1)
397: (7b) *(u64 *)(r10 -112) = r6     ; R6=scalar(id=701) R10=fp0 fp-112=scalar(id=701)
398: (bf) r8 = addr_space_cast(r0, 0, 1)      ; R0=scalar(id=703,umin=1) R8=arena
399: (bc) w1 = w7                     ; R1=scalar(id=704,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) R7=scalar(id=704,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff))
; from_domc = taskc->domc; @ lb_domain.bpf.c:291
400: (79) r9 = *(u64 *)(r8 +16)       ; R8=arena R9=scalar()
; if (dom_id >= MAX_DOMS) @ lb_domain.bpf.c:116
401: (bf) r2 = addr_space_cast(r9, 0, 1)      ; R2=arena R9=scalar()
402: (7b) *(u64 *)(r10 -96) = r2      ; R2=arena R10=fp0 fp-96=arena
403: (26) if w7 > 0x3f goto pc+7      ; R7=scalar(id=704,smin=smin32=0,smax=umax=smax32=umax32=63,var_off=(0x0; 0x3f))
; return (dom_ptr)topo_nodes[TOPO_LLC][dom_id]; @ lb_domain.bpf.c:119
404: (bf) r2 = r1                     ; R1=scalar(id=704,smin=smin32=0,smax=umax=smax32=umax32=63,var_off=(0x0; 0x3f)) R2=scalar(id=704,smin=smin32=0,smax=umax=smax32=umax32=63,var_off=(0x0; 0x3f))
405: (67) r2 <<= 3                    ; R2=scalar(smin=smin32=0,smax=umax=smax32=umax32=504,var_off=(0x0; 0x1f8))
406: (18) r3 = 0xffffd1536a00e188     ; R3=map_value(map=bpf_bpf.bss,ks=4,vs=75072,off=392)
408: (0f) r3 += r2                    ; R2=scalar(smin=smin32=0,smax=umax=smax32=umax32=504,var_off=(0x0; 0x1f8)) R3=map_value(map=bpf_bpf.bss,ks=4,vs=75072,off=392,smin=smin32=0,smax=umax=smax32=umax32=504,var_off=(0x0; 0x1f8))
409: (79) r6 = *(u64 *)(r3 +16384)    ; R3=map_value(map=bpf_bpf.bss,ks=4,vs=75072,off=392,smin=smin32=0,smax=umax=smax32=umax32=504,var_off=(0x0; 0x1f8)) R6=scalar()
; if (!domc) @ lb_domain.bpf.c:128
410: (55) if r6 != 0x0 goto pc+8      ; R6=0
; scx_bpf_error("Failed to lookup dom[%u]", dom_id); @ lb_domain.bpf.c:129
411: (7b) *(u64 *)(r10 -88) = r1      ; R1=scalar(id=704,smin=smin32=0,smax=umax=smax32=umax32=63,var_off=(0x0; 0x3f)) R10=fp0 fp-88=scalar(id=704,smin=smin32=0,smax=umax=smax32=umax32=63,var_off=(0x0; 0x3f))
412: (bf) r2 = r10                    ; R2=fp0 R10=fp0
413: (07) r2 += -88                   ; R2=fp-88
414: (18) r1 = 0xffffd15341c5c105     ; R1=map_value(map=bpf_bpf.data,ks=4,vs=2361,off=261)
416: (b4) w3 = 8                      ; R3=8
417: (85) call scx_bpf_error_bstr#127836      ;
418: (b7) r6 = 0                      ; R6=0
419: (7b) *(u64 *)(r10 -120) = r8     ; R8=arena R10=fp0 fp-120=arena
; u32 idx = 0, weight = taskc->weight; @ lb_domain.bpf.c:211
420: (61) r8 = *(u32 *)(r8 +28)       ; R8=scalar(smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff))
; return weight * LB_LOAD_BUCKETS / LB_MAX_WEIGHT; @ lb_domain.bpf.c:137
421: (24) w8 *= 100                   ; R8=scalar(smin=0,smax=umax=umax32=0xfffffffc,smax32=0x7ffffffc,var_off=(0x0; 0xfffffffc))
422: (18) r1 = 0xd1b71759             ; R1=0xd1b71759
424: (2f) r8 *= r1                    ; R1=0xd1b71759 R8=scalar(smax=0x7ffffffffffffffc,umax=0xd1b71755b923a29c,smax32=0x7ffffffc,umax32=0xfffffffc,var_off=(0x0; 0xfffffffffffffffc))
425: (77) r8 >>= 45                   ; R8=scalar(smin=smin32=0,smax=umax=smax32=umax32=0x68db8,var_off=(0x0; 0x7ffff))
; from_lockw = lookup_dom_bkt_lock(from_domc->id, weight); @ lb_domain.bpf.c:216
426: (79) r1 = *(u64 *)(r10 -96)      ; R1=arena R10=fp0 fp-96=arena
427: (61) r1 = *(u32 *)(r1 +0)        ; R1=scalar(smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff))
; u32 idx = dom_id * LB_LOAD_BUCKETS + weight_to_bucket_idx(weight); @ lb_domain.bpf.c:157
428: (24) w1 *= 100                   ; R1=scalar(smin=0,smax=umax=umax32=0xfffffffc,smax32=0x7ffffffc,var_off=(0x0; 0xfffffffc))
429: (0c) w1 += w8                    ; R1=scalar(smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) R8=scalar(smin=smin32=0,smax=umax=smax32=umax32=0x68db8,var_off=(0x0; 0x7ffff))
430: (63) *(u32 *)(r10 -32) = r1      ; R1=scalar(id=705,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) R10=fp0 fp-32=????scalar(id=705,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff))
431: (bf) r2 = r10                    ; R2=fp0 R10=fp0
432: (07) r2 += -32                   ; R2=fp-32
; lockw = bpf_map_lookup_elem(&dom_dcycle_locks, &idx); @ lb_domain.bpf.c:160
433: (18) r1 = 0xffffd1534af91000     ; R1=map_ptr(map=dom_dcycle_lock,ks=4,vs=4)
435: (85) call bpf_map_lookup_elem#1          ; R0=map_value_or_null(id=706,map=dom_dcycle_lock,ks=4,vs=4)
; u32 idx = 0, weight = taskc->weight; @ lb_domain.bpf.c:211
436: (bf) r7 = addr_space_cast(r6, 0, 1)      ; R6=0 R7=arena
437: (7b) *(u64 *)(r10 -104) = r0     ; R0=map_value_or_null(id=706,map=dom_dcycle_lock,ks=4,vs=4) R10=fp0 fp-104=map_value_or_null(id=706,map=dom_dcycle_lock,ks=4,vs=4)
; if (lockw) @ lb_domain.bpf.c:161
438: (55) if r0 != 0x0 goto pc+8 447: R0=map_value(id=706,map=dom_dcycle_lock,ks=4,vs=4) R6=0 R7=arena R8=scalar(smin=smin32=0,smax=umax=smax32=umax32=0x68db8,var_off=(0x0; 0x7ffff)) R9=scalar() R10=fp0 fp-32=????scalar(id=705,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) fp-88=mmmmmmmm fp-96=arena fp-104=map_value(id=706,map=dom_dcycle_lock,ks=4,vs=4) fp-112=scalar(id=701) fp-120=arena
; scx_bpf_error("Failed to lookup dom lock"); @ lb_domain.bpf.c:164
447: (7b) *(u64 *)(r10 -128) = r7     ; R7=arena R10=fp0 fp-128=arena
; to_lockw = lookup_dom_bkt_lock(to_domc->id, weight); @ lb_domain.bpf.c:217
448: (61) r1 = *(u32 *)(r7 +0)        ; R1=scalar(smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) R7=arena
; u32 idx = dom_id * LB_LOAD_BUCKETS + weight_to_bucket_idx(weight); @ lb_domain.bpf.c:157
449: (24) w1 *= 100                   ; R1=scalar(smin=0,smax=umax=umax32=0xfffffffc,smax32=0x7ffffffc,var_off=(0x0; 0xfffffffc))
450: (0c) w1 += w8                    ; R1=scalar(smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) R8=scalar(smin=smin32=0,smax=umax=smax32=umax32=0x68db8,var_off=(0x0; 0x7ffff))
451: (63) *(u32 *)(r10 -32) = r1      ; R1=scalar(id=709,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) R10=fp0 fp-32=????scalar(id=709,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff))
452: (bf) r2 = r10                    ; R2=fp0 R10=fp0
453: (07) r2 += -32                   ; R2=fp-32
; lockw = bpf_map_lookup_elem(&dom_dcycle_locks, &idx); @ lb_domain.bpf.c:160
454: (18) r1 = 0xffffd1534af91000     ; R1=map_ptr(map=dom_dcycle_lock,ks=4,vs=4)
456: (85) call bpf_map_lookup_elem#1          ; R0=map_value_or_null(id=710,map=dom_dcycle_lock,ks=4,vs=4)
; if (lockw) @ lb_domain.bpf.c:161
457: (55) if r0 != 0x0 goto pc+7 465: R0=map_value(id=710,map=dom_dcycle_lock,ks=4,vs=4) R6=0 R7=arena R8=scalar(smin=smin32=0,smax=umax=smax32=umax32=0x68db8,var_off=(0x0; 0x7ffff)) R9=scalar() R10=fp0 fp-32=????scalar(id=709,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) fp-88=mmmmmmmm fp-96=arena fp-104=map_value(id=706,map=dom_dcycle_lock,ks=4,vs=4) fp-112=scalar(id=701) fp-120=arena fp-128=arena
465: (79) r1 = *(u64 *)(r10 -104)     ; R1=map_value(id=706,map=dom_dcycle_lock,ks=4,vs=4) R10=fp0 fp-104=map_value(id=706,map=dom_dcycle_lock,ks=4,vs=4)
; if (!from_lockw || !to_lockw) @ lb_domain.bpf.c:218
466: (15) if r1 == 0x0 goto pc+31     ; R1=map_value(id=706,map=dom_dcycle_lock,ks=4,vs=4)
; bucket = (struct bucket_ctx *)&dom_ctx->buckets[idx]; @ lb_domain.bpf.c:147
467: (bc) w8 = w8                     ; R8=scalar(id=711,smin=smin32=0,smax=umax=smax32=umax32=0x68db8,var_off=(0x0; 0x7ffff))
468: (27) r8 *= 40                    ; R8=scalar(smin=smin32=0,smax=umax=smax32=umax32=0x10624c0,var_off=(0x0; 0x1fffff8))
469: (0f) r9 += r8                    ; R8=scalar(smin=smin32=0,smax=umax=smax32=umax32=0x10624c0,var_off=(0x0; 0x1fffff8)) R9=scalar()
470: (07) r9 += 24                    ; R9=scalar()
471: (bf) r7 = addr_space_cast(r9, 0, 1)      ; R7=arena R9=scalar()
; if (bucket) @ lb_domain.bpf.c:148
472: (55) if r7 != 0x0 goto pc+13 486: R0=map_value(id=710,map=dom_dcycle_lock,ks=4,vs=4) R1=map_value(id=706,map=dom_dcycle_lock,ks=4,vs=4) R6=0 R7=arena R8=scalar(smin=smin32=0,smax=umax=smax32=umax32=0x10624c0,var_off=(0x0; 0x1fffff8)) R9=scalar() R10=fp0 fp-32=????scalar(id=709,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) fp-88=mmmmmmmm fp-96=arena fp-104=map_value(id=706,map=dom_dcycle_lock,ks=4,vs=4) fp-112=scalar(id=701) fp-120=arena fp-128=arena
; bucket = (struct bucket_ctx *)&dom_ctx->buckets[idx]; @ lb_domain.bpf.c:147
486: (0f) r6 += r8                    ; R6=scalar(smin=smin32=0,smax=umax=smax32=umax32=0x10624c0,var_off=(0x0; 0x1fffff8)) R8=scalar(smin=smin32=0,smax=umax=smax32=umax32=0x10624c0,var_off=(0x0; 0x1fffff8))
487: (07) r6 += 24                    ; R6=scalar(smin=umin=smin32=umin32=24,smax=umax=smax32=umax32=0x10624d8,var_off=(0x0; 0x1fffff8))
488: (bf) r6 = addr_space_cast(r6, 0, 1)      ; R6=arena
; if (bucket) @ lb_domain.bpf.c:148
489: (55) if r6 != 0x0 goto pc+10 500: R0=map_value(id=710,map=dom_dcycle_lock,ks=4,vs=4) R1=map_value(id=706,map=dom_dcycle_lock,ks=4,vs=4) R6=arena R7=arena R8=scalar(smin=smin32=0,smax=umax=smax32=umax32=0x10624c0,var_off=(0x0; 0x1fffff8)) R9=scalar() R10=fp0 fp-32=????scalar(id=709,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) fp-88=mmmmmmmm fp-96=arena fp-104=map_value(id=706,map=dom_dcycle_lock,ks=4,vs=4) fp-112=scalar(id=701) fp-120=arena fp-128=arena
; } @ lb_domain.bpf.c:296
500: (7b) *(u64 *)(r10 -136) = r0     ; R0=map_value(id=710,map=dom_dcycle_lock,ks=4,vs=4) R10=fp0 fp-136=map_value(id=710,map=dom_dcycle_lock,ks=4,vs=4)
; ravg_accumulate(&task_dcyc_rd,  taskc->runnable, now, load_half_life); @ lb_domain.bpf.c:233
501: (79) r1 = *(u64 *)(r10 -120)     ; R1=arena R10=fp0 fp-120=arena
502: (71) r2 = *(u8 *)(r1 +32)        ; R1=arena R2=scalar(smin=smin32=0,smax=umax=smax32=umax32=255,var_off=(0x0; 0xff))
503: (18) r8 = 0xffffd1534d4f6e10     ; R8=map_value(map=bpf_bpf.rodata,ks=4,vs=10577,off=7696)
505: (61) r4 = *(u32 *)(r8 +0)        ; R4=0x3b9aca00 R8=map_value(map=bpf_bpf.rodata,ks=4,vs=10577,off=7696)
506: (bf) r1 = r10                    ; R1=fp0 R10=fp0
507: (07) r1 += -32                   ; R1=fp-32
508: (79) r3 = *(u64 *)(r10 -112)     ; R3=scalar(id=701) R10=fp0 fp-112=scalar(id=701)
509: (85) call pc+186
Func#11 ('ravg_accumulate') is global and assumed valid.
510: R0=scalar()
510: (b7) r0 = 0                      ; R0=0
; if (debug >= 2) @ lb_domain.bpf.c:235
511: (18) r1 = 0xffffd1534d4f6f88     ; R1=map_value(map=bpf_bpf.rodata,ks=4,vs=10577,off=8072)
513: (61) r1 = *(u32 *)(r1 +0)        ; R1=0
514: (a6) if w1 < 0x2 goto pc+6       ; R1=0
; task_dcycle >> RAVG_FRAC_BITS, @ lb_domain.bpf.c:273
521: (7b) *(u64 *)(r10 -144) = r0     ; R0=0 R10=fp0 fp-144=0
; bpf_spin_lock(&from_lockw->lock); @ lb_domain.bpf.c:239
522: (79) r1 = *(u64 *)(r10 -104)     ; R1=map_value(id=706,map=dom_dcycle_lock,ks=4,vs=4) R10=fp0 fp-104=map_value(id=706,map=dom_dcycle_lock,ks=4,vs=4)
523: (85) call bpf_spin_lock#93       ; refs=706
; if (taskc->runnable) @ lb_domain.bpf.c:240
524: (79) r1 = *(u64 *)(r10 -120)     ; R1=arena R10=fp0 fp-120=arena refs=706
525: (71) r2 = *(u8 *)(r1 +32)        ; R1=arena R2=scalar(smin=smin32=0,smax=umax=smax32=umax32=255,var_off=(0x0; 0xff)) refs=706
526: (56) if w2 != 0x1 goto pc+3      ; R2=1 refs=706
; from_bucket->dcycle--; @ lb_domain.bpf.c:241
527: (79) r1 = *(u64 *)(r7 +0)        ; R1=scalar() R7=arena refs=706
528: (07) r1 += -1                    ; R1=scalar() refs=706
529: (7b) *(u64 *)(r7 +0) = r1        ; R1=scalar() R7=arena refs=706
530: (b7) r0 = 0                      ; R0=0 refs=706
; if (debug >= 2) @ lb_domain.bpf.c:243
531: (18) r1 = 0xffffd1534d4f6f88     ; R1=map_value(map=bpf_bpf.rodata,ks=4,vs=10577,off=8072) refs=706
533: (61) r1 = *(u32 *)(r1 +0)        ; R1=0 refs=706
534: (79) r8 = *(u64 *)(r10 -112)     ; R8=scalar(id=701) R10=fp0 fp-112=scalar(id=701) refs=706
535: (a6) if w1 < 0x2 goto pc+10      ; R1=0 refs=706
; from_dcycle[0] >> RAVG_FRAC_BITS, @ lb_domain.bpf.c:274
546: (7b) *(u64 *)(r10 -152) = r0     ; R0=0 R10=fp0 fp-152=0 refs=706
; ravg_transfer(&from_bucket->rd, from_bucket->dcycle, @ lb_domain.bpf.c:246
547: (79) r5 = *(u64 *)(r7 +0)        ; R5=scalar() R7=arena refs=706
548: (bf) r9 = r7                     ; R7=arena R9=arena refs=706
549: (07) r9 += 8                     ; R9=arena refs=706
; &task_dcyc_rd, taskc->runnable, load_half_life, false); @ lb_domain.bpf.c:247
550: (18) r1 = 0xffffd1534d4f6e10     ; R1=map_value(map=bpf_bpf.rodata,ks=4,vs=10577,off=7696) refs=706
552: (61) r4 = *(u32 *)(r1 +0)        ; R1=map_value(map=bpf_bpf.rodata,ks=4,vs=10577,off=7696) R4=0x3b9aca00 refs=706
; if ((s64)(base->val_at - xfer->val_at) < 0) @ ravg.h:103
553: (79) r3 = *(u64 *)(r7 +16)       ; R3=scalar() R7=arena refs=706
554: (79) r0 = *(u64 *)(r10 -24)      ; R0=scalar() R10=fp0 fp-24=mmmmmmmm refs=706
555: (bf) r1 = r3                     ; R1=scalar(id=712) R3=scalar(id=712) refs=706
556: (1f) r1 -= r0                    ; R0=scalar() R1=scalar() refs=706
557: (65) if r1 s> 0xffffffff goto pc+5       ; R1=scalar(smax=-1,umin=0x8000000000000000,var_off=(0x8000000000000000; 0x7fffffffffffffff)) refs=706
558: (bf) r8 = r9                     ; R8=arena R9=arena refs=706
; ravg_accumulate(base, base_new_val, xfer->val_at, half_life); @ ravg.h:104
559: (bf) r1 = r9                     ; R1=arena R9=arena refs=706
560: (bf) r2 = r5                     ; R2=scalar(id=713) R5=scalar(id=713) refs=706
561: (bf) r3 = r0                     ; R0=scalar(id=714) R3=scalar(id=714) refs=706
562: (05) goto pc+4
; else if ((s64)(base->val_at - xfer->val_at) > 0) @ ravg.h:105
567: (85) call pc+128
R1 type=arena expected=fp
global function calls are not allowed while holding a lock,
use static function instead
processed 23980 insns (limit 1000000) max_states_per_insn 65 total_states 1665 peak_states 290 mark_read 0
-- END PROG LOAD LOG --

17:30:32 [WARN] libbpf: prog 'wd40_enqueue': failed to load: -EINVAL

17:30:32 [WARN] libbpf: failed to load object 'bpf_bpf'

17:30:32 [WARN] libbpf: failed to load BPF skeleton 'bpf_bpf': -EINVAL

Error: Failed to load BPF program

Caused by:
    Invalid argument (os error 22)
```