### PR TITLE
scx_cosmos: Bump version to 1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "scx_cosmos"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_cosmos"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Andrea Righi <arighi@nvidia.com>"]
 edition = "2021"
 description = "Lightweight scheduler optimized for preserving task-to-CPU locality. https://github.com/sched-ext/scx/tree/main"


### PR DESCRIPTION
With commit 605c7d2c700c ("Fix lib/pmu.bpf.c path") fixing a Rust crate packaging issue we need to cut a new version for scx_cosmos and publish a new crate.

Link: https://github.com/sched-ext/scx/pull/3583