### PR TITLE
scx_cosmos: Change default time slice to 1ms

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -144,7 +144,7 @@ const volatile bool no_early_clear;
 /*
  * Default time slice.
  */
-const volatile u64 slice_ns = 20000000ULL;
+const volatile u64 slice_ns = 1000000ULL;
 
 /*
  * Maximum runtime that can be charged to a task.

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -259,7 +259,7 @@ struct Opts {
     exit_dump_len: u32,
 
     /// Maximum scheduling slice duration in microseconds.
-    #[clap(short = 's', long, default_value = "20000")]
+    #[clap(short = 's', long, default_value = "1000")]
     slice_us: u64,
 
     /// Maximum runtime (since last sleep) that can be charged to a task in microseconds.


### PR DESCRIPTION
Commit e589435e86aa ("scx_cosmos: Tune default time slice for server workloads") increased the default time slice to 20ms to better target CPU-intensive workloads.

However, a 20ms time slice appears overly aggressive and can lead to performance regressions in multiple scenarios, including for CPU-bound workloads.

Scale down the default time slice to 1ms, which provides a more balanced trade-off and serves as a more reasonable default for general-purpose use.