### PR TITLE
lib/atq: treat arena_spin_lock -ETIMEDOUT as fatal

### DIFF
--- a/lib/atq.bpf.c
+++ b/lib/atq.bpf.c
@@ -97,13 +97,13 @@ int scx_atq_insert_vtime(scx_atq_t __arg_arena *atq, scx_task_common __arg_arena
 {
 	int ret;
 
-	ret = arena_spin_lock(&atq->lock);
+	ret = scx_atq_lock(atq);
 	if (ret)
 		return ret;
 
 	ret = scx_atq_insert_vtime_unlocked(atq, taskc, vtime);
 
-	arena_spin_unlock(&atq->lock);
+	scx_atq_unlock(atq);
 
 	return ret;
 }
@@ -140,13 +140,13 @@ int scx_atq_remove(scx_atq_t *atq, scx_task_common __arg_arena *taskc)
 {
        int ret;
 
-       ret = arena_spin_lock(&atq->lock);
+       ret = scx_atq_lock(atq);
        if (ret)
                return ret;
 
        ret = scx_atq_remove_unlocked(atq, taskc);
 
-       arena_spin_unlock(&atq->lock);
+       scx_atq_unlock(atq);
 
        return ret;
 }
@@ -158,12 +158,12 @@ u64 scx_atq_pop(scx_atq_t *atq)
 	u64 vtime, taskc_ptr;
 	int ret;
 
-	ret = arena_spin_lock(&atq->lock);
+	ret = scx_atq_lock(atq);
 	if (ret)
 		return (u64)NULL;
 
 	if (!scx_atq_nr_queued(atq)) {
-		arena_spin_unlock(&atq->lock);
+		scx_atq_unlock(atq);
 		return (u64)NULL;
 	}
 
@@ -174,7 +174,7 @@ u64 scx_atq_pop(scx_atq_t *atq)
 	taskc = (scx_task_common *)taskc_ptr;
 	taskc->atq = NULL;
 
-	arena_spin_unlock(&atq->lock);
+	scx_atq_unlock(atq);
 
 	if (ret) {
 		if (ret != -ENOENT)
@@ -191,18 +191,18 @@ u64 scx_atq_peek(scx_atq_t *atq)
 	u64 vtime, taskc_ptr;
 	int ret;
 
-	ret = arena_spin_lock(&atq->lock);
+	ret = scx_atq_lock(atq);
 	if (ret)
 		return (u64)NULL;
 
 	if (!scx_atq_nr_queued(atq)) {
-		arena_spin_unlock(&atq->lock);
+		scx_atq_unlock(atq);
 		return (u64)NULL;
 	}
 
 	ret = rb_least(atq->tree, &vtime, &taskc_ptr);
 
-	arena_spin_unlock(&atq->lock);
+	scx_atq_unlock(atq);
 
 	return taskc_ptr;
 }

--- a/scheds/include/lib/atq.h
+++ b/scheds/include/lib/atq.h
@@ -63,7 +63,22 @@ int scx_atq_cancel(scx_task_common *taskc);
 static __always_inline
 int scx_atq_lock(scx_atq_t __arg_arena *atq)
 {
-	return arena_spin_lock(&atq->lock);
+	int ret = arena_spin_lock(&atq->lock);
+
+	/*
+	 * arena_spin_lock() returns -ETIMEDOUT when one of the bounded spin
+	 * loops inside arena_spin_lock_slowpath() exhausts its iterations
+	 * (see scheds/include/bpf_arena_spin_lock.h).  The timed-out waiter
+	 * just bails, leaving the MCS chain with stale ->next links and any
+	 * waiters queued behind it stuck on their own bounded spins.
+	 * Subsequent acquires race against an inconsistent queue; retrying
+	 * is unsafe.  Treat the timeout as a fatal scheduler error so the
+	 * system tears down cleanly.
+	 */
+	if (ret == -ETIMEDOUT)
+		scx_bpf_error("scx_atq: arena_spin_lock timed out");
+
+	return ret;
 }
 
 static __always_inline


### PR DESCRIPTION
arena_spin_lock() returns -ETIMEDOUT when one of the bounded spin loops inside arena_spin_lock_slowpath() exhausts its iterations (see scheds/include/bpf_arena_spin_lock.h).  The timed-out waiter just bails, leaving the MCS chain with stale ->next links and any waiters queued behind it stuck on their own bounded spins.  A later acquire races against an inconsistent queue; retrying is unsafe.

Route the four scx_atq_* call sites in lib/atq.bpf.c through the existing scx_atq_lock()/scx_atq_unlock() wrappers so there is one chokepoint, then have scx_atq_lock() call scx_bpf_error() on -ETIMEDOUT.  The error is still returned so callers cannot proceed on stale state; scx_bpf_error() triggers ops_exit so the scheduler tears down cleanly instead of stalling on a dead lock.