### PR TITLE
scx_rustland: add doc comments to clarify dispatch_task layers

### DIFF
--- a/rust/scx_rustland_core/assets/bpf.rs
+++ b/rust/scx_rustland_core/assets/bpf.rs
@@ -540,7 +540,12 @@ impl<'cb> BpfScheduler<'cb> {
         }
     }
 
-    // Send a task to the dispatcher.
+    /// Serialize a [`DispatchedTask`] into the user ring buffer for the
+    /// BPF program to consume and execute on the target CPU.
+    ///
+    /// Note: this is the low-level BPF submission layer. For the scheduler-level
+    /// entry point that selects which task to dispatch, see
+    /// `Scheduler::dispatch_task` in `scx_rustland`.
     pub fn dispatch_task(&mut self, task: &DispatchedTask) -> Result<(), libbpf_rs::Error> {
         // Reserve a slot in the user ring buffer.
         let mut urb_sample = self

--- a/scheds/rust/scx_rustland/src/main.rs
+++ b/scheds/rust/scx_rustland/src/main.rs
@@ -277,6 +277,10 @@ impl<'a> Scheduler<'a> {
     ///
     /// Return true if dispatching succeeded or there was no task to dispatch, or false if
     /// dispatching failed (the task is automatically re-enqueued in that case).
+    ///
+    /// Note: this is the scheduler-level entry point. It selects the next
+    /// [`Task`] from the internal pool and delegates BPF submission to
+    /// [`BpfScheduler::dispatch_task`].
     fn dispatch_task(&mut self) -> bool {
         // Retrieve the next task to dispatch, if any.
         let Some(task) = self.tasks.pop_first() else {


### PR DESCRIPTION
There are two dispatch_task() functions with the same name but different
responsibilities, which can confuse new contributors reading the code.

- Scheduler::dispatch_task() in main.rs: scheduler-level, picks the
  next task from the internal pool and calls BpfScheduler::dispatch_task().

- BpfScheduler::dispatch_task() in bpf.rs: BPF-level, serializes the
  task into the user ring buffer for the BPF program to consume.

Also converts the existing // comment to /// so it appears in generated
documentation.