### PR TITLE
ci: disable scx_p2dq and scx_chaos veristat on bpf-next

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
           - name: scx__bpf__bpf-next
             url: https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git
             tag: master
+            veristat-disable: scx_p2dq scx_chaos
     runs-on: ubuntu-24.04
     timeout-minutes: 35
     continue-on-error: true
@@ -153,6 +154,15 @@ jobs:
           sudo cp /tmp/veristat/src/veristat /usr/local/bin/
           sudo setcap cap_bpf,cap_perfmon+ep /usr/local/bin/veristat
           cargo install cargo-veristat --locked
+      - name: Disable veristat for excluded packages
+        if: matrix.kernel.veristat-disable != ''
+        run: |
+          for pkg in ${{ matrix.kernel.veristat-disable }}; do
+            manifest=$(cargo metadata --format-version 1 --no-deps | jq -r ".packages[] | select(.name == \"$pkg\") | .manifest_path")
+            if [ -n "$manifest" ]; then
+              printf '\n[package.metadata.veristat]\ndisable = true\n' >> "$manifest"
+            fi
+          done
       - name: Build packages and generate metadata
         run: |
           cargo build --profile ci --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
           - name: scx__sched_ext__for-next
             url: https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git
             tag: for-next
+            veristat-disable: scx_p2dq scx_chaos
           - name: scx__bpf__bpf-next
             url: https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git
             tag: master


### PR DESCRIPTION
Mirrors the existing veristat-disable pattern already used by the gating veristat job for scx_layered/scx_lavd/scx_arena_selftests. The bpf-next veristat job (continue-on-error) was reporting verifier rejections for p2dq_select_cpu/enqueue/update_idle and the equivalent chaos programs even though the same BPF objects load and run cleanly under the same kernel via the actual scheduler binaries (verified with vng on bpf-next/master @ 2ca6723a5f7b).