### PR TITLE
scx_cosmos: Server tuning

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -127,9 +127,9 @@ const volatile u64 perf_sticky;
 volatile u64 perf_sticky_threshold;
 
 /*
- * Enable tick-based preemption enforcement.
+ * Disable high-resolution preemption enforcement.
  */
-const volatile bool tick_preempt = true;
+const volatile bool time_preemption;
 
 /*
  * Ignore synchronous wakeup events.
@@ -1111,7 +1111,7 @@ void BPF_STRUCT_OPS(cosmos_tick, struct task_struct *p)
 {
 	struct task_ctx *tctx;
 
-	if (!tick_preempt)
+	if (!time_preemption)
 		return;
 
 	tctx = try_lookup_task_ctx(p);

--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -468,23 +468,6 @@ static void update_cpufreq(s32 cpu)
 }
 
 /*
- * Timer used to defer idle CPU wakeups.
- *
- * Instead of triggering wake-up events directly from hot paths, such as
- * ops.enqueue(), idle CPUs are kicked using the wake-up timer.
- */
-struct wakeup_timer {
-	struct bpf_timer timer;
-};
-
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, u32);
-	__type(value, struct wakeup_timer);
-} wakeup_timer SEC(".maps");
-
-/*
  * Return the global system shared DSQ.
  */
 static inline u64 shared_dsq(s32 cpu)

--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -584,6 +584,33 @@ static s32 smt_sibling(s32 cpu)
 }
 
 /*
+ * Return the cpumask of idle CPUs within the NUMA node that contains @cpu.
+ *
+ * If NUMA support is disabled, @cpu is ignored.
+ */
+static inline const struct cpumask *get_idle_cpumask(s32 cpu)
+{
+	if (!numa_enabled)
+		return scx_bpf_get_idle_cpumask();
+
+	return __COMPAT_scx_bpf_get_idle_cpumask_node(__COMPAT_scx_bpf_cpu_node(cpu));
+}
+
+/*
+ * Return the cpumask of idle SMT cores within the NUMA node that contains
+ * @cpu.
+ *
+ * If NUMA support is disabled, @cpu is ignored.
+ */
+static inline const struct cpumask *get_idle_smtmask(s32 cpu)
+{
+	if (!numa_enabled)
+		return scx_bpf_get_idle_smtmask();
+
+	return __COMPAT_scx_bpf_get_idle_smtmask_node(__COMPAT_scx_bpf_cpu_node(cpu));
+}
+
+/*
  * Return true if the CPU is part of a fully busy SMT core, false
  * otherwise.
  *
@@ -602,7 +629,7 @@ static bool is_smt_contended(s32 cpu)
 	 * If the sibling SMT CPU is not idle and there are other full-idle
 	 * SMT cores available, consider the current CPU as contended.
 	 */
-	idle_mask = scx_bpf_get_idle_cpumask();
+	idle_mask = get_idle_cpumask(cpu);
 	is_contended = !bpf_cpumask_test_cpu(smt_sibling(cpu), idle_mask) &&
 		       !bpf_cpumask_empty(idle_mask);
 	scx_bpf_put_cpumask(idle_mask);
@@ -741,7 +768,7 @@ static s32 pick_idle_cpu_flat(struct task_struct *p, s32 prev_cpu)
 	s32 cpu;
 
 	primary = !primary_all ? cast_mask(primary_cpumask) : NULL;
-	smt = smt_enabled ? scx_bpf_get_idle_smtmask() : NULL;
+	smt = smt_enabled ? get_idle_smtmask(prev_cpu) : NULL;
 
 	/*
 	 * If the task can't migrate, there's no point looking for other

--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -144,7 +144,7 @@ const volatile bool no_early_clear;
 /*
  * Default time slice.
  */
-const volatile u64 slice_ns = 1000000ULL;
+const volatile u64 slice_ns = 20000000ULL;
 
 /*
  * Maximum runtime that can be charged to a task.

--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -101,13 +101,6 @@ const volatile bool numa_enabled;
 const volatile bool gpu_enabled = true;
 
 /*
- * Aggressively try to avoid SMT contention.
- *
- * Default to true here, so veristat takes the more complicated path.
- */
-const volatile bool avoid_smt = true;
-
-/*
  * Enable address space affinity.
  */
 const volatile bool mm_affinity;
@@ -895,12 +888,11 @@ static s32 pick_idle_cpu(struct task_struct *p, s32 prev_cpu, s32 this_cpu,
 	}
 
 	/*
-	 * If a primary domain is defined, try to pick an idle CPU from
-	 * there first.
+	 * If a primary domain is defined, try to pick an idle CPU from there
+	 * first.
 	 */
 	if (!primary_all && mask) {
-		cpu = scx_bpf_select_cpu_and(p, prev_cpu, wake_flags, mask,
-					     avoid_smt ? SCX_PICK_IDLE_CORE : 0);
+		cpu = scx_bpf_select_cpu_and(p, prev_cpu, wake_flags, mask, 0);
 		if (cpu >= 0)
 			return cpu;
 	}
@@ -1137,11 +1129,10 @@ void BPF_STRUCT_OPS(cosmos_tick, struct task_struct *p)
 	 */
 	if (time_delta(bpf_ktime_get_ns(), tctx->last_run_at) > task_slice(p)) {
 		s32 cpu = scx_bpf_task_cpu(p);
-		bool smt_contention = avoid_smt && is_smt_contended(cpu);
 		bool cpu_busy = scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | cpu) ||
 				scx_bpf_dsq_nr_queued(shared_dsq(cpu));
 
-		if (smt_contention || (is_cpu_busy(cpu) && cpu_busy))
+		if (is_smt_contended(cpu) || (is_cpu_busy(cpu) && cpu_busy))
 			p->scx.slice = 0;
 	}
 }
@@ -1184,7 +1175,7 @@ void BPF_STRUCT_OPS(cosmos_enqueue, struct task_struct *p, u64 enq_flags)
 	 */
 	if (is_sticky_event_heavy(tctx) &&
 	    (is_primary_cpu(prev_cpu) || is_pcpu_task(p)) &&
-	    (!avoid_smt || !is_smt_contended(prev_cpu))) {
+	    !is_smt_contended(prev_cpu)) {
 		const struct task_struct *q = __COMPAT_scx_bpf_dsq_peek(shared_dsq(prev_cpu));
 
 		/*
@@ -1207,7 +1198,7 @@ void BPF_STRUCT_OPS(cosmos_enqueue, struct task_struct *p, u64 enq_flags)
 	 */
 	if (task_should_migrate(p, enq_flags) ||
 	    !is_cpu_idle(prev_cpu) ||
-	    (avoid_smt && is_smt_contended(prev_cpu)) ||
+	    is_smt_contended(prev_cpu) ||
 	    (!is_pcpu_task(p) && (is_event_heavy(tctx) || !is_primary_cpu(prev_cpu)))) {
 		if (is_pcpu_task(p))
 			cpu = test_cpu_idle(prev_cpu) ? prev_cpu : -EBUSY;
@@ -1270,7 +1261,7 @@ static bool keep_running(const struct task_struct *p, s32 cpu)
 	 * full-idle SMT cores available in the system, give it a chance to
 	 * migrate elsewhere.
 	 */
-	if (avoid_smt && is_smt_contended(cpu))
+	if (is_smt_contended(cpu))
 		return false;
 
 	/*

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -371,11 +371,7 @@ struct Opts {
     #[clap(long, action = clap::ArgAction::SetTrue)]
     disable_smt: bool,
 
-    /// SMT contention avoidance.
-    ///
-    /// When enabled, the scheduler aggressively avoids placing tasks on sibling SMT threads.
-    /// This may increase task migrations and lower overall throughput, but can lead to more
-    /// consistent performance by reducing contention on shared SMT cores.
+    /// ***DEPRECATED*** SMT contention avoidance.
     #[clap(short = 'S', long, action = clap::ArgAction::SetTrue)]
     avoid_smt: bool,
 
@@ -785,7 +781,6 @@ impl<'a> Scheduler<'a> {
         rodata.numa_enabled = numa_enabled;
         rodata.nr_node_ids = topo.nodes.len() as u32;
         rodata.no_wake_sync = opts.no_wake_sync;
-        rodata.avoid_smt = opts.avoid_smt;
         rodata.no_early_clear = opts.no_early_clear;
         rodata.tick_preempt = !opts.no_tick_preempt;
         rodata.mm_affinity = opts.mm_affinity;

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -396,12 +396,13 @@ struct Opts {
     #[clap(short = 'd', long, action = clap::ArgAction::SetTrue)]
     no_deferred_wakeup: bool,
 
-    /// Disable tick-based preemption enforcement.
+    /// Enable high-resolution timer preemption.
     ///
-    /// By default, the scheduler preempts tasks that exceed their time slice when the system is
-    /// busy or SMT contention is detected. Use this flag to disable this behavior.
+    /// By default, the scheduler preempts tasks that exceed their time slice, measuing the time
+    /// slice via the tick handler. Add an option to enforce preemption based on the high-precision
+    /// timer and CPU occupancy. Enable this option to improve latency-sensitive workloads.
     #[clap(long, action = clap::ArgAction::SetTrue)]
-    no_tick_preempt: bool,
+    time_preemption: bool,
 
     /// Enable address space affinity.
     ///
@@ -782,7 +783,7 @@ impl<'a> Scheduler<'a> {
         rodata.nr_node_ids = topo.nodes.len() as u32;
         rodata.no_wake_sync = opts.no_wake_sync;
         rodata.no_early_clear = opts.no_early_clear;
-        rodata.tick_preempt = !opts.no_tick_preempt;
+        rodata.time_preemption = opts.time_preemption;
         rodata.mm_affinity = opts.mm_affinity;
 
         // Enable perf event scheduling settings.

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -259,7 +259,7 @@ struct Opts {
     exit_dump_len: u32,
 
     /// Maximum scheduling slice duration in microseconds.
-    #[clap(short = 's', long, default_value = "1000")]
+    #[clap(short = 's', long, default_value = "20000")]
     slice_us: u64,
 
     /// Maximum runtime (since last sleep) that can be charged to a task in microseconds.

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -861,7 +861,12 @@ impl<'a> Scheduler<'a> {
         skel.struct_ops.cosmos_ops_mut().flags = *compat::SCX_OPS_ENQ_EXITING
             | *compat::SCX_OPS_ENQ_LAST
             | *compat::SCX_OPS_ENQ_MIGRATION_DISABLED
-            | *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP;
+            | *compat::SCX_OPS_ALLOW_QUEUED_WAKEUP
+            | if numa_enabled {
+                *compat::SCX_OPS_BUILTIN_IDLE_PER_NODE
+            } else {
+                0
+            };
 
         info!(
             "scheduler flags: {:#x}",

--- a/services/scx
+++ b/services/scx
@@ -2,4 +2,4 @@
 SCX_SCHEDULER=scx_cosmos
 
 # Set custom flags for each scheduler, below is an example of how to use
-SCX_FLAGS='-s 700 -S'
+#SCX_FLAGS='-s 700 -S'


### PR DESCRIPTION
scx_cosmos has recently shifted its focus toward more CPU-intensive, server-oriented workloads. This set of changes tunes the scheduler defaults to better match large server systems out of the box. At the same time, the scheduler continues to prioritize latency and responsiveness, so little to no behavioral changes are expected on desktops or smaller systems.

A follow-up change will also update the default settings in scx-loader accordingly:
https://github.com/sched-ext/scx-loader