### PR TITLE
scx_lavd: Gate dsq_peek_task_load behind no-fast-lb

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -383,7 +383,9 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 
 			/*
 			 * Peek at the head task to get its size for budget
-			 * accounting.
+			 * accounting. Skip the peek when no_fast_lb is set
+			 * since the budget path below is bypassed and the
+			 * value would be unused.
 			 *
 			 * TOCTOU: the task peeked here may not be the one
 			 * actually consumed by consume_dsq() below. To be more
@@ -394,7 +396,7 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 			 * because the next LB round recomputes budgets from
 			 * scratch.
 			 */
-			u64 task_load = dsq_peek_task_load(dsq_id);
+			u64 task_load = no_fast_lb ? 0 : dsq_peek_task_load(dsq_id);
 
 			/*
 			 * On success, decrement both egress and ingress
@@ -468,9 +470,12 @@ static bool force_to_steal_task(struct cpdom_ctx *cpdomc)
 			dsq_id = pick_most_loaded_dsq(cpdomc_pick);
 
 			/*
-			 * Peek at the head task to get its size.
+			 * Peek at the head task to get its size. Skip the
+			 * peek when no_fast_lb is set since the budget
+			 * accounting below is bypassed and the value would
+			 * be unused.
 			 */
-			u64 task_load = dsq_peek_task_load(dsq_id);
+			u64 task_load = no_fast_lb ? 0 : dsq_peek_task_load(dsq_id);
 
 			/*
 			 * Force steal is unconditional for work
@@ -478,8 +483,10 @@ static bool force_to_steal_task(struct cpdom_ctx *cpdomc)
 			 * the accounting consistent.
 			 */
 			if (consume_dsq(cpdomc_pick, dsq_id)) {
-				decrement_stealee_budget(cpdomc_pick, task_load);
-				decrement_stealer_budget(cpdomc, task_load);
+				if (!no_fast_lb) {
+					decrement_stealee_budget(cpdomc_pick, task_load);
+					decrement_stealer_budget(cpdomc, task_load);
+				}
 				return true;
 			}
 		}


### PR DESCRIPTION
Some production kernels are missing fixes[1][2] for peek operation where the task_struct pointers are stale and we can run into UAF kernel crashes when the check for the race window is large enough:

  bpf_task_storage_get+0x36/0x110
  bpf_prog_81e5a6181f79e459_scx_task_data+0x41/0x58
  bpf_prog_9bcd89b94a3f9fb2___get_task_ctx_slowpath+0x26/0x79
  bpf_prog_72d45f938176613a_dsq_peek_task_load+0x72/0x8b
  bpf_prog_0514a0e1f88fcbdc_consume_task+0x730/0x852
  bpf_prog_7509fba73b418dbd_lavd_dispatch+0x208/0x679
  bpf__sched_ext_ops_dispatch+0x47/0xa3
  balance_scx.llvm.5618296179579790706+0x1d2/0xf30
  __schedule+0x2c9/0xb70
  schedule+0x38/0x90
  schedule_hrtimeout_range+0x75/0xf0
  __x64_sys_epoll_wait+0x753/0x920
  do_syscall_64+0x6a/0x250
  entry_SYSCALL_64_after_hwframe+0x4b/0x53

In theory, the same race can occur for the common pattern of getting the vtime as well after checking for the p pointer, but the timing window is far short to observe in production.

While patching the kernels are in progress, gate the dsq_peek_task_load behind no-fast-lb to make forward progress and retest once kernel side fixes are widely available.

[1] https://lore.kernel.org/all/20251024220102.1556384-1-arighi@nvidia.com/
[2] https://lore.kernel.org/all/20260424204418.3809733-8-tj@kernel.org/