### PR TITLE
scheds/experimental/scx_flow: v2.2.4 — priority-aware rt_sensitive and relaxed preempt threshold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "scx_flow"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "scx_flow"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "scx_flow"
-version = "2.2.0"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/scheds/experimental/scx_flow/Cargo.toml
+++ b/scheds/experimental/scx_flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_flow"
-version = "2.2.3"
+version = "2.2.4"
 authors = ["Galih Tama <galpt@v.recipes>"]
 edition = "2021"
 description = "A multi-lane budget-based sched_ext scheduler for interactive responsiveness and general-purpose throughput. https://github.com/sched-ext/scx/tree/main"

--- a/scheds/experimental/scx_flow/Cargo.toml
+++ b/scheds/experimental/scx_flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_flow"
-version = "2.2.0"
+version = "2.2.2"
 authors = ["Galih Tama <galpt@v.recipes>"]
 edition = "2021"
 description = "A multi-lane budget-based sched_ext scheduler for interactive responsiveness and general-purpose throughput. https://github.com/sched-ext/scx/tree/main"

--- a/scheds/experimental/scx_flow/Cargo.toml
+++ b/scheds/experimental/scx_flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_flow"
-version = "2.2.2"
+version = "2.2.3"
 authors = ["Galih Tama <galpt@v.recipes>"]
 edition = "2021"
 description = "A multi-lane budget-based sched_ext scheduler for interactive responsiveness and general-purpose throughput. https://github.com/sched-ext/scx/tree/main"

--- a/scheds/experimental/scx_flow/README.md
+++ b/scheds/experimental/scx_flow/README.md
@@ -57,6 +57,22 @@ https://github.com/galpt/testing-scx_flow
 Direct `v2.2.3` benchmark snapshot:
 https://github.com/galpt/testing-scx_flow/tree/benchmark-archives/20260409_scx_flow_v2.2.0_release
 
+## Changelog
+
+### v2.2.4 — fix rt_sensitive_ready predicate regression
+
+The v2.2.3 change that relaxed the rt_sensitive_ready condition contained
+a logical error: any task with 80 us or more of recent refill qualified as
+RT-sensitive, regardless of whether it was genuinely RT-classified
+(SCHED_FIFO/RR or pinned to a single CPU). This caused regular periodic
+tasks such as cyclictest to be blocked from the latency lane and forced
+into the preemption-based RT path with 50 us slices, regressing max
+latency from 173 us (v2.2.0) to 476 us (v2.2.3) in the 100 us benchmark.
+
+The refill threshold is now properly ANDed with the genuine RT
+classification instead of being a standalone OR condition, restoring the
+intended behaviour:
+
 In practice, the stronger results there usually translate to better foreground
 responsiveness, steadier behavior under background load, and fewer obvious
 hiccups when interactive and CPU-heavy work happen at the same time.

--- a/scheds/experimental/scx_flow/README.md
+++ b/scheds/experimental/scx_flow/README.md
@@ -54,24 +54,8 @@ Benchmark scripts, validation helpers, and archived result bundles used during
 development are available at:
 https://github.com/galpt/testing-scx_flow
 
-Direct `v2.2.3` benchmark snapshot:
+Direct `v2.2.4` benchmark snapshot:
 https://github.com/galpt/testing-scx_flow/tree/benchmark-archives/20260409_scx_flow_v2.2.0_release
-
-## Changelog
-
-### v2.2.4 — fix rt_sensitive_ready predicate regression
-
-The v2.2.3 change that relaxed the rt_sensitive_ready condition contained
-a logical error: any task with 80 us or more of recent refill qualified as
-RT-sensitive, regardless of whether it was genuinely RT-classified
-(SCHED_FIFO/RR or pinned to a single CPU). This caused regular periodic
-tasks such as cyclictest to be blocked from the latency lane and forced
-into the preemption-based RT path with 50 us slices, regressing max
-latency from 173 us (v2.2.0) to 476 us (v2.2.3) in the 100 us benchmark.
-
-The refill threshold is now properly ANDed with the genuine RT
-classification instead of being a standalone OR condition, restoring the
-intended behaviour:
 
 In practice, the stronger results there usually translate to better foreground
 responsiveness, steadier behavior under background load, and fewer obvious

--- a/scheds/experimental/scx_flow/README.md
+++ b/scheds/experimental/scx_flow/README.md
@@ -54,7 +54,7 @@ Benchmark scripts, validation helpers, and archived result bundles used during
 development are available at:
 https://github.com/galpt/testing-scx_flow
 
-Direct `v2.2.2` benchmark snapshot:
+Direct `v2.2.3` benchmark snapshot:
 https://github.com/galpt/testing-scx_flow/tree/benchmark-archives/20260409_scx_flow_v2.2.0_release
 
 In practice, the stronger results there usually translate to better foreground

--- a/scheds/experimental/scx_flow/README.md
+++ b/scheds/experimental/scx_flow/README.md
@@ -54,7 +54,7 @@ Benchmark scripts, validation helpers, and archived result bundles used during
 development are available at:
 https://github.com/galpt/testing-scx_flow
 
-Direct `v2.2.0` benchmark snapshot:
+Direct `v2.2.2` benchmark snapshot:
 https://github.com/galpt/testing-scx_flow/tree/benchmark-archives/20260409_scx_flow_v2.2.0_release
 
 In practice, the stronger results there usually translate to better foreground

--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -699,8 +699,7 @@ static __always_inline void recompute_wake_profile(const struct task_struct *p,
 		tctx->last_refill_ns >= (s64)FLOW_INTERACTIVE_FLOOR_MIN_NS;
 	preempt_ready = !containment_active &&
 		(p->nr_cpus_allowed == 1 ||
-		 (tctx->last_refill_ns >= (s64)preempt_refill_min_ns &&
-		  tctx->budget_ns >= (s64)preempt_budget_min_ns));
+		 tctx->budget_ns >= (s64)preempt_budget_min_ns);
 	latency_lane_ready = (allowance_ready || pressure_ready) &&
 		!rt_sensitive_ready;
 
@@ -1371,7 +1370,8 @@ void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 				 has_wake_profile(tctx, WAKE_PROFILE_PREEMPT_READY));
 
 			use_local_reserved = should_preempt || direct_local_wakeup ||
-				ipc_confidence_wakeup;
+				ipc_confidence_wakeup ||
+				(tctx->wake_cpu_idle && is_wakeup);
 			ordinary_local_reserved = use_local_reserved && !should_preempt;
 
 			if (ordinary_local_reserved &&

--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -695,9 +695,8 @@ static __always_inline void recompute_wake_profile(const struct task_struct *p,
 		has_urgent_latency_pressure(tctx);
 	rt_sensitive_ready = !containment_active &&
 		tctx->last_refill_ns > 0 &&
-		(p->nr_cpus_allowed == 1 ||
-		 p->prio < 100 ||
-		 tctx->last_refill_ns >= (s64)FLOW_INTERACTIVE_FLOOR_MIN_NS);
+		(p->nr_cpus_allowed == 1 || p->prio < 100) &&
+		tctx->last_refill_ns >= (s64)FLOW_INTERACTIVE_FLOOR_MIN_NS;
 	preempt_ready = !containment_active &&
 		(p->nr_cpus_allowed == 1 ||
 		 tctx->budget_ns >= (s64)preempt_budget_min_ns);

--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -1361,6 +1361,31 @@ void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 		if (is_wakeup && !containment_active)
 			enq_flags |= SCX_ENQ_HEAD;
 
+		/*
+		 * Short-sleep fast path: tasks that have been sleeping for less
+		 * than FLOW_INTERACTIVE_SLEEP_MIN_NS are extremely high-frequency
+		 * wakeups (e.g. cyclictest, timer-driven periodic work).  They
+		 * should bypass all lane analysis and be dispatched directly to
+		 * the target CPU's local DSQ with a minimal slice.
+		 *
+		 * A positive accumulated budget is sufficient evidence of
+		 * responsiveness — the refill and lane gates only add per-wakeup
+		 * BPF overhead without changing the outcome for such tasks.
+		 */
+		if (is_wakeup && tctx && tctx->budget_ns > 0 &&
+		    !containment_active &&
+		    tctx->last_sleep_ns > 0 &&
+		    tctx->last_sleep_ns <= FLOW_INTERACTIVE_SLEEP_MIN_NS &&
+		    (has_wake_target ||
+		     (target_cpu >= 0 && bpf_cpumask_test_cpu(target_cpu, p->cpus_ptr)))) {
+			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | target_cpu,
+					   FLOW_SLICE_MIN_NS,
+					   enq_flags | SCX_ENQ_HEAD);
+			FLOW_CPUSTAT_INC(cstate, local_fast_dispatches);
+			clear_wake_target(tctx);
+			return;
+		}
+
 		if (has_wake_target ||
 		    (target_cpu >= 0 && bpf_cpumask_test_cpu(target_cpu, p->cpus_ptr))) {
 			bool should_preempt;

--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -694,9 +694,10 @@ static __always_inline void recompute_wake_profile(const struct task_struct *p,
 	pressure_ready = !containment_active &&
 		has_urgent_latency_pressure(tctx);
 	rt_sensitive_ready = !containment_active &&
-		p->nr_cpus_allowed == 1 &&
 		tctx->last_refill_ns > 0 &&
-		tctx->last_refill_ns >= (s64)FLOW_INTERACTIVE_FLOOR_MIN_NS;
+		(p->nr_cpus_allowed == 1 ||
+		 p->prio < 100 ||
+		 tctx->last_refill_ns >= (s64)FLOW_INTERACTIVE_FLOOR_MIN_NS);
 	preempt_ready = !containment_active &&
 		(p->nr_cpus_allowed == 1 ||
 		 tctx->budget_ns >= (s64)preempt_budget_min_ns);
@@ -1360,31 +1361,6 @@ void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 
 		if (is_wakeup && !containment_active)
 			enq_flags |= SCX_ENQ_HEAD;
-
-		/*
-		 * Short-sleep fast path: tasks that have been sleeping for less
-		 * than FLOW_INTERACTIVE_SLEEP_MIN_NS are extremely high-frequency
-		 * wakeups (e.g. cyclictest, timer-driven periodic work).  They
-		 * should bypass all lane analysis and be dispatched directly to
-		 * the target CPU's local DSQ with a minimal slice.
-		 *
-		 * A positive accumulated budget is sufficient evidence of
-		 * responsiveness — the refill and lane gates only add per-wakeup
-		 * BPF overhead without changing the outcome for such tasks.
-		 */
-		if (is_wakeup && tctx && tctx->budget_ns > 0 &&
-		    !containment_active &&
-		    tctx->last_sleep_ns > 0 &&
-		    tctx->last_sleep_ns <= FLOW_INTERACTIVE_SLEEP_MIN_NS &&
-		    (has_wake_target ||
-		     (target_cpu >= 0 && bpf_cpumask_test_cpu(target_cpu, p->cpus_ptr)))) {
-			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | target_cpu,
-					   FLOW_SLICE_MIN_NS,
-					   enq_flags | SCX_ENQ_HEAD);
-			FLOW_CPUSTAT_INC(cstate, local_fast_dispatches);
-			clear_wake_target(tctx);
-			return;
-		}
 
 		if (has_wake_target ||
 		    (target_cpu >= 0 && bpf_cpumask_test_cpu(target_cpu, p->cpus_ptr))) {

--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -1370,8 +1370,7 @@ void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 				 has_wake_profile(tctx, WAKE_PROFILE_PREEMPT_READY));
 
 			use_local_reserved = should_preempt || direct_local_wakeup ||
-				ipc_confidence_wakeup ||
-				(tctx->wake_cpu_idle && is_wakeup);
+				ipc_confidence_wakeup;
 			ordinary_local_reserved = use_local_reserved && !should_preempt;
 
 			if (ordinary_local_reserved &&


### PR DESCRIPTION
## Summary

This is an incremental update on top of the `scx_flow v2.2.0` scheduler that
landed in PR #3525.  It carries two changes since that submission, both aimed
at improving worst-case wakeup latency without adding code paths that bypass
the existing lane analysis or containment machinery:

- **Priority-aware rt_sensitive** — the `rt_sensitive_ready` condition now
  checks `p->prio` so that kernel RT-class tasks (SCHED_FIFO / SCHED_RR at
  any priority) qualify for `WAKE_PROFILE_RT_SENSITIVE` on sufficient refill,
  rather than needing the combination of being pinned and having the 80us
  refill floor.  Fixed in v2.2.4: the refill threshold is properly ANDed with
  the genuine RT classification `(pinned || prio < 100)` so well-refilled
  SCHED_OTHER tasks are not falsely classified as RT-sensitive.
- **Relaxed preempt_ready refill check** — the original `preempt_ready`
  condition required both `last_refill_ns >= preempt_refill_min_ns` (200us)
  and `budget_ns >= preempt_budget_min_ns` (150us).  For short-interval
  wakeups such as cyclictest at 200us the per-wakeup refill is only
  `sleep_ns / 100 = 2us`, far below the 200us threshold.  Dropped the
  refill gate so that accumulated positive budget alone qualifies a task for
  the preempt path.

## Changes

The BPF changes are confined to one function in `main.bpf.c`.

### 1. Priority-aware rt_sensitive (v2.2.3, fixed in v2.2.4)

```c
// v2.2.0 baseline — pinned + refill >= 80us
p->nr_cpus_allowed == 1 &&
tctx->last_refill_ns > 0 &&
tctx->last_refill_ns >= (s64)FLOW_INTERACTIVE_FLOOR_MIN_NS

// v2.2.3 (buggy) — last_refill_ns >= 80us was a standalone OR
tctx->last_refill_ns > 0 &&
(p->nr_cpus_allowed == 1 ||
 p->prio < 100 ||
 tctx->last_refill_ns >= (s64)FLOW_INTERACTIVE_FLOOR_MIN_NS)

// v2.2.4 (fixed) — refill threshold ANDed with RT classification
tctx->last_refill_ns > 0 &&
(p->nr_cpus_allowed == 1 || p->prio < 100) &&
tctx->last_refill_ns >= (s64)FLOW_INTERACTIVE_FLOOR_MIN_NS
```

`p->prio < 100` identifies kernel SCHED_FIFO and SCHED_RR tasks (which have
priority 0--99).

### 2. Relaxed preempt_ready refill check

```c
// before
(tctx->last_refill_ns >= (s64)preempt_refill_min_ns &&
 tctx->budget_ns >= (s64)preempt_budget_min_ns)

// after
tctx->budget_ns >= (s64)preempt_budget_min_ns
```

The idle-CPU local-reserved path that was present in v2.2.2/v2.2.3 has been
removed — it bypassed the latency lane routing, causing periodic tasks to
lose their priority dispatch slot.  The net submission only carries the two
changes above.

## Benchmark Results

Full tagged artifacts (PNG, SVG, CSV, report):
<https://github.com/galpt/testing-scx_flow/tree/benchmark-archives/20260409_scx_flow_v2.2.0_release/mini/v2.2.4>

All runs on CachyOS 7.0.3-1-cachyos, 16-core AMD system, Balanced power profile.

### Normal mode (cyclictest -D 30 -t 4 -a 0 -m -v)

| Scheduler | Max Latency (us) | Spikes >100us |
|-----------|-----------------|---------------|
| baseline (CFS/EEVDF) | 1106 | 304 |
| scx_cosmos | 852 | 821 |
| scx_bpfland | 2724 | 222 |
| **scx_flow v2.2.4** | **142** | **2** |

### Hard RT mode (cyclictest --priority=99 --smp --interval=200 --histogram=20)

| Scheduler | Overflows >20us | Max Latency (us) |
|-----------|----------------|-------------------|
| baseline (CFS/EEVDF) | 344 | 407 |
| scx_cosmos | 351 | 227 |
| scx_bpfland | 376 | 375 |
| **scx_flow v2.2.4** | **402** | **339** |

Note: hard RT cyclictest runs at SCHED_FIFO 99 which is dispatched by the
kernel's rt_sched_class, not by ext_sched_class.  The hard RT results reflect
system noise under SCX background load rather than the scheduler policy
itself, and are consistent across all tested schedulers.

## Files Changed

```
 Cargo.lock                                      | 2 +-
 scheds/experimental/scx_flow/Cargo.toml         | 2 +-
 scheds/experimental/scx_flow/README.md          | 2 +-
 scheds/experimental/scx_flow/src/bpf/main.bpf.c | 5 ++---
 4 files changed, 4 insertions(+), 5 deletions(-)
```

Signed-off-by: Galih Tama <galpt@v.recipes>