### PR TITLE
compat.bpf.h: Gate scx_bpf_dsq_peek kfunc behind kernel version 7.1.0

### DIFF
--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -92,15 +92,20 @@ int bpf_cpumask_populate(struct cpumask *dst, void *src, size_t src__sz) __ksym 
 
 /*
  * v6.19: Introduce lockless peek API for user DSQs.
+ * v7.1:  Resolve the stale pointer issue of the lockless peek API.
  *
- * Preserve the following macro until v6.21.
+ * The kfunc exists on earlier kernels but its lockless implementation could
+ * return stale task pointers. Require kernel version >= 7.1.0 before calling
+ * it; otherwise fall through to the bpf_iter_scx_dsq fallback below.
+ *
  */
 static inline struct task_struct *__COMPAT_scx_bpf_dsq_peek(u64 dsq_id)
 {
 	struct task_struct *p = NULL;
 	struct bpf_iter_scx_dsq it;
 
-	if (bpf_ksym_exists(scx_bpf_dsq_peek))
+	if (bpf_ksym_exists(scx_bpf_dsq_peek) &&
+	    LINUX_KERNEL_VERSION >= KERNEL_VERSION(7, 1, 0))
 		return scx_bpf_dsq_peek(dsq_id);
 	if (!bpf_iter_scx_dsq_new(&it, dsq_id, 0))
 		p = bpf_iter_scx_dsq_next(&it);


### PR DESCRIPTION
__COMPAT_scx_bpf_dsq_peek() selects the lockless kfunc whenever the
symbol resolves in the kernel BTF. However, its lockless implementation
could return a stale task_struct pointer. The stale pointer issues are
resolved only after v7.1 kernel with the following patches:

1). 2f2ea7709266 ("sched_ext: Use dsq->first_task instead of list_empty() in dispatch_enqueue() FIFO-tail")
2). 71d7847cad44 ("sched_ext: Fix scx_bpf_dsq_peek() with FIFO DSQs")

Require bpf_ksym_exists(scx_bpf_dsq_peek) AND LINUX_KERNEL_VERSION >=
KERNEL_VERSION(7, 1, 0) before calling the kfunc to mitigate the issue;
otherwise fall through to the existing bpf_iter_scx_dsq path instead.

See also the lavd patch, working around the bug by avoiding calling
the kfunc when unnecessary and having more context explanation:
ac863374ce4f ("scx_lavd: Gate dsq_peek_task_load behind no-fast-lb")