### PR TITLE
scx_layered: add Overload layer kind

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -395,6 +395,7 @@ struct layer {
 	bool			has_cpuset;
 	bool			skip_remote_node;
 	bool			prev_over_idle_core;
+	bool			idle_confined;
 	int			growth_algo;
 
 	u64			nr_tasks;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1437,6 +1437,15 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 	if (!idle_smtmask)
 		return -1;
 
+	/*
+	 * Grouped layers may opt to act like Confined for idle selection
+	 * until the layer becomes saturated (check_no_idle is set), at
+	 * which point they fall back to searching unprotected CPUs.
+	 */
+	bool can_use_open = layer->kind != LAYER_KIND_CONFINED &&
+		(!layer->idle_confined ||
+		 READ_ONCE(layer->check_no_idle));
+
 	if (is_float)
 		goto no_locality;
 
@@ -1499,7 +1508,7 @@ no_locality:
 	 * masks which respect p->cpus_ptr.
 	 */
 	if (nr_nodes > 1 && taskc->all_cpus_allowed) {
-		bool is_open = layer->kind != LAYER_KIND_CONFINED;
+		bool is_open = can_use_open;
 		u32 src_nid = prev_cpuc->node_id;
 		struct node_ctx *src_nodec;
 		s32 i;
@@ -1588,7 +1597,7 @@ xnuma_done: ;
 					     idle_smtmask, layer)) >= 0)
 			goto out;
 
-		if (layer->kind != LAYER_KIND_CONFINED) {
+		if (can_use_open) {
 			maybe_refresh_layered_cpus_unprotected(p, taskc,
 							       layered_cpumask);
 			unprot_mask = taskc->layered_unprotected_mask;

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -198,6 +198,15 @@ pub enum LayerKind {
         #[serde(default)]
         protected: bool,
 
+        /// When true, idle CPU selection only considers the layer's own
+        /// CPUs until the layer becomes saturated (i.e., no idle CPU is
+        /// found and check_no_idle is set). At that point, idle search
+        /// falls back to unprotected CPUs like a normal Grouped layer.
+        /// Provides Confined-style cache locality under normal load with
+        /// Grouped-style overflow under pressure.
+        #[serde(default)]
+        idle_confined: bool,
+
         #[serde(flatten)]
         common: LayerCommon,
     },

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -312,7 +312,11 @@ lazy_static! {
 ///
 /// - Grouped: Similar to Confined but tasks may spill outside if there are
 ///   idle CPUs outside the allocated ones. The range can optionally be
-///   restricted with the "cpus_range" property.
+///   restricted with the "cpus_range" property. The optional
+///   "idle_confined" flag restricts idle selection to
+///   the layer's CPUs until the layer becomes saturated, providing
+///   Confined-style cache locality under normal load with Grouped-style
+///   overflow under pressure.
 ///
 /// - Open: Prefer the CPUs which are not occupied by Confined or Grouped
 ///   layers. Tasks in this group will spill into occupied CPUs if there are
@@ -2064,6 +2068,11 @@ impl<'a> Scheduler<'a> {
                 LayerKind::Confined { protected, .. } | LayerKind::Grouped { protected, .. } => {
                     protected
                 }
+            });
+
+            layer.idle_confined.write(match spec.kind {
+                LayerKind::Grouped { idle_confined, .. } => idle_confined,
+                _ => false,
             });
 
             match &spec.cpuset {


### PR DESCRIPTION
Add a new `Overload` layer type that behaves like `Confined` by default but allows tasks to spill to idle unprotected CPUs when all of the layer's allocated CPUs are busy. This provides cache locality benefits under normal load while allowing overflow under pressure.

BPF side: `pick_idle_cpu()` searches layer CPUs first then falls back to unprotected CPUs. `try_consume_layer()` gates cross-layer consumption on `check_no_idle`. `keep_running()` and preemption use confined-style restrictions. Dispatch ordering counts Overload in the grouped bucket.

Rust side: Overload has the same config fields as Confined (`util_range`, `cpus_range`, `cpus_range_frac`, `membw_gb`, `protected`) and participates in CPU allocation identically.