### PR TITLE
scx_lavd: harden placement for migrate-disabled and throttled tasks

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -680,10 +680,20 @@ s32 pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle)
 	 */
 	if (!init_active_ovrflw_masks(ctx))
 		goto err_out;
-	if (is_pinned(ctx->p) || is_migration_disabled(ctx->p)) {
+	/*
+	 * Use effective pinning here so we cover both permanent pinning
+	 * (nr_cpus_allowed == 1) and transient migrate_disable narrowing
+	 * (cpus_ptr weight == 1, cached via ops.set_cpumask).
+	 */
+	if (is_effectively_pinned(ctx->taskc) || is_migration_disabled(ctx->p)) {
 		cpu = ctx->prev_cpu;
 		if (!bpf_cpumask_test_cpu(cpu, cast_mask(ctx->active))) {
-			if (is_pinned(ctx->p))
+			/*
+			 * Extend the overflow set only for permanent pinning;
+			 * migrate_disable is transient, so we don't want to
+			 * pollute the overflow set with short-lived restrictions.
+			 */
+			if (is_permanently_pinned(ctx->p))
 				bpf_cpumask_test_and_set_cpu(cpu, ctx->ovrflw);
 		}
 		*is_idle = scx_bpf_test_and_clear_cpu_idle(cpu);

--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -35,7 +35,7 @@ bool init_idle_i_mask(struct pick_ctx *ctx, const struct cpumask *idle_cpumask)
 	if (!test_task_flag(ctx->taskc, LAVD_FLAG_IS_AFFINITIZED))
 		ctx->i_mask = idle_cpumask;
 	else {
-		struct bpf_cpumask *_i_mask = ctx->cpuc_cur->tmp_i_mask;
+		struct bpf_cpumask *_i_mask = ctx->cpuc_cur->i_mask;
 		if (!_i_mask)
 			return false;
 		bpf_cpumask_and(_i_mask, ctx->p->cpus_ptr, idle_cpumask);
@@ -69,8 +69,8 @@ bool init_ao_masks(struct pick_ctx *ctx)
 		return true;
 	}
 
-	ctx->a_mask = ctx->cpuc_cur->tmp_a_mask;
-	ctx->o_mask = ctx->cpuc_cur->tmp_o_mask;
+	ctx->a_mask = ctx->cpuc_cur->a_mask;
+	ctx->o_mask = ctx->cpuc_cur->o_mask;
 	if (!ctx->a_mask || !ctx->o_mask)
 		return false;
 
@@ -106,8 +106,8 @@ bool is_preemption_vulnerable(struct pick_ctx *ctx)
 static __always_inline
 bool repartition_masks_for_latency(struct pick_ctx *ctx)
 {
-	struct bpf_cpumask *steady_set = ctx->cpuc_cur->tmp_a_mask;
-	struct bpf_cpumask *turb_set = ctx->cpuc_cur->tmp_o_mask;
+	struct bpf_cpumask *steady_set = ctx->cpuc_cur->a_mask;
+	struct bpf_cpumask *turb_set = ctx->cpuc_cur->o_mask;
 	struct bpf_cpumask *steady = steady_cpumask;
 
 	if (!steady_set || !turb_set || !steady)
@@ -116,7 +116,7 @@ bool repartition_masks_for_latency(struct pick_ctx *ctx)
 	/*
 	 * Start from the unfiltered active/overflow masks and apply
 	 * affinity if needed. We can't reuse a_mask/o_mask from
-	 * init_ao_masks() because they share the same tmp buffers
+	 * init_ao_masks() because they share the same scratch buffers
 	 * we're about to overwrite.
 	 *
 	 * steady_set = eligible_cpus ∩ steady
@@ -146,10 +146,15 @@ bool repartition_masks_for_latency(struct pick_ctx *ctx)
 static __always_inline
 bool init_idle_ato_masks(struct pick_ctx *ctx, const struct cpumask *idle_mask)
 {
-	ctx->ia_mask = ctx->cpuc_cur->tmp_t_mask;
-	ctx->io_mask = ctx->cpuc_cur->tmp_t2_mask;
-	ctx->iat_mask = ctx->cpuc_cur->tmp_t3_mask;
-	ctx->temp_mask = ctx->cpuc_cur->tmp_l_mask; /* l_mask is no longer used, recycle it. */
+	/*
+	 * temp_mask is also used by find_cpu_in() earlier in pick_idle_cpu(),
+	 * but find_cpu_in()'s caller goes straight to unlock_out, so the
+	 * scratch is free by the time we reach here.
+	 */
+	ctx->ia_mask = ctx->cpuc_cur->ia_mask;
+	ctx->io_mask = ctx->cpuc_cur->io_mask;
+	ctx->iat_mask = ctx->cpuc_cur->iat_mask;
+	ctx->temp_mask = ctx->cpuc_cur->temp_mask;
 	if (!ctx->ia_mask || !ctx->io_mask || !ctx->iat_mask || !ctx->temp_mask)
 		return false;
 
@@ -189,7 +194,7 @@ s32 find_cpu_in(const struct cpumask *src_mask, struct cpu_ctx *cpuc_cur)
 	/*
 	 * online_src_mask = src_mask ∩ online_mask
 	 */
-	online_src_mask = cpuc_cur->tmp_l_mask;
+	online_src_mask = cpuc_cur->temp_mask;
 	if (!online_src_mask)
 		return -ENOENT;
 

--- a/scheds/rust/scx_lavd/src/bpf/lat_cri.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lat_cri.bpf.c
@@ -92,10 +92,11 @@ static u64 calc_weight_factor(struct task_struct *p, task_ctx *taskc)
 		weight_boost += LAVD_LC_WEIGHT_BOOST_REGULAR;
 
 	/*
-	 * Prioritize a pinned task since it has restrictions in placement
-	 * so it tends to be delayed.
+	 * Prioritize an effectively pinned task (permanent pinning or
+	 * migrate_disable) since its restricted placement tends to delay
+	 * it; boost its latency criticality.
 	 */
-	if (is_pinned(p) || is_migration_disabled(p))
+	if (is_effectively_pinned(taskc) || is_migration_disabled(p))
 		weight_boost += LAVD_LC_WEIGHT_BOOST_MEDIUM;
 
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -142,6 +142,7 @@ enum consts_flags {
 	LAVD_FLAG_WOKEN_BY_SOFTIRQ	= (0x1 << 13), /* woken by a softirq */
 	LAVD_FLAG_MIGRATION_AGGRESSIVE  = (0x1 << 14), /* immediate task migration is necessary. */
 	LAVD_FLAG_DOMAIN_PINNED		= (0x1 << 15), /* task's cpumask is confined to a single compute domain */
+	LAVD_FLAG_IS_EFFECTIVELY_PINNED	= (0x1 << 16), /* effective cpumask weight is 1 (permanent or migrate-disable) */
 };
 
 #define LAVD_MASK_MIGRATION		(LAVD_FLAG_MIGRATION_AGGRESSIVE)

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -517,14 +517,14 @@ struct cpu_ctx {
 	 */
 	u64		prev_pelt_clk;
 
-	/* --- cacheline 4 boundary (256 bytes): cpumask temps --- */
-	struct bpf_cpumask __kptr *tmp_a_mask; /* for active set */
-	struct bpf_cpumask __kptr *tmp_o_mask; /* for overflow set */
-	struct bpf_cpumask __kptr *tmp_l_mask; /* for online cpumask */
-	struct bpf_cpumask __kptr *tmp_i_mask; /* for idle cpumask */
-	struct bpf_cpumask __kptr *tmp_t_mask;
-	struct bpf_cpumask __kptr *tmp_t2_mask;
-	struct bpf_cpumask __kptr *tmp_t3_mask;
+	/* --- cacheline 4 boundary (256 bytes): cpumask scratch --- */
+	struct bpf_cpumask __kptr *a_mask;	/* scratch: task & active */
+	struct bpf_cpumask __kptr *o_mask;	/* scratch: task & overflow */
+	struct bpf_cpumask __kptr *temp_mask;	/* scratch: general-purpose */
+	struct bpf_cpumask __kptr *i_mask;	/* scratch: task & idle */
+	struct bpf_cpumask __kptr *ia_mask;	/* scratch: idle & active */
+	struct bpf_cpumask __kptr *io_mask;	/* scratch: idle & overflow */
+	struct bpf_cpumask __kptr *iat_mask;	/* scratch: idle & active & turbo */
 
 	struct ravg_data avg_irq_steal_ravg;	/* Running average of IRQ steal utilization using ravg */
 	struct ravg_data avg_util_ravg;	/* Running average of CPU utilization using ravg */

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -200,9 +200,9 @@ struct task_ctx {
 	u16	lat_cri_waker;		/* waker's latency criticality */
 	u16	lat_cri_wakee;		/* wakee's latency criticality */
 	u16	perf_cri;		/* performance criticality of a task */
-	u32	cpdom_id;		/* chosen compute domain id at ops.enqueue() */
-	u32	suggested_cpu_id;	/* suggested CPU ID at ops.enqueue() and ops.select_cpu() */
-	s32	pinned_cpu_id;		/* pinned CPU id. -ENOENT if not pinned or not runnable. */
+	volatile u32	cpdom_id;		/* chosen compute domain id at ops.enqueue() */
+	volatile u32	suggested_cpu_id;	/* suggested CPU ID at ops.enqueue() and ops.select_cpu() */
+	volatile s32	pinned_cpu_id;		/* pinned CPU id. -ENOENT if not pinned or not runnable. */
 	u32	__pad0;
 	u64	last_running_clk;	/* last time when scheduled in */
 	u64	run_freq;		/* scheduling frequency in a second */

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -2169,31 +2169,31 @@ static s32 init_per_cpu_ctx(u64 now)
 			goto unlock_out;
 		}
 
-		err = calloc_cpumask(&cpuc->tmp_a_mask);
+		err = calloc_cpumask(&cpuc->a_mask);
 		if (err)
 			goto unlock_out;
 
-		err = calloc_cpumask(&cpuc->tmp_o_mask);
+		err = calloc_cpumask(&cpuc->o_mask);
 		if (err)
 			goto unlock_out;
 
-		err = calloc_cpumask(&cpuc->tmp_l_mask);
+		err = calloc_cpumask(&cpuc->temp_mask);
 		if (err)
 			goto unlock_out;
 
-		err = calloc_cpumask(&cpuc->tmp_i_mask);
+		err = calloc_cpumask(&cpuc->i_mask);
 		if (err)
 			goto unlock_out;
 
-		err = calloc_cpumask(&cpuc->tmp_t_mask);
+		err = calloc_cpumask(&cpuc->ia_mask);
 		if (err)
 			goto unlock_out;
 
-		err = calloc_cpumask(&cpuc->tmp_t2_mask);
+		err = calloc_cpumask(&cpuc->io_mask);
 		if (err)
 			goto unlock_out;
 
-		err = calloc_cpumask(&cpuc->tmp_t3_mask);
+		err = calloc_cpumask(&cpuc->iat_mask);
 		if (err)
 			goto unlock_out;
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -876,9 +876,12 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 	}
 
 	/*
-	 * Increase the number of pinned tasks waiting for execution.
+	 * Track tasks that are effectively pinned (permanent pinning or
+	 * migrate_disable) so nr_pinned_tasks drives slice shrinking for
+	 * both cases. The matching decrement in lavd_quiescent() uses the
+	 * same predicate.
 	 */
-	if (is_pinned(p) && (taskc->pinned_cpu_id == -ENOENT)) {
+	if (is_effectively_pinned(taskc) && (taskc->pinned_cpu_id == -ENOENT)) {
 		taskc->pinned_cpu_id = cpu;
 		__sync_fetch_and_add(&cpuc->nr_pinned_tasks, 1);
 
@@ -955,9 +958,10 @@ int enqueue_cb(struct task_struct __arg_trusted *p, task_ctx *taskc)
 	}
 
 	/*
-	 * Increase the number of pinned tasks waiting for execution.
+	 * Mirror the lavd_enqueue() accounting: count effectively pinned
+	 * tasks (permanent or migrate_disable) for slice shrinking.
 	 */
-	if (is_pinned(p))
+	if (is_effectively_pinned(taskc))
 		__sync_fetch_and_add(&cpuc->nr_pinned_tasks, 1);
 
 	/*
@@ -1131,10 +1135,12 @@ void BPF_STRUCT_OPS(lavd_dispatch, s32 cpu, struct task_struct *prev)
 
 	if (prev) {
 		/*
-		 * If the previous task is pinned to this CPU,
-		 * extend the overflow set and go.
+		 * If the previous task is permanently pinned to this CPU,
+		 * extend the overflow set so future picks keep it serviced.
+		 * Use permanent pinning here: migrate_disable is transient
+		 * and handled in the else-if branch without overflow churn.
 		 */
-		if (is_pinned(prev)) {
+		if (is_permanently_pinned(prev)) {
 			bpf_cpumask_set_cpu(cpu, ovrflw);
 			bpf_rcu_read_unlock();
 			goto consume_out;
@@ -1192,11 +1198,12 @@ void BPF_STRUCT_OPS(lavd_dispatch, s32 cpu, struct task_struct *prev)
 			continue; /* ignore the lookup error */
 
 		/*
-		 * if the task is pinned to this cpu,
-		 * extend the overflow set and go.
-		 * but not on this cpu, try another task.
+		 * If the task is permanently pinned to its CPU, extend the
+		 * overflow set (and kick if it's a remote CPU). Same rationale
+		 * as the prev-task branch above: migrate_disable is transient,
+		 * so its handling is split into the else-if below.
 		 */
-		if (is_pinned(p)) {
+		if (is_permanently_pinned(p)) {
 			new_cpu = scx_bpf_task_cpu(p);
 			if (new_cpu == cpu) {
 				bpf_cpumask_set_cpu(new_cpu, ovrflw);
@@ -1543,9 +1550,11 @@ void BPF_STRUCT_OPS(lavd_quiescent, struct task_struct *p, u64 deq_flags)
 	cpuc->flags = 0;
 
 	/*
-	 * Decrease the number of pinned tasks waiting for execution.
+	 * Mirror the lavd_enqueue() increment: decrement when the task
+	 * is effectively pinned (permanent pinning or migrate_disable)
+	 * and was tracked at enqueue time (pinned_cpu_id set).
 	 */
-	if (is_pinned(p) && (taskc->pinned_cpu_id != -ENOENT)) {
+	if (is_effectively_pinned(taskc) && (taskc->pinned_cpu_id != -ENOENT)) {
 		__sync_fetch_and_sub(&cpuc->nr_pinned_tasks, 1);
 		taskc->pinned_cpu_id = -ENOENT;
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -666,6 +666,35 @@ static __always_inline void unaccount_queued_load(task_ctx *taskc)
 	WRITE_ONCE(taskc->queued_in_cpdom_id, LAVD_CPDOM_MAX_NR);
 }
 
+static int cgroup_throttled(struct task_struct *p, task_ctx *taskc, bool put_aside)
+{
+	int ret, ret2;
+
+	/*
+	 * Never throttle the scheduler process itself, so it can always
+	 * make forward progress.
+	 */
+	if (p->pid == lavd_pid)
+		return 0;
+
+	/*
+	 * Under CPU bandwidth control using cpu.max, we should first check
+	 * if the cgroup is throttled or not. If not, we will go ahead.
+	 * Otherwise, we should put the task aside for later execution.
+	 *
+	 * Note that we cannot use scx_bpf_task_cgroup() here because this can
+	 * be called only from ops.enqueue() and ops.dispatch().
+	 */
+	ret = scx_cgroup_bw_throttled(taskc->cgrp_id, p, (u64)taskc);
+	if ((ret == -EAGAIN) && put_aside) {
+		ret2 = scx_cgroup_bw_put_aside(p, (u64)taskc, p->scx.dsq_vtime,
+					       taskc->cgrp_id);
+		if (ret2)
+			return ret2;
+	}
+	return ret;
+}
+
 s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 		   u64 wake_flags)
 {
@@ -745,9 +774,8 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 			 * dispatch if the cgroup is throttled; the task will
 			 * fall through to ops.enqueue() which puts it in the BTQ.
 			 */
-			if (enable_cpu_bw && (p->pid != lavd_pid) &&
-			    (scx_cgroup_bw_throttled(ictx.taskc->cgrp_id, p,
-						     (u64)ictx.taskc) == -EAGAIN))
+			if (enable_cpu_bw &&
+			    (cgroup_throttled(p, ictx.taskc, false) == -EAGAIN))
 				goto out;
 			p->scx.dsq_vtime = calc_when_to_run(p, ictx.taskc);
 			p->scx.slice = LAVD_SLICE_MAX_NS_DFL;
@@ -760,30 +788,6 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 	}
 out:
 	return cpu_id;
-}
-
-static int cgroup_throttled(struct task_struct *p, task_ctx *taskc, bool put_aside)
-{
-	int ret, ret2;
-
-	/*
-	 * Under CPU bandwidth control using cpu.max, we should first check
-	 * if the cgroup is throttled or not. If not, we will go ahead.
-	 * Otherwise, we should put the task aside for later execution.
-	 * In the forced mode, we should enqueue the task even if the cgroup
-	 * is throttled (-EAGAIN).
-	 *
-	 * Note that we cannot use scx_bpf_task_cgroup() here because this can
-	 * be called only from ops.enqueue() and ops.dispatch().
-	 */
-	ret = scx_cgroup_bw_throttled(taskc->cgrp_id, p, (u64)taskc);
-	if ((ret == -EAGAIN) && put_aside) {
-		ret2 = scx_cgroup_bw_put_aside(p, (u64)taskc, p->scx.dsq_vtime,
-					       taskc->cgrp_id);
-		if (ret2)
-			return ret2;
-	}
-	return ret;
 }
 
 void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
@@ -864,12 +868,8 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 	 * Note that we calculate the task's deadline before checking the
 	 * cgroup, as we need the deadline to put aside the task when the
 	 * cgroup is throttled.
-	 *
-	 * Also, we do not throttle the scheduler process itself to
-	 * guarantee forward progress.
 	 */
-	if (enable_cpu_bw && (p->pid != lavd_pid) &&
-	    (cgroup_throttled(p, taskc, true) == -EAGAIN)) {
+	if (enable_cpu_bw && (cgroup_throttled(p, taskc, true) == -EAGAIN)) {
 		debugln("Task %s[pid%d/cgid%llu] is throttled.",
 			p->comm, p->pid, taskc->cgrp_id);
 		return;
@@ -1078,8 +1078,7 @@ void consume_prev(struct task_struct *prev, task_ctx *taskc_prev, struct cpu_ctx
 	 * check if the cgroup is throttled before executing
 	 * the task.
 	 */
-	if (enable_cpu_bw && (prev->pid != lavd_pid) &&
-		(cgroup_throttled(prev, taskc_prev, false) == -EAGAIN))
+	if (enable_cpu_bw && (cgroup_throttled(prev, taskc_prev, false) == -EAGAIN))
 		return;
 
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -932,30 +932,65 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 static
 int enqueue_cb(struct task_struct __arg_trusted *p, task_ctx *taskc)
 {
-	struct cpu_ctx *cpuc, *cpuc_cur;
+	struct cpu_ctx *cpuc;
 	u64 dsq_id;
 	s32 cpu;
 
-	cpuc_cur = get_cpu_ctx();
-	if (!taskc || !cpuc_cur) {
+	if (!taskc) {
 		scx_bpf_error("Failed to lookup a task context: %d", p->pid);
 		return 0;
 	}
 
 	/*
-	 * Calculate when a task can be scheduled.
+	 * Note that we don't need to calculate p->scx.dsq_vtime again
+	 * since it was already calculated and assigned to p->scx.dsq_vtime
+	 * before the task was throttled.
 	 */
-	p->scx.dsq_vtime = calc_when_to_run(p, taskc);
 
 	/*
-	 * Fetch the chosen CPU and DSQ for the task.
+	 * Validate the cached CPU choice before dispatch.
+	 *
+	 * sched_setaffinity() on a runnable SCX task runs a four-step
+	 * sched_change sequence under the task's rq lock:
+	 *   1. ops.dequeue (lavd_dequeue) -- for a put-aside task, our
+	 *      scx_cgroup_bw_cancel clears taskc->atq.
+	 *   2. set_cpus_allowed_common() writes p->cpus_mask, so the
+	 *      contents of *p->cpus_ptr now reflect the new affinity.
+	 *   3. ops.set_cpumask (lavd_set_cpumask) fires, but any refresh
+	 *      path would gate on atq != NULL, which is now false after
+	 *      step 1.
+	 *   4. ops.enqueue (lavd_enqueue) recomputes
+	 *      taskc->suggested_cpu_id against the new mask and put_aside
+	 *      the task back into the BTQ.
+	 *
+	 * enqueue_cb() runs from the BTQ drain (cbw_drain_btq_batch ->
+	 * scx_cgroup_bw_enqueue_cb) holding only the atq spinlock, NOT
+	 * the task's rq lock. If the drain has already popped this taskc
+	 * (clearing atq) and a sched_setaffinity() on another CPU
+	 * interleaves, p->cpus_ptr (updated at step 2) may already be
+	 * the new mask while taskc->suggested_cpu_id (only refreshed at
+	 * step 4) is still the stale pre-change pick.
+	 *
+	 * Fall back to scx_bpf_task_cpu(p) when the cached pick is no
+	 * longer in p->cpus_ptr -- the kernel keeps task_cpu consistent
+	 * with affinity. A full pick_idle_cpu() refresh would be more
+	 * accurate but extends the call chain (lavd_dispatch ->
+	 * scx_cgroup_bw_reenqueue -> cbw_reenqueue_cgroup ->
+	 * cbw_drain_btq_batch -> enqueue_cb -> pick_idle_cpu) past the
+	 * BPF verifier's combined-stack budget.
 	 */
 	cpu = taskc->suggested_cpu_id;
+	if (cpu < 0 || cpu >= nr_cpu_ids ||
+	    !bpf_cpumask_test_cpu(cpu, p->cpus_ptr))
+		cpu = scx_bpf_task_cpu(p);
+
 	cpuc = get_cpu_ctx_id(cpu);
 	if (!cpuc) {
 		scx_bpf_error("Failed to lookup cpu_ctx %d", cpu);
 		return 0;
 	}
+	taskc->suggested_cpu_id = cpu;
+	taskc->cpdom_id = cpuc->cpdom_id;
 
 	/*
 	 * Account effectively pinned tasks (permanent pinning or
@@ -987,9 +1022,12 @@ int enqueue_cb(struct task_struct __arg_trusted *p, task_ctx *taskc)
 	account_queued_load(taskc, cpuc->cpdom_id);
 
 	/*
-	 * Kick the target CPU if it is idle.
+	 * Kick the target CPU if it is idle. Test-and-clear avoids
+	 * waking a CPU that is already busy with another task and
+	 * generating a spurious reschedule IPI.
 	 */
-	scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
+	if (scx_bpf_test_and_clear_cpu_idle(cpu))
+		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 	return 0;
 }
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -958,11 +958,26 @@ int enqueue_cb(struct task_struct __arg_trusted *p, task_ctx *taskc)
 	}
 
 	/*
-	 * Mirror the lavd_enqueue() accounting: count effectively pinned
-	 * tasks (permanent or migrate_disable) for slice shrinking.
+	 * Account effectively pinned tasks (permanent pinning or
+	 * migrate_disable) so nr_pinned_tasks drives slice shrinking.
+	 *
+	 * For tasks that hit the BTQ, this is the first increment:
+	 * lavd_enqueue() returns early at its cgroup_throttled() check
+	 * before reaching its own pinned-accounting block, so the
+	 * throttled path skips the increment there. enqueue_cb() (which
+	 * runs when the BTQ drains) is where it actually gets counted.
+	 *
+	 * pinned_cpu_id is the single marker for "this task currently
+	 * holds +1 in cpuc[pinned_cpu_id].nr_pinned_tasks", paired with
+	 * the matching decrement in lavd_quiescent(). The
+	 * pinned_cpu_id == -ENOENT guard ensures one increment per
+	 * accounting cycle and defends against the rare sequence where
+	 * a prior non-throttled lavd_enqueue() already set the marker.
 	 */
-	if (is_effectively_pinned(taskc))
+	if (is_effectively_pinned(taskc) && (taskc->pinned_cpu_id == -ENOENT)) {
+		taskc->pinned_cpu_id = cpu;
 		__sync_fetch_and_add(&cpuc->nr_pinned_tasks, 1);
+	}
 
 	/*
 	 * Enqueue the task to a DSQ.
@@ -1550,17 +1565,25 @@ void BPF_STRUCT_OPS(lavd_quiescent, struct task_struct *p, u64 deq_flags)
 	cpuc->flags = 0;
 
 	/*
-	 * Mirror the lavd_enqueue() increment: decrement when the task
-	 * is effectively pinned (permanent pinning or migrate_disable)
-	 * and was tracked at enqueue time (pinned_cpu_id set).
+	 * Mirror the lavd_enqueue() / enqueue_cb() increment. Decrement
+	 * on cpuc[pinned_cpu_id] -- the CPU recorded when the increment
+	 * happened -- not on the current task_cpu. The two can briefly
+	 * disagree when an enqueue_cb() pick differs from the kernel's
+	 * eventual task_cpu (e.g., the BTQ-drain race with
+	 * sched_setaffinity). Pairing the decrement with the recorded
+	 * pinned_cpu_id keeps the per-CPU nr_pinned_tasks exact.
 	 */
 	if (is_effectively_pinned(taskc) && (taskc->pinned_cpu_id != -ENOENT)) {
-		__sync_fetch_and_sub(&cpuc->nr_pinned_tasks, 1);
-		taskc->pinned_cpu_id = -ENOENT;
+		struct cpu_ctx *cpuc_pinned =
+			get_cpu_ctx_id(taskc->pinned_cpu_id);
 
-		debugln("%d [%d] -- %s:%d -- %s:%d", cpuc->cpu_id,
-			cpuc->nr_pinned_tasks, p->comm, p->pid, __func__,
-			__LINE__);
+		if (cpuc_pinned) {
+			__sync_fetch_and_sub(&cpuc_pinned->nr_pinned_tasks, 1);
+			debugln("%d [%d] -- %s:%d -- %s:%d", cpuc_pinned->cpu_id,
+				cpuc_pinned->nr_pinned_tasks, p->comm, p->pid,
+				__func__, __LINE__);
+		}
+		taskc->pinned_cpu_id = -ENOENT;
 	}
 
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -406,7 +406,7 @@ void try_find_and_kick_victim_cpu(struct task_struct *p,
 	if (!cpuc_cur)
 		return;
 
-	cpumask = cpuc_cur->tmp_l_mask;
+	cpumask = cpuc_cur->temp_mask;
 	cpdom_id = dsq_to_cpdom(dsq_id);
 	cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpdom_id]);
 	cd_cpumask = MEMBER_VPTR(cpdom_cpumask, [cpdom_id]);

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -406,7 +406,7 @@ void try_find_and_kick_victim_cpu(struct task_struct *p,
 	if (!cpuc_cur)
 		return;
 
-	cpumask = cpuc_cur->tmp_t_mask;
+	cpumask = cpuc_cur->tmp_l_mask;
 	cpdom_id = dsq_to_cpdom(dsq_id);
 	cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpdom_id]);
 	cd_cpumask = MEMBER_VPTR(cpdom_cpumask, [cpdom_id]);

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
@@ -161,9 +161,15 @@ bool is_ksoftirqd(struct task_struct *p)
 }
 
 __hidden
-bool is_pinned(const struct task_struct *p)
+bool is_permanently_pinned(const struct task_struct *p)
 {
 	return p->nr_cpus_allowed == 1;
+}
+
+__hidden
+bool is_effectively_pinned(task_ctx __arg_arena *taskc)
+{
+	return test_task_flag(taskc, LAVD_FLAG_IS_EFFECTIVELY_PINNED);
 }
 
 __hidden
@@ -269,12 +275,18 @@ void set_affinity_flags(task_ctx __arg_arena *taskc,
 	bool on_big = false, on_little = false;
 	s32 first_cpdom_id = -ENOENT;
 	struct cpu_ctx *cpuc;
+	u32 weight;
 	int cpu;
 
 	if (!cpumask)
 		return;
 
-	is_affinitized = bpf_cpumask_weight(cpumask) != nr_cpu_ids;
+	weight = bpf_cpumask_weight(cpumask);
+	is_affinitized = weight != nr_cpu_ids;
+	if (weight == 1)
+		set_task_flag(taskc, LAVD_FLAG_IS_EFFECTIVELY_PINNED);
+	else
+		reset_task_flag(taskc, LAVD_FLAG_IS_EFFECTIVELY_PINNED);
 	if (nr_cpdoms == 1) {
 		dom_pinned = false;
 		dom_pinned_settled = true;
@@ -424,7 +436,13 @@ u64 get_target_dsq_id(struct task_struct *p, struct cpu_ctx *cpuc, task_ctx *tas
 {
 	struct cpdom_ctx *cpdomc;
 
-	if (per_cpu_dsq || (pinned_slice_ns && is_pinned(p)))
+	/*
+	 * Route effectively pinned tasks (permanent pinning or
+	 * migrate_disable) to the per-CPU DSQ when pinned_slice_ns is
+	 * enabled, so the slice-shrinking heuristic in preempt.bpf.c can
+	 * act on them consistently.
+	 */
+	if (per_cpu_dsq || (pinned_slice_ns && is_effectively_pinned(taskc)))
 		return cpu_to_dsq(cpuc->cpu_id);
 
 	cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpuc->cpdom_id]);

--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.h
@@ -34,7 +34,8 @@ u32 calc_avg32(u32 old_val, u32 new_val);
 bool is_kernel_task(struct task_struct *p);
 bool is_kernel_worker(struct task_struct *p);
 bool is_ksoftirqd(struct task_struct *p);
-bool is_pinned(const struct task_struct *p);
+bool is_permanently_pinned(const struct task_struct *p);
+bool is_effectively_pinned(task_ctx __arg_arena *taskc);
 bool use_full_cpus(void);
 void set_affinity_flags(task_ctx __arg_arena *taskc,
 			const struct cpumask *cpumask);


### PR DESCRIPTION
This series hardens scx_lavd's placement decisions for tasks whose
effective cpumask is narrower than p->nr_cpus_allowed suggests:
migrate_disable() narrows p->cpus_ptr without touching nr_cpus_allowed,
and sched_setaffinity() on a task parked in the cpu.max BTQ changes
the allowed set without notifying the scheduler.

Distinguish permanent vs effective pinning
------------------------------------------

is_pinned() tested p->nr_cpus_allowed == 1 and silently missed tasks
narrowed only via migrate_disable() (e.g., unbound kworkers in short
migrate_disable sections).  Rename it to is_permanently_pinned(), add
is_effectively_pinned(taskc) backed by a "cpus_ptr weight == 1" flag
maintained at every ops.set_cpumask(), and partition call sites by
intent.

- [1/6] c9dc38b51 scx_lavd: distinguish permanent vs effective task pinning

Clean up cpu_ctx scratch fields
-------------------------------

Prep for the next section.  Switch try_find_and_kick_victim_cpu() off
the buffer init_idle_ato_masks() uses for the idle/active intersection
onto a general-purpose scratch, and rename the tmp_*_mask fields to
match the pick_ctx alias names that already describe each role.

- [2/6] 4fe93241d scx_lavd: use a more general scratch in try_find_and_kick_victim_cpu
- [3/6] 0272ec5b0 scx_lavd: rename cpu_ctx tmp_*_mask scratch fields for clarity

Harden placement under cpu.max throttling
-----------------------------------------

sched_setaffinity() on a BTQ-parked task narrows p->cpus_ptr silently,
so taskc->suggested_cpu_id can go stale by the time enqueue_cb()
drains the task back and lands it on a forbidden CPU.  Fix with two
complementary mechanisms: enqueue_cb() validates suggested_cpu_id at
drain time and falls back to scx_bpf_task_cpu(p) if stale;
lavd_set_cpumask() runs a fresh pick_idle_cpu() for throttled tasks
so the cache is refreshed at the cpumask-change event itself.

- [4/6] 1d151a925 scx_lavd: refresh CPU choice in enqueue_cb on BTQ reenqueue
- [5/6] 59aa8b879 scx_lavd: refresh placement on cpumask change for throttled tasks

Consolidate throttle checks
---------------------------

Hoist the "skip the scheduler's own task" guard into
cgroup_throttled() and route lavd_select_cpu()'s direct-dispatch path
through it, collapsing all four sites to a uniform
"if (enable_cpu_bw && cgroup_throttled(...) == -EAGAIN)".

- [6/6] cc8c51f80 scx_lavd: consolidate throttle checks in cgroup_throttled()

Signed-off-by: Changwoo Min <changwoo@igalia.com>
