### PR TITLE
scx_cargo: Enforce pahole >= 1.26

### DIFF
--- a/rust/scx_cargo/src/bpf_builder.rs
+++ b/rust/scx_cargo/src/bpf_builder.rs
@@ -249,6 +249,8 @@ impl BpfBuilder {
     /// configure and `build` method to compile and generate bindings. See
     /// the struct documentation for details.
     pub fn new() -> Result<Self> {
+        crate::pahole_info::check()?;
+
         let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
         let clang = ClangInfo::new()?;

--- a/rust/scx_cargo/src/lib.rs
+++ b/rust/scx_cargo/src/lib.rs
@@ -6,5 +6,7 @@
 mod clang_info;
 pub use clang_info::ClangInfo;
 
+mod pahole_info;
+
 mod bpf_builder;
 pub use bpf_builder::BpfBuilder;

--- a/rust/scx_cargo/src/pahole_info.rs
+++ b/rust/scx_cargo/src/pahole_info.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 NVIDIA Corporation.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use std::env;
+use std::process::Command;
+
+use anyhow::{bail, Result};
+
+const MIN_PAHOLE_VERSION: &str = "1.26";
+const SKIP_ENV: &str = "SCX_SKIP_PAHOLE_CHECK";
+
+/// Verify that pahole on the build host is recent enough to produce correct BTF for kfuncs
+/// annotated with KF_IMPLICIT_ARGS (e.g., scx_bpf_cpu_rq).
+///
+/// pahole < 1.26 omits the DECL_TAG entries for __bpf_kfunc functions that resolve_btfids needs in
+/// order to split a kfunc into its public-facing prototype (without implicit args) and the matching
+/// `_impl` variant (with the full prototype). Without that split, the visible BTF prototype keeps
+/// the implicit argument and libbpf rejects the BPF program with:
+///
+///   libbpf: extern (func ksym) 'scx_bpf_cpu_rq': func_proto [N] incompatible with vmlinux [M]
+///
+/// This affects e.g. Ubuntu 24.04 LTS (pahole 1.25). See kernel commit 9edd04c4189e ("docs: Raise
+/// minimum pahole version to 1.26 for KF_IMPLICIT_ARGS kfuncs").
+///
+/// Set SCX_SKIP_PAHOLE_CHECK=1 to skip this check (useful when the running kernel was built on a
+/// different machine with a newer pahole).
+pub fn check() -> Result<()> {
+    println!("cargo:rerun-if-env-changed={SKIP_ENV}");
+
+    if env::var_os(SKIP_ENV).is_some() {
+        return Ok(());
+    }
+
+    let output = match Command::new("pahole").arg("--version").output() {
+        Ok(o) => o,
+        // pahole isn't installed: it can't have built the running kernel
+        // with a too-old version. Skip silently.
+        Err(_) => return Ok(()),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let raw = stdout.lines().next().unwrap_or("").trim();
+    let ver = raw
+        .trim_start_matches('v')
+        .split_whitespace()
+        .next()
+        .unwrap_or("");
+
+    if ver.is_empty() || !ver.chars().next().unwrap().is_ascii_digit() {
+        println!("cargo:warning=could not parse pahole version: {raw:?}");
+        return Ok(());
+    }
+
+    if version_compare::compare(ver, MIN_PAHOLE_VERSION) == Ok(version_compare::Cmp::Lt) {
+        bail!(
+            "pahole >= {MIN_PAHOLE_VERSION} required (found {ver}).\n\
+             \n\
+             pahole < 1.26 generates incorrect BTF for kfuncs annotated with\n\
+             KF_IMPLICIT_ARGS (e.g. scx_bpf_cpu_rq), which causes BPF programs\n\
+             to fail to load with 'func_proto incompatible with vmlinux'.\n\
+             \n\
+             Affected distros include Ubuntu 24.04 LTS. See kernel commit\n\
+             9edd04c4189e (\"docs: Raise minimum pahole version to 1.26 for\n\
+             KF_IMPLICIT_ARGS kfuncs\") for details.\n\
+             \n\
+             Fix: upgrade pahole and rebuild the kernel, or set\n\
+             {SKIP_ENV}=1 if the running kernel was built elsewhere with a\n\
+             newer pahole."
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Schedulers built against a kernel produced by pahole < 1.26 fail at runtime with a confusing libbpf error:
```
  libbpf: extern (func ksym) 'scx_bpf_cpu_rq': func_proto [N] incompatible with vmlinux [M]
  libbpf: failed to load BPF skeleton 'bpf_bpf': -EINVAL
  Error: Failed to load BPF program
```
The root cause is that pahole < 1.26 does not emit DECL_TAG entries for __bpf_kfunc functions (it is missing the --btf_features=decl_tag_kfuncs option that scripts/Makefile.btf only enables for pahole >= 1.26).

Without those tags, resolve_btfids short-circuits in collect_kfuncs() and never splits a KF_IMPLICIT_ARGS kfunc into its public-facing prototype (without the implicit 'struct bpf_prog_aux *') and the matching _impl variant (with the full prototype). The visible BTF prototype keeps the implicit argument, so when libbpf compares it against the BPF program's 1-arg declaration the two are flagged as incompatible and the skeleton fails to load.

Many sched_ext kfuncs are affected (scx_bpf_cpu_rq, scx_bpf_create_dsq, scx_bpf_kick_cpu, ...). The most common environment hitting this is Ubuntu 24.04 LTS, which ships pahole 1.25. The kernel itself bumped its documented minimum to 1.26 in commit 9edd04c4189e ("docs: Raise minimum pahole version to 1.26 for KF_IMPLICIT_ARGS kfuncs").

Catch this at build time to get a clear error instead of chasing a quite obscure runtime BPF load failure. Add a pahole version check to BpfBuilder::new() that all scheds_ext schedulers go through:

  - pahole not installed: skip silently (cross-build is a valid case and the local pahole is irrelevant).
  - pahole >= 1.26: silent pass.
  - pahole < 1.26: bail with a clear message explaining the failure mode, the affected distros, and the kernel commit reference.
  - SCX_SKIP_PAHOLE_CHECK=1 in env: skip the check, for cases where the running kernel was built on a different machine with a newer pahole.