### PR TITLE
ci: fix apt install timeout and missing error propagation

### DIFF
--- a/.github/actions/install-deps-action/action.yml
+++ b/.github/actions/install-deps-action/action.yml
@@ -24,13 +24,19 @@ runs:
       run: |
         if sudo -n true 2>/dev/null; then
           read -ra pkgs <<< "$SCX_PACKAGES"
+          ok=false
           for attempt in 1 2 3; do
-            if timeout 90 sudo apt-get update && timeout 90 sudo apt-get install -y "${pkgs[@]}"; then
+            if timeout 300 sudo apt-get update -y && timeout 300 sudo apt-get install -y "${pkgs[@]}"; then
+              ok=true
               break
             fi
             echo "::warning::apt attempt $attempt failed, retrying in 5s..."
             sleep 5
           done
+          if [ "$ok" != true ]; then
+            echo "::error::All apt install attempts failed"
+            exit 1
+          fi
         fi
         echo /usr/lib/llvm-19/bin >> $GITHUB_PATH
       shell: bash

--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -771,20 +771,19 @@ impl<'a> App<'a> {
 
         // Handle perf sampling attachment/detachment for PerfTop view
         match (self.prev_state.clone(), self.state.clone()) {
-            (prev, AppState::PerfTop) if prev != AppState::PerfTop => {
-                if self.has_perf_cap {
-                    // Entering PerfTop view - attach perf sampling and reset selection
-                    self.selected_symbol_index = 0;
-                    if let Err(e) = self.attach_perf_sampling() {
-                        eprintln!("Failed to attach perf sampling: {e}");
-                    }
+            (prev, AppState::PerfTop) if prev != AppState::PerfTop && self.has_perf_cap => {
+                // Entering PerfTop view - attach perf sampling and reset selection
+                self.selected_symbol_index = 0;
+                if let Err(e) = self.attach_perf_sampling() {
+                    eprintln!("Failed to attach perf sampling: {e}");
                 }
             }
-            (AppState::PerfTop, new) if new != AppState::PerfTop => {
+            (AppState::PerfTop, new)
+                if new != AppState::PerfTop
                 // Leaving PerfTop view - detach perf sampling
-                if self.has_perf_cap {
-                    self.detach_perf_sampling();
-                }
+                && self.has_perf_cap =>
+            {
+                self.detach_perf_sampling();
             }
             _ => {}
         }
@@ -5515,15 +5514,11 @@ impl<'a> App<'a> {
                     self.set_state(state.clone());
                 }
             }
-            Action::NextEvent => {
-                if self.next_event().is_err() {
-                    // XXX handle error
-                }
+            Action::NextEvent if self.next_event().is_err() => {
+                // XXX handle error
             }
-            Action::PrevEvent => {
-                if self.prev_event().is_err() {
-                    // XXX handle error
-                }
+            Action::PrevEvent if self.prev_event().is_err() => {
+                // XXX handle error
             }
             Action::NextViewState => self.next_view_state(),
             Action::SchedReg => {
@@ -5709,12 +5704,10 @@ impl<'a> App<'a> {
                 AppState::Help => {
                     self.handle_action(&Action::SetState(AppState::Help))?;
                 }
-                AppState::Default | AppState::Llc | AppState::Node | AppState::Process => {
-                    if self.in_thread_view {
-                        self.in_thread_view = false;
-                    } else {
-                        self.should_quit.store(true, Ordering::Relaxed);
-                    }
+                AppState::Default | AppState::Llc | AppState::Node | AppState::Process
+                    if self.in_thread_view =>
+                {
+                    self.in_thread_view = false;
                 }
                 _ => {
                     self.should_quit.store(true, Ordering::Relaxed);

--- a/tools/scxtop/src/bpf_prog_data.rs
+++ b/tools/scxtop/src/bpf_prog_data.rs
@@ -578,10 +578,7 @@ impl BpfProgStats {
                 let calls_delta = new_prog_data.run_cnt.saturating_sub(prev_data.run_cnt);
 
                 // Calculate per-call runtime from delta
-                let avg_runtime = if calls_delta > 0 {
-                    let avg = runtime_delta / calls_delta;
-
-                    // Update min/max
+                let avg_runtime = if let Some(avg) = runtime_delta.checked_div(calls_delta) {
                     if new_prog_data.min_runtime_ns == 0 || avg < new_prog_data.min_runtime_ns {
                         new_prog_data.min_runtime_ns = avg;
                     } else {

--- a/tools/scxtop/src/mcp/analyzers.rs
+++ b/tools/scxtop/src/mcp/analyzers.rs
@@ -517,7 +517,7 @@ impl MigrationAnalyzer {
         }
 
         let mut process_patterns: Vec<_> = per_process.into_values().collect();
-        process_patterns.sort_by(|a, b| b.migration_count.cmp(&a.migration_count));
+        process_patterns.sort_by_key(|b| std::cmp::Reverse(b.migration_count));
         process_patterns.truncate(20);
 
         // CPU pair analysis
@@ -535,7 +535,7 @@ impl MigrationAnalyzer {
             })
             .collect();
 
-        cpu_pair_stats.sort_by(|a, b| b.count.cmp(&a.count));
+        cpu_pair_stats.sort_by_key(|b| std::cmp::Reverse(b.count));
         cpu_pair_stats.truncate(20);
 
         MigrationAnalysis {

--- a/tools/scxtop/src/mcp/event_aggregator.rs
+++ b/tools/scxtop/src/mcp/event_aggregator.rs
@@ -200,7 +200,7 @@ impl EventAggregator {
             .collect();
 
         // Sort by count descending
-        results.sort_by(|a, b| b.count.cmp(&a.count));
+        results.sort_by_key(|b| std::cmp::Reverse(b.count));
 
         // Apply top_n limit
         if let Some(n) = self.config.top_n {

--- a/tools/scxtop/src/mcp/extended_analyzers.rs
+++ b/tools/scxtop/src/mcp/extended_analyzers.rs
@@ -709,11 +709,11 @@ impl SoftirqAnalyzer {
                     count: type_stats.count,
                     rate_per_sec: type_stats.count as f64 / window_duration_sec,
                     total_time_us: type_stats.total_duration_ns / 1000,
-                    avg_duration_us: if type_stats.count > 0 {
-                        (type_stats.total_duration_ns / type_stats.count) / 1000
-                    } else {
-                        0
-                    },
+                    avg_duration_us: type_stats
+                        .total_duration_ns
+                        .checked_div(type_stats.count)
+                        .unwrap_or(0)
+                        / 1000,
                     min_duration_us: duration_us.first().copied().unwrap_or(0),
                     max_duration_us: duration_us.last().copied().unwrap_or(0),
                     p50_duration_us: percentile_u64(&duration_us, 50.0),
@@ -723,7 +723,7 @@ impl SoftirqAnalyzer {
             })
             .collect();
 
-        stats.sort_by(|a, b| b.count.cmp(&a.count));
+        stats.sort_by_key(|b| std::cmp::Reverse(b.count));
         stats
     }
 
@@ -755,7 +755,7 @@ impl SoftirqAnalyzer {
             })
             .collect();
 
-        stats.sort_by(|a, b| b.count.cmp(&a.count));
+        stats.sort_by_key(|b| std::cmp::Reverse(b.count));
         stats.truncate(top_n);
         stats
     }
@@ -792,7 +792,7 @@ impl SoftirqAnalyzer {
             })
             .collect();
 
-        stats.sort_by(|a, b| b.total_time_us.cmp(&a.total_time_us));
+        stats.sort_by_key(|b| std::cmp::Reverse(b.total_time_us));
         stats.truncate(top_n);
         stats
     }
@@ -820,11 +820,7 @@ impl SoftirqAnalyzer {
             total_events,
             event_rate_per_sec: total_events as f64 / window_duration_sec,
             total_time_us: total_time_ns / 1000,
-            avg_duration_us: if total_events > 0 {
-                (total_time_ns / total_events) / 1000
-            } else {
-                0
-            },
+            avg_duration_us: total_time_ns.checked_div(total_events).unwrap_or(0) / 1000,
             p50_duration_us: percentile_u64(&duration_us, 50.0),
             p95_duration_us: percentile_u64(&duration_us, 95.0),
             p99_duration_us: percentile_u64(&duration_us, 99.0),

--- a/tools/scxtop/src/mcp/perfetto_analyzers.rs
+++ b/tools/scxtop/src/mcp/perfetto_analyzers.rs
@@ -330,7 +330,7 @@ impl ContextSwitchAnalyzer {
             .collect();
 
         // Sort by total runtime (descending)
-        stats.sort_by(|a, b| b.total_runtime_ns.cmp(&a.total_runtime_ns));
+        stats.sort_by_key(|b| std::cmp::Reverse(b.total_runtime_ns));
 
         stats
     }
@@ -460,7 +460,7 @@ impl ContextSwitchAnalyzer {
             })
             .collect();
 
-        stats.sort_by(|a, b| b.total_runtime_ns.cmp(&a.total_runtime_ns));
+        stats.sort_by_key(|b| std::cmp::Reverse(b.total_runtime_ns));
         stats
     }
 }
@@ -946,7 +946,7 @@ impl CorrelationAnalyzer {
         }
 
         // Sort by latency (descending)
-        correlations.sort_by(|a, b| b.wakeup_latency_ns.cmp(&a.wakeup_latency_ns));
+        correlations.sort_by_key(|b| std::cmp::Reverse(b.wakeup_latency_ns));
 
         correlations
     }

--- a/tools/scxtop/src/mcp/perfetto_analyzers_extended.rs
+++ b/tools/scxtop/src/mcp/perfetto_analyzers_extended.rs
@@ -162,7 +162,7 @@ impl TaskStateAnalyzer {
         };
 
         let mut sorted_stats = stats;
-        sorted_stats.sort_by(|a, b| b.total_time_ns.cmp(&a.total_time_ns));
+        sorted_stats.sort_by_key(|b| std::cmp::Reverse(b.total_time_ns));
         sorted_stats
     }
 
@@ -516,7 +516,7 @@ impl PreemptionAnalyzer {
             .map(|(_, tracker)| tracker.into_stats())
             .collect();
 
-        stats.sort_by(|a, b| b.preempted_count.cmp(&a.preempted_count));
+        stats.sort_by_key(|b| std::cmp::Reverse(b.preempted_count));
         stats
     }
 }
@@ -944,7 +944,7 @@ impl PreemptionTracker {
 
     fn into_stats(self) -> PreemptionStats {
         let mut preempted_by: Vec<PreemptorInfo> = self.preempted_by.into_values().collect();
-        preempted_by.sort_by(|a, b| b.count.cmp(&a.count));
+        preempted_by.sort_by_key(|b| std::cmp::Reverse(b.count));
 
         PreemptionStats {
             pid: self.pid,

--- a/tools/scxtop/src/mcp/perfetto_analyzers_scheduling.rs
+++ b/tools/scxtop/src/mcp/perfetto_analyzers_scheduling.rs
@@ -106,7 +106,7 @@ impl LlcLocalityAnalyzer {
 
         // Build top cross-LLC processes
         let mut cross_llc_sorted: Vec<_> = process_cross_llc.into_iter().collect();
-        cross_llc_sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        cross_llc_sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
         let processes = self.trace.get_processes();
         stats.top_cross_llc_processes = cross_llc_sorted
             .into_iter()
@@ -204,9 +204,9 @@ impl RunqueueDepthAnalyzer {
                 let ts = event_with_idx.event.timestamp.unwrap_or(0);
 
                 match &event_with_idx.event.event {
-                    Some(ftrace_event::Event::SchedWakeup(wakeup)) => {
+                    Some(ftrace_event::Event::SchedWakeup(wakeup))
                         // Task placed on this CPU's runqueue
-                        if wakeup.target_cpu == Some(cpu_id as i32) {
+                        if wakeup.target_cpu == Some(cpu_id as i32) => {
                             // Accumulate weighted depth before changing it
                             if ts > last_ts {
                                 total_depth_time += depth as f64 * (ts - last_ts) as f64;
@@ -218,7 +218,6 @@ impl RunqueueDepthAnalyzer {
                             }
                             depth_samples.push((ts, depth));
                         }
-                    }
                     Some(ftrace_event::Event::SchedSwitch(switch)) => {
                         // Accumulate weighted depth before changing it
                         if ts > last_ts {
@@ -573,7 +572,7 @@ impl FairnessAnalyzer {
                 }
             })
             .collect();
-        starved.sort_by(|a, b| a.runtime_ns.cmp(&b.runtime_ns));
+        starved.sort_by_key(|a| a.runtime_ns);
 
         // Identify hogging processes (> 10x fair share)
         let hogging_threshold = fair_share.saturating_mul(10);
@@ -595,7 +594,7 @@ impl FairnessAnalyzer {
                 }
             })
             .collect();
-        hogging.sort_by(|a, b| b.runtime_ns.cmp(&a.runtime_ns));
+        hogging.sort_by_key(|b| std::cmp::Reverse(b.runtime_ns));
 
         FairnessStats {
             total_processes: num_processes,

--- a/tools/scxtop/src/mcp/perfetto_parser.rs
+++ b/tools/scxtop/src/mcp/perfetto_parser.rs
@@ -988,35 +988,35 @@ impl PerfettoTrace {
                                 });
                             }
                         }
-                        Some(ftrace_event::Event::SchedWakeup(wakeup)) => {
-                            if wakeup.pid == Some(pid) {
-                                events.push(ProcessTimelineEvent::Woken {
-                                    by_pid: event_with_idx.event.pid.unwrap_or(0),
-                                    timestamp: ts,
-                                });
-                            }
+                        Some(ftrace_event::Event::SchedWakeup(wakeup))
+                            if wakeup.pid == Some(pid) =>
+                        {
+                            events.push(ProcessTimelineEvent::Woken {
+                                by_pid: event_with_idx.event.pid.unwrap_or(0),
+                                timestamp: ts,
+                            });
                         }
-                        Some(ftrace_event::Event::SchedMigrateTask(migrate)) => {
-                            if migrate.pid == Some(pid) {
-                                events.push(ProcessTimelineEvent::Migrated {
-                                    from_cpu: 0, // Would need to track current CPU
-                                    to_cpu: migrate.dest_cpu.unwrap_or(0) as u32,
-                                    timestamp: ts,
-                                });
-                            }
+                        Some(ftrace_event::Event::SchedMigrateTask(migrate))
+                            if migrate.pid == Some(pid) =>
+                        {
+                            events.push(ProcessTimelineEvent::Migrated {
+                                from_cpu: 0, // Would need to track current CPU
+                                to_cpu: migrate.dest_cpu.unwrap_or(0) as u32,
+                                timestamp: ts,
+                            });
                         }
-                        Some(ftrace_event::Event::SchedProcessFork(fork)) => {
-                            if fork.parent_pid == Some(pid) {
-                                events.push(ProcessTimelineEvent::Forked {
-                                    child_pid: fork.child_pid.unwrap_or(0),
-                                    timestamp: ts,
-                                });
-                            }
+                        Some(ftrace_event::Event::SchedProcessFork(fork))
+                            if fork.parent_pid == Some(pid) =>
+                        {
+                            events.push(ProcessTimelineEvent::Forked {
+                                child_pid: fork.child_pid.unwrap_or(0),
+                                timestamp: ts,
+                            });
                         }
-                        Some(ftrace_event::Event::SchedProcessExit(exit)) => {
-                            if exit.pid == Some(pid) {
-                                events.push(ProcessTimelineEvent::Exited { timestamp: ts });
-                            }
+                        Some(ftrace_event::Event::SchedProcessExit(exit))
+                            if exit.pid == Some(pid) =>
+                        {
+                            events.push(ProcessTimelineEvent::Exited { timestamp: ts });
                         }
                         _ => {}
                     }

--- a/tools/scxtop/src/mcp/shared_state.rs
+++ b/tools/scxtop/src/mcp/shared_state.rs
@@ -238,11 +238,10 @@ impl SharedStats {
             .cpu_stats
             .values()
             .map(|stats| {
-                let avg_latency_ns = if stats.latency_samples > 0 {
-                    stats.total_latency_ns / stats.latency_samples
-                } else {
-                    0
-                };
+                let avg_latency_ns = stats
+                    .total_latency_ns
+                    .checked_div(stats.latency_samples)
+                    .unwrap_or(0);
 
                 serde_json::json!({
                     "cpu_id": stats.cpu_id,
@@ -271,17 +270,16 @@ impl SharedStats {
         let mut processes: Vec<_> = self.process_stats.values().collect();
 
         // Sort by total runtime or latency
-        processes.sort_by(|a, b| b.nr_switches.cmp(&a.nr_switches));
+        processes.sort_by_key(|b| std::cmp::Reverse(b.nr_switches));
 
         let processes: Vec<JsonValue> = processes
             .iter()
             .take(limit.unwrap_or(100))
             .map(|stats| {
-                let avg_latency_ns = if stats.latency_samples > 0 {
-                    stats.total_latency_ns / stats.latency_samples
-                } else {
-                    0
-                };
+                let avg_latency_ns = stats
+                    .total_latency_ns
+                    .checked_div(stats.latency_samples)
+                    .unwrap_or(0);
 
                 serde_json::json!({
                     "tid": stats.pid,  // This is actually TID
@@ -346,17 +344,16 @@ impl SharedStats {
         }
 
         let mut processes: Vec<_> = process_aggregates.iter().collect();
-        processes.sort_by(|(_, a), (_, b)| b.nr_switches.cmp(&a.nr_switches));
+        processes.sort_by_key(|(_, b)| std::cmp::Reverse(b.nr_switches));
 
         let processes: Vec<JsonValue> = processes
             .iter()
             .take(limit.unwrap_or(100))
             .map(|(tgid, stats)| {
-                let avg_latency_ns = if stats.latency_samples > 0 {
-                    stats.total_latency_ns / stats.latency_samples
-                } else {
-                    0
-                };
+                let avg_latency_ns = stats
+                    .total_latency_ns
+                    .checked_div(stats.latency_samples)
+                    .unwrap_or(0);
 
                 serde_json::json!({
                     "pid": tgid,
@@ -436,11 +433,10 @@ impl SharedStats {
         let llcs: Vec<JsonValue> = llc_aggregates
             .iter()
             .map(|(llc_id, stats)| {
-                let avg_latency_ns = if stats.latency_samples > 0 {
-                    stats.total_latency_ns / stats.latency_samples
-                } else {
-                    0
-                };
+                let avg_latency_ns = stats
+                    .total_latency_ns
+                    .checked_div(stats.latency_samples)
+                    .unwrap_or(0);
 
                 serde_json::json!({
                     "llc_id": llc_id,
@@ -499,11 +495,10 @@ impl SharedStats {
         let nodes: Vec<JsonValue> = node_aggregates
             .iter()
             .map(|(node_id, stats)| {
-                let avg_latency_ns = if stats.latency_samples > 0 {
-                    stats.total_latency_ns / stats.latency_samples
-                } else {
-                    0
-                };
+                let avg_latency_ns = stats
+                    .total_latency_ns
+                    .checked_div(stats.latency_samples)
+                    .unwrap_or(0);
 
                 serde_json::json!({
                     "node_id": node_id,

--- a/tools/scxtop/src/mcp/tools.rs
+++ b/tools/scxtop/src/mcp/tools.rs
@@ -2548,7 +2548,7 @@ impl McpTools {
 
                 // Sort per-CPU stats by avg latency descending, show top N worst
                 let mut per_cpu_sorted: Vec<_> = stats.per_cpu_stats.values().collect();
-                per_cpu_sorted.sort_by(|a, b| b.avg_latency_ns.cmp(&a.avg_latency_ns));
+                per_cpu_sorted.sort_by_key(|b| std::cmp::Reverse(b.avg_latency_ns));
                 let total_cpus = per_cpu_sorted.len();
                 let top_n = limit.min(20);
                 let worst_cpus: Vec<_> = per_cpu_sorted.iter().take(top_n).collect();
@@ -2654,8 +2654,7 @@ impl McpTools {
                     Some(stats) => {
                         // Limit per-LLC stats and top processes
                         let mut per_llc_sorted: Vec<_> = stats.per_llc_stats.values().collect();
-                        per_llc_sorted
-                            .sort_by(|a, b| b.outbound_migrations.cmp(&a.outbound_migrations));
+                        per_llc_sorted.sort_by_key(|b| std::cmp::Reverse(b.outbound_migrations));
                         let top_n = limit.min(20);
                         let limited_llc: Vec<_> = per_llc_sorted.into_iter().take(top_n).collect();
                         let limited_procs: Vec<_> =
@@ -2700,7 +2699,7 @@ impl McpTools {
 
                 // Sort CPUs by max depth descending
                 let mut cpu_sorted: Vec<_> = stats.per_cpu.values().collect();
-                cpu_sorted.sort_by(|a, b| b.max_depth.cmp(&a.max_depth));
+                cpu_sorted.sort_by_key(|b| std::cmp::Reverse(b.max_depth));
                 let top_n = limit.min(20);
                 let worst_cpus: Vec<_> = cpu_sorted.iter().take(top_n).collect();
 

--- a/tools/scxtop/src/mcp/waker_wakee_analyzer.rs
+++ b/tools/scxtop/src/mcp/waker_wakee_analyzer.rs
@@ -445,11 +445,9 @@ impl RelationshipStats {
     }
 
     pub fn avg_latency_us(&self) -> u64 {
-        if self.sample_count > 0 {
-            self.total_latency_us / self.sample_count
-        } else {
-            0
-        }
+        self.total_latency_us
+            .checked_div(self.sample_count)
+            .unwrap_or(0)
     }
 
     pub fn criticality_score(&self) -> u64 {

--- a/tools/scxtop/src/render/bpf_programs.rs
+++ b/tools/scxtop/src/render/bpf_programs.rs
@@ -396,7 +396,7 @@ impl BpfProgramRenderer {
         // Sort operations by runtime descending
         let mut ops: Vec<(&SchedExtOpType, &crate::bpf_prog_data::OperationStats)> =
             bpf_program_stats.operation_stats.iter().collect();
-        ops.sort_by(|a, b| b.1.total_runtime_ns.cmp(&a.1.total_runtime_ns));
+        ops.sort_by_key(|b| std::cmp::Reverse(b.1.total_runtime_ns));
 
         let mut text = vec![
             Line::from(Span::styled(
@@ -435,11 +435,10 @@ impl BpfProgramRenderer {
 
         // Show top 8 operations
         for (op_type, stats) in ops.iter().take(8) {
-            let avg_ns = if stats.total_calls > 0 {
-                stats.total_runtime_ns / stats.total_calls
-            } else {
-                0
-            };
+            let avg_ns = stats
+                .total_runtime_ns
+                .checked_div(stats.total_calls)
+                .unwrap_or(0);
 
             let pct = if bpf_program_stats.total_runtime_ns > 0 {
                 (stats.total_runtime_ns as f64 / bpf_program_stats.total_runtime_ns as f64) * 100.0
@@ -589,11 +588,10 @@ impl BpfProgramRenderer {
         bpf_program_stats: &BpfProgStats,
         theme: &AppTheme,
     ) -> Result<()> {
-        let avg_runtime_ns = if prog_data.run_cnt > 0 {
-            prog_data.run_time_ns / prog_data.run_cnt
-        } else {
-            0
-        };
+        let avg_runtime_ns = prog_data
+            .run_time_ns
+            .checked_div(prog_data.run_cnt)
+            .unwrap_or(0);
 
         let runtime_percentage = prog_data.runtime_percentage(bpf_program_stats.total_runtime_ns);
 

--- a/tools/scxtop/src/render/network.rs
+++ b/tools/scxtop/src/render/network.rs
@@ -210,7 +210,7 @@ impl NetworkRenderer {
 
         let mut interfaces: Vec<(&String, &InterfaceStats)> =
             network_stats.interfaces.iter().collect();
-        interfaces.sort_by(|a, b| b.1.recv_bytes.cmp(&a.1.recv_bytes));
+        interfaces.sort_by_key(|b| std::cmp::Reverse(b.1.recv_bytes));
 
         // Limit to top 5 interfaces by received bytes
         let top_interfaces = interfaces.into_iter().take(5);
@@ -283,7 +283,7 @@ impl NetworkRenderer {
             .iter()
             .map(|(name, stats)| (name.clone(), stats.recv_bytes + stats.sent_bytes))
             .collect();
-        interface_activity.sort_by(|a, b| b.1.cmp(&a.1));
+        interface_activity.sort_by_key(|b| std::cmp::Reverse(b.1));
         let top_interfaces: Vec<String> = interface_activity
             .into_iter()
             .take(3)

--- a/tools/scxtop/src/render/scheduler.rs
+++ b/tools/scxtop/src/render/scheduler.rs
@@ -352,7 +352,7 @@ impl SchedulerRenderer {
         }
 
         // Sort by p90 descending (highest latency first)
-        entries.sort_by(|a, b| b.p90.cmp(&a.p90));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.p90));
 
         let header = Row::new(vec![
             Cell::from("PID"),

--- a/tools/scxtop/src/search.rs
+++ b/tools/scxtop/src/search.rs
@@ -60,7 +60,7 @@ pub fn fuzzy_search(entries: &[String], input: &str) -> Vec<String> {
             .collect()
     }
 
-    fuzzy_results.sort_by(|a, b| b.1.cmp(&a.1));
+    fuzzy_results.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     fuzzy_results
         .into_iter()

--- a/tools/scxtop/src/symbol_data.rs
+++ b/tools/scxtop/src/symbol_data.rs
@@ -292,7 +292,7 @@ impl SymbolData {
 
     pub fn get_top_symbols(&self, limit: usize) -> Vec<&SymbolSample> {
         let mut samples: Vec<&SymbolSample> = self.symbol_samples.values().collect();
-        samples.sort_by(|a, b| b.count.cmp(&a.count));
+        samples.sort_by_key(|b| std::cmp::Reverse(b.count));
         samples.into_iter().take(limit).collect()
     }
 


### PR DESCRIPTION
The 90s timeout is too short for the ~104 MB package download on slow GitHub runner mirrors (~800 kB/s). Bump to 300s. Also fail the step when all three attempts exhaust instead of silently continuing without dependencies installed.