### PR TITLE
scx_lavd: Per-CPU DSQ queued-load tracking

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -281,7 +281,7 @@ u64 __attribute__((noinline)) dsq_peek_task_load(u64 dsq_id)
 u64 __attribute__((noinline)) pick_most_loaded_dsq(struct cpdom_ctx *cpdomc)
 {
 	u64 pick_dsq_id = -ENOENT;
-	s32 highest_queued = -1;
+	u64 highest_load = 0;
 
 	if (!cpdomc) {
 		scx_bpf_error("Invalid cpdom context");
@@ -289,13 +289,12 @@ u64 __attribute__((noinline)) pick_most_loaded_dsq(struct cpdom_ctx *cpdomc)
 	}
 
 	/*
-	 * For simplicity, try to just steal from the (either per-CPU or
-	 * per-domain) DSQs with the highest number of queued_tasks
-	 * in this domain.
+	 * Pick the (per-CPU or per-domain) DSQ in this compute domain
+	 * with the highest RAVG-weighted queued load.
 	 */
 	if (use_cpdom_dsq()) {
 		pick_dsq_id = cpdom_to_dsq(cpdomc->id);
-		highest_queued = scx_bpf_dsq_nr_queued(pick_dsq_id);
+		highest_load = READ_ONCE(cpdomc->qload_invr);
 	}
 
 	/*
@@ -309,17 +308,20 @@ u64 __attribute__((noinline)) pick_most_loaded_dsq(struct cpdom_ctx *cpdomc)
 		bpf_for(i, 0, LAVD_CPU_ID_MAX/64) {
 			u64 cpumask = cpdomc->__cpumask[i];
 			bpf_for(k, 0, 64) {
-				s32 queued;
+				struct cpu_ctx *cpuc;
+				u64 load;
+
 				j = cpumask_next_set_bit(&cpumask);
 				if (j < 0)
 					break;
 				cpu = (i * 64) + j;
 				if (cpu >= nr_cpu_ids)
 					break;
-				queued = scx_bpf_dsq_nr_queued(cpu_to_dsq(cpu)) +
-					 scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | cpu);
-				if (queued > highest_queued) {
-					highest_queued = queued;
+
+				cpuc = get_cpu_ctx_id(cpu);
+				load = cpuc ? READ_ONCE(cpuc->qload_invr) : 0;
+				if (load > highest_load) {
+					highest_load = load;
 					pick_cpu = cpu;
 				}
 			}
@@ -380,6 +382,15 @@ static bool try_to_steal_task(struct cpdom_ctx *cpdomc)
 				continue;
 
 			dsq_id = pick_most_loaded_dsq(cpdomc_pick);
+
+			/*
+			 * No DSQ in cpdomc_pick has any queued load.
+			 * Move on to the next neighbor rather than passing
+			 * -ENOENT to dsq_peek_task_load() / consume_dsq(),
+			 * which would abort the scheduler.
+			 */
+			if ((s64)dsq_id < 0)
+				continue;
 
 			/*
 			 * Peek at the head task to get its size for budget
@@ -468,6 +479,12 @@ static bool force_to_steal_task(struct cpdom_ctx *cpdomc)
 				continue;
 
 			dsq_id = pick_most_loaded_dsq(cpdomc_pick);
+			/*
+			 * Same defensive check as the try_to_steal_task
+			 * path above.
+			 */
+			if ((s64)dsq_id < 0)
+				continue;
 
 			/*
 			 * Peek at the head task to get its size. Skip the

--- a/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/balance.bpf.c
@@ -294,7 +294,10 @@ u64 __attribute__((noinline)) pick_most_loaded_dsq(struct cpdom_ctx *cpdomc)
 	 */
 	if (use_cpdom_dsq()) {
 		pick_dsq_id = cpdom_to_dsq(cpdomc->id);
-		highest_load = READ_ONCE(cpdomc->qload_invr);
+		if (no_fast_lb)
+			highest_load = scx_bpf_dsq_nr_queued(pick_dsq_id);
+		else
+			highest_load = READ_ONCE(cpdomc->qload_invr);
 	}
 
 	/*
@@ -308,7 +311,6 @@ u64 __attribute__((noinline)) pick_most_loaded_dsq(struct cpdom_ctx *cpdomc)
 		bpf_for(i, 0, LAVD_CPU_ID_MAX/64) {
 			u64 cpumask = cpdomc->__cpumask[i];
 			bpf_for(k, 0, 64) {
-				struct cpu_ctx *cpuc;
 				u64 load;
 
 				j = cpumask_next_set_bit(&cpumask);
@@ -318,8 +320,13 @@ u64 __attribute__((noinline)) pick_most_loaded_dsq(struct cpdom_ctx *cpdomc)
 				if (cpu >= nr_cpu_ids)
 					break;
 
-				cpuc = get_cpu_ctx_id(cpu);
-				load = cpuc ? READ_ONCE(cpuc->qload_invr) : 0;
+				if (no_fast_lb) {
+					load = scx_bpf_dsq_nr_queued(cpu_to_dsq(cpu)) +
+					       scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | cpu);
+				} else {
+					struct cpu_ctx *cpuc = get_cpu_ctx_id(cpu);
+					load = cpuc ? READ_ONCE(cpuc->qload_invr) : 0;
+				}
 				if (load > highest_load) {
 					highest_load = load;
 					pick_cpu = cpu;

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -228,12 +228,15 @@ struct task_ctx {
 	u32	cpu_id;			/* where a task is running now */
 	u32	prev_cpu_id;		/* where a task ran last time */
 	u8	queued_in_cpdom_id;	/* cpdom this task's load is counted in; LAVD_CPDOM_MAX_NR = not queued */
-	u32	queued_load_snapshot;	/* task_load_metric() value snapshotted at enqueue time */
+	s16	queued_on_cpu_id;	/* primary CPU id this task's load is counted on; -1 = not queued */
+	u32	queued_load_snapshot;	/* task_load_metric() value snapshotted at enqueue time for the per-cpdom counter */
+	u32	queued_load_snapshot_cpu; /* task_load_metric() value snapshotted at enqueue time for the per-CPU counter */
 	pid_t	pid;			/* pid for this task */
 	pid_t	waker_pid;		/* last waker's PID */
 
-	/* --- cacheline 4 boundary (256 bytes) --- */
-	u32	util_est;		/* Estimated task util using ravg duty cycle */
+	/* --- cacheline 5 boundary (320 bytes): ravg/util read-mostly group --- */
+	u32	util_est __attribute__((aligned(CACHELINE_SIZE)));
+					/* Estimated task util using ravg duty cycle */
 	struct ravg_data avg_util_ravg;	/* Running average of task utilization using ravg */
 	char	waker_comm[TASK_COMM_LEN + 1]; /* last waker's comm */
 } __attribute__((aligned(CACHELINE_SIZE)));
@@ -529,6 +532,14 @@ struct cpu_ctx {
 	struct ravg_data avg_irq_steal_ravg;	/* Running average of IRQ steal utilization using ravg */
 	struct ravg_data avg_util_ravg;	/* Running average of CPU utilization using ravg */
 	volatile u32	util_est;	/* Estimated CPU utilization from ravg tracking */
+
+	/* --- cacheline 7 boundary (448 bytes): cross-CPU write-heavy accumulator --- */
+	/*
+	 * qload_invr is incremented from any CPU on enqueue (remote write
+	 * via bpf_map_lookup_percpu_elem + __sync_fetch_and_add) and
+	 * decremented likewise on dispatch/dequeue/exit.
+	 */
+	u64	qload_invr __attribute__((aligned(CACHELINE_SIZE)));
 } __attribute__((aligned(CACHELINE_SIZE)));
 
 extern const volatile u64	nr_llcs;	/* number of LLC domains */

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -706,6 +706,41 @@ static __always_inline void unaccount_queued_load(task_ctx *taskc)
 	WRITE_ONCE(taskc->queued_in_cpdom_id, LAVD_CPDOM_MAX_NR);
 }
 
+static __always_inline void account_queued_load_pcpu(task_ctx *taskc,
+						     s32 primary_cpu)
+{
+	struct cpu_ctx *cpuc;
+	u32 load;
+
+	if (primary_cpu < 0 || primary_cpu >= LAVD_CPU_ID_MAX)
+		return;
+
+	if (READ_ONCE(taskc->queued_on_cpu_id) >= 0)
+		return;
+
+	load = task_load_metric(taskc);
+	cpuc = get_cpu_ctx_id(primary_cpu);
+	if (cpuc)
+		__sync_fetch_and_add(&cpuc->qload_invr, load);
+	taskc->queued_load_snapshot_cpu = load;
+	WRITE_ONCE(taskc->queued_on_cpu_id, (s16)primary_cpu);
+}
+
+static __always_inline void unaccount_queued_load_pcpu(task_ctx *taskc)
+{
+	struct cpu_ctx *cpuc;
+	s16 primary_cpu = READ_ONCE(taskc->queued_on_cpu_id);
+
+	if (primary_cpu < 0)
+		return;
+
+	cpuc = get_cpu_ctx_id(primary_cpu);
+	if (cpuc)
+		__sync_fetch_and_sub(&cpuc->qload_invr,
+				     taskc->queued_load_snapshot_cpu);
+	WRITE_ONCE(taskc->queued_on_cpu_id, -1);
+}
+
 static int cgroup_throttled(struct task_struct *p, task_ctx *taskc, bool put_aside)
 {
 	int ret, ret2;
@@ -820,6 +855,8 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 			p->scx.dsq_vtime = calc_when_to_run(p, ictx.taskc);
 			p->scx.slice = LAVD_SLICE_MAX_NS_DFL;
 			account_queued_load(ictx.taskc, cpuc->cpdom_id);
+			account_queued_load_pcpu(ictx.taskc,
+						 get_primary_cpu(cpuc->cpu_id));
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, p->scx.slice, 0);
 			goto out;
 		}
@@ -941,10 +978,13 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 	if (can_direct_dispatch(cpuc, is_idle)) {
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, p->scx.slice,
 				   enq_flags);
+		account_queued_load_pcpu(taskc, get_primary_cpu(cpu));
 	} else {
 		dsq_id = get_target_dsq_id(p, cpuc, taskc);
 		scx_bpf_dsq_insert_vtime(p, dsq_id, p->scx.slice,
 					 p->scx.dsq_vtime, enq_flags);
+		if (dsq_type(dsq_id) == LAVD_DSQ_TYPE_CPU)
+			account_queued_load_pcpu(taskc, dsq_to_cpu(dsq_id));
 	}
 	account_queued_load(taskc, cpuc->cpdom_id);
 
@@ -1060,6 +1100,8 @@ int enqueue_cb(struct task_struct __arg_trusted *p, task_ctx *taskc)
 	dsq_id = get_target_dsq_id(p, cpuc, taskc);
 	scx_bpf_dsq_insert_vtime(p, dsq_id, p->scx.slice, p->scx.dsq_vtime, 0);
 	account_queued_load(taskc, cpuc->cpdom_id);
+	if (dsq_type(dsq_id) == LAVD_DSQ_TYPE_CPU)
+		account_queued_load_pcpu(taskc, dsq_to_cpu(dsq_id));
 
 	/*
 	 * Kick the target CPU if it is idle. Test-and-clear avoids
@@ -1087,8 +1129,10 @@ void BPF_STRUCT_OPS(lavd_dequeue, struct task_struct *p, u64 deq_flags)
 	 * in lavd_running(). Skip for non-running dequeues only
 	 * (SCX_DEQ_CORE_SCHED_EXEC, migration, etc.).
 	 */
-	if (p != __COMPAT_scx_bpf_cpu_curr(scx_bpf_task_cpu(p)))
+	if (p != __COMPAT_scx_bpf_cpu_curr(scx_bpf_task_cpu(p))) {
 		unaccount_queued_load(taskc);
+		unaccount_queued_load_pcpu(taskc);
+	}
 
 	if (!enable_cpu_bw)
 		return;
@@ -1510,6 +1554,7 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 	}
 
 	unaccount_queued_load(taskc);
+	unaccount_queued_load_pcpu(taskc);
 
 	/*
 	 * If the sched_ext core directly dispatched a task, calculating the
@@ -2026,6 +2071,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init_task, struct task_struct *p,
 	taskc->suggested_cpu_id = scx_bpf_task_cpu(p);
 	taskc->pinned_cpu_id = -ENOENT;
 	WRITE_ONCE(taskc->queued_in_cpdom_id, LAVD_CPDOM_MAX_NR);
+	WRITE_ONCE(taskc->queued_on_cpu_id, -1);
 	taskc->pid = p->pid;
 	taskc->cgrp_id = args->cgroup->kn->id;
 
@@ -2061,8 +2107,10 @@ s32 BPF_STRUCT_OPS(lavd_exit_task, struct task_struct *p,
 	 * still be queued. Unaccount its load. If running,
 	 * lavd_running() already unaccounted it.
 	 */
-	if (taskc && p != __COMPAT_scx_bpf_cpu_curr(scx_bpf_task_cpu(p)))
+	if (taskc && p != __COMPAT_scx_bpf_cpu_curr(scx_bpf_task_cpu(p))) {
 		unaccount_queued_load(taskc);
+		unaccount_queued_load_pcpu(taskc);
+	}
 
 	scx_task_free(p);
 	return 0;
@@ -2301,6 +2349,7 @@ static s32 init_per_cpu_ctx(u64 now)
 		cpuc->idle_start_clk = 0;
 		cpuc->lat_cri = 0;
 		cpuc->running_clk = 0;
+		cpuc->qload_invr = 0;
 		cpuc->est_stopping_clk = SCX_SLICE_INF;
 		cpuc->is_online = bpf_cpumask_test_cpu(cpu, online_cpumask);
 		cpuc->max_capacity = cpu_capacity[cpu];

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -7,6 +7,7 @@
 #include <scx/common.bpf.h>
 #include "intf.h"
 #include "lavd.bpf.h"
+#include "util.bpf.h"
 #include "power.bpf.h"
 #include <errno.h>
 #include <stdbool.h>
@@ -142,7 +143,7 @@ static void collect_sys_stat(void)
 					break;
 
 				cpdomc->nr_queued_task += scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | cpu);
-				if (use_per_cpu_dsq())
+				if (use_per_cpu_dsq() && cpu == get_primary_cpu(cpu))
 					cpdomc->nr_queued_task += scx_bpf_dsq_nr_queued(cpu_to_dsq(cpu));
 			}
 		}


### PR DESCRIPTION
# scx_lavd: Per-CPU DSQ queued-load tracking

This series extends scx_lavd's RAVG-weighted `qload_invr` accumulator —
introduced for the per-domain load balancer in 7a4266eab0f5 and consumed
by the cross-cpdom fast-LB picker in e63dc3b64f3e — onto the per-CPU DSQ
path. When `--per-cpu-dsq` is enabled, `pick_most_loaded_dsq` now reads
the same task-size-weighted metric the cross-cpdom LB has used instead
of falling back to raw `scx_bpf_dsq_nr_queued()` counts.

The change is intended as the bedrock for a future inter-CPU load
balancer.

## Patches

1. **scx_lavd: Track per-CPU queued load using RAVG util_est** — Lays
   the bedrock for per-CPU load balancing by mirroring the per-domain
   `qload_invr` accumulator onto `cpu_ctx`. Future load-tracking and
   enqueue-decision heuristics get an accurate, per-CPU load signal.

2. **scx_lavd: Use per-CPU queued load in pick_most_loaded_dsq** —
   Switches the comparison metric from raw DSQ queue lengths
   to the RAVG-weighted `qload_invr`. 

3. **scx_lavd: Fix nr_queued double-count for SMT in sys_stat
   aggregation** — Pre-existing aggregation bug uncovered while
   reviewing the area: `cpu_to_dsq()` collapses SMT siblings to the
   primary (since fbd147521961), so the `sys_stat` loop counted each
   per-CPU DSQ twice on SMT hosts when `--per-cpu-dsq` was set.

4. **scx_lavd: Respect --no-fast-lb in pick_most_loaded_dsq** —
   Mirrors the dual-metric pattern `plan_x_cpdom_migration` has had
   since c2678ad99827: `--no-fast-lb` falls back to the pre-feature
   count metric, giving users who set that knob the same end-to-end
   picker behavior as before this series.

## Testing

Workload: memtier_benchmark against memcached, **Zipfian access**
(`--key-pattern=Z:Z --key-zipf-exp=0.99`) over 1 M keys, OLAP ratio
(`--ratio=1:10`, ~91 % read), 16 threads × 50 conns = 800 client
connections, 128 B values. Per scenario: 1 × 10 s warm-up + **10 × 30 s**
measurement runs, **trimmed mean** (drop min+max, average middle 8).

Three schedulers compared:

- `eevdf` — kernel default
- `lavd_pcd` — `scx_lavd --performance --slice-min-us 3000 --slice-max-us 10000 --pinned-slice-us 3000 --per-cpu-dsq` (current behavior)
- `lavd_pcd_ql` — same flags, **this branch** with queue-load tracking

Six scenarios: unpinned 100 % / 75 % / 50 % / 25 % (rate-limited),
`pin16` (cpu 0-15, 2 CCDs), `pin8` (cpu 0-7, single CCD / single L3).
Loopback only, no NIC. 800 client connections × per-conn rate =
total target RPS.

### pin8 (cpu 0-7, single CCD / single L3)

The previous behavior had a catastrophic worst-case tail when
constrained to one CCD. The new queue-load tracking eliminates it:

| metric | eevdf | lavd_pcd (old) | **lavd_pcd_ql (new)** | new vs old |
|---|---:|---:|---:|---:|
| ops/sec | 1,091,087 | 1,371,969 | **1,403,858** | +2.3 % |
| p50 (ms) | 0.725 | **0.060** | 0.192 | +220 % (still 3.8× better than EEVDF) |
| p90 | **0.964** | 1.013 | 1.661 | +64 % |
| p99 | **1.171** | 7.323 | **2.477** | **−66.2 %** |
| **p99.9** | 2.033 | **40.823** | **4.139** | **−89.9 %** |

### Unpinned (192 CPUs)

ops/sec — the new branch wins back the throughput that old
`--per-cpu-dsq` lost at 192-CPU saturation:

| load | eevdf | lavd_pcd (old) | **lavd_pcd_ql (new)** | new vs old |
|---|---:|---:|---:|---:|
| 100 % | 1,088,371 | 915,424 | **1,148,894** | **+25.5 %** |
| 75 % | 830,292 | 789,724 | 844,659 | +7.0 % |
| 50 % | 599,687 | 595,078 | 597,678 | +0.4 % |
| 25 % | 294,408 | 294,367 | 294,330 | −0.0 % |

p99 latency:

| load | eevdf | lavd_pcd (old) | **lavd_pcd_ql (new)** | new vs old |
|---|---:|---:|---:|---:|
| 100 % | **0.826** | 1.825 | 0.919 | −49.6 % |
| 75 % | **0.842** | 1.627 | 1.052 | −35.3 % |
| 50 % | **0.824** | 1.433 | 1.102 | −23.1 % |
| 25 % | **1.599** | 2.274 | 2.575 | +13.2 % |

p99.9 latency — **most metrics improved, one regression at 75 % load**:

| load | eevdf | lavd_pcd (old) | **lavd_pcd_ql (new)** | new vs old |
|---|---:|---:|---:|---:|
| 100 % | **1.314** | 2.697 | 1.611 | −40.3 % |
| 75 % | **1.449** | 5.315 | **9.439** | **+77.6 %** ⚠️ |
| 50 % | **1.554** | 8.091 | 7.663 | −5.3 % |
| 25 % | **2.467** | 5.391 | 5.443 | +1.0 % |

### Pinned 16 CPUs (2 CCDs on socket 0)

| metric | eevdf | lavd_pcd (old) | **lavd_pcd_ql (new)** | new vs old |
|---|---:|---:|---:|---:|
| ops/sec | 1,308,808 | **1,555,573** | 1,510,863 | −2.9 % |
| p50 | 0.521 | 0.353 | **0.326** | −7.6 % |
| p90 | **1.080** | 1.183 | 1.254 | +6.0 % |
| p99 | **1.840** | 2.026 | 2.076 | +2.5 % |
| p99.9 | 10.375 | **3.185** | 4.261 | +33.8 % |

## Notes

- **Cache-line placement of `cpu_ctx::qload_invr` is still open.**
  The current patch force-aligns the new field to its own cacheline
  to avoid false-sharing. It's not obvious whether there's a
  better slot inside the existing layout that would avoid introducing
  a new cacheline without disturbing the established access
  patterns Changwoo carefully laid out — would appreciate Changwoo's
  take on whether this placement is acceptable as-is or whether the
  field should be tucked into existing slack elsewhere. Verified the
  current layout via `pahole`.
