### PR TITLE
lib/cgroup_bw: close task-loss and use-after-free windows under arena_spin_lock contention

### DIFF
--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -61,6 +61,13 @@ enum scx_cgroup_consts {
 	 * CBW_NR_CGRP_LLC_MAX * 2 = 131072 slots, 1024 KB.
 	 */
 	CBW_DEFERRED_BTQ_SIZE		= (CBW_NR_CGRP_LLC_MAX * 2),
+	/*
+	 * Slots for BTQs whose drain in cbw_free_llc_ctx() was
+	 * interrupted by lock contention.  Much rarer than cgroup
+	 * destruction, so sized well below CBW_DEFERRED_BTQ_SIZE.
+	 * CBW_DEFERRED_BTQ_SIZE / 2 = 65536 slots, 512 KB.
+	 */
+	CBW_DEFERRED_DRAIN_SIZE		= (CBW_DEFERRED_BTQ_SIZE / 2),
 };
 
 /*
@@ -400,6 +407,23 @@ static u64		cbw_cgroup_ids[CBW_NR_CGRP_MAX];
  * An array of throttled cgroups that need to be reenqueued.
  */
 static u64		cbw_throttled_cgroup_ids[CBW_NR_CGRP_MAX];
+
+/*
+ * Ring buffer of BTQs whose cgroup-exit drain in cbw_free_llc_ctx() was
+ * interrupted by lock contention and therefore still hold tasks.
+ * cbw_drain_deferred_atqs() finishes the drain on each replenish tick
+ * and schedules destruction once empty.
+ *
+ * cbw_nr_deferred_drains counts currently parked BTQs.  The timer skips
+ * cbw_drain_deferred_atqs() entirely when the count is zero, avoiding
+ * a full ring scan in the (common) case of no deferred work.
+ */
+static u64		cbw_deferred_drain_slots[CBW_DEFERRED_DRAIN_SIZE]
+			__attribute__((aligned(SCX_CACHELINE_SIZE)));
+static u64		cbw_deferred_drain_tail
+			__attribute__((aligned(SCX_CACHELINE_SIZE)));
+static u64		cbw_nr_deferred_drains
+			__attribute__((aligned(SCX_CACHELINE_SIZE)));
 
 /*
  * Timer to replenish time budget for all cgroups periodically.
@@ -828,7 +852,8 @@ int cbw_init_llc_ctx(struct cgroup *cgrp, scx_cgroup_ctx_t *cgx)
 __hidden
 int cbw_put_aside(u64 ctx, u64 vtime, u64 cgrp_id);
 
-static void schedule_atq_destroy(scx_atq_t *btq)
+static __always_inline
+void schedule_atq_destroy(scx_atq_t *btq)
 {
 	static u64 slots[CBW_DEFERRED_BTQ_SIZE] __attribute__((aligned(SCX_CACHELINE_SIZE)));
 	static u64 tail __attribute__((aligned(SCX_CACHELINE_SIZE)));
@@ -867,6 +892,92 @@ static void schedule_atq_destroy(scx_atq_t *btq)
 	 * unlikely that real-world workloads will continuously and concurrently
 	 * destroy cgroups. So, let’s keep the design simple for now.
 	 */
+}
+
+static __always_inline
+void cbw_drain_atq_to_root(scx_atq_t *btq)
+{
+	u64 taskc_raw;
+	int ret;
+
+	/*
+	 * Finish the drain of one BTQ whose cgroup has exited: pop each
+	 * task and put it aside into the root cgroup.  On lock
+	 * contention in cbw_put_aside(), push the popped task back into
+	 * the old BTQ so it has a home, and stop.  The caller should
+	 * either leave the BTQ on the deferred-drain ring for another
+	 * tick, or (if the queue drained empty) schedule its destruction.
+	 *
+	 * Used by both schedule_atq_drain() (synchronous eviction on
+	 * slot collision) and cbw_drain_deferred_atqs() (timer-driven
+	 * pass).
+	 */
+	while (can_loop && (taskc_raw = scx_atq_pop(btq))) {
+		scx_task_cgroup_bw_t *taskc =
+			(scx_task_cgroup_bw_t *)taskc_raw;
+
+		/*
+		 * Invalidate the per-task cgx/llcx caches before handing
+		 * the task to the root cgroup; the old cgroup context may
+		 * already be freed.  Same reasoning as the main drain in
+		 * cbw_free_llc_ctx().
+		 */
+		WRITE_ONCE(taskc->cgx_raw, 0);
+		WRITE_ONCE(taskc->llcx_raw, 0);
+
+		ret = cbw_put_aside(taskc_raw, 0, ROOT_CGID);
+		if (unlikely(ret)) {
+			/*
+			 * Push-back preserves the "popped tasks always
+			 * have a home" invariant.
+			 */
+			scx_atq_insert_vtime(btq,
+				(scx_task_common *)taskc, 0);
+			break;
+		}
+	}
+}
+
+static __always_inline
+void schedule_atq_drain(scx_atq_t *btq)
+{
+	u64 slot, old;
+
+	/*
+	 * Park a BTQ whose cgroup-exit drain was cut short onto the
+	 * deferred-drain ring.  On collision, advance to the next slot.
+	 * The timer pass (cbw_drain_deferred_atqs) handles the drain +
+	 * destroy of parked BTQs -- we don't do synchronous drain here
+	 * because calling schedule_atq_destroy() on eviction would push
+	 * the call-graph depth past BPF's 8-frame limit on the chain
+	 * that flows through replenish_timerfn -> cbw_cgroup_bw_offline
+	 * -> cbw_free_llc_ctx.
+	 *
+	 * With CBW_DEFERRED_DRAIN_SIZE = 65536 slots and a replenish
+	 * period of ~100 ms (which drains and frees slots), wrap-around
+	 * is practically unreachable; can_loop bounds the worst case.
+	 */
+	do {
+		slot = __sync_fetch_and_add(&cbw_deferred_drain_tail, 1)
+			% CBW_DEFERRED_DRAIN_SIZE;
+
+		old = __sync_val_compare_and_swap(&cbw_deferred_drain_slots[slot],
+						  0, (u64)btq);
+		if (!old) {
+			__sync_fetch_and_add(&cbw_nr_deferred_drains, 1);
+			return;
+		}
+	} while (can_loop);
+
+	/*
+	 * Ring exhausted (all CBW_DEFERRED_DRAIN_SIZE slots occupied).
+	 * Extraordinarily rare; log and accept drop so the BTQ does not
+	 * leak.  Task loss here is equivalent to what the pre-defense
+	 * code did on any exit-drain contention.
+	 */
+	cbw_err("deferred-drain ring exhausted; dropping btq with %d tasks",
+		scx_atq_nr_queued(btq));
+	schedule_atq_destroy(btq);
 }
 
 static __always_inline
@@ -918,11 +1029,10 @@ int cbw_free_llc_ctx(scx_cgroup_ctx_t *cgx, u64 cgrp_id)
 		 *
 		 * scx_atq_pop() returns NULL both when the BTQ is empty and
 		 * when its bounded-retry spinlock fails under contention.
-		 * Here the two cases are indistinguishable, so a lock failure
-		 * mid-drain leaves tasks stranded in the BTQ: they will be
-		 * silently dropped by scx_atq_destroy() below. We flag that
-		 * outcome with an error print right before scheduling the
-		 * destroy, so such task loss does not go unnoticed.
+		 * Either case exits the loop; if any task remains in the BTQ
+		 * afterwards, we route the BTQ to the deferred-drain ring
+		 * (see below) so a later replenish tick can finish the drain
+		 * without losing tasks.
 		 */
 		if (cgrp_id != ROOT_CGID) {
 			while (can_loop && (taskc = scx_atq_pop(btq))) {
@@ -959,9 +1069,19 @@ int cbw_free_llc_ctx(scx_cgroup_ctx_t *cgx, u64 cgrp_id)
 				if (likely(!ret)) {
 					nr_moved++;
 				} else {
-					cbw_err("Failed to put aside a task "
+					/*
+					 * Put-aside to root hit lock contention.
+					 * Push the popped task back into the
+					 * old BTQ so the deferred-drain pass
+					 * can retry; the old BTQ is still alive
+					 * and exclusively owned by us here.
+					 */
+					cbw_dbg("Failed to put aside a task "
 						"while exiting cgid%llu: %d",
 						cgrp_id, ret);
+					scx_atq_insert_vtime(btq,
+						(scx_task_common *)t, 0);
+					break;
 				}
 			}
 		}
@@ -989,27 +1109,64 @@ int cbw_free_llc_ctx(scx_cgroup_ctx_t *cgx, u64 cgrp_id)
 		}
 
 		/*
-		 * If any task is still queued in the BTQ at this point, the
-		 * drain loop above terminated early on a lock-contention NULL
-		 * instead of an empty-queue NULL. Those tasks will be dropped
-		 * by scx_atq_destroy() and never rescheduled -- report it so
-		 * the loss is visible.
+		 * If any task is still queued in the BTQ, the drain loop
+		 * above terminated early on a lock-contention NULL from
+		 * scx_atq_pop() or a push-back from a failed cbw_put_aside()
+		 * to root. Park the BTQ on the deferred-drain ring so a
+		 * later replenish tick can finish without losing tasks.
+		 * Otherwise, defer scx_atq_destroy() to avoid a
+		 * use-after-free in cbw_drain_btq_batch(): that function
+		 * snapshots llcx->btq under READ_ONCE(), and
+		 * cbw_free_llc_ctx() may destroy the BTQ in the window
+		 * between the snapshot and scx_atq_pop().
 		 */
-		if (cgrp_id != ROOT_CGID && scx_atq_nr_queued(btq) > 0)
-			cbw_err("Dropping %d stranded task(s) in BTQ while "
-				"exiting cgid%llu/%d",
-				scx_atq_nr_queued(btq), cgrp_id, i);
-
-		/*
-		 * Defer scx_atq_destroy() to avoid a use-after-free in
-		 * cbw_drain_btq_batch(): that function snapshots llcx->btq
-		 * under READ_ONCE(), and cbw_free_llc_ctx() may destroy the
-		 * BTQ in the window between the snapshot and scx_atq_pop().
-		 */
-		schedule_atq_destroy(btq);
+		if (unlikely(cgrp_id != ROOT_CGID && scx_atq_nr_queued(btq) > 0))
+			schedule_atq_drain(btq);
+		else
+			schedule_atq_destroy(btq);
 	}
 
 	return nr_moved;
+}
+
+static __always_inline
+void cbw_drain_deferred_atqs(void)
+{
+	int i;
+	u64 btq_raw;
+	scx_atq_t *btq;
+
+	/*
+	 * Iterate the deferred-drain ring once per replenish tick.  For
+	 * each slot that still holds a BTQ, drain it towards the root
+	 * cgroup via cbw_drain_atq_to_root().  Slots that drain empty
+	 * are CAS-cleared and their BTQ scheduled for destruction;
+	 * slots that still hold tasks are left for another tick.
+	 */
+	bpf_for(i, 0, CBW_DEFERRED_DRAIN_SIZE) {
+		btq_raw = READ_ONCE(cbw_deferred_drain_slots[i]);
+		if (!btq_raw)
+			continue;
+
+		btq = (scx_atq_t *)btq_raw;
+
+		cbw_drain_atq_to_root(btq);
+
+		if (scx_atq_nr_queued(btq) != 0)
+			continue; /* leave for next tick */
+
+		/*
+		 * Fully drained.  CAS the slot to 0 and destroy.  A
+		 * failing CAS means schedule_atq_drain() already evicted
+		 * this slot via its own synchronous drain path; skip to
+		 * avoid double-destroy.
+		 */
+		if (__sync_bool_compare_and_swap(&cbw_deferred_drain_slots[i],
+						 btq_raw, 0)) {
+			__sync_fetch_and_sub(&cbw_nr_deferred_drains, 1);
+			schedule_atq_destroy(btq);
+		}
+	}
 }
 
 __noinline
@@ -1956,8 +2113,11 @@ bool cbw_has_backlogged_tasks(scx_cgroup_ctx_t *cgx)
 static
 bool cbw_replenish_cgroup(scx_cgroup_ctx_t *cgx, u64 now)
 {
-	s64 burst_credit = 0, debt = 0, budget;
-	bool period_end, was_throttled, keep_throttled = false;
+	static s64 burst_credit, debt, budget; /* Add `static` to work around the verifier error (-E2BIG) */
+	bool period_end, was_throttled, keep_throttled;
+
+	burst_credit = debt = 0;
+	keep_throttled = false;
 
 	/*
 	 * If the nquota_ub is infinite, we don’t need to replenish the cgroup.
@@ -2331,11 +2491,14 @@ offline_cgroup:
 		nr_moved += cbw_cgroup_bw_offline(ids[0]);
 	}
 	/*
-	 * At least one throttled task was moved to the root cgroup and the
-	 * root cgroup is not in the table. So we should add the root cgroup
-	 * to the table.
+	 * The root cgroup may have received throttled tasks from the
+	 * offline-cgroup drain (nr_moved) or from BTQs parked on the
+	 * deferred-drain ring (cbw_nr_deferred_drains).  If so, and
+	 * root is not already in the table, add it so the bottom half
+	 * can dispatch those tasks.
 	 */
-	if (nr_moved > 0 && !root_added) {
+	if (!root_added &&
+	    (nr_moved > 0 || READ_ONCE(cbw_nr_deferred_drains) > 0)) {
 		ids = MEMBER_VPTR(cbw_throttled_cgroup_ids, [nr_throttled]);
 		if (ids) {
 			WRITE_ONCE(ids[0], ROOT_CGID);
@@ -2400,6 +2563,17 @@ offline_cgroup:
 	 * for the delay of the timer execution, CBW_REPLENISH_PERIOD.
 	 */
 rearm_out:
+	/*
+	 * Finish draining BTQs that were parked on the deferred-drain
+	 * ring by a prior cbw_free_llc_ctx() whose drain was cut short
+	 * by lock contention.  Placed under rearm_out: so it still runs
+	 * when the main replenish path bails out on an error.  Gated on
+	 * cbw_nr_deferred_drains to skip the ring scan in the common
+	 * case of no deferred work.
+	 */
+	if (unlikely(READ_ONCE(cbw_nr_deferred_drains)))
+		cbw_drain_deferred_atqs();
+
 	interval = time_delta(now, cbw_last_replenish_at);
 	jitter = time_delta(interval, CBW_REPLENISH_PERIOD);
 	period = max(time_delta(CBW_REPLENISH_PERIOD, jitter), CBW_REPLENISH_PERIOD_MIN);

--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -56,8 +56,11 @@ enum scx_cgroup_consts {
 	CBW_RUNTUME_INF			= ((s64)~((u64)1 << 63)),
 	/* maximum number of re-enqueue tasks in one dispatch */
 	CBW_REENQ_MAX_BATCH		= 2,
-	/* size of the deferred BTQ destroy queue */
-	CBW_DEFERRED_BTQ_SIZE		= 256,
+	/*
+	 * Size of the deferred BTQ destroy queue.
+	 * CBW_NR_CGRP_LLC_MAX * 2 = 131072 slots, 1024 KB.
+	 */
+	CBW_DEFERRED_BTQ_SIZE		= (CBW_NR_CGRP_LLC_MAX * 2),
 };
 
 /*

--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -68,6 +68,15 @@ enum scx_cgroup_consts {
 	 * CBW_DEFERRED_BTQ_SIZE / 2 = 65536 slots, 512 KB.
 	 */
 	CBW_DEFERRED_DRAIN_SIZE		= (CBW_DEFERRED_BTQ_SIZE / 2),
+	/*
+	 * Slots for individual tasks that were popped from an exiting
+	 * cgroup's BTQ but whose move to the root cgroup failed both
+	 * via cbw_put_aside() and push-back into the old BTQ.  Requires
+	 * two lock failures on the same task, so sized even smaller
+	 * than the deferred-drain ring.
+	 * CBW_DEFERRED_DRAIN_SIZE / 2 = 32768 slots, 256 KB.
+	 */
+	CBW_DEFERRED_MOVE_SIZE		= (CBW_DEFERRED_DRAIN_SIZE / 2),
 };
 
 /*
@@ -423,6 +432,20 @@ static u64		cbw_deferred_drain_slots[CBW_DEFERRED_DRAIN_SIZE]
 static u64		cbw_deferred_drain_tail
 			__attribute__((aligned(SCX_CACHELINE_SIZE)));
 static u64		cbw_nr_deferred_drains
+			__attribute__((aligned(SCX_CACHELINE_SIZE)));
+
+/*
+ * Ring buffer of individual tasks whose move to the root cgroup failed
+ * in both cbw_put_aside() and the subsequent push-back into the old
+ * BTQ.  cbw_move_deferred_tasks() retries cbw_put_aside() on each
+ * replenish tick.  cbw_nr_deferred_moves is the fast-path gate that
+ * lets the timer skip the ring scan in the common case.
+ */
+static u64		cbw_deferred_move_slots[CBW_DEFERRED_MOVE_SIZE]
+			__attribute__((aligned(SCX_CACHELINE_SIZE)));
+static u64		cbw_deferred_move_tail
+			__attribute__((aligned(SCX_CACHELINE_SIZE)));
+static u64		cbw_nr_deferred_moves
 			__attribute__((aligned(SCX_CACHELINE_SIZE)));
 
 /*
@@ -894,6 +917,8 @@ void schedule_atq_destroy(scx_atq_t *btq)
 	 */
 }
 
+static void schedule_task_move_to_root(u64 taskc_raw);
+
 static __always_inline
 void cbw_drain_atq_to_root(scx_atq_t *btq)
 {
@@ -929,10 +954,16 @@ void cbw_drain_atq_to_root(scx_atq_t *btq)
 		if (unlikely(ret)) {
 			/*
 			 * Push-back preserves the "popped tasks always
-			 * have a home" invariant.
+			 * have a home" invariant.  If push-back itself
+			 * fails (arena_spin_lock() contention on the
+			 * old BTQ), park the orphaned task on the
+			 * deferred-move ring so a later tick can retry
+			 * the move to root.
 			 */
-			scx_atq_insert_vtime(btq,
+			ret = scx_atq_insert_vtime(btq,
 				(scx_task_common *)taskc, 0);
+			if (unlikely(ret))
+				schedule_task_move_to_root(taskc_raw);
 			break;
 		}
 	}
@@ -978,6 +1009,95 @@ void schedule_atq_drain(scx_atq_t *btq)
 	cbw_err("deferred-drain ring exhausted; dropping btq with %d tasks",
 		scx_atq_nr_queued(btq));
 	schedule_atq_destroy(btq);
+}
+
+static void schedule_task_move_to_root(u64 taskc_raw)
+{
+	u64 slot, old, prev;
+
+	/*
+	 * Park an individual task that was popped from an exiting
+	 * cgroup's BTQ but could not be moved to the root cgroup --
+	 * both cbw_put_aside() to root and push-back into the old BTQ
+	 * failed due to arena_spin_lock() contention.
+	 *
+	 * Shape mirrors schedule_atq_drain() / schedule_atq_destroy():
+	 * the usual case is an empty slot, and a collision means the
+	 * ring is full enough that an older parked task is still
+	 * waiting.  Try to retire the occupant synchronously by
+	 * retrying cbw_put_aside() to root; if it succeeds, evict via
+	 * CAS and loop to retry parking our task.  Otherwise advance
+	 * to the next slot.
+	 *
+	 * The parked task is not in any ATQ (taskc->atq == NULL after
+	 * the pop) and not on any DSQ, so no other path races with us
+	 * on it until we either re-park or a future tick moves it
+	 * successfully.
+	 */
+	do {
+		slot = __sync_fetch_and_add(&cbw_deferred_move_tail, 1)
+			% CBW_DEFERRED_MOVE_SIZE;
+
+		/*
+		 * Fast path: slot empty, park taskc here.
+		 */
+		old = __sync_val_compare_and_swap(&cbw_deferred_move_slots[slot],
+						  0, taskc_raw);
+		if (!old) {
+			__sync_fetch_and_add(&cbw_nr_deferred_moves, 1);
+			return;
+		}
+
+		/*
+		 * Slot occupied by a still-parked task.  Try to move it
+		 * to root synchronously so the slot can be freed.
+		 */
+		if (cbw_put_aside(old, 0, ROOT_CGID) != 0)
+			continue;
+
+		/*
+		 * Occupant moved.  Atomically clear the slot and loop to
+		 * retry parking our task.  A lost CAS means another CPU
+		 * cleared it first -- retry on the next slot.
+		 */
+		prev = __sync_val_compare_and_swap(&cbw_deferred_move_slots[slot],
+						   old, 0);
+		if (likely(old == prev))
+			__sync_fetch_and_sub(&cbw_nr_deferred_moves, 1);
+	} while (can_loop);
+}
+
+static __always_inline
+void cbw_move_deferred_tasks(void)
+{
+	int i, ret;
+	u64 taskc_raw;
+
+	/*
+	 * Iterate the deferred-move ring once per replenish tick.  For
+	 * each slot that still holds a parked task, retry
+	 * cbw_put_aside() to root; on success, CAS the slot to 0.  On
+	 * failure, leave the task for another tick.
+	 */
+	bpf_for(i, 0, CBW_DEFERRED_MOVE_SIZE) {
+		taskc_raw = READ_ONCE(cbw_deferred_move_slots[i]);
+		if (!taskc_raw)
+			continue;
+
+		ret = cbw_put_aside(taskc_raw, 0, ROOT_CGID);
+		if (ret)
+			continue; /* leave for next tick */
+
+		/*
+		 * Successfully moved.  CAS the slot to 0.  A failing CAS
+		 * means schedule_task_move_to_root() already evicted this
+		 * slot via its own synchronous retry path; skip to avoid
+		 * double accounting.
+		 */
+		if (__sync_bool_compare_and_swap(&cbw_deferred_move_slots[i],
+						 taskc_raw, 0))
+			__sync_fetch_and_sub(&cbw_nr_deferred_moves, 1);
+	}
 }
 
 static __always_inline
@@ -1075,12 +1195,17 @@ int cbw_free_llc_ctx(scx_cgroup_ctx_t *cgx, u64 cgrp_id)
 					 * old BTQ so the deferred-drain pass
 					 * can retry; the old BTQ is still alive
 					 * and exclusively owned by us here.
+					 * If push-back itself fails, park the
+					 * orphaned task on the deferred-move
+					 * ring for retry on a later tick.
 					 */
 					cbw_dbg("Failed to put aside a task "
 						"while exiting cgid%llu: %d",
 						cgrp_id, ret);
-					scx_atq_insert_vtime(btq,
+					ret = scx_atq_insert_vtime(btq,
 						(scx_task_common *)t, 0);
+					if (unlikely(ret))
+						schedule_task_move_to_root(taskc);
 					break;
 				}
 			}
@@ -2492,13 +2617,15 @@ offline_cgroup:
 	}
 	/*
 	 * The root cgroup may have received throttled tasks from the
-	 * offline-cgroup drain (nr_moved) or from BTQs parked on the
-	 * deferred-drain ring (cbw_nr_deferred_drains).  If so, and
-	 * root is not already in the table, add it so the bottom half
-	 * can dispatch those tasks.
+	 * offline-cgroup drain (nr_moved), from BTQs parked on the
+	 * deferred-drain ring (cbw_nr_deferred_drains), or from tasks
+	 * parked on the deferred-move ring (cbw_nr_deferred_moves).
+	 * If so, and root is not already in the table, add it so the
+	 * bottom half can dispatch those tasks.
 	 */
 	if (!root_added &&
-	    (nr_moved > 0 || READ_ONCE(cbw_nr_deferred_drains) > 0)) {
+	    (nr_moved > 0 || READ_ONCE(cbw_nr_deferred_drains) > 0 ||
+	     READ_ONCE(cbw_nr_deferred_moves) > 0)) {
 		ids = MEMBER_VPTR(cbw_throttled_cgroup_ids, [nr_throttled]);
 		if (ids) {
 			WRITE_ONCE(ids[0], ROOT_CGID);
@@ -2573,6 +2700,16 @@ rearm_out:
 	 */
 	if (unlikely(READ_ONCE(cbw_nr_deferred_drains)))
 		cbw_drain_deferred_atqs();
+
+	/*
+	 * Retry cbw_put_aside() for individual tasks whose move to
+	 * root failed both via cbw_put_aside() and push-back into the
+	 * old BTQ.  Runs after the drain pass so that any tasks parked
+	 * by push-back failures in cbw_drain_atq_to_root() are
+	 * immediately retried on this same tick.
+	 */
+	if (unlikely(READ_ONCE(cbw_nr_deferred_moves)))
+		cbw_move_deferred_tasks();
 
 	interval = time_delta(now, cbw_last_replenish_at);
 	jitter = time_delta(interval, CBW_REPLENISH_PERIOD);

--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -915,6 +915,14 @@ int cbw_free_llc_ctx(scx_cgroup_ctx_t *cgx, u64 cgrp_id)
 		/*
 		 * Move all the throttled exiting tasks into the root cgroup.
 		 * Then, delete the LLC context and its associated BTQ.
+		 *
+		 * scx_atq_pop() returns NULL both when the BTQ is empty and
+		 * when its bounded-retry spinlock fails under contention.
+		 * Here the two cases are indistinguishable, so a lock failure
+		 * mid-drain leaves tasks stranded in the BTQ: they will be
+		 * silently dropped by scx_atq_destroy() below. We flag that
+		 * outcome with an error print right before scheduling the
+		 * destroy, so such task loss does not go unnoticed.
 		 */
 		if (cgrp_id != ROOT_CGID) {
 			while (can_loop && (taskc = scx_atq_pop(btq))) {
@@ -979,6 +987,18 @@ int cbw_free_llc_ctx(scx_cgroup_ctx_t *cgx, u64 cgrp_id)
 			 */
 			cbw_free_llcx(llcx);
 		}
+
+		/*
+		 * If any task is still queued in the BTQ at this point, the
+		 * drain loop above terminated early on a lock-contention NULL
+		 * instead of an empty-queue NULL. Those tasks will be dropped
+		 * by scx_atq_destroy() and never rescheduled -- report it so
+		 * the loss is visible.
+		 */
+		if (cgrp_id != ROOT_CGID && scx_atq_nr_queued(btq) > 0)
+			cbw_err("Dropping %d stranded task(s) in BTQ while "
+				"exiting cgid%llu/%d",
+				scx_atq_nr_queued(btq), cgrp_id, i);
 
 		/*
 		 * Defer scx_atq_destroy() to avoid a use-after-free in
@@ -1835,6 +1855,32 @@ int cbw_put_aside(u64 ctx, u64 vtime, u64 cgrp_id)
 	if (!btq)
 		return -ESRCH;
 
+	/*
+	 * If the task is still recorded as being in an ATQ, drop that
+	 * stale membership before the insert below. Otherwise the
+	 * duplicate rb-tree insert would corrupt the tree.
+	 *
+	 * A stale taskc->atq can arise when an earlier scx_atq_cancel()
+	 * (from scx_cgroup_bw_cancel(), a cgroup-move path, etc.) had
+	 * its bounded-retry spinlock fail under contention, leaving the
+	 * task still linked in an old ATQ. scx_cgroup_bw_is_task_throttled()
+	 * is a lock-free pointer check, so we pay the scx_atq_cancel()
+	 * lock cost only when a stale membership actually exists.
+	 *
+	 * If scx_atq_cancel() itself fails under contention, return
+	 * -EBUSY. The BPF scheduler will enqueue the task via the normal
+	 * path -- the cgroup will briefly overuse its budget, but the
+	 * stale ATQ membership will be cleaned up the next time the task
+	 * is throttled and cbw_put_aside() runs again.
+	 */
+	if (scx_cgroup_bw_is_task_throttled((u64)taskc)) {
+		ret = scx_atq_cancel(taskc);
+		if (ret) {
+			cbw_dbg("Failed to cancel stale ATQ membership: %d", ret);
+			return -EBUSY;
+		}
+	}
+
 	ret = scx_atq_lock(btq);
 	if (ret) {
 		cbw_err("Failed to lock ATQ.");
@@ -2394,6 +2440,11 @@ int cbw_drain_btq_batch(scx_cgroup_ctx_t *cgx,
 		 * Note that we do not worry about racing with .dequeue() here,
 		 * because even if we do, the callback's insert_vtime call will
 		 * fail silently in the scx core. 
+		 *
+		 * scx_atq_pop() returns NULL both when the BTQ is empty and
+		 * when its bounded-retry spinlock fails under contention. Both
+		 * outcomes are safe here: any task we did not pop stays in the
+		 * BTQ and will be retried at the next replenish tick.
 		 */
 
 		scx_cgroup_bw_enqueue_cb((u64)taskc);

--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -2707,9 +2707,17 @@ int scx_cgroup_bw_move(struct task_struct *p __arg_trusted, u64 taskc,
 		return 0;
 
 	if ((ret = scx_cgroup_bw_cancel(taskc))) {
-		cbw_err("Fail to cancel a throttled task (%s:%d) from a cgroup (cgid%llu): %d",
+		/*
+		 * Lock contention: the BTQ spinlock timed out. The task
+		 * remains in the old BTQ and will be re-enqueued naturally
+		 * when that BTQ drains at the next replenishment. Because the
+		 * caller (e.g., lavd_cgroup_move) updates taskc->cgrp_id to
+		 * @to before calling this function, the drain callback will
+		 * check throttle against the new cgroup. Not fatal.
+		 */
+		cbw_dbg("Failed to cancel task (%s:%d) from cgid%llu during move: %d, will drain naturally",
 			p->comm, p->pid, cgroup_get_id(from), ret);
-		return ret;
+		return 0;
 	}
 
 	if ((ret = scx_cgroup_bw_put_aside(p, taskc, p->scx.dsq_vtime, cgroup_get_id(to)))) {


### PR DESCRIPTION
This series closes a set of task-loss and use-after-free windows in
lib/cgroup_bw uncovered while stress-testing scx_lavd under heavy CPU
bandwidth throttling with concurrent cgroup churn. ATQ (BTQ)
operations use arena_spin_lock(), a bounded-retry spinlock that can
fail under contention. Existing call sites assumed those failures
were either impossible or benign; in practice they orphan tasks,
corrupt rb-trees, or trigger use-after-frees.

Existing-path fixes
-------------------

The deferred-destroy ring's 256-slot size is too small under heavy
cgroup churn: more than 256 BTQs can be queued before a reader (e.g.
cbw_drain_btq_batch() with a snapshotted llcx->btq) releases its
pointer, wrapping the ring and triggering a UAF. Resized to
CBW_NR_CGRP_LLC_MAX * 2.

scx_cgroup_bw_move()'s scx_cgroup_bw_cancel() can time out under
contention with the replenish-time drain; the -ETIMEDOUT was
propagated up to lavd_cgroup_move() and terminated the scheduler.
The failure is self-healing (the task stays in the old BTQ and the
drain re-checks throttle against the updated cgrp_id), so log and
return 0 instead.

scx_atq_cancel() failing under contention leaves taskc->atq stale, so
the next cbw_put_aside() could insert into the rb-tree while still
linked in the old ATQ. Cancel any stale membership first, gated on a
lock-free is_task_throttled() check.

- [1/5] 964cc555f lib/cgroup_bw: size deferred-BTQ ring to CBW_NR_CGRP_LLC_MAX * 2
- [2/5] f1b5a75b9 lib/cgroup_bw: treat BTQ cancel failure during cgroup move as non-fatal
- [3/5] 370a7718e lib/cgroup_bw: cancel stale ATQ membership in cbw_put_aside()

Deferred-retry rings for cgroup-exit drains
-------------------------------------------

cbw_free_llc_ctx() drains an exiting cgroup's BTQ to root before
destroying it. Two contention paths could silently lose tasks:
scx_atq_pop() returning NULL on lock failure (drain exits early,
remaining tasks dropped by scx_atq_destroy()), and cbw_put_aside() to
root returning -EBUSY (task already popped, now homeless). A
deferred-drain ring parks stranded BTQs and cbw_drain_deferred_atqs()
finishes them from rearm_out: each tick, pushing back into the old
BTQ on cbw_put_aside() failure so a popped task always has a home.

The push-back's scx_atq_insert_vtime() can itself fail under
contention. A task-level deferred-move ring parks such orphans and
cbw_move_deferred_tasks() retries cbw_put_aside() each tick. Together
the two rings give every throttled task during cgroup exit a
guaranteed home: old BTQ, root BTQ, deferred-drain ring, or
deferred-move ring.

- [4/5] 6323450cf lib/cgroup_bw: defer interrupted cgroup-exit drains to close a task-loss window
- [5/5] 383b673c5 lib/cgroup_bw: defer orphaned tasks when push-back also fails

Signed-off-by: Changwoo Min <changwoo@igalia.com>
