### PR TITLE
scx_lavd: per-CPU task_ctx lookup cache

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -293,9 +293,6 @@ extern int			nr_cpdoms;
 
 typedef struct task_ctx __arena task_ctx;
 
-u64 get_task_ctx_internal(struct task_struct *p);
-#define get_task_ctx(p) ((task_ctx *)get_task_ctx_internal((p)))
-
 struct cpu_ctx *get_cpu_ctx(void);
 struct cpu_ctx *get_cpu_ctx_id(s32 cpu_id);
 struct cpu_ctx *get_cpu_ctx_task(const struct task_struct *p);
@@ -368,6 +365,29 @@ struct cpu_ctx {
 	volatile u32	nr_sched;	/* number of schedules */
 	volatile u32	nr_preempt;
 
+	/*
+	 * Per-CPU task_ctx lookup cache. Local-only writes/reads, never
+	 * accessed remotely. Used by get_task_ctx_curcpu() / get_task_ctx()
+	 * to skip bpf_task_storage_get() when consecutive ops callbacks
+	 * reference the same task on the same CPU.
+	 *
+	 * Keyed by (task_struct *, pid). Either alone is unsafe:
+	 *  - task_struct * alone: SLUB can recycle a freed task_struct
+	 *    address; a stale cache entry on an idle CPU would then alias
+	 *    the new task and return the freed taskc.
+	 *  - pid alone: a non-leader thread's pid changes when it calls
+	 *    execve() -- de_thread() / exchange_tids() swaps the calling
+	 *    thread's pid with the leader's, and the leader is then
+	 *    released; entries keyed on the old pid would become stale
+	 *    hits for the surviving thread.
+	 *
+	 * Together: ABA defeated by pid mismatch, execve swap defeated
+	 * by address mismatch. cached_pid == 0 means invalid.
+	 */
+	u64		cached_task;		/* (struct task_struct *) as u64 */
+	u64		cached_taskc_raw;	/* (task_ctx __arena *) as u64 */
+	u32		cached_pid;
+
 	/* --- cacheline 2 boundary (128 bytes): per-interval results --- */
 	/*
 	 * Updated once per sys_stat collection interval. Read by userspace
@@ -403,7 +423,6 @@ struct cpu_ctx {
 	u32		avg_dom_pinned_util_wall;
 	u32		cur_dom_pinned_util_invr;
 	u32		avg_dom_pinned_util_invr;
-	u32		__pad1;
 
 	/* --- cacheline 3 boundary (192 bytes): sys_stat raw inputs --- */
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lock.bpf.c
@@ -7,6 +7,7 @@
 #include <scx/common.bpf.h>
 #include "intf.h"
 #include "lavd.bpf.h"
+#include "util.bpf.h"
 #include <errno.h>
 #include <stdbool.h>
 #include <bpf/bpf_core_read.h>

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1839,6 +1839,17 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init_task, struct task_struct *p,
 s32 BPF_STRUCT_OPS(lavd_exit_task, struct task_struct *p,
 		   struct scx_exit_task_args *args)
 {
+	struct cpu_ctx *cpuc = get_cpu_ctx();
+
+	/*
+	 * Drop the local CPU's task_ctx cache entry if it points at @p.
+	 * Remote CPUs that may have cached @p rely on natural eviction by
+	 * subsequent lookups -- by design, no cross-CPU sweep here.
+	 */
+	if (cpuc && (cpuc->cached_task == (u64)p ||
+		     cpuc->cached_pid == p->pid))
+		cpuc->cached_pid = 0;
+
 	scx_task_free(p);
 	return 0;
 }

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -613,11 +613,12 @@ static bool can_direct_dispatch(struct cpu_ctx *cpuc, bool is_cpu_idle)
 s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 		   u64 wake_flags)
 {
+	struct cpu_ctx *cpuc_cur = get_cpu_ctx();
 	struct pick_ctx ictx = {
 		.p = p,
-		.taskc = get_task_ctx(p),
+		.taskc = get_task_ctx_curcpu(p, cpuc_cur),
 		.prev_cpu = prev_cpu,
-		.cpuc_cur = get_cpu_ctx(),
+		.cpuc_cur = cpuc_cur,
 		.wake_flags = wake_flags,
 	};
 	struct task_struct *waker;
@@ -736,8 +737,8 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 	task_ctx *taskc;
 	u64 dsq_id;
 
-	taskc = get_task_ctx(p);
 	cpuc_cur = get_cpu_ctx();
+	taskc = get_task_ctx_curcpu(p, cpuc_cur);
 	if (!taskc || !cpuc_cur) {
 		scx_bpf_error("Failed to lookup cpu_ctx %d", cpu);
 		return;
@@ -1331,6 +1332,14 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 	task_ctx *taskc;
 	u64 now = scx_bpf_now();
 
+	/*
+	 * lavd_running() may run on a CPU other than @p's: the kernel
+	 * invokes this op with @p's rq lock held, but the calling CPU
+	 * isn't necessarily @p's CPU. For example, scx_enable_workfn()
+	 * iterates over every rq from a worker thread, locks each in
+	 * turn, and triggers set_next_task_scx() on it -- so the op
+	 * fires for tasks on remote rqs.
+	 */
 	cpuc = get_cpu_ctx_task(p);
 	taskc = get_task_ctx(p);
 	if (!cpuc || !taskc) {
@@ -1387,7 +1396,14 @@ void BPF_STRUCT_OPS(lavd_tick, struct task_struct *p)
 	u64 now;
 
 	/*
-	 * Update task statistics
+	 * Update task statistics.
+	 *
+	 * lavd_tick() may run on a CPU other than @p's: the kernel
+	 * invokes this op with @p's rq lock held, but the calling CPU
+	 * isn't necessarily @p's CPU. In NOHZ_FULL mode,
+	 * sched_tick_remote() runs as a delayed_work on a worker
+	 * thread, locks the remote rq, and calls task_tick_scx() on
+	 * its curr task -- so the op fires for tasks on remote rqs.
 	 */
 	cpuc = get_cpu_ctx_task(p);
 	taskc = get_task_ctx(p);
@@ -1421,7 +1437,14 @@ void BPF_STRUCT_OPS(lavd_stopping, struct task_struct *p, bool runnable)
 	task_ctx *taskc;
 
 	/*
-	 * Update task statistics
+	 * Update task statistics.
+	 *
+	 * lavd_stopping() may run on a CPU other than @p's: the kernel
+	 * invokes this op with @p's rq lock held, but the calling CPU
+	 * isn't necessarily @p's CPU. The kernel calls it from both
+	 * put_prev_task_scx() (always on @p's CPU) and
+	 * dequeue_task_scx() (which can run on a different CPU during
+	 * migration paths).
 	 */
 	cpuc = get_cpu_ctx_task(p);
 	taskc = get_task_ctx(p);
@@ -1439,6 +1462,13 @@ void BPF_STRUCT_OPS(lavd_quiescent, struct task_struct *p, u64 deq_flags)
 	task_ctx *taskc;
 	u64 now, interval;
 
+	/*
+	 * lavd_quiescent() may run on a CPU other than @p's: the kernel
+	 * invokes this op with @p's rq lock held, but the calling CPU
+	 * isn't necessarily @p's CPU. dequeue_task_scx() can be called
+	 * from migration paths on a different CPU than where @p was
+	 * running.
+	 */
 	cpuc = get_cpu_ctx_task(p);
 	taskc = get_task_ctx(p);
 	if (!cpuc || !taskc) {
@@ -2418,9 +2448,10 @@ int set_aggressive_migration(void)
 		return 0;
 
 	cpu = bpf_get_smp_processor_id();
-	if ((curr = bpf_get_current_task_btf()) &&
-	    (taskc = get_task_ctx(curr)) &&
-	    (cpuc = get_cpu_ctx_id(cpu)) &&
+	cpuc = get_cpu_ctx();
+	if (cpuc &&
+	    (curr = bpf_get_current_task_btf()) &&
+	    (taskc = get_task_ctx_curcpu(curr, cpuc)) &&
 	    (cpdc = MEMBER_VPTR(cpdom_ctxs, [cpuc->cpdom_id])) &&
 	    READ_ONCE(cpdc->is_stealee)) {
 		set_task_flag(taskc, LAVD_FLAG_MIGRATION_AGGRESSIVE);

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -63,9 +63,17 @@ struct {
 } cpu_ctx_stor SEC(".maps");
 
 __hidden
-u64 get_task_ctx_internal(struct task_struct __arg_trusted *p)
+u64 __get_task_ctx_slowpath(struct task_struct __arg_trusted *p,
+			    struct cpu_ctx *cpuc)
 {
-	return (u64)scx_task_data(p);
+	u64 raw = (u64)scx_task_data(p);
+
+	if (cpuc && raw) {
+		cpuc->cached_task = (u64)p;
+		cpuc->cached_pid = p->pid;
+		cpuc->cached_taskc_raw = raw;
+	}
+	return raw;
 }
 
 __hidden

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.h
@@ -45,4 +45,42 @@ static inline bool rt_or_dl_task(struct task_struct *p)
 {
 	return unlikely(p->prio < MAX_RT_PRIO);
 }
+
+/*
+ * task_ctx lookup with per-CPU cache.
+ *
+ * get_task_ctx_curcpu(p, cpuc) -- @cpuc MUST be the current CPU's cpu_ctx
+ * (i.e. obtained via get_cpu_ctx(), not get_cpu_ctx_id(...) or
+ * get_cpu_ctx_task(...) for an arbitrary CPU). Misuse silently corrupts
+ * the cache of a remote CPU and racing reads can return torn results.
+ *
+ * get_task_ctx(p) is a foot-gun-free wrapper that always uses
+ * get_cpu_ctx() internally.
+ */
+struct cpu_ctx;
+u64 __get_task_ctx_slowpath(struct task_struct *p, struct cpu_ctx *cpuc);
+
+static __always_inline u64
+__get_task_ctx_curcpu(struct task_struct *p, struct cpu_ctx *cpuc)
+{
+	if (cpuc) {
+#ifdef LAVD_DEBUG
+		if (cpuc->cpu_id != bpf_get_smp_processor_id())
+			scx_bpf_error("get_task_ctx_curcpu: non-local cpuc "
+				      "(cpu_id=%u, cur=%d)",
+				      cpuc->cpu_id,
+				      bpf_get_smp_processor_id());
+#endif
+		if (cpuc->cached_task == (u64)p &&
+		    cpuc->cached_pid == p->pid)
+			return cpuc->cached_taskc_raw;
+	}
+	return __get_task_ctx_slowpath(p, cpuc);
+}
+
+#define get_task_ctx_curcpu(p, cpuc) \
+	((task_ctx *)__get_task_ctx_curcpu((p), (cpuc)))
+#define get_task_ctx(p)	get_task_ctx_curcpu((p), get_cpu_ctx())
+
+
 #endif /* __UTIL_H */


### PR DESCRIPTION
This series caches the most recently looked-up task_ctx per CPU so
consecutive SCX ops callbacks against the same task skip
bpf_task_storage_get().  Its kernel-side fast path is per-task (not
per-CPU) and small (16 slots shared across all maps a task uses),
and every call still pays the BPF helper boundary plus several
RCU-protected loads even on a hit; a miss adds an hlist walk and a
lock-protected cache insert.  Under stress-ng --cpu, the series cuts
scheduler overhead by ~5.7%.

Caching the lookup
------------------

Three new fields in struct cpu_ctx (cached_task, cached_pid,
cached_taskc_raw) hold the last hit.  __get_task_ctx_curcpu() is a
static __always_inline fast path that compares
(cpuc->cached_task, cpuc->cached_pid) against (p, p->pid) and
returns the cached pointer on hit; __get_task_ctx_slowpath()
(out-of-line) calls scx_task_data() and refills the cache on miss.

The cache is keyed by (task_struct *, pid).  Either alone is
unsafe: task_struct * alone is broken by SLUB recycling a freed
task_struct address, and pid alone is broken by non-leader
execve() swapping pids via exchange_tids().  Together: ABA
defeated by pid mismatch, execve swap defeated by address
mismatch.  lavd_exit_task() also clears the local slot if either
key matches the exiting task.

Two macros are exposed: get_task_ctx(p) is a foot-gun-free drop-in
that uses get_cpu_ctx() internally; get_task_ctx_curcpu(p, cpuc) is
the explicit form for hot sites that already hold the current CPU's
cpuc, with an LAVD_DEBUG-gated runtime assertion to catch misuse.

- [1/2] 66da81a30 scx_lavd: cache last task_ctx lookup per CPU

Migrating hot sites
-------------------

lavd_select_cpu(), lavd_enqueue(), and the execve handler
set_aggressive_migration() switch to get_task_ctx_curcpu(p, cpuc) so
the inline fast path skips the redundant get_cpu_ctx() that
get_task_ctx(p) would otherwise do.

lavd_running(), lavd_tick(), lavd_stopping(), and lavd_quiescent()
keep using get_cpu_ctx_task(@p)/get_task_ctx(p): the kernel invokes
these ops with @p's rq lock held but not necessarily on @p's CPU.

- [2/2] a1b5b3993 scx_lavd: migrate hot ops to get_task_ctx_curcpu()

Signed-off-by: Changwoo Min <changwoo@igalia.com>
