### PR TITLE
scx_layered: fix per-node fallback for confined layers with skip_remote_node

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2518,7 +2518,8 @@ static bool try_drain_layer_node_llcs(struct layer *layer, struct cpu_ctx *cpuc)
 }
 
 static __always_inline bool try_consume_layer(u32 layer_id, struct cpu_ctx *cpuc,
-					      struct llc_ctx *llcc)
+					      struct llc_ctx *llcc,
+					      bool rescue_stranded)
 {
 	struct llc_prox_map *llc_pmap = &llcc->prox_map;
 	struct layer *layer;
@@ -2531,10 +2532,13 @@ static __always_inline bool try_consume_layer(u32 layer_id, struct cpu_ctx *cpuc
 		return false;
 
 	/*
-	 * If a layer is confined, and the CPU doesn't belong to it, we shouldn't
-	 * consume from it.
+	 * If a layer is confined, and the CPU doesn't belong to it, we
+	 * shouldn't consume from it — unless rescue_stranded is set,
+	 * which indicates fallback draining of stranded tasks on nodes
+	 * where the layer has no CPUs.
 	 */
-	if (layer->kind == LAYER_KIND_CONFINED && cpuc->layer_id != layer_id)
+	if (!rescue_stranded &&
+	    layer->kind == LAYER_KIND_CONFINED && cpuc->layer_id != layer_id)
 		return false;
 
 	skip_remote_node = layer->skip_remote_node;
@@ -2606,7 +2610,8 @@ static __always_inline bool try_consume_layer(u32 layer_id, struct cpu_ctx *cpuc
 
 static __always_inline
 bool try_consume_layers(u32 *layer_order, u32 nr, u32 exclude_layer_id,
-			struct cpu_ctx *cpuc, struct llc_ctx *llcc)
+			struct cpu_ctx *cpuc, struct llc_ctx *llcc,
+			bool rescue_stranded)
 {
 	u32 u;
 
@@ -2621,7 +2626,7 @@ bool try_consume_layers(u32 *layer_order, u32 nr, u32 exclude_layer_id,
 		if (layer_id == exclude_layer_id)
 			continue;
 
-		if (try_consume_layer(layer_id, cpuc, llcc))
+		if (try_consume_layer(layer_id, cpuc, llcc, rescue_stranded))
 			return true;
 	}
 
@@ -2719,7 +2724,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 	    (nodec = lookup_node_ctx(cpuc->node_id)) &&
 	    try_consume_layers(nodec->empty_layer_ids,
 			       nodec->nr_empty_layer_ids,
-			       MAX_LAYERS, cpuc, llcc)) {
+			       MAX_LAYERS, cpuc, llcc, true)) {
 		trace("FALLBACK cpu=%d node=%d (node_cpus=0)",
 		      cpuc->cpu, cpuc->node_id);
 		cpuc->running_fallback = true;
@@ -2768,26 +2773,26 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 		 */
 		if (cpuc->protect_owned) {
 			if (try_consume_layers(cpuc->op_layer_order, nr_op_layers,
-					       MAX_LAYERS, cpuc, llcc))
+					       MAX_LAYERS, cpuc, llcc, false))
 				return;
 			if (try_consume_layers(cpuc->on_layer_order, nr_on_layers,
-					       MAX_LAYERS, cpuc, llcc))
+					       MAX_LAYERS, cpuc, llcc, false))
 				return;
 			if (try_consume_layers(cpuc->gp_layer_order, nr_gp_layers,
-					       MAX_LAYERS, cpuc, llcc))
+					       MAX_LAYERS, cpuc, llcc, false))
 				return;
 			if (try_consume_layers(cpuc->gn_layer_order, nr_gn_layers,
-					       MAX_LAYERS, cpuc, llcc))
+					       MAX_LAYERS, cpuc, llcc, false))
 				return;
 		} else {
 			if (try_consume_layers(cpuc->op_layer_order, nr_op_layers,
-					       MAX_LAYERS, cpuc, llcc))
+					       MAX_LAYERS, cpuc, llcc, false))
 				return;
 			if (try_consume_layers(cpuc->gp_layer_order, nr_gp_layers,
-					       MAX_LAYERS, cpuc, llcc))
+					       MAX_LAYERS, cpuc, llcc, false))
 				return;
 			if (try_consume_layers(cpuc->ogn_layer_order, nr_ogn_layers,
-					       MAX_LAYERS, cpuc, llcc))
+					       MAX_LAYERS, cpuc, llcc, false))
 				return;
 		}
 	} else {
@@ -2805,7 +2810,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 		 */
 		if (!owner_layer || (!owner_layer->is_protected && !cpuc->protect_owned && !owner_layer->preempt)) {
 			if (try_consume_layers(cpuc->ogp_layer_order, nr_ogp_layers,
-					       cpuc->layer_id, cpuc, llcc))
+					       cpuc->layer_id, cpuc, llcc, false))
 				return;
 
 			tried_preempting = true;
@@ -2817,7 +2822,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 			    owner_layer->node[cpuc->node_id].llcs_to_drain &&
 			    try_drain_layer_node_llcs(owner_layer, cpuc))
 				return;
-			if (try_consume_layer(owner_layer->id, cpuc, llcc))
+			if (try_consume_layer(owner_layer->id, cpuc, llcc, false))
 				return;
 
 			/* CPU is in a protected layer, do not pull from other layers. */
@@ -2828,12 +2833,12 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 		/* try grouped/open preempting if not tried yet */
 		if (!tried_preempting &&
 		    try_consume_layers(cpuc->ogp_layer_order, nr_ogp_layers,
-				       cpuc->layer_id, cpuc, llcc))
+				       cpuc->layer_id, cpuc, llcc, false))
 			return;
 
 		/* grouped/open non-preempt layers */
 		if (try_consume_layers(cpuc->ogn_layer_order, nr_ogn_layers,
-				       cpuc->layer_id, cpuc, llcc))
+				       cpuc->layer_id, cpuc, llcc, false))
 			return;
 	}
 


### PR DESCRIPTION
On multi-NUMA systems with virtual LLCs (e.g. 4 nodes, 32 LLCs, 64 CPUs), confined layers using skip_remote_node and the `Topo` growth algo may only have CPUs allocated on a subset of NUMA nodes. When tasks wake up on a node where their layer has no CPUs, they are enqueued to per-LLC DSQs on that node. The per-node fallback mechanism is designed to rescue these stranded tasks — each node has a designated fallback CPU that drains DSQs for layers with zero CPUs on that node.

However, two checks in `try_consume_layer()` prevented the fallback from actually consuming these tasks:

1. The confined layer gate `(LAYER_KIND_CONFINED && cpuc->layer_id != layer_id)` caused `try_consume_layer()` to return false immediately when the fallback CPU belonged to a different layer than the one being drained. Since the fallback CPU is allocated to whatever layer owns it, not to the empty layer it is rescuing, this blocked all confined layer fallback. With all layers configured as Confined, the entire fallback mechanism was effectively dead.

2. The `skip_remote_node` check skipped consumption from DSQs on remote NUMA nodes. When the fallback CPU on node N tried to drain a layer that had CPUs only on node M, it skipped node M's DSQs because they were "remote" — even though the stranded tasks were local to node N and the layer's CPUs were what was remote. This inverted the intent of skip_remote_node for the fallback case.

Together these caused runnable task starvation: tasks accumulated in per-LLC DSQs on nodes where their layer had no CPUs, no CPU could drain them, and the sched_ext watchdog triggered after 30 seconds with hundreds of tasks queued across starved DSQs.

Fix by adding a consume_remote parameter to `try_consume_layer()`. When set, it bypasses both the confined layer gate and the `skip_remote_node` check. The per-node fallback dispatch path passes `consume_remote=true`; all other call sites pass false, preserving existing behavior for normal scheduling.