### PR TITLE
scx_mitosis: Introduce subcell support and profile config ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,6 +3891,7 @@ dependencies = [
  "libc",
  "maplit",
  "nix 0.31.2",
+ "regex",
  "scx_cargo",
  "scx_stats",
  "scx_stats_derive",

--- a/scheds/rust/scx_mitosis/.clang-format
+++ b/scheds/rust/scx_mitosis/.clang-format
@@ -803,4 +803,12 @@ SpacesInSquareBrackets: false
 Standard: Cpp03
 TabWidth: 8
 UseTab: Always
+WhitespaceSensitiveMacros:
+  - '__uint'
+  - '_Static_assert'
+  - 'BOOST_PP_STRINGIZE'
+  - 'CF_SWIFT_NAME'
+  - 'NS_SWIFT_NAME'
+  - 'PP_STRINGIZE'
+  - 'STRINGIZE'
 ...

--- a/scheds/rust/scx_mitosis/Cargo.toml
+++ b/scheds/rust/scx_mitosis/Cargo.toml
@@ -23,6 +23,7 @@ inotify = "0.11"
 nix = { version = "0.31", features = ["event"] }
 crossbeam = "0.8"
 maplit = "1"
+regex = "1"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.1.1" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.1.1" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.1.1" }

--- a/scheds/rust/scx_mitosis/src/bpf/cell_cpumask.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/cell_cpumask.bpf.h
@@ -66,7 +66,7 @@ struct subcell_cpumask_map {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__type(key, u32);
 	__type(value, struct cell_cpumask_wrapper);
-	__uint(max_entries, MAX_CELLS *MAX_SUBCELLS_PER_CELL);
+	__uint(max_entries, MAX_CELLS * MAX_SUBCELLS_PER_CELL);
 	__uint(map_flags, 0);
 };
 

--- a/scheds/rust/scx_mitosis/src/bpf/cell_cpumask.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/cell_cpumask.bpf.h
@@ -62,7 +62,16 @@ struct cell_cpumask_map {
 	__uint(map_flags, 0);
 };
 
+struct subcell_cpumask_map {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, u32);
+	__type(value, struct cell_cpumask_wrapper);
+	__uint(max_entries, MAX_CELLS *MAX_SUBCELLS_PER_CELL);
+	__uint(map_flags, 0);
+};
+
 extern struct cell_cpumask_map cell_cpumasks;
+extern struct subcell_cpumask_map subcell_cpumasks;
 extern const volatile u32 nr_possible_cpus;
 
 /* Strict lookup of the per-cell cpumask pair group stored in the cell_cpumasks map. */
@@ -107,6 +116,70 @@ static inline const struct cpumask *lookup_cell_borrowable_cpumask(int idx)
 	cpumask = (const struct cpumask *)cpumaskw->borrowable.cpumask;
 	if (!cpumask)
 		scx_bpf_error("borrowable cpumask is NULL for cell %d", idx);
+
+	return cpumask;
+}
+
+static inline int subcell_cpumask_idx(u32 cell_id, u32 subcell_id)
+{
+	if (cell_id >= MAX_CELLS || subcell_id >= MAX_SUBCELLS_PER_CELL)
+		return -EINVAL;
+	return (cell_id * MAX_SUBCELLS_PER_CELL) + subcell_id;
+}
+
+static inline struct cell_cpumask_wrapper *lookup_subcell_cpumask_wrapper(u32 cell_id,
+									  u32 subcell_id)
+{
+	int idx;
+	u32 key;
+	struct cell_cpumask_wrapper *cpumaskw;
+
+	idx = subcell_cpumask_idx(cell_id, subcell_id);
+	if (idx < 0) {
+		scx_bpf_error("invalid subcell cpumask index cell=%u subcell=%u", cell_id,
+			      subcell_id);
+		return NULL;
+	}
+
+	key = idx;
+	cpumaskw = bpf_map_lookup_elem(&subcell_cpumasks, &key);
+	if (!cpumaskw)
+		scx_bpf_error("no subcell cpumask wrapper for cell=%u subcell=%u", cell_id,
+			      subcell_id);
+
+	return cpumaskw;
+}
+
+static inline const struct cpumask *lookup_subcell_cpumask(u32 cell_id, u32 subcell_id)
+{
+	struct cell_cpumask_wrapper *cpumaskw;
+	const struct cpumask *cpumask;
+
+	cpumaskw = lookup_subcell_cpumask_wrapper(cell_id, subcell_id);
+	if (!cpumaskw)
+		return NULL;
+
+	cpumask = (const struct cpumask *)cpumaskw->primary.cpumask;
+	if (!cpumask)
+		scx_bpf_error("subcell cpumask is NULL for cell=%u subcell=%u", cell_id,
+			      subcell_id);
+
+	return cpumask;
+}
+
+static inline const struct cpumask *lookup_subcell_borrowable_cpumask(u32 cell_id, u32 subcell_id)
+{
+	struct cell_cpumask_wrapper *cpumaskw;
+	const struct cpumask *cpumask;
+
+	cpumaskw = lookup_subcell_cpumask_wrapper(cell_id, subcell_id);
+	if (!cpumaskw)
+		return NULL;
+
+	cpumask = (const struct cpumask *)cpumaskw->borrowable.cpumask;
+	if (!cpumask)
+		scx_bpf_error("subcell borrowable cpumask is NULL for cell=%u subcell=%u", cell_id,
+			      subcell_id);
 
 	return cpumask;
 }

--- a/scheds/rust/scx_mitosis/src/bpf/dsq.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/dsq.bpf.h
@@ -5,7 +5,7 @@
  *
  * This header defines the 64-bit dispatch queue (DSQ) ID encoding
  * scheme for scx_mitosis, using type fields to distinguish between
- * per-CPU and cell+LLC domain queues. It includes helper functions to
+ * per-CPU and subcell+LLC queues. It includes helper functions to
  * construct, validate, and parse these DSQ IDs for queue management.
  */
 #pragma once
@@ -50,10 +50,13 @@
  *       [ 0001 ] [          CPU#            ]
  *       [Q-TYPE:1]
  *
- *     QTYPE = 0x2 -> Cell+LLC Q
+ *     QTYPE = 0x2 -> Subcell+LLC Q
  *       [31..28] [27 .. 16] [15      ..    0]
- *       [ 0010 ] [  CELL# ] [     LLCID     ]
+ *       [ 0010 ] [ SUBCELL] [     LLCID     ]
  *       [Q-TYPE:2]
+ *
+ *       SUBCELL is a packed subcell ID:
+ *         cell * MAX_SUBCELLS_PER_CELL + subcell
  *
  */
 /*
@@ -71,14 +74,15 @@
 /* ---- Bitfield widths (bits) ---- */
 #define CPU_B 28
 #define LLC_B 16
-#define CELL_B 12
+#define SUBCELL_B 12
 #define TYPE_B 4
 #define DATA_B 28
 #define RSVD_B 32
 
 /* Sum checks (in bits) */
 _Static_assert(CPU_B + TYPE_B == 32, "CPU layout low half must be 32 bits");
-_Static_assert(LLC_B + CELL_B + TYPE_B == 32, "CELL+LLC layout low half must be 32 bits");
+_Static_assert(LLC_B + SUBCELL_B + TYPE_B == 32,
+	       "subcell+LLC layout low half must be 32 bits");
 _Static_assert(DATA_B + TYPE_B == 32, "Common layout low half must be 32 bits");
 
 typedef union {
@@ -91,13 +95,13 @@ typedef union {
 		u64 rsvd : RSVD_B;
 	} cpu_dsq;
 
-	/* Cell+LLC user DSQ */
+	/* Subcell+LLC user DSQ */
 	struct {
 		u64 llc : LLC_B;
-		u64 cell : CELL_B;
+		u64 subcell : SUBCELL_B;
 		u64 type : TYPE_B;
 		u64 rsvd : RSVD_B;
-	} cell_llc_dsq;
+	} subcell_llc_dsq;
 
 	/* Generic user view */
 	struct {
@@ -124,8 +128,8 @@ typedef union {
 #define DSQ_INVALID ((dsq_id_t){ 0 })
 
 _Static_assert(sizeof(((dsq_id_t){ 0 }).cpu_dsq) == sizeof(u64), "cpu view must be 8 bytes");
-_Static_assert(sizeof(((dsq_id_t){ 0 }).cell_llc_dsq) == sizeof(u64),
-	       "cell+LLC view must be 8 bytes");
+_Static_assert(sizeof(((dsq_id_t){ 0 }).subcell_llc_dsq) == sizeof(u64),
+	       "subcell+LLC view must be 8 bytes");
 _Static_assert(sizeof(((dsq_id_t){ 0 }).user_dsq) == sizeof(u64),
 	       "user common view must be 8 bytes");
 _Static_assert(sizeof(((dsq_id_t){ 0 }).builtin_dsq) == sizeof(u64),
@@ -139,14 +143,15 @@ _Static_assert(_Alignof(dsq_id_t) == sizeof(u64), "dsq_id_t must be 8-byte align
 enum dsq_type {
 	DSQ_TYPE_NONE,
 	DSQ_TYPE_CPU,
-	DSQ_TYPE_CELL_LLC,
+	DSQ_TYPE_SUBCELL_LLC,
 };
 
 /* Range guards */
 _Static_assert(MAX_CPUS <= (1u << CPU_B), "MAX_CPUS must fit in field");
 _Static_assert(MAX_LLCS <= (1u << LLC_B), "MAX_LLCS must fit in field");
-_Static_assert(MAX_CELLS <= (1u << CELL_B), "MAX_CELLS must fit in field");
-_Static_assert(DSQ_TYPE_CELL_LLC < (1u << TYPE_B), "DSQ_TYPE_CELL_LLC must fit in field");
+_Static_assert(MAX_CELLS * MAX_SUBCELLS_PER_CELL <= (1u << SUBCELL_B),
+	       "packed subcell count must fit in field");
+_Static_assert(DSQ_TYPE_SUBCELL_LLC < (1u << TYPE_B), "DSQ_TYPE_SUBCELL_LLC must fit in field");
 
 static inline bool dsq_is_invalid(dsq_id_t dsq_id)
 {
@@ -187,13 +192,30 @@ static inline dsq_id_t get_cpu_dsq_id(u32 cpu)
 	return (dsq_id_t){ .cpu_dsq = { .cpu = cpu, .type = DSQ_TYPE_CPU } };
 }
 
-static inline dsq_id_t get_cell_llc_dsq_id(u32 cell, u32 llc)
+static inline s32 pack_subcell_id(u32 cell, u32 subcell)
 {
-	if (cell >= MAX_CELLS || llc >= MAX_LLCS) {
-		scx_bpf_error("cell %u or llc %u too large", cell, llc);
+	if (cell >= MAX_CELLS || subcell >= MAX_SUBCELLS_PER_CELL) {
+		scx_bpf_error("cell %u or subcell %u too large", cell, subcell);
+		return -EINVAL;
+	}
+
+	return (cell * MAX_SUBCELLS_PER_CELL) + subcell;
+}
+
+static inline dsq_id_t get_subcell_llc_dsq_id(u32 cell, u32 subcell, u32 llc)
+{
+	s32 packed_subcell;
+
+	if (llc >= MAX_LLCS) {
+		scx_bpf_error("llc %u too large", llc);
 		return DSQ_INVALID;
 	}
 
-	return (dsq_id_t){ .cell_llc_dsq = {
-				   .llc = llc, .cell = cell, .type = DSQ_TYPE_CELL_LLC } };
+	packed_subcell = pack_subcell_id(cell, subcell);
+	if (packed_subcell < 0)
+		return DSQ_INVALID;
+
+	return (dsq_id_t){ .subcell_llc_dsq = { .llc = llc,
+						.subcell = packed_subcell,
+						.type = DSQ_TYPE_SUBCELL_LLC } };
 }

--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -19,6 +19,9 @@ enum consts {
 	MAX_CPUS_U8 = MAX_CPUS / 8,
 	MAX_CELLS = 256,
 	MAX_SUBCELLS_PER_CELL = 8,
+	MAX_COMM = 16,
+	MAX_SUBCELL_MATCH_ORS = 4,
+	MAX_SUBCELL_MATCH_ANDS = 4,
 	USAGE_HALF_LIFE = 100000000, /* 100ms */
 	TIMER_INTERVAL_NS = 100000000, /* 100 ms */
 	CLOCK_BOOTTIME = 7,
@@ -82,6 +85,11 @@ enum cell_stat_idx {
 	NR_CSTATS,
 };
 
+enum subcell_match_kind {
+	SUBCELL_MATCH_NONE,
+	SUBCELL_MATCH_COMM_PREFIX,
+};
+
 struct cpu_ctx {
 	u64 cstats[MAX_CELLS][NR_CSTATS];
 	u64 cell_cycles[MAX_CELLS];
@@ -115,10 +123,22 @@ struct cell_cpumask_data {
 	unsigned char mask[MAX_CPUS_U8];
 };
 
+struct subcell_match {
+	u32 kind;
+	char value[MAX_COMM];
+};
+
+struct subcell_match_and_group {
+	u32 nr_matches;
+	struct subcell_match matches[MAX_SUBCELL_MATCH_ANDS];
+};
+
 /* Serialized subcell config shared between userspace and BPF. */
 struct subcell_config {
 	u32 id;
 	u32 in_use;
+	u32 nr_match_ors;
+	struct subcell_match_and_group matches[MAX_SUBCELL_MATCH_ORS];
 	struct cell_cpumask_data primary;
 	struct cell_cpumask_data borrowable;
 };
@@ -128,6 +148,8 @@ struct subcell {
 	u32 id;
 	u32 in_use;
 	u32 cpu_cnt;
+	u32 nr_match_ors;
+	struct subcell_match_and_group matches[MAX_SUBCELL_MATCH_ORS];
 	struct cell_cpumask_data primary;
 	struct cell_cpumask_data borrowable;
 	struct subcell_llc llcs[MAX_LLCS];

--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -88,6 +88,7 @@ struct cpu_ctx {
 	u64 running_ns[MAX_CELLS];
 	u64 vtime_now;
 	u32 cell;
+	u32 subcell;
 	u32 llc;
 };
 
@@ -100,26 +101,36 @@ struct cgrp_ctx {
  * Per-LLC data is cacheline-aligned to prevent false sharing when
  * CPUs on different LLCs update their vtime concurrently.
  */
-struct cell_llc {
+struct subcell_llc {
 	u64 vtime_now;
 	u32 cpu_cnt;
 } __attribute__((aligned(CACHELINE_SIZE)));
 
 // Ensure we don't have multiple of these on the same cacheline.
-_Static_assert(sizeof(struct cell_llc) >= CACHELINE_SIZE,
-	       "cell_llc must be at least one cache line");
+_Static_assert(sizeof(struct subcell_llc) >= CACHELINE_SIZE,
+	       "subcell_llc must be at least one cache line");
 
 /* Cell cpumask data for a single cell or subcell */
 struct cell_cpumask_data {
 	unsigned char mask[MAX_CPUS_U8];
 };
 
-/* Subcell state shared between kernel and userspace. */
-struct subcell {
+/* Serialized subcell config shared between userspace and BPF. */
+struct subcell_config {
 	u32 id;
 	u32 in_use;
 	struct cell_cpumask_data primary;
 	struct cell_cpumask_data borrowable;
+};
+
+/* Subcell state shared between kernel and userspace. */
+struct subcell {
+	u32 id;
+	u32 in_use;
+	u32 cpu_cnt;
+	struct cell_cpumask_data primary;
+	struct cell_cpumask_data borrowable;
+	struct subcell_llc llcs[MAX_LLCS];
 };
 
 // CELL_LOCK_T is a lock for kernel and padding for user.
@@ -154,9 +165,6 @@ struct cell {
 	// Number of CPUs in this cell
 	u32 cpu_cnt;
 
-	// Per-LLC data (cacheline-aligned)
-	struct cell_llc llcs[MAX_LLCS];
-
 	// Fixed-size subcell state owned by this cell.
 	struct subcell subcells[MAX_SUBCELLS_PER_CELL];
 };
@@ -173,8 +181,8 @@ _Static_assert(sizeof(((struct cell *)0)->lock) == 4, "lock/padding must be 4 by
 _Static_assert(_Alignof(CELL_LOCK_T) == 4, "lock/padding must be 4-byte aligned");
 
 // Verify these are the same size in both BPF and Rust.
-_Static_assert(sizeof(struct cell) == (CACHELINE_SIZE + (CACHELINE_SIZE * MAX_LLCS) +
-				       (sizeof(struct subcell) * MAX_SUBCELLS_PER_CELL)),
+_Static_assert(sizeof(struct cell) ==
+		       (CACHELINE_SIZE + (sizeof(struct subcell) * MAX_SUBCELLS_PER_CELL)),
 	       "struct cell size must be stable for Rust bindings");
 
 /* Cell assignment entry: maps a cgroup to a cell */
@@ -198,7 +206,7 @@ struct cell_config {
 	struct cell_assignment assignments[MAX_CELLS];
 	struct cell_cpumask_data cpumasks[MAX_CELLS];
 	struct cell_cpumask_data borrowable_cpumasks[MAX_CELLS];
-	struct subcell subcells[MAX_CELLS][MAX_SUBCELLS_PER_CELL];
+	struct subcell_config subcells[MAX_CELLS][MAX_SUBCELLS_PER_CELL];
 };
 
 #endif /* __INTF_H */

--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -154,9 +154,6 @@ struct cell {
 	// Number of CPUs in this cell
 	u32 cpu_cnt;
 
-	// Number of LLCs with at least one CPU in this cell
-	u32 llc_present_cnt;
-
 	// Per-LLC data (cacheline-aligned)
 	struct cell_llc llcs[MAX_LLCS];
 

--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -18,6 +18,7 @@ enum consts {
 	MAX_CPUS = 1 << MAX_CPUS_SHIFT,
 	MAX_CPUS_U8 = MAX_CPUS / 8,
 	MAX_CELLS = 256,
+	MAX_SUBCELLS_PER_CELL = 8,
 	USAGE_HALF_LIFE = 100000000, /* 100ms */
 	TIMER_INTERVAL_NS = 100000000, /* 100 ms */
 	CLOCK_BOOTTIME = 7,
@@ -108,6 +109,19 @@ struct cell_llc {
 _Static_assert(sizeof(struct cell_llc) >= CACHELINE_SIZE,
 	       "cell_llc must be at least one cache line");
 
+/* Cell cpumask data for a single cell or subcell */
+struct cell_cpumask_data {
+	unsigned char mask[MAX_CPUS_U8];
+};
+
+/* Subcell state shared between kernel and userspace. */
+struct subcell {
+	u32 id;
+	u32 in_use;
+	struct cell_cpumask_data primary;
+	struct cell_cpumask_data borrowable;
+};
+
 // CELL_LOCK_T is a lock for kernel and padding for user.
 #if !defined(__BINDGEN_RUNNING__)
 #define CELL_LOCK_T struct bpf_spin_lock
@@ -145,6 +159,9 @@ struct cell {
 
 	// Per-LLC data (cacheline-aligned)
 	struct cell_llc llcs[MAX_LLCS];
+
+	// Fixed-size subcell state owned by this cell.
+	struct subcell subcells[MAX_SUBCELLS_PER_CELL];
 };
 
 // Putting the lock first in the struct is our convention.
@@ -159,18 +176,14 @@ _Static_assert(sizeof(((struct cell *)0)->lock) == 4, "lock/padding must be 4 by
 _Static_assert(_Alignof(CELL_LOCK_T) == 4, "lock/padding must be 4-byte aligned");
 
 // Verify these are the same size in both BPF and Rust.
-_Static_assert(sizeof(struct cell) == (CACHELINE_SIZE + (CACHELINE_SIZE * MAX_LLCS)),
+_Static_assert(sizeof(struct cell) == (CACHELINE_SIZE + (CACHELINE_SIZE * MAX_LLCS) +
+				       (sizeof(struct subcell) * MAX_SUBCELLS_PER_CELL)),
 	       "struct cell size must be stable for Rust bindings");
 
 /* Cell assignment entry: maps a cgroup to a cell */
 struct cell_assignment {
 	u64 cgid; /* cgroup ID (from cgroup file inode) */
 	u32 cell_id; /* cell ID to assign */
-};
-
-/* Cell cpumask data for a single cell */
-struct cell_cpumask_data {
-	unsigned char mask[MAX_CPUS_U8];
 };
 
 /*
@@ -180,6 +193,7 @@ struct cell_cpumask_data {
  * BPF program invocation:
  * - Cell-to-cgroup assignments (which cgroups own which cells)
  * - Cell cpumasks (which CPUs belong to each cell)
+ * - Per-cell subcell cpumasks
  */
 struct cell_config {
 	u32 num_cell_assignments;
@@ -187,6 +201,7 @@ struct cell_config {
 	struct cell_assignment assignments[MAX_CELLS];
 	struct cell_cpumask_data cpumasks[MAX_CELLS];
 	struct cell_cpumask_data borrowable_cpumasks[MAX_CELLS];
+	struct subcell subcells[MAX_CELLS][MAX_SUBCELLS_PER_CELL];
 };
 
 #endif /* __INTF_H */

--- a/scheds/rust/scx_mitosis/src/bpf/llc_aware.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/llc_aware.bpf.h
@@ -55,22 +55,29 @@ static inline const struct cpumask *lookup_llc_cpumask(u32 llc)
 }
 
 /*
- * Recompute cell->llc_cpu_cnt[] for a cell cpumask.
+ * Recompute subcell->llcs[].cpu_cnt for a subcell cpumask.
  *
  * @cell_idx: The cell index to update LLC counts for
+ * @subcell_idx: The subcell index to update LLC counts for
  * @explicit_mask: If non-NULL, use this cpumask instead of looking up current
- *                 cell cpumask. This allows pre-calculating counts for a new
+ *                 subcell cpumask. This allows pre-calculating counts for a new
  *                 cpumask BEFORE swapping it in, avoiding race conditions.
  */
-static __always_inline int recalc_cell_llc_counts(u32 cell_idx, const struct cpumask *explicit_mask)
+static __always_inline int recalc_subcell_llc_counts(u32 cell_idx, u32 subcell_idx,
+						     const struct cpumask *explicit_mask)
 {
 	struct cell *cell = lookup_cell(cell_idx);
+	struct subcell *subcell;
 	if (!cell)
+		return -ENOENT;
+
+	subcell = lookup_subcell(cell_idx, subcell_idx);
+	if (!subcell)
 		return -ENOENT;
 
 	struct bpf_cpumask *tmp_mask __free(bpf_cpumask) = bpf_cpumask_create();
 	if (!tmp_mask) {
-		scx_bpf_error("recalc_cell_llc_counts: failed to create tmp mask");
+		scx_bpf_error("recalc_subcell_llc_counts: failed to create tmp mask");
 		return -ENOMEM;
 	}
 
@@ -82,7 +89,7 @@ static __always_inline int recalc_cell_llc_counts(u32 cell_idx, const struct cpu
 	if (explicit_mask) {
 		cell_mask = explicit_mask;
 	} else {
-		cell_mask = lookup_cell_cpumask(cell_idx); // RCU ptr
+		cell_mask = lookup_subcell_cpumask(cell_idx, subcell_idx); // RCU ptr
 		if (!cell_mask)
 			return -EINVAL;
 	}
@@ -99,19 +106,20 @@ static __always_inline int recalc_cell_llc_counts(u32 cell_idx, const struct cpu
 
 		llc_cpu_cnt_tmp[llc] = cnt;
 
-		// These are counted across the whole cell
+		// These are counted across the whole subcell.
 		total_cpus += cnt;
-
 	}
 
-	// Write to cell
+	// Write to subcell
 	scoped_guard(spin_lock, &cell->lock)
 	{
 		for (u32 llc_idx = 0; llc_idx < nr_llc; llc_idx++) {
-			cell->llcs[llc_idx].cpu_cnt = llc_cpu_cnt_tmp[llc_idx];
+			subcell->llcs[llc_idx].cpu_cnt = llc_cpu_cnt_tmp[llc_idx];
 		}
 
-		cell->cpu_cnt = total_cpus;
+		if (subcell_idx == 0)
+			cell->cpu_cnt = total_cpus;
+		subcell->cpu_cnt = total_cpus;
 	}
 	return 0;
 }
@@ -119,19 +127,24 @@ static __always_inline int recalc_cell_llc_counts(u32 cell_idx, const struct cpu
 /**
  * Weighted random selection of an LLC cache domain for a task.
  *
- * Uses the CPU count in each LLC domain within the cell as weights to
- * probabilistically select an LLC. LLC domains with more CPUs in the cell
+ * Uses the CPU count in each LLC domain within the subcell as weights to
+ * probabilistically select an LLC. LLCs with more CPUs in the subcell
  * have higher probability of being selected.
  *
  * @cell_id: The cell ID to select an LLC from
+ * @subcell_id: The subcell ID to select an LLC from
  * @return: LLC ID on success, LLC_INVALID on error
  */
-static inline s32 pick_llc_for_task(u32 cell_id)
+static inline s32 pick_llc_for_task(u32 cell_id, u32 subcell_id)
 {
 	struct cell *cell;
+	struct subcell *subcell;
 
 	/* Look up the cell structure */
 	if (!(cell = lookup_cell(cell_id)))
+		return LLC_INVALID;
+	subcell = lookup_subcell(cell_id, subcell_id);
+	if (!subcell)
 		return LLC_INVALID;
 
 	/*
@@ -144,13 +157,14 @@ static inline s32 pick_llc_for_task(u32 cell_id)
 	scoped_guard(spin_lock, &cell->lock)
 	{
 		for (u32 i = 0; i < MAX_LLCS; i++)
-			llc_cpu_cnt[i] = cell->llcs[i].cpu_cnt;
+			llc_cpu_cnt[i] = subcell->llcs[i].cpu_cnt;
 
-		total_cpu_cnt = cell->cpu_cnt;
+		total_cpu_cnt = subcell->cpu_cnt;
 	}
 
 	if (!total_cpu_cnt) {
-		scx_bpf_error("pick_llc_for_task: cell %d has no CPUs accounted yet", cell_id);
+		scx_bpf_error("pick_llc_for_task: cell %d subcell %d has no CPUs accounted yet",
+			      cell_id, subcell_id);
 		return LLC_INVALID;
 	}
 
@@ -180,16 +194,16 @@ static inline s32 pick_llc_for_task(u32 cell_id)
 	return ret;
 }
 
-static void zero_cell_vtimes(struct cell *cell)
+static void zero_subcell_vtimes(struct subcell *subcell)
 {
 	if (enable_llc_awareness) {
 		u32 llc_idx;
 		bpf_for(llc_idx, 0, MAX_LLCS)
 		{
-			WRITE_ONCE(cell->llcs[llc_idx].vtime_now, 0);
+			WRITE_ONCE(subcell->llcs[llc_idx].vtime_now, 0);
 		}
 	} else {
-		WRITE_ONCE(cell->llcs[FAKE_FLAT_CELL_LLC].vtime_now, 0);
+		WRITE_ONCE(subcell->llcs[FAKE_FLAT_SUBCELL_LLC].vtime_now, 0);
 	}
 }
 
@@ -216,27 +230,29 @@ static inline int maybe_retag_stolen_task(struct task_struct *p, struct task_ctx
 
 	/*
 	 * New LLC, need new cpumask. This updates the task vtime
-	 * to that of the new cell-LLC DSQ.
+	 * to that of the new subcell+LLC DSQ.
 	 */
 	return update_task_cpumask(p, tctx);
 }
 
-/* Work stealing:
- * Scan sibling (cell,LLC) DSQs in the same cell and steal the first queued task if it can run on this cpu
+/*
+ * Work stealing:
+ * Scan sibling subcell+LLC DSQs in the same subcell and steal the first queued
+ * task if it can run on this CPU.
  * Returns:
  *  true == 1;  task was stolen
  *  false == 0; no tasks were stolen
  *  error <0;   error encountered
 */
-static inline s32 try_stealing_work(u32 cell, s32 local_llc)
+static inline s32 try_stealing_work(u32 cell, u32 subcell_id, s32 local_llc)
 {
 	if (!llc_is_valid(local_llc)) {
 		scx_bpf_error("try_stealing_work: invalid local_llc: %d", local_llc);
 		return -EINVAL;
 	}
 
-	struct cell *cell_ptr = lookup_cell(cell);
-	if (!cell_ptr)
+	struct subcell *subcell = lookup_subcell(cell, subcell_id);
+	if (!subcell)
 		return -EINVAL;
 
 	// Loop over all other LLCs, looking for a queued task to steal
@@ -254,18 +270,17 @@ static inline s32 try_stealing_work(u32 cell, s32 local_llc)
 			continue;
 
 		/*
-    * Skip if the cell doesn't have CPUs in this LLC.
-    * Note: rechecking cell_ptr for verifier.
-    * This is racy with try_stealing_this_task, but we don't care -
-    * if the LLC actually doesn't have CPUs come steal time,
-    * we will fail the steal and continue to the next LLC.
-    */
-		if (cell_ptr && READ_ONCE(cell_ptr->llcs[candidate_llc].cpu_cnt) == 0)
+		 * Skip if the subcell doesn't have CPUs in this LLC.
+		 * This is racy with try_stealing_this_task, but we don't care -
+		 * if the LLC actually doesn't have CPUs come steal time,
+		 * we will fail the steal and continue to the next LLC.
+		 */
+		if (READ_ONCE(subcell->llcs[candidate_llc].cpu_cnt) == 0)
 			continue;
 
-		dsq_id_t candidate_dsq = get_cell_llc_dsq_id(cell, candidate_llc);
+		dsq_id_t candidate_dsq = get_subcell_llc_dsq_id(cell, subcell_id, candidate_llc);
 		if (dsq_is_invalid(candidate_dsq))
-			return -EINVAL; // already errored in get_cell_llc_dsq_id
+			return -EINVAL; // already errored in get_subcell_llc_dsq_id
 
 		// Optimization: skip if faster than constructing an iterator
 		// Not redundant with later checking if task found (race)
@@ -298,7 +313,7 @@ static inline int update_task_llc_assignment(struct task_struct *p, struct task_
 	const struct cpumask *llc_mask = NULL;
 
 	// Let's get a new LLC for this task
-	s32 new_llc = pick_llc_for_task(tctx->cell);
+	s32 new_llc = pick_llc_for_task(tctx->cell, 0);
 	if (new_llc < 0)
 		return -EINVAL;
 
@@ -323,14 +338,14 @@ static inline int update_task_llc_assignment(struct task_struct *p, struct task_
 	}
 
 	/* --- Point to the correct (cell,LLC) DSQ and set vtime baseline --- */
-	tctx->dsq = get_cell_llc_dsq_id(tctx->cell, tctx->llc);
+	tctx->dsq = get_subcell_llc_dsq_id(tctx->cell, 0, tctx->llc);
 	if (dsq_is_invalid(tctx->dsq))
 		return -EINVAL;
 
-	struct cell *cell = lookup_cell(tctx->cell);
-	if (!cell)
+	struct subcell *subcell = lookup_subcell(tctx->cell, 0);
+	if (!subcell)
 		return -ENOENT;
 
-	p->scx.dsq_vtime = READ_ONCE(cell->llcs[new_llc].vtime_now);
+	p->scx.dsq_vtime = READ_ONCE(subcell->llcs[new_llc].vtime_now);
 	return 0;
 }

--- a/scheds/rust/scx_mitosis/src/bpf/llc_aware.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/llc_aware.bpf.h
@@ -313,7 +313,7 @@ static inline int update_task_llc_assignment(struct task_struct *p, struct task_
 	const struct cpumask *llc_mask = NULL;
 
 	// Let's get a new LLC for this task
-	s32 new_llc = pick_llc_for_task(tctx->cell, 0);
+	s32 new_llc = pick_llc_for_task(tctx->cell, tctx->subcell);
 	if (new_llc < 0)
 		return -EINVAL;
 
@@ -338,11 +338,11 @@ static inline int update_task_llc_assignment(struct task_struct *p, struct task_
 	}
 
 	/* --- Point to the correct (cell,LLC) DSQ and set vtime baseline --- */
-	tctx->dsq = get_subcell_llc_dsq_id(tctx->cell, 0, tctx->llc);
+	tctx->dsq = get_subcell_llc_dsq_id(tctx->cell, tctx->subcell, tctx->llc);
 	if (dsq_is_invalid(tctx->dsq))
 		return -EINVAL;
 
-	struct subcell *subcell = lookup_subcell(tctx->cell, 0);
+	struct subcell *subcell = lookup_subcell(tctx->cell, tctx->subcell);
 	if (!subcell)
 		return -ENOENT;
 

--- a/scheds/rust/scx_mitosis/src/bpf/llc_aware.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/llc_aware.bpf.h
@@ -74,7 +74,7 @@ static __always_inline int recalc_cell_llc_counts(u32 cell_idx, const struct cpu
 		return -ENOMEM;
 	}
 
-	u32 llc, llcs_present = 0, total_cpus = 0;
+	u32 llc, total_cpus = 0;
 	// Just so we don't hold the lock longer than necessary
 	u32 llc_cpu_cnt_tmp[MAX_LLCS] = { 0 };
 
@@ -102,9 +102,6 @@ static __always_inline int recalc_cell_llc_counts(u32 cell_idx, const struct cpu
 		// These are counted across the whole cell
 		total_cpus += cnt;
 
-		// Number of non-empty LLCs in this cell
-		if (cnt)
-			llcs_present++;
 	}
 
 	// Write to cell
@@ -114,7 +111,6 @@ static __always_inline int recalc_cell_llc_counts(u32 cell_idx, const struct cpu
 			cell->llcs[llc_idx].cpu_cnt = llc_cpu_cnt_tmp[llc_idx];
 		}
 
-		cell->llc_present_cnt = llcs_present;
 		cell->cpu_cnt = total_cpus;
 	}
 	return 0;

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -234,6 +234,8 @@ static inline int allocate_cell()
 			return -1;
 
 		if (__sync_bool_compare_and_swap(&c->in_use, 0, 1)) {
+			/* In timer-managed mode, only subcell 0 is used. */
+			c->subcells[0].in_use = 1;
 			zero_cell_vtimes(c);
 			return cell_idx;
 		}
@@ -244,6 +246,7 @@ static inline int allocate_cell()
 
 static inline int free_cell(int cell_idx)
 {
+	u32 subcell_id;
 	struct cell *c;
 
 	if (cell_idx < 0 || cell_idx >= MAX_CELLS) {
@@ -254,6 +257,11 @@ static inline int free_cell(int cell_idx)
 	if (!(c = lookup_cell(cell_idx)))
 		return -1;
 
+	bpf_for(subcell_id, 0, MAX_SUBCELLS_PER_CELL)
+	{
+		c->subcells[subcell_id].id = subcell_id;
+		c->subcells[subcell_id].in_use = 0;
+	}
 	WRITE_ONCE(c->in_use, 0);
 	return 0;
 }
@@ -323,6 +331,7 @@ static inline void record_cgroup_exit(u64 cgid)
 }
 
 struct cell_cpumask_map cell_cpumasks SEC(".maps");
+struct subcell_cpumask_map subcell_cpumasks SEC(".maps");
 
 static inline int update_task_cpumask(struct task_struct *p, struct task_ctx *tctx)
 {
@@ -464,6 +473,7 @@ static inline int update_task_cell(struct task_struct *p, struct task_ctx *tctx,
 	tctx->configuration_seq = READ_ONCE(applied_configuration_seq);
 	barrier();
 	tctx->cell = cgc->cell;
+	tctx->subcell = 0;
 	tctx->cgid = cg->kn->id;
 
 	return update_task_cpumask(p, tctx);
@@ -2030,6 +2040,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 	bpf_for(i, 0, MAX_CELLS)
 	{
 		struct cell_cpumask_wrapper *cpumaskw;
+		u32 subcell_id;
 
 		if (enable_llc_awareness) {
 			u32 llc;
@@ -2075,6 +2086,33 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 					"failed to init borrowable cpumask slot for cell %d: %d", i,
 					ret);
 				return ret;
+			}
+		}
+
+		bpf_for(subcell_id, 0, MAX_SUBCELLS_PER_CELL)
+		{
+			struct cell_cpumask_wrapper *subcell_cpumaskw;
+
+			subcell_cpumaskw = lookup_subcell_cpumask_wrapper(i, subcell_id);
+			if (!subcell_cpumaskw)
+				return -ENOENT;
+
+			ret = init_cpumask_slot(&subcell_cpumaskw->primary, true);
+			if (ret) {
+				scx_bpf_error(
+					"failed to init primary cpumask slot for cell=%u subcell=%u: %d",
+					i, subcell_id, ret);
+				return ret;
+			}
+
+			if (enable_borrowing) {
+				ret = init_cpumask_slot(&subcell_cpumaskw->borrowable, false);
+				if (ret) {
+					scx_bpf_error(
+						"failed to init borrowable cpumask slot for cell=%u subcell=%u: %d",
+						i, subcell_id, ret);
+					return ret;
+				}
 			}
 		}
 	}
@@ -2148,7 +2186,7 @@ int apply_cell_config(void *ctx)
 	struct cell_cpumask_wrapper *cpumaskw;
 	struct cgroup_subsys_state *root_css, *pos;
 	struct cgroup *cur_cgrp;
-	u32 i, cell_id;
+	u32 i, cell_id, subcell_id;
 
 	/* Read configuration from global struct (populated by userspace) */
 	struct cell_config *config = &cell_config;
@@ -2169,7 +2207,8 @@ int apply_cell_config(void *ctx)
 	}
 
 	/*
-	 * Phase 2: Apply cell cpumasks and derive CPU-to-cell mappings.
+	 * Phase 2: Apply cell cpumasks, derive CPU-to-cell mappings, and store
+	 * subcell cpumasks for each cell.
 	 * For each cell, we update the cell's cpumask and set each CPU's
 	 * cell assignment based on which cell's cpumask contains it.
 	 *
@@ -2269,6 +2308,47 @@ int apply_cell_config(void *ctx)
 					      cell_id);
 				return -EINVAL;
 			}
+		}
+
+		cell = lookup_cell(cell_id);
+		if (!cell)
+			return -EINVAL;
+
+		bpf_for(subcell_id, 0, MAX_SUBCELLS_PER_CELL)
+		{
+			struct cell_cpumask_wrapper *subcell_cpumaskw;
+			struct subcell *subcell_config;
+
+			subcell_cpumaskw = lookup_subcell_cpumask_wrapper(cell_id, subcell_id);
+			if (!subcell_cpumaskw)
+				return -EINVAL;
+
+			subcell_config = MEMBER_VPTR(config->subcells[cell_id], [subcell_id]);
+			if (!subcell_config) {
+				scx_bpf_error("subcell_id %d out of bounds for cell_id %d",
+					      subcell_id, cell_id);
+				return -EINVAL;
+			}
+
+			if (set_cpumask_from_data(&subcell_cpumaskw->primary,
+						  &subcell_config->primary)) {
+				scx_bpf_error(
+					"failed to set primary subcell cpumask for cell=%u subcell=%u",
+					cell_id, subcell_id);
+				return -EINVAL;
+			}
+
+			if (enable_borrowing) {
+				if (set_cpumask_from_data(&subcell_cpumaskw->borrowable,
+							  &subcell_config->borrowable)) {
+					scx_bpf_error(
+						"failed to set borrowable subcell cpumask for cell=%u subcell=%u",
+						cell_id, subcell_id);
+					return -EINVAL;
+				}
+			}
+
+			cell->subcells[subcell_id] = config->subcells[cell_id][subcell_id];
 		}
 	}
 

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -2172,6 +2172,175 @@ void BPF_STRUCT_OPS(mitosis_exit, struct scx_exit_info *ei)
 	UEI_RECORD(uei, ei);
 }
 
+int reset_configured_cells(void)
+{
+	u32 cell_id;
+
+	bpf_for(cell_id, 1, MAX_CELLS)
+	{
+		struct cell *cell = lookup_cell(cell_id);
+		if (!cell)
+			return -EINVAL;
+
+		WRITE_ONCE(cell->in_use, 0);
+		cell->owner_cgid = 0;
+	}
+
+	return 0;
+}
+
+int apply_configured_cell_cpumask(u32 cell_id, struct cell_config *config)
+{
+	struct cell_cpumask_data *cpumask_data;
+	struct cell_cpumask_wrapper *cpumaskw;
+	struct cell *cell;
+	u32 cpu;
+
+	if (!config || cell_id >= MAX_CELLS)
+		return -EINVAL;
+
+	cpumaskw = lookup_cell_cpumask_wrapper(cell_id);
+	if (!cpumaskw)
+		return -EINVAL;
+
+	cpumask_data = MEMBER_VPTR(config->cpumasks, [cell_id]);
+	if (!cpumask_data) {
+		scx_bpf_error("cell_id %d out of bounds", cell_id);
+		return -EINVAL;
+	}
+
+	/* Get the tmp_cpumask to build the new mask */
+	struct bpf_cpumask *new_cpumask __free(bpf_cpumask) = get_tmp_cpumask(&cpumaskw->primary);
+	if (!new_cpumask) {
+		scx_bpf_error("tmp cpumask is NULL for cell_id %d", cell_id);
+		return -EINVAL;
+	}
+
+	bpf_cpumask_clear(new_cpumask);
+
+	/* Build the mask and update CPU-to-cell mappings in one pass. */
+	bpf_for(cpu, 0, nr_possible_cpus)
+	{
+		struct cpu_ctx *cctx;
+		bool cpu_in_cell;
+
+		if (cell_cpumask_data_test_cpu(cpumask_data, cpu, &cpu_in_cell)) {
+			scx_bpf_error("failed to decode cpumask for cell_id %d", cell_id);
+			return -EINVAL;
+		}
+
+		if (!cpu_in_cell)
+			continue;
+
+		bpf_cpumask_set_cpu(cpu, new_cpumask);
+
+		cctx = bpf_map_lookup_percpu_elem(&cpu_ctxs, &(u32){ 0 }, cpu);
+		if (!cctx)
+			return -ENOENT;
+		/*
+		 * If the CPU is changing cells, advance the new cell's vtime to
+		 * at least match this CPU's per-CPU vtime. Otherwise the per-CPU
+		 * DSQ and cell DSQ are in different vtime domains and dispatch
+		 * will starve the per-CPU DSQ tasks.
+		 */
+		if (cctx->cell != cell_id) {
+			u32 llc_idx;
+
+			cell = lookup_cell(cell_id);
+			if (!cell)
+				return -ENOENT;
+			llc_idx = enable_llc_awareness && llc_is_valid(cctx->llc) ?
+					  cctx->llc :
+					  FAKE_FLAT_CELL_LLC;
+			if (time_before(READ_ONCE(cell->llcs[llc_idx].vtime_now), cctx->vtime_now))
+				WRITE_ONCE(cell->llcs[llc_idx].vtime_now, cctx->vtime_now);
+		}
+		cctx->cell = cell_id;
+	}
+
+	/* Swap the new cpumask into place */
+	if (publish_prepared_cpumask(&cpumaskw->primary, &new_cpumask)) {
+		scx_bpf_error("failed to publish cpumask for cell_id %d", cell_id);
+		return -EINVAL;
+	}
+
+	/* Apply borrowable cpumask for this cell */
+	if (enable_borrowing) {
+		struct cell_cpumask_data *borrowable_data;
+
+		borrowable_data = MEMBER_VPTR(config->borrowable_cpumasks, [cell_id]);
+		if (!borrowable_data) {
+			scx_bpf_error("cell_id %d out of bounds for borrowable", cell_id);
+			return -EINVAL;
+		}
+
+		if (set_cpumask_from_data(&cpumaskw->borrowable, borrowable_data)) {
+			scx_bpf_error("failed to set borrowable cpumask for cell_id %d", cell_id);
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+int apply_configured_cell_subcells(u32 cell_id, struct cell_config *config)
+{
+	struct subcell(*subcell_configs)[MAX_SUBCELLS_PER_CELL];
+	struct cell *cell;
+	u32 subcell_id;
+
+	if (!config || cell_id >= MAX_CELLS)
+		return -EINVAL;
+
+	cell = lookup_cell(cell_id);
+	if (!cell)
+		return -EINVAL;
+
+	subcell_configs = MEMBER_VPTR(config->subcells, [cell_id]);
+	if (!subcell_configs) {
+		scx_bpf_error("cell_id %d out of bounds for subcells", cell_id);
+		return -EINVAL;
+	}
+
+	bpf_for(subcell_id, 0, MAX_SUBCELLS_PER_CELL)
+	{
+		struct cell_cpumask_wrapper *subcell_cpumaskw;
+		struct subcell *subcell_config;
+
+		subcell_cpumaskw = lookup_subcell_cpumask_wrapper(cell_id, subcell_id);
+		if (!subcell_cpumaskw)
+			return -EINVAL;
+
+		subcell_config = MEMBER_VPTR(*subcell_configs, [subcell_id]);
+		if (!subcell_config) {
+			scx_bpf_error("subcell_id %d out of bounds for cell_id %d", subcell_id,
+				      cell_id);
+			return -EINVAL;
+		}
+
+		if (set_cpumask_from_data(&subcell_cpumaskw->primary, &subcell_config->primary)) {
+			scx_bpf_error(
+				"failed to set primary subcell cpumask for cell=%u subcell=%u",
+				cell_id, subcell_id);
+			return -EINVAL;
+		}
+
+		if (enable_borrowing) {
+			if (set_cpumask_from_data(&subcell_cpumaskw->borrowable,
+						  &subcell_config->borrowable)) {
+				scx_bpf_error(
+					"failed to set borrowable subcell cpumask for cell=%u subcell=%u",
+					cell_id, subcell_id);
+				return -EINVAL;
+			}
+		}
+
+		cell->subcells[subcell_id] = *subcell_config;
+	}
+
+	return 0;
+}
+
 /*
  * Apply a complete cell configuration.
  *
@@ -2195,11 +2364,9 @@ int apply_cell_config(void *ctx)
 {
 	struct cgrp_ctx *cgc;
 	struct cell *cell;
-	struct cpu_ctx *cctx;
-	struct cell_cpumask_wrapper *cpumaskw;
 	struct cgroup_subsys_state *root_css, *pos;
 	struct cgroup *cur_cgrp;
-	u32 i, cell_id, subcell_id;
+	u32 i, cell_id;
 
 	/* Read configuration from global struct (populated by userspace) */
 	struct cell_config *config = &cell_config;
@@ -2209,15 +2376,8 @@ int apply_cell_config(void *ctx)
 	 * This handles cell destruction - cells not in the new config
 	 * will remain marked as not in use.
 	 */
-	bpf_for(i, 1, MAX_CELLS)
-	{
-		cell = lookup_cell(i);
-		if (!cell)
-			return -EINVAL;
-
-		WRITE_ONCE(cell->in_use, 0);
-		cell->owner_cgid = 0;
-	}
+	if (reset_configured_cells())
+		return -EINVAL;
 
 	/*
 	 * Phase 2: Apply cell cpumasks, derive CPU-to-cell mappings, and store
@@ -2234,142 +2394,18 @@ int apply_cell_config(void *ctx)
 
 	bpf_for(cell_id, 0, MAX_CELLS)
 	{
-		struct cell_cpumask_data *cpumask_data;
+		int ret;
 
 		if (cell_id >= config->num_cells)
 			break;
 
-		cpumaskw = lookup_cell_cpumask_wrapper(cell_id);
-		if (!cpumaskw)
-			return -EINVAL;
+		ret = apply_configured_cell_cpumask(cell_id, config);
+		if (ret)
+			return ret;
 
-		cpumask_data = MEMBER_VPTR(config->cpumasks, [cell_id]);
-		if (!cpumask_data) {
-			scx_bpf_error("cell_id %d out of bounds", cell_id);
-			return -EINVAL;
-		}
-
-		/* Get the tmp_cpumask to build the new mask */
-		struct bpf_cpumask *new_cpumask __free(bpf_cpumask) =
-			get_tmp_cpumask(&cpumaskw->primary);
-		if (!new_cpumask) {
-			scx_bpf_error("tmp cpumask is NULL for cell_id %d", cell_id);
-			return -EINVAL;
-		}
-
-		bpf_cpumask_clear(new_cpumask);
-
-		/* Build the mask and update CPU-to-cell mappings in one pass. */
-		u32 cpu;
-		bpf_for(cpu, 0, nr_possible_cpus)
-		{
-			bool cpu_in_cell;
-
-			if (cell_cpumask_data_test_cpu(cpumask_data, cpu, &cpu_in_cell)) {
-				scx_bpf_error("failed to decode cpumask for cell_id %d", cell_id);
-				return -EINVAL;
-			}
-
-			if (!cpu_in_cell)
-				continue;
-
-			bpf_cpumask_set_cpu(cpu, new_cpumask);
-
-			cctx = bpf_map_lookup_percpu_elem(&cpu_ctxs, &(u32){ 0 }, cpu);
-			if (!cctx)
-				return -ENOENT;
-			/*
-			 * If the CPU is changing cells, advance the
-			 * new cell's vtime to at least match this
-			 * CPU's per-CPU vtime. Otherwise the per-CPU
-			 * DSQ and cell DSQ are in different vtime
-			 * domains and dispatch will starve the
-			 * per-CPU DSQ tasks.
-			 */
-			if (cctx->cell != cell_id) {
-				cell = lookup_cell(cell_id);
-				if (!cell)
-					return -ENOENT;
-				u32 llc_idx = enable_llc_awareness && llc_is_valid(cctx->llc) ?
-						      cctx->llc :
-						      FAKE_FLAT_CELL_LLC;
-				if (time_before(READ_ONCE(cell->llcs[llc_idx].vtime_now),
-						cctx->vtime_now))
-					WRITE_ONCE(cell->llcs[llc_idx].vtime_now, cctx->vtime_now);
-			}
-			cctx->cell = cell_id;
-		}
-
-		/* Swap the new cpumask into place */
-		if (publish_prepared_cpumask(&cpumaskw->primary, &new_cpumask)) {
-			scx_bpf_error("failed to publish cpumask for cell_id %d", cell_id);
-			return -EINVAL;
-		}
-
-		/* Apply borrowable cpumask for this cell */
-		if (enable_borrowing) {
-			struct cell_cpumask_data *borrowable_data;
-
-			borrowable_data = MEMBER_VPTR(config->borrowable_cpumasks, [cell_id]);
-			if (!borrowable_data) {
-				scx_bpf_error("cell_id %d out of bounds for borrowable", cell_id);
-				return -EINVAL;
-			}
-
-			if (set_cpumask_from_data(&cpumaskw->borrowable, borrowable_data)) {
-				scx_bpf_error("failed to set borrowable cpumask for cell_id %d",
-					      cell_id);
-				return -EINVAL;
-			}
-		}
-
-		cell = lookup_cell(cell_id);
-		if (!cell)
-			return -EINVAL;
-
-		bpf_for(subcell_id, 0, MAX_SUBCELLS_PER_CELL)
-		{
-			struct cell_cpumask_wrapper *subcell_cpumaskw;
-			struct subcell(*subcell_configs)[MAX_SUBCELLS_PER_CELL];
-			struct subcell *subcell_config;
-
-			subcell_cpumaskw = lookup_subcell_cpumask_wrapper(cell_id, subcell_id);
-			if (!subcell_cpumaskw)
-				return -EINVAL;
-
-			subcell_configs = MEMBER_VPTR(config->subcells, [cell_id]);
-			if (!subcell_configs) {
-				scx_bpf_error("cell_id %d out of bounds for subcells", cell_id);
-				return -EINVAL;
-			}
-
-			subcell_config = MEMBER_VPTR(*subcell_configs, [subcell_id]);
-			if (!subcell_config) {
-				scx_bpf_error("subcell_id %d out of bounds for cell_id %d",
-					      subcell_id, cell_id);
-				return -EINVAL;
-			}
-
-			if (set_cpumask_from_data(&subcell_cpumaskw->primary,
-						  &subcell_config->primary)) {
-				scx_bpf_error(
-					"failed to set primary subcell cpumask for cell=%u subcell=%u",
-					cell_id, subcell_id);
-				return -EINVAL;
-			}
-
-			if (enable_borrowing) {
-				if (set_cpumask_from_data(&subcell_cpumaskw->borrowable,
-							  &subcell_config->borrowable)) {
-					scx_bpf_error(
-						"failed to set borrowable subcell cpumask for cell=%u subcell=%u",
-						cell_id, subcell_id);
-					return -EINVAL;
-				}
-			}
-
-			cell->subcells[subcell_id] = config->subcells[cell_id][subcell_id];
-		}
+		ret = apply_configured_cell_subcells(cell_id, config);
+		if (ret)
+			return ret;
 	}
 
 	/* Phase 2.5: Recompute per-LLC CPU counts for all cells */

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -624,17 +624,26 @@ static __always_inline s32 try_pick_idle_cpu(struct task_struct *p, s32 prev_cpu
 
 	/* cpu == -EBUSY: no idle CPU in subcell, try borrowing */
 	if (enable_borrowing) {
-		const struct cpumask *borrowable =
-			lookup_subcell_borrowable_cpumask(tctx->cell, tctx->subcell);
-		if (!borrowable)
+		const struct cpumask *idle_smtmask __free(idle_cpumask) = NULL;
+		const struct cpumask *subcell_borrowable;
+
+		subcell_borrowable = lookup_subcell_borrowable_cpumask(tctx->cell, tctx->subcell);
+		if (!subcell_borrowable)
 			return -1;
-		const struct cpumask *idle_smtmask __free(idle_cpumask) =
-			scx_bpf_get_idle_smtmask();
+		idle_smtmask = scx_bpf_get_idle_smtmask();
 		if (!idle_smtmask) {
 			scx_bpf_error("Failed to get idle smtmask");
 			return -1;
 		}
-		cpu = pick_idle_cpu_from(p, borrowable, prev_cpu, idle_smtmask);
+		cpu = pick_idle_cpu_from(p, subcell_borrowable, prev_cpu, idle_smtmask);
+		if (cpu < 0) {
+			const struct cpumask *cell_borrowable;
+
+			cell_borrowable = lookup_cell_borrowable_cpumask(tctx->cell);
+			if (!cell_borrowable)
+				return -1;
+			cpu = pick_idle_cpu_from(p, cell_borrowable, prev_cpu, idle_smtmask);
+		}
 		if (cpu >= 0) {
 			tctx->borrowed = true;
 			cstat_inc(CSTAT_BORROWED, tctx->cell, cctx);

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -1200,7 +1200,8 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 	}
 
 	guard(rcu)();
-	if (!all_cpumask) {
+	const struct cpumask *all_mask = (const struct cpumask *)all_cpumask;
+	if (!all_mask) {
 		scx_bpf_error("NULL all_cpumask");
 		return 0;
 	}
@@ -1209,8 +1210,8 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 	 * Initialize root cell cpumask to all cpus, and then remove from it as we
 	 * go
 	 */
-	bpf_cpumask_copy(root_cell_bpf_cpumask, (const struct cpumask *)all_cpumask);
-	bpf_cpumask_copy(root_subcell_bpf_cpumask, (const struct cpumask *)all_cpumask);
+	bpf_cpumask_copy(root_cell_bpf_cpumask, all_mask);
+	bpf_cpumask_copy(root_subcell_bpf_cpumask, all_mask);
 
 	struct cgroup_subsys_state *root_css, *pos;
 	struct cgroup *cur_cgrp;

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -8,8 +8,8 @@
  * of cells is dynamic, as is cgroup to cell assignment and cell to CPU
  * assignment (all are determined by userspace).
  *
- * Each cell has one or more DSQs for vtime scheduling. With LLC-awareness
- * enabled, each cell has a DSQ per LLC domain; otherwise a single flat DSQ.
+ * Each subcell has one or more DSQs for vtime scheduling. With LLC-awareness
+ * enabled, each subcell has a DSQ per LLC; otherwise a single flat DSQ.
  */
 
 #ifdef LSP
@@ -21,10 +21,10 @@
 
 /*
  * When LLC awareness is disabled, we use a single "fake" LLC index to flatten
- * the entire cell's topology into one scheduling domain. All CPUs in the cell
+ * the subcell's topology into one scheduling queue. All CPUs in the subcell
  * share the same DSQ and vtime, ignoring actual LLC cache boundaries.
  */
-#define FAKE_FLAT_CELL_LLC 0
+#define FAKE_FLAT_SUBCELL_LLC 0
 
 #include "mitosis.bpf.h"
 #include "dsq.bpf.h"
@@ -237,7 +237,7 @@ static inline int allocate_cell()
 			/* In timer-managed mode, only subcell 0 is used. */
 			c->subcells[0].id = 0;
 			c->subcells[0].in_use = 1;
-			zero_cell_vtimes(c);
+			zero_subcell_vtimes(&c->subcells[0]);
 			return cell_idx;
 		}
 	}
@@ -261,8 +261,10 @@ static inline int free_cell(int cell_idx)
 	bpf_for(subcell_id, 0, MAX_SUBCELLS_PER_CELL)
 	{
 		c->subcells[subcell_id].id = subcell_id;
+		c->subcells[subcell_id].cpu_cnt = 0;
 		c->subcells[subcell_id].in_use = 0;
 	}
+	c->cpu_cnt = 0;
 	WRITE_ONCE(c->in_use, 0);
 	return 0;
 }
@@ -416,15 +418,15 @@ static inline int update_task_cpumask(struct task_struct *p, struct task_ctx *tc
 	}
 
 	/* Non-LLC aware version */
-	tctx->dsq = get_cell_llc_dsq_id(tctx->cell, FAKE_FLAT_CELL_LLC);
+	tctx->dsq = get_subcell_llc_dsq_id(tctx->cell, 0, FAKE_FLAT_SUBCELL_LLC);
 	if (dsq_is_invalid(tctx->dsq))
 		return -EINVAL;
 
-	struct cell *cell;
-	if (!(cell = lookup_cell(tctx->cell)))
+	struct subcell *subcell;
+	if (!(subcell = lookup_subcell(tctx->cell, 0)))
 		return -ENOENT;
 
-	p->scx.dsq_vtime = READ_ONCE(cell->llcs[FAKE_FLAT_CELL_LLC].vtime_now);
+	p->scx.dsq_vtime = READ_ONCE(subcell->llcs[FAKE_FLAT_SUBCELL_LLC].vtime_now);
 
 	return 0;
 }
@@ -774,7 +776,7 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 {
 	struct cpu_ctx *cctx;
 	struct task_ctx *tctx;
-	struct cell *cell;
+	struct subcell *subcell;
 	s32 task_cpu = scx_bpf_task_cpu(p);
 	u64 vtime;
 	s32 cpu = -1;
@@ -789,13 +791,13 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 	/*
 	 * CPU -> cell mappings can change between enqueue() and stopping().
 	 * If that happens, the task's dsq_vtime may no longer belong to the
-	 * CPU-local or shared cell vtime domains visible at stopping(), and
-	 * advancing either one would charge the wrong domain.
+	 * CPU-local or shared cell vtime visible at stopping(), and
+	 * advancing either one would charge the wrong cell.
 	 * Direct local insert paths snapshot the same state before inserting.
 	 *
-	 * Snapshot the cell whose vtime domain this placement expects to
-	 * charge. stopping() only advances local and cell vtime if the task
-	 * is not borrowed and the CPU it stops on is still in this same cell.
+	 * Snapshot the cell whose vtime this placement expects to charge.
+	 * stopping() only advances local and shared vtime if the task is not
+	 * borrowed and the CPU it stops on is still in this same cell.
 	 */
 	tctx->vtime_charge_cell = tctx->cell;
 
@@ -842,8 +844,8 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 
 	if (tctx->all_cell_cpus_allowed) {
 		cstat_inc(CSTAT_CELL_DSQ, tctx->cell, cctx);
-		/* Task can use any CPU in its cell, so use the cell DSQ */
-		if (!(cell = lookup_cell(tctx->cell)))
+		/* Task can use any CPU in its cell, so use the default subcell DSQ */
+		if (!(subcell = lookup_subcell(tctx->cell, 0)))
 			return;
 
 		if (enable_llc_awareness) {
@@ -852,9 +854,9 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 				return;
 			}
 
-			basis_vtime = READ_ONCE(cell->llcs[tctx->llc].vtime_now);
+			basis_vtime = READ_ONCE(subcell->llcs[tctx->llc].vtime_now);
 		} else {
-			basis_vtime = READ_ONCE(cell->llcs[FAKE_FLAT_CELL_LLC].vtime_now);
+			basis_vtime = READ_ONCE(subcell->llcs[FAKE_FLAT_SUBCELL_LLC].vtime_now);
 		}
 	} else {
 		cstat_inc(CSTAT_CPU_DSQ, tctx->cell, cctx);
@@ -916,20 +918,20 @@ void BPF_STRUCT_OPS(mitosis_dispatch, s32 cpu, struct task_struct *prev)
 
 	struct task_struct *p;
 
-	/* Check the cell-LLC DSQ (use FAKE_FLAT_CELL_LLC when not LLC-aware) */
-	u32 llc = enable_llc_awareness ? cctx->llc : FAKE_FLAT_CELL_LLC;
-	dsq_id_t cell_dsq = get_cell_llc_dsq_id(cell, llc);
+	/* Check the cell-LLC DSQ (use FAKE_FLAT_SUBCELL_LLC when not LLC-aware) */
+	u32 llc = enable_llc_awareness ? cctx->llc : FAKE_FLAT_SUBCELL_LLC;
+	dsq_id_t subcell_dsq = get_subcell_llc_dsq_id(cell, 0, llc);
 	dsq_id_t cpu_dsq = get_cpu_dsq_id(cpu);
 
-	if (dsq_is_invalid(cell_dsq) || dsq_is_invalid(cpu_dsq)) {
+	if (dsq_is_invalid(subcell_dsq) || dsq_is_invalid(cpu_dsq)) {
 		return;
 	}
 
 	/* Peek at cell-LLC DSQ head */
-	p = dsq_peek(cell_dsq.raw);
+	p = dsq_peek(subcell_dsq.raw);
 	if (p) {
 		min_vtime = p->scx.dsq_vtime;
-		min_vtime_dsq = cell_dsq;
+		min_vtime_dsq = subcell_dsq;
 		found = true;
 	}
 
@@ -950,7 +952,7 @@ void BPF_STRUCT_OPS(mitosis_dispatch, s32 cpu, struct task_struct *prev)
 		/* Try work stealing if enabled */
 		if (enable_llc_awareness && enable_work_stealing) {
 			/* Returns: <0 error, 0 no steal, >0 stole work */
-			s32 ret = try_stealing_work(cell, llc);
+			s32 ret = try_stealing_work(cell, 0, llc);
 			if (ret < 0)
 				return;
 			if (ret > 0) {
@@ -961,9 +963,8 @@ void BPF_STRUCT_OPS(mitosis_dispatch, s32 cpu, struct task_struct *prev)
 	}
 
 	/*
-	 * The move_to_local can fail if we raced with some other cpu in the cell
-	 * and now the cell is empty. We have to ensure to try the cpu_dsq or else
-	 * we might never wakeup.
+	 * The move_to_local can fail if we raced with another CPU in the cell
+	 * and now the cell queue is empty. Try the CPU DSQ as a fallback.
 	 */
 
 	/* Try the winner first */
@@ -971,7 +972,7 @@ void BPF_STRUCT_OPS(mitosis_dispatch, s32 cpu, struct task_struct *prev)
 		return;
 
 	/* Winner was cell DSQ but failed - try the CPU DSQ */
-	if (min_vtime_dsq.raw == cell_dsq.raw)
+	if (min_vtime_dsq.raw == subcell_dsq.raw)
 		scx_bpf_dsq_move_to_local(cpu_dsq.raw, 0);
 }
 
@@ -1269,6 +1270,7 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 				if (!(cpu_ctx = lookup_cpu_ctx(cpu_idx)))
 					return 0;
 				cpu_ctx->cell = cell_idx;
+				cpu_ctx->subcell = 0;
 				bpf_cpumask_clear_cpu(cpu_idx, root_bpf_cpumask);
 			}
 		}
@@ -1279,7 +1281,8 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 		 * if recalc did a lookup_cell_cpumask()
 		 */
 		if (enable_llc_awareness) {
-			if (recalc_cell_llc_counts(cell_idx, (const struct cpumask *)bpf_cpumask))
+			if (recalc_subcell_llc_counts(cell_idx, 0,
+						      (const struct cpumask *)bpf_cpumask))
 				return 0;
 		}
 
@@ -1309,16 +1312,18 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 			if (!(cpu_ctx = lookup_cpu_ctx(cpu_idx)))
 				return 0;
 			cpu_ctx->cell = 0;
+			cpu_ctx->subcell = 0;
 		}
 	}
 
 	/*
-	 * Recalc LLC counts for root cell BEFORE making cpumask visible.
+	 * Recalc LLC counts for the root cell BEFORE making cpumask visible.
 	 * Pass the new mask explicitly to avoid race if recalc did a
 	 * lookup_cell_cpumask()
 	 */
 	if (enable_llc_awareness)
-		if (recalc_cell_llc_counts(ROOT_CELL_ID, (const struct cpumask *)root_bpf_cpumask))
+		if (recalc_subcell_llc_counts(ROOT_CELL_ID, 0,
+					      (const struct cpumask *)root_bpf_cpumask))
 			return 0;
 
 	/*
@@ -1336,13 +1341,14 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 	return 0;
 }
 
-static inline void advance_cell_llc_vtime(struct cell *cell, struct task_ctx *tctx, u64 task_vtime)
+static inline void advance_subcell_llc_vtime(struct subcell *subcell, struct task_ctx *tctx,
+					     u64 task_vtime)
 {
 	u32 llc_idx = enable_llc_awareness && llc_is_valid(tctx->llc) ? tctx->llc :
-									FAKE_FLAT_CELL_LLC;
+									FAKE_FLAT_SUBCELL_LLC;
 
-	if (time_before(READ_ONCE(cell->llcs[llc_idx].vtime_now), task_vtime))
-		WRITE_ONCE(cell->llcs[llc_idx].vtime_now, task_vtime);
+	if (time_before(READ_ONCE(subcell->llcs[llc_idx].vtime_now), task_vtime))
+		WRITE_ONCE(subcell->llcs[llc_idx].vtime_now, task_vtime);
 }
 
 void BPF_STRUCT_OPS(mitosis_running, struct task_struct *p)
@@ -1374,7 +1380,7 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 {
 	struct cpu_ctx *cctx;
 	struct task_ctx *tctx;
-	struct cell *cell;
+	struct subcell *subcell;
 	u64 now, used;
 	u32 cidx;
 
@@ -1387,7 +1393,7 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 	 * E.g. a cell 0 kworker pinned to a cell 1 CPU.
 	 */
 	cidx = cctx->cell;
-	if (!(cell = lookup_cell(cidx)))
+	if (!(subcell = lookup_subcell(cidx, 0)))
 		return;
 
 	now = scx_bpf_now();
@@ -1414,7 +1420,7 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 	 * Only advance this CPU's local vtime when the slice ends on a CPU
 	 * whose cell matches this task's vtime charge cell and the task was
 	 * not borrowed. If execution ends in some other cell, drop the local
-	 * charge rather than risk charging an unexpected domain.
+	 * charge rather than risk charging an unexpected cell.
 	 */
 	if (!tctx->borrowed && tctx->vtime_charge_cell == cidx) {
 		if (time_before(READ_ONCE(cctx->vtime_now), p->scx.dsq_vtime))
@@ -1429,7 +1435,7 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 	 * domain.
 	 */
 	if (!tctx->borrowed && tctx->vtime_charge_cell == cidx) {
-		advance_cell_llc_vtime(cell, tctx, p->scx.dsq_vtime);
+		advance_subcell_llc_vtime(subcell, tctx, p->scx.dsq_vtime);
 	}
 
 	/* Clear the borrowed flag — it is one-shot, consumed above */
@@ -1828,6 +1834,8 @@ void BPF_STRUCT_OPS(mitosis_dump, struct scx_dump_ctx *dctx)
 
 	bpf_for(i, 0, MAX_CELLS)
 	{
+		struct subcell *subcell;
+
 		if (!(cell = lookup_cell(i)))
 			return;
 
@@ -1837,13 +1845,17 @@ void BPF_STRUCT_OPS(mitosis_dump, struct scx_dump_ctx *dctx)
 		scx_bpf_dump("CELL[%d] CPUS=", i);
 		dump_cell_cpumask(i);
 		scx_bpf_dump("\n");
-		/* Per-LLC stats deferred: FAKE_FLAT_CELL_LLC used for now */
-		dsq_id_t dsq_id = get_cell_llc_dsq_id(i, FAKE_FLAT_CELL_LLC);
+		subcell = lookup_subcell(i, 0);
+		if (!subcell)
+			return;
+
+		/* Per-LLC stats deferred: FAKE_FLAT_SUBCELL_LLC used for now */
+		dsq_id_t dsq_id = get_subcell_llc_dsq_id(i, 0, FAKE_FLAT_SUBCELL_LLC);
 		if (dsq_is_invalid(dsq_id))
 			return;
 
 		scx_bpf_dump("CELL[%d] vtime=%llu nr_queued=%d\n", i,
-			     READ_ONCE(cell->llcs[FAKE_FLAT_CELL_LLC].vtime_now),
+			     READ_ONCE(subcell->llcs[FAKE_FLAT_SUBCELL_LLC].vtime_now),
 			     scx_bpf_dsq_nr_queued(dsq_id.raw));
 	}
 
@@ -1855,8 +1867,9 @@ void BPF_STRUCT_OPS(mitosis_dump, struct scx_dump_ctx *dctx)
 		dsq_id = get_cpu_dsq_id(i);
 		if (dsq_is_invalid(dsq_id))
 			return;
-		scx_bpf_dump("CPU[%d] cell=%d vtime=%llu nr_queued=%d\n", i, cpu_ctx->cell,
-			     READ_ONCE(cpu_ctx->vtime_now), scx_bpf_dsq_nr_queued(dsq_id.raw));
+		scx_bpf_dump("CPU[%d] cell=%d subcell=%d vtime=%llu nr_queued=%d\n", i,
+			     cpu_ctx->cell, cpu_ctx->subcell, READ_ONCE(cpu_ctx->vtime_now),
+			     scx_bpf_dsq_nr_queued(dsq_id.raw));
 	}
 
 	if (!debug_events_enabled)
@@ -1989,8 +2002,9 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 			if (i < MAX_CPUS) // explicit bounds check for verifier
 				cpu_ctx->llc = cpu_to_llc[i];
 		} else {
-			cpu_ctx->llc = FAKE_FLAT_CELL_LLC;
+			cpu_ctx->llc = FAKE_FLAT_SUBCELL_LLC;
 		}
+		cpu_ctx->subcell = 0;
 	}
 
 	cpumask = bpf_kptr_xchg(&all_cpumask, cpumask);
@@ -2048,18 +2062,18 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 			u32 llc;
 			bpf_for(llc, 0, nr_llc)
 			{
-				dsq_id_t dsq_id = get_cell_llc_dsq_id(i, llc);
+				dsq_id_t dsq_id = get_subcell_llc_dsq_id(i, 0, llc);
 				if (dsq_is_invalid(dsq_id))
-					return -EINVAL; // scx_bpf_error called in get_cell_llc_dsq_id
+					return -EINVAL; // scx_bpf_error called in get_subcell_llc_dsq_id
 
 				ret = scx_bpf_create_dsq(dsq_id.raw, ANY_NUMA);
 				if (ret < 0)
 					return ret;
 			}
 		} else {
-			dsq_id_t dsq_id = get_cell_llc_dsq_id(i, FAKE_FLAT_CELL_LLC);
+			dsq_id_t dsq_id = get_subcell_llc_dsq_id(i, 0, FAKE_FLAT_SUBCELL_LLC);
 			if (dsq_is_invalid(dsq_id))
-				return -EINVAL; // scx_bpf_error called in get_cell_llc_dsq_id
+				return -EINVAL; // scx_bpf_error called in get_subcell_llc_dsq_id
 
 			ret = scx_bpf_create_dsq(dsq_id.raw, ANY_NUMA);
 			if (ret < 0)
@@ -2076,8 +2090,10 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 		bpf_for(subcell_id, 0, MAX_SUBCELLS_PER_CELL)
 		{
 			cell->subcells[subcell_id].id = subcell_id;
+			cell->subcells[subcell_id].cpu_cnt = 0;
 			cell->subcells[subcell_id].in_use = 0;
 		}
+		cell->cpu_cnt = 0;
 
 		/*
 		 * Start with full cpumask for all cells. The timer will set up
@@ -2132,7 +2148,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 	if (enable_llc_awareness) {
 		{
 			guard(rcu)();
-			if (recalc_cell_llc_counts(ROOT_CELL_ID, NULL))
+			if (recalc_subcell_llc_counts(ROOT_CELL_ID, 0, NULL))
 				return -EINVAL;
 		}
 	}
@@ -2193,7 +2209,7 @@ int apply_configured_cell_cpumask(u32 cell_id, struct cell_config *config)
 {
 	struct cell_cpumask_data *cpumask_data;
 	struct cell_cpumask_wrapper *cpumaskw;
-	struct cell *cell;
+	struct subcell *subcell;
 	u32 cpu;
 
 	if (!config || cell_id >= MAX_CELLS)
@@ -2238,24 +2254,26 @@ int apply_configured_cell_cpumask(u32 cell_id, struct cell_config *config)
 		if (!cctx)
 			return -ENOENT;
 		/*
-		 * If the CPU is changing cells, advance the new cell's vtime to
+		 * If the CPU is changing subcells, advance the new subcell's vtime to
 		 * at least match this CPU's per-CPU vtime. Otherwise the per-CPU
-		 * DSQ and cell DSQ are in different vtime domains and dispatch
+		 * DSQ and subcell DSQ are in different vtimes and dispatch
 		 * will starve the per-CPU DSQ tasks.
 		 */
-		if (cctx->cell != cell_id) {
+		if (cctx->cell != cell_id || cctx->subcell != 0) {
 			u32 llc_idx;
 
-			cell = lookup_cell(cell_id);
-			if (!cell)
+			subcell = lookup_subcell(cell_id, 0);
+			if (!subcell)
 				return -ENOENT;
 			llc_idx = enable_llc_awareness && llc_is_valid(cctx->llc) ?
 					  cctx->llc :
-					  FAKE_FLAT_CELL_LLC;
-			if (time_before(READ_ONCE(cell->llcs[llc_idx].vtime_now), cctx->vtime_now))
-				WRITE_ONCE(cell->llcs[llc_idx].vtime_now, cctx->vtime_now);
+					  FAKE_FLAT_SUBCELL_LLC;
+			if (time_before(READ_ONCE(subcell->llcs[llc_idx].vtime_now),
+					cctx->vtime_now))
+				WRITE_ONCE(subcell->llcs[llc_idx].vtime_now, cctx->vtime_now);
 		}
 		cctx->cell = cell_id;
+		cctx->subcell = 0;
 	}
 
 	/* Swap the new cpumask into place */
@@ -2285,7 +2303,7 @@ int apply_configured_cell_cpumask(u32 cell_id, struct cell_config *config)
 
 int apply_configured_cell_subcells(u32 cell_id, struct cell_config *config)
 {
-	struct subcell(*subcell_configs)[MAX_SUBCELLS_PER_CELL];
+	struct subcell_config(*subcell_configs)[MAX_SUBCELLS_PER_CELL];
 	struct cell *cell;
 	u32 subcell_id;
 
@@ -2305,7 +2323,8 @@ int apply_configured_cell_subcells(u32 cell_id, struct cell_config *config)
 	bpf_for(subcell_id, 0, MAX_SUBCELLS_PER_CELL)
 	{
 		struct cell_cpumask_wrapper *subcell_cpumaskw;
-		struct subcell *subcell_config;
+		struct subcell_config *subcell_config;
+		struct subcell *subcell;
 
 		subcell_cpumaskw = lookup_subcell_cpumask_wrapper(cell_id, subcell_id);
 		if (!subcell_cpumaskw)
@@ -2335,7 +2354,16 @@ int apply_configured_cell_subcells(u32 cell_id, struct cell_config *config)
 			}
 		}
 
-		cell->subcells[subcell_id] = *subcell_config;
+		subcell = MEMBER_VPTR(cell->subcells, [subcell_id]);
+		if (!subcell) {
+			scx_bpf_error("subcell_id %d out of bounds for cell_id %d", subcell_id,
+				      cell_id);
+			return -EINVAL;
+		}
+		subcell->id = subcell_config->id;
+		subcell->in_use = subcell_config->in_use;
+		subcell->primary = subcell_config->primary;
+		subcell->borrowable = subcell_config->borrowable;
 	}
 
 	return 0;
@@ -2408,7 +2436,7 @@ int apply_cell_config(void *ctx)
 			return ret;
 	}
 
-	/* Phase 2.5: Recompute per-LLC CPU counts for all cells */
+	/* Phase 2.5: Recompute per-LLC CPU counts for default subcells */
 	if (enable_llc_awareness) {
 		u32 c;
 		scoped_guard(rcu)
@@ -2417,7 +2445,7 @@ int apply_cell_config(void *ctx)
 			{
 				if (c >= config->num_cells)
 					break;
-				if (recalc_cell_llc_counts(c, NULL))
+				if (recalc_subcell_llc_counts(c, 0, NULL))
 					return -EINVAL;
 			}
 		}

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -2330,13 +2330,20 @@ int apply_cell_config(void *ctx)
 		bpf_for(subcell_id, 0, MAX_SUBCELLS_PER_CELL)
 		{
 			struct cell_cpumask_wrapper *subcell_cpumaskw;
+			struct subcell(*subcell_configs)[MAX_SUBCELLS_PER_CELL];
 			struct subcell *subcell_config;
 
 			subcell_cpumaskw = lookup_subcell_cpumask_wrapper(cell_id, subcell_id);
 			if (!subcell_cpumaskw)
 				return -EINVAL;
 
-			subcell_config = MEMBER_VPTR(config->subcells[cell_id], [subcell_id]);
+			subcell_configs = MEMBER_VPTR(config->subcells, [cell_id]);
+			if (!subcell_configs) {
+				scx_bpf_error("cell_id %d out of bounds for subcells", cell_id);
+				return -EINVAL;
+			}
+
+			subcell_config = MEMBER_VPTR(*subcell_configs, [subcell_id]);
 			if (!subcell_config) {
 				scx_bpf_error("subcell_id %d out of bounds for cell_id %d",
 					      subcell_id, cell_id);

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -235,6 +235,7 @@ static inline int allocate_cell()
 
 		if (__sync_bool_compare_and_swap(&c->in_use, 0, 1)) {
 			/* In timer-managed mode, only subcell 0 is used. */
+			c->subcells[0].id = 0;
 			c->subcells[0].in_use = 1;
 			zero_cell_vtimes(c);
 			return cell_idx;
@@ -2041,6 +2042,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 	{
 		struct cell_cpumask_wrapper *cpumaskw;
 		u32 subcell_id;
+		struct cell *cell;
 
 		if (enable_llc_awareness) {
 			u32 llc;
@@ -2066,6 +2068,16 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 
 		if (!(cpumaskw = lookup_cell_cpumask_wrapper(i)))
 			return -ENOENT;
+
+		cell = lookup_cell(i);
+		if (!cell)
+			return -ENOENT;
+
+		bpf_for(subcell_id, 0, MAX_SUBCELLS_PER_CELL)
+		{
+			cell->subcells[subcell_id].id = subcell_id;
+			cell->subcells[subcell_id].in_use = 0;
+		}
 
 		/*
 		 * Start with full cpumask for all cells. The timer will set up
@@ -2131,6 +2143,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 			return -ENOENT;
 
 		cell->in_use = true;
+		cell->subcells[0].in_use = 1;
 	}
 
 	/*

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -339,16 +339,20 @@ struct subcell_cpumask_map subcell_cpumasks SEC(".maps");
 static inline int update_task_cpumask(struct task_struct *p, struct task_ctx *tctx)
 {
 	const struct cpumask *cell_cpumask;
+	const struct cpumask *subcell_cpumask;
 	struct cpu_ctx *cpu_ctx;
 	u32 cpu;
 
 	if (!(cell_cpumask = lookup_cell_cpumask(tctx->cell)))
 		return -ENOENT;
 
+	if (!(subcell_cpumask = lookup_subcell_cpumask(tctx->cell, tctx->subcell)))
+		return -ENOENT;
+
 	if (!tctx->cpumask)
 		return -EINVAL;
 
-	bpf_cpumask_and(tctx->cpumask, cell_cpumask, p->cpus_ptr);
+	bpf_cpumask_and(tctx->cpumask, subcell_cpumask, p->cpus_ptr);
 
 	if (cell_cpumask)
 		tctx->all_cell_cpus_allowed = bpf_cpumask_subset(cell_cpumask, p->cpus_ptr);
@@ -411,23 +415,34 @@ static inline int update_task_cpumask(struct task_struct *p, struct task_ctx *tc
 		return 0;
 	}
 
-	/* Cell-wide path */
+	/* Cell-wide affinity path, backed by the assigned subcell DSQ. */
 	/* LLC aware version */
 	if (enable_llc_awareness) {
 		return update_task_llc_assignment(p, tctx);
 	}
 
 	/* Non-LLC aware version */
-	tctx->dsq = get_subcell_llc_dsq_id(tctx->cell, 0, FAKE_FLAT_SUBCELL_LLC);
+	tctx->dsq = get_subcell_llc_dsq_id(tctx->cell, tctx->subcell, FAKE_FLAT_SUBCELL_LLC);
 	if (dsq_is_invalid(tctx->dsq))
 		return -EINVAL;
 
 	struct subcell *subcell;
-	if (!(subcell = lookup_subcell(tctx->cell, 0)))
+	if (!(subcell = lookup_subcell(tctx->cell, tctx->subcell)))
 		return -ENOENT;
 
 	p->scx.dsq_vtime = READ_ONCE(subcell->llcs[FAKE_FLAT_SUBCELL_LLC].vtime_now);
 
+	return 0;
+}
+
+static __always_inline int set_vtime_charge_subcell(struct task_ctx *tctx)
+{
+	s32 packed_subcell = pack_subcell_id(tctx->cell, tctx->subcell);
+
+	if (packed_subcell < 0)
+		return -EINVAL;
+
+	tctx->vtime_charge_subcell = packed_subcell;
 	return 0;
 }
 
@@ -597,7 +612,8 @@ static __always_inline s32 try_pick_idle_cpu(struct task_struct *p, s32 prev_cpu
 		 * enqueue), SCX_DSQ_LOCAL resolves to task_rq(p) -- not
 		 * the idle CPU we picked.
 		 */
-		tctx->vtime_charge_cell = tctx->cell;
+		if (set_vtime_charge_subcell(tctx))
+			return -1;
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, slice_ns, 0);
 		if (kick)
 			scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
@@ -606,9 +622,10 @@ static __always_inline s32 try_pick_idle_cpu(struct task_struct *p, s32 prev_cpu
 	if (cpu == -1)
 		return -1; /* error from pick_idle_cpu, propagate */
 
-	/* cpu == -EBUSY: no idle CPU in cell, try borrowing */
+	/* cpu == -EBUSY: no idle CPU in subcell, try borrowing */
 	if (enable_borrowing) {
-		const struct cpumask *borrowable = lookup_cell_borrowable_cpumask(tctx->cell);
+		const struct cpumask *borrowable =
+			lookup_subcell_borrowable_cpumask(tctx->cell, tctx->subcell);
 		if (!borrowable)
 			return -1;
 		const struct cpumask *idle_smtmask __free(idle_cpumask) =
@@ -621,7 +638,8 @@ static __always_inline s32 try_pick_idle_cpu(struct task_struct *p, s32 prev_cpu
 		if (cpu >= 0) {
 			tctx->borrowed = true;
 			cstat_inc(CSTAT_BORROWED, tctx->cell, cctx);
-			tctx->vtime_charge_cell = tctx->cell;
+			if (set_vtime_charge_subcell(tctx))
+				return -1;
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, slice_ns, 0);
 			if (kick)
 				scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
@@ -685,8 +703,8 @@ static __always_inline s32 select_pinned_cpu(struct task_struct *p, s32 prev_cpu
 }
 
 /*
- * select_cpu is where we update each task's cell assignment and then try to
- * dispatch to an idle core in the cell if possible
+ * select_cpu is where we update each task's subcell assignment and then try to
+ * dispatch to an idle core in the subcell if possible.
  */
 s32 BPF_STRUCT_OPS(mitosis_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wake_flags)
 {
@@ -719,7 +737,8 @@ s32 BPF_STRUCT_OPS(mitosis_select_cpu, struct task_struct *p, s32 prev_cpu, u64 
 			return prev_cpu;
 
 		if (idle_cpu_cleared || scx_bpf_test_and_clear_cpu_idle(cpu)) {
-			tctx->vtime_charge_cell = tctx->cell;
+			if (set_vtime_charge_subcell(tctx))
+				return prev_cpu;
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, slice_ns, 0);
 		}
 		return cpu;
@@ -789,19 +808,20 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 		return;
 
 	/*
-	 * CPU -> cell mappings can change between enqueue() and stopping().
+	 * CPU -> subcell mappings can change between enqueue() and stopping().
 	 * If that happens, the task's dsq_vtime may no longer belong to the
-	 * CPU-local or shared cell vtime visible at stopping(), and
-	 * advancing either one would charge the wrong cell.
+	 * CPU-local or shared subcell vtime visible at stopping(), and
+	 * advancing either one would charge the wrong subcell.
 	 * Direct local insert paths snapshot the same state before inserting.
 	 *
-	 * Snapshot the cell whose vtime this placement expects to charge.
-	 * stopping() only advances local and shared vtime if the task is not
-	 * borrowed and the CPU it stops on is still in this same cell.
+	 * Snapshot the subcell whose vtime this placement expects to charge.
+	 * stopping() only advances local and subcell vtime if the task is not
+	 * borrowed and the CPU it stops on is still in this same subcell.
 	 */
-	tctx->vtime_charge_cell = tctx->cell;
+	if (set_vtime_charge_subcell(tctx))
+		return;
 
-	/* Ensure this is done *AFTER* refreshing cell which might manipulate vtime */
+	/* Ensure this is done *AFTER* refreshing placement, which might manipulate vtime. */
 	vtime = p->scx.dsq_vtime;
 
 	if (!tctx->all_cell_cpus_allowed) {
@@ -844,8 +864,8 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 
 	if (tctx->all_cell_cpus_allowed) {
 		cstat_inc(CSTAT_CELL_DSQ, tctx->cell, cctx);
-		/* Task can use any CPU in its cell, so use the default subcell DSQ */
-		if (!(subcell = lookup_subcell(tctx->cell, 0)))
+		/* Task can use any CPU in its subcell, so use the subcell DSQ */
+		if (!(subcell = lookup_subcell(tctx->cell, tctx->subcell)))
 			return;
 
 		if (enable_llc_awareness) {
@@ -874,9 +894,10 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 	tctx->basis_vtime = basis_vtime;
 
 	if (time_after(vtime, basis_vtime + 8192 * slice_ns)) {
-		scx_bpf_error("vtime too far ahead: pid=%d vtime=%llu basis=%llu diff=%llu cell=%u",
-			      p->pid, p->scx.dsq_vtime, basis_vtime, p->scx.dsq_vtime - basis_vtime,
-			      tctx->cell);
+		scx_bpf_error(
+			"vtime too far ahead: pid=%d vtime=%llu basis=%llu diff=%llu cell=%u subcell=%u",
+			p->pid, p->scx.dsq_vtime, basis_vtime, p->scx.dsq_vtime - basis_vtime,
+			tctx->cell, tctx->subcell);
 		return;
 	}
 	/*
@@ -906,11 +927,13 @@ void BPF_STRUCT_OPS(mitosis_dispatch, s32 cpu, struct task_struct *prev)
 {
 	struct cpu_ctx *cctx;
 	u32 cell;
+	u32 subcell;
 
 	if (!(cctx = lookup_cpu_ctx(-1)))
 		return;
 
 	cell = READ_ONCE(cctx->cell);
+	subcell = READ_ONCE(cctx->subcell);
 
 	bool found = false;
 	dsq_id_t min_vtime_dsq = DSQ_INVALID;
@@ -918,16 +941,16 @@ void BPF_STRUCT_OPS(mitosis_dispatch, s32 cpu, struct task_struct *prev)
 
 	struct task_struct *p;
 
-	/* Check the cell-LLC DSQ (use FAKE_FLAT_SUBCELL_LLC when not LLC-aware) */
+	/* Check the subcell+LLC DSQ (use FAKE_FLAT_SUBCELL_LLC when not LLC-aware) */
 	u32 llc = enable_llc_awareness ? cctx->llc : FAKE_FLAT_SUBCELL_LLC;
-	dsq_id_t subcell_dsq = get_subcell_llc_dsq_id(cell, 0, llc);
+	dsq_id_t subcell_dsq = get_subcell_llc_dsq_id(cell, subcell, llc);
 	dsq_id_t cpu_dsq = get_cpu_dsq_id(cpu);
 
 	if (dsq_is_invalid(subcell_dsq) || dsq_is_invalid(cpu_dsq)) {
 		return;
 	}
 
-	/* Peek at cell-LLC DSQ head */
+	/* Peek at subcell+LLC DSQ head */
 	p = dsq_peek(subcell_dsq.raw);
 	if (p) {
 		min_vtime = p->scx.dsq_vtime;
@@ -952,7 +975,7 @@ void BPF_STRUCT_OPS(mitosis_dispatch, s32 cpu, struct task_struct *prev)
 		/* Try work stealing if enabled */
 		if (enable_llc_awareness && enable_work_stealing) {
 			/* Returns: <0 error, 0 no steal, >0 stole work */
-			s32 ret = try_stealing_work(cell, 0, llc);
+			s32 ret = try_stealing_work(cell, subcell, llc);
 			if (ret < 0)
 				return;
 			if (ret > 0) {
@@ -963,15 +986,15 @@ void BPF_STRUCT_OPS(mitosis_dispatch, s32 cpu, struct task_struct *prev)
 	}
 
 	/*
-	 * The move_to_local can fail if we raced with another CPU in the cell
-	 * and now the cell queue is empty. Try the CPU DSQ as a fallback.
+	 * The move_to_local can fail if we raced with another CPU in the subcell
+	 * and now the subcell queue is empty. Try the CPU DSQ as a fallback.
 	 */
 
 	/* Try the winner first */
 	if (scx_bpf_dsq_move_to_local(min_vtime_dsq.raw, 0))
 		return;
 
-	/* Winner was cell DSQ but failed - try the CPU DSQ */
+	/* Winner was subcell DSQ but failed - try the CPU DSQ */
 	if (min_vtime_dsq.raw == subcell_dsq.raw)
 		scx_bpf_dsq_move_to_local(cpu_dsq.raw, 0);
 }
@@ -1133,21 +1156,37 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 	if (!entry)
 		return 0;
 
-	/* Get the root cell (cell 0) and its cpumask */
+	/* Get the root cell and default subcell cpumasks. */
 	int zero = 0;
 	struct cell_cpumask_wrapper *root_cell_cpumaskw;
+	struct cell_cpumask_wrapper *root_subcell_cpumaskw;
+
 	if (!(root_cell_cpumaskw = lookup_cell_cpumask_wrapper(zero))) {
 		return 0;
 	}
+	if (!(root_subcell_cpumaskw = lookup_subcell_cpumask_wrapper(ROOT_CELL_ID, 0))) {
+		return 0;
+	}
 
-	struct bpf_cpumask *root_bpf_cpumask __free(bpf_cpumask) =
+	struct bpf_cpumask *root_cell_bpf_cpumask __free(bpf_cpumask) =
 		get_tmp_cpumask(&root_cell_cpumaskw->primary);
-	if (!root_bpf_cpumask) {
-		scx_bpf_error("root tmp cpumask is NULL");
+	if (!root_cell_bpf_cpumask) {
+		scx_bpf_error("root cell tmp cpumask is NULL");
 		return 0;
 	}
 	if (!root_cell_cpumaskw->primary.cpumask) {
-		scx_bpf_error("root cpumasks should never be null");
+		scx_bpf_error("root cell cpumasks should never be null");
+		return 0;
+	}
+
+	struct bpf_cpumask *root_subcell_bpf_cpumask __free(bpf_cpumask) =
+		get_tmp_cpumask(&root_subcell_cpumaskw->primary);
+	if (!root_subcell_bpf_cpumask) {
+		scx_bpf_error("root subcell tmp cpumask is NULL");
+		return 0;
+	}
+	if (!root_subcell_cpumaskw->primary.cpumask) {
+		scx_bpf_error("root subcell cpumasks should never be null");
 		return 0;
 	}
 
@@ -1161,7 +1200,8 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 	 * Initialize root cell cpumask to all cpus, and then remove from it as we
 	 * go
 	 */
-	bpf_cpumask_copy(root_bpf_cpumask, (const struct cpumask *)all_cpumask);
+	bpf_cpumask_copy(root_cell_bpf_cpumask, (const struct cpumask *)all_cpumask);
+	bpf_cpumask_copy(root_subcell_bpf_cpumask, (const struct cpumask *)all_cpumask);
 
 	struct cgroup_subsys_state *root_css, *pos;
 	struct cgroup *cur_cgrp;
@@ -1250,17 +1290,29 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 		}
 
 		struct cell_cpumask_wrapper *cell_cpumaskw;
+		struct cell_cpumask_wrapper *subcell_cpumaskw;
+
 		if (!(cell_cpumaskw = lookup_cell_cpumask_wrapper(cell_idx))) {
 			return 0;
 		}
+		if (!(subcell_cpumaskw = lookup_subcell_cpumask_wrapper(cell_idx, 0))) {
+			return 0;
+		}
 
-		struct bpf_cpumask *bpf_cpumask __free(bpf_cpumask) =
+		struct bpf_cpumask *cell_bpf_cpumask __free(bpf_cpumask) =
 			get_tmp_cpumask(&cell_cpumaskw->primary);
-		if (!bpf_cpumask) {
+		if (!cell_bpf_cpumask) {
 			scx_bpf_error("tmp cpumask is NULL for cell %d", cell_idx);
 			return 0;
 		}
-		bpf_cpumask_copy(bpf_cpumask, (const struct cpumask *)&entry->cpumask);
+		struct bpf_cpumask *subcell_bpf_cpumask __free(bpf_cpumask) =
+			get_tmp_cpumask(&subcell_cpumaskw->primary);
+		if (!subcell_bpf_cpumask) {
+			scx_bpf_error("tmp cpumask is NULL for cell %d subcell 0", cell_idx);
+			return 0;
+		}
+		bpf_cpumask_copy(cell_bpf_cpumask, (const struct cpumask *)&entry->cpumask);
+		bpf_cpumask_copy(subcell_bpf_cpumask, (const struct cpumask *)&entry->cpumask);
 		int cpu_idx;
 		bpf_for(cpu_idx, 0, nr_possible_cpus)
 		{
@@ -1271,23 +1323,28 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 					return 0;
 				cpu_ctx->cell = cell_idx;
 				cpu_ctx->subcell = 0;
-				bpf_cpumask_clear_cpu(cpu_idx, root_bpf_cpumask);
+				bpf_cpumask_clear_cpu(cpu_idx, root_cell_bpf_cpumask);
+				bpf_cpumask_clear_cpu(cpu_idx, root_subcell_bpf_cpumask);
 			}
 		}
 
 		/*
 		 * Recalc LLC counts BEFORE making cpumask visible.
 		 * Pass the new mask explicitly to avoid race
-		 * if recalc did a lookup_cell_cpumask()
+		 * if recalc did a lookup_subcell_cpumask()
 		 */
 		if (enable_llc_awareness) {
 			if (recalc_subcell_llc_counts(cell_idx, 0,
-						      (const struct cpumask *)bpf_cpumask))
+						      (const struct cpumask *)subcell_bpf_cpumask))
 				return 0;
 		}
 
-		if (publish_prepared_cpumask(&cell_cpumaskw->primary, &bpf_cpumask)) {
+		if (publish_prepared_cpumask(&cell_cpumaskw->primary, &cell_bpf_cpumask)) {
 			scx_bpf_error("failed to publish cpumask for cell %d", cell_idx);
+			return 0;
+		}
+		if (publish_prepared_cpumask(&subcell_cpumaskw->primary, &subcell_bpf_cpumask)) {
+			scx_bpf_error("failed to publish cpumask for cell %d subcell 0", cell_idx);
 			return 0;
 		}
 
@@ -1307,7 +1364,8 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 	int cpu_idx;
 	bpf_for(cpu_idx, 0, nr_possible_cpus)
 	{
-		if (bpf_cpumask_test_cpu(cpu_idx, (const struct cpumask *)root_bpf_cpumask)) {
+		if (bpf_cpumask_test_cpu(cpu_idx,
+					 (const struct cpumask *)root_subcell_bpf_cpumask)) {
 			struct cpu_ctx *cpu_ctx;
 			if (!(cpu_ctx = lookup_cpu_ctx(cpu_idx)))
 				return 0;
@@ -1317,21 +1375,25 @@ static int update_timer_cb(void *map, int *key, struct bpf_timer *timer)
 	}
 
 	/*
-	 * Recalc LLC counts for the root cell BEFORE making cpumask visible.
+	 * Recalc LLC counts for the root subcell BEFORE making cpumask visible.
 	 * Pass the new mask explicitly to avoid race if recalc did a
-	 * lookup_cell_cpumask()
+	 * lookup_subcell_cpumask()
 	 */
 	if (enable_llc_awareness)
 		if (recalc_subcell_llc_counts(ROOT_CELL_ID, 0,
-					      (const struct cpumask *)root_bpf_cpumask))
+					      (const struct cpumask *)root_subcell_bpf_cpumask))
 			return 0;
 
 	/*
 	 * Publish: swap new cpumask in, get old one back.
 	 * After this point, all CPUs see the new mask.
 	 */
-	if (publish_prepared_cpumask(&root_cell_cpumaskw->primary, &root_bpf_cpumask)) {
+	if (publish_prepared_cpumask(&root_cell_cpumaskw->primary, &root_cell_bpf_cpumask)) {
 		scx_bpf_error("failed to publish root cpumask");
+		return 0;
+	}
+	if (publish_prepared_cpumask(&root_subcell_cpumaskw->primary, &root_subcell_bpf_cpumask)) {
+		scx_bpf_error("failed to publish root subcell cpumask");
 		return 0;
 	}
 
@@ -1383,6 +1445,8 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 	struct subcell *subcell;
 	u64 now, used;
 	u32 cidx;
+	u32 subcell_idx;
+	s32 packed_subcell;
 
 	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)))
 		return;
@@ -1393,7 +1457,11 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 	 * E.g. a cell 0 kworker pinned to a cell 1 CPU.
 	 */
 	cidx = cctx->cell;
-	if (!(subcell = lookup_subcell(cidx, 0)))
+	subcell_idx = cctx->subcell;
+	if (!(subcell = lookup_subcell(cidx, subcell_idx)))
+		return;
+	packed_subcell = pack_subcell_id(cidx, subcell_idx);
+	if (packed_subcell < 0)
 		return;
 
 	now = scx_bpf_now();
@@ -1418,23 +1486,23 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 
 	/*
 	 * Only advance this CPU's local vtime when the slice ends on a CPU
-	 * whose cell matches this task's vtime charge cell and the task was
-	 * not borrowed. If execution ends in some other cell, drop the local
-	 * charge rather than risk charging an unexpected cell.
+	 * whose subcell matches this task's vtime charge subcell and the task
+	 * was not borrowed. If execution ends in some other subcell, drop the
+	 * local charge rather than risk charging an unexpected subcell.
 	 */
-	if (!tctx->borrowed && tctx->vtime_charge_cell == cidx) {
+	if (!tctx->borrowed && tctx->vtime_charge_subcell == packed_subcell) {
 		if (time_before(READ_ONCE(cctx->vtime_now), p->scx.dsq_vtime))
 			WRITE_ONCE(cctx->vtime_now, p->scx.dsq_vtime);
 	}
 
 	/*
-	 * Only advance cell vtime when the task stops on a CPU whose cell
-	 * still matches this task's vtime charge cell and the task was not
-	 * borrowed. If the CPU was retagged into a different cell after the
-	 * task was placed, drop the charge rather than advance the wrong cell
-	 * domain.
+	 * Only advance subcell vtime when the task stops on a CPU whose
+	 * subcell still matches this task's vtime charge subcell and the task
+	 * was not borrowed. If the CPU was retagged into a different subcell
+	 * after the task was placed, drop the charge rather than advance the
+	 * wrong subcell.
 	 */
-	if (!tctx->borrowed && tctx->vtime_charge_cell == cidx) {
+	if (!tctx->borrowed && tctx->vtime_charge_subcell == packed_subcell) {
 		advance_subcell_llc_vtime(subcell, tctx, p->scx.dsq_vtime);
 	}
 
@@ -1854,7 +1922,7 @@ void BPF_STRUCT_OPS(mitosis_dump, struct scx_dump_ctx *dctx)
 		if (dsq_is_invalid(dsq_id))
 			return;
 
-		scx_bpf_dump("CELL[%d] vtime=%llu nr_queued=%d\n", i,
+		scx_bpf_dump("SUBCELL[%d:%d] vtime=%llu nr_queued=%d\n", i, 0,
 			     READ_ONCE(subcell->llcs[FAKE_FLAT_SUBCELL_LLC].vtime_now),
 			     scx_bpf_dsq_nr_queued(dsq_id.raw));
 	}
@@ -1923,9 +1991,9 @@ void BPF_STRUCT_OPS(mitosis_dump_task, struct scx_dump_ctx *dctx, struct task_st
 		return;
 
 	scx_bpf_dump(
-		"Task[%d] vtime=%llu basis_vtime=%llu cell=%u dsq=%llx all_cell_cpus_allowed=%d\n",
-		p->pid, p->scx.dsq_vtime, tctx->basis_vtime, tctx->cell, tctx->dsq.raw,
-		tctx->all_cell_cpus_allowed);
+		"Task[%d] vtime=%llu basis_vtime=%llu cell=%u subcell=%u dsq=%llx all_cell_cpus_allowed=%d\n",
+		p->pid, p->scx.dsq_vtime, tctx->basis_vtime, tctx->cell, tctx->subcell,
+		tctx->dsq.raw, tctx->all_cell_cpus_allowed);
 	scx_bpf_dump("Task[%d] CPUS=", p->pid);
 	dump_cpumask(p->cpus_ptr);
 	scx_bpf_dump("\n");

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -237,6 +237,7 @@ static inline int allocate_cell()
 			/* In timer-managed mode, only subcell 0 is used. */
 			c->subcells[0].id = 0;
 			c->subcells[0].in_use = 1;
+			c->subcells[0].nr_match_ors = 0;
 			zero_subcell_vtimes(&c->subcells[0]);
 			return cell_idx;
 		}
@@ -263,6 +264,7 @@ static inline int free_cell(int cell_idx)
 		c->subcells[subcell_id].id = subcell_id;
 		c->subcells[subcell_id].cpu_cnt = 0;
 		c->subcells[subcell_id].in_use = 0;
+		c->subcells[subcell_id].nr_match_ors = 0;
 	}
 	c->cpu_cnt = 0;
 	WRITE_ONCE(c->in_use, 0);
@@ -446,6 +448,94 @@ static __always_inline int set_vtime_charge_subcell(struct task_ctx *tctx)
 	return 0;
 }
 
+static __always_inline bool match_comm_prefix(const char *prefix, const char *comm)
+{
+	u32 i;
+
+	bpf_for(i, 0, MAX_COMM)
+	{
+		if (prefix[i] == '\0')
+			return true;
+		if (comm[i] != prefix[i])
+			return false;
+	}
+
+	return true;
+}
+
+static __always_inline bool match_subcell_match(struct subcell_match *match, const char *comm)
+{
+	switch (match->kind) {
+	case SUBCELL_MATCH_COMM_PREFIX:
+		return match_comm_prefix(match->value, comm);
+	default:
+		return false;
+	}
+}
+
+static __always_inline bool task_matches_subcell(struct subcell *subcell, const char *comm)
+{
+	u32 or_idx;
+
+	bpf_for(or_idx, 0, MAX_SUBCELL_MATCH_ORS)
+	{
+		struct subcell_match_and_group *and_group;
+		bool matches = true;
+		u32 and_idx;
+
+		if (or_idx >= subcell->nr_match_ors)
+			break;
+
+		and_group = MEMBER_VPTR(subcell->matches, [or_idx]);
+		if (!and_group)
+			return false;
+
+		if (and_group->nr_matches == 0)
+			return true;
+
+		bpf_for(and_idx, 0, MAX_SUBCELL_MATCH_ANDS)
+		{
+			struct subcell_match *match;
+
+			if (and_idx >= and_group->nr_matches)
+				break;
+
+			match = MEMBER_VPTR(and_group->matches, [and_idx]);
+			if (!match || !match_subcell_match(match, comm)) {
+				matches = false;
+				break;
+			}
+		}
+
+		if (matches)
+			return true;
+	}
+
+	return false;
+}
+
+static __always_inline u32 pick_task_subcell(struct task_struct *p, u32 cell_id)
+{
+	char comm[MAX_COMM];
+	u32 subcell_id;
+
+	__builtin_memcpy(comm, p->comm, MAX_COMM);
+
+	bpf_for(subcell_id, 1, MAX_SUBCELLS_PER_CELL)
+	{
+		struct subcell *subcell = lookup_subcell(cell_id, subcell_id);
+
+		if (!subcell)
+			break;
+		if (!subcell->in_use)
+			continue;
+		if (task_matches_subcell(subcell, comm))
+			return subcell_id;
+	}
+
+	return 0;
+}
+
 /*
  * Figure out the task's cell, dsq and store the corresponding cpumask in the
  * task_ctx.
@@ -491,7 +581,7 @@ static inline int update_task_cell(struct task_struct *p, struct task_ctx *tctx,
 	tctx->configuration_seq = READ_ONCE(applied_configuration_seq);
 	barrier();
 	tctx->cell = cgc->cell;
-	tctx->subcell = 0;
+	tctx->subcell = pick_task_subcell(p, tctx->cell);
 	tctx->cgid = cg->kn->id;
 
 	return update_task_cpumask(p, tctx);
@@ -2170,6 +2260,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 			cell->subcells[subcell_id].id = subcell_id;
 			cell->subcells[subcell_id].cpu_cnt = 0;
 			cell->subcells[subcell_id].in_use = 0;
+			cell->subcells[subcell_id].nr_match_ors = 0;
 		}
 		cell->cpu_cnt = 0;
 
@@ -2238,6 +2329,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 
 		cell->in_use = true;
 		cell->subcells[0].in_use = 1;
+		cell->subcells[0].nr_match_ors = 0;
 	}
 
 	/*
@@ -2384,6 +2476,7 @@ int apply_configured_cell_subcells(u32 cell_id, struct cell_config *config)
 	struct subcell_config(*subcell_configs)[MAX_SUBCELLS_PER_CELL];
 	struct cell *cell;
 	u32 subcell_id;
+	u32 cpu;
 
 	if (!config || cell_id >= MAX_CELLS)
 		return -EINVAL;
@@ -2440,8 +2533,50 @@ int apply_configured_cell_subcells(u32 cell_id, struct cell_config *config)
 		}
 		subcell->id = subcell_config->id;
 		subcell->in_use = subcell_config->in_use;
+		subcell->nr_match_ors = subcell_config->nr_match_ors;
+		__builtin_memcpy(subcell->matches, subcell_config->matches,
+				 sizeof(subcell->matches));
 		subcell->primary = subcell_config->primary;
 		subcell->borrowable = subcell_config->borrowable;
+
+		if (!subcell_config->in_use)
+			continue;
+
+		bpf_for(cpu, 0, nr_possible_cpus)
+		{
+			struct cpu_ctx *cctx;
+			bool cpu_in_subcell;
+
+			if (cell_cpumask_data_test_cpu(&subcell_config->primary, cpu,
+						       &cpu_in_subcell)) {
+				scx_bpf_error(
+					"failed to decode subcell cpumask for cell=%u subcell=%u",
+					cell_id, subcell_id);
+				return -EINVAL;
+			}
+
+			if (!cpu_in_subcell)
+				continue;
+
+			cctx = bpf_map_lookup_percpu_elem(&cpu_ctxs, &(u32){ 0 }, cpu);
+			if (!cctx)
+				return -ENOENT;
+
+			if (cctx->cell != cell_id || cctx->subcell != subcell_id) {
+				u32 llc_idx;
+
+				llc_idx = enable_llc_awareness && llc_is_valid(cctx->llc) ?
+						  cctx->llc :
+						  FAKE_FLAT_SUBCELL_LLC;
+				if (time_before(READ_ONCE(subcell->llcs[llc_idx].vtime_now),
+						cctx->vtime_now))
+					WRITE_ONCE(subcell->llcs[llc_idx].vtime_now,
+						   cctx->vtime_now);
+			}
+
+			cctx->cell = cell_id;
+			cctx->subcell = subcell_id;
+		}
 	}
 
 	return 0;
@@ -2514,17 +2649,34 @@ int apply_cell_config(void *ctx)
 			return ret;
 	}
 
-	/* Phase 2.5: Recompute per-LLC CPU counts for default subcells */
+	/* Phase 2.5: Recompute per-LLC CPU counts for configured subcells */
 	if (enable_llc_awareness) {
 		u32 c;
 		scoped_guard(rcu)
 		{
 			bpf_for(c, 0, MAX_CELLS)
 			{
+				u32 subcell_id;
+				struct cell *cur_cell;
+
 				if (c >= config->num_cells)
 					break;
-				if (recalc_subcell_llc_counts(c, 0, NULL))
+
+				cur_cell = lookup_cell(c);
+				if (!cur_cell)
 					return -EINVAL;
+
+				bpf_for(subcell_id, 0, MAX_SUBCELLS_PER_CELL)
+				{
+					struct subcell *subcell =
+						MEMBER_VPTR(cur_cell->subcells, [subcell_id]);
+					if (!subcell)
+						return -EINVAL;
+					if (!subcell->in_use)
+						continue;
+					if (recalc_subcell_llc_counts(c, subcell_id, NULL))
+						return -EINVAL;
+				}
 			}
 		}
 	}

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -227,6 +227,43 @@ static inline struct cpu_ctx *lookup_cpu_ctx(int cpu)
 	return cctx;
 }
 
+static __always_inline int create_subcell_dsqs(u32 cell_id, u32 subcell_id)
+{
+	int ret;
+
+	if (enable_llc_awareness) {
+		u32 llc;
+
+		bpf_for(llc, 0, MAX_LLCS)
+		{
+			dsq_id_t dsq_id;
+
+			if (llc >= nr_llc)
+				break;
+
+			dsq_id = get_subcell_llc_dsq_id(cell_id, subcell_id, llc);
+			if (dsq_is_invalid(dsq_id))
+				return -EINVAL;
+
+			ret = scx_bpf_create_dsq(dsq_id.raw, ANY_NUMA);
+			if (ret < 0 && ret != -EEXIST)
+				return ret;
+		}
+	} else {
+		dsq_id_t dsq_id =
+			get_subcell_llc_dsq_id(cell_id, subcell_id, FAKE_FLAT_SUBCELL_LLC);
+
+		if (dsq_is_invalid(dsq_id))
+			return -EINVAL;
+
+		ret = scx_bpf_create_dsq(dsq_id.raw, ANY_NUMA);
+		if (ret < 0 && ret != -EEXIST)
+			return ret;
+	}
+
+	return 0;
+}
+
 /*
  * Cells are allocated in the timer callback and freed in cgroup exit handlers.
  * allocate_cell and free_cell use atomic operations to handle concurrent access.
@@ -2497,6 +2534,7 @@ int apply_configured_cell_subcells(u32 cell_id, struct cell_config *config)
 	struct cell *cell;
 	u32 subcell_id;
 	u32 cpu;
+	int ret;
 
 	if (!config || cell_id >= MAX_CELLS)
 		return -EINVAL;
@@ -2561,6 +2599,12 @@ int apply_configured_cell_subcells(u32 cell_id, struct cell_config *config)
 
 		if (!subcell_config->in_use)
 			continue;
+
+		if ((ret = create_subcell_dsqs(cell_id, subcell_id))) {
+			scx_bpf_error("failed to create DSQs for cell=%u subcell=%u: %d", cell_id,
+				      subcell_id, ret);
+			return ret;
+		}
 
 		bpf_for(cpu, 0, nr_possible_cpus)
 		{

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -202,6 +202,13 @@ struct {
 	__uint(max_entries, 1);
 } cpu_ctxs SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CELLS * MAX_SUBCELLS_PER_CELL);
+} subcell_running_ns SEC(".maps");
+
 static inline struct cpu_ctx *lookup_cpu_ctx(int cpu)
 {
 	struct cpu_ctx *cctx;
@@ -1547,6 +1554,7 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 	u32 cidx;
 	u32 subcell_idx;
 	s32 packed_subcell;
+	s32 task_packed_subcell;
 
 	if (!(cctx = lookup_cpu_ctx(-1)) || !(tctx = lookup_task_ctx(p)))
 		return;
@@ -1562,6 +1570,9 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 		return;
 	packed_subcell = pack_subcell_id(cidx, subcell_idx);
 	if (packed_subcell < 0)
+		return;
+	task_packed_subcell = pack_subcell_id(tctx->cell, tctx->subcell);
+	if (task_packed_subcell < 0)
 		return;
 
 	now = scx_bpf_now();
@@ -1611,11 +1622,20 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 
 	{
 		u64 *running = MEMBER_VPTR(cctx->running_ns, [tctx->cell]);
+		u32 subcell_running_key = task_packed_subcell;
+		u64 *subcell_running =
+			bpf_map_lookup_elem(&subcell_running_ns, &subcell_running_key);
 		if (!running) {
 			scx_bpf_error("Task cell index too large: %d", tctx->cell);
 			return;
 		}
+		if (!subcell_running) {
+			scx_bpf_error("Task cell or subcell index too large: %d, %d", tctx->cell,
+				      tctx->subcell);
+			return;
+		}
 		*running += used;
+		*subcell_running += used;
 	}
 }
 

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.h
@@ -84,19 +84,20 @@ static inline struct subcell *lookup_subcell(u32 cell_idx, u32 subcell_idx)
  */
 struct task_ctx {
 	/* cpumask is the set of valid cpus this task can schedule on */
-	/* (task's cpumask and-ed with its cell cpumask) */
+	/* (task's cpumask and-ed with its subcell cpumask) */
 	struct bpf_cpumask __kptr *cpumask;
 	/* started_running_at for recording runtime */
 	u64 started_running_at;
-	/* Cell whose vtime domain should be charged for this task */
-	u32 vtime_charge_cell;
+	/* Packed subcell whose vtime should be charged for this task. */
+	u32 vtime_charge_subcell;
 	u64 basis_vtime;
 	/* For the sake of monitoring, each task is owned by a cell */
 	u32 cell;
 	/* Subcell within the task's cell. Defaults to subcell 0 for now. */
 	u32 subcell;
-	/* For the sake of scheduling, a task is exclusively owned by either a cell
-	 * or a cpu */
+	/* For the sake of scheduling, a task is exclusively owned by either a
+	 * subcell or a cpu.
+	 */
 	dsq_id_t dsq;
 	/* latest configuration that was applied for this task */
 	/* (to know if it has to be re-applied) */
@@ -104,8 +105,8 @@ struct task_ctx {
 	/* Is this task allowed on all cores of its cell? */
 	bool all_cell_cpus_allowed;
 	/* Set when task is dispatched to a borrowed CPU from another cell.
-	 * Consumed and cleared in mitosis_stopping to avoid advancing the
-	 * lending cell's per-CPU DSQ vtime with this task's execution.
+	 * Consumed and cleared in mitosis_stopping to avoid advancing the CPU
+	 * or subcell vtime with this task's borrowed execution.
 	 */
 	bool borrowed;
 	/* Last known cgroup ID for detecting cgroup moves (used when cpu_controller_disabled) */

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.h
@@ -56,6 +56,29 @@ static inline struct cell *lookup_cell(int idx)
 	return cell;
 }
 
+static inline struct subcell *lookup_subcell(u32 cell_idx, u32 subcell_idx)
+{
+	struct cell *cell;
+	struct subcell *subcell;
+
+	if (subcell_idx >= MAX_SUBCELLS_PER_CELL) {
+		scx_bpf_error("invalid subcell %u for cell %u", subcell_idx, cell_idx);
+		return NULL;
+	}
+
+	cell = lookup_cell(cell_idx);
+	if (!cell)
+		return NULL;
+
+	subcell = MEMBER_VPTR(cell->subcells, [subcell_idx]);
+	if (!subcell) {
+		scx_bpf_error("subcell %u out of bounds for cell %u", subcell_idx, cell_idx);
+		return NULL;
+	}
+
+	return subcell;
+}
+
 /*
  * task_ctx is the per-task information kept by scx_mitosis
  */

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.h
@@ -70,6 +70,8 @@ struct task_ctx {
 	u64 basis_vtime;
 	/* For the sake of monitoring, each task is owned by a cell */
 	u32 cell;
+	/* Subcell within the task's cell. Defaults to subcell 0 for now. */
+	u32 subcell;
 	/* For the sake of scheduling, a task is exclusively owned by either a cell
 	 * or a cpu */
 	dsq_id_t dsq;

--- a/scheds/rust/scx_mitosis/src/cell_manager.rs
+++ b/scheds/rust/scx_mitosis/src/cell_manager.rs
@@ -34,10 +34,10 @@ pub struct CellInfo {
 /// `allowed=None` means unpinned: the recipient does not claim any specific CPUs
 /// and only participates in the unclaimed pool.
 #[derive(Debug, Clone)]
-struct CpuRecipient {
-    id: u32,
-    weight: f64,
-    allowed: Option<Cpumask>,
+pub(crate) struct CpuRecipient {
+    pub id: u32,
+    pub weight: f64,
+    pub allowed: Option<Cpumask>,
 }
 
 /// Result of CPU assignment computation, containing both primary and optional borrowable masks.
@@ -824,6 +824,18 @@ impl CellManager {
         compute_borrowable: bool,
     ) -> Result<Vec<CpuAssignment>> {
         self.compute_cpu_assignments_inner(Some(cell_demands), compute_borrowable)
+    }
+
+    /// Compute CPU assignments for subcells inside a cell's primary CPU domain.
+    ///
+    /// Subcells are treated as recipients over `domain`, which is expected to be
+    /// the parent cell's exclusive CPU allocation.
+    pub(crate) fn compute_subcell_cpu_assignments(
+        domain: &Cpumask,
+        subcells: &[CpuRecipient],
+        compute_borrowable: bool,
+    ) -> Result<Vec<CpuAssignment>> {
+        CpuManager::new(domain).compute_assignments(subcells, compute_borrowable)
     }
 
     /// Internal implementation shared by equal-weight and demand-weighted assignment.
@@ -2807,6 +2819,65 @@ mod tests {
             union = union.or(&assignment.primary);
         }
         assert_eq!(union, domain, "Primary masks should cover the whole domain");
+    }
+
+    #[test]
+    fn test_compute_subcell_cpu_assignments_matches_domain() {
+        let domain = cpumask_from_cpulist(32, "8-9,12,14-15");
+        let recipients = vec![CpuRecipient {
+            id: 0,
+            weight: 1.0,
+            allowed: None,
+        }];
+
+        let assignments =
+            CellManager::compute_subcell_cpu_assignments(&domain, &recipients, false).unwrap();
+
+        assert_eq!(assignments.len(), 1);
+        let subcell0 = find_assignment(&assignments, 0);
+        assert_eq!(subcell0.primary, domain);
+        assert!(subcell0.borrowable.is_none());
+    }
+
+    #[test]
+    fn test_compute_subcell_cpu_assignments_borrowable_is_empty_when_enabled() {
+        let domain = cpumask_from_cpulist(32, "3-4,8,10-11");
+        let recipients = vec![CpuRecipient {
+            id: 0,
+            weight: 1.0,
+            allowed: None,
+        }];
+
+        let assignments =
+            CellManager::compute_subcell_cpu_assignments(&domain, &recipients, true).unwrap();
+        let subcell0 = find_assignment(&assignments, 0);
+
+        assert_eq!(subcell0.primary, domain);
+        assert_eq!(subcell0.borrowable.as_ref().unwrap().weight(), 0);
+    }
+
+    #[test]
+    fn test_compute_subcell_cpu_assignments_preserves_existing_custom_subcells() {
+        let domain = cpumask_from_cpulist(32, "8-15");
+        let recipients = vec![
+            CpuRecipient {
+                id: 0,
+                weight: 1.0,
+                allowed: None,
+            },
+            CpuRecipient {
+                id: 2,
+                weight: 1.0,
+                allowed: None,
+            },
+        ];
+
+        let assignments =
+            CellManager::compute_subcell_cpu_assignments(&domain, &recipients, false).unwrap();
+
+        assert_eq!(assignments.len(), 2);
+        assert_eq!(find_assignment(&assignments, 0).primary.weight(), 4);
+        assert_eq!(find_assignment(&assignments, 2).primary.weight(), 4);
     }
 
     /// Symmetric pairwise overlaps must produce equal cell sizes regardless

--- a/scheds/rust/scx_mitosis/src/cell_manager.rs
+++ b/scheds/rust/scx_mitosis/src/cell_manager.rs
@@ -835,7 +835,16 @@ impl CellManager {
         subcells: &[CpuRecipient],
         compute_borrowable: bool,
     ) -> Result<Vec<CpuAssignment>> {
-        CpuManager::new(domain).compute_assignments(subcells, compute_borrowable)
+        Self::compute_cpu_assignments_for(domain, subcells, compute_borrowable)
+    }
+
+    /// Compute CPU assignments over `domain` for an explicit recipient list.
+    pub(crate) fn compute_cpu_assignments_for(
+        domain: &Cpumask,
+        recipients: &[CpuRecipient],
+        compute_borrowable: bool,
+    ) -> Result<Vec<CpuAssignment>> {
+        CpuManager::new(domain).compute_assignments(recipients, compute_borrowable)
     }
 
     /// Internal implementation shared by equal-weight and demand-weighted assignment.

--- a/scheds/rust/scx_mitosis/src/cell_manager.rs
+++ b/scheds/rust/scx_mitosis/src/cell_manager.rs
@@ -29,113 +29,84 @@ pub struct CellInfo {
     pub cpuset: Option<Cpumask>,
 }
 
-/// Compute the global target CPU count for each cell.
+/// Generic allocation input for a CPU partitioning recipient.
 ///
-/// Each cell gets a floor of 1 CPU, with the remainder distributed proportionally
-/// by weight. Returns only counts, not actual CPU assignments.
-fn compute_targets(total_cpus: usize, cells: &[(u32, f64)]) -> Result<HashMap<u32, usize>> {
-    if cells.is_empty() {
-        bail!("compute_targets called with no cells");
-    }
-    if total_cpus < cells.len() {
-        bail!(
-            "Not enough CPUs ({}) for {} cells (need at least 1 each)",
-            total_cpus,
-            cells.len()
-        );
-    }
-
-    let total_weight: f64 = cells.iter().map(|(_, w)| w).sum();
-    let num_cells = cells.len();
-
-    if total_weight <= 0.0 {
-        // Equal division fallback
-        let per = total_cpus / num_cells;
-        let remainder = total_cpus % num_cells;
-        return Ok(cells
-            .iter()
-            .enumerate()
-            .map(|(i, (cell_id, _))| {
-                let extra = if i < remainder { 1 } else { 0 };
-                (*cell_id, per + extra)
-            })
-            .collect());
-    }
-
-    let distributable = total_cpus - num_cells;
-    let mut assigned = num_cells;
-    let mut raw: Vec<(u32, f64, usize)> = cells
-        .iter()
-        .map(|(cell_id, w)| {
-            let frac = w / total_weight * distributable as f64;
-            let floored = frac.floor() as usize;
-            assigned += floored;
-            (*cell_id, frac - frac.floor(), 1 + floored)
-        })
-        .collect();
-
-    let mut remainder = total_cpus - assigned;
-    raw.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-    for entry in raw.iter_mut() {
-        if remainder == 0 {
-            break;
-        }
-        entry.2 += 1;
-        remainder -= 1;
-    }
-
-    Ok(raw
-        .iter()
-        .map(|(cell_id, _, count)| (*cell_id, *count))
-        .collect())
+/// `allowed=None` means unpinned: the recipient does not claim any specific CPUs
+/// and only participates in the unclaimed pool.
+#[derive(Debug, Clone)]
+struct CpuRecipient {
+    id: u32,
+    weight: f64,
+    allowed: Option<Cpumask>,
 }
 
-/// Distribute CPUs among recipients proportionally by weight.
-///
-/// Recipients with weight 0 receive 0 CPUs. If all weights are 0, falls back to
-/// equal division. As a post-processing step, if any positive-weight recipient got
-/// 0 CPUs, 1 CPU is stolen from the recipient with the highest allocation (that has
-/// > 1) to prevent starvation.
-fn distribute_cpus_proportional(
-    cpus: &[usize],
-    recipients: &[(u32, f64)],
-) -> Result<HashMap<u32, Vec<usize>>> {
-    if cpus.is_empty() {
-        bail!("distribute_cpus_proportional called with no CPUs");
-    }
-    if recipients.is_empty() {
-        bail!("distribute_cpus_proportional called with no recipients");
+/// Result of CPU assignment computation, containing both primary and optional borrowable masks.
+#[derive(Debug)]
+pub struct CpuAssignment {
+    pub id: u32,
+    pub primary: Cpumask,
+    pub borrowable: Option<Cpumask>,
+}
+
+/// Generic CPU allocator over a fixed domain of CPUs.
+struct CpuManager<'a> {
+    domain: &'a Cpumask,
+}
+
+impl<'a> CpuManager<'a> {
+    fn new(domain: &'a Cpumask) -> Self {
+        Self { domain }
     }
 
-    let total_weight: f64 = recipients.iter().map(|(_, w)| w).sum();
-    let n = cpus.len();
+    /// Compute the global target CPU count for each recipient.
+    ///
+    /// Each recipient gets a floor of 1 CPU, with the remainder distributed
+    /// proportionally by weight. Returns only counts, not actual CPU assignments.
+    fn compute_targets(
+        total_cpus: usize,
+        recipients: &[(u32, f64)],
+    ) -> Result<HashMap<u32, usize>> {
+        if recipients.is_empty() {
+            bail!("compute_targets called with no cells");
+        }
+        if total_cpus < recipients.len() {
+            bail!(
+                "Not enough CPUs ({}) for {} cells (need at least 1 each)",
+                total_cpus,
+                recipients.len()
+            );
+        }
 
-    let mut allocs: Vec<(u32, usize)> = if total_weight <= 0.0 {
-        // Equal division fallback
-        let per = n / recipients.len();
-        let remainder = n % recipients.len();
-        recipients
+        let total_weight: f64 = recipients.iter().map(|(_, w)| w).sum();
+        let num_recipients = recipients.len();
+
+        if total_weight <= 0.0 {
+            // Equal division fallback
+            let per = total_cpus / num_recipients;
+            let remainder = total_cpus % num_recipients;
+            return Ok(recipients
+                .iter()
+                .enumerate()
+                .map(|(i, (id, _))| {
+                    let extra = if i < remainder { 1 } else { 0 };
+                    (*id, per + extra)
+                })
+                .collect());
+        }
+
+        let distributable = total_cpus - num_recipients;
+        let mut assigned = num_recipients;
+        let mut raw: Vec<(u32, f64, usize)> = recipients
             .iter()
-            .enumerate()
-            .map(|(i, (cell_id, _))| {
-                let extra = if i < remainder { 1 } else { 0 };
-                (*cell_id, per + extra)
-            })
-            .collect()
-    } else {
-        // Standard proportional distribution
-        let mut assigned = 0usize;
-        let mut raw: Vec<(u32, f64, usize, bool)> = recipients
-            .iter()
-            .map(|(cell_id, w)| {
-                let frac = w / total_weight * n as f64;
+            .map(|(id, weight)| {
+                let frac = weight / total_weight * distributable as f64;
                 let floored = frac.floor() as usize;
                 assigned += floored;
-                (*cell_id, frac - frac.floor(), floored, *w > 0.0)
+                (*id, frac - frac.floor(), 1 + floored)
             })
             .collect();
 
-        let mut remainder = n - assigned;
+        let mut remainder = total_cpus - assigned;
         raw.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         for entry in raw.iter_mut() {
             if remainder == 0 {
@@ -145,63 +116,358 @@ fn distribute_cpus_proportional(
             remainder -= 1;
         }
 
-        // Post-processing floor guarantee: if any positive-weight recipient got 0
-        // CPUs, steal 1 from the recipient with the highest allocation (> 1).
-        // This prevents death spirals where cells with low but non-zero demand
-        // get starved of CPUs entirely.
-        loop {
-            let Some(starved_idx) = raw
-                .iter()
-                .position(|(_, _, count, pos_weight)| *pos_weight && *count == 0)
-            else {
-                break;
-            };
-            let Some(donor_idx) = raw
-                .iter()
-                .enumerate()
-                .filter(|(_, (_, _, count, _))| *count > 1)
-                .max_by_key(|(_, (_, _, count, _))| *count)
-                .map(|(i, _)| i)
-            else {
-                break; // No donor with > 1 CPU available
-            };
-            raw[donor_idx].2 -= 1;
-            raw[starved_idx].2 += 1;
-        }
-
-        raw.iter()
-            .map(|(cell_id, _, count, _)| (*cell_id, *count))
-            .collect()
-    };
-
-    // Assign actual CPU numbers
-    let mut cpu_iter = cpus.iter().copied();
-    allocs.sort_by_key(|(cell_id, _)| *cell_id);
-    let mut result: HashMap<u32, Vec<usize>> = HashMap::new();
-    for (cell_id, count) in allocs {
-        let cpus_for_cell: Vec<usize> = cpu_iter.by_ref().take(count).collect();
-        if cpus_for_cell.len() != count {
-            bail!(
-                "BUG: distribute_cpus_proportional: cell {} expected {} CPUs but got {}",
-                cell_id,
-                count,
-                cpus_for_cell.len()
-            );
-        }
-        if !cpus_for_cell.is_empty() {
-            result.insert(cell_id, cpus_for_cell);
-        }
+        Ok(raw.iter().map(|(id, _, count)| (*id, *count)).collect())
     }
 
-    Ok(result)
-}
+    /// Distribute CPUs among recipients proportionally by weight.
+    ///
+    /// Recipients with weight 0 receive 0 CPUs. If all weights are 0, falls back to
+    /// equal division. As a post-processing step, if any positive-weight recipient got
+    /// 0 CPUs, 1 CPU is stolen from the recipient with the highest allocation (that has
+    /// > 1) to prevent starvation.
+    fn distribute_cpus_proportional(
+        cpus: &[usize],
+        recipients: &[(u32, f64)],
+    ) -> Result<HashMap<u32, Vec<usize>>> {
+        if cpus.is_empty() {
+            bail!("distribute_cpus_proportional called with no CPUs");
+        }
+        if recipients.is_empty() {
+            bail!("distribute_cpus_proportional called with no recipients");
+        }
 
-/// Result of CPU assignment computation, containing both primary and optional borrowable masks.
-#[derive(Debug)]
-pub struct CpuAssignment {
-    pub cell_id: u32,
-    pub primary: Cpumask,
-    pub borrowable: Option<Cpumask>,
+        let total_weight: f64 = recipients.iter().map(|(_, w)| w).sum();
+        let n = cpus.len();
+
+        let mut allocs: Vec<(u32, usize)> = if total_weight <= 0.0 {
+            // Equal division fallback
+            let per = n / recipients.len();
+            let remainder = n % recipients.len();
+            recipients
+                .iter()
+                .enumerate()
+                .map(|(i, (id, _))| {
+                    let extra = if i < remainder { 1 } else { 0 };
+                    (*id, per + extra)
+                })
+                .collect()
+        } else {
+            // Standard proportional distribution
+            let mut assigned = 0usize;
+            let mut raw: Vec<(u32, f64, usize, bool)> = recipients
+                .iter()
+                .map(|(id, weight)| {
+                    let frac = weight / total_weight * n as f64;
+                    let floored = frac.floor() as usize;
+                    assigned += floored;
+                    (*id, frac - frac.floor(), floored, *weight > 0.0)
+                })
+                .collect();
+
+            let mut remainder = n - assigned;
+            raw.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            for entry in raw.iter_mut() {
+                if remainder == 0 {
+                    break;
+                }
+                entry.2 += 1;
+                remainder -= 1;
+            }
+
+            // Post-processing floor guarantee: if any positive-weight recipient got 0
+            // CPUs, steal 1 from the recipient with the highest allocation (> 1).
+            // This prevents death spirals where cells with low but non-zero demand
+            // get starved of CPUs entirely.
+            loop {
+                let Some(starved_idx) = raw
+                    .iter()
+                    .position(|(_, _, count, pos_weight)| *pos_weight && *count == 0)
+                else {
+                    break;
+                };
+                let Some(donor_idx) = raw
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, (_, _, count, _))| *count > 1)
+                    .max_by_key(|(_, (_, _, count, _))| *count)
+                    .map(|(i, _)| i)
+                else {
+                    break; // No donor with > 1 CPU available
+                };
+                raw[donor_idx].2 -= 1;
+                raw[starved_idx].2 += 1;
+            }
+
+            raw.iter().map(|(id, _, count, _)| (*id, *count)).collect()
+        };
+
+        // Assign actual CPU numbers
+        let mut cpu_iter = cpus.iter().copied();
+        allocs.sort_by_key(|(id, _)| *id);
+        let mut result: HashMap<u32, Vec<usize>> = HashMap::new();
+        for (id, count) in allocs {
+            let cpus_for_recipient: Vec<usize> = cpu_iter.by_ref().take(count).collect();
+            if cpus_for_recipient.len() != count {
+                bail!(
+                    "BUG: distribute_cpus_proportional: cell {} expected {} CPUs but got {}",
+                    id,
+                    count,
+                    cpus_for_recipient.len()
+                );
+            }
+            if !cpus_for_recipient.is_empty() {
+                result.insert(id, cpus_for_recipient);
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Compute CPU assignments over `domain` for a generic set of recipients.
+    ///
+    /// Recipients with `allowed=Some(mask)` claim CPUs in that mask. Recipients with
+    /// `allowed=None` are unpinned and only receive from the unclaimed pool.
+    ///
+    /// When allowed masks overlap, contested CPUs are divided proportionally among
+    /// claimants. Unclaimed CPUs go to unpinned recipients.
+    ///
+    /// If `compute_borrowable` is true, each assignment includes a borrowable
+    /// cpumask consisting of `domain - primary`, intersected with `allowed` if
+    /// present.
+    fn compute_assignments(
+        &self,
+        recipients: &[CpuRecipient],
+        compute_borrowable: bool,
+    ) -> Result<Vec<CpuAssignment>> {
+        let domain = self.domain;
+
+        if recipients.is_empty() {
+            bail!("compute_cpu_assignments called with no recipients");
+        }
+
+        let mut seen_ids = HashSet::new();
+        for recipient in recipients {
+            if recipient.weight < 0.0 {
+                bail!(
+                    "Recipient {} has negative weight {}",
+                    recipient.id,
+                    recipient.weight
+                );
+            }
+            if !seen_ids.insert(recipient.id) {
+                bail!("Duplicate recipient id {}", recipient.id);
+            }
+        }
+
+        // Phase 1: Build contention map - for each CPU, track which recipients claim it
+        let mut contention: HashMap<usize, Vec<u32>> = HashMap::new();
+        for recipient in recipients {
+            if let Some(ref allowed) = recipient.allowed {
+                for cpu in allowed.iter() {
+                    contention.entry(cpu).or_default().push(recipient.id);
+                }
+            }
+        }
+
+        // Phase 2: Categorize CPUs and build initial assignments
+        // - Exclusive: claimed by exactly 1 recipient -> assigned directly
+        // - Contested: claimed by 2+ recipients -> distributed by weight
+        // - Unclaimed: no allowed mask claims it -> shared among unpinned recipients
+        let mut recipient_cpus: HashMap<u32, Cpumask> = HashMap::new();
+        let mut contested_cpus: Vec<usize> = Vec::new();
+        let mut unclaimed_cpus: Vec<usize> = Vec::new();
+
+        for cpu in domain.iter() {
+            match contention.get(&cpu) {
+                None => unclaimed_cpus.push(cpu),
+                Some(claimants) if claimants.len() == 1 => {
+                    let id = claimants[0];
+                    recipient_cpus
+                        .entry(id)
+                        .or_insert_with(Cpumask::new)
+                        .set_cpu(cpu)
+                        .ok();
+                }
+                Some(_) => contested_cpus.push(cpu),
+            }
+        }
+
+        // Compute global targets and initialize running count of CPUs assigned per recipient
+        let total_cpu_count = domain.weight();
+        let mut all_recipients_with_weights: Vec<(u32, f64)> =
+            recipients.iter().map(|r| (r.id, r.weight)).collect();
+        all_recipients_with_weights.sort_by_key(|(id, _)| *id);
+
+        let targets = Self::compute_targets(total_cpu_count, &all_recipients_with_weights)?;
+
+        // Seed assigned_count from exclusive assignments
+        let mut assigned_count: HashMap<u32, usize> = HashMap::new();
+        for (id, mask) in &recipient_cpus {
+            assigned_count.insert(*id, mask.weight());
+        }
+
+        // Phase 3: Distribute contested CPUs among claimants using deficit weights
+        let mut contested_groups: HashMap<Vec<u32>, Vec<usize>> = HashMap::new();
+        for cpu in contested_cpus {
+            if let Some(claimants) = contention.get(&cpu) {
+                let mut sorted_claimants = claimants.clone();
+                sorted_claimants.sort();
+                contested_groups
+                    .entry(sorted_claimants)
+                    .or_default()
+                    .push(cpu);
+            }
+        }
+
+        // Freeze deficit weights before processing any group. Each group is an
+        // independent allocation decision, so a recipient's weight should not depend
+        // on HashMap iteration order (i.e., which other groups were processed
+        // first). Using the initial deficit (target - exclusive_count) as weight
+        // for all groups makes the result deterministic.
+        let initial_deficit: HashMap<u32, f64> = targets
+            .iter()
+            .map(|(&id, &target)| {
+                // Recipients with no exclusive CPUs have no entry yet; 0 is correct.
+                let already = assigned_count.get(&id).copied().unwrap_or(0);
+                let deficit = if target > already {
+                    (target - already) as f64
+                } else {
+                    0.0
+                };
+                (id, deficit)
+            })
+            .collect();
+
+        for (claimants, cpus) in contested_groups {
+            let mut recipients_with_deficit: Vec<(u32, f64)> = Vec::new();
+            let mut all_zero = true;
+            for &id in &claimants {
+                let deficit = *initial_deficit.get(&id).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "BUG: recipient {} in contention map but missing from targets",
+                        id
+                    )
+                })?;
+                if deficit > 0.0 {
+                    all_zero = false;
+                }
+                recipients_with_deficit.push((id, deficit));
+            }
+
+            // If all claimants already meet/exceed their target, fall back to equal weights
+            if all_zero {
+                recipients_with_deficit = claimants.iter().map(|&id| (id, 1.0)).collect();
+            }
+
+            let distribution = Self::distribute_cpus_proportional(&cpus, &recipients_with_deficit)?;
+            for (id, assigned_cpus) in distribution {
+                let count = assigned_cpus.len();
+                for cpu in assigned_cpus {
+                    recipient_cpus
+                        .entry(id)
+                        .or_insert_with(Cpumask::new)
+                        .set_cpu(cpu)
+                        .ok();
+                }
+                *assigned_count.entry(id).or_insert(0) += count;
+            }
+        }
+
+        // Phase 4: Distribute unclaimed CPUs among unpinned recipients using deficit weights
+        if !unclaimed_cpus.is_empty() {
+            let mut unpinned_recipients: Vec<(u32, f64)> = Vec::new();
+            let mut all_zero = true;
+
+            for recipient in recipients {
+                if recipient.allowed.is_some() {
+                    continue; // pinned recipients don't receive unclaimed CPUs
+                }
+                let target = *targets.get(&recipient.id).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "BUG: recipient {} is unpinned but missing from targets",
+                        recipient.id
+                    )
+                })?;
+                // Recipients with no exclusive CPUs have no entry yet; 0 is correct.
+                let already = assigned_count.get(&recipient.id).copied().unwrap_or(0);
+                let deficit = if target > already {
+                    (target - already) as f64
+                } else {
+                    0.0
+                };
+                if deficit > 0.0 {
+                    all_zero = false;
+                }
+                unpinned_recipients.push((recipient.id, deficit));
+            }
+            unpinned_recipients.sort_by_key(|(id, _)| *id);
+
+            // If all recipients already meet/exceed their target, fall back to equal weights
+            if all_zero {
+                unpinned_recipients = unpinned_recipients
+                    .iter()
+                    .map(|(id, _)| (*id, 1.0))
+                    .collect();
+            }
+
+            let distribution =
+                Self::distribute_cpus_proportional(&unclaimed_cpus, &unpinned_recipients)?;
+            for (id, assigned_cpus) in distribution {
+                let count = assigned_cpus.len();
+                for cpu in assigned_cpus {
+                    recipient_cpus
+                        .entry(id)
+                        .or_insert_with(Cpumask::new)
+                        .set_cpu(cpu)
+                        .ok();
+                }
+                *assigned_count.entry(id).or_insert(0) += count;
+            }
+        }
+
+        // Phase 5: Verify all recipients have at least one CPU assigned
+        for recipient in recipients {
+            if !recipient_cpus.contains_key(&recipient.id)
+                || recipient_cpus
+                    .get(&recipient.id)
+                    .map_or(true, |m| m.weight() == 0)
+            {
+                bail!(
+                    "Cell {} has no CPUs assigned (nr_cpus={}, num_cells={})",
+                    recipient.id,
+                    domain.weight(),
+                    recipients.len()
+                );
+            }
+        }
+
+        let allowed_by_id: HashMap<u32, Option<Cpumask>> = recipients
+            .iter()
+            .map(|recipient| (recipient.id, recipient.allowed.clone()))
+            .collect();
+
+        // Phase 6: Build CpuAssignment results, optionally computing borrowable masks
+        Ok(recipient_cpus
+            .into_iter()
+            .map(|(id, primary)| {
+                let borrowable = if compute_borrowable {
+                    let mut borrow_mask = domain.and(&primary.not());
+                    // If this recipient has an allowed mask, restrict borrowable to it
+                    if let Some(Some(allowed)) = allowed_by_id.get(&id) {
+                        borrow_mask = borrow_mask.and(allowed);
+                    }
+                    Some(borrow_mask)
+                } else {
+                    None
+                };
+                CpuAssignment {
+                    id,
+                    primary,
+                    borrowable,
+                }
+            })
+            .collect())
+    }
 }
 
 /// Manages cells for direct child cgroups of a specified parent
@@ -566,238 +832,38 @@ impl CellManager {
         cell_demands: Option<&HashMap<u32, f64>>,
         compute_borrowable: bool,
     ) -> Result<Vec<CpuAssignment>> {
-        // Validate that all demand weights are non-negative
-        if let Some(demands) = cell_demands {
-            for (&cell_id, &weight) in demands {
-                if weight < 0.0 {
-                    bail!("Cell {} has negative demand weight {}", cell_id, weight);
-                }
-            }
-        }
-
-        // Phase 1: Build contention map - for each CPU, track which cells claim it
-        let mut contention: HashMap<usize, Vec<u32>> = HashMap::new();
-        for cell_info in self.cells.values() {
-            if let Some(ref cpuset) = cell_info.cpuset {
-                for cpu in cpuset.iter() {
-                    contention.entry(cpu).or_default().push(cell_info.cell_id);
-                }
-            }
-        }
-
-        // Phase 2: Categorize CPUs and build initial assignments
-        // - Exclusive: claimed by exactly 1 cell -> assigned directly
-        // - Contested: claimed by 2+ cells -> distributed by weight
-        // - Unclaimed: no cpuset claims it -> shared among cell 0 + unpinned cells
-        let mut cell_cpus: HashMap<u32, Cpumask> = HashMap::new();
-        let mut contested_cpus: Vec<usize> = Vec::new();
-        let mut unclaimed_cpus: Vec<usize> = Vec::new();
-
-        for cpu in self.all_cpus.iter() {
-            match contention.get(&cpu) {
-                None => unclaimed_cpus.push(cpu),
-                Some(claimants) if claimants.len() == 1 => {
-                    let cell_id = claimants[0];
-                    cell_cpus
-                        .entry(cell_id)
-                        .or_insert_with(Cpumask::new)
-                        .set_cpu(cpu)
-                        .ok();
-                }
-                Some(_) => contested_cpus.push(cpu),
-            }
-        }
-
-        // Compute global targets and initialize running count of CPUs assigned per cell
-        let total_cpu_count = self.all_cpus.weight();
-        let mut all_cells_with_weights: Vec<(u32, f64)> = self
+        let recipients: Vec<CpuRecipient> = self
             .cells
             .values()
             .map(|info| {
                 let weight = match cell_demands {
-                    Some(demands) => *demands.get(&info.cell_id).ok_or_else(|| {
-                        anyhow::anyhow!("Cell {} is missing from demands map", info.cell_id)
-                    })?,
+                    Some(demands) => {
+                        let weight = *demands
+                            .get(&info.cell_id)
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("Cell {} is missing from demands map", info.cell_id)
+                            })
+                            .context("building cell demand weights map")?;
+                        if weight < 0.0 {
+                            bail!(
+                                "Cell {} has negative demand weight {}",
+                                info.cell_id,
+                                weight
+                            );
+                        }
+                        weight
+                    }
                     None => 1.0,
                 };
-                Ok((info.cell_id, weight))
+                Ok(CpuRecipient {
+                    id: info.cell_id,
+                    weight,
+                    allowed: info.cpuset.clone(),
+                })
             })
-            .collect::<Result<Vec<_>>>()
-            .context("building cell demand weights map")?;
-        all_cells_with_weights.sort_by_key(|(cell_id, _)| *cell_id);
+            .collect::<Result<Vec<_>>>()?;
 
-        let targets = compute_targets(total_cpu_count, &all_cells_with_weights)
-            .context("computing per-cell CPU targets")?;
-
-        // Seed assigned_count from exclusive assignments
-        let mut assigned_count: HashMap<u32, usize> = HashMap::new();
-        for (cell_id, mask) in &cell_cpus {
-            assigned_count.insert(*cell_id, mask.weight());
-        }
-
-        // Phase 3: Distribute contested CPUs among claimants using deficit weights
-        let mut contested_groups: HashMap<Vec<u32>, Vec<usize>> = HashMap::new();
-        for cpu in contested_cpus {
-            if let Some(claimants) = contention.get(&cpu) {
-                let mut sorted_claimants = claimants.clone();
-                sorted_claimants.sort();
-                contested_groups
-                    .entry(sorted_claimants)
-                    .or_default()
-                    .push(cpu);
-            }
-        }
-
-        // Freeze deficit weights before processing any group. Each group is an
-        // independent allocation decision, so a cell's weight should not depend
-        // on HashMap iteration order (i.e., which other groups were processed
-        // first). Using the initial deficit (target - exclusive_count) as weight
-        // for all groups makes the result deterministic.
-        let initial_deficit: HashMap<u32, f64> = targets
-            .iter()
-            .map(|(&cell_id, &target)| {
-                // Cells with no exclusive CPUs have no entry yet; 0 is correct.
-                let already = assigned_count.get(&cell_id).copied().unwrap_or(0);
-                let deficit = if target > already {
-                    (target - already) as f64
-                } else {
-                    0.0
-                };
-                (cell_id, deficit)
-            })
-            .collect();
-
-        for (claimants, cpus) in contested_groups {
-            let mut recipients: Vec<(u32, f64)> = Vec::new();
-            let mut all_zero = true;
-            for &cell_id in &claimants {
-                let deficit = *initial_deficit.get(&cell_id).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "BUG: cell {} in contention map but missing from targets",
-                        cell_id
-                    )
-                })?;
-                if deficit > 0.0 {
-                    all_zero = false;
-                }
-                recipients.push((cell_id, deficit));
-            }
-
-            // If all claimants already meet/exceed their target, fall back to equal weights
-            if all_zero {
-                recipients = claimants.iter().map(|&cell_id| (cell_id, 1.0)).collect();
-            }
-
-            let distribution = distribute_cpus_proportional(&cpus, &recipients)
-                .context("distributing contested CPUs among claimants")?;
-            for (cell_id, assigned_cpus) in distribution {
-                let count = assigned_cpus.len();
-                for cpu in assigned_cpus {
-                    cell_cpus
-                        .entry(cell_id)
-                        .or_insert_with(Cpumask::new)
-                        .set_cpu(cpu)
-                        .ok();
-                }
-                *assigned_count.entry(cell_id).or_insert(0) += count;
-            }
-        }
-
-        // Phase 4: Distribute unclaimed CPUs among unpinned cells (including cell 0) using deficit weights
-        if !unclaimed_cpus.is_empty() {
-            let mut recipients: Vec<(u32, f64)> = Vec::new();
-            let mut all_zero = true;
-
-            for info in self.cells.values() {
-                if info.cpuset.is_some() {
-                    continue; // pinned cells don't receive unclaimed CPUs
-                }
-                let target = *targets.get(&info.cell_id).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "BUG: cell {} is unpinned but missing from targets",
-                        info.cell_id
-                    )
-                })?;
-                // Cells with no exclusive CPUs have no entry yet; 0 is correct.
-                let already = assigned_count.get(&info.cell_id).copied().unwrap_or(0);
-                let deficit = if target > already {
-                    (target - already) as f64
-                } else {
-                    0.0
-                };
-                if deficit > 0.0 {
-                    all_zero = false;
-                }
-                recipients.push((info.cell_id, deficit));
-            }
-            recipients.sort_by_key(|(cell_id, _)| *cell_id);
-
-            // If all recipients already meet/exceed their target, fall back to equal weights
-            if all_zero {
-                recipients = recipients
-                    .iter()
-                    .map(|(cell_id, _)| (*cell_id, 1.0))
-                    .collect();
-            }
-
-            let distribution = distribute_cpus_proportional(&unclaimed_cpus, &recipients)
-                .context("distributing unclaimed CPUs among unpinned cells")?;
-            for (cell_id, assigned_cpus) in distribution {
-                let count = assigned_cpus.len();
-                for cpu in assigned_cpus {
-                    cell_cpus
-                        .entry(cell_id)
-                        .or_insert_with(Cpumask::new)
-                        .set_cpu(cpu)
-                        .ok();
-                }
-                *assigned_count.entry(cell_id).or_insert(0) += count;
-            }
-        }
-
-        // Phase 5: Verify all cells have at least one CPU assigned
-        for info in self.cells.values() {
-            if !cell_cpus.contains_key(&info.cell_id)
-                || cell_cpus
-                    .get(&info.cell_id)
-                    .map_or(true, |m| m.weight() == 0)
-            {
-                bail!(
-                    "Cell {} has no CPUs assigned (nr_cpus={}, num_cells={})",
-                    info.cell_id,
-                    self.all_cpus.weight(),
-                    self.cells.len()
-                );
-            }
-        }
-
-        // Phase 6: Build CpuAssignment results, optionally computing borrowable masks
-        let assignments: Vec<CpuAssignment> = cell_cpus
-            .into_iter()
-            .map(|(cell_id, primary)| {
-                let borrowable = if compute_borrowable {
-                    let mut borrow_mask = self.all_cpus.and(&primary.not());
-
-                    // If this cell has a cpuset, restrict borrowable to it
-                    if let Some(cell_info) = self.cells.values().find(|c| c.cell_id == cell_id) {
-                        if let Some(ref cpuset) = cell_info.cpuset {
-                            borrow_mask = borrow_mask.and(cpuset);
-                        }
-                    }
-
-                    Some(borrow_mask)
-                } else {
-                    None
-                };
-                CpuAssignment {
-                    cell_id,
-                    primary,
-                    borrowable,
-                }
-            })
-            .collect();
-
-        Ok(assignments)
+        CpuManager::new(&self.all_cpus).compute_assignments(&recipients, compute_borrowable)
     }
 
     /// Returns all cell assignments as (cgid, cell_id) pairs.
@@ -819,26 +885,26 @@ impl CellManager {
     /// Example output: "[0: 0-7] [1(container-a): 8-15] [2(container-b): 16-23]"
     pub fn format_cell_config(&self, cpu_assignments: &[CpuAssignment]) -> String {
         let mut sorted: Vec<_> = cpu_assignments.iter().collect();
-        sorted.sort_by_key(|a| a.cell_id);
+        sorted.sort_by_key(|a| a.id);
 
         let mut parts = Vec::new();
         for assignment in sorted {
             let cpulist = assignment.primary.to_cpulist();
-            if assignment.cell_id == 0 {
+            if assignment.id == 0 {
                 parts.push(format!("[0: {}]", cpulist));
             } else {
                 // Find cgroup name for this cell
                 let name = self
                     .cells
                     .values()
-                    .find(|info| info.cell_id == assignment.cell_id)
+                    .find(|info| info.cell_id == assignment.id)
                     .and_then(|info| {
                         info.cgroup_path
                             .as_ref()
                             .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
                     })
                     .unwrap_or_else(|| "?".to_string());
-                parts.push(format!("[{}({}): {}]", assignment.cell_id, name, cpulist));
+                parts.push(format!("[{}({}): {}]", assignment.id, name, cpulist));
             }
         }
         parts.join(" ")
@@ -920,6 +986,15 @@ mod tests {
             mask.set_cpu(cpu).unwrap();
         }
         mask
+    }
+
+    fn cpumask_from_cpulist(nr_cpus: usize, cpulist: &str) -> Cpumask {
+        scx_utils::set_cpumask_test_width(nr_cpus);
+        Cpumask::from_cpulist(cpulist).unwrap()
+    }
+
+    fn find_assignment(assignments: &[CpuAssignment], id: u32) -> &CpuAssignment {
+        assignments.iter().find(|a| a.id == id).unwrap()
     }
 
     // ==================== Cell scanning and creation tests ====================
@@ -1100,7 +1175,7 @@ mod tests {
 
         // Only cell 0 with all CPUs
         assert_eq!(assignments.len(), 1);
-        assert_eq!(assignments[0].cell_id, 0);
+        assert_eq!(assignments[0].id, 0);
         assert_eq!(assignments[0].primary.weight(), 16);
     }
 
@@ -1121,8 +1196,8 @@ mod tests {
         // 16 CPUs / 2 cells = 8 each
         assert_eq!(assignments.len(), 2);
 
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
-        let cell1 = assignments.iter().find(|a| a.cell_id == 1).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
+        let cell1 = assignments.iter().find(|a| a.id == 1).unwrap();
 
         assert_eq!(cell0.primary.weight(), 8);
         assert_eq!(cell1.primary.weight(), 8);
@@ -1144,7 +1219,7 @@ mod tests {
         let assignments = mgr.compute_cpu_assignments(false).unwrap();
 
         // 10 CPUs / 3 cells = 3 each + 1 remainder to cell 0
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
         assert_eq!(cell0.primary.weight(), 4); // 3 + 1 remainder
     }
 
@@ -1205,14 +1280,14 @@ mod tests {
         let cell1_info = mgr.find_cell_by_name("cell1").unwrap();
         let cell2_info = mgr.find_cell_by_name("cell2").unwrap();
 
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
         let cell1 = assignments
             .iter()
-            .find(|a| a.cell_id == cell1_info.cell_id)
+            .find(|a| a.id == cell1_info.cell_id)
             .unwrap();
         let cell2 = assignments
             .iter()
-            .find(|a| a.cell_id == cell2_info.cell_id)
+            .find(|a| a.id == cell2_info.cell_id)
             .unwrap();
 
         // cell1 gets CPUs 0-3
@@ -1290,8 +1365,8 @@ mod tests {
 
         assert_eq!(assignments.len(), 2);
 
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
-        let cell1 = assignments.iter().find(|a| a.cell_id != 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
+        let cell1 = assignments.iter().find(|a| a.id != 0).unwrap();
 
         // cell1 gets even CPUs
         assert_eq!(cell1.primary.weight(), 4);
@@ -1376,18 +1451,18 @@ mod tests {
         // cell1 gets its cpuset (0-3)
         let cell1_assignment = assignments
             .iter()
-            .find(|a| a.cell_id == cell1_info.cell_id)
+            .find(|a| a.id == cell1_info.cell_id)
             .unwrap();
         assert_eq!(cell1_assignment.primary.weight(), 4);
 
         // cell0 gets 7 CPUs (deficit-proportional share of unclaimed)
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
         assert_eq!(cell0.primary.weight(), 7);
 
         // cell2 (unpinned) gets 5 CPUs
         let cell2_assignment = assignments
             .iter()
-            .find(|a| a.cell_id == cell2_info.cell_id)
+            .find(|a| a.id == cell2_info.cell_id)
             .unwrap();
         assert_eq!(cell2_assignment.primary.weight(), 5);
     }
@@ -1421,13 +1496,13 @@ mod tests {
 
         let cell_a = assignments
             .iter()
-            .find(|a| a.cell_id == cell_a_info.cell_id)
+            .find(|a| a.id == cell_a_info.cell_id)
             .unwrap();
         let cell_b = assignments
             .iter()
-            .find(|a| a.cell_id == cell_b_info.cell_id)
+            .find(|a| a.id == cell_b_info.cell_id)
             .unwrap();
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
 
         // Cell A gets exclusive 0-3 (4 CPUs) + half of contested 4-7 (2 CPUs) = 6 CPUs
         // Cell B gets half of contested 4-7 (2 CPUs) + exclusive 8-11 (4 CPUs) = 6 CPUs
@@ -1513,17 +1588,17 @@ mod tests {
 
         let cell_a = assignments
             .iter()
-            .find(|a| a.cell_id == cell_a_info.cell_id)
+            .find(|a| a.id == cell_a_info.cell_id)
             .unwrap();
         let cell_b = assignments
             .iter()
-            .find(|a| a.cell_id == cell_b_info.cell_id)
+            .find(|a| a.id == cell_b_info.cell_id)
             .unwrap();
         let cell_c = assignments
             .iter()
-            .find(|a| a.cell_id == cell_c_info.cell_id)
+            .find(|a| a.id == cell_c_info.cell_id)
             .unwrap();
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
 
         // 6 contested CPUs / 3 cells = 2 each
         assert_eq!(cell_a.primary.weight(), 2);
@@ -1574,11 +1649,11 @@ mod tests {
 
         let cell_a = assignments
             .iter()
-            .find(|a| a.cell_id == cell_a_info.cell_id)
+            .find(|a| a.id == cell_a_info.cell_id)
             .unwrap();
         let cell_b = assignments
             .iter()
-            .find(|a| a.cell_id == cell_b_info.cell_id)
+            .find(|a| a.id == cell_b_info.cell_id)
             .unwrap();
 
         // 3 CPUs / 2 cells = 1 each + 1 remainder
@@ -1623,13 +1698,13 @@ mod tests {
 
         let cell_a = assignments
             .iter()
-            .find(|a| a.cell_id == cell_a_info.cell_id)
+            .find(|a| a.id == cell_a_info.cell_id)
             .unwrap();
         let cell_b = assignments
             .iter()
-            .find(|a| a.cell_id == cell_b_info.cell_id)
+            .find(|a| a.id == cell_b_info.cell_id)
             .unwrap();
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
 
         // 8 contested CPUs / 2 cells = 4 each
         assert_eq!(cell_a.primary.weight(), 4);
@@ -1676,13 +1751,13 @@ mod tests {
 
         let cell_a = assignments
             .iter()
-            .find(|a| a.cell_id == cell_a_info.cell_id)
+            .find(|a| a.id == cell_a_info.cell_id)
             .unwrap();
         let cell_b = assignments
             .iter()
-            .find(|a| a.cell_id == cell_b_info.cell_id)
+            .find(|a| a.id == cell_b_info.cell_id)
             .unwrap();
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
 
         // No overlap - each cell gets its exact cpuset
         assert_eq!(cell_a.primary.weight(), 4);
@@ -1721,7 +1796,7 @@ mod tests {
         }
 
         let assignments = vec![CpuAssignment {
-            cell_id: 0,
+            id: 0,
             primary: mask,
             borrowable: None,
         }];
@@ -1755,12 +1830,12 @@ mod tests {
 
         let assignments = vec![
             CpuAssignment {
-                cell_id: 0,
+                id: 0,
                 primary: mask0,
                 borrowable: None,
             },
             CpuAssignment {
-                cell_id: 1,
+                id: 1,
                 primary: mask1,
                 borrowable: None,
             },
@@ -1920,7 +1995,7 @@ mod tests {
                 overlap.weight(),
                 0,
                 "Cell {} borrowable overlaps with primary",
-                assignment.cell_id
+                assignment.id
             );
             // borrowable + primary should cover all CPUs
             let union = borrow_mask.or(&assignment.primary);
@@ -1928,7 +2003,7 @@ mod tests {
                 union.weight(),
                 16,
                 "Cell {} union doesn't cover all CPUs",
-                assignment.cell_id
+                assignment.id
             );
         }
     }
@@ -1962,7 +2037,7 @@ mod tests {
                 overlap.weight(),
                 0,
                 "Cell {} borrowable overlaps with primary",
-                assignment.cell_id
+                assignment.id
             );
         }
     }
@@ -1997,7 +2072,7 @@ mod tests {
         // the borrowable within 0-7 is whatever it doesn't own.
         let cell1_assignment = assignments
             .iter()
-            .find(|a| a.cell_id == cell1_info.cell_id)
+            .find(|a| a.id == cell1_info.cell_id)
             .unwrap();
         let cell1_borrow = cell1_assignment.borrowable.as_ref().unwrap();
         // Cell 1's borrowable should NOT include CPUs outside its cpuset (0-7)
@@ -2012,7 +2087,7 @@ mod tests {
         // Cell 2's borrowable should be restricted to its cpuset (8-15)
         let cell2_assignment = assignments
             .iter()
-            .find(|a| a.cell_id == cell2_info.cell_id)
+            .find(|a| a.id == cell2_info.cell_id)
             .unwrap();
         let cell2_borrow = cell2_assignment.borrowable.as_ref().unwrap();
         for cpu in 0..8 {
@@ -2052,16 +2127,16 @@ mod tests {
         let assignments = mgr.compute_demand_cpu_assignments(&demands, false).unwrap();
 
         // 12 / 3 = 4 each
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
         let cell1_info = mgr.find_cell_by_name("cell1").unwrap();
         let cell2_info = mgr.find_cell_by_name("cell2").unwrap();
         let c1 = assignments
             .iter()
-            .find(|a| a.cell_id == cell1_info.cell_id)
+            .find(|a| a.id == cell1_info.cell_id)
             .unwrap();
         let c2 = assignments
             .iter()
-            .find(|a| a.cell_id == cell2_info.cell_id)
+            .find(|a| a.id == cell2_info.cell_id)
             .unwrap();
 
         assert_eq!(cell0.primary.weight(), 4);
@@ -2095,14 +2170,14 @@ mod tests {
         .into();
         let assignments = mgr.compute_demand_cpu_assignments(&demands, false).unwrap();
 
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
         let c1 = assignments
             .iter()
-            .find(|a| a.cell_id == cell1_info.cell_id)
+            .find(|a| a.id == cell1_info.cell_id)
             .unwrap();
         let c2 = assignments
             .iter()
-            .find(|a| a.cell_id == cell2_info.cell_id)
+            .find(|a| a.id == cell2_info.cell_id)
             .unwrap();
 
         // Busy cell should get more CPUs than idle cell
@@ -2157,11 +2232,11 @@ mod tests {
 
         let cell_a = assignments
             .iter()
-            .find(|a| a.cell_id == cell_a_info.cell_id)
+            .find(|a| a.id == cell_a_info.cell_id)
             .unwrap();
         let cell_b = assignments
             .iter()
-            .find(|a| a.cell_id == cell_b_info.cell_id)
+            .find(|a| a.id == cell_b_info.cell_id)
             .unwrap();
 
         // Cell A should get more of the contested CPUs 4-7
@@ -2205,14 +2280,14 @@ mod tests {
         .into();
         let assignments = mgr.compute_demand_cpu_assignments(&demands, false).unwrap();
 
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
         let c1 = assignments
             .iter()
-            .find(|a| a.cell_id == cell1_info.cell_id)
+            .find(|a| a.id == cell1_info.cell_id)
             .unwrap();
         let c2 = assignments
             .iter()
-            .find(|a| a.cell_id == cell2_info.cell_id)
+            .find(|a| a.id == cell2_info.cell_id)
             .unwrap();
 
         // Idle cell gets its minimum target (1 CPU) via deficit-based distribution:
@@ -2301,13 +2376,13 @@ mod tests {
 
         let cell_a = assignments
             .iter()
-            .find(|a| a.cell_id == cell_a_info.cell_id)
+            .find(|a| a.id == cell_a_info.cell_id)
             .unwrap();
         let cell_b = assignments
             .iter()
-            .find(|a| a.cell_id == cell_b_info.cell_id)
+            .find(|a| a.id == cell_b_info.cell_id)
             .unwrap();
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
 
         // Verify total = 16
         assert_eq!(
@@ -2357,14 +2432,14 @@ mod tests {
 
         let assignments = mgr.compute_cpu_assignments(false).unwrap();
 
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
         let cell1 = assignments
             .iter()
-            .find(|a| a.cell_id == cell1_info.cell_id)
+            .find(|a| a.id == cell1_info.cell_id)
             .unwrap();
         let cell2 = assignments
             .iter()
-            .find(|a| a.cell_id == cell2_info.cell_id)
+            .find(|a| a.id == cell2_info.cell_id)
             .unwrap();
 
         // Targets (equal weight, 3 cells, 16 CPUs): cell0=6, cell1=5, cell2=5
@@ -2427,13 +2502,13 @@ mod tests {
 
         let cell_a = assignments
             .iter()
-            .find(|a| a.cell_id == cell_a_info.cell_id)
+            .find(|a| a.id == cell_a_info.cell_id)
             .unwrap();
         let cell_b = assignments
             .iter()
-            .find(|a| a.cell_id == cell_b_info.cell_id)
+            .find(|a| a.id == cell_b_info.cell_id)
             .unwrap();
-        let cell0 = assignments.iter().find(|a| a.cell_id == 0).unwrap();
+        let cell0 = assignments.iter().find(|a| a.id == 0).unwrap();
 
         // cell_a exceeded its target from exclusive alone, so it gets 0 contested CPUs.
         // cell_b has deficit, so it gets all 2 contested CPUs.
@@ -2472,7 +2547,7 @@ mod tests {
     fn test_distribute_proportional_basic() {
         let cpus: Vec<usize> = (0..8).collect();
         let recipients = vec![(0, 3.0), (1, 1.0)];
-        let result = distribute_cpus_proportional(&cpus, &recipients).unwrap();
+        let result = CpuManager::distribute_cpus_proportional(&cpus, &recipients).unwrap();
 
         // 3/4 * 8 = 6 for cell 0, 1/4 * 8 = 2 for cell 1
         assert_eq!(result.get(&0).unwrap().len(), 6);
@@ -2483,7 +2558,7 @@ mod tests {
     fn test_distribute_proportional_zero_weight_gets_nothing() {
         let cpus: Vec<usize> = (0..6).collect();
         let recipients = vec![(0, 1.0), (1, 0.0)];
-        let result = distribute_cpus_proportional(&cpus, &recipients).unwrap();
+        let result = CpuManager::distribute_cpus_proportional(&cpus, &recipients).unwrap();
 
         // Cell 0 gets all, cell 1 gets nothing
         assert_eq!(result.get(&0).unwrap().len(), 6);
@@ -2494,7 +2569,7 @@ mod tests {
     fn test_distribute_proportional_all_zero_fallback() {
         let cpus: Vec<usize> = (0..6).collect();
         let recipients = vec![(0, 0.0), (1, 0.0)];
-        let result = distribute_cpus_proportional(&cpus, &recipients).unwrap();
+        let result = CpuManager::distribute_cpus_proportional(&cpus, &recipients).unwrap();
 
         // Falls back to equal division
         assert_eq!(result.get(&0).unwrap().len(), 3);
@@ -2507,7 +2582,7 @@ mod tests {
         // Without floor guarantee, cell 0 would get floor(1/101 * 38) = 0.
         let cpus: Vec<usize> = (0..38).collect();
         let recipients = vec![(2, 1.0), (3, 100.0)];
-        let result = distribute_cpus_proportional(&cpus, &recipients).unwrap();
+        let result = CpuManager::distribute_cpus_proportional(&cpus, &recipients).unwrap();
 
         // Both cells must get at least 1 CPU
         let cell2_count = result.get(&2).map_or(0, |v| v.len());
@@ -2532,7 +2607,7 @@ mod tests {
         // Without floor guarantee, cell A gets 0 → death spiral.
         let cpus: Vec<usize> = (24..62).collect(); // 38 CPUs (24-61)
         let recipients = vec![(2, 1.0), (3, 87.0)];
-        let result = distribute_cpus_proportional(&cpus, &recipients).unwrap();
+        let result = CpuManager::distribute_cpus_proportional(&cpus, &recipients).unwrap();
 
         let cell2_count = result.get(&2).map_or(0, |v| v.len());
         let cell3_count = result.get(&3).map_or(0, |v| v.len());
@@ -2553,7 +2628,7 @@ mod tests {
 
     #[test]
     fn test_compute_targets_equal_weight() {
-        let targets = compute_targets(12, &[(0, 1.0), (1, 1.0), (2, 1.0)]).unwrap();
+        let targets = CpuManager::compute_targets(12, &[(0, 1.0), (1, 1.0), (2, 1.0)]).unwrap();
         assert_eq!(*targets.get(&0).unwrap(), 4);
         assert_eq!(*targets.get(&1).unwrap(), 4);
         assert_eq!(*targets.get(&2).unwrap(), 4);
@@ -2561,13 +2636,177 @@ mod tests {
 
     #[test]
     fn test_compute_targets_with_remainder() {
-        let targets = compute_targets(10, &[(0, 1.0), (1, 1.0), (2, 1.0)]).unwrap();
+        let targets = CpuManager::compute_targets(10, &[(0, 1.0), (1, 1.0), (2, 1.0)]).unwrap();
         // 10 / 3 = 3 each + 1 remainder
         let total: usize = targets.values().sum();
         assert_eq!(total, 10);
         for (_, &count) in &targets {
             assert!(count >= 3 && count <= 4);
         }
+    }
+
+    // ==================== CpuManager domain tests ====================
+
+    #[test]
+    fn test_cpu_manager_non_root_domain_unpinned_invariants() {
+        let domain = cpumask_from_cpulist(32, "8-15");
+        let recipients = vec![
+            CpuRecipient {
+                id: 10,
+                weight: 1.0,
+                allowed: None,
+            },
+            CpuRecipient {
+                id: 11,
+                weight: 1.0,
+                allowed: None,
+            },
+            CpuRecipient {
+                id: 12,
+                weight: 2.0,
+                allowed: None,
+            },
+        ];
+
+        let assignments = CpuManager::new(&domain)
+            .compute_assignments(&recipients, false)
+            .unwrap();
+
+        assert_eq!(assignments.len(), 3);
+        assert_eq!(find_assignment(&assignments, 10).primary.weight(), 2);
+        assert_eq!(find_assignment(&assignments, 11).primary.weight(), 2);
+        assert_eq!(find_assignment(&assignments, 12).primary.weight(), 4);
+
+        let total: usize = assignments.iter().map(|a| a.primary.weight()).sum();
+        assert_eq!(total, domain.weight());
+
+        for assignment in &assignments {
+            assert!(
+                assignment.borrowable.is_none(),
+                "borrowable should stay disabled in this case"
+            );
+            for cpu in assignment.primary.iter() {
+                assert!(domain.test_cpu(cpu), "CPU {} escaped the domain", cpu);
+            }
+        }
+
+        for i in 0..assignments.len() {
+            for j in (i + 1)..assignments.len() {
+                let overlap = assignments[i].primary.and(&assignments[j].primary);
+                assert_eq!(
+                    overlap.weight(),
+                    0,
+                    "Recipients {} and {} overlap",
+                    assignments[i].id,
+                    assignments[j].id
+                );
+            }
+        }
+
+        let mut union = Cpumask::new();
+        for assignment in &assignments {
+            union = union.or(&assignment.primary);
+        }
+        assert_eq!(union, domain, "Primary masks should cover the whole domain");
+    }
+
+    #[test]
+    fn test_cpu_manager_non_contiguous_domain_borrowable_invariants() {
+        let domain = cpumask_from_cpulist(32, "8-9,12,14-15,20-21,26");
+        let allowed_1 = cpumask_from_cpulist(32, "0-1,8-9,12");
+        let allowed_2 = cpumask_from_cpulist(32, "9,14-15,20-22");
+        let recipients = vec![
+            CpuRecipient {
+                id: 1,
+                weight: 1.0,
+                allowed: Some(allowed_1.clone()),
+            },
+            CpuRecipient {
+                id: 2,
+                weight: 2.0,
+                allowed: Some(allowed_2.clone()),
+            },
+            CpuRecipient {
+                id: 3,
+                weight: 1.0,
+                allowed: None,
+            },
+        ];
+
+        let assignments = CpuManager::new(&domain)
+            .compute_assignments(&recipients, true)
+            .unwrap();
+
+        assert_eq!(assignments.len(), 3);
+
+        for assignment in &assignments {
+            for cpu in assignment.primary.iter() {
+                assert!(
+                    domain.test_cpu(cpu),
+                    "Primary CPU {} escaped the domain",
+                    cpu
+                );
+            }
+            let borrowable = assignment.borrowable.as_ref().unwrap();
+            for cpu in borrowable.iter() {
+                assert!(
+                    domain.test_cpu(cpu),
+                    "Borrowable CPU {} escaped the domain",
+                    cpu
+                );
+            }
+            assert_eq!(
+                assignment.primary.and(borrowable).weight(),
+                0,
+                "Primary and borrowable overlap for recipient {}",
+                assignment.id
+            );
+        }
+
+        let recipient_1 = find_assignment(&assignments, 1);
+        let recipient_2 = find_assignment(&assignments, 2);
+        let recipient_3 = find_assignment(&assignments, 3);
+
+        for cpu in recipient_1.primary.iter() {
+            assert!(
+                allowed_1.test_cpu(cpu),
+                "Recipient 1 got CPU {} outside allowed",
+                cpu
+            );
+        }
+        for cpu in recipient_2.primary.iter() {
+            assert!(
+                allowed_2.test_cpu(cpu),
+                "Recipient 2 got CPU {} outside allowed",
+                cpu
+            );
+        }
+
+        let allowed_1_in_domain = domain.and(&allowed_1);
+        let allowed_2_in_domain = domain.and(&allowed_2);
+        let recipient_1_union = recipient_1
+            .primary
+            .or(recipient_1.borrowable.as_ref().unwrap());
+        let recipient_2_union = recipient_2
+            .primary
+            .or(recipient_2.borrowable.as_ref().unwrap());
+        assert_eq!(recipient_1_union, allowed_1_in_domain);
+        assert_eq!(recipient_2_union, allowed_2_in_domain);
+
+        let recipient_3_union = recipient_3
+            .primary
+            .or(recipient_3.borrowable.as_ref().unwrap());
+        assert_eq!(recipient_3_union, domain);
+        assert_eq!(recipient_3.primary.weight(), 1);
+        assert!(!recipient_3.primary.test_cpu(8));
+        assert!(!recipient_3.primary.test_cpu(9));
+        assert!(recipient_3.primary.test_cpu(26));
+
+        let mut union = Cpumask::new();
+        for assignment in &assignments {
+            union = union.or(&assignment.primary);
+        }
+        assert_eq!(union, domain, "Primary masks should cover the whole domain");
     }
 
     /// Symmetric pairwise overlaps must produce equal cell sizes regardless
@@ -2608,13 +2847,13 @@ mod tests {
 
         let assignments = mgr.compute_cpu_assignments(false).unwrap();
 
-        let workload: Vec<_> = assignments.iter().filter(|a| a.cell_id != 0).collect();
+        let workload: Vec<_> = assignments.iter().filter(|a| a.id != 0).collect();
         assert_eq!(workload.len(), 5, "Expected 5 workload cells");
 
         // All workload cells must have equal CPU counts.
         let counts: Vec<(u32, usize)> = workload
             .iter()
-            .map(|a| (a.cell_id, a.primary.weight()))
+            .map(|a| (a.id, a.primary.weight()))
             .collect();
         for &(cell_id, count) in &counts {
             assert_eq!(
@@ -2634,8 +2873,8 @@ mod tests {
                             && assignments[j].primary.test_cpu(cpu)),
                         "CPU {} assigned to both cell {} and cell {}",
                         cpu,
-                        assignments[i].cell_id,
-                        assignments[j].cell_id,
+                        assignments[i].id,
+                        assignments[j].id,
                     );
                 }
             }

--- a/scheds/rust/scx_mitosis/src/config.rs
+++ b/scheds/rust/scx_mitosis/src/config.rs
@@ -23,6 +23,7 @@ use crate::cell_manager::CpuRecipient;
 #[derive(Clone, Debug)]
 pub struct ConfiguredSubcell {
     pub id: u32,
+    pub name: String,
     pub matches: Vec<Vec<SubcellMatch>>,
 }
 
@@ -61,8 +62,7 @@ struct CellSpec {
 
 #[derive(Clone, Debug, Deserialize)]
 struct SubcellSpec {
-    #[serde(rename = "name")]
-    _name: String,
+    name: String,
     #[serde(default = "default_subcell_matches")]
     matches: Vec<Vec<SubcellMatch>>,
 }
@@ -393,6 +393,7 @@ fn normalize_subcells(subcells: Vec<SubcellSpec>) -> Result<Vec<ConfiguredSubcel
             }
             catch_all = Some(ConfiguredSubcell {
                 id: 0,
+                name: subcell.name,
                 matches: subcell.matches,
             });
             continue;
@@ -400,6 +401,7 @@ fn normalize_subcells(subcells: Vec<SubcellSpec>) -> Result<Vec<ConfiguredSubcel
 
         normalized.push(ConfiguredSubcell {
             id: next_id,
+            name: subcell.name,
             matches: subcell.matches,
         });
         next_id += 1;
@@ -430,6 +432,7 @@ fn default_configured_subcells() -> Vec<ConfiguredSubcell> {
 fn default_catch_all_subcell() -> ConfiguredSubcell {
     ConfiguredSubcell {
         id: 0,
+        name: "rest".to_string(),
         matches: vec![Vec::new()],
     }
 }
@@ -572,8 +575,11 @@ mod tests {
         assert_eq!(configured.root_spec_idx, Some(2));
         let subcells = &configured.specs[0].subcells;
         assert_eq!(subcells[0].id, 0);
+        assert_eq!(subcells[0].name, "rest");
         assert_eq!(subcells[1].id, 1);
+        assert_eq!(subcells[1].name, "hhvmworker");
         assert_eq!(subcells[2].id, 2);
+        assert_eq!(subcells[2].name, "mcrpxy-web");
     }
 
     #[test]

--- a/scheds/rust/scx_mitosis/src/config.rs
+++ b/scheds/rust/scx_mitosis/src/config.rs
@@ -1,0 +1,631 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Result;
+use regex::Regex;
+use scx_utils::Cpumask;
+use serde::de;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::cell_manager::CpuRecipient;
+
+#[derive(Clone, Debug)]
+pub struct ConfiguredSubcell {
+    pub id: u32,
+    pub matches: Vec<Vec<SubcellMatch>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ConfiguredCell {
+    pub id: u32,
+    pub subcells: Vec<ConfiguredSubcell>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ConfiguredCellResolution {
+    pub cell_assignments: Vec<(u64, u32)>,
+    pub cell_recipients: Vec<CpuRecipient>,
+    pub cells: Vec<ConfiguredCell>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub enum SubcellMatch {
+    CommPrefix(String),
+}
+
+#[derive(Clone, Debug, Deserialize)]
+enum CellMatch {
+    CgroupContains(String),
+    CgroupRegex(String),
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct CellSpec {
+    name: String,
+    #[serde(default, deserialize_with = "deserialize_optional_cell_match")]
+    matches: Option<CellMatch>,
+    #[serde(default)]
+    subcells: Vec<SubcellSpec>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct SubcellSpec {
+    #[serde(rename = "name")]
+    _name: String,
+    #[serde(default = "default_subcell_matches")]
+    matches: Vec<Vec<SubcellMatch>>,
+}
+
+#[derive(Clone, Debug)]
+struct CompiledCellSpec {
+    matcher: Option<CompiledCellMatch>,
+    subcells: Vec<ConfiguredSubcell>,
+}
+
+#[derive(Clone, Debug)]
+enum CompiledCellMatch {
+    CgroupContains(String),
+    CgroupRegex(Regex),
+}
+
+#[derive(Clone, Debug)]
+struct CgroupEntry {
+    path: PathBuf,
+    path_string: String,
+    cgid: u64,
+    cpuset: Option<Cpumask>,
+}
+
+#[derive(Clone, Debug)]
+struct MatchedCgroup {
+    spec_idx: usize,
+    cgid: u64,
+    cpuset: Option<Cpumask>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ConfiguredCells {
+    specs: Vec<CompiledCellSpec>,
+    root_spec_idx: Option<usize>,
+    cgroup_root: PathBuf,
+    all_cpus: Cpumask,
+    max_cells: u32,
+    path_cell_ids: HashMap<PathBuf, u32>,
+    free_cell_ids: Vec<u32>,
+    next_cell_id: u32,
+}
+
+impl ConfiguredCells {
+    pub fn load(path: &Path, max_cells: u32, all_cpus: Cpumask) -> Result<Self> {
+        Self::load_with_root(path, PathBuf::from("/sys/fs/cgroup"), max_cells, all_cpus)
+    }
+
+    fn load_with_root(
+        path: &Path,
+        cgroup_root: PathBuf,
+        max_cells: u32,
+        all_cpus: Cpumask,
+    ) -> Result<Self> {
+        let contents = fs::read_to_string(path)
+            .with_context(|| format!("reading cell config {}", path.display()))?;
+        let specs: Vec<CellSpec> = serde_json::from_str(&contents)
+            .with_context(|| format!("parsing cell config {}", path.display()))?;
+        let specs = compile_specs(specs)?;
+        let root_spec_idx = specs.iter().rposition(|spec| spec.matcher.is_none());
+        if specs
+            .iter()
+            .enumerate()
+            .any(|(idx, spec)| spec.matcher.is_none() && Some(idx) != root_spec_idx)
+        {
+            bail!("only the final catch-all cell spec may use an empty match");
+        }
+
+        Ok(Self {
+            specs,
+            root_spec_idx,
+            cgroup_root,
+            all_cpus,
+            max_cells,
+            path_cell_ids: HashMap::new(),
+            free_cell_ids: Vec::new(),
+            next_cell_id: 1,
+        })
+    }
+
+    pub fn resolve(
+        &mut self,
+        cell_demands: Option<&HashMap<u32, f64>>,
+    ) -> Result<ConfiguredCellResolution> {
+        let cgroups = collect_cgroups(&self.cgroup_root)?;
+        let matched = self.match_cgroups(&cgroups);
+        self.reconcile_cell_ids(&matched)?;
+
+        let mut cell_assignments = Vec::new();
+        let mut cell_recipients = Vec::new();
+        let mut cells = Vec::new();
+
+        cells.push(ConfiguredCell {
+            id: 0,
+            subcells: self.root_subcells(),
+        });
+        cell_recipients.push(CpuRecipient {
+            id: 0,
+            weight: demand_weight(cell_demands, 0),
+            allowed: None,
+        });
+
+        let mut matched_paths: Vec<_> = matched.keys().cloned().collect();
+        matched_paths.sort();
+
+        for path in matched_paths {
+            let matched_cgroup = matched
+                .get(&path)
+                .expect("BUG: matched path disappeared during config resolution");
+            let cell_id = *self
+                .path_cell_ids
+                .get(&path)
+                .expect("BUG: matched path is missing a cell id");
+            let spec = self
+                .specs
+                .get(matched_cgroup.spec_idx)
+                .expect("BUG: matched cgroup references missing spec");
+
+            cell_assignments.push((matched_cgroup.cgid, cell_id));
+            cell_recipients.push(CpuRecipient {
+                id: cell_id,
+                weight: demand_weight(cell_demands, cell_id),
+                allowed: matched_cgroup.cpuset.clone(),
+            });
+            cells.push(ConfiguredCell {
+                id: cell_id,
+                subcells: spec.subcells.clone(),
+            });
+        }
+
+        Ok(ConfiguredCellResolution {
+            cell_assignments,
+            cell_recipients,
+            cells,
+        })
+    }
+
+    pub fn format_cell_config(&self, assignments: &[crate::cell_manager::CpuAssignment]) -> String {
+        let names: HashMap<u32, String> = self
+            .path_cell_ids
+            .iter()
+            .map(|(path, id)| {
+                let name = path
+                    .strip_prefix(&self.cgroup_root)
+                    .ok()
+                    .and_then(|rel| rel.to_str())
+                    .filter(|rel| !rel.is_empty())
+                    .map(|rel| format!("/{}", rel.trim_start_matches('/')))
+                    .unwrap_or_else(|| path.display().to_string());
+                (*id, name)
+            })
+            .collect();
+
+        assignments
+            .iter()
+            .map(|assignment| {
+                let name = names
+                    .get(&assignment.id)
+                    .cloned()
+                    .unwrap_or_else(|| "root".to_string());
+                format!(
+                    "cell{}({})={}",
+                    assignment.id,
+                    name,
+                    assignment.primary.to_cpulist()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn match_cgroups(&self, cgroups: &[CgroupEntry]) -> HashMap<PathBuf, MatchedCgroup> {
+        let mut raw_matches = HashMap::new();
+
+        for cgroup in cgroups {
+            if cgroup.path == self.cgroup_root {
+                continue;
+            }
+
+            for (spec_idx, spec) in self.specs.iter().enumerate() {
+                if Some(spec_idx) == self.root_spec_idx {
+                    continue;
+                }
+                if !spec.matches(&cgroup.path_string) {
+                    continue;
+                }
+
+                raw_matches.insert(
+                    cgroup.path.clone(),
+                    MatchedCgroup {
+                        spec_idx,
+                        cgid: cgroup.cgid,
+                        cpuset: cgroup.cpuset.clone(),
+                    },
+                );
+                break;
+            }
+        }
+
+        let mut paths: Vec<_> = raw_matches.keys().cloned().collect();
+        paths.sort_by_key(|path| path.components().count());
+
+        let mut matched: HashMap<PathBuf, MatchedCgroup> = HashMap::new();
+        for path in paths {
+            let raw_match = raw_matches
+                .get(&path)
+                .expect("BUG: raw matched path disappeared");
+            let covered_by_ancestor = path.ancestors().skip(1).any(|ancestor| {
+                matched
+                    .get(ancestor)
+                    .is_some_and(|ancestor_match| ancestor_match.spec_idx <= raw_match.spec_idx)
+            });
+            if covered_by_ancestor {
+                continue;
+            }
+
+            matched.insert(path.clone(), raw_match.clone());
+        }
+
+        matched
+    }
+
+    fn reconcile_cell_ids(&mut self, matched: &HashMap<PathBuf, MatchedCgroup>) -> Result<()> {
+        let matched_paths: HashSet<_> = matched.keys().cloned().collect();
+        let removed: Vec<_> = self
+            .path_cell_ids
+            .keys()
+            .filter(|path| !matched_paths.contains(*path))
+            .cloned()
+            .collect();
+
+        for path in removed {
+            if let Some(cell_id) = self.path_cell_ids.remove(&path) {
+                debug!("Removed configured cell {} for {}", cell_id, path.display());
+                self.free_cell_ids.push(cell_id);
+            }
+        }
+
+        let mut paths: Vec<_> = matched.keys().cloned().collect();
+        paths.sort();
+        for path in paths {
+            if self.path_cell_ids.contains_key(&path) {
+                continue;
+            }
+            let cell_id = self.allocate_cell_id()?;
+            debug!("Created configured cell {} for {}", cell_id, path.display());
+            self.path_cell_ids.insert(path, cell_id);
+        }
+
+        Ok(())
+    }
+
+    fn allocate_cell_id(&mut self) -> Result<u32> {
+        if let Some(id) = self.free_cell_ids.pop() {
+            return Ok(id);
+        }
+        if self.next_cell_id >= self.max_cells {
+            bail!("Cell ID space exhausted (max_cells={})", self.max_cells);
+        }
+        let id = self.next_cell_id;
+        self.next_cell_id += 1;
+        Ok(id)
+    }
+
+    fn root_subcells(&self) -> Vec<ConfiguredSubcell> {
+        self.root_spec_idx
+            .and_then(|idx| self.specs.get(idx))
+            .map(|spec| spec.subcells.clone())
+            .unwrap_or_else(default_configured_subcells)
+    }
+
+    pub fn all_cpus(&self) -> &Cpumask {
+        &self.all_cpus
+    }
+}
+
+impl CompiledCellSpec {
+    fn matches(&self, cgroup_path: &str) -> bool {
+        match &self.matcher {
+            Some(CompiledCellMatch::CgroupContains(substr)) => cgroup_path.contains(substr),
+            Some(CompiledCellMatch::CgroupRegex(regex)) => regex.is_match(cgroup_path),
+            None => true,
+        }
+    }
+}
+
+fn compile_specs(specs: Vec<CellSpec>) -> Result<Vec<CompiledCellSpec>> {
+    if specs.is_empty() {
+        bail!("cell config must contain at least one cell spec");
+    }
+
+    specs
+        .into_iter()
+        .map(|spec| {
+            let matcher = match spec.matches {
+                Some(CellMatch::CgroupContains(substr)) => {
+                    Some(CompiledCellMatch::CgroupContains(substr))
+                }
+                Some(CellMatch::CgroupRegex(expr)) => Some(CompiledCellMatch::CgroupRegex(
+                    Regex::new(&expr).with_context(|| {
+                        format!("invalid CgroupRegex '{}' for cell '{}'", expr, spec.name)
+                    })?,
+                )),
+                None => None,
+            };
+
+            Ok(CompiledCellSpec {
+                matcher,
+                subcells: normalize_subcells(spec.subcells)?,
+            })
+        })
+        .collect()
+}
+
+fn normalize_subcells(subcells: Vec<SubcellSpec>) -> Result<Vec<ConfiguredSubcell>> {
+    if subcells.is_empty() {
+        return Ok(default_configured_subcells());
+    }
+
+    let mut normalized = Vec::new();
+    let mut next_id = 1;
+    let mut catch_all = None;
+
+    for subcell in subcells {
+        if is_catch_all_subcell(&subcell) {
+            if catch_all.is_some() {
+                bail!("cell config contains multiple catch-all subcells");
+            }
+            catch_all = Some(ConfiguredSubcell {
+                id: 0,
+                matches: subcell.matches,
+            });
+            continue;
+        }
+
+        normalized.push(ConfiguredSubcell {
+            id: next_id,
+            matches: subcell.matches,
+        });
+        next_id += 1;
+    }
+
+    let mut result = vec![catch_all.unwrap_or_else(default_catch_all_subcell)];
+    result.extend(normalized);
+
+    if result.len() > crate::MAX_SUBCELLS_PER_CELL {
+        bail!(
+            "cell config has too many subcells: {} > {}",
+            result.len(),
+            crate::MAX_SUBCELLS_PER_CELL
+        );
+    }
+
+    Ok(result)
+}
+
+fn is_catch_all_subcell(subcell: &SubcellSpec) -> bool {
+    subcell.matches.iter().any(|ands| ands.is_empty())
+}
+
+fn default_configured_subcells() -> Vec<ConfiguredSubcell> {
+    vec![default_catch_all_subcell()]
+}
+
+fn default_catch_all_subcell() -> ConfiguredSubcell {
+    ConfiguredSubcell {
+        id: 0,
+        matches: vec![Vec::new()],
+    }
+}
+
+fn default_subcell_matches() -> Vec<Vec<SubcellMatch>> {
+    vec![Vec::new()]
+}
+
+fn demand_weight(cell_demands: Option<&HashMap<u32, f64>>, cell_id: u32) -> f64 {
+    cell_demands
+        .and_then(|demands| demands.get(&cell_id).copied())
+        .unwrap_or(1.0)
+        .max(0.0)
+}
+
+fn collect_cgroups(root: &Path) -> Result<Vec<CgroupEntry>> {
+    let mut cgroups = Vec::new();
+    collect_cgroups_inner(root, &mut cgroups)?;
+    cgroups.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(cgroups)
+}
+
+fn collect_cgroups_inner(path: &Path, cgroups: &mut Vec<CgroupEntry>) -> Result<()> {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(e).with_context(|| format!("reading metadata for {}", path.display()))
+        }
+    };
+
+    if !metadata.is_dir() {
+        return Ok(());
+    }
+
+    cgroups.push(CgroupEntry {
+        path: path.to_path_buf(),
+        path_string: path.display().to_string(),
+        cgid: metadata.ino(),
+        cpuset: read_cpuset(path)?,
+    });
+
+    for entry in fs::read_dir(path).with_context(|| format!("reading {}", path.display()))? {
+        let entry =
+            entry.with_context(|| format!("reading directory entry in {}", path.display()))?;
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("reading file type for {}", entry.path().display()))
+            }
+        };
+        if file_type.is_dir() {
+            collect_cgroups_inner(&entry.path(), cgroups)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn read_cpuset(cgroup_path: &Path) -> Result<Option<Cpumask>> {
+    let cpuset_path = cgroup_path.join("cpuset.cpus");
+    match fs::read_to_string(&cpuset_path) {
+        Ok(content) => {
+            let content = content.trim();
+            if content.is_empty() {
+                Ok(None)
+            } else {
+                Cpumask::from_cpulist(content)
+                    .with_context(|| {
+                        format!(
+                            "failed to parse cpuset '{}' from {}",
+                            content,
+                            cpuset_path.display()
+                        )
+                    })
+                    .map(Some)
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).with_context(|| format!("reading {}", cpuset_path.display())),
+    }
+}
+
+fn deserialize_optional_cell_match<'de, D>(deserializer: D) -> Result<Option<CellMatch>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    if value.as_object().is_some_and(|obj| obj.is_empty()) {
+        return Ok(None);
+    }
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(de::Error::custom)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+    use tempfile::TempDir;
+
+    fn write_config(contents: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(contents.as_bytes()).unwrap();
+        file
+    }
+
+    #[test]
+    fn parses_example_config_and_makes_rest_subcell_zero() {
+        let config = write_config(
+            r#"
+            [
+              {
+                "name": "allotment",
+                "matches": { "CgroupRegex": "workload-tw-[^/]+\\.allotment\\.slice" },
+                "subcells": [
+                  { "name": "hhvmworker", "matches": [[{ "CommPrefix": "hhvmworker" }]] },
+                  { "name": "mcrpxy-web", "matches": [[{ "CommPrefix": "mcrpxy-web" }]] },
+                  { "name": "rest", "matches": [[]] }
+                ]
+              },
+              { "name": "workload.slice", "matches": { "CgroupContains": "workload.slice" } },
+              { "name": "rest", "matches": {} }
+            ]
+            "#,
+        );
+        let configured = ConfiguredCells::load_with_root(
+            config.path(),
+            PathBuf::from("/tmp"),
+            256,
+            Cpumask::new(),
+        )
+        .unwrap();
+
+        assert_eq!(configured.root_spec_idx, Some(2));
+        let subcells = &configured.specs[0].subcells;
+        assert_eq!(subcells[0].id, 0);
+        assert_eq!(subcells[1].id, 1);
+        assert_eq!(subcells[2].id, 2);
+    }
+
+    #[test]
+    fn descendant_inherits_same_matching_cell_spec() {
+        let config = write_config(
+            r#"
+            [
+              { "name": "parent", "matches": { "CgroupContains": "parent.slice" } },
+              { "name": "rest", "matches": {} }
+            ]
+            "#,
+        );
+        let root = TempDir::new().unwrap();
+        fs::create_dir(root.path().join("parent.slice")).unwrap();
+        fs::create_dir(root.path().join("parent.slice/child.scope")).unwrap();
+
+        let mut configured = ConfiguredCells::load_with_root(
+            config.path(),
+            root.path().to_path_buf(),
+            256,
+            Cpumask::new(),
+        )
+        .unwrap();
+        let resolution = configured.resolve(None).unwrap();
+
+        assert_eq!(resolution.cell_assignments.len(), 1);
+    }
+
+    #[test]
+    fn higher_priority_descendant_gets_own_cell() {
+        let config = write_config(
+            r#"
+            [
+              { "name": "child", "matches": { "CgroupContains": "child.scope" } },
+              { "name": "parent", "matches": { "CgroupContains": "parent.slice" } },
+              { "name": "rest", "matches": {} }
+            ]
+            "#,
+        );
+        let root = TempDir::new().unwrap();
+        fs::create_dir(root.path().join("parent.slice")).unwrap();
+        fs::create_dir(root.path().join("parent.slice/child.scope")).unwrap();
+
+        let mut configured = ConfiguredCells::load_with_root(
+            config.path(),
+            root.path().to_path_buf(),
+            256,
+            Cpumask::new(),
+        )
+        .unwrap();
+        let resolution = configured.resolve(None).unwrap();
+
+        assert_eq!(resolution.cell_assignments.len(), 2);
+    }
+}

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -11,7 +11,7 @@ mod cell_manager;
 mod mitosis_topology_utils;
 mod stats;
 
-use cell_manager::{CellManager, CpuAssignment};
+use cell_manager::{CellManager, CpuAssignment, CpuRecipient};
 
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
@@ -228,6 +228,33 @@ const QUEUE_STATS_IDX: [bpf_intf::cell_stat_idx; 4] = [
 #[derive(Debug)]
 struct Cell {
     cpus: Cpumask,
+    subcells: Vec<Subcell>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Subcell {
+    id: u32,
+    primary: Cpumask,
+    borrowable: Option<Cpumask>,
+}
+
+impl Cell {
+    fn new() -> Self {
+        Self {
+            cpus: Cpumask::new(),
+            subcells: vec![Subcell::new(0)],
+        }
+    }
+}
+
+impl Subcell {
+    fn new(id: u32) -> Self {
+        Self {
+            id,
+            primary: Cpumask::new(),
+            borrowable: None,
+        }
+    }
 }
 
 struct Scheduler<'a> {
@@ -657,7 +684,7 @@ impl<'a> Scheduler<'a> {
         &mut self,
         new_cell_ids: &[u32],
     ) -> Result<Vec<CpuAssignment>> {
-        let (cell_assignments, cpu_assignments) = {
+        let (cell_assignments, cpu_assignments, _subcell_assignments) = {
             let cell_manager = self
                 .cell_manager
                 .as_ref()
@@ -716,7 +743,13 @@ impl<'a> Scheduler<'a> {
                     .context("computing equal-weight CPU assignments (rebalancing disabled)")?
             };
 
-            (cell_manager.get_cell_assignments(), cpu_assignments)
+            let subcell_assignments = self.compute_subcell_assignments(&cpu_assignments)?;
+
+            (
+                cell_manager.get_cell_assignments(),
+                cpu_assignments,
+                subcell_assignments,
+            )
         };
 
         self.apply_cell_config(&cell_assignments, &cpu_assignments)
@@ -762,7 +795,7 @@ impl<'a> Scheduler<'a> {
             .collect();
 
         // Compute new assignments and check if they differ from current
-        let (cell_assignments, cpu_assignments) = {
+        let (cell_assignments, cpu_assignments, _subcell_assignments) = {
             let cell_manager = self
                 .cell_manager
                 .as_ref()
@@ -781,7 +814,13 @@ impl<'a> Scheduler<'a> {
                 return Ok(());
             }
 
-            (cell_manager.get_cell_assignments(), cpu_assignments)
+            let subcell_assignments = self.compute_subcell_assignments(&cpu_assignments)?;
+
+            (
+                cell_manager.get_cell_assignments(),
+                cpu_assignments,
+                subcell_assignments,
+            )
         };
 
         self.apply_cell_config(&cell_assignments, &cpu_assignments)
@@ -801,6 +840,72 @@ impl<'a> Scheduler<'a> {
             self.rebalance_count,
             cell_manager.format_cell_config(&cpu_assignments)
         );
+
+        Ok(())
+    }
+
+    fn compute_subcell_assignments(
+        &self,
+        cell_cpu_assignments: &[CpuAssignment],
+    ) -> Result<Vec<Vec<CpuAssignment>>> {
+        cell_cpu_assignments
+            .iter()
+            .map(|cell_assignment| {
+                let recipients: Vec<CpuRecipient> = self
+                    .cells
+                    .get(&cell_assignment.id)
+                    .map(|cell| {
+                        cell.subcells
+                            .iter()
+                            .map(|subcell| CpuRecipient {
+                                id: subcell.id,
+                                weight: 1.0,
+                                allowed: None,
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_else(|| {
+                        vec![CpuRecipient {
+                            id: 0,
+                            weight: 1.0,
+                            allowed: None,
+                        }]
+                    });
+
+                CellManager::compute_subcell_cpu_assignments(
+                    &cell_assignment.primary,
+                    &recipients,
+                    self.enable_borrowing,
+                )
+            })
+            .collect()
+    }
+
+    fn refresh_bpf_subcells(
+        &mut self,
+        cell_to_cpus: &HashMap<u32, Cpumask>,
+        active_cells: &HashSet<u32>,
+    ) -> Result<()> {
+        if self.cell_manager.is_none() {
+            return Ok(());
+        }
+
+        // Until subcell state is read back from BPF, mirror each cell's observed
+        // primary mask into all of its subcells and keep borrowable empty.
+        for cell_id in active_cells {
+            let primary = cell_to_cpus
+                .get(cell_id)
+                .cloned()
+                .unwrap_or_else(Cpumask::new);
+            let cell = self.cells.get_mut(cell_id).ok_or_else(|| {
+                anyhow::anyhow!("Cell {} missing during subcell refresh", cell_id)
+            })?;
+
+            for subcell in &mut cell.subcells {
+                subcell.primary = primary.clone();
+                subcell.borrowable = Some(Cpumask::new());
+            }
+        }
 
         Ok(())
     }
@@ -874,6 +979,9 @@ impl<'a> Scheduler<'a> {
             }
         }
         config.num_cells = max_cell_id;
+
+        // When subcell configuration is applied to BPF, extend this function to
+        // write and apply the computed subcell state here as well.
 
         // Trigger the BPF program to apply the configuration
         let prog = &mut self.skel.progs.apply_cell_config;
@@ -1421,18 +1529,15 @@ impl<'a> Scheduler<'a> {
                 .get(cell_idx)
                 .cloned()
                 .unwrap_or_else(|| Cpumask::new());
-            self.cells
-                .entry(*cell_idx)
-                .or_insert_with(|| Cell {
-                    cpus: Cpumask::new(),
-                })
-                .cpus = cpus;
+            self.cells.entry(*cell_idx).or_insert_with(Cell::new).cpus = cpus;
             self.metrics.cells.insert(*cell_idx, CellMetrics::default());
         }
 
         // Remove cells that no longer have CPUs assigned
         self.cells.retain(|&k, _| active_cells.contains(&k));
         self.metrics.cells.retain(|&k, _| active_cells.contains(&k));
+
+        self.refresh_bpf_subcells(&cell_to_cpus, &active_cells)?;
 
         self.last_configuration_seq = Some(applied_configuration);
 

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -773,7 +773,7 @@ impl<'a> Scheduler<'a> {
 
             let changed = cpu_assignments.iter().any(|a| {
                 self.cells
-                    .get(&a.cell_id)
+                    .get(&a.id)
                     .map_or(true, |cell| cell.cpus != a.primary)
             });
 
@@ -855,21 +855,21 @@ impl<'a> Scheduler<'a> {
         // Set cell cpumasks and borrowable cpumasks
         let mut max_cell_id: u32 = 0;
         for a in cpu_assignments {
-            if a.cell_id >= bpf_intf::consts_MAX_CELLS {
+            if a.id >= bpf_intf::consts_MAX_CELLS {
                 bail!(
                     "Cell ID {} exceeds MAX_CELLS ({})",
-                    a.cell_id,
+                    a.id,
                     bpf_intf::consts_MAX_CELLS
                 );
             }
-            max_cell_id = max_cell_id.max(a.cell_id + 1);
+            max_cell_id = max_cell_id.max(a.id + 1);
 
-            write_cpumask_to_config(&a.primary, &mut config.cpumasks[a.cell_id as usize].mask);
+            write_cpumask_to_config(&a.primary, &mut config.cpumasks[a.id as usize].mask);
 
             if let Some(ref borrowable) = a.borrowable {
                 write_cpumask_to_config(
                     borrowable,
-                    &mut config.borrowable_cpumasks[a.cell_id as usize].mask,
+                    &mut config.borrowable_cpumasks[a.id as usize].mask,
                 );
             }
         }

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -975,6 +975,12 @@ impl<'a> Scheduler<'a> {
         }
         config.num_cell_assignments = cell_assignments.len() as u32;
 
+        for cell_id in 0..MAX_CELLS {
+            for subcell_id in 0..MAX_SUBCELLS_PER_CELL {
+                config.subcells[cell_id][subcell_id].id = subcell_id as u32;
+            }
+        }
+
         for (i, (cgid, cell_id)) in cell_assignments.iter().enumerate() {
             config.assignments[i].cgid = *cgid;
             config.assignments[i].cell_id = *cell_id;

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -13,6 +13,7 @@ mod mitosis_topology_utils;
 mod stats;
 
 use cell_manager::{CellManager, CpuAssignment, CpuRecipient};
+use config::{ConfiguredCells, SubcellMatch};
 
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
@@ -20,6 +21,7 @@ use std::fmt;
 use std::fmt::Display;
 use std::mem::MaybeUninit;
 use std::os::fd::AsFd;
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
@@ -157,6 +159,11 @@ struct Opts {
     #[clap(long)]
     cell_parent_cgroup: Option<String>,
 
+    /// JSON cell configuration file. Each matching cgroup becomes a cell and
+    /// inherits the subcell layout from its matching cell spec.
+    #[clap(long, value_name = "PATH")]
+    cell_config: Option<PathBuf>,
+
     /// Exact directory name of a direct child cgroup to exclude from cell creation
     /// (excluded cgroups remain in cell 0). Matched against the directory basename,
     /// not the full path. Can be specified multiple times. Requires --cell-parent-cgroup.
@@ -238,6 +245,7 @@ struct Subcell {
     id: u32,
     primary: Cpumask,
     borrowable: Option<Cpumask>,
+    matches: Vec<Vec<SubcellMatch>>,
 }
 
 impl Cell {
@@ -255,6 +263,7 @@ impl Subcell {
             id,
             primary: Cpumask::new(),
             borrowable: None,
+            matches: Vec::new(),
         }
     }
 }
@@ -277,6 +286,8 @@ struct Scheduler<'a> {
     last_cpuset_seq: u32,
     /// Optional cell manager for --cell-parent-cgroup mode
     cell_manager: Option<CellManager>,
+    /// Optional configured cell manager for --cell-config mode
+    configured_cells: Option<ConfiguredCells>,
     /// Whether CPU borrowing is enabled
     enable_borrowing: bool,
     /// Whether demand-based rebalancing is enabled
@@ -297,6 +308,10 @@ struct Scheduler<'a> {
     epoll: Epoll,
     /// EventFd to wake up main loop when stats are requested
     stats_waker: EventFd,
+    /// Interval for rescanning configured cgroups
+    reconfiguration_interval: Duration,
+    /// Last time configured cgroups were rescanned
+    last_config_refresh: Instant,
 }
 
 struct DistributionStats {
@@ -415,7 +430,8 @@ impl<'a> Scheduler<'a> {
         rodata.enable_llc_awareness = opts.enable_llc_awareness;
         rodata.enable_work_stealing = opts.enable_work_stealing;
 
-        rodata.userspace_managed_cell_mode = opts.cell_parent_cgroup.is_some();
+        rodata.userspace_managed_cell_mode =
+            opts.cell_parent_cgroup.is_some() || opts.cell_config.is_some();
 
         rodata.enable_borrowing = opts.enable_borrowing;
         rodata.use_lockless_peek = opts.use_lockless_peek;
@@ -449,6 +465,9 @@ impl<'a> Scheduler<'a> {
         if !opts.cell_exclude.is_empty() && opts.cell_parent_cgroup.is_none() {
             bail!("--cell-exclude requires --cell-parent-cgroup");
         }
+        if opts.cell_parent_cgroup.is_some() && opts.cell_config.is_some() {
+            bail!("--cell-parent-cgroup and --cell-config are mutually exclusive");
+        }
         let cell_manager = if let Some(ref parent_cgroup) = opts.cell_parent_cgroup {
             let exclude: HashSet<String> = opts.cell_exclude.iter().cloned().collect();
             Some(
@@ -461,6 +480,19 @@ impl<'a> Scheduler<'a> {
                 .with_context(|| {
                     format!("initializing cell manager for cgroup {}", parent_cgroup)
                 })?,
+            )
+        } else {
+            None
+        };
+        let configured_cells = if let Some(ref cell_config) = opts.cell_config {
+            Some(
+                ConfiguredCells::load(cell_config, MAX_CELLS as u32, topology.span.clone())
+                    .with_context(|| {
+                        format!(
+                            "initializing configured cells from {}",
+                            cell_config.display()
+                        )
+                    })?,
             )
         } else {
             None
@@ -507,6 +539,7 @@ impl<'a> Scheduler<'a> {
             last_configuration_seq: None,
             last_cpuset_seq: 0,
             cell_manager,
+            configured_cells,
             enable_borrowing: opts.enable_borrowing,
             enable_rebalancing: opts.enable_rebalancing,
             rebalance_threshold: opts.rebalance_threshold,
@@ -517,6 +550,8 @@ impl<'a> Scheduler<'a> {
             rebalance_count: 0,
             epoll,
             stats_waker,
+            reconfiguration_interval: Duration::from_secs(opts.reconfiguration_interval_s),
+            last_config_refresh: Instant::now(),
         })
     }
 
@@ -589,9 +624,13 @@ impl<'a> Scheduler<'a> {
                 .context("refreshing BPF cell state")?;
             self.check_cpuset_changes()
                 .context("checking cpuset changes")?;
+            self.maybe_refresh_configured_cells()
+                .context("refreshing configured cells")?;
             self.collect_metrics().context("collecting metrics")?;
 
-            if self.enable_rebalancing && self.cell_manager.is_some() {
+            if self.enable_rebalancing
+                && (self.cell_manager.is_some() || self.configured_cells.is_some())
+            {
                 self.maybe_rebalance().context("running rebalance check")?;
             }
         }
@@ -606,6 +645,23 @@ impl<'a> Scheduler<'a> {
 
     /// Apply initial cell assignments discovered at startup
     fn apply_initial_cells(&mut self) -> Result<()> {
+        if self.configured_cells.is_some() {
+            let cpu_assignments = self
+                .compute_and_apply_configured_cell_config()
+                .context("computing initial configured cell configuration")?;
+            self.last_config_refresh = Instant::now();
+
+            let configured_cells = self
+                .configured_cells
+                .as_ref()
+                .expect("BUG: configured_cells missing in apply_initial_cells");
+            info!(
+                "Applied initial configured cell configuration: {}",
+                configured_cells.format_cell_config(&cpu_assignments)
+            );
+            return Ok(());
+        }
+
         if self.cell_manager.is_none() {
             return Ok(());
         }
@@ -762,10 +818,90 @@ impl<'a> Scheduler<'a> {
         Ok(cpu_assignments)
     }
 
+    /// Compute cell configuration from --cell-config and apply it to BPF.
+    fn compute_and_apply_configured_cell_config(&mut self) -> Result<Vec<CpuAssignment>> {
+        let cell_demands = if self.enable_rebalancing {
+            Some(self.active_cell_demands())
+        } else {
+            None
+        };
+
+        let (resolution, all_cpus) = {
+            let configured_cells = self.configured_cells.as_mut().expect(
+                "BUG: configured_cells missing in compute_and_apply_configured_cell_config",
+            );
+            let resolution = configured_cells
+                .resolve(cell_demands.as_ref())
+                .context("resolving configured cells")?;
+            (resolution, configured_cells.all_cpus().clone())
+        };
+
+        for configured_cell in &resolution.cells {
+            let cell = self
+                .cells
+                .entry(configured_cell.id)
+                .or_insert_with(Cell::new);
+            cell.subcells = configured_cell
+                .subcells
+                .iter()
+                .map(|subcell| Subcell {
+                    id: subcell.id,
+                    primary: Cpumask::new(),
+                    borrowable: None,
+                    matches: subcell.matches.clone(),
+                })
+                .collect();
+        }
+
+        let cpu_assignments = CellManager::compute_cpu_assignments_for(
+            &all_cpus,
+            &resolution.cell_recipients,
+            self.enable_borrowing,
+        )
+        .context("computing configured cell CPU assignments")?;
+        let subcell_assignments = self.compute_subcell_assignments(&cpu_assignments)?;
+
+        let cell_assignments = resolution.cell_assignments;
+
+        self.apply_cell_config(&cell_assignments, &cpu_assignments, &subcell_assignments)
+            .context("applying configured cell configuration to BPF")?;
+
+        Ok(cpu_assignments)
+    }
+
+    fn active_cell_demands(&self) -> HashMap<u32, f64> {
+        self.cells
+            .keys()
+            .map(|&id| (id, self.smoothed_util[id as usize]))
+            .collect()
+    }
+
     /// Check if rebalancing should be triggered and apply demand-weighted CPU assignments.
     fn maybe_rebalance(&mut self) -> Result<()> {
         // Check cooldown
         if self.last_rebalance.elapsed() < self.rebalance_cooldown {
+            return Ok(());
+        }
+
+        if self.configured_cells.is_some() {
+            let cpu_assignments = self
+                .compute_and_apply_configured_cell_config()
+                .context("recomputing configured cell configuration for rebalance")?;
+            self.last_rebalance = Instant::now();
+            self.last_config_refresh = Instant::now();
+            self.rebalance_count += 1;
+            self.metrics.rebalance_count = self.rebalance_count;
+
+            let configured_cells = self
+                .configured_cells
+                .as_ref()
+                .expect("BUG: configured_cells missing in maybe_rebalance");
+            info!(
+                "Rebalanced configured cells (count={}): {}",
+                self.rebalance_count,
+                configured_cells.format_cell_config(&cpu_assignments)
+            );
+
             return Ok(());
         }
 
@@ -908,6 +1044,7 @@ impl<'a> Scheduler<'a> {
                         } else {
                             None
                         },
+                        matches: Vec::new(),
                     })
                 })
                 .collect::<Result<_>>()?;
@@ -935,6 +1072,16 @@ impl<'a> Scheduler<'a> {
         cpu_assignments: &[CpuAssignment],
         subcell_assignments: &[Vec<CpuAssignment>],
     ) -> Result<()> {
+        let subcell_matches: HashMap<(u32, u32), Vec<Vec<SubcellMatch>>> = self
+            .cells
+            .iter()
+            .flat_map(|(&cell_id, cell)| {
+                cell.subcells
+                    .iter()
+                    .map(move |subcell| ((cell_id, subcell.id), subcell.matches.clone()))
+            })
+            .collect();
+
         let bss_data = self
             .skel
             .maps
@@ -1036,6 +1183,16 @@ impl<'a> Scheduler<'a> {
 
                 config.subcells[a.id as usize][slot].id = subcell.id;
                 config.subcells[a.id as usize][slot].in_use = 1;
+                let matches = subcell_matches
+                    .get(&(a.id, subcell.id))
+                    .map_or(&[][..], |matches| matches.as_slice());
+                write_subcell_matches(matches, &mut config.subcells[a.id as usize][slot])
+                    .with_context(|| {
+                        format!(
+                            "writing subcell matches for cell {} subcell {}",
+                            a.id, subcell.id
+                        )
+                    })?;
                 write_cpumask_to_config(
                     &subcell.primary,
                     &mut config.subcells[a.id as usize][slot].primary.mask,
@@ -1501,9 +1658,9 @@ impl<'a> Scheduler<'a> {
 
     /// Check if any cell's cpuset was modified and recompute if so.
     fn check_cpuset_changes(&mut self) -> Result<()> {
-        let Some(ref mut cm) = self.cell_manager else {
+        if self.cell_manager.is_none() && self.configured_cells.is_none() {
             return Ok(());
-        };
+        }
 
         let current_seq = unsafe {
             let ptr = &self
@@ -1524,23 +1681,63 @@ impl<'a> Scheduler<'a> {
         }
         self.last_cpuset_seq = current_seq;
 
-        if !cm.refresh_cpusets().context("refreshing cell cpusets")? {
-            // seq changed but no cpusets on our cells changed
+        if let Some(ref mut cm) = self.cell_manager {
+            if !cm.refresh_cpusets().context("refreshing cell cpusets")? {
+                // seq changed but no cpusets on our cells changed
+                self.update_applied_cpuset_seq();
+                return Ok(());
+            }
+
+            let cpu_assignments = self
+                .compute_and_apply_cell_config(&[])
+                .context("recomputing cell configuration after cpuset change")?;
             self.update_applied_cpuset_seq();
+            let cell_manager = self
+                .cell_manager
+                .as_ref()
+                .expect("BUG: cell_manager missing in check_cpuset_changes");
+            info!(
+                "Cpuset change detected, recomputed config: {}",
+                cell_manager.format_cell_config(&cpu_assignments)
+            );
             return Ok(());
         }
 
         let cpu_assignments = self
-            .compute_and_apply_cell_config(&[])
-            .context("recomputing cell configuration after cpuset change")?;
+            .compute_and_apply_configured_cell_config()
+            .context("recomputing configured cell configuration after cpuset change")?;
+        self.last_config_refresh = Instant::now();
         self.update_applied_cpuset_seq();
-        let cell_manager = self
-            .cell_manager
+        let configured_cells = self
+            .configured_cells
             .as_ref()
-            .expect("BUG: cell_manager missing in check_cpuset_changes");
+            .expect("BUG: configured_cells missing in check_cpuset_changes");
         info!(
-            "Cpuset change detected, recomputed config: {}",
-            cell_manager.format_cell_config(&cpu_assignments)
+            "Cpuset change detected, recomputed configured cells: {}",
+            configured_cells.format_cell_config(&cpu_assignments)
+        );
+        Ok(())
+    }
+
+    fn maybe_refresh_configured_cells(&mut self) -> Result<()> {
+        if self.configured_cells.is_none()
+            || self.last_config_refresh.elapsed() < self.reconfiguration_interval
+        {
+            return Ok(());
+        }
+
+        let cpu_assignments = self
+            .compute_and_apply_configured_cell_config()
+            .context("recomputing configured cells")?;
+        self.last_config_refresh = Instant::now();
+
+        let configured_cells = self
+            .configured_cells
+            .as_ref()
+            .expect("BUG: configured_cells missing in maybe_refresh_configured_cells");
+        info!(
+            "Refreshed configured cells: {}",
+            configured_cells.format_cell_config(&cpu_assignments)
         );
         Ok(())
     }
@@ -1624,6 +1821,63 @@ fn write_cpumask_to_config(cpumask: &Cpumask, dest: &mut [u8]) {
             }
         }
     }
+}
+
+fn write_subcell_matches(
+    matches: &[Vec<SubcellMatch>],
+    dest: &mut types::subcell_config,
+) -> Result<()> {
+    if matches.len() > bpf_intf::consts_MAX_SUBCELL_MATCH_ORS as usize {
+        bail!(
+            "Too many subcell match OR groups: {} > {}",
+            matches.len(),
+            bpf_intf::consts_MAX_SUBCELL_MATCH_ORS
+        );
+    }
+
+    dest.nr_match_ors = matches.len() as u32;
+    for (or_idx, ands) in matches.iter().enumerate() {
+        if ands.len() > bpf_intf::consts_MAX_SUBCELL_MATCH_ANDS as usize {
+            bail!(
+                "Too many subcell match AND terms: {} > {}",
+                ands.len(),
+                bpf_intf::consts_MAX_SUBCELL_MATCH_ANDS
+            );
+        }
+
+        dest.matches[or_idx].nr_matches = ands.len() as u32;
+        for (and_idx, subcell_match) in ands.iter().enumerate() {
+            match subcell_match {
+                SubcellMatch::CommPrefix(prefix) => {
+                    dest.matches[or_idx].matches[and_idx].kind =
+                        bpf_intf::subcell_match_kind_SUBCELL_MATCH_COMM_PREFIX;
+                    copy_cstr(&mut dest.matches[or_idx].matches[and_idx].value, prefix)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn copy_cstr(dest: &mut [i8], src: &str) -> Result<()> {
+    if dest.is_empty() {
+        return Ok(());
+    }
+    if src.as_bytes().contains(&0) {
+        bail!("subcell match string contains NUL byte");
+    }
+
+    for value in dest.iter_mut() {
+        *value = 0;
+    }
+
+    let len = src.len().min(dest.len() - 1);
+    for (dst, src) in dest.iter_mut().zip(src.as_bytes().iter()).take(len) {
+        *dst = *src as i8;
+    }
+
+    Ok(())
 }
 
 fn read_cpumask_from_bytes(src: &[u8]) -> Result<Cpumask> {

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -243,6 +243,7 @@ struct Cell {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct Subcell {
     id: u32,
+    name: String,
     primary: Cpumask,
     borrowable: Option<Cpumask>,
     matches: Vec<Vec<SubcellMatch>>,
@@ -261,6 +262,7 @@ impl Subcell {
     fn new(id: u32) -> Self {
         Self {
             id,
+            name: default_subcell_name(id),
             primary: Cpumask::new(),
             borrowable: None,
             matches: Vec::new(),
@@ -856,6 +858,7 @@ impl<'a> Scheduler<'a> {
                 .iter()
                 .map(|subcell| Subcell {
                     id: subcell.id,
+                    name: subcell.name.clone(),
                     primary: Cpumask::new(),
                     borrowable: None,
                     matches: subcell.matches.clone(),
@@ -1066,6 +1069,16 @@ impl<'a> Scheduler<'a> {
                         .collect()
                 })
                 .unwrap_or_default();
+            let existing_names: HashMap<u32, String> = self
+                .cells
+                .get(cell_id)
+                .map(|cell| {
+                    cell.subcells
+                        .iter()
+                        .map(|subcell| (subcell.id, subcell.name.clone()))
+                        .collect()
+                })
+                .unwrap_or_default();
             let subcells: Vec<Subcell> = bpf_cell
                 .subcells
                 .iter()
@@ -1073,6 +1086,10 @@ impl<'a> Scheduler<'a> {
                 .map(|subcell| {
                     Ok(Subcell {
                         id: subcell.id,
+                        name: existing_names
+                            .get(&subcell.id)
+                            .cloned()
+                            .unwrap_or_else(|| default_subcell_name(subcell.id)),
                         primary: read_cpumask_from_bytes(&subcell.primary.mask)?,
                         borrowable: if self.enable_borrowing {
                             Some(read_cpumask_from_bytes(&subcell.borrowable.mask)?)
@@ -1552,7 +1569,7 @@ impl<'a> Scheduler<'a> {
                             .subcells
                             .entry(subcell.id)
                             .or_default()
-                            .num_cpus = subcell.primary.weight() as u32;
+                            .update_name_and_cpus(&subcell.name, subcell.primary.weight() as u32);
                     }
                 });
         }
@@ -2003,6 +2020,14 @@ fn write_cpumask_to_config(cpumask: &Cpumask, dest: &mut [u8]) {
                 dest[idx] = *byte;
             }
         }
+    }
+}
+
+fn default_subcell_name(id: u32) -> String {
+    if id == 0 {
+        "rest".to_string()
+    } else {
+        format!("subcell{}", id)
     }
 }
 

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -76,7 +76,7 @@ fn parse_ewma_factor(s: &str) -> Result<f64, String> {
 /// scx_mitosis: A dynamic affinity scheduler
 ///
 /// Cgroups are assigned to a dynamic number of Cells which are assigned to a
-/// dynamic set of CPUs. The BPF part does simple vtime scheduling for each cell.
+/// dynamic set of CPUs. The BPF part does simple vtime scheduling for each subcell.
 ///
 /// Userspace makes the dynamic decisions of which Cells should be merged or
 /// split and which CPUs they should be assigned to.

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -8,6 +8,7 @@ mod bpf_skel;
 pub use bpf_skel::*;
 pub mod bpf_intf;
 mod cell_manager;
+mod config;
 mod mitosis_topology_utils;
 mod stats;
 

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -1719,14 +1719,14 @@ impl<'a> Scheduler<'a> {
         let mut total_running_ns = [[0u64; MAX_SUBCELLS_PER_CELL]; MAX_CELLS];
         let mut on_own_ns = [[0u64; MAX_SUBCELLS_PER_CELL]; MAX_CELLS];
         let mut lent_ns = [[0u64; MAX_SUBCELLS_PER_CELL]; MAX_CELLS];
-        let active_subcells: HashMap<(usize, usize), usize> = self
+        let active_subcells: HashMap<(usize, usize), (usize, String)> = self
             .cells
             .iter()
             .flat_map(|(&cell_id, cell)| {
                 cell.subcells.iter().map(move |subcell| {
                     (
                         (cell_id as usize, subcell.id as usize),
-                        subcell.primary.weight(),
+                        (subcell.primary.weight(), subcell.name.clone()),
                     )
                 })
             })
@@ -1785,11 +1785,19 @@ impl<'a> Scheduler<'a> {
                     continue;
                 }
 
-                let Some(&nr_cpus) = active_subcells.get(&(cell, subcell)) else {
+                let Some((nr_cpus, name)) = active_subcells.get(&(cell, subcell)) else {
                     continue;
                 };
-                if nr_cpus == 0 {
+                if *nr_cpus == 0 {
                     self.smoothed_subcell_util[cell][subcell] = 0.0;
+                    self.metrics
+                        .cells
+                        .entry(cell as u32)
+                        .or_default()
+                        .subcells
+                        .entry(subcell as u32)
+                        .or_default()
+                        .update_name_and_cpus(name, 0);
                     self.metrics
                         .cells
                         .entry(cell as u32)
@@ -1801,7 +1809,7 @@ impl<'a> Scheduler<'a> {
                     continue;
                 }
 
-                let capacity = (nr_cpus as u64) * interval_ns;
+                let capacity = (*nr_cpus as u64) * interval_ns;
                 let delta_borrowed = delta_running.saturating_sub(delta_on_own);
                 let util_pct = 100.0 * (delta_running as f64) / (capacity as f64);
                 let demand_borrow_pct = if delta_running > 0 {
@@ -1832,7 +1840,7 @@ impl<'a> Scheduler<'a> {
                     delta_borrowed,
                     delta_lent,
                 );
-                subcell_metrics.num_cpus = nr_cpus as u32;
+                subcell_metrics.update_name_and_cpus(name, *nr_cpus as u32);
                 if self.enable_rebalancing {
                     subcell_metrics.smoothed_util_pct = self.smoothed_subcell_util[cell][subcell];
                 }

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -279,6 +279,9 @@ struct Scheduler<'a> {
     prev_cell_running_ns: [u64; MAX_CELLS],
     prev_cell_own_ns: [u64; MAX_CELLS],
     prev_cell_lent_ns: [u64; MAX_CELLS],
+    prev_subcell_running_ns: [[u64; MAX_SUBCELLS_PER_CELL]; MAX_CELLS],
+    prev_subcell_own_ns: [[u64; MAX_SUBCELLS_PER_CELL]; MAX_CELLS],
+    prev_subcell_lent_ns: [[u64; MAX_SUBCELLS_PER_CELL]; MAX_CELLS],
     metrics: Metrics,
     stats_server: Option<StatsServer<(), Metrics>>,
     last_configuration_seq: Option<u32>,
@@ -300,6 +303,8 @@ struct Scheduler<'a> {
     demand_smoothing: f64,
     /// EWMA-smoothed utilization per cell
     smoothed_util: [f64; MAX_CELLS],
+    /// EWMA-smoothed utilization per subcell
+    smoothed_subcell_util: [[f64; MAX_SUBCELLS_PER_CELL]; MAX_CELLS],
     /// Last time rebalancing was performed
     last_rebalance: Instant,
     /// Number of rebalancing events
@@ -534,6 +539,9 @@ impl<'a> Scheduler<'a> {
             prev_cell_running_ns: [0; MAX_CELLS],
             prev_cell_own_ns: [0; MAX_CELLS],
             prev_cell_lent_ns: [0; MAX_CELLS],
+            prev_subcell_running_ns: [[0; MAX_SUBCELLS_PER_CELL]; MAX_CELLS],
+            prev_subcell_own_ns: [[0; MAX_SUBCELLS_PER_CELL]; MAX_CELLS],
+            prev_subcell_lent_ns: [[0; MAX_SUBCELLS_PER_CELL]; MAX_CELLS],
             metrics: Metrics::default(),
             stats_server: Some(stats_server),
             last_configuration_seq: None,
@@ -546,6 +554,7 @@ impl<'a> Scheduler<'a> {
             rebalance_cooldown: Duration::from_secs(opts.rebalance_cooldown_s),
             demand_smoothing: opts.demand_smoothing,
             smoothed_util: [0.0; MAX_CELLS],
+            smoothed_subcell_util: [[0.0; MAX_SUBCELLS_PER_CELL]; MAX_CELLS],
             last_rebalance: Instant::now(),
             rebalance_count: 0,
             epoll,
@@ -710,6 +719,7 @@ impl<'a> Scheduler<'a> {
         // leak if the cell ID is reused later.
         for &cell_id in &destroyed_cell_ids {
             self.smoothed_util[cell_id as usize] = 0.0;
+            self.smoothed_subcell_util[cell_id as usize] = [0.0; MAX_SUBCELLS_PER_CELL];
         }
 
         let cpu_assignments = self
@@ -998,11 +1008,26 @@ impl<'a> Scheduler<'a> {
                     .cells
                     .get(&cell_assignment.id)
                     .map(|cell| {
+                        let use_demand = self.enable_rebalancing
+                            && (cell_assignment.id as usize) < MAX_CELLS
+                            && cell.subcells.iter().any(|subcell| {
+                                (subcell.id as usize) < MAX_SUBCELLS_PER_CELL
+                                    && self.smoothed_subcell_util[cell_assignment.id as usize]
+                                        [subcell.id as usize]
+                                        > 0.0
+                            });
                         cell.subcells
                             .iter()
                             .map(|subcell| CpuRecipient {
                                 id: subcell.id,
-                                weight: 1.0,
+                                weight: if use_demand
+                                    && (subcell.id as usize) < MAX_SUBCELLS_PER_CELL
+                                {
+                                    self.smoothed_subcell_util[cell_assignment.id as usize]
+                                        [subcell.id as usize]
+                                } else {
+                                    1.0
+                                },
                                 allowed: None,
                             })
                             .collect()
@@ -1025,12 +1050,22 @@ impl<'a> Scheduler<'a> {
     }
 
     fn refresh_bpf_subcells(&mut self, active_cells: &HashSet<u32>) -> Result<()> {
-        if self.cell_manager.is_none() {
+        if self.cell_manager.is_none() && self.configured_cells.is_none() {
             return Ok(());
         }
 
         for cell_id in active_cells {
             let bpf_cell = read_bpf_cell(&self.skel, *cell_id)?;
+            let existing_matches: HashMap<u32, Vec<Vec<SubcellMatch>>> = self
+                .cells
+                .get(cell_id)
+                .map(|cell| {
+                    cell.subcells
+                        .iter()
+                        .map(|subcell| (subcell.id, subcell.matches.clone()))
+                        .collect()
+                })
+                .unwrap_or_default();
             let subcells: Vec<Subcell> = bpf_cell
                 .subcells
                 .iter()
@@ -1044,7 +1079,10 @@ impl<'a> Scheduler<'a> {
                         } else {
                             None
                         },
-                        matches: Vec::new(),
+                        matches: existing_matches
+                            .get(&subcell.id)
+                            .cloned()
+                            .unwrap_or_default(),
                     })
                 })
                 .collect::<Result<_>>()?;
@@ -1491,9 +1529,11 @@ impl<'a> Scheduler<'a> {
         self.log_all_queue_stats(&cell_stats_delta)
             .context("logging queue stats")?;
 
-        if self.cell_manager.is_some() {
+        if self.cell_manager.is_some() || self.configured_cells.is_some() {
             self.collect_demand_metrics(&cpu_ctxs)
                 .context("collecting demand metrics")?;
+            self.collect_subcell_demand_metrics(&cpu_ctxs)
+                .context("collecting subcell demand metrics")?;
         }
 
         for (cell_id, cell) in &self.cells {
@@ -1505,7 +1545,16 @@ impl<'a> Scheduler<'a> {
             self.metrics
                 .cells
                 .entry(*cell_id)
-                .and_modify(|cell_metrics| cell_metrics.num_cpus = cell.cpus.weight() as u32);
+                .and_modify(|cell_metrics| {
+                    cell_metrics.num_cpus = cell.cpus.weight() as u32;
+                    for subcell in &cell.subcells {
+                        cell_metrics
+                            .subcells
+                            .entry(subcell.id)
+                            .or_default()
+                            .num_cpus = subcell.primary.weight() as u32;
+                    }
+                });
         }
         self.metrics.num_cells = self.cells.len() as u32;
 
@@ -1638,6 +1687,125 @@ impl<'a> Scheduler<'a> {
 
         self.metrics
             .update_demand(global_util_pct, global_borrow_pct, global_lent_pct);
+
+        Ok(())
+    }
+
+    /// Compute per-subcell demand metrics from BPF running_ns counters.
+    fn collect_subcell_demand_metrics(&mut self, cpu_ctxs: &[bpf_intf::cpu_ctx]) -> Result<()> {
+        let mut total_running_ns = [[0u64; MAX_SUBCELLS_PER_CELL]; MAX_CELLS];
+        let mut on_own_ns = [[0u64; MAX_SUBCELLS_PER_CELL]; MAX_CELLS];
+        let mut lent_ns = [[0u64; MAX_SUBCELLS_PER_CELL]; MAX_CELLS];
+        let active_subcells: HashMap<(usize, usize), usize> = self
+            .cells
+            .iter()
+            .flat_map(|(&cell_id, cell)| {
+                cell.subcells.iter().map(move |subcell| {
+                    (
+                        (cell_id as usize, subcell.id as usize),
+                        subcell.primary.weight(),
+                    )
+                })
+            })
+            .collect();
+        let subcell_running_ns =
+            read_subcell_running_ns(&self.skel, active_subcells.keys().copied())
+                .context("reading subcell running_ns")?;
+
+        for (cpu, cpu_ctx) in cpu_ctxs.iter().enumerate() {
+            let owner_cell = cpu_ctx.cell as usize;
+            let owner_subcell = cpu_ctx.subcell as usize;
+            if owner_cell >= MAX_CELLS || owner_subcell >= MAX_SUBCELLS_PER_CELL {
+                bail!(
+                    "CPU has invalid subcell assignment {}:{} (max {}:{})",
+                    owner_cell,
+                    owner_subcell,
+                    MAX_CELLS,
+                    MAX_SUBCELLS_PER_CELL
+                );
+            }
+
+            let mut total_on_cpu = 0u64;
+            for (&(cell, subcell), per_cpu_running_ns) in &subcell_running_ns {
+                let ns = per_cpu_running_ns[cpu];
+                total_running_ns[cell][subcell] =
+                    total_running_ns[cell][subcell].saturating_add(ns);
+                total_on_cpu = total_on_cpu.saturating_add(ns);
+                if owner_cell == cell && owner_subcell == subcell {
+                    on_own_ns[cell][subcell] = on_own_ns[cell][subcell].saturating_add(ns);
+                }
+            }
+
+            let owner_on_cpu = subcell_running_ns
+                .get(&(owner_cell, owner_subcell))
+                .map_or(0, |per_cpu_running_ns| per_cpu_running_ns[cpu]);
+            lent_ns[owner_cell][owner_subcell] = lent_ns[owner_cell][owner_subcell]
+                .saturating_add(total_on_cpu.saturating_sub(owner_on_cpu));
+        }
+
+        let interval_ns = self.monitor_interval.as_nanos() as u64;
+
+        for cell in 0..MAX_CELLS {
+            for subcell in 0..MAX_SUBCELLS_PER_CELL {
+                let delta_running = total_running_ns[cell][subcell]
+                    .saturating_sub(self.prev_subcell_running_ns[cell][subcell]);
+                let delta_on_own = on_own_ns[cell][subcell]
+                    .saturating_sub(self.prev_subcell_own_ns[cell][subcell]);
+                let delta_lent =
+                    lent_ns[cell][subcell].saturating_sub(self.prev_subcell_lent_ns[cell][subcell]);
+
+                self.prev_subcell_running_ns[cell][subcell] = total_running_ns[cell][subcell];
+                self.prev_subcell_own_ns[cell][subcell] = on_own_ns[cell][subcell];
+                self.prev_subcell_lent_ns[cell][subcell] = lent_ns[cell][subcell];
+
+                if delta_running == 0 && delta_lent == 0 {
+                    continue;
+                }
+
+                let Some(&nr_cpus) = active_subcells.get(&(cell, subcell)) else {
+                    continue;
+                };
+                if nr_cpus == 0 {
+                    bail!("Cell {} subcell {} has 0 CPUs assigned", cell, subcell);
+                }
+
+                let capacity = (nr_cpus as u64) * interval_ns;
+                let delta_borrowed = delta_running.saturating_sub(delta_on_own);
+                let util_pct = 100.0 * (delta_running as f64) / (capacity as f64);
+                let demand_borrow_pct = if delta_running > 0 {
+                    100.0 * (delta_borrowed as f64) / (delta_running as f64)
+                } else {
+                    0.0
+                };
+                let lent_pct = 100.0 * (delta_lent as f64) / (capacity as f64);
+
+                if self.enable_rebalancing {
+                    self.smoothed_subcell_util[cell][subcell] = self.demand_smoothing * util_pct
+                        + (1.0 - self.demand_smoothing) * self.smoothed_subcell_util[cell][subcell];
+                }
+
+                let subcell_metrics = self
+                    .metrics
+                    .cells
+                    .entry(cell as u32)
+                    .or_default()
+                    .subcells
+                    .entry(subcell as u32)
+                    .or_default();
+                subcell_metrics.update_demand(
+                    util_pct,
+                    demand_borrow_pct,
+                    lent_pct,
+                    delta_running,
+                    delta_borrowed,
+                    delta_lent,
+                );
+                subcell_metrics.num_cpus = nr_cpus as u32;
+                if self.enable_rebalancing {
+                    subcell_metrics.smoothed_util_pct = self.smoothed_subcell_util[cell][subcell];
+                }
+            }
+        }
 
         Ok(())
     }
@@ -1936,6 +2104,66 @@ fn read_cpu_ctxs(skel: &BpfSkel) -> Result<Vec<bpf_intf::cpu_ctx>> {
         });
     }
     Ok(cpu_ctxs)
+}
+
+fn read_subcell_running_ns<I>(
+    skel: &BpfSkel,
+    active_subcells: I,
+) -> Result<HashMap<(usize, usize), Vec<u64>>>
+where
+    I: IntoIterator<Item = (usize, usize)>,
+{
+    let mut running_ns_by_subcell = HashMap::new();
+
+    for (cell, subcell) in active_subcells {
+        if cell >= MAX_CELLS || subcell >= MAX_SUBCELLS_PER_CELL {
+            bail!(
+                "Invalid subcell running_ns key {}:{} (max {}:{})",
+                cell,
+                subcell,
+                MAX_CELLS,
+                MAX_SUBCELLS_PER_CELL
+            );
+        }
+
+        let packed = ((cell * MAX_SUBCELLS_PER_CELL) + subcell) as u32;
+        let per_cpu_values = skel
+            .maps
+            .subcell_running_ns
+            .lookup_percpu(&packed.to_ne_bytes(), libbpf_rs::MapFlags::ANY)
+            .with_context(|| format!("Failed to lookup subcell_running_ns key {}", packed))?
+            .with_context(|| format!("subcell_running_ns key {} is missing", packed))?;
+
+        if per_cpu_values.len() < *NR_CPUS_POSSIBLE {
+            bail!(
+                "subcell_running_ns returned {} entries but expected {}",
+                per_cpu_values.len(),
+                *NR_CPUS_POSSIBLE
+            );
+        }
+
+        let mut values = Vec::with_capacity(*NR_CPUS_POSSIBLE);
+        for cpu in 0..*NR_CPUS_POSSIBLE {
+            let value = per_cpu_values[cpu].as_slice();
+            if value.len() < std::mem::size_of::<u64>() {
+                bail!(
+                    "subcell_running_ns key {} cpu {} value is too small: {}",
+                    packed,
+                    cpu,
+                    value.len()
+                );
+            }
+            values.push(u64::from_ne_bytes(
+                value[..std::mem::size_of::<u64>()]
+                    .try_into()
+                    .expect("BUG: u64 slice has wrong length"),
+            ));
+        }
+
+        running_ns_by_subcell.insert((cell, subcell), values);
+    }
+
+    Ok(running_ns_by_subcell)
 }
 
 #[clap_main::clap_main]

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -58,6 +58,7 @@ use stats::Metrics;
 
 const SCHEDULER_NAME: &str = "scx_mitosis";
 const MAX_CELLS: usize = bpf_intf::consts_MAX_CELLS as usize;
+const MAX_SUBCELLS_PER_CELL: usize = bpf_intf::consts_MAX_SUBCELLS_PER_CELL as usize;
 const NR_CSTATS: usize = bpf_intf::cell_stat_idx_NR_CSTATS as usize;
 /// Epoll token for inotify events (cgroup creation/destruction)
 const INOTIFY_TOKEN: u64 = 1;
@@ -684,7 +685,7 @@ impl<'a> Scheduler<'a> {
         &mut self,
         new_cell_ids: &[u32],
     ) -> Result<Vec<CpuAssignment>> {
-        let (cell_assignments, cpu_assignments, _subcell_assignments) = {
+        let (cell_assignments, cpu_assignments, subcell_assignments) = {
             let cell_manager = self
                 .cell_manager
                 .as_ref()
@@ -743,6 +744,8 @@ impl<'a> Scheduler<'a> {
                     .context("computing equal-weight CPU assignments (rebalancing disabled)")?
             };
 
+            // TODO(kkd): Plug in demand weighted subcell assignments once
+            // supported.
             let subcell_assignments = self.compute_subcell_assignments(&cpu_assignments)?;
 
             (
@@ -752,7 +755,7 @@ impl<'a> Scheduler<'a> {
             )
         };
 
-        self.apply_cell_config(&cell_assignments, &cpu_assignments)
+        self.apply_cell_config(&cell_assignments, &cpu_assignments, &subcell_assignments)
             .context("applying cell configuration to BPF")?;
 
         Ok(cpu_assignments)
@@ -795,7 +798,7 @@ impl<'a> Scheduler<'a> {
             .collect();
 
         // Compute new assignments and check if they differ from current
-        let (cell_assignments, cpu_assignments, _subcell_assignments) = {
+        let (cell_assignments, cpu_assignments, subcell_assignments) = {
             let cell_manager = self
                 .cell_manager
                 .as_ref()
@@ -810,6 +813,9 @@ impl<'a> Scheduler<'a> {
                     .map_or(true, |cell| cell.cpus != a.primary)
             });
 
+            // TODO(kkd): Need logic to check changed demand assignments for
+            // subcells as well once demand weighted allocations work.
+
             if !changed {
                 return Ok(());
             }
@@ -823,7 +829,7 @@ impl<'a> Scheduler<'a> {
             )
         };
 
-        self.apply_cell_config(&cell_assignments, &cpu_assignments)
+        self.apply_cell_config(&cell_assignments, &cpu_assignments, &subcell_assignments)
             .context("applying rebalanced cell configuration to BPF")?;
 
         self.last_rebalance = Instant::now();
@@ -881,30 +887,38 @@ impl<'a> Scheduler<'a> {
             .collect()
     }
 
-    fn refresh_bpf_subcells(
-        &mut self,
-        cell_to_cpus: &HashMap<u32, Cpumask>,
-        active_cells: &HashSet<u32>,
-    ) -> Result<()> {
+    fn refresh_bpf_subcells(&mut self, active_cells: &HashSet<u32>) -> Result<()> {
         if self.cell_manager.is_none() {
             return Ok(());
         }
 
-        // Until subcell state is read back from BPF, mirror each cell's observed
-        // primary mask into all of its subcells and keep borrowable empty.
         for cell_id in active_cells {
-            let primary = cell_to_cpus
-                .get(cell_id)
-                .cloned()
-                .unwrap_or_else(Cpumask::new);
+            let bpf_cell = read_bpf_cell(&self.skel, *cell_id)?;
+            let subcells: Vec<Subcell> = bpf_cell
+                .subcells
+                .iter()
+                .filter(|subcell| subcell.in_use != 0)
+                .map(|subcell| {
+                    Ok(Subcell {
+                        id: subcell.id,
+                        primary: read_cpumask_from_bytes(&subcell.primary.mask)?,
+                        borrowable: if self.enable_borrowing {
+                            Some(read_cpumask_from_bytes(&subcell.borrowable.mask)?)
+                        } else {
+                            None
+                        },
+                    })
+                })
+                .collect::<Result<_>>()?;
+
+            if subcells.is_empty() {
+                bail!("Cell {} has no active subcells in BPF state", cell_id);
+            }
+
             let cell = self.cells.get_mut(cell_id).ok_or_else(|| {
                 anyhow::anyhow!("Cell {} missing during subcell refresh", cell_id)
             })?;
-
-            for subcell in &mut cell.subcells {
-                subcell.primary = primary.clone();
-                subcell.borrowable = Some(Cpumask::new());
-            }
+            cell.subcells = subcells;
         }
 
         Ok(())
@@ -918,6 +932,7 @@ impl<'a> Scheduler<'a> {
         &mut self,
         cell_assignments: &[(u64, u32)],
         cpu_assignments: &[CpuAssignment],
+        subcell_assignments: &[Vec<CpuAssignment>],
     ) -> Result<()> {
         let bss_data = self
             .skel
@@ -943,6 +958,14 @@ impl<'a> Scheduler<'a> {
             );
         }
 
+        if subcell_assignments.len() != cpu_assignments.len() {
+            bail!(
+                "Mismatched subcell assignments: {} cell assignments vs {} subcell groups",
+                cpu_assignments.len(),
+                subcell_assignments.len()
+            );
+        }
+
         if cell_assignments.len() > bpf_intf::consts_MAX_CELLS as usize {
             bail!(
                 "Too many cell assignments: {} > MAX_CELLS ({})",
@@ -959,7 +982,7 @@ impl<'a> Scheduler<'a> {
 
         // Set cell cpumasks and borrowable cpumasks
         let mut max_cell_id: u32 = 0;
-        for a in cpu_assignments {
+        for (a, cell_subcells) in cpu_assignments.iter().zip(subcell_assignments.iter()) {
             if a.id >= bpf_intf::consts_MAX_CELLS {
                 bail!(
                     "Cell ID {} exceeds MAX_CELLS ({})",
@@ -977,11 +1000,48 @@ impl<'a> Scheduler<'a> {
                     &mut config.borrowable_cpumasks[a.id as usize].mask,
                 );
             }
+
+            if cell_subcells.len() > MAX_SUBCELLS_PER_CELL {
+                bail!(
+                    "Cell {} has too many subcells: {} > MAX_SUBCELLS_PER_CELL ({})",
+                    a.id,
+                    cell_subcells.len(),
+                    MAX_SUBCELLS_PER_CELL
+                );
+            }
+
+            let mut used_subcell_slots = [false; MAX_SUBCELLS_PER_CELL];
+            for subcell in cell_subcells {
+                if subcell.id >= bpf_intf::consts_MAX_SUBCELLS_PER_CELL {
+                    bail!(
+                        "Subcell ID {} for cell {} exceeds MAX_SUBCELLS_PER_CELL ({})",
+                        subcell.id,
+                        a.id,
+                        bpf_intf::consts_MAX_SUBCELLS_PER_CELL
+                    );
+                }
+
+                let slot = subcell.id as usize;
+                if used_subcell_slots[slot] {
+                    bail!("Duplicate subcell ID {} for cell {}", subcell.id, a.id);
+                }
+                used_subcell_slots[slot] = true;
+
+                config.subcells[a.id as usize][slot].id = subcell.id;
+                config.subcells[a.id as usize][slot].in_use = 1;
+                write_cpumask_to_config(
+                    &subcell.primary,
+                    &mut config.subcells[a.id as usize][slot].primary.mask,
+                );
+                if let Some(ref borrowable) = subcell.borrowable {
+                    write_cpumask_to_config(
+                        borrowable,
+                        &mut config.subcells[a.id as usize][slot].borrowable.mask,
+                    );
+                }
+            }
         }
         config.num_cells = max_cell_id;
-
-        // When subcell configuration is applied to BPF, extend this function to
-        // write and apply the computed subcell state here as well.
 
         // Trigger the BPF program to apply the configuration
         let prog = &mut self.skel.progs.apply_cell_config;
@@ -1537,7 +1597,7 @@ impl<'a> Scheduler<'a> {
         self.cells.retain(|&k, _| active_cells.contains(&k));
         self.metrics.cells.retain(|&k, _| active_cells.contains(&k));
 
-        self.refresh_bpf_subcells(&cell_to_cpus, &active_cells)?;
+        self.refresh_bpf_subcells(&active_cells)?;
 
         self.last_configuration_seq = Some(applied_configuration);
 
@@ -1557,6 +1617,41 @@ fn write_cpumask_to_config(cpumask: &Cpumask, dest: &mut [u8]) {
             }
         }
     }
+}
+
+fn read_cpumask_from_bytes(src: &[u8]) -> Result<Cpumask> {
+    let mut cpumask = Cpumask::new();
+
+    for (byte_idx, byte) in src.iter().copied().enumerate() {
+        let mut bits = byte;
+        while bits != 0 {
+            let bit = bits.trailing_zeros() as usize;
+            bits &= !(1u8 << bit);
+            cpumask.set_cpu((byte_idx * 8) + bit)?;
+        }
+    }
+
+    Ok(cpumask)
+}
+
+fn read_bpf_cell(skel: &BpfSkel, cell_id: u32) -> Result<bpf_intf::cell> {
+    let raw = skel
+        .maps
+        .cells
+        .lookup(&cell_id.to_ne_bytes(), libbpf_rs::MapFlags::ANY)
+        .with_context(|| format!("Failed to lookup cell {}", cell_id))?
+        .ok_or_else(|| anyhow::anyhow!("Cell {} missing from BPF map", cell_id))?;
+
+    if raw.len() != std::mem::size_of::<bpf_intf::cell>() {
+        bail!(
+            "Unexpected cell {} value size: {} != {}",
+            cell_id,
+            raw.len(),
+            std::mem::size_of::<bpf_intf::cell>()
+        );
+    }
+
+    Ok(unsafe { std::ptr::read_unaligned(raw.as_ptr() as *const bpf_intf::cell) })
 }
 
 fn read_cpu_ctxs(skel: &BpfSkel) -> Result<Vec<bpf_intf::cpu_ctx>> {

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -1626,7 +1626,13 @@ impl<'a> Scheduler<'a> {
 
             let nr_cpus = cell_info.cpus.weight() as u64;
             if nr_cpus == 0 {
-                bail!("Cell {} has 0 CPUs assigned", cell);
+                self.smoothed_util[cell] = 0.0;
+                self.metrics
+                    .cells
+                    .entry(cell as u32)
+                    .or_default()
+                    .smoothed_util_pct = 0.0;
+                continue;
             }
 
             // capacity = total available CPU-time this interval
@@ -1766,7 +1772,16 @@ impl<'a> Scheduler<'a> {
                     continue;
                 };
                 if nr_cpus == 0 {
-                    bail!("Cell {} subcell {} has 0 CPUs assigned", cell, subcell);
+                    self.smoothed_subcell_util[cell][subcell] = 0.0;
+                    self.metrics
+                        .cells
+                        .entry(cell as u32)
+                        .or_default()
+                        .subcells
+                        .entry(subcell as u32)
+                        .or_default()
+                        .smoothed_util_pct = 0.0;
+                    continue;
                 }
 
                 let capacity = (nr_cpus as u64) * interval_ns;

--- a/scheds/rust/scx_mitosis/src/stats.rs
+++ b/scheds/rust/scx_mitosis/src/stats.rs
@@ -17,6 +17,48 @@ use crate::DistributionStats;
 
 #[stat_doc]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
+#[stat(_om_prefix = "s_")]
+#[stat(top)]
+pub struct SubcellMetrics {
+    #[stat(desc = "Number of cpus")]
+    pub num_cpus: u32,
+    #[stat(desc = "CPU utilization %")]
+    pub util_pct: f64,
+    #[stat(desc = "Borrowed CPU time % of running")]
+    pub demand_borrow_pct: f64,
+    #[stat(desc = "Lent CPU time %")]
+    pub lent_pct: f64,
+    #[stat(desc = "EWMA-smoothed utilization %")]
+    pub smoothed_util_pct: f64,
+    #[stat(desc = "Running time in this interval")]
+    pub running_ns: u64,
+    #[stat(desc = "Borrowed running time in this interval")]
+    pub borrowed_ns: u64,
+    #[stat(desc = "Lent running time in this interval")]
+    pub lent_ns: u64,
+}
+
+impl SubcellMetrics {
+    pub fn update_demand(
+        &mut self,
+        util_pct: f64,
+        demand_borrow_pct: f64,
+        lent_pct: f64,
+        running_ns: u64,
+        borrowed_ns: u64,
+        lent_ns: u64,
+    ) {
+        self.util_pct = util_pct;
+        self.demand_borrow_pct = demand_borrow_pct;
+        self.lent_pct = lent_pct;
+        self.running_ns = running_ns;
+        self.borrowed_ns = borrowed_ns;
+        self.lent_ns = lent_ns;
+    }
+}
+
+#[stat_doc]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(_om_prefix = "c_")]
 #[stat(top)]
 pub struct CellMetrics {
@@ -56,6 +98,8 @@ pub struct CellMetrics {
     pub lent_pct: f64,
     #[stat(desc = "EWMA-smoothed utilization %")]
     pub smoothed_util_pct: f64,
+    #[stat(desc = "Per-subcell metrics")]
+    pub subcells: BTreeMap<u32, SubcellMetrics>,
 }
 
 impl CellMetrics {
@@ -170,6 +214,7 @@ pub fn server_data() -> StatsServerData<(), Metrics> {
     StatsServerData::new()
         .add_meta(Metrics::meta())
         .add_meta(CellMetrics::meta())
+        .add_meta(SubcellMetrics::meta())
         .add_ops("top", StatsOps { open, close: None })
 }
 

--- a/scheds/rust/scx_mitosis/src/stats.rs
+++ b/scheds/rust/scx_mitosis/src/stats.rs
@@ -20,6 +20,8 @@ use crate::DistributionStats;
 #[stat(_om_prefix = "s_")]
 #[stat(top)]
 pub struct SubcellMetrics {
+    #[stat(desc = "Subcell name")]
+    pub name: String,
     #[stat(desc = "Number of cpus")]
     pub num_cpus: u32,
     #[stat(desc = "CPU utilization %")]
@@ -39,6 +41,11 @@ pub struct SubcellMetrics {
 }
 
 impl SubcellMetrics {
+    pub fn update_name_and_cpus(&mut self, name: &str, num_cpus: u32) {
+        self.name = name.to_string();
+        self.num_cpus = num_cpus;
+    }
+
     pub fn update_demand(
         &mut self,
         util_pct: f64,


### PR DESCRIPTION
Stacked on top of #3513.

Adds the meat of the logic to support demand-weighted subcells, parsing of configs generated from profiling workloads. Topological awareness is still missing, but the rest is there.