### PR TITLE
scx_layered: allow idle_confined spillover when system is fully allocated

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/intf.h
+++ b/scheds/rust/scx_layered/src/bpf/intf.h
@@ -397,6 +397,7 @@ struct layer {
 	bool			skip_remote_node;
 	bool			prev_over_idle_core;
 	bool			idle_confined;
+	bool			fully_allocated;
 	int			growth_algo;
 
 	u64			nr_tasks;

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1439,12 +1439,20 @@ s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu,
 
 	/*
 	 * Grouped layers may opt to act like Confined for idle selection
-	 * until the layer becomes saturated (check_no_idle is set), at
+	 * until the layer becomes saturated (check_no_idle is set) or
+	 * the system is fully allocated (no free CPUs to grow into), at
 	 * which point they fall back to searching unprotected CPUs.
+	 *
+	 * check_no_idle alone is too restrictive: CPUs degraded by
+	 * softirq/IRQ overhead still appear briefly idle between bursts,
+	 * keeping check_no_idle cleared even though the CPUs are
+	 * effectively saturated.  fully_allocated lets userspace override
+	 * when there's no room to grow.
 	 */
 	bool can_use_open = layer->kind != LAYER_KIND_CONFINED &&
 		(!layer->idle_confined ||
-		 READ_ONCE(layer->check_no_idle));
+		 READ_ONCE(layer->check_no_idle) ||
+		 READ_ONCE(layer->fully_allocated));
 
 	if (is_float)
 		goto no_locality;

--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -200,10 +200,11 @@ pub enum LayerKind {
 
         /// When true, idle CPU selection only considers the layer's own
         /// CPUs until the layer becomes saturated (i.e., no idle CPU is
-        /// found and check_no_idle is set). At that point, idle search
-        /// falls back to unprotected CPUs like a normal Grouped layer.
-        /// Provides Confined-style cache locality under normal load with
-        /// Grouped-style overflow under pressure.
+        /// found and check_no_idle is set) or the system is fully
+        /// allocated (all CPUs assigned to layers). At that point, idle
+        /// search falls back to unprotected CPUs like a normal Grouped
+        /// layer. Provides Confined-style cache locality under normal
+        /// load with Grouped-style overflow under pressure.
         #[serde(default)]
         idle_confined: bool,
 

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -314,9 +314,9 @@ lazy_static! {
 ///   idle CPUs outside the allocated ones. The range can optionally be
 ///   restricted with the "cpus_range" property. The optional
 ///   "idle_confined" flag restricts idle selection to
-///   the layer's CPUs until the layer becomes saturated, providing
-///   Confined-style cache locality under normal load with Grouped-style
-///   overflow under pressure.
+///   the layer's CPUs until the layer becomes saturated or the system
+///   is fully allocated, providing Confined-style cache locality under
+///   normal load with Grouped-style overflow under pressure.
 ///
 /// - Open: Prefer the CPUs which are not occupied by Confined or Grouped
 ///   layers. Tasks in this group will spill into occupied CPUs if there are
@@ -3904,6 +3904,20 @@ impl<'a> Scheduler<'a> {
                     &mut self.skel.maps.bss_data.as_mut().unwrap().layers[idx],
                 );
                 updated = true;
+            }
+        }
+
+        // Tell BPF whether all CPUs are allocated.  When the system is
+        // fully allocated, idle_confined layers have nowhere to grow, so
+        // they should be allowed to use open (unprotected) idle CPUs from
+        // other layers.
+        let total_allocated: usize = self.layers.iter().map(|l| l.nr_cpus).sum();
+        let fully_allocated = total_allocated >= total_cpus;
+        for (idx, layer) in self.layers.iter().enumerate() {
+            if !layer_is_open(layer) {
+                self.skel.maps.bss_data.as_mut().unwrap().layers[idx]
+                    .fully_allocated
+                    .write(fully_allocated);
             }
         }
 


### PR DESCRIPTION
`idle_confined` gates open CPU search on `check_no_idle`, a per-layer flag that clears whenever ANY idle CPU is found within the layer's allocated CPUs.  This BPF-side check is too restrictive: on CPUs degraded by softirq or IRQ overhead (e.g. ~50% softirq from network processing), brief idle moments between bursts keep `check_no_idle` cleared even though the CPUs are effectively saturated.  The layer stays trapped on degraded CPUs with no way to spill to other layers' idle capacity.

When all CPUs are assigned to layers, `idle_confined` layers have nowhere to grow — the only relief valve is spillover.  Add a `fully_allocated` flag to the BPF layer struct, set by userspace when total allocated CPUs >= total system CPUs.  When set, `idle_confined` layers act as a regular `Grouped` layer for idle CPU selection.

When the system has unallocated CPUs, `idle_confined` continues to act like Confined for cache locality.