### PR TITLE
fix: in lib/scxtest/scx_test_map in scx_test_map.c

### DIFF
--- a/lib/scxtest/scx_test_map.c
+++ b/lib/scxtest/scx_test_map.c
@@ -95,8 +95,8 @@ void *scx_test_map_lookup_percpu_elem(void *map, const void *key, int cpu)
 	}
 
 	for (int i = 0; i < test_map->nr; i++) {
-		if (memcmp(&test_map->keys[i], key, test_map->key_size) == 0) {
-			return &test_map->values[i];
+		if (memcmp((char *)test_map->keys + i * test_map->key_size, key, test_map->key_size) == 0) {
+			return (char *)test_map->values + i * test_map->value_size;
 		}
 	}
 
@@ -111,8 +111,8 @@ void *scx_test_map_lookup_elem(void *map, const void *key)
 	}
 
 	for (int i = 0; i < test_map->nr; i++) {
-		if (memcmp(&test_map->keys[i], key, test_map->key_size) == 0) {
-			return &test_map->values[i];
+		if (memcmp((char *)test_map->keys + i * test_map->key_size, key, test_map->key_size) == 0) {
+			return (char *)test_map->values + i * test_map->value_size;
 		}
 	}
 
@@ -125,11 +125,11 @@ static int map_update_elem(struct scx_test_map *test_map, const void *key,
 	int index;
 
 	for (int i = 0; i < test_map->nr; i++) {
-		if (memcmp(&test_map->keys[i], key, test_map->key_size) == 0) {
+		if (memcmp((char *)test_map->keys + i * test_map->key_size, key, test_map->key_size) == 0) {
 			if (flags & BPF_NOEXIST) {
 				return -1;
 			}
-			memcpy(&test_map->values[i], value, test_map->value_size);
+			memcpy((char *)test_map->values + i * test_map->value_size, value, test_map->value_size);
 			return 0;
 		}
 	}
@@ -158,8 +158,8 @@ static int map_update_elem(struct scx_test_map *test_map, const void *key,
 		perror("Failed to allocate memory for values");
 		exit(EXIT_FAILURE);
 	}
-	memcpy(&test_map->keys[index], key, test_map->key_size);
-	memcpy(&test_map->values[index], value, test_map->value_size);
+	memcpy((char *)test_map->keys + index * test_map->key_size, key, test_map->key_size);
+	memcpy((char *)test_map->values + index * test_map->value_size, value, test_map->value_size);
 	return 0;
 }
 


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `lib/scxtest/scx_test_map.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `lib/scxtest/scx_test_map.c:132` |
| **CWE** | CWE-120 |

**Description**: In lib/scxtest/scx_test_map.c at lines 132, 161, and 162, memcpy is called using test_map->value_size and test_map->key_size as the copy length without verifying that these sizes do not exceed the allocated buffer sizes for test_map->values[i] and test_map->keys[index]. An attacker or malicious caller who can influence value_size or key_size fields can trigger a heap buffer overflow, overwriting adjacent heap memory and enabling heap exploitation techniques (e.g., tcache poisoning) to achieve arbitrary write primitives in the kernel or privileged scheduler context.

## Changes
- `lib/scxtest/scx_test_map.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
