### PR TITLE
scx_flash: Disable sleep-intensive tasks penalization by default

### DIFF
--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -47,6 +47,9 @@ const volatile bool debug;
 /* Enable round-robin mode */
 const volatile bool rr_sched;
 
+/* Throttle tasks that abuse the wakeup-frequency boost */
+const volatile bool wakeup_throttle;
+
 /* Primary domain includes all CPU */
 const volatile bool primary_all = true;
 
@@ -393,7 +396,8 @@ static u64 task_dl(struct task_struct *p, struct task_ctx *tctx, u64 enq_flags)
 	 * by charging them @slice_lag, excluding per-CPU kthreads, which may
 	 * legitimately exhibit sleep-intensive behavior.
 	 */
-	if ((!is_kthread(p) || p->nr_cpus_allowed > 1) &&
+	if (wakeup_throttle &&
+	    (!is_kthread(p) || p->nr_cpus_allowed > 1) &&
 	    tctx->slice_ns_ewma && tctx->slice_ns_ewma < SLICE_MIN_NS)
 		vtime += slice_lag;
 

--- a/scheds/rust/scx_flash/src/main.rs
+++ b/scheds/rust/scx_flash/src/main.rs
@@ -194,6 +194,15 @@ struct Opts {
     #[clap(short = 'R', long, action = clap::ArgAction::SetTrue)]
     rr_sched: bool,
 
+    /// Throttle tasks that abuse the wakeup-frequency prioritization.
+    ///
+    /// When enabled, tasks whose exponentially weighted moving average (EWMA) of the time slice
+    /// used falls below the minimum slice are charged an extra `slice_lag` of vruntime, reducing
+    /// the priority boost they receive from frequent wakeups. This mechanism prevents giving too
+    /// much priority to tasks that may abuse the sleep/wakeup frequency prioritization.
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    wakeup_throttle: bool,
+
     /// Specifies the initial set of CPUs, represented as a bitmask in hex (e.g., 0xff), that the
     /// scheduler will use to dispatch tasks, until the system becomes saturated, at which point
     /// tasks may overflow to other available CPUs.
@@ -337,6 +346,7 @@ impl<'a> Scheduler<'a> {
         rodata.smt_enabled = smt_enabled;
         rodata.numa_disabled = numa_disabled;
         rodata.rr_sched = opts.rr_sched;
+        rodata.wakeup_throttle = opts.wakeup_throttle;
         rodata.tickless_sched = opts.tickless;
         rodata.slice_max = opts.slice_us * 1000;
         rodata.slice_lag = opts.slice_us_lag * 1000;


### PR DESCRIPTION
In task_dl() a task whose average consumed time slice falls below SLICE_MIN_NS is charged an extra slice_lag of vruntime, effectively cancelling the sleep credit it would otherwise receive on wakeup.

The intent is to suppress tasks abusing the wakeup-frequency prioritization (sleep briefly, wake briefly, repeat) from monopolizing the CPU via the @exec_vruntime reset on wakeup.

In practice the heuristic also hits genuinely latency-sensitive workloads that legitimately use very short bursts of CPU (UI threads, audio, message passing, etc.), which are exactly the tasks scx_flash is designed to prioritize. The sleep credit is already bounded by slice_lag through the vtime_min clamp, so the additional penalty can produce collateral damage on interactive workloads.

Disable the penalization by default and gate it behind a new --wakeup-throttle command line option for the workloads where the abuse pattern is actually a concern.

This should also prevent scx_flash failures in the CI.