### PR TITLE
scx_rustland_core: move 'include' key from [lib] to [package]

### DIFF
--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -6,6 +6,13 @@ authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"
 repository = "https://github.com/sched-ext/scx"
 description = "Framework to implement sched_ext schedulers running in user space"
+include = [
+    "src/*.rs",
+    "src/**/*.rs",
+    "assets/bpf/intf.h",
+    "assets/bpf/main.bpf.c",
+    "assets/bpf.rs",
+]
 
 [dependencies]
 anyhow = "1"
@@ -18,11 +25,7 @@ scx_cargo = { path = "../scx_cargo", version = "1.1.1" }
 [lib]
 name = "scx_rustland_core"
 path = "src/lib.rs"
-include = [
-    "assets/bpf/intf.h",
-    "assets/bpf/main.bpf.c",
-    "assets/bpf.rs",
-]
 
 [lints.clippy]
 not_unsafe_ptr_arg_deref = "allow"
+

--- a/rust/scx_rustland_core/Cargo.toml
+++ b/rust/scx_rustland_core/Cargo.toml
@@ -6,6 +6,13 @@ authors = ["Andrea Righi <andrea.righi@linux.dev>"]
 license = "GPL-2.0-only"
 repository = "https://github.com/sched-ext/scx"
 description = "Framework to implement sched_ext schedulers running in user space"
+include = [
+    "src/*.rs",
+    "src/**/*.rs",
+    "assets/bpf/intf.h",
+    "assets/bpf/main.bpf.c",
+    "assets/bpf.rs",
+]
 
 [dependencies]
 anyhow = "1"
@@ -18,11 +25,7 @@ scx_cargo = { path = "../scx_cargo", version = "1.1.2" }
 [lib]
 name = "scx_rustland_core"
 path = "src/lib.rs"
-include = [
-    "assets/bpf/intf.h",
-    "assets/bpf/main.bpf.c",
-    "assets/bpf.rs",
-]
 
 [lints.clippy]
 not_unsafe_ptr_arg_deref = "allow"
+


### PR DESCRIPTION
## Problem

The `include` manifest key in `rust/scx_rustland_core/Cargo.toml` is
placed under `[lib]`, but per the [Cargo manifest specification](https://doc.rust-lang.org/cargo/reference/manifest.html#the-include-and-exclude-fields)
it belongs to `[package]`.

Cargo versions prior to 1.88 tolerated the misplacement with a warning:

    warning: .../scx_rustland_core/Cargo.toml: unused manifest key: lib.include

Cargo >= 1.88 (available e.g. via Debian trixie-backports rustc 1.90,
Fedora 42+) upgrades this to a hard error when the workspace is parsed
in strict mode (`cargo check` without `-p`, or workspace-level commands):

    error: key with no value, expected `=`
      --> rust/scx_rustland_core/Cargo.toml:21:24

`cargo build -p <scheduler>` still succeeds because it bypasses full
workspace manifest resolution, which is why the issue doesn't surface
in targeted scheduler builds but does break `cargo check` on the
full workspace.

## Fix

Move the `include = [...]` array from the `[lib]` section to the
`[package]` section. Semantics unchanged; the key was being ignored
before and will now be honored correctly.

## Testing

Verified on Debian 13 (trixie) with trixie-backports rustc 1.90.0:

- `cargo check -p scx_rustland_core`: pass, no warnings
- `cargo check -p scx_lavd -p scx_flash -p scx_bpfland`: pass
- `cargo build --release -p scx_lavd -p scx_flash -p scx_bpfland`: pass

Schedulers load and run correctly.