### PR TITLE
scx_cosmos: Skip CPU-less NUMA nodes when creating per-node DSQ

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -1485,14 +1485,29 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(cosmos_init)
 		int node;
 
 		bpf_for(node, 0, nr_node_ids) {
-			err = scx_bpf_create_dsq(node, node);
-			if (err) {
-				scx_bpf_error("failed to create node DSQ %d: %d", node, err);
-				return err;
-			}
+			struct node_ctx *nctx;
+
 			err = init_node(node);
 			if (err) {
 				scx_bpf_error("failed to initialize NUMA node %d: %d", node, err);
+				return err;
+			}
+
+			/*
+			 * Skip per-node DSQ creation for CPU-less NUMA nodes
+			 * (e.g. GPU-memory or CXL-memory nodes): with no CPU
+			 * to consume from it, the DSQ would never be used.
+			 * init_node() already populated nctx->cpumask, so an
+			 * empty mask means the node has no CPU.
+			 */
+			nctx = try_lookup_node_ctx(node);
+			if (!nctx || !nctx->cpumask ||
+			    bpf_cpumask_empty(cast_mask(nctx->cpumask)))
+				continue;
+
+			err = scx_bpf_create_dsq(node, node);
+			if (err) {
+				scx_bpf_error("failed to create node DSQ %d: %d", node, err);
 				return err;
 			}
 		}


### PR DESCRIPTION
## Summary
`cosmost_init()` iterates over every NUMA node and creates a per-node DSQ plus a node context. On systems with CPU-less NUMA nodes, e.g. GPU-memory node or CXL memory node, this will create DSQs with node contexts for nodes that have no CPU at all.

Implement `node_has_cpus()` helper and skip CPU-less nodes in the init loop.

On a 40-node system with 38 CPU-less nodes this drops per-node DSQ creation from 40 to 2, and shortens the init loop by ~27%.

## Result Before/After
  | Metric                     | Baseline           | Patched            | Δ                        |
  |----------------------------|--------------------|--------------------|--------------------------|
  | **Per-node DSQs created**  | **40** (all runs)  | **2** (all runs)   | −38 dead DSQs            |
  | Init loop, median          | 240.5 µs           | 174.4 µs           | **−66 µs (~27% faster)** |
  | Init loop, min             | 211.6 µs           | 162.4 µs           | −49 µs (~23%)            |

## Note
The same "dead DSQ for CPU-less NUMA node" scenario pattern likely exists in other scx schedulers as well, if it is the case, I'll be happy for assist on fixing those cases, and I think "node_has_cpus()" helper will be put in utils file , etc rather than inside scx_cosmos only.