### PR TITLE
scx_mitosis: downgrade zero-decisions bail to warn

### DIFF
--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -1039,9 +1039,9 @@ impl<'a> Scheduler<'a> {
             .flat_map(|cell| QUEUE_STATS_IDX.iter().map(|&idx| cell[idx as usize]))
             .sum();
 
-        // We don't want to divide by zero later, but this is never expected.
         if global_queue_decisions == 0 {
-            bail!("Error: No queueing decisions made globally");
+            warn!("No queueing decisions made globally");
+            return Ok(());
         }
 
         self.update_and_log_global_queue_stats(global_queue_decisions, &cell_stats_delta)?;


### PR DESCRIPTION
  log_all_queue_stats bails when global_queue_decisions is zero. In
  cgroup-cpuset auto-mode, cell 0 can transiently hold no CPUs when
  child cpusets collectively cover every CPU. Tasks that would
  otherwise be queued via cell 0's DSQ sit idle in that window, so
  the QUEUE_STATS_IDX buckets summed across all cells can stay at
  zero for the monitor interval.

  Downgrade to warn! + return so an empty interval no longer kills
  the scheduler.
