### PR TITLE
scx_layered: fix clippy lints and crash on IO only NUMA nodes

### DIFF
--- a/scheds/rust/scx_layered/src/alloc.rs
+++ b/scheds/rust/scx_layered/src/alloc.rs
@@ -354,6 +354,7 @@ pub fn unified_alloc(
 /// layer with per-node `pinned` counts and `unpinned_budget` set.
 /// Per-node `unpinned` distribution is NOT resolved here — that's done
 /// by `resolve_spread` and `place_unpinned`.
+#[allow(clippy::needless_range_loop)]
 fn allocate_budgets(
     total_units: usize,
     node_caps: &[usize],
@@ -523,6 +524,7 @@ fn allocate_budgets(
 ///    layers by weight.  Each layer gets at most `total / nr_nodes` per node.
 /// 4. Freed capacity (from capping) is redistributed to non-spread layers
 ///    proportionally via `water_fill`, increasing their `unpinned_budget`.
+#[allow(clippy::needless_range_loop)]
 fn resolve_spread(allocs: &mut [LayerAlloc], demands: &[LayerDemand], node_caps: &[usize]) {
     if allocs.is_empty() {
         return;
@@ -640,6 +642,7 @@ fn resolve_spread(allocs: &mut [LayerAlloc], demands: &[LayerDemand], node_caps:
 ///
 /// No-op when `cur_node_cpus` is empty (first cycle or tests without
 /// per-node state).
+#[allow(clippy::needless_range_loop)]
 fn place_unpinned(
     allocs: &mut [LayerAlloc],
     demands: &[LayerDemand],

--- a/scheds/rust/scx_layered/src/layer_core_growth.rs
+++ b/scheds/rust/scx_layered/src/layer_core_growth.rs
@@ -38,8 +38,10 @@ use crate::LayerSpec;
 /// within-node core ordering degenerates to the non-spread equivalent
 /// (e.g. NodeSpread uses Linear ordering within each node) since the
 /// even-split budget handles cross-node distribution.
+#[derive(Default)]
 pub enum LayerGrowthAlgo {
     /// Evenly space layers across cores within each node.
+    #[default]
     Sticky,
     /// Lowest-numbered CPUs first within each node.
     Linear,
@@ -128,12 +130,10 @@ fn parse_cpu_ranges(s: &str) -> Result<BTreeSet<usize>> {
 fn collect_cpuset_effective() -> Result<BTreeSet<BTreeSet<usize>>> {
     let mut result = BTreeSet::new();
 
-    for entry in WalkDir::new("/sys/fs/cgroup") {
-        if let Ok(entry) = entry {
-            if entry.file_name() == "cpuset.cpus.effective" {
-                if let Ok(content) = fs::read_to_string(entry.path()) {
-                    result.insert(parse_cpu_ranges(&content)?);
-                }
+    for entry in WalkDir::new("/sys/fs/cgroup").into_iter().flatten() {
+        if entry.file_name() == "cpuset.cpus.effective" {
+            if let Ok(content) = fs::read_to_string(entry.path()) {
+                result.insert(parse_cpu_ranges(&content)?);
             }
         }
     }
@@ -247,7 +247,7 @@ impl LayerGrowthAlgo {
             spec,
             layer_idx,
             topo,
-            cpusets: &get_cpusets(&topo)?,
+            cpusets: &get_cpusets(topo)?,
         };
         Ok(match self {
             LayerGrowthAlgo::Sticky => generator.grow_sticky(),
@@ -270,12 +270,6 @@ impl LayerGrowthAlgo {
             LayerGrowthAlgo::RandomTopo => generator.grow_random_topo(),
             LayerGrowthAlgo::StickyDynamic => generator.grow_sticky_dynamic(),
         })
-    }
-}
-
-impl Default for LayerGrowthAlgo {
-    fn default() -> Self {
-        LayerGrowthAlgo::Sticky
     }
 }
 
@@ -331,7 +325,6 @@ struct LayerCoreOrderGenerator<'a> {
 
 impl<'a> LayerCoreOrderGenerator<'a> {
     #[allow(dead_code)]
-
     fn node_order(&self) -> Vec<usize> {
         let all: Vec<&[usize]> = self
             .layer_specs
@@ -353,7 +346,7 @@ impl<'a> LayerCoreOrderGenerator<'a> {
     /// Per-node variant of rotate_layer_offset — rotates within a
     /// node-scoped core vec using node_cores.len() instead of
     /// all_cores.len().
-    fn rotate_node_layer_offset(&self, vec: &mut Vec<usize>) {
+    fn rotate_node_layer_offset(&self, vec: &mut [usize]) {
         if vec.is_empty() {
             return;
         }
@@ -363,6 +356,7 @@ impl<'a> LayerCoreOrderGenerator<'a> {
     }
 
     fn grow_sticky(&self) -> Vec<Vec<usize>> {
+        #[allow(clippy::manual_is_multiple_of)]
         let is_left = self.layer_idx % 2 == 0;
         let rot_by = |layer_idx, len| -> usize {
             if layer_idx <= len {

--- a/scheds/rust/scx_layered/src/lib.rs
+++ b/scheds/rust/scx_layered/src/lib.rs
@@ -191,12 +191,15 @@ impl CpuPool {
 
     fn update_fallback_cpus(&mut self) {
         for node in self.topo.nodes.values() {
-            let fb = self
+            let Some(fb) = self
                 .available_cpus
                 .and(&node.span)
                 .iter()
                 .next()
-                .unwrap_or_else(|| node.span.iter().next().unwrap());
+                .or_else(|| node.span.iter().next())
+            else {
+                continue;
+            };
             self.fallback_cpus.insert(node.id, fb);
         }
     }

--- a/scheds/rust/scx_layered/src/lib.rs
+++ b/scheds/rust/scx_layered/src/lib.rs
@@ -94,11 +94,11 @@ pub fn round_targets_to_alloc_units(
         .iter()
         .map(|&(target, min)| {
             // Round target up to next alloc_unit multiple.
-            let aligned = (target + alloc_unit - 1) / alloc_unit * alloc_unit;
+            let aligned = target.div_ceil(alloc_unit) * alloc_unit;
             // Cap at total_cpus.
             let aligned = aligned.min(total_cpus);
             // Round min up similarly.
-            let min_aligned = (min + alloc_unit - 1) / alloc_unit * alloc_unit;
+            let min_aligned = min.div_ceil(alloc_unit) * alloc_unit;
             let min_aligned = min_aligned.min(total_cpus);
             (aligned, min_aligned)
         })
@@ -240,7 +240,7 @@ impl CpuPool {
         for alloc_core in core_alloc_order {
             // Constrain CPUs by NUMA node or LLC. Since allowed_cpus is NUMA/LLC aligned,
             // this operation is guaranteed to produce either the core mask or an empty mask.
-            let core_cpus = &self.topo.all_cores[alloc_core].span.and(&allowed_cpus);
+            let core_cpus = &self.topo.all_cores[alloc_core].span.and(allowed_cpus);
             if core_cpus.is_empty() {
                 continue;
             }
@@ -289,7 +289,7 @@ impl CpuPool {
             bail!("Some of CPUs {} are already free", cpus_to_free);
         }
 
-        self.available_cpus = self.available_cpus.or(&cpus_to_free);
+        self.available_cpus = self.available_cpus.or(cpus_to_free);
         self.update_fallback_cpus();
 
         self.check_partial()?;
@@ -298,7 +298,7 @@ impl CpuPool {
     }
 
     pub fn mark_allocated(&mut self, cpus_to_alloc: &Cpumask) -> Result<()> {
-        if *&cpus_to_alloc.and(&self.available_cpus.not()).weight() > 0 {
+        if cpus_to_alloc.and(&self.available_cpus.not()).weight() > 0 {
             bail!(
                 "Some of CPUs {} are not available to allocate",
                 cpus_to_alloc

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -24,7 +24,6 @@ use std::time::Duration;
 use std::time::Instant;
 
 use inotify::{Inotify, WatchMask};
-use libc;
 use std::os::unix::io::AsRawFd;
 
 use anyhow::anyhow;
@@ -46,7 +45,6 @@ use nvml_wrapper::error::NvmlError;
 use nvml_wrapper::Nvml;
 use once_cell::sync::OnceCell;
 use regex::Regex;
-use scx_bpf_compat;
 use scx_layered::alloc::{unified_alloc, LayerAlloc, LayerDemand};
 use scx_layered::*;
 use scx_raw_pmu::PMUManager;
@@ -242,7 +240,7 @@ lazy_static! {
 ///   When false, matches if the task is *not* the group leader (i.e. the rest).
 ///
 /// - CmdJoin: Matches when the task uses pthread_setname_np to send a join/leave
-/// command to the scheduler. See examples/cmdjoin.c for more details.
+///   command to the scheduler. See examples/cmdjoin.c for more details.
 ///
 /// - UsedGpuTid: Bool. When true, matches if the tasks which have used
 ///   gpus by tid.
@@ -728,6 +726,7 @@ fn copy_into_cstr(dst: &mut [i8], src: &str) {
     dst[0..bytes.len()].copy_from_slice(bytes);
 }
 
+#[allow(clippy::needless_range_loop)]
 fn read_cpu_ctxs(skel: &BpfSkel) -> Result<Vec<bpf_intf::cpu_ctx>> {
     let mut cpu_ctxs = vec![];
     let cpu_ctxs_vec = skel
@@ -754,6 +753,7 @@ struct BpfStats {
 }
 
 impl BpfStats {
+    #[allow(clippy::needless_range_loop)]
     fn read(skel: &BpfSkel, cpu_ctxs: &[bpf_intf::cpu_ctx]) -> Self {
         let nr_layers = skel.maps.rodata_data.as_ref().unwrap().nr_layers as usize;
         let nr_llcs = skel.maps.rodata_data.as_ref().unwrap().nr_llcs as usize;
@@ -762,20 +762,20 @@ impl BpfStats {
         let mut llc_lstats = vec![vec![vec![0u64; NR_LLC_LSTATS]; nr_llcs]; nr_layers];
 
         for cpu in 0..*NR_CPUS_POSSIBLE {
-            for stat in 0..NR_GSTATS {
-                gstats[stat] += cpu_ctxs[cpu].gstats[stat];
+            for (stat, value) in gstats.iter_mut().enumerate() {
+                *value += cpu_ctxs[cpu].gstats[stat];
             }
-            for layer in 0..nr_layers {
-                for stat in 0..NR_LSTATS {
-                    lstats[layer][stat] += cpu_ctxs[cpu].lstats[layer][stat];
+            for (layer, layer_stats) in lstats.iter_mut().enumerate() {
+                for (stat, value) in layer_stats.iter_mut().enumerate() {
+                    *value += cpu_ctxs[cpu].lstats[layer][stat];
                 }
             }
         }
 
         let mut lstats_sums = vec![0u64; NR_LSTATS];
-        for layer in 0..nr_layers {
-            for stat in 0..NR_LSTATS {
-                lstats_sums[stat] += lstats[layer][stat];
+        for layer_stats in lstats.iter() {
+            for (stat, value) in lstats_sums.iter_mut().enumerate() {
+                *value += layer_stats[stat];
             }
         }
 
@@ -794,9 +794,9 @@ impl BpfStats {
             let llcc: &bpf_intf::llc_ctx =
                 plain::from_bytes(v.as_slice()).expect("llc_ctx: short or misaligned buffer");
 
-            for layer_id in 0..nr_layers {
-                for stat_id in 0..NR_LLC_LSTATS {
-                    llc_lstats[layer_id][llc_id][stat_id] = llcc.lstats[layer_id][stat_id];
+            for (layer_id, layer_llc_stats) in llc_lstats.iter_mut().enumerate() {
+                for (stat_id, stat_value) in layer_llc_stats[llc_id].iter_mut().enumerate() {
+                    *stat_value = llcc.lstats[layer_id][stat_id];
                 }
             }
         }
@@ -810,7 +810,7 @@ impl BpfStats {
     }
 }
 
-impl<'a, 'b> Sub<&'b BpfStats> for &'a BpfStats {
+impl<'b> Sub<&'b BpfStats> for &BpfStats {
     type Output = BpfStats;
 
     fn sub(self, rhs: &'b BpfStats) -> BpfStats {
@@ -887,13 +887,14 @@ struct Stats {
 }
 
 impl Stats {
+    #[allow(clippy::needless_range_loop)]
     fn read_layer_usages(cpu_ctxs: &[bpf_intf::cpu_ctx], nr_layers: usize) -> Vec<Vec<u64>> {
         let mut layer_usages = vec![vec![0u64; NR_LAYER_USAGES]; nr_layers];
 
         for cpu in 0..*NR_CPUS_POSSIBLE {
-            for layer in 0..nr_layers {
-                for usage in 0..NR_LAYER_USAGES {
-                    layer_usages[layer][usage] += cpu_ctxs[cpu].layer_usages[layer][usage];
+            for (layer, layer_usage) in layer_usages.iter_mut().enumerate() {
+                for (usage, value) in layer_usage.iter_mut().enumerate() {
+                    *value += cpu_ctxs[cpu].layer_usages[layer][usage];
                 }
             }
         }
@@ -902,13 +903,14 @@ impl Stats {
     }
 
     // Same as above, but for aggregate memory bandwidth consumption.
+    #[allow(clippy::needless_range_loop)]
     fn read_layer_membw_agg(cpu_ctxs: &[bpf_intf::cpu_ctx], nr_layers: usize) -> Vec<Vec<u64>> {
         let mut layer_membw_agg = vec![vec![0u64; NR_LAYER_USAGES]; nr_layers];
 
         for cpu in 0..*NR_CPUS_POSSIBLE {
-            for layer in 0..nr_layers {
-                for usage in 0..NR_LAYER_USAGES {
-                    layer_membw_agg[layer][usage] += cpu_ctxs[cpu].layer_membw_agg[layer][usage];
+            for (layer, layer_membw) in layer_membw_agg.iter_mut().enumerate() {
+                for (usage, value) in layer_membw.iter_mut().enumerate() {
+                    *value += cpu_ctxs[cpu].layer_membw_agg[layer][usage];
                 }
             }
         }
@@ -916,6 +918,7 @@ impl Stats {
         layer_membw_agg
     }
 
+    #[allow(clippy::needless_range_loop)]
     fn read_layer_node_pinned_usages(
         cpu_ctxs: &[bpf_intf::cpu_ctx],
         topo: &Topology,
@@ -926,14 +929,15 @@ impl Stats {
 
         for cpu in 0..*NR_CPUS_POSSIBLE {
             let node = topo.all_cpus.get(&cpu).map_or(0, |c| c.node_id);
-            for layer in 0..nr_layers {
-                usages[layer][node] += cpu_ctxs[cpu].node_pinned_usage[layer];
+            for (layer, layer_usages) in usages.iter_mut().enumerate().take(nr_layers) {
+                layer_usages[node] += cpu_ctxs[cpu].node_pinned_usage[layer];
             }
         }
 
         usages
     }
 
+    #[allow(clippy::needless_range_loop)]
     fn read_layer_node_usages(
         cpu_ctxs: &[bpf_intf::cpu_ctx],
         topo: &Topology,
@@ -944,9 +948,9 @@ impl Stats {
 
         for cpu in 0..*NR_CPUS_POSSIBLE {
             let node = topo.all_cpus.get(&cpu).map_or(0, |c| c.node_id);
-            for layer in 0..nr_layers {
+            for (layer, layer_usages) in usages.iter_mut().enumerate().take(nr_layers) {
                 for usage in 0..=LAYER_USAGE_SUM_UPTO {
-                    usages[layer][node] += cpu_ctxs[cpu].layer_usages[layer][usage];
+                    layer_usages[node] += cpu_ctxs[cpu].layer_usages[layer][usage];
                 }
             }
         }
@@ -954,6 +958,7 @@ impl Stats {
         usages
     }
 
+    #[allow(clippy::needless_range_loop)]
     fn read_layer_node_duty_raw(
         cpu_ctxs: &[bpf_intf::cpu_ctx],
         topo: &Topology,
@@ -964,8 +969,8 @@ impl Stats {
 
         for cpu in 0..*NR_CPUS_POSSIBLE {
             let node = topo.all_cpus.get(&cpu).map_or(0, |c| c.node_id);
-            for layer in 0..nr_layers {
-                sums[layer][node] += cpu_ctxs[cpu].layer_duty_sum[layer];
+            for (layer, layer_sums) in sums.iter_mut().enumerate().take(nr_layers) {
+                layer_sums[node] += cpu_ctxs[cpu].layer_duty_sum[layer];
             }
         }
 
@@ -975,10 +980,10 @@ impl Stats {
     /// Use the membw reported by resctrl to normalize the values reported by hw counters.
     /// We have the following problem:
     /// 1) We want per-task memory bandwidth reporting. We cannot do this with resctrl, much
-    /// less transparently, since we would require different RMID for each task.
+    ///    less transparently, since we would require different RMID for each task.
     /// 2) We want to directly use perf counters for tracking per-task memory bandwidth, but
-    /// we can't: Non-resctrl counters do not measure the right thing (e.g., they only measure
-    /// proxies like load operations),
+    ///    we can't: Non-resctrl counters do not measure the right thing (e.g., they only measure
+    ///    proxies like load operations),
     /// 3) Resctrl counters are not accessible directly so we cannot read them from the BPF side.
     ///
     /// Approximate per-task memory bandwidth using perf counters to measure _relative_ memory
@@ -1152,7 +1157,7 @@ impl Stats {
                 .map(|(cur, prev)| {
                     cur.iter()
                         .zip(prev.iter())
-                        .map(|(c, p)| (*c as i64 - *p as i64) as f64 / (1024 as f64).powf(3.0))
+                        .map(|(c, p)| (*c as i64 - *p as i64) as f64 / 1024_f64.powf(3.0))
                         .collect()
                 })
                 .collect()
@@ -1500,7 +1505,7 @@ impl GpuTaskAffinitizer {
                 if (mask & inner_offset) != 0 {
                     return Ok((64 * chunk + u64::trailing_zeros(inner_offset) as usize) as u32);
                 }
-                inner_offset = inner_offset << 1;
+                inner_offset <<= 1;
             }
         }
         anyhow::bail!("unable to get CPU from NVML bitmask");
@@ -1508,7 +1513,7 @@ impl GpuTaskAffinitizer {
 
     fn node_to_cpuset(&self, node: &scx_utils::Node) -> Result<CpuSet> {
         let mut cpuset = CpuSet::new();
-        for (cpu_id, _cpu) in &node.all_cpus {
+        for cpu_id in node.all_cpus.keys() {
             cpuset.set(*cpu_id)?;
         }
         Ok(cpuset)
@@ -1594,7 +1599,7 @@ impl GpuTaskAffinitizer {
         for (pid, dev) in &self.gpu_pids_to_devs {
             let node_info = self
                 .gpu_devs_to_node_info
-                .get(&dev)
+                .get(dev)
                 .expect("Unable to get gpu pid node mask");
             for child in self.get_child_pids_and_tids(*pid) {
                 match nix::sched::sched_setaffinity(
@@ -1650,8 +1655,6 @@ impl GpuTaskAffinitizer {
         };
         self.last_process_time = Some(now);
         self.last_task_affinitization_ms = (Instant::now() - now).as_millis() as u64;
-
-        return;
     }
 
     pub fn init(&mut self, topo: Arc<Topology>) {
@@ -1666,7 +1669,6 @@ impl GpuTaskAffinitizer {
             }
         };
         self.sys = System::new_all();
-        return;
     }
 }
 
@@ -2046,13 +2048,13 @@ impl<'a> Scheduler<'a> {
                 let task_place = |place: u32| crate::types::layer_task_place(place);
                 layer.task_place = match placement {
                     LayerPlacement::Standard => {
-                        task_place(bpf_intf::layer_task_place_PLACEMENT_STD as u32)
+                        task_place(bpf_intf::layer_task_place_PLACEMENT_STD)
                     }
                     LayerPlacement::Sticky => {
-                        task_place(bpf_intf::layer_task_place_PLACEMENT_STICK as u32)
+                        task_place(bpf_intf::layer_task_place_PLACEMENT_STICK)
                     }
                     LayerPlacement::Floating => {
-                        task_place(bpf_intf::layer_task_place_PLACEMENT_FLOAT as u32)
+                        task_place(bpf_intf::layer_task_place_PLACEMENT_FLOAT)
                     }
                 };
             }
@@ -2066,7 +2068,7 @@ impl<'a> Scheduler<'a> {
 
             match &spec.cpuset {
                 Some(mask) => {
-                    Self::update_cpumask(&mask, &mut layer.cpuset);
+                    Self::update_cpumask(mask, &mut layer.cpuset);
                     layer.has_cpuset.write(true);
                 }
                 None => {
@@ -2668,9 +2670,9 @@ impl<'a> Scheduler<'a> {
 
         let rodata = skel.maps.rodata_data.as_mut().unwrap();
 
-        if ext_sched_class_addr.is_ok() && idle_sched_class_addr.is_ok() {
-            rodata.ext_sched_class_addr = ext_sched_class_addr.unwrap();
-            rodata.idle_sched_class_addr = idle_sched_class_addr.unwrap();
+        if let (Ok(ext_addr), Ok(idle_addr)) = (ext_sched_class_addr, idle_sched_class_addr) {
+            rodata.ext_sched_class_addr = ext_addr;
+            rodata.idle_sched_class_addr = idle_addr;
         } else {
             warn!(
                 "Unable to get sched_class addresses from /proc/kallsyms, disabling skip_preempt."
@@ -2779,7 +2781,7 @@ impl<'a> Scheduler<'a> {
         let layered_task_hint_map_path = &opts.task_hint_map;
         let hint_map = &mut skel.maps.scx_layered_task_hint_map;
         // Only set pin path if a path is provided.
-        if layered_task_hint_map_path.is_empty() == false {
+        if !layered_task_hint_map_path.is_empty() {
             hint_map.set_pin_path(layered_task_hint_map_path).unwrap();
             rodata.task_hint_map_enabled = true;
         }
@@ -2797,7 +2799,7 @@ impl<'a> Scheduler<'a> {
         let mut skel = scx_ops_load!(skel, layered, uei)?;
 
         // Populate the mapping of hints to layer IDs for faster lookups
-        if hint_to_layer_map.len() != 0 {
+        if !hint_to_layer_map.is_empty() {
             for (k, v) in hint_to_layer_map.iter() {
                 let key: u32 = *k as u32;
 
@@ -2870,7 +2872,7 @@ impl<'a> Scheduler<'a> {
 
         // Allow all tasks to open and write to BPF task hint map, now that
         // we should have it pinned at the desired location.
-        if layered_task_hint_map_path.is_empty() == false {
+        if !layered_task_hint_map_path.is_empty() {
             let path = CString::new(layered_task_hint_map_path.as_bytes()).unwrap();
             let mode: libc::mode_t = 0o666;
             unsafe {
@@ -3008,8 +3010,8 @@ impl<'a> Scheduler<'a> {
         curtarget: u64,
     ) -> usize {
         let ncpu: u64 = layer.cpus.weight() as u64;
-        let membw = (membw * (1024 as f64).powf(3.0)).round() as u64;
-        let membw_limit = (membw_limit * (1024 as f64).powf(3.0)).round() as u64;
+        let membw = (membw * 1024_f64.powf(3.0)).round() as u64;
+        let membw_limit = (membw_limit * 1024_f64.powf(3.0)).round() as u64;
         let last_membw_percpu = if ncpu > 0 { membw / ncpu } else { 0 };
 
         // Either there is no memory bandwidth limit set, or the counters
@@ -3018,7 +3020,7 @@ impl<'a> Scheduler<'a> {
             return curtarget as usize;
         }
 
-        return (membw_limit / last_membw_percpu) as usize;
+        (membw_limit / last_membw_percpu) as usize
     }
 
     /// Decompose per-layer CPU targets into per-node pinned demand and
@@ -3074,7 +3076,7 @@ impl<'a> Scheduler<'a> {
                     }
                     let cpus = (pu / util_high).ceil() as usize;
                     // Round up to alloc units.
-                    let units = (cpus + au - 1) / au;
+                    let units = cpus.div_ceil(au);
                     raw_pinned[n] = units;
                 }
 
@@ -3168,12 +3170,8 @@ impl<'a> Scheduler<'a> {
                     ));
 
                     let target = target.clamp(cpus_range.0, cpus_range.1);
-                    let membw_target = self.clamp_target_by_membw(
-                        &layer,
-                        membw_limit as f64,
-                        membw as f64,
-                        target as u64,
-                    );
+                    let membw_target =
+                        self.clamp_target_by_membw(layer, membw_limit, membw, target as u64);
 
                     trace!("CPU target pre- and post-membw adjustment: {target} -> {membw_target}");
 
@@ -3976,8 +3974,8 @@ impl<'a> Scheduler<'a> {
                     bpf_layer.node[src].xnuma[dst].rate = result.rates[src][dst];
                 }
             }
-            for nid in 0..nr_nodes {
-                bpf_layer.node[nid].xnuma_is_mig_src.write(is_mig_src[nid]);
+            for (nid, is_src) in is_mig_src.iter().enumerate().take(nr_nodes) {
+                bpf_layer.node[nid].xnuma_is_mig_src.write(*is_src);
             }
         }
     }
@@ -4322,7 +4320,7 @@ impl<'a> Scheduler<'a> {
                         );
                         let stats =
                             Stats::new(&mut self.skel, &self.proc_reader, self.topo.clone(), &self.gpu_task_handler)?;
-                        res_ch.send(StatsRes::Hello(stats))?;
+                        res_ch.send(StatsRes::Hello(Box::new(stats)))?;
                     }
                     Ok(StatsReq::Refresh(tid, mut stats)) => {
                         // Propagate self's layer cpu ranges into each stat's.
@@ -4346,7 +4344,7 @@ impl<'a> Scheduler<'a> {
                         )?;
                         let sys_stats =
                             self.generate_sys_stats(&stats, cpus_ranges.get_mut(&tid).unwrap())?;
-                        res_ch.send(StatsRes::Refreshed((stats, sys_stats)))?;
+                        res_ch.send(StatsRes::Refreshed(Box::new((*stats, sys_stats))))?;
                     }
                     Ok(StatsReq::Bye(tid)) => {
                         cpus_ranges.remove(&tid);
@@ -4443,10 +4441,8 @@ fn verify_layer_specs(specs: &[LayerSpec]) -> Result<HashMap<u64, HintLayerInfo>
             if spec.matches.is_empty() {
                 bail!("Non-terminal spec {:?} has NULL matches", spec.name);
             }
-        } else {
-            if spec.matches.len() != 1 || !spec.matches[0].is_empty() {
-                bail!("Terminal spec {:?} must have an empty match", spec.name);
-            }
+        } else if spec.matches.len() != 1 || !spec.matches[0].is_empty() {
+            bail!("Terminal spec {:?} must have an empty match", spec.name);
         }
 
         if spec.matches.len() > MAX_LAYER_MATCH_ORS {
@@ -4707,11 +4703,13 @@ fn expand_template(rule: &LayerMatch) -> Result<Vec<(LayerMatch, Cpumask)>> {
 }
 
 fn create_perf_fds(skel: &mut BpfSkel, event: u64) -> Result<()> {
-    let mut attr = perf::bindings::perf_event_attr::default();
-    attr.size = std::mem::size_of::<perf::bindings::perf_event_attr>() as u32;
-    attr.type_ = perf::bindings::PERF_TYPE_RAW;
-    attr.config = event;
-    attr.sample_type = 0u64;
+    let mut attr = perf::bindings::perf_event_attr {
+        size: std::mem::size_of::<perf::bindings::perf_event_attr>() as u32,
+        type_: perf::bindings::PERF_TYPE_RAW,
+        config: event,
+        sample_type: 0u64,
+        ..Default::default()
+    };
     attr.__bindgen_anon_1.sample_period = 0u64;
     attr.set_disabled(0);
 
@@ -4908,7 +4906,7 @@ fn main(opts: Opts) -> Result<()> {
         for spec in specs {
             match spec.template {
                 Some(ref rule) => {
-                    let matches = expand_template(&rule)?;
+                    let matches = expand_template(rule)?;
                     // in the absence of matching cgroups, have template layers
                     // behave as non-template layers do.
                     if matches.is_empty() {

--- a/scheds/rust/scx_layered/src/stats.rs
+++ b/scheds/rust/scx_layered/src/stats.rs
@@ -290,7 +290,7 @@ impl LayerStats {
                         .iter()
                         .take(LAYER_USAGE_SUM_UPTO + 1)
                         .sum::<f64>()
-                        / ((*membw_limit_gb * (1024_u64.pow(3) as f64)) as f64)
+                        / (*membw_limit_gb * (1024_u64.pow(3) as f64))
                 } else {
                     0.0
                 }
@@ -319,7 +319,7 @@ impl LayerStats {
             enq_reenq: lstat_pct(LSTAT_ENQ_REENQ),
             enq_dsq: lstat_pct(LSTAT_ENQ_DSQ),
             min_exec: lstat_pct(LSTAT_MIN_EXEC),
-            min_exec_us: (lstat(LSTAT_MIN_EXEC_NS) / 1000) as u64,
+            min_exec_us: lstat(LSTAT_MIN_EXEC_NS) / 1000,
             open_idle: lstat_pct(LSTAT_OPEN_IDLE),
             preempt: lstat_pct(LSTAT_PREEMPT),
             preempt_xllc: lstat_pct(LSTAT_PREEMPT_XLLC),
@@ -335,7 +335,7 @@ impl LayerStats {
             excl_collision: lstat_pct(LSTAT_EXCL_COLLISION),
             excl_preempt: lstat_pct(LSTAT_EXCL_PREEMPT),
             yielded: lstat_pct(LSTAT_YIELD),
-            yield_ignore: lstat(LSTAT_YIELD_IGNORE) as u64,
+            yield_ignore: lstat(LSTAT_YIELD_IGNORE),
             migration: lstat_pct(LSTAT_MIGRATION),
             xnuma_migration: lstat_pct(LSTAT_XNUMA_MIGRATION),
             xlayer_wake: lstat_pct(LSTAT_XLAYER_WAKE),
@@ -799,14 +799,14 @@ impl SysStats {
 #[derive(Debug)]
 pub enum StatsReq {
     Hello(ThreadId),
-    Refresh(ThreadId, Stats),
+    Refresh(ThreadId, Box<Stats>),
     Bye(ThreadId),
 }
 
 #[derive(Debug)]
 pub enum StatsRes {
-    Hello(Stats),
-    Refreshed((Stats, SysStats)),
+    Hello(Box<Stats>),
+    Refreshed(Box<(Stats, SysStats)>),
     Bye,
 }
 
@@ -815,15 +815,15 @@ pub fn server_data() -> StatsServerData<StatsReq, StatsRes> {
         let tid = current().id();
         req_ch.send(StatsReq::Hello(tid))?;
         let mut stats = Some(match res_ch.recv()? {
-            StatsRes::Hello(v) => v,
+            StatsRes::Hello(v) => *v,
             res => bail!("invalid response to Hello: {:?}", res),
         });
 
         let read: Box<dyn StatsReader<StatsReq, StatsRes>> =
             Box::new(move |_args, (req_ch, res_ch)| {
-                req_ch.send(StatsReq::Refresh(tid, stats.take().unwrap()))?;
+                req_ch.send(StatsReq::Refresh(tid, Box::new(stats.take().unwrap())))?;
                 let (new_stats, sys_stats) = match res_ch.recv()? {
-                    StatsRes::Refreshed(v) => v,
+                    StatsRes::Refreshed(v) => *v,
                     res => bail!("invalid response to Refresh: {:?}", res),
                 };
                 stats = Some(new_stats);


### PR DESCRIPTION
On systems with I/O-only NUMA nodes (no CPUs/CXL), `node.span` can be empty
causing `update_fallback_cpus` to panic on `unwrap()`. Skip nodes with empty
spans since they have no CPUs that need a fallback.

Address clippy warnings across scx_layered:

- Replace manual index loops with idiomatic iterators (iter_mut, enumerate, zip, flatten, keys)
- Remove redundant borrows and derefs
- Remove unnecessary imports (libc, scx_bpf_compat)
- Use #[derive(Default)] instead of manual Default impl
- Use div_ceil, is_multiple_of, <<=, and !is_empty() idioms
- Remove unnecessary return statements and as casts
- Use struct literal initialization for perf_event_attr
- Box large variants in StatsReq/StatsRes to reduce enum size
- Collapse else-if blocks and fix doc comment alignment
- Use &mut [usize] instead of &mut Vec<usize> in fn parameter