### PR TITLE
docs: sync OVERVIEW.md with renamed DSQ helpers

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -368,13 +368,12 @@ and one local dsq per CPU (`SCX_DSQ_LOCAL`). The BPF scheduler can manage
 an arbitrary number of dsq's using `scx_bpf_create_dsq()` and
 `scx_bpf_destroy_dsq()`.
 
-A CPU always executes a task from its local DSQ. A task is "dispatched" to a
-DSQ. A non-local DSQ is "consumed" to transfer a task to the consuming CPU's
-local DSQ.
+A CPU always executes a task from its local DSQ. A task is "inserted" into a
+DSQ. A task in a non-local DSQ is "moved" into the target CPU's local DSQ.
 
 When a CPU is looking for the next task to run, if the local DSQ is not
-empty, the first task is picked. Otherwise, the CPU tries to consume the
-global DSQ. If that doesn't yield a runnable task either, `ops.dispatch()`
+empty, the first task is picked. Otherwise, the CPU tries to move a task from
+the global DSQ. If that doesn't yield a runnable task either, `ops.dispatch()`
 is invoked.
 
 ### Scheduling cycle
@@ -394,9 +393,9 @@ The following briefly shows how a waking task is scheduled and executed.
    scheduler can wake up any cpu using the `scx_bpf_kick_cpu()` helper,
    using `ops.select_cpu()` judiciously can be simpler and more efficient.
 
-   A task can be immediately dispatched to a DSQ from `ops.select_cpu()` by
-   calling `scx_bpf_dispatch()`. If the task is dispatched to
-   `SCX_DSQ_LOCAL` from `ops.select_cpu()`, it will be dispatched to the
+   A task can be immediately inserted into a DSQ from `ops.select_cpu()` by
+   calling `scx_bpf_dsq_insert()`. If the task is inserted into
+   `SCX_DSQ_LOCAL` from `ops.select_cpu()`, it will be inserted into the
    local DSQ of whichever CPU is returned from `ops.select_cpu()`.
    Additionally, dispatching directly from `ops.select_cpu()` will cause the
    `ops.enqueue()` callback to be skipped.
@@ -408,12 +407,12 @@ The following briefly shows how a waking task is scheduled and executed.
    task was dispatched directly from `ops.select_cpu()`). `ops.enqueue()`
    can make one of the following decisions:
 
-   * Immediately dispatch the task to either the global or local DSQ by
-     calling `scx_bpf_dispatch()` with `SCX_DSQ_GLOBAL` or
+   * Immediately insert the task into either the global or local DSQ by
+     calling `scx_bpf_dsq_insert()` with `SCX_DSQ_GLOBAL` or
      `SCX_DSQ_LOCAL`, respectively.
 
-   * Immediately dispatch the task to a custom DSQ by calling
-     `scx_bpf_dispatch()` with a DSQ ID which is smaller than $2^{63}$.
+   * Immediately insert the task into a custom DSQ by calling
+     `scx_bpf_dsq_insert()` with a DSQ ID which is smaller than $2^{63}$.
 
    * Queue the task on the BPF side.
 
@@ -422,23 +421,24 @@ The following briefly shows how a waking task is scheduled and executed.
    run, `ops.dispatch()` is invoked which can use the following two
    functions to populate the local DSQ.
 
-   * `scx_bpf_dispatch()` dispatches a task to a DSQ. Any target DSQ can
+   * `scx_bpf_dsq_insert()` inserts a task into a DSQ. Any target DSQ can
      be used - `SCX_DSQ_LOCAL`, `SCX_DSQ_LOCAL_ON | cpu`,
-     `SCX_DSQ_GLOBAL` or a custom DSQ. While `scx_bpf_dispatch()`
+     `SCX_DSQ_GLOBAL` or a custom DSQ. While `scx_bpf_dsq_insert()`
      currently can't be called with BPF locks held, this is being worked on
-     and will be supported. `scx_bpf_dispatch()` schedules dispatching
+     and will be supported. `scx_bpf_dsq_insert()` schedules insertions
      rather than performing them immediately. There can be up to
      `ops.dispatch_max_batch` pending tasks.
 
-   * `scx_bpf_consume()` transfers a task from the specified non-local DSQ
-     to the dispatching DSQ. This function cannot be called with any BPF
-     locks held. `scx_bpf_consume()` flushes the pending dispatched tasks
-     before trying to consume the specified DSQ.
+   * `scx_bpf_dsq_move_to_local()` moves a task from the specified
+     non-local DSQ to the dispatching CPU's local DSQ. This function cannot
+     be called with any BPF locks held. `scx_bpf_dsq_move_to_local()`
+     flushes the pending insertions before trying to move from the
+     specified DSQ.
 
 4. After `ops.dispatch()` returns, if there are tasks in the local DSQ,
    the CPU runs the first one. If empty, the following steps are taken:
 
-   * Try to consume the global DSQ. If successful, run the task.
+   * Try to move from the global DSQ. If successful, run the task.
 
    * If `ops.dispatch()` has dispatched any tasks, retry #3.
 
@@ -452,17 +452,17 @@ there is no need to implement `ops.dispatch()` as a task is never queued on
 the BPF scheduler and both the local and global DSQs are consumed
 automatically.
 
-`scx_bpf_dispatch()` queues the task on the FIFO of the target DSQ. Use
-`scx_bpf_dispatch_vtime()` for the priority queue. Internal DSQs such as
+`scx_bpf_dsq_insert()` queues the task on the FIFO of the target DSQ. Use
+`scx_bpf_dsq_insert_vtime()` for the priority queue. Internal DSQs such as
 `SCX_DSQ_LOCAL` and `SCX_DSQ_GLOBAL` do not support priority-queue
-dispatching, and must be dispatched to with `scx_bpf_dispatch()`.
+dispatching, and tasks must be inserted into them with `scx_bpf_dsq_insert()`.
 
 ### Verifying callback behavior
 
 `sched_ext` always verifies that any value returned from a callback is valid, and
 will issue an error and unload the scheduler if it is not. For example, if
 `.select_cpu()` returns an invalid CPU, or if an attempt is made to invoke the
-`scx_bpf_dispatch()` with invalid enqueue flags. Furthermore, if a task remains
+`scx_bpf_dsq_insert()` with invalid enqueue flags. Furthermore, if a task remains
 runnable for too long without being scheduled, `sched_ext` will detect it and
 error-out the scheduler.
 


### PR DESCRIPTION
## Summary

`OVERVIEW.md` still documents the pre-v6.13 dispatch-queue helper names. The kernel renamed them:

| old | new |
|---|---|
| `scx_bpf_dispatch()` | `scx_bpf_dsq_insert()` |
| `scx_bpf_dispatch_vtime()` | `scx_bpf_dsq_insert_vtime()` |
| `scx_bpf_consume()` | `scx_bpf_dsq_move_to_local()` |

All in-tree schedulers under `scheds/` and the compat layer in `scheds/include/scx/compat.bpf.h` already use the new names — see e.g. `scheds/rust/scx_lavd/src/bpf/main.bpf.c:783` and the wrapper at `compat.bpf.h:336`. `OVERVIEW.md` is the last place a new reader encounters the old API.

This patch updates the helper references and adjusts the surrounding prose (`dispatched to` → `inserted into`, `consume` → `move from`) so the file matches the phrasing in the kernel's current [`Documentation/scheduler/sched-ext.rst`](https://www.kernel.org/doc/html/latest/scheduler/sched-ext.html).

No behavior claims are changed.

## Test plan

- [x] `grep -n "scx_bpf_dispatch\b\|scx_bpf_dispatch_vtime\b\|scx_bpf_consume\b" OVERVIEW.md` returns nothing
- [x] Resulting prose verified against upstream `sched-ext.rst` phrasing
- [x] `git diff --stat`: 24 insertions / 24 deletions, single file