### PR TITLE
scx_cake: Downgrade sysinfo dependency

### DIFF
--- a/scheds/rust/scx_cake/Cargo.toml
+++ b/scheds/rust/scx_cake/Cargo.toml
@@ -20,7 +20,7 @@ arboard = "3"
 
 scx_utils = { path = "../../../rust/scx_utils", version = "1.1.1" }
 scx_arena = { path = "../../../rust/scx_arena/scx_arena", version = "1.1.1" }
-sysinfo = "0.39"
+sysinfo = "0.38"
 core_affinity = "0.8"
 quanta = "0.12"
 crossbeam-utils = "0.8"


### PR DESCRIPTION
scx_cake currently rewquires sysinfo >= 0.39, which in turn requires rustc >= 1.95. This breaks builds on Ubuntu 24.04, where the newest rustc version currently available in the distro is 1.91:

 error: rustc 1.91.1 is not supported by the following package:
  sysinfo@0.39.1 requires rustc 1.95

scx_cake does not rely on any specific features introduced in sysinfo 0.39, so downgrade the dependency to 0.38 to restore compatibility with Ubuntu.