### PR TITLE
kernel.config: Document CONFIG_SCHED_DEBUG removal in v6.15

### DIFF
--- a/kernel.config
+++ b/kernel.config
@@ -26,6 +26,9 @@ CONFIG_FUNCTION_TRACER=y
 
 # Enable scheduling debugging
 #
+# NOTE: CONFIG_SCHED_DEBUG was removed in Linux 6.15-rc1 (commit b52173065e0a)
+# as the functionality was made unconditional. This option is only applicable
+# to kernel versions < 6.15 and can be safely ignored for newer kernels.
 CONFIG_SCHED_DEBUG=y
 
 # Enable extra scheduling features (for a better code coverage while testing


### PR DESCRIPTION
Add a note explaining that CONFIG_SCHED_DEBUG was removed in Linux 6.15-rc1 (commit b52173065e0a) as the functionality became unconditional. This option is only applicable to kernel versions older than 6.15 and can be safely ignored when building newer kernels.

This helps avoid confusion when newer kernel configurations report this option as unrecognized or invalid.

Signed-off-by: Liang Luo <luoliang@kylinos.cn>