### PR TITLE
compat.bpf.h: Add override for scx_bpf_dsq_peek version gate

### DIFF
--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -90,6 +90,8 @@ int bpf_cpumask_populate(struct cpumask *dst, void *src, size_t src__sz) __ksym 
 	(bpf_ksym_exists(bpf_cpumask_populate) ?			\
 	 (bpf_cpumask_populate(cpumask, src, size__sz)) : -EOPNOTSUPP)
 
+__weak const volatile bool __COMPAT_scx_allow_lockless_peek_unsafe = false;
+
 /*
  * v6.19: Introduce lockless peek API for user DSQs.
  * v7.1:  Resolve the stale pointer issue of the lockless peek API.
@@ -98,6 +100,9 @@ int bpf_cpumask_populate(struct cpumask *dst, void *src, size_t src__sz) __ksym 
  * return stale task pointers. Require kernel version >= 7.1.0 before calling
  * it; otherwise fall through to the bpf_iter_scx_dsq fallback below.
  *
+ * The version gate can be bypassed at runtime by setting
+ * __COMPAT_scx_allow_lockless_peek_unsafe if the bug fixes have been backported
+ * to the LTS kernel.
  */
 static inline struct task_struct *__COMPAT_scx_bpf_dsq_peek(u64 dsq_id)
 {
@@ -105,7 +110,8 @@ static inline struct task_struct *__COMPAT_scx_bpf_dsq_peek(u64 dsq_id)
 	struct bpf_iter_scx_dsq it;
 
 	if (bpf_ksym_exists(scx_bpf_dsq_peek) &&
-	    LINUX_KERNEL_VERSION >= KERNEL_VERSION(7, 1, 0))
+	    (LINUX_KERNEL_VERSION >= KERNEL_VERSION(7, 1, 0) ||
+	     __COMPAT_scx_allow_lockless_peek_unsafe))
 		return scx_bpf_dsq_peek(dsq_id);
 	if (!bpf_iter_scx_dsq_new(&it, dsq_id, 0))
 		p = bpf_iter_scx_dsq_next(&it);

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -200,6 +200,21 @@ struct Opts {
     #[clap(long = "no-fast-lb", action = clap::ArgAction::SetTrue)]
     no_fast_lb: bool,
 
+    /// Use the lockless scx_bpf_dsq_peek() kfunc even on kernels that report
+    /// LINUX_KERNEL_VERSION < 7.1.0. By default the BPF compat falls back to
+    /// the bpf_iter_scx_dsq_* path on such kernels because the kfunc could
+    /// return stale task pointers before the upstream fixes landed:
+    ///
+    ///   71d7847cad44 ("sched_ext: Fix scx_bpf_dsq_peek() with FIFO
+    ///                   DSQs")
+    ///   2f2ea7709266 ("sched_ext: Use dsq->first_task instead of
+    ///                   list_empty() in dispatch_enqueue() FIFO-tail")
+    ///
+    /// Only enable this flag if you have verified your kernel has
+    /// both fixes backported.
+    #[clap(long = "allow-lockless-peek-unsafe", action = clap::ArgAction::SetTrue)]
+    allow_lockless_peek_unsafe: bool,
+
     /// Disable preemption.
     #[clap(long = "no-preemption", action = clap::ArgAction::SetTrue)]
     no_preemption: bool,
@@ -694,6 +709,7 @@ impl<'a> Scheduler<'a> {
         rodata.lb_local_dsq_util_wall = ((opts.lb_local_dsq_util_pct as u64) << 10) / 100;
         rodata.no_use_em = opts.no_use_em as u8;
         rodata.no_fast_lb = opts.no_fast_lb as u8;
+        rodata.__COMPAT_scx_allow_lockless_peek_unsafe = opts.allow_lockless_peek_unsafe;
         rodata.no_wake_sync = opts.no_wake_sync;
         rodata.no_slice_boost = opts.no_slice_boost;
         rodata.per_cpu_dsq = opts.per_cpu_dsq;


### PR DESCRIPTION
a3f2784c432b ("compat.bpf.h: Gate scx_bpf_dsq_peek kfunc behind kernel
version 7.1.0") gates the lockless peek kfunc by LINUX_KERNEL_VERSION,
but the version check misses stable backports. A kernel that has both
upstream FIFO fixes

  71d7847cad44 ("sched_ext: Fix scx_bpf_dsq_peek() with FIFO DSQs")
  2f2ea7709266 ("sched_ext: Use dsq->first_task instead of list_empty()
                  in dispatch_enqueue() FIFO-tail")

cherry-picked but still reporting < 7.1.0 ends up on the iterator
fallback. CachyOS users on 6.18.31 reported a 4x FPS drop in Cyberpunk
2077.

Add __COMPAT_scx_allow_lockless_peek_unsafe as a __weak rodata bool.
When true, bpf_ksym_exists() alone is enough to take the fast path.
Expose it in scx_lavd as --allow-lockless-peek-unsafe. Default false,
so kernels without the fixes stay on the iterator path. Only enable
on kernels that have both fixes backported.