### PR TITLE
scx_soft_domain: ‌through topology-aware scheduling to improve perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6453,6 +6453,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scx_soft_domain"
+version = "1.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ctrlc",
+ "libbpf-rs",
+ "libc",
+ "log",
+ "num_cpus",
+ "scx_bpf_compat",
+ "scx_cargo",
+ "scx_stats",
+ "scx_stats_derive",
+ "scx_utils",
+ "simplelog",
+]
+
+[[package]]
 name = "scx_stats"
 version = "1.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "scheds/rust/scx_tickless",
     "scheds/experimental/scx_flow",
     "scheds/experimental/scx_rlfifo",
+    "scheds/experimental/scx_soft_domain",
     "tools/scx_characterize",
     "tools/scxtop",
     "tools/scx_forge_agent",

--- a/scheds/experimental/scx_soft_domain/Cargo.toml
+++ b/scheds/experimental/scx_soft_domain/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "scx_soft_domain"
+version = "1.1.0"
+authors = ["Yang Chen <yangchen145@huawei.com>"]
+edition = "2021"
+description = "A Rust sched_ext soft-domain scheduler that preserves LLC and NUMA locality."
+license = "GPL-2.0-only"
+
+[dependencies]
+anyhow = "1.0.102"
+clap = { version = "4.6.1", features = ["derive", "env", "unicode", "wrap_help"] }
+libbpf-rs = "=0.26.2"
+ctrlc = { version = "3.5.2", features = ["termination"] }
+libc = "0.2.186"
+log = "0.4.29"
+simplelog = "0.12.2"
+num_cpus = "1.17.0"
+
+scx_bpf_compat = { path = "../../../rust/scx_bpf_compat", version = "1.1.2" }
+scx_stats = { path = "../../../rust/scx_stats", version = "1.1.2" }
+scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.1.2" }
+scx_utils = { path = "../../../rust/scx_utils", version = "1.1.2" }
+
+[build-dependencies]
+scx_cargo = { path = "../../../rust/scx_cargo", version = "1.1.2" }
+

--- a/scheds/experimental/scx_soft_domain/README.md
+++ b/scheds/experimental/scx_soft_domain/README.md
@@ -1,0 +1,55 @@
+# scx_soft_domain
+
+`scx_soft_domain` is a Rust scheduler for [`sched_ext`](https://github.com/sched-ext/scx/tree/main) that favors LLC and NUMA locality by keeping tasks on local domain CPUs.
+
+## Overview
+
+The scheduler reduces cross-node and cross-cache traffic by selecting CPUs based on underlying hardware topology and task affinity. It is intended for environments where memory locality and interference reduction are important.
+
+## Features
+
+- LLC-aware CPU selection
+- NUMA node affinity preservation
+- Per-task command filtering
+- Lightweight BPF-based policy for `sched_ext`
+
+## Building
+
+```bash
+cargo build -p scx_soft_domain
+cargo build --release -p scx_soft_domain
+```
+
+## Running
+
+For debug builds:
+
+```bash
+./target/debug/scx_soft_domain [options]
+```
+
+For release builds:
+
+```bash
+./target/release/scx_soft_domain [options]
+```
+
+## Options
+
+- `-l <node>`: restrict scheduling to the specified NUMA node
+- `-P <comm>`: only schedule tasks whose command name matches `comm`
+- `-v`: increase verbose logging; repeat for more detail
+- `-V`: print scheduler version and exit
+- `--help`: show scheduler and libbpf options
+
+> Note: the scheduler currently does not expose interactive debug output or runtime statistics printing beyond internal CPU load tracking.
+
+## Requirements
+
+- Linux with `sched_ext` support
+- `libbpf` and the Rust `libbpf-rs` bindings
+- root privileges to load the BPF scheduler
+
+## License
+
+GPL-2.0-only

--- a/scheds/experimental/scx_soft_domain/build.rs
+++ b/scheds/experimental/scx_soft_domain/build.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+fn main() {
+    let commit_id = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|hash| format!(" (git commit id: {})", hash.trim()))
+        .unwrap_or_else(|| "".to_string());
+
+    println!("cargo:rustc-env=GIT_COMMIT_ID={}", commit_id);
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
+    scx_cargo::BpfBuilder::new()
+        .unwrap()
+        .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
+        .enable_skel("src/bpf/main.bpf.c", "bpf")
+        .compile_link_gen()
+        .unwrap();
+}

--- a/scheds/experimental/scx_soft_domain/src/bpf/intf.h
+++ b/scheds/experimental/scx_soft_domain/src/bpf/intf.h
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef __INTF_H
+#define __INTF_H
+
+#include <stdbool.h>
+
+#ifndef __kptr
+#ifdef __KERNEL__
+#error "__kptr_ref not defined in the kernel"
+#endif
+#define __kptr
+#endif
+
+#ifndef __KERNEL__
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef int s32;
+typedef unsigned int u32;
+typedef long long s64;
+typedef unsigned long long u64;
+#else
+#include <scx/common.bpf.h>
+#endif
+
+#ifndef MAX_NUMA_NODES
+#define MAX_NUMA_NODES 8
+#endif
+
+#ifndef MAX_LLCS
+#define MAX_LLCS 96
+#endif
+
+#ifndef MAX_LLC_ID
+#define MAX_LLC_ID 16334
+#endif
+
+#ifndef MAX_CPUS
+#define MAX_CPUS 640
+#endif
+
+#ifndef TASK_COMM_LEN
+#define TASK_COMM_LEN 16
+#endif
+
+#define MAX_CPUS_PER_NODE 192
+#define MAX_CPUS_PER_LLC 192
+#define IRQ_THRESHOLD 307               /* 30% */
+#define LOAD_THRESHOLD 614              /* 60% */
+#define SCX_DSQ_ID_BASE 1000
+
+typedef enum {
+	ALLOW_LLC_CPUS  = 0,
+	ALLOW_NODE_CPUS = 1,
+	ALLOW_TASK_CPUS = 2,
+} cpu_allow_mask_t;
+
+#define CPUMASK_BYTES ((MAX_CPUS + 7) / 8)
+
+struct task_ctx {
+	u64 last_sum_exec;
+	u64 last_running_ns;
+	u64 last_stopping_ns;
+	u64 last_runnable_ns;
+	u64 runtime_ewma_sum_exec;
+};
+
+struct cpu_ctx {
+	u32 cpu;
+	u32 node_id;
+	u32 llc_id;
+	u32 llc_idx;
+	u32 task_pid;
+} __attribute__((aligned(8)));
+
+struct llc_ctx {
+	u32 id;
+	u32 nr_cpus;
+	u32 last_cpu_id;
+	u8 cpumask[CPUMASK_BYTES];
+	struct bpf_cpumask __kptr *bpf_cpumask;
+} __attribute__((aligned(8)));
+
+struct node_ctx {
+	u32 id;
+	u32 nr_llcs;
+	u32 nr_cpus;
+	u32 last_cpu_id;
+	u32 last_llc_idx;
+	u8 cpumask[CPUMASK_BYTES];
+	struct bpf_cpumask __kptr *bpf_cpumask;
+} __attribute__((aligned(8)));
+
+struct topo_ctx {
+	u32 nr_cpus;
+	u32 nr_nodes;
+	u32 nr_llcs;
+	u32 last_cpu_id;
+	u32 last_llc_id;
+	u32 last_node_id;
+} __attribute__((aligned(8)));
+
+#endif /* __INTF_H */

--- a/scheds/experimental/scx_soft_domain/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_soft_domain/src/bpf/main.bpf.c
@@ -1,0 +1,774 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * A soft_domain scheduler.
+ *
+ * This scheduler is designed to reduce cross-NUMA and cross-cluster memory
+ * access overhead caused by CPU migration across NUMA nodes or clusters.
+ * It keeps tasks on CPUs that preserve local memory affinity, improving
+ * performance by reducing remote memory accesses and cross-node/cache traffic.
+ */
+#ifdef LSP
+#ifndef __bpf__
+#define __bpf__
+#endif
+#include "../../../../include/scx/common.bpf.h"
+#else
+#include <scx/common.bpf.h>
+#endif
+
+#include "intf.h"
+char _license[] SEC("license") = "GPL";
+
+const volatile u32 max_cpus = MAX_CPUS;
+const volatile s32 allowed_node = -1;
+const volatile char target_comm[TASK_COMM_LEN] = "";
+static const __u16 pelt_subperiod_q10[9] = {
+	1024, /*   0us */
+	1021, /* 128us */
+	1018, /* 256us */
+	1016, /* 384us */
+	1013, /* 512us */
+	1010, /* 640us */
+	1007, /* 768us */
+	1005, /* 896us */
+	1002  /* 1024us ~= 1 period */
+};
+
+static const __u16 pelt_period_q10[33] = {
+	1024, /*  0 */
+	1002, /*  1 */
+	 981, /*  2 */
+	 960, /*  3 */
+	 939, /*  4 */
+	 919, /*  5 */
+	 899, /*  6 */
+	 880, /*  7 */
+	 861, /*  8 */
+	 843, /*  9 */
+	 825, /* 10 */
+	 807, /* 11 */
+	 790, /* 12 */
+	 773, /* 13 */
+	 756, /* 14 */
+	 740, /* 15 */
+	 724, /* 16 */
+	 709, /* 17 */
+	 693, /* 18 */
+	 679, /* 19 */
+	 664, /* 20 */
+	 650, /* 21 */
+	 636, /* 22 */
+	 622, /* 23 */
+	 609, /* 24 */
+	 596, /* 25 */
+	 583, /* 26 */
+	 571, /* 27 */
+	 558, /* 28 */
+	 546, /* 29 */
+	 535, /* 30 */
+	 523, /* 31 */
+	 512  /* 32 => 0.5 */
+};
+
+UEI_DEFINE(uei);
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, uint32_t);
+	__type(value, struct cpu_ctx);
+	__uint(max_entries, MAX_CPUS);
+} cpu_ctxs SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, uint32_t);
+	__type(value, struct llc_ctx);
+	__uint(max_entries, MAX_LLC_ID);
+} llc_ctxs SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, uint32_t);
+	__type(value, struct node_ctx);
+	__uint(max_entries, MAX_NUMA_NODES);
+} node_ctxs SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(key_size, sizeof(uint32_t));
+	__uint(value_size, sizeof(struct topo_ctx));
+	__uint(max_entries, 1);
+} topo_ctxs SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_LLCS);
+	__type(key, u32);
+	__type(value, u32);
+} llc_cpu_idx SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_LLCS * MAX_CPUS_PER_LLC);
+	__type(key, u32);
+	__type(value, u32);
+} llc_sorted_cpu_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_CPUS);
+	__type(key, u32);
+	__type(value, u32);
+} cpu_load_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__type(key, u32);
+	__type(value, s32);
+	__uint(max_entries, 65535);
+} cpus_selected SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_TASK_STORAGE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__type(key, u32);
+	__type(value, struct task_ctx);
+} task_storage SEC(".maps");
+
+static __maybe_unused struct cpu_ctx *lookup_cpu_ctx(int cpu)
+{
+	struct cpu_ctx *cpuc;
+
+	cpuc = bpf_map_lookup_elem(&cpu_ctxs, &cpu);
+
+	if (!cpuc) {
+		scx_bpf_error("no cpu_ctx for cpu %d", cpu);
+		return NULL;
+	}
+
+	return cpuc;
+}
+
+static struct node_ctx *lookup_node_ctx(uint32_t node)
+{
+	struct node_ctx *nodec;
+
+	nodec = bpf_map_lookup_elem(&node_ctxs, &node);
+	if (!nodec) {
+		scx_bpf_error("no node_ctx for node %u", node);
+		return NULL;
+	}
+
+	return nodec;
+}
+
+static struct llc_ctx *lookup_llc_ctx(uint32_t llc)
+{
+	struct llc_ctx *llcx;
+
+	llcx = bpf_map_lookup_elem(&llc_ctxs, &llc);
+	if (!llcx) {
+		scx_bpf_error("no llc_ctx for llc %u", llc);
+		return NULL;
+	}
+
+	return llcx;
+}
+
+static __always_inline s32 pick_next_idle_cpu_in_llc(u32 llc_idx)
+{
+	u32 key;
+	u32 *cpu_idx_ptr;
+	u32 next_cpu_idx;
+	struct llc_ctx *llcx;
+	u32 map_key;
+	u32 *cpu_ptr;
+
+	key = llc_idx;
+	cpu_idx_ptr = bpf_map_lookup_elem(&llc_cpu_idx, &key);
+	if (!cpu_idx_ptr) {
+		return -1;
+	}
+
+	next_cpu_idx = __sync_fetch_and_add(cpu_idx_ptr, 1);
+	llcx = lookup_llc_ctx(llc_idx);
+	if (!llcx) {
+		return -1;
+	}
+
+	next_cpu_idx = next_cpu_idx % llcx->nr_cpus;
+	map_key = llc_idx * MAX_CPUS_PER_LLC + next_cpu_idx;
+	cpu_ptr = bpf_map_lookup_elem(&llc_sorted_cpu_map, &map_key);
+	if (!cpu_ptr) {
+		return -1;
+	}
+
+	return (s32)*cpu_ptr;
+}
+
+static __always_inline s32 round_robin_select_llc_in_node(struct topo_ctx *topo, u32 node_id)
+{
+	u32 node_nr_llcs;
+	u32 llc_start;
+	u32 next_llc_idx;
+	struct node_ctx *nodec;
+
+	if (!topo || topo->nr_llcs <= 0 || topo->nr_nodes <= 0) {
+		bpf_printk("topo nr_llcs/nr_nodes <= 0, topo info err.");
+		return -1;
+	}
+
+	node_nr_llcs = topo->nr_llcs / topo->nr_nodes;
+	if (node_nr_llcs == 0) {
+		bpf_printk("node_nr_llcs == 0");
+		return -EINVAL;
+	}
+
+	llc_start = node_id * node_nr_llcs;
+	nodec = lookup_node_ctx(node_id);
+	if (nodec) {
+		next_llc_idx = __sync_fetch_and_add(&nodec->last_llc_idx, 1);
+		next_llc_idx = llc_start + next_llc_idx % node_nr_llcs;
+	} else {
+		next_llc_idx = llc_start;
+	}
+
+	return next_llc_idx;
+}
+
+static __always_inline s32 round_robin_select_llc(struct topo_ctx *topo)
+{
+	u32 next_node_id;
+
+	if (topo->nr_nodes > 0) {
+		next_node_id = __sync_fetch_and_add(&topo->last_node_id, 1);
+		next_node_id = next_node_id % topo->nr_nodes;
+	} else {
+		next_node_id = 0;
+	}
+
+	return round_robin_select_llc_in_node(topo, next_node_id);
+}
+
+static __always_inline s32 round_robin_select_cpu(struct topo_ctx *topo, u32 node_id, s32 cpu_allowed_flag)
+{
+	s32 llc_idx = 0;
+	u32 next_cpu_id;
+	struct llc_ctx *llcx;
+	u32 cpu_start;
+
+	if (cpu_allowed_flag == ALLOW_LLC_CPUS) {
+		llc_idx = round_robin_select_llc(topo);
+	} else if (cpu_allowed_flag == ALLOW_NODE_CPUS) {
+		llc_idx = round_robin_select_llc_in_node(topo, node_id);
+	}
+
+	llcx = lookup_llc_ctx(llc_idx);
+	if (!llcx || llcx->nr_cpus == 0) {
+		bpf_printk("Invalid LLC or nr_cpus == 0");
+		return -EINVAL;
+	}
+
+	cpu_start = llc_idx * llcx->nr_cpus;
+	next_cpu_id = __sync_fetch_and_add(&llcx->last_cpu_id, 1);
+	next_cpu_id = cpu_start + next_cpu_id % llcx->nr_cpus;
+
+	return next_cpu_id;
+}
+
+static __always_inline u32 get_cpu_allowed_flag(struct topo_ctx *topo)
+{
+	if (allowed_node < 0) {
+		return ALLOW_LLC_CPUS;
+	}
+
+	if (allowed_node > 0 && allowed_node < topo->nr_nodes) {
+		return ALLOW_NODE_CPUS;
+	}
+
+	return ALLOW_TASK_CPUS;
+}
+
+static __always_inline bool scx_bpf_check_comm(struct task_struct *p)
+{
+	char comm[TASK_COMM_LEN];
+
+	if (!p) {
+		return false;
+	}
+
+	__builtin_memset(comm, 0, sizeof(comm));
+	bpf_probe_read_kernel_str(comm, sizeof(comm), p->comm);
+
+	/* If target_comm is not specified, tasks are scheduled for all. */
+	if (target_comm[0] == '\0') {
+		return true;
+	}
+
+	#pragma unroll
+	for (int i = 0; i < TASK_COMM_LEN; i++) {
+		if (comm[i] != target_comm[i]) {
+			return false;
+		}
+		if (comm[i] == '\0') {
+			break;
+		}
+	}
+
+	return true;
+}
+
+static __always_inline void update_cpu_tasks_by_pid(u32 pid_key, s32 cpu_new)
+{
+	s32 *cpu_old = bpf_map_lookup_elem(&cpus_selected, &pid_key);
+	struct cpu_ctx *cpuc_old;
+	struct cpu_ctx *cpuc_new;
+
+	if (cpu_old) {
+		if (*cpu_old == cpu_new) {
+			return;
+		}
+
+		cpuc_old = lookup_cpu_ctx(*cpu_old);
+		if (cpuc_old) {
+			cpuc_old->task_pid = 0;
+		}
+	}
+
+	cpuc_new = lookup_cpu_ctx(cpu_new);
+	if (cpuc_new) {
+		cpuc_new->task_pid = pid_key;
+	}
+}
+
+static __always_inline void update_cpu_by_pid(u32 pid, s32 cpu_id)
+{
+	if (bpf_map_update_elem(&cpus_selected, &pid, &cpu_id, BPF_ANY) != 0) {
+		bpf_printk("Warning: Failed to update cpu_id, pid %d\n", pid);
+	}
+}
+
+static __always_inline bool can_fast_insert_local(struct task_struct *p, s32 cpu)
+{
+	u32 *cpu_load = bpf_map_lookup_elem(&cpu_load_map, &cpu);
+	struct task_ctx *taskc = bpf_task_storage_get(&task_storage, p, 0, BPF_LOCAL_STORAGE_GET_F_CREATE);
+	if (!taskc || !cpu_load) {
+		return false;
+	}
+
+	if (*cpu_load < LOAD_THRESHOLD || (taskc->runtime_ewma_sum_exec * 100) / *cpu_load > 80) {
+		return true;
+	}
+
+	return false;
+}
+
+static __always_inline s32 scx_prev_select_cpu(struct task_struct *p, s32 prev_cpu, u64 wake_flags)
+{
+	s32 cpu;
+
+	if (scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
+		cpu = prev_cpu;
+		goto insert;
+	}
+
+	if (!p || p->cpus_ptr == NULL) {
+		return prev_cpu;
+	}
+
+	cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
+	if (cpu >= 0) {
+		goto insert;
+	}
+
+	return prev_cpu;
+
+insert:
+	scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL, 0);
+	return cpu;
+}
+
+s32 BPF_STRUCT_OPS(soft_domain_select_cpu, struct task_struct *p, s32 prev_cpu, u64 wake_flags)
+{
+	if (!scx_bpf_check_comm(p)) {
+		return scx_prev_select_cpu(p, prev_cpu, wake_flags);
+	}
+
+	s32 cpu = -1;
+	u32 cpu_allowed_flag;
+	u32 key = 0;
+	u32 *cpu_sid;
+	u32 pid_key = p->pid;
+	u32 pid_parent;
+	struct topo_ctx *topo;
+
+	if (wake_flags & SCX_WAKE_FORK) {
+		pid_parent = p->real_parent->pid;
+		cpu_sid = bpf_map_lookup_elem(&cpus_selected, &pid_parent);
+		if (cpu_sid) {
+			cpu = *cpu_sid;
+			update_cpu_tasks_by_pid(pid_key, cpu);
+			update_cpu_by_pid(pid_key, cpu);
+			goto insert_cpu;
+		}
+
+		cpu = scx_bpf_task_cpu(p->real_parent);
+		if (cpu >= 0) {
+			goto insert_cpu;
+		}
+	}
+
+	if (wake_flags & SCX_WAKE_TTWU) {
+		if (scx_bpf_check_comm(p->real_parent)) {
+			pid_parent = p->real_parent->pid;
+			cpu_sid = bpf_map_lookup_elem(&cpus_selected, &pid_parent);
+			if (cpu_sid) {
+				cpu = *cpu_sid;
+				update_cpu_tasks_by_pid(pid_key, cpu);
+				update_cpu_by_pid(pid_key, cpu);
+				goto insert_cpu;
+			}
+		}
+		cpu_sid = bpf_map_lookup_elem(&cpus_selected, &pid_key);
+		if (cpu_sid) {
+			cpu = *cpu_sid;
+			goto insert_cpu;
+		}
+	}
+
+	topo = bpf_map_lookup_elem(&topo_ctxs, &key);
+	if (!topo) {
+		goto insert_prev_cpu;
+	}
+
+	cpu_allowed_flag = get_cpu_allowed_flag(topo);
+	if (cpu_allowed_flag == ALLOW_TASK_CPUS) {
+		return scx_prev_select_cpu(p, prev_cpu, wake_flags);
+	}
+
+	cpu_sid = bpf_map_lookup_elem(&cpus_selected, &pid_key);
+	if (cpu_sid) {
+		cpu = *cpu_sid;
+		goto insert_cpu;
+	}
+
+	cpu = round_robin_select_cpu(topo, allowed_node, cpu_allowed_flag);
+	if (cpu >= 0) {
+		update_cpu_tasks_by_pid(pid_key, cpu);
+		update_cpu_by_pid(pid_key, cpu);
+		goto insert_cpu;
+	}
+
+	goto insert_prev_cpu;
+
+insert_cpu:
+	scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu, SCX_SLICE_DFL, 0);
+	return cpu;
+
+insert_prev_cpu:
+	return prev_cpu;
+}
+
+void BPF_STRUCT_OPS(soft_domain_enqueue, struct task_struct *p, u64 enq_flags)
+{
+	u32 pid;
+	s32 *cpu_ptr;
+	struct task_ctx *taskc;
+	struct cpu_ctx *cpuc;
+	struct cpu_ctx *cpuc_idle_cpu;
+	u64 dsq_id;
+	u32 idle_cpu;
+	u32 *idle_cpu_load;
+	u32 pid_idle_cpu;
+
+	if (!scx_bpf_check_comm(p)) {
+		scx_bpf_dsq_insert(p, SCX_DSQ_GLOBAL, SCX_SLICE_DFL, 0);
+		return;
+	}
+
+	pid = p->pid;
+	cpu_ptr = bpf_map_lookup_elem(&cpus_selected, &pid);
+	if (!cpu_ptr) {
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL, 0);
+		return;
+	}
+
+	if (can_fast_insert_local(p, *cpu_ptr)) {
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | *cpu_ptr, SCX_SLICE_DFL, 0);
+		return;
+	}
+
+	taskc = bpf_task_storage_get(&task_storage, p, 0, BPF_LOCAL_STORAGE_GET_F_CREATE);
+	cpuc = lookup_cpu_ctx(*cpu_ptr);
+	if (!taskc || !cpuc) {
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL, 0);
+		return;
+	}
+
+	dsq_id = SCX_DSQ_ID_BASE + cpuc->llc_idx;
+	scx_bpf_dsq_insert(p, dsq_id, SCX_SLICE_DFL, 0);
+	idle_cpu = pick_next_idle_cpu_in_llc(cpuc->llc_idx);
+	idle_cpu_load = bpf_map_lookup_elem(&cpu_load_map, &idle_cpu);
+	if (!idle_cpu_load || *idle_cpu_load > 307 || taskc->runtime_ewma_sum_exec + *idle_cpu_load > 900) {
+		return;
+	}
+
+	cpuc_idle_cpu = lookup_cpu_ctx(idle_cpu);
+	if (!cpuc_idle_cpu) {
+		return;
+	}
+
+	pid_idle_cpu = cpuc_idle_cpu->task_pid;
+	if (!pid_idle_cpu) {
+		update_cpu_tasks_by_pid(pid, idle_cpu);
+		update_cpu_by_pid(pid, idle_cpu);
+		scx_bpf_kick_cpu(idle_cpu, SCX_KICK_IDLE);
+		return;
+	}
+
+	scx_bpf_kick_cpu(idle_cpu, SCX_KICK_IDLE);
+}
+void BPF_STRUCT_OPS(soft_domain_dispatch, s32 cpu, struct task_struct *p)
+{
+	u64 dsq_id;
+
+	if (!scx_bpf_check_comm(p)) {
+		return;
+	}
+
+	struct cpu_ctx *cpuc = lookup_cpu_ctx(cpu);
+	if (cpuc) {
+		dsq_id = SCX_DSQ_ID_BASE + cpuc->llc_idx;
+		scx_bpf_dsq_move_to_local(dsq_id, 0);
+		return;
+	}
+}
+static s32 create_topo_cpumask(struct bpf_cpumask **kptr)
+{
+	struct bpf_cpumask *cpumask;
+
+	cpumask = bpf_cpumask_create();
+	if (!cpumask) {
+		scx_bpf_error("Failed to create cpumask");
+		return -ENOMEM;
+	}
+
+	cpumask = bpf_kptr_xchg(kptr, cpumask);
+	if (cpumask) {
+		scx_bpf_error("kptr already had cpumask");
+		bpf_cpumask_release(cpumask);
+	}
+
+	return 0;
+}
+
+static bool check_cpu_in_mask(int cpu, const u8 *cpumask)
+{
+	u8 byte;
+	u32 ucpu = (u32)cpu;
+	u32 byte_idx = ucpu / 8;
+	u32 bit_idx = ucpu % 8;
+
+	if (cpu < 0 || cpu >= max_cpus) {
+		return false;
+	}
+
+	if (byte_idx >= (max_cpus / 8)) {
+		return false;
+	}
+
+	if (bpf_probe_read_kernel(&byte, sizeof(byte), &cpumask[byte_idx]) != 0) {
+		return false;
+	}
+
+	return (byte & (1 << bit_idx)) != 0;
+}
+
+static s32 init_llc_bpf_mask(u32 llc)
+{
+	u32 cpu;
+	struct bpf_cpumask *cpumask;
+	struct llc_ctx *llcx;
+	s32 ret;
+
+	if (!(llcx = lookup_llc_ctx(llc))) {
+		return -ENOENT;
+	}
+
+	ret = create_topo_cpumask(&llcx->bpf_cpumask);
+	if (ret) {
+		return ret;
+	}
+
+	bpf_rcu_read_lock();
+	cpumask = llcx->bpf_cpumask;
+	if (!cpumask) {
+		bpf_rcu_read_unlock();
+		scx_bpf_error("Failed to lookup llc cpumask");
+		return -ENOENT;
+	}
+
+	bpf_for(cpu, 0, max_cpus) {
+		if (check_cpu_in_mask(cpu, llcx->cpumask)) {
+			bpf_cpumask_set_cpu(cpu, cpumask);
+		}
+	}
+
+	bpf_rcu_read_unlock();
+	return ret;
+}
+
+static s32 init_node_bpf_mask(u32 node)
+{
+	u32 cpu;
+	struct bpf_cpumask *cpumask;
+	struct node_ctx *nodec;
+	s32 ret;
+
+	if (!(nodec = lookup_node_ctx(node))) {
+		return -ENOENT;
+	}
+
+	ret = create_topo_cpumask(&nodec->bpf_cpumask);
+	if (ret) {
+		return ret;
+	}
+
+	bpf_rcu_read_lock();
+	cpumask = nodec->bpf_cpumask;
+	if (!cpumask) {
+		bpf_rcu_read_unlock();
+		scx_bpf_error("Failed to lookup node cpumask");
+		return -ENOENT;
+	}
+
+	bpf_for(cpu, 0, max_cpus) {
+		if (check_cpu_in_mask(cpu, nodec->cpumask)) {
+			bpf_cpumask_set_cpu(cpu, cpumask);
+		}
+	}
+
+	bpf_rcu_read_unlock();
+	return ret;
+}
+
+int32_t BPF_STRUCT_OPS_SLEEPABLE(soft_domain_init)
+{
+	int i, ret;
+	uint32_t key = 0;
+	struct topo_ctx *topo;
+	u64 dsq_id;
+
+	topo = bpf_map_lookup_elem(&topo_ctxs, &key);
+	if (!topo) {
+		bpf_printk("topo_ctxs lookup failed\n");
+		return -ENOENT;
+	}
+
+	bpf_for(i, 0, topo->nr_nodes) {
+		ret = init_node_bpf_mask(i);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	bpf_for(i, 0, topo->nr_llcs) {
+		ret = init_llc_bpf_mask(i);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	bpf_for(i, 0, topo->nr_llcs) {
+		dsq_id = SCX_DSQ_ID_BASE + i;
+		ret = scx_bpf_create_dsq(dsq_id, -1);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+void BPF_STRUCT_OPS(soft_domain_runnable, struct task_struct *p)
+{
+	struct task_ctx *taskc;
+	taskc = bpf_task_storage_get(&task_storage, p, 0, BPF_LOCAL_STORAGE_GET_F_CREATE);
+	if (!taskc) {
+		return;
+	}
+
+	if (!scx_bpf_check_comm(p)) {
+		return;
+	}
+
+	taskc->last_runnable_ns = bpf_ktime_get_ns();
+	taskc->last_sum_exec = BPF_CORE_READ(p, se.sum_exec_runtime);
+}
+
+static __always_inline u64 update_pelt_load(u64 runtime_ewma_sum_exec, u64 delta_running, u64 delta_runnable)
+{
+	u64 elapsed_us = delta_runnable / 1000;
+	u64 decay_periods = elapsed_us / 1024;
+	u64 rem_us = elapsed_us % 1024;
+	u64 sub_idx = rem_us / 128;
+
+	if (delta_runnable == 0) {
+		return runtime_ewma_sum_exec;
+	}
+
+	if (decay_periods > 32) {
+		decay_periods = 32;
+	}
+
+	if (sub_idx > 8) {
+		sub_idx = 8;
+	}
+	barrier_var(sub_idx);
+
+	if (decay_periods == 0) {
+		if (sub_idx == 0) {
+			sub_idx = 1;
+		}
+
+		return ((runtime_ewma_sum_exec * pelt_subperiod_q10[sub_idx]) >> 10) +
+			delta_running * (1024 - pelt_subperiod_q10[sub_idx]) / delta_runnable;
+	}
+
+	return ((runtime_ewma_sum_exec * pelt_period_q10[decay_periods]) >> 10) +
+		delta_running * (1024 - pelt_period_q10[decay_periods]) / delta_runnable;
+}
+
+void BPF_STRUCT_OPS(soft_domain_quiescent, struct task_struct *p)
+{
+	u64 now, delta_runnable, delta_running_exec;
+
+	struct task_ctx *taskc = bpf_task_storage_get(&task_storage, p, 0, 0);
+	if (!taskc || !taskc->last_runnable_ns) {
+		return;
+	}
+
+	if (!scx_bpf_check_comm(p)) {
+		return;
+	}
+
+	now = bpf_ktime_get_ns();
+	delta_running_exec = BPF_CORE_READ(p, se.sum_exec_runtime) - taskc->last_sum_exec;
+	delta_runnable = now - taskc->last_runnable_ns;
+	taskc->runtime_ewma_sum_exec = update_pelt_load(taskc->runtime_ewma_sum_exec, delta_running_exec, delta_runnable);
+}
+
+void BPF_STRUCT_OPS(soft_domain_exit, struct scx_exit_info *ei)
+{
+	UEI_RECORD(uei, ei);
+}
+
+SCX_OPS_DEFINE(soft_domain_ops,
+		.select_cpu		= (void *)soft_domain_select_cpu,
+		.enqueue 		= (void *)soft_domain_enqueue,
+		.dispatch 		= (void *)soft_domain_dispatch,
+		.runnable		= (void *)soft_domain_runnable,
+		.quiescent		= (void *)soft_domain_quiescent,
+		.init			= (void *)soft_domain_init,
+		.exit			= (void *)soft_domain_exit,
+		.name			= "soft_domain");

--- a/scheds/experimental/scx_soft_domain/src/main.rs
+++ b/scheds/experimental/scx_soft_domain/src/main.rs
@@ -1,0 +1,555 @@
+// SPDX-License-Identifier: GPL-2.0
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::mem::MaybeUninit;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use libbpf_rs::{MapCore, MapFlags, OpenObject, PrintLevel};
+use log::{debug, info, warn};
+use scx_utils::{
+    build_id, init_libbpf_logging, libbpf_clap_opts::LibbpfOpts, scx_ops_attach, scx_ops_load,
+    scx_ops_open, try_set_rlimit_infinity, uei_exited, uei_report, UserExitInfo,
+};
+
+mod bpf_intf {
+    #![allow(dead_code)]
+    #![allow(non_snake_case)]
+    #![allow(non_camel_case_types)]
+    #![allow(non_upper_case_globals)]
+    include!(concat!(env!("OUT_DIR"), "/bpf_intf.rs"));
+}
+
+mod bpf_skel {
+    #![allow(dead_code)]
+    #![allow(non_snake_case)]
+    #![allow(non_camel_case_types)]
+    #![allow(non_upper_case_globals)]
+    include!(concat!(env!("OUT_DIR"), "/bpf_skel.rs"));
+}
+
+use bpf_intf::*;
+use bpf_skel::*;
+
+const SCHEDULER_NAME: &str = "scx_soft_domain";
+
+struct Scheduler<'a> {
+    skel: BpfSkel<'a>,
+    _link: libbpf_rs::Link,
+    shutdown: Arc<AtomicBool>,
+    nr_cpus: u32,
+    nr_llc: usize,
+    cpu_llc_idxs: Vec<u32>,
+    prev_stats: Vec<u64>,
+}
+
+impl<'a> Scheduler<'a> {
+    fn init(opts: &'a Opts, open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
+        try_set_rlimit_infinity();
+
+        let print_level = if opts.verbose > 0 {
+            PrintLevel::Debug
+        } else {
+            PrintLevel::Info
+        };
+        init_libbpf_logging(Some(print_level));
+
+        let skel_builder = BpfSkelBuilder::default();
+        let open_opts = opts.libbpf.clone().into_bpf_open_opts();
+        let mut open_skel = scx_ops_open!(skel_builder, open_object, soft_domain_ops, open_opts)?;
+
+        info!(
+            "{} {}{}",
+            SCHEDULER_NAME,
+            build_id::full_version(env!("CARGO_PKG_VERSION")),
+            env!("GIT_COMMIT_ID"),
+        );
+
+        let nr_cpus = Self::init_globals(&mut open_skel, opts)?;
+        let cpu_llcs = Self::detect_cpu_llc_mapping(nr_cpus as usize)?;
+        let nr_llc = cpu_llcs.iter().copied().collect::<HashSet<u32>>().len();
+        let cpu_llc_idxs = Self::build_llc_idx_map(&cpu_llcs);
+        let mut skel = scx_ops_load!(open_skel, soft_domain_ops, uei)?;
+        Self::init_topology(&mut skel, nr_cpus, nr_llc)?;
+        let link = scx_ops_attach!(skel, soft_domain_ops)?;
+
+        Ok(Self {
+            skel,
+            _link: link,
+            shutdown: Arc::new(AtomicBool::new(false)),
+            nr_cpus,
+            nr_llc,
+            cpu_llc_idxs,
+            prev_stats: vec![0u64; MAX_CPUS as usize * 2],
+        })
+    }
+
+    fn detect_cpu_llc_mapping(nr_cpus: usize) -> Result<Vec<u32>> {
+        let mut map = vec![0u32; nr_cpus];
+        for cpu in 0..nr_cpus {
+            let path = format!("/sys/devices/system/cpu/cpu{}/topology/cluster_id", cpu);
+            if !std::path::Path::new(&path).exists() {
+                continue;
+            }
+            let content = std::fs::read_to_string(&path)?;
+            let cluster_id = content.trim().parse::<u32>().unwrap_or(u32::MAX);
+            map[cpu] = if cluster_id == u32::MAX {
+                0
+            } else {
+                cluster_id
+            };
+        }
+        Ok(map)
+    }
+
+    fn build_llc_idx_map(cpu_llcs: &[u32]) -> Vec<u32> {
+        let mut unique_llc_ids: Vec<u32> = cpu_llcs
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        unique_llc_ids.sort();
+        let llc_id_to_idx: std::collections::HashMap<u32, u32> = unique_llc_ids
+            .iter()
+            .enumerate()
+            .map(|(idx, &id)| (id, idx as u32))
+            .collect();
+        cpu_llcs
+            .iter()
+            .map(|id| *llc_id_to_idx.get(id).unwrap_or(&0))
+            .collect()
+    }
+
+    fn init_globals(skel: &mut OpenBpfSkel, opts: &Opts) -> Result<u32> {
+        let rodata = skel.maps.rodata_data.as_mut().unwrap();
+
+        let nr_cpus = num_cpus::get() as u32;
+        if nr_cpus > MAX_CPUS as u32 {
+            warn!(
+                "System has {} CPUs, but BPF supports max {}",
+                nr_cpus, MAX_CPUS
+            );
+        }
+        rodata.max_cpus = nr_cpus.min(MAX_CPUS as u32);
+        rodata.allowed_node = opts.allowed_node.unwrap_or(-1);
+
+        let comm_bytes = opts.target_comm.as_bytes();
+        let len = comm_bytes.len().min((TASK_COMM_LEN - 1) as usize);
+        for i in 0..len {
+            rodata.target_comm[i] = comm_bytes[i] as i8;
+        }
+        rodata.target_comm[len] = 0;
+
+        Ok(rodata.max_cpus)
+    }
+
+    fn init_topology(skel: &mut BpfSkel, nr_cpus: u32, nr_llc: usize) -> Result<()> {
+        let nr_cpus = nr_cpus as usize;
+
+        let mut cpu_node = vec![0u32; nr_cpus];
+        let mut cpu_llc = vec![0u32; nr_cpus];
+        let mut node_cpus = vec![Vec::new(); MAX_CPUS as usize];
+
+        for cpu in 0..nr_cpus {
+            let node_id = read_sysfs_node_id(cpu).unwrap_or(0);
+            let llc_id = read_sysfs_llc_id(cpu).unwrap_or(cpu as u32);
+            cpu_node[cpu] = node_id;
+            cpu_llc[cpu] = llc_id;
+            node_cpus[node_id as usize].push(cpu);
+        }
+
+        let mut unique_llc_ids = HashSet::new();
+        for &llc in &cpu_llc {
+            unique_llc_ids.insert(llc);
+        }
+        let mut llc_list: Vec<u32> = unique_llc_ids.into_iter().collect();
+        llc_list.sort();
+        let llc_id_to_idx: std::collections::HashMap<u32, usize> = llc_list
+            .iter()
+            .enumerate()
+            .map(|(idx, &id)| (id, idx))
+            .collect();
+        let nr_llcs = llc_list.len();
+
+        for cpu in 0..nr_cpus {
+            let ctx = cpu_ctx {
+                cpu: cpu as u32,
+                node_id: cpu_node[cpu],
+                llc_id: cpu_llc[cpu],
+                llc_idx: llc_id_to_idx[&cpu_llc[cpu]] as u32,
+                task_pid: 0,
+            };
+            let key = (cpu as u32).to_ne_bytes();
+            let value = unsafe {
+                std::slice::from_raw_parts(
+                    &ctx as *const _ as *const u8,
+                    std::mem::size_of_val(&ctx),
+                )
+            };
+            skel.maps
+                .cpu_ctxs
+                .update(&key, value, MapFlags::ANY)
+                .with_context(|| format!("Failed to update cpu_ctx for CPU {}", cpu))?;
+        }
+
+        let nr_nodes = node_cpus.iter().filter(|v| !v.is_empty()).count();
+        for node in 0..nr_nodes {
+            let mut mask = [0u8; CPUMASK_BYTES as usize];
+            let mut nr_cpus_in_node = 0;
+            for &cpu in &node_cpus[node] {
+                if cpu < nr_cpus {
+                    set_cpu_in_mask(cpu, &mut mask);
+                    nr_cpus_in_node += 1;
+                }
+            }
+            let node_ctx = node_ctx {
+                id: node as u32,
+                nr_llcs: (nr_llcs / nr_nodes) as u32,
+                nr_cpus: nr_cpus_in_node,
+                last_cpu_id: 0,
+                last_llc_idx: 0,
+                cpumask: mask,
+                bpf_cpumask: std::ptr::null_mut(),
+            };
+            let key = (node as u32).to_ne_bytes();
+            let value = unsafe {
+                std::slice::from_raw_parts(
+                    &node_ctx as *const _ as *const u8,
+                    std::mem::size_of_val(&node_ctx),
+                )
+            };
+            skel.maps
+                .node_ctxs
+                .update(&key, value, MapFlags::ANY)
+                .with_context(|| format!("Failed to update node_ctx for node {}", node))?;
+        }
+
+        let mut llc_cpus_list = vec![Vec::new(); nr_llcs];
+        for cpu in 0..nr_cpus {
+            let llc_id = cpu_llc[cpu];
+            let idx = llc_id_to_idx[&llc_id];
+            llc_cpus_list[idx].push(cpu);
+        }
+        for (idx, &llc_id) in llc_list.iter().enumerate() {
+            let mut mask = [0u8; CPUMASK_BYTES as usize];
+            let mut nr_cpus_in_llc = 0;
+            for &cpu in &llc_cpus_list[idx] {
+                if cpu < nr_cpus {
+                    set_cpu_in_mask(cpu, &mut mask);
+                    nr_cpus_in_llc += 1;
+                }
+            }
+            let llc_ctx = llc_ctx {
+                id: llc_id,
+                nr_cpus: nr_cpus_in_llc,
+                last_cpu_id: 0,
+                cpumask: mask,
+                bpf_cpumask: std::ptr::null_mut(),
+            };
+            let key = (idx as u32).to_ne_bytes();
+            let value = unsafe {
+                std::slice::from_raw_parts(
+                    &llc_ctx as *const _ as *const u8,
+                    std::mem::size_of_val(&llc_ctx),
+                )
+            };
+            skel.maps
+                .llc_ctxs
+                .update(&key, value, MapFlags::ANY)
+                .with_context(|| format!("Failed to update llc_ctx for llc index {}", idx))?;
+        }
+
+        let topo = topo_ctx {
+            nr_cpus: nr_cpus as u32,
+            nr_nodes: nr_nodes as u32,
+            nr_llcs: nr_llcs as u32,
+            last_cpu_id: 0,
+            last_llc_id: 0,
+            last_node_id: 0,
+        };
+        let key = 0u32.to_ne_bytes();
+        let value = unsafe {
+            std::slice::from_raw_parts(&topo as *const _ as *const u8, std::mem::size_of_val(&topo))
+        };
+        skel.maps
+            .topo_ctxs
+            .update(&key, value, MapFlags::ANY)
+            .context("Failed to update topo_ctxs")?;
+
+        for llc in 0..nr_llc {
+            let key = (llc as u32).to_ne_bytes();
+            let zero = 0u32.to_ne_bytes();
+            skel.maps
+                .llc_cpu_idx
+                .update(&key, &zero, MapFlags::ANY)
+                .context("Failed to init llc_cpu_idx")?;
+        }
+
+        for llc in 0..nr_llc {
+            for idx in 0..MAX_CPUS {
+                let map_key = (llc as u32) * MAX_CPUS_PER_LLC as u32 + idx as u32;
+                let val = 0u32.to_ne_bytes();
+                let _ = skel.maps.llc_sorted_cpu_map.update(
+                    &map_key.to_ne_bytes(),
+                    &val,
+                    MapFlags::ANY,
+                );
+            }
+        }
+
+        info!(
+            "Topology: {} CPUs, {} NUMA nodes, {} LLCs",
+            nr_cpus, nr_nodes, nr_llcs
+        );
+
+        Ok(())
+    }
+
+    fn update_cpu_loads(&mut self) {
+        let nr_cpus = self.nr_cpus as usize;
+
+        let curr_stats = match read_cpu_stats() {
+            Ok(stats) => stats,
+            Err(e) => {
+                debug!("Failed to read CPU stats: {}", e);
+                return;
+            }
+        };
+
+        if self.prev_stats.iter().all(|&v| v == 0) {
+            self.prev_stats = curr_stats;
+            return;
+        }
+
+        let mut loads = vec![0u32; MAX_CPUS as usize];
+        for cpu in 0..nr_cpus {
+            const STATS_PER_CPU: usize = 2;
+            let prev_total = self.prev_stats[cpu * STATS_PER_CPU];
+            let prev_idle = self.prev_stats[cpu * STATS_PER_CPU + 1];
+            let curr_total = curr_stats[cpu * STATS_PER_CPU];
+            let curr_idle = curr_stats[cpu * STATS_PER_CPU + 1];
+
+            let total_diff = curr_total.saturating_sub(prev_total);
+            let idle_diff = curr_idle.saturating_sub(prev_idle);
+
+            if total_diff > 0 {
+                let busy = total_diff.saturating_sub(idle_diff);
+                loads[cpu] = ((busy as u64 * 1024) / total_diff) as u32;
+                loads[cpu] = loads[cpu].min(1024);
+            }
+        }
+
+        for cpu in 0..nr_cpus {
+            let key = (cpu as u32).to_ne_bytes();
+            let val = loads[cpu].to_ne_bytes();
+            if let Err(e) = self
+                .skel
+                .maps
+                .cpu_load_map
+                .update(&key, &val, MapFlags::ANY)
+            {
+                debug!("Failed to update cpu_load_map[{}]: {}", cpu, e);
+            }
+        }
+
+        let mut cpu_load_pairs: Vec<(u32, u32)> = (0..nr_cpus as u32)
+            .map(|cpu| (cpu, loads[cpu as usize]))
+            .collect();
+        cpu_load_pairs.sort_by_key(|(_, load)| *load);
+
+        let mut llc_cpus: Vec<Vec<u32>> = vec![Vec::new(); self.nr_llc];
+        for cpu in 0..self.nr_cpus {
+            let llc = self.cpu_llc_idxs[cpu as usize] as usize;
+            if let Some(bucket) = llc_cpus.get_mut(llc) {
+                bucket.push(cpu as u32);
+            } else {
+                debug!("Skipping invalid llc idx {} for cpu {}", llc, cpu);
+            }
+        }
+        for llc in 0..self.nr_llc {
+            llc_cpus[llc].sort_by_key(|&cpu| loads[cpu as usize]);
+
+            for (idx, &cpu) in llc_cpus[llc].iter().enumerate() {
+                let map_key = (llc as u32) * MAX_CPUS_PER_LLC as u32 + (idx as u32);
+                let val = (cpu as u32).to_ne_bytes();
+                let _ = self.skel.maps.llc_sorted_cpu_map.update(
+                    &map_key.to_ne_bytes(),
+                    &val,
+                    MapFlags::ANY,
+                );
+            }
+
+            let llc_key = (llc as u32).to_ne_bytes();
+            let zero = 0u32.to_ne_bytes();
+            let _ = self
+                .skel
+                .maps
+                .llc_cpu_idx
+                .update(&llc_key, &zero, MapFlags::ANY);
+        }
+
+        self.prev_stats = curr_stats;
+    }
+
+    fn run(&mut self, _opts: &Opts) -> Result<UserExitInfo> {
+        let shutdown = self.shutdown.clone();
+        self.update_cpu_loads();
+
+        while !shutdown.load(Ordering::Relaxed) && !uei_exited!(&self.skel, uei) {
+            std::thread::sleep(Duration::from_millis(100));
+            self.update_cpu_loads();
+        }
+        uei_report!(&self.skel, uei)
+    }
+}
+
+fn read_cpu_stats() -> Result<Vec<u64>> {
+    let file = File::open("/proc/stat")?;
+    let reader = BufReader::new(file);
+    let mut stats = Vec::new();
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.starts_with("cpu ") {
+            continue;
+        }
+        if !line.starts_with("cpu") {
+            continue;
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 5 {
+            continue;
+        }
+        let user: u64 = parts[1].parse().unwrap_or(0);
+        let nice: u64 = parts[2].parse().unwrap_or(0);
+        let system: u64 = parts[3].parse().unwrap_or(0);
+        let idle: u64 = parts[4].parse().unwrap_or(0);
+        let iowait: u64 = parts.get(5).and_then(|s| s.parse().ok()).unwrap_or(0);
+        let irq: u64 = parts.get(6).and_then(|s| s.parse().ok()).unwrap_or(0);
+        let softirq: u64 = parts.get(7).and_then(|s| s.parse().ok()).unwrap_or(0);
+        let steal: u64 = parts.get(8).and_then(|s| s.parse().ok()).unwrap_or(0);
+
+        let total = user + nice + system + idle + iowait + irq + softirq + steal;
+        stats.push(total);
+        stats.push(idle);
+    }
+    Ok(stats)
+}
+
+fn read_sysfs_node_id(cpu: usize) -> Option<u32> {
+    let cpu_path = format!("/sys/devices/system/cpu/cpu{}", cpu);
+    if let Ok(entries) = std::fs::read_dir(&cpu_path) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().into_string().unwrap_or_default();
+            if let Some(node_str) = name.strip_prefix("node") {
+                if entry.path().is_dir() {
+                    if let Ok(node_id) = node_str.parse::<u32>() {
+                        return Some(node_id);
+                    }
+                }
+            }
+        }
+    }
+    let path = format!("/sys/devices/system/cpu/cpu{}/node", cpu);
+    if let Ok(link) = std::fs::read_link(&path) {
+        let name = link.file_name()?.to_string_lossy();
+        let node_str = name.strip_prefix("node")?;
+        return node_str.parse().ok();
+    }
+    Some(0)
+}
+
+fn read_sysfs_llc_id(cpu: usize) -> Option<u32> {
+    let path = format!("/sys/devices/system/cpu/cpu{}/topology/cluster_id", cpu);
+    if let Ok(content) = std::fs::read_to_string(&path) {
+        let llc = content.trim().parse::<u32>().unwrap_or(u32::MAX);
+        if llc == u32::MAX {
+            Some(0)
+        } else {
+            Some(llc)
+        }
+    } else {
+        Some(cpu as u32)
+    }
+}
+
+fn set_cpu_in_mask(cpu: usize, mask: &mut [u8]) {
+    let byte = cpu / 8;
+    let bit = cpu % 8;
+    if byte < mask.len() {
+        mask[byte] |= 1 << bit;
+    }
+}
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[clap(short = 'i', long, default_value = "1")]
+    stat_interval: u64,
+
+    #[clap(short = 'l', long)]
+    allowed_node: Option<i32>,
+
+    #[clap(short = 'P', long, default_value = "redis-server")]
+    target_comm: String,
+
+    #[clap(short = 'v', long, action = clap::ArgAction::Count)]
+    verbose: u8,
+
+    #[clap(short = 'V', long)]
+    version: bool,
+
+    #[clap(flatten)]
+    libbpf: LibbpfOpts,
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+
+    if opts.version {
+        println!(
+            "{} {}",
+            SCHEDULER_NAME,
+            build_id::full_version(env!("CARGO_PKG_VERSION"))
+        );
+        return Ok(());
+    }
+
+    let log_level = match opts.verbose {
+        0 => simplelog::LevelFilter::Info,
+        1 => simplelog::LevelFilter::Debug,
+        _ => simplelog::LevelFilter::Trace,
+    };
+    let mut log_config = simplelog::ConfigBuilder::new();
+    log_config.set_time_offset_to_local().unwrap();
+    simplelog::TermLogger::init(
+        log_level,
+        log_config.build(),
+        simplelog::TerminalMode::Stderr,
+        simplelog::ColorChoice::Auto,
+    )?;
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_clone = shutdown.clone();
+    ctrlc::set_handler(move || {
+        shutdown_clone.store(true, Ordering::Relaxed);
+        eprintln!("Received Ctrl+C, exiting...");
+        std::process::exit(0);
+    })
+    .context("Error setting Ctrl-C handler")?;
+
+    let mut open_object = MaybeUninit::uninit();
+    loop {
+        let mut sched = Scheduler::init(&opts, &mut open_object)?;
+        info!("{} scheduler started (CTRL+C TO EXIT)", SCHEDULER_NAME);
+        if !sched.run(&opts)?.should_restart() {
+            break;
+        }
+        info!("Restarting scheduler...");
+    }
+    Ok(())
+}


### PR DESCRIPTION
scx_soft_domain: ‌through topology-aware scheduling to improve performance

### Background
In the performance test of multi-instance applications, such as Redis, a large number of CPU migrations across clusters or NUMA nodes are detected by capturing cputrace. In addition, there is cross-NUMA memory access. In addition, multiple Redis processes on the same CPU are switched back and forth. When the test pressure is high, the CPU competition is fierce. 
We hope to reduce the Redis migration and competition and reduce the cross-NUMA memory access based on the topology information.

### Introduce
scx_soft_domain is a scheduler dedicated to multi-instance services, such as Redis. It detects the CPU hardware topology (LLC and NUMA) and task affinity, and executes tasks on the CPUs in the domain where the tasks are located as much as possible. This reduces data transmission across LLCs and NUMAs, improves cache locality, and improves the overall system performance.

### Core implementation logic
The CPU selection policy is implemented as follows: Multiple instances are evenly distributed on the machine. Within the same scheduling domain (that is, the same LLC or NUMA node), tasks are preferentially scheduled to CPUs in the domain, and cross-domain migration is avoided as much as possible.

When the load is high, load balancing is performed. First, whether the task can be directly executed on the selected CPU is quickly determined based on the load of the selected CPU and the running status of the task on the selected CPU. If the task cannot be directly executed on the selected CPU, the task is inserted into a user-defined queue of the LLC where the selected CPU is located and waits for an idle CPU to execute the task. Then, a CPU with the lowest load is selected in the LLC domain, and it is determined whether the CPU can be used as a new selected CPU. If the conditions are met, the corresponding mapping table is updated.

### Test
The test environment consists of machines with 384 CPUs and 4 NUMA nodes. The performance of Redis's set and get operations is tested, with a total of 384 instances, using the valkey_benchmark tool. The kernel source code used in the test is obtained from https://atomgit.com/openeuler/kernel/tree/openEuler-26.09.

./target/release/scx_soft_domain -P redis-server

set
| metric  | cfs          | scx_soft_domain | scx_soft_domain vs cfs |
| ------- | ------------ | --------------- | :--------------------- |
| rps     | 126557166.47 | 136862901.07    | +8.14 %                |
| avg(ms) | 1.497        | 1.392           |                        |
| p50(ms) | 1.308        | 1.169           |                        |
| p95(ms) | 2.664        | 2.446           |                        |
| p99(ms) | 6.531        | 4.696           |                        |

get
| metric  | cfs          | scx_soft_domain | scx_soft_domain vs cfs |
| ------- | ------------ | --------------- | :--------------------- |
| rps     | 127227716.58 | 136673083.79    | +7.42 %                |
| avg(ms) | 1.486        | 1.391           |                        |
| p50(ms) | 1.31         | 1.193           |                        |
| p95(ms) | 2.523        | 2.363           |                        |
| p99(ms) | 5.845        | 4.163           |                        |

- `cargo build --release -p scx_soft_domain` passes
- `cargo fmt --check` passes

## Notes
Currently, this feature only applies to the Redis performance improvement in the entire system scenario, including bare metal scenarios or container scenarios. In the future, more service scenarios will be supported.