### PR TITLE
common.bpf.h: probe BPF prolog migrate_disable() from non-sleepable context

### DIFF
--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -1114,10 +1114,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(flow_init)
 	s32 cpu;
 	s32 ret;
 
-	ret = scx_lib_init();
-	if (ret)
-		return ret;
-
 	nr_cpu_ids = scx_bpf_nr_cpu_ids();
 
 	bpf_for(cpu, 0, nr_cpu_ids) {

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -547,16 +547,6 @@ int scx_lib_init_probe(void *ctx)
 }
 
 /*
- * scx_lib_init - deprecated no-op stub; the probe now runs from
- * scx_lib_init_probe. Kept for source compatibility; remove once all
- * in-tree schedulers have migrated.
- */
-static inline int scx_lib_init(void)
-{
-	return 0;
-}
-
-/*
  * Return true if task @p cannot migrate to a different CPU, false
  * otherwise.
  *
@@ -590,7 +580,7 @@ static inline bool is_migration_disabled(const struct task_struct *p)
 	 * A slow path handles pre-v6.18 kernels without CONFIG_PREEMPT_RCU,
 	 * where the prolog historically called migrate_disable() unconditionally
 	 * but a cherry-picked downstream kernel may not. The runtime-probed flag
-	 * __scx_prolog_disables_migration (set by scx_lib_init()) distinguishes
+	 * __scx_prolog_disables_migration (set by scx_lib_init_probe) distinguishes
 	 * the two cases without relying on the kernel version alone.
 	 */
 	if (bpf_core_field_exists(p->migration_disabled)) {

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -500,40 +500,72 @@ static __always_inline const struct cpumask *cast_mask(struct bpf_cpumask *mask)
 }
 
 /*
- * True if the BPF prolog (__bpf_prog_enter) calls migrate_disable() for the
- * current task. Probed at runtime by scx_lib_init(). Defaults to true because
- * the prolog called migrate_disable() unconditionally on kernels before v6.18,
- * so schedulers that omit scx_lib_init() safely fall back to the original
- * p == current disambiguation.
+ * True if the non-sleepable BPF trampoline prolog (__bpf_prog_enter) calls
+ * migrate_disable() for the current task. Recorded once by
+ * scx_lib_init_probe, an fentry program on bpf_scx_reg() that fires during
+ * the natural scheduler-attach call chain (auto-attached by scx_ops_attach!).
+ *
+ * Defaults to true (conservative). Over-reporting in is_migration_disabled()
+ * causes local-only dispatch, which is safe. Under-reporting can crash the
+ * scheduler, so we err high if the probe somehow fails to run.
  */
-static bool __scx_prolog_disables_migration = true;
+bool __scx_prolog_disables_migration __weak = true;
 
 /*
- * scx_lib_init - initialize the scx BPF library
+ * scx_lib_init_probe - non-sleepable prolog probe.
  *
- * Must be called at the top of ops.init(). Probes runtime behavior needed by
- * library functions such as is_migration_disabled().
+ * Attached to bpf_scx_reg(), the .reg callback in bpf_sched_ext_ops
+ * (kernel/sched/ext.c). The kernel's struct_ops machinery invokes
+ * bpf_scx_reg when userspace creates the scheduler link, before
+ * ops.init() fires. Its address is taken in the vtable, so the symbol
+ * is non-inlinable and has been stable since introduction.
  *
- * Returns 0 on success.
+ * Entering via fentry runs us through __bpf_prog_enter -- the
+ * non-sleepable prolog that consumers of is_migration_disabled() live
+ * under.
+ *
+ * Loud warning: the prolog adds at most 1 to migration_disabled.
+ * Reading > 1 means something upstream in the
+ * bpf_struct_ops_link_create -> bpf_scx_reg path disabled migration
+ * before the prolog ran, invalidating the probe; audit and adjust.
+ */
+SEC("fentry/bpf_scx_reg") __weak
+int scx_lib_init_probe(void *ctx)
+{
+	if (bpf_core_field_exists(((struct task_struct *)0)->migration_disabled)) {
+		const struct task_struct *p = bpf_get_current_task_btf();
+		unsigned int md = p->migration_disabled;
+
+		if (md > 1)
+			bpf_printk("scx_lib_init_probe: unexpected migration_disabled=%u "
+				   "upstream of BPF prolog; probe result unreliable",
+				   md);
+
+		__scx_prolog_disables_migration = md > 0;
+	}
+	return 0;
+}
+
+/*
+ * scx_lib_init - deprecated no-op stub; the probe now runs from
+ * scx_lib_init_probe. Kept for source compatibility; remove once all
+ * in-tree schedulers have migrated.
  */
 static inline int scx_lib_init(void)
 {
-	/*
-	 * Probe whether the BPF prolog calls migrate_disable() by checking
-	 * migration_disabled of the current task. Since we are executing BPF
-	 * code right now, the prolog has already run: if it called
-	 * migrate_disable(), migration_disabled is non-zero.
-	 */
-	if (bpf_core_field_exists(((struct task_struct *)0)->migration_disabled)) {
-		const struct task_struct *p = bpf_get_current_task_btf();
-		__scx_prolog_disables_migration = p->migration_disabled > 0;
-	}
 	return 0;
 }
 
 /*
  * Return true if task @p cannot migrate to a different CPU, false
  * otherwise.
+ *
+ * IMPORTANT: designed for NON-SLEEPABLE BPF contexts only. Sleepable
+ * contexts (BPF_STRUCT_OPS_SLEEPABLE, SEC("syscall"),
+ * SEC("fentry.s/...")) enter via __bpf_prog_enter_sleepable() or
+ * __bpf_prog_enter_sleepable_recur(), both of which unconditionally
+ * call migrate_disable(); this helper can yield a false negative for
+ * p == current there, which can crash the scheduler.
  */
 static inline bool is_migration_disabled(const struct task_struct *p)
 {

--- a/scheds/rust/scx_beerland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_beerland/src/bpf/main.bpf.c
@@ -911,11 +911,6 @@ void BPF_STRUCT_OPS(beerland_exit, struct scx_exit_info *ei)
 s32 BPF_STRUCT_OPS_SLEEPABLE(beerland_init)
 {
 	s32 cpu;
-	int err;
-
-	err = scx_lib_init();
-	if (err)
-		return err;
 
 	nr_cpu_ids = scx_bpf_nr_cpu_ids();
 

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -1389,10 +1389,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(bpfland_init)
 	int err, i;
 	u32 key = 0;
 
-	err = scx_lib_init();
-	if (err)
-		return err;
-
 	/* Initialize amount of online and possible CPUs */
 	nr_online_cpus = get_nr_online_cpus();
 	nr_cpu_ids = scx_bpf_nr_cpu_ids();

--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -1475,10 +1475,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(cosmos_init)
 	int cpu;
 	struct cpu_ctx *cctx;
 
-	err = scx_lib_init();
-	if (err)
-		return err;
-
 	nr_cpu_ids = scx_bpf_nr_cpu_ids();
 
 	/*

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -1226,10 +1226,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(flash_init)
 	int err, node;
 	u32 key = 0;
 
-	err = scx_lib_init();
-	if (err)
-		return err;
-
 	/* Initialize amount of online and possible CPUs */
 	nr_online_cpus = get_nr_online_cpus();
 	nr_cpu_ids = scx_bpf_nr_cpu_ids();

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -2419,10 +2419,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init)
 	u64 now = scx_bpf_now();
 	int err;
 
-	err = scx_lib_init();
-	if (err)
-		return err;
-
 	/*
 	 * Create compute domains.
 	 */

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -4580,10 +4580,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(layered_init)
 {
 	int i, nr_online_cpus, ret;
 
-	ret = scx_lib_init();
-	if (ret)
-		return ret;
-
 	struct bpf_cpumask *cpumask __free(bpf_cpumask) = bpf_cpumask_create();
 	if (!cpumask)
 		return -ENOMEM;

--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -3769,12 +3769,6 @@ int BPF_PROG(on_thermal_pressure, u32 cpu, u64 hw_pressure)
 #if P2DQ_CREATE_STRUCT_OPS
 s32 BPF_STRUCT_OPS_SLEEPABLE(p2dq_init)
 {
-	int err;
-
-	err = scx_lib_init();
-	if (err)
-		return err;
-
 	return p2dq_init_impl();
 }
 

--- a/scheds/rust/scx_tickless/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_tickless/src/bpf/main.bpf.c
@@ -691,10 +691,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(tickless_init)
 {
 	int ret;
 
-	ret = scx_lib_init();
-	if (ret)
-		return ret;
-
 	ret = scx_bpf_create_dsq(SHARED_DSQ, -1);
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
This series fixes a probe in common.bpf.h that mischaracterised the
BPF trampoline prolog.  scx_lib_init() probed migration_disabled from
ops.init() -- a sleepable struct_ops context whose prolog always
disables migration -- but consumers of is_migration_disabled() run
under the non-sleepable prolog, which on modern kernels does not.
The wrong probe value caused is_migration_disabled() to false-negative
for p == current, and schedulers with SCX_OPS_ENQ_MIGRATION_DISABLED
(notably scx_lavd) to dispatch migration-disabled tasks cross-CPU via
SCX_DSQ_LOCAL_ON, self-disabling on task_can_run_on_remote_rq().

Probe from a non-sleepable context
----------------------------------

Replace scx_lib_init() with scx_lib_init_probe, an fentry program on
bpf_scx_reg() -- the .reg callback in bpf_sched_ext_ops, whose vtable
address makes it non-inlinable.  The kernel calls bpf_scx_reg during
scheduler registration before ops.init(), entering it through the
non-sleepable prolog.  scx_ops_attach! already auto-attaches via
$skel.attach() before attach_struct_ops(), so no new userspace code
is needed.

- [1/2] c98c5ad22 common.bpf.h: probe BPF prolog migrate_disable() from non-sleepable context

Drop scx_lib_init() and its callers
-----------------------------------

The helper is no longer needed since the probe runs automatically.
Remove it and drop the call from each in-tree scheduler's ops.init().

- [2/2] 4f648f26e scx: drop scx_lib_init() and its callers from BPF

Fixes: a6101f6c277f ("compat.bpf.h: Add scx_lib_init() to reliably probe BPF prolog migrate_disable() behavior")
Signed-off-by: Changwoo Min <changwoo@igalia.com>
