### PR TITLE
scx_flow: cpufreq performance hint for latency-lane dispatches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "scx_flow"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/scheds/experimental/scx_flow/Cargo.toml
+++ b/scheds/experimental/scx_flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_flow"
-version = "2.2.5"
+version = "2.2.6"
 authors = ["Galih Tama <galpt@v.recipes>"]
 edition = "2021"
 description = "A multi-lane budget-based sched_ext scheduler for interactive responsiveness and general-purpose throughput. https://github.com/sched-ext/scx/tree/main"

--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -971,7 +971,8 @@ static __always_inline void note_local_reserved_fast(struct flow_cpu_state *csta
 		cstate->local_reserved_burst_rounds++;
 }
 
-static __always_inline void note_urgent_latency_dispatch(struct flow_cpu_state *cstate)
+static __always_inline void note_urgent_latency_dispatch(struct flow_cpu_state *cstate,
+							  s32 cpu)
 {
 	if (cstate && cstate->urgent_latency_burst_rounds > 0)
 		FLOW_CPUSTAT_INC(cstate, urgent_latency_burst_continuations);
@@ -982,6 +983,7 @@ static __always_inline void note_urgent_latency_dispatch(struct flow_cpu_state *
 	FLOW_CPUSTAT_INC(cstate, urgent_latency_burst_grants);
 	reset_reserved_lane_burst(cstate);
 	note_high_priority_dispatch(cstate);
+	scx_bpf_cpuperf_set(cpu, SCX_CPUPERF_ONE);
 }
 
 static __always_inline void note_reserved_dispatch(struct flow_cpu_state *cstate)
@@ -1614,7 +1616,7 @@ void BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
 	if (urgent_burst_rounds < tuned_urgent_latency_burst_max() &&
 	    scx_bpf_dsq_move_to_local(URGENT_LATENCY_DSQ, 0)) {
 		reset_local_reserved_burst(cstate);
-		note_urgent_latency_dispatch(cstate);
+		note_urgent_latency_dispatch(cstate, cpu);
 		return;
 	}
 
@@ -1624,6 +1626,7 @@ void BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
 		reset_local_reserved_burst(cstate);
 		FLOW_CPUSTAT_INC(cstate, latency_dispatches);
 		note_high_priority_dispatch(cstate);
+		scx_bpf_cpuperf_set(cpu, SCX_CPUPERF_ONE);
 		return;
 	}
 


### PR DESCRIPTION
scx_flow's dispatch path for latency-sensitive tasks (LATENCY_DSQ and URGENT_LATENCY_DSQ) does not set a cpufreq performance hint. The kernel tracks PELT utilization for sched_ext tasks, but the PELT time constant (~32ms half-life) can be slower to respond than an explicit hint on each scheduling event. On a latency-lane dispatch the scheduler already knows the task is time-sensitive, so it can request a frequency ramp immediately rather than waiting for the utilization signal to build up.

Fix by calling scx_bpf_cpuperf_set(SCX_CPUPERF_ONE) at two sites:

  - note_urgent_latency_dispatch(), the existing helper that tracks urgent-latency burst accounting
  - the LATENCY_DSQ consume path in flow_dispatch()

Only these two lanes are targeted. Tasks reach them only after accumulating latency allowance or latency pressure through the scheduler's own classification, so the hint is backed by proven sensitivity. Reserved, contained, and shared dispatches are left to the kernel's default governor.

Signed-off-by: Galih Tama <galpt@v.recipes>
