### PR TITLE
scx_lavd: fix delayed scheduling of turbulent-DSQ tasks

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -512,21 +512,29 @@ static bool force_to_steal_task(struct cpdom_ctx *cpdomc)
 }
 
 __hidden
-bool consume_task(u64 cpu_dsq_id, u64 cpdom_dsq_id)
+bool consume_task(u64 cpdom_id)
 {
 	struct cpdom_ctx *cpdomc;
 	struct cpu_ctx *cpuc;
-	u64 cpdom_turb_dsq_id;
+	u64 cpu_dsq_id, cpdom_dsq_id, cpdom_turb_dsq_id;
 	bool turbulent;
 	struct dsq_entry dsqs[3];
+	int i;
 
-	cpdomc = MEMBER_VPTR(cpdom_ctxs, [dsq_to_cpdom(cpdom_dsq_id)]);
+	cpdomc = MEMBER_VPTR(cpdom_ctxs, [cpdom_id]);
 	if (!cpdomc) {
-		scx_bpf_error("Failed to lookup cpdom_ctx for %llu", dsq_to_cpdom(cpdom_dsq_id));
+		scx_bpf_error("Failed to lookup cpdom_ctx for %llu", cpdom_id);
 		return false;
 	}
 
-	cpdom_turb_dsq_id = cpdom_to_turb_dsq(dsq_to_cpdom(cpdom_dsq_id));
+	cpuc = get_cpu_ctx();
+	if (!cpuc) {
+		return false;
+	}
+
+	cpu_dsq_id        = cpu_to_dsq(cpuc->cpu_id);
+	cpdom_dsq_id      = cpdom_to_dsq(cpdom_id);
+	cpdom_turb_dsq_id = cpdom_to_turb_dsq(cpdom_id);
 
 	/*
 	 * Determine if this CPU is turbulent (high IRQ/steal time).
@@ -534,9 +542,6 @@ bool consume_task(u64 cpu_dsq_id, u64 cpdom_dsq_id)
 	 * Turbulent CPUs only consume from the turbulent DSQ
 	 * (which holds non-latency-critical tasks).
 	 */
-	cpuc = get_cpu_ctx();
-	if (!cpuc)
-		return false;
 	turbulent = cpuc->lat_headroom < LAVD_LC_LATENCY_SENSITIVE_THRESH;
 
 	/*
@@ -561,21 +566,21 @@ bool consume_task(u64 cpu_dsq_id, u64 cpdom_dsq_id)
 		 cpdomc->nr_steady_cpus == 0) };
 	dsqs[2] = (struct dsq_entry){ cpdom_turb_dsq_id, U64_MAX, use_cpdom_dsq() };
 
-	if (dsqs[0].eligible)
-		dsqs[0].vtime = peek_dsq_vtime(dsqs[0].dsq_id);
-	if (dsqs[1].eligible)
-		dsqs[1].vtime = peek_dsq_vtime(dsqs[1].dsq_id);
-	if (dsqs[2].eligible)
-		dsqs[2].vtime = peek_dsq_vtime(dsqs[2].dsq_id);
+	/* Peek vtimes of eligible DSQs so sort_dsqs() can order them. */
+	for (i = 0; i < 3; i++) {
+		if (dsqs[i].eligible) {
+			dsqs[i].vtime = peek_dsq_vtime(dsqs[i].dsq_id);
+		}
+	}
 
 	sort_dsqs(&dsqs[0], &dsqs[1], &dsqs[2]);
 
-	if (dsqs[0].eligible && consume_dsq(cpdomc, dsqs[0].dsq_id))
-		return true;
-	if (dsqs[1].eligible && consume_dsq(cpdomc, dsqs[1].dsq_id))
-		return true;
-	if (dsqs[2].eligible && consume_dsq(cpdomc, dsqs[2].dsq_id))
-		return true;
+	/* Consume in lowest-vtime-first order. */
+	for (i = 0; i < 3; i++) {
+		if (dsqs[i].eligible && consume_dsq(cpdomc, dsqs[i].dsq_id)) {
+			return true;
+		}
+	}
 
 	/*
 	 * If there is no task in the associated DSQ, traverse neighbor

--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -294,8 +294,24 @@ u64 __attribute__((noinline)) pick_most_loaded_dsq(struct cpdom_ctx *cpdomc)
 	 * in this domain.
 	 */
 	if (use_cpdom_dsq()) {
-		pick_dsq_id = cpdom_to_dsq(cpdomc->id);
-		highest_queued = scx_bpf_dsq_nr_queued(pick_dsq_id);
+		u64 dsq1 = cpdom_to_dsq(cpdomc->id);
+		u64 dsq2 = cpdom_to_turb_dsq(cpdomc->id);
+		s32 q1 = scx_bpf_dsq_nr_queued(dsq1);
+		s32 q2 = scx_bpf_dsq_nr_queued(dsq2);
+
+		/*
+		 * When the counts tie, prefer the non-turbulent DSQ -- that's
+		 * where latency-critical tasks live, so draining it first
+		 * matches the existing priority of non-turbulent over turbulent
+		 * within consume order.
+		 */
+		if (q1 >= q2) {
+			pick_dsq_id = dsq1;
+			highest_queued = q1;
+		} else {
+			pick_dsq_id = dsq2;
+			highest_queued = q2;
+		}
 	}
 
 	/*

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -791,7 +791,7 @@ struct pick_ctx {
 s32 find_cpu_in(const struct cpumask *src_mask, struct cpu_ctx *cpuc_cur);
 s32  pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle);
 
-bool consume_task(u64 cpu_dsq_id, u64 cpdom_dsq_id);
+bool consume_task(u64 cpdom_id);
 
 extern u64 cur_logical_clk;
 u64 calc_when_to_run(struct task_struct *p, task_ctx *taskc);

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1101,13 +1101,114 @@ void consume_prev(struct task_struct *prev, task_ctx *taskc_prev, struct cpu_ctx
 	cpuc->flags = taskc_prev->flags;
 }
 
+__hidden __attribute__ ((noinline))
+bool scan_dsq_for_ovflw_ext(u64 dsq_id, s32 cpu,
+			    struct cpu_ctx *cpuc,
+			    struct bpf_cpumask *active,
+			    struct bpf_cpumask *ovrflw)
+{
+	struct task_struct *p;
+	task_ctx *taskc;
+	s32 new_cpu;
+
+	/*
+	 * Scan @dsq_id for a task that needs this CPU (permanently
+	 * pinned, migrate_disabled, or affinitized only to CPUs outside
+	 * the active+overflow set) and, as a side effect, extend the
+	 * overflow set so such a task can be serviced.
+	 *
+	 *   - When the task's target CPU is @cpu, add @cpu to the
+	 *     overflow set and return true so the caller drains a task
+	 *     locally via consume_task().
+	 *   - When the target is remote, extend the overflow set on
+	 *     that CPU (when not already a member) and kick it.
+	 *
+	 * Returns true if a locally-runnable match was found; false if
+	 * the scan completed without one. Callers may invoke this
+	 * against more than one DSQ to cover both the non-turbulent
+	 * and the turbulent cpdom DSQs (see get_target_dsq_id()).
+	 *
+	 * Must be called with bpf_rcu_read_lock() held; @active and
+	 * @ovrflw are borrowed under that critical section.
+	 */
+	bpf_for_each(scx_dsq, p, dsq_id, 0) {
+		/*
+		 * note that this is a hack to bypass the restriction of the
+		 * current bpf not trusting the pointer p. once the bpf
+		 * verifier gets smarter, we can remove bpf_task_from_pid().
+		 */
+		p = bpf_task_from_pid(p->pid);
+		if (!p)
+			continue; /* ignore the lookup error */
+
+		/*
+		 * If the task is permanently pinned to its CPU, extend the
+		 * overflow set (and kick if it's a remote CPU). Same
+		 * rationale as the prev-task branch in lavd_dispatch():
+		 * migrate_disable is transient, so its handling is split
+		 * into the else-if below.
+		 */
+		if (is_permanently_pinned(p)) {
+			new_cpu = scx_bpf_task_cpu(p);
+			if (new_cpu == cpu) {
+				bpf_cpumask_set_cpu(new_cpu, ovrflw);
+				bpf_task_release(p);
+				return true;
+			}
+			if (!bpf_cpumask_test_and_set_cpu(new_cpu, ovrflw))
+				scx_bpf_kick_cpu(new_cpu, SCX_KICK_IDLE);
+			bpf_task_release(p);
+			continue;
+		} else if (is_migration_disabled(p)) {
+			new_cpu = scx_bpf_task_cpu(p);
+			if (new_cpu == cpu) {
+				bpf_task_release(p);
+				return true;
+			}
+			scx_bpf_kick_cpu(new_cpu, SCX_KICK_IDLE);
+			bpf_task_release(p);
+			continue;
+		}
+
+		/*
+		 * if the task can run on either active or overflow set,
+		 * try another task.
+		 */
+		taskc = get_task_ctx(p);
+		if(taskc &&
+		(!test_task_flag(taskc, LAVD_FLAG_IS_AFFINITIZED) ||
+		bpf_cpumask_intersects(cast_mask(active), p->cpus_ptr) ||
+		bpf_cpumask_intersects(cast_mask(ovrflw), p->cpus_ptr))) {
+			bpf_task_release(p);
+			continue;
+		}
+
+		/*
+		 * now, we know that the task cannot run on either active
+		 * or overflow set. then, let's consider to extend the
+		 * overflow set.
+		 */
+		new_cpu = find_cpu_in(p->cpus_ptr, cpuc);
+		if (new_cpu >= 0) {
+			if (new_cpu == cpu) {
+				bpf_cpumask_set_cpu(new_cpu, ovrflw);
+				bpf_task_release(p);
+				return true;
+			}
+			else if (!bpf_cpumask_test_and_set_cpu(new_cpu, ovrflw))
+				scx_bpf_kick_cpu(new_cpu, SCX_KICK_IDLE);
+		}
+		bpf_task_release(p);
+	}
+
+	return false;
+}
+
 void BPF_STRUCT_OPS(lavd_dispatch, s32 cpu, struct task_struct *prev)
 {
 	struct bpf_cpumask *active, *ovrflw;
-	u64 cpu_dsq_id, cpdom_dsq_id;
 	task_ctx *taskc_prev = NULL;
 	bool try_consume = false;
-	struct task_struct *p;
 	struct cpu_ctx *cpuc;
 	int ret;
 
@@ -1116,9 +1217,6 @@ void BPF_STRUCT_OPS(lavd_dispatch, s32 cpu, struct task_struct *prev)
 		scx_bpf_error("Failed to lookup cpu_ctx %d", cpu);
 		return;
 	}
-
-	cpu_dsq_id = cpu_to_dsq(cpu);
-	cpdom_dsq_id = cpdom_to_dsq(cpuc->cpdom_id);
 
 	/*
 	 * When the CPU bandwidth control is enabled, check if there are
@@ -1179,7 +1277,7 @@ void BPF_STRUCT_OPS(lavd_dispatch, s32 cpu, struct task_struct *prev)
 	 * Since this CPU is neither active nor overflow set,
 	 * add this CPU to the overflow set.
 	 */
-	if (use_per_cpu_dsq() && scx_bpf_dsq_nr_queued(cpu_dsq_id)) {
+	if (use_per_cpu_dsq() && scx_bpf_dsq_nr_queued(cpu_to_dsq(cpu))) {
 		bpf_cpumask_set_cpu(cpu, ovrflw);
 		bpf_rcu_read_unlock();
 		goto consume_out;
@@ -1229,85 +1327,26 @@ void BPF_STRUCT_OPS(lavd_dispatch, s32 cpu, struct task_struct *prev)
 	/* NOTE: We use per-domain DSQ. */
 
 	/*
-	 * If this CPU is neither in active nor overflow CPUs,
-	 * try to find and run the task affinitized on this CPU
-	 * from the per-domain DSQ.
+	 * If this CPU is neither in active nor overflow CPUs, try to
+	 * find a task affinitized on this CPU from the per-domain DSQs.
 	 *
-	 * Note that we don't need to traverse the per-CPU DSQ,
-	 * as it is already handled by the fast path above.
+	 * Scan both the non-turbulent and the turbulent cpdom DSQs:
+	 * get_target_dsq_id() routes pinned / affinitized tasks to
+	 * either one depending on their preemption_vulnerability, so
+	 * the turbulent DSQ can hold tasks that only this CPU can run.
+	 * Skipping it would leave them stalled when this CPU is the
+	 * only legal target and the regular cpdom DSQ happens to be
+	 * empty.
+	 *
+	 * We don't need to traverse the per-CPU DSQ; it is already
+	 * handled by the fast path above.
 	 */
-	bpf_for_each(scx_dsq, p, cpdom_dsq_id, 0) {
-		task_ctx *taskc;
-		s32 new_cpu;
-
-		/*
-		 * note that this is a hack to bypass the restriction of the
-		 * current bpf not trusting the pointer p. once the bpf
-		 * verifier gets smarter, we can remove bpf_task_from_pid().
-		 */
-		p = bpf_task_from_pid(p->pid);
-		if (!p)
-			continue; /* ignore the lookup error */
-
-		/*
-		 * If the task is permanently pinned to its CPU, extend the
-		 * overflow set (and kick if it's a remote CPU). Same rationale
-		 * as the prev-task branch above: migrate_disable is transient,
-		 * so its handling is split into the else-if below.
-		 */
-		if (is_permanently_pinned(p)) {
-			new_cpu = scx_bpf_task_cpu(p);
-			if (new_cpu == cpu) {
-				bpf_cpumask_set_cpu(new_cpu, ovrflw);
-				bpf_task_release(p);
-				try_consume = true;
-				break;
-			}
-			if (!bpf_cpumask_test_and_set_cpu(new_cpu, ovrflw))
-				scx_bpf_kick_cpu(new_cpu, SCX_KICK_IDLE);
-			bpf_task_release(p);
-			continue;
-		} else if (is_migration_disabled(p)) {
-			new_cpu = scx_bpf_task_cpu(p);
-			if (new_cpu == cpu) {
-				bpf_task_release(p);
-				try_consume = true;
-				break;
-			}
-			bpf_task_release(p);
-			continue;
-		}
-
-		/*
-		 * if the task can run on either active or overflow set,
-		 * try another task.
-		 */
-		taskc = get_task_ctx(p);
-		if(taskc &&
-		(!test_task_flag(taskc, LAVD_FLAG_IS_AFFINITIZED) ||
-		bpf_cpumask_intersects(cast_mask(active), p->cpus_ptr) ||
-		bpf_cpumask_intersects(cast_mask(ovrflw), p->cpus_ptr))) {
-			bpf_task_release(p);
-			continue;
-		}
-
-		/*
-		 * now, we know that the task cannot run on either active
-		 * or overflow set. then, let's consider to extend the
-		 * overflow set.
-		 */
-		new_cpu = find_cpu_in(p->cpus_ptr, cpuc);
-		if (new_cpu >= 0) {
-			if (new_cpu == cpu) {
-				bpf_cpumask_set_cpu(new_cpu, ovrflw);
-				bpf_task_release(p);
-				try_consume = true;
-				break;
-			}
-			else if (!bpf_cpumask_test_and_set_cpu(new_cpu, ovrflw))
-				scx_bpf_kick_cpu(new_cpu, SCX_KICK_IDLE);
-		}
-		bpf_task_release(p);
+	try_consume = scan_dsq_for_ovflw_ext(cpdom_to_dsq(cpuc->cpdom_id),
+					     cpu, cpuc, active, ovrflw);
+	if (!try_consume) {
+		try_consume = scan_dsq_for_ovflw_ext(
+				cpdom_to_turb_dsq(cpuc->cpdom_id),
+				cpu, cpuc, active, ovrflw);
 	}
 
 	bpf_rcu_read_unlock();
@@ -1322,7 +1361,7 @@ consume_out:
 	/*
 	 * Otherwise, consume a task.
 	 */
-	if (consume_task(cpu_dsq_id, cpdom_dsq_id))
+	if (consume_task(cpuc->cpdom_id))
 		return;
 
 	/*


### PR DESCRIPTION
Two cross-cpdom paths skip the per-cpdom turbulent DSQ
(cpdom_to_turb_dsq) when scanning for work.  Tasks routed there
become invisible to load-balancing and dispatch, raising their
scheduling latency.

Stealer path
------------

pick_most_loaded_dsq() doesn't include the turbulent cpdom DSQ
in its depth comparison.  A cpdom whose backlog sits in its
turbulent DSQ looks empty to stealers, so its turbulent tasks
are not migrated to an under-loaded neighbor cpdom.  Fix:
compare both cpdom DSQ depths and pick the deeper; tie ->
non-turbulent first, matching the existing consume priority.

- [1/2] scx_lavd: include turbulent cpdom DSQ in pick_most_loaded_dsq()

Dispatch overflow extension
---------------------------

When lavd_dispatch() runs on a CPU outside the active+overflow
set, it scans only the non-turbulent cpdom DSQ for a
pinned/affinitized task that only this CPU can run.  A
non-vulnerable pinned task routed to the turbulent DSQ (per
get_target_dsq_id()) is missed when this CPU is its only legal
target, delaying its dispatch.  Fix: extract the body into
scan_dsq_for_ovflw_ext() and call it once per cpdom DSQ flavor.

- [2/2] scx_lavd: scan turbulent cpdom DSQ in dispatch overflow extension

Signed-off-by: Changwoo Min <changwoo@igalia.com>
