### PR TITLE
lib/topology: eliminate pointer chasing in topo_cpu_to_llc_id()

### DIFF
--- a/lib/selftests/st_arena_topology_timer.bpf.c
+++ b/lib/selftests/st_arena_topology_timer.bpf.c
@@ -273,7 +273,7 @@ int scx_selftest_arena_topology_timer_timer_with_helpers(void)
 
 		child_data->magic_value = magic + i + 1;
 		child_data->access_count = i;
-		child_data->cpu_id = child->id;
+		child_data->cpu_id = child->level_ids[child->level];
 		child->data = (void __arena *)child_data;
 		i++;
 	}
@@ -411,10 +411,10 @@ int scx_selftest_arena_topology_timer_arena_data(void)
 
 		child_data->magic_value = magic + i + 2;
 		child_data->access_count = 0;
-		child_data->cpu_id = child->id;
+		child_data->cpu_id = child->level_ids[child->level];
 		child->data = (void __arena *)child_data;
 
-		ret = topo_update_data(child, magic + i + 2, child->id);
+		ret = topo_update_data(child, magic + i + 2, child->level_ids[child->level]);
 		if (ret) {
 			bpf_printk("TOPO ARENA DATA: failed to update child %d data", i);
 			return ret;

--- a/lib/topology.bpf.c
+++ b/lib/topology.bpf.c
@@ -38,18 +38,19 @@ int topo_subset(topo_ptr topo, scx_bitmap_t mask)
 }
 
 static
-topo_ptr topo_node(topo_ptr parent, scx_bitmap_t mask, u64 id)
+topo_ptr topo_node(topo_ptr parent, scx_bitmap_t mask, s16 id)
 {
 	volatile topo_ptr topo; /* add volatile to satisfy the verifier. */
 	u32 level = parent ? parent->level + 1 : 0;
 	u32 max_ch;
+	int i;
 
 	if (level >= TOPO_MAX_LEVEL) {
 		bpf_printk("topology is too deep");
 		return NULL;
 	}
 
-	if (id >= NR_CPUS) {
+	if (id < 0 || id >= NR_CPUS) {
 		bpf_printk("invalid node id");
 		return NULL;
 	}
@@ -64,7 +65,6 @@ topo_ptr topo_node(topo_ptr parent, scx_bitmap_t mask, u64 id)
 	topo->parent = parent;
 	topo->nr_children = 0;
 	topo->level = level;
-	topo->id = id;
 	/*
 	 * The passed-in mask is deliberately consumed; topo_node takes ownership.
 	 * Do not reuse the same mask elsewhere after this call.
@@ -80,8 +80,21 @@ topo_ptr topo_node(topo_ptr parent, scx_bitmap_t mask, u64 id)
 	 */
 	barrier_var(level);
 	barrier_var(id);
-	if (level >= TOPO_MAX_LEVEL || id >= NR_CPUS)
+	if (level >= TOPO_MAX_LEVEL || id < 0 || id >= NR_CPUS)
 		return NULL;
+
+	/*
+	 * Populate level_ids: levels below this node are copied from the
+	 * parent, this node's own level gets id, levels above are -EINVAL.
+	 */
+	bpf_for(i, 0, TOPO_MAX_LEVEL) {
+		if (i < (int)level && parent)
+			topo->level_ids[i] = parent->level_ids[i];
+		else if (i == (int)level)
+			topo->level_ids[i] = id;
+		else
+			topo->level_ids[i] = -EINVAL;
+	}
 
 	topo_nodes[level][id] = (u64)topo;
 
@@ -90,7 +103,7 @@ topo_ptr topo_node(topo_ptr parent, scx_bitmap_t mask, u64 id)
 
 
 static __noinline
-int topo_add(topo_ptr parent, scx_bitmap_t mask, u64 id)
+int topo_add(topo_ptr parent, scx_bitmap_t mask, s16 id)
 {
 	topo_ptr child;
 
@@ -119,7 +132,7 @@ int topo_add(topo_ptr parent, scx_bitmap_t mask, u64 id)
 }
 
 __weak
-int topo_init(scx_bitmap_t __arg_arena mask, u64 data_size, u64 id)
+int topo_init(scx_bitmap_t __arg_arena mask, u64 data_size, s16 id)
 {
 	/* Initializing the child to appease the verifier. */
 	topo_ptr topo, child = NULL;
@@ -398,7 +411,6 @@ __weak int
 topo_cpu_to_llc_id(u32 cpu)
 {
 	topo_ptr topo;
-	u32 id;
 
 	if (cpu >= nr_cpu_ids) {
 		bpf_printk("invalid cpu id: %u", cpu);
@@ -411,9 +423,7 @@ topo_cpu_to_llc_id(u32 cpu)
 		return -EINVAL;
 	}
 
-	/* TOPO_CPU -> TOPO_CORE -> TOPO_LLC */
-	id = topo->parent->parent->id;
-	return id;
+	return topo->level_ids[TOPO_LLC];
 }
 
 volatile u64 a;

--- a/scheds/include/lib/topology.h
+++ b/scheds/include/lib/topology.h
@@ -18,8 +18,12 @@ struct topology {
 	topo_ptr parent;
 	size_t nr_children;
 	scx_bitmap_t mask;
+	/*
+	 * level and level_ids are hot in the fast path; keep them adjacent
+	 * to ensure they land in the same cache line.
+	 */
 	enum topo_level level;
-	u64 id;
+	s16 level_ids[TOPO_MAX_LEVEL];
 
 	/* Generic pointer, can be used for anything. */
 	void __arena *data;
@@ -41,7 +45,7 @@ extern volatile topo_ptr topo_all;
  */
 extern u32 topo_max_children[TOPO_MAX_LEVEL];
 
-int topo_init(scx_bitmap_t __arg_arena mask, u64 data_size, u64 id);
+int topo_init(scx_bitmap_t __arg_arena mask, u64 data_size, s16 id);
 int topo_contains(topo_ptr topo, u32 cpu);
 int topo_cpu_to_llc_id(u32 cpu);
 


### PR DESCRIPTION
topo_cpu_to_llc_id() can be called very frequently in the scheduler's critical path. For example, the cpu.max bandwidth controller calls it on every task execution via scx_cgroup_bw_consume() and cbw_put_aside() to determine which LLC domain the current CPU belongs to.

The original implementation traverses two hops of parent pointers to reach the LLC node:

    id = topo->parent->parent->id;

Each hop is a pointer dereference into arena memory that likely lands on a different cache line, resulting in two cache misses per call.

Replace struct topology's u64 id with s16 level_ids[TOPO_MAX_LEVEL]. Each entry holds the id of this node's ancestor (or self) at that topology level, with entries above the node's own level set to -EINVAL.

s16 is sufficient for CPU ids (max 32767) and chosen over u16 so that -EINVAL can be stored directly for uninitialised entries.

level and level_ids are placed adjacent in the struct to ensure they share the same cache line for fast-path access.

topo_cpu_to_llc_id() is then simplified to a single constant-index array lookup within the CPU node itself (one cache line):

    return topo->level_ids[TOPO_LLC];