### PR TITLE
Multiple randomized proximity maps

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -45,6 +45,7 @@ enum consts {
 	DUTY_CYCLE_SHIFT	= 20,		/* duty_cycle 1.0 = 1 << 20 */
 	LAYER_LAT_DECAY_FACTOR	= 32,
 	CLEAR_PREEMPTING_AFTER	= 10000000,	/* 10ms */
+	NUM_PROXIMITY_MAPS = 32,
 
 	DSQ_ID_SPECIAL_MASK	= 0xc0000000,
 	HI_FB_DSQ_BASE		= 0x40000000,
@@ -241,7 +242,7 @@ struct llc_ctx {
 	u64			queued_runtime[MAX_LAYERS];
 	u64			lo_fb_seq;
 	u64			lstats[MAX_LAYERS][NR_LLC_LSTATS];
-	struct llc_prox_map	prox_map;
+	struct llc_prox_map	prox_maps[NUM_PROXIMITY_MAPS];
 };
 
 struct node_prox_map {

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2530,7 +2530,12 @@ static __always_inline bool try_consume_layer(u32 layer_id, struct cpu_ctx *cpuc
 					      struct llc_ctx *llcc,
 					      bool rescue_stranded)
 {
-	struct llc_prox_map *llc_pmap = &llcc->prox_map;
+	/*
+	 * Select random proximity map from NUM_PROXIMITY_MAPS to avoid
+	 * bias in proximity map ordering of LLCs with same locality.
+	 */
+	u32 pmap_idx = bpf_get_prandom_u32() % NUM_PROXIMITY_MAPS;
+	struct llc_prox_map *llc_pmap = &llcc->prox_maps[pmap_idx];
 	struct layer *layer;
 	u32 nid = llc_node_id(llcc->id);
 	bool xllc_mig_skipped = false;
@@ -3456,7 +3461,7 @@ static s32 create_llc(u32 llc_id)
 
 	dbg("CFG creating llc %d with %d cpus", llc_id, llcc->nr_cpus);
 
-	pmap = &llcc->prox_map;
+	pmap = &llcc->prox_maps[0];
 	dbg("CFG: LLC[%d] prox_map node/sys=%d/%d",
 	    llc_id, pmap->node_end, pmap->sys_end);
 	if (pmap->sys_end > nr_possible_cpus || pmap->sys_end > MAX_CPUS) {

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -2455,7 +2455,11 @@ impl<'a> Scheduler<'a> {
         Ok(())
     }
 
-    fn init_llc_prox_map(skel: &mut BpfSkel, topo: &Topology) -> Result<()> {
+    fn init_single_prox_map_per_llc(
+        skel: &mut BpfSkel,
+        topo: &Topology,
+        prox_map_idx: &usize,
+    ) -> Result<()> {
         for (&llc_id, llc) in &topo.all_llcs {
             // Collect the orders.
             let mut node_order: Vec<usize> =
@@ -2468,7 +2472,7 @@ impl<'a> Scheduler<'a> {
 
             // Shuffle so that different LLCs follow different orders. See
             // init_cpu_prox_map().
-            fastrand::seed(llc_id as u64);
+            fastrand::seed((*prox_map_idx as u64) << 32 | llc_id as u64);
             fastrand::shuffle(&mut sys_order);
             fastrand::shuffle(&mut node_order);
 
@@ -2488,8 +2492,8 @@ impl<'a> Scheduler<'a> {
             let sys_end = idx;
 
             debug!(
-                "LLC[{}] proximity map[{}/{}]: {:?}",
-                llc_id, node_end, sys_end, &order
+                "LLC[{}] proximity map {}[{}/{}]: {:?}",
+                llc_id, prox_map_idx, node_end, sys_end, &order
             );
 
             // Record in llc_ctx.
@@ -2506,7 +2510,7 @@ impl<'a> Scheduler<'a> {
             let mut llcc: bpf_intf::llc_ctx =
                 *plain::from_bytes(v.as_slice()).expect("llc_ctx: short or misaligned buffer");
 
-            let pmap = &mut llcc.prox_map;
+            let pmap = &mut llcc.prox_maps[*prox_map_idx];
             for (i, &llc_id) in order.iter().enumerate() {
                 pmap.llcs[i] = llc_id as u16;
             }
@@ -2518,6 +2522,15 @@ impl<'a> Scheduler<'a> {
                 unsafe { plain::as_bytes(&llcc) },
                 libbpf_rs::MapFlags::ANY,
             )?
+        }
+
+        Ok(())
+    }
+
+    fn init_llc_prox_map(skel: &mut BpfSkel, topo: &Topology) -> Result<()> {
+        let num_proximity_maps = bpf_intf::consts_NUM_PROXIMITY_MAPS as usize;
+        for prox_map_idx in 0..num_proximity_maps {
+            Self::init_single_prox_map_per_llc(skel, topo, &prox_map_idx)?;
         }
 
         Ok(())


### PR DESCRIPTION
We are looking for opportunities to make scx_layered more generic and get the best trade-offs of tail queueing latencies vs cache locality. This PR aims to provide a win in tail queueing latency without sacrificing cache locality. Noticed a consistent bias in DSQs of a layer where some queues had larger sizes consistently related to the initial proximity map ordering. Specifically, noticed a specific LLC being ordered later in each proximity map resulting in that LLC having higher queue size due to less frequently dispatched.

This diff produces 32 randomized proximity maps instead of just 1 per LLC, each with unique seed. Upon dispatch's attempt to consume a layer, a random map is selected instead of always using the same map.

Test Plan:

Ran a high utilization hhvm workload on a server with 2 modifications (1) extra logging logic to track average queue-size of DSQs every 100ms and (2) variable amount of maps to use ranging up to 64. I did a parameter sweep of 1 to 64 in powers of 2. Noticed consistently that not much extra balance (tightness of spread) after 32, so using 32 in this PR.

Chart has 1 line of average queue-size every minute per 8 active LLCs for the workload, looking for tighter spread.
<img width="861" height="544" alt="Screenshot 2026-05-03 at 1 25 34 PM" src="https://github.com/user-attachments/assets/28522762-a12b-4046-bd80-6cf96eb9b122" />

