### PR TITLE
scx_lavd: Wrap peek use cases for safe pointer access with RCU lock

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -268,14 +268,18 @@ static bool consume_dsq(struct cpdom_ctx *cpdomc, u64 dsq_id)
 
 u64 __attribute__((noinline)) dsq_peek_task_load(u64 dsq_id)
 {
-	struct task_struct *peek_p = __COMPAT_scx_bpf_dsq_peek(dsq_id);
+	struct task_struct *peek_p;
+	u64 load = 0;
 
+	bpf_rcu_read_lock();
+	peek_p = __COMPAT_scx_bpf_dsq_peek(dsq_id);
 	if (peek_p) {
 		task_ctx *peek_taskc = get_task_ctx(peek_p);
 		if (peek_taskc)
-			return task_load_metric(peek_taskc);
+			load = task_load_metric(peek_taskc);
 	}
-	return 0;
+	bpf_rcu_read_unlock();
+	return load;
 }
 
 u64 __attribute__((noinline)) pick_most_loaded_dsq(struct cpdom_ctx *cpdomc)

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -403,9 +403,13 @@ __hidden
 u64 peek_dsq_vtime(u64 dsq_id)
 {
 	struct task_struct *p;
+	u64 vtime;
 
+	bpf_rcu_read_lock();
 	p = __COMPAT_scx_bpf_dsq_peek(dsq_id);
-	return p ? p->scx.dsq_vtime : U64_MAX;
+	vtime = p ? p->scx.dsq_vtime : U64_MAX;
+	bpf_rcu_read_unlock();
+	return vtime;
 }
 
 __hidden


### PR DESCRIPTION
As the commit dsq_peek_task_load gating (ac863374ce4f) noted, the
task_struct can be stale. On the other hand, accessing the task_struct
pointer from __COMPAT_scx_bpf_dsq_peek is not safe and the pointer can
be freed nondeterministically. The race window exists for both
peek_dsq_vtime and dsq_peek_task_load. This patch fixes both.

