### PR TITLE
lib/cgroup_bw: fix cgroup under-throttling in deep hierarchies

### DIFF
--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -1074,7 +1074,7 @@ int cbw_update_nquota_ub(struct cgroup *cgrp __arg_trusted, u64 cgx_raw)
 			return -ESRCH;
 		}
 
-		cgx->nquota_ub = min(cgx->nquota_ub, parentx->nquota);
+		cgx->nquota_ub = min(cgx->nquota_ub, parentx->nquota_ub);
 		bpf_cgroup_release(parent);
 	}
 	return 0;


### PR DESCRIPTION
cbw_update_nquota_ub() clamped each cgroup's effective quota (nquota_ub) against its parent's raw nquota instead of the parent's nquota_ub. A grandparent's tighter cap was lost two levels down, so a grandchild could be under-throttled and consume more CPU than the hierarchy permits.

Clamp against parentx->nquota_ub; the pre-order traversal already finalizes the parent's nquota_ub first.