### PR TITLE
[scx_layered] Add opt-in peak-hold shrink resistance

### DIFF
--- a/scheds/rust/scx_layered/src/config.rs
+++ b/scheds/rust/scx_layered/src/config.rs
@@ -137,6 +137,10 @@ pub struct LayerCommon {
     pub idle_smt: Option<bool>,
     #[serde(default)]
     pub growth_algo: LayerGrowthAlgo,
+    /// Half-life in milliseconds for holding recent utilization peaks when
+    /// deciding whether a layer should shrink. 0 disables peak holding.
+    #[serde(default)]
+    pub util_peak_half_life_ms: u64,
     #[serde(default)]
     pub perf: u64,
     #[serde(default)]

--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -1487,6 +1487,26 @@ fn resolve_cpus_pct_range(
     }
 }
 
+fn update_peak_util(
+    prev_peak: f64,
+    cur_util: f64,
+    half_life: Duration,
+    elapsed: Duration,
+) -> f64 {
+    let decay = 0.5f64.powf(elapsed.as_secs_f64() / half_life.as_secs_f64());
+    (prev_peak * decay).max(cur_util)
+}
+
+fn calc_peak_aware_target_range(
+    util: f64,
+    peak_util: f64,
+    util_range: (f64, f64),
+) -> (usize, usize) {
+    let low = (util / util_range.1).ceil() as usize;
+    let high = ((util.max(peak_util) / util_range.0).floor() as usize).max(low);
+    (low, high)
+}
+
 impl Layer {
     fn new(spec: &LayerSpec, topo: &Topology, core_order: &Vec<Vec<usize>>) -> Result<Self> {
         let name = &spec.name;
@@ -1564,6 +1584,8 @@ impl Layer {
             if util_range.0 < 0.0 || util_range.1 < 0.0 || util_range.0 >= util_range.1 {
                 bail!("invalid util_range {:?}", util_range);
             }
+        } else if kind.common().util_peak_half_life_ms != 0 {
+            bail!("util_peak_half_life_ms requires util_range");
         }
 
         let layer_growth_algo = kind.common().growth_algo.clone();
@@ -1815,6 +1837,7 @@ struct Scheduler<'a> {
 
     proc_reader: fb_procfs::ProcReader,
     sched_stats: Stats,
+    layer_peak_utils: Vec<f64>,
 
     cgroup_regexes: Option<HashMap<u32, Regex>>,
 
@@ -3068,6 +3091,7 @@ impl<'a> Scheduler<'a> {
                 &gpu_task_handler,
                 opts.util_compensation,
             )?,
+            layer_peak_utils: vec![0.0; nr_layers],
 
             cgroup_regexes: Some(cgroup_regexes),
             nr_layer_cpus_ranges: vec![(0, 0); nr_layers],
@@ -3258,16 +3282,11 @@ impl<'a> Scheduler<'a> {
     /// applying the inverse of util_range and capping by cpus_range.
     /// If the current allocation is within the acceptable range, no
     /// change is made. Returns (target, min) pair for each layer.
-    fn calc_target_nr_cpus(&self) -> Vec<(usize, usize)> {
+    fn calc_target_nr_cpus(&mut self) -> Vec<(usize, usize)> {
         let nr_cpus = self.cpu_pool.topo.all_cpus.len();
-        let utils = if self.sched_stats.util_compensation {
-            &self.sched_stats.layer_utils_compensated
-        } else {
-            &self.sched_stats.layer_utils
-        };
         let membws = &self.sched_stats.layer_membws;
 
-        let mut records: Vec<(u64, u64, u64, usize, usize, usize)> = vec![];
+        let mut records: Vec<(u64, u64, u64, u64, usize, usize, usize)> = vec![];
         let mut targets: Vec<(usize, usize)> = vec![];
 
         for (idx, layer) in self.layers.iter().enumerate() {
@@ -3293,8 +3312,14 @@ impl<'a> Scheduler<'a> {
                     // for sizing. Also, as an empty layer can only get CPU
                     // time through fallback (counted as owned) or open
                     // execution, add open cputime for empty layers.
-                    let owned = utils[idx][LAYER_USAGE_OWNED];
-                    let open = utils[idx][LAYER_USAGE_OPEN];
+                    let (owned, open) = {
+                        let utils = if self.sched_stats.util_compensation {
+                            &self.sched_stats.layer_utils_compensated[idx]
+                        } else {
+                            &self.sched_stats.layer_utils[idx]
+                        };
+                        (utils[LAYER_USAGE_OWNED], utils[LAYER_USAGE_OPEN])
+                    };
 
                     let membw_owned = membws[idx][LAYER_USAGE_OWNED];
                     let membw_open = membws[idx][LAYER_USAGE_OPEN];
@@ -3308,8 +3333,19 @@ impl<'a> Scheduler<'a> {
 
                     let util = if util < 0.01 { 0.0 } else { util };
 
-                    let low = (util / util_range.1).ceil() as usize;
-                    let high = ((util / util_range.0).floor() as usize).max(low);
+                    let peak_util = if layer.kind.common().util_peak_half_life_ms == 0 {
+                        util
+                    } else {
+                        update_peak_util(
+                            self.layer_peak_utils[idx],
+                            util,
+                            Duration::from_millis(layer.kind.common().util_peak_half_life_ms),
+                            self.sched_stats.elapsed,
+                        )
+                    };
+                    self.layer_peak_utils[idx] = peak_util;
+                    let (low, high) =
+                        calc_peak_aware_target_range(util, peak_util, *util_range);
 
                     let membw_limit = match membw_gb {
                         Some(membw_limit) => *membw_limit,
@@ -3327,6 +3363,7 @@ impl<'a> Scheduler<'a> {
                         (owned * 100.0) as u64,
                         (open * 100.0) as u64,
                         (util * 100.0) as u64,
+                        (peak_util * 100.0) as u64,
                         low,
                         high,
                         target,
@@ -3355,7 +3392,7 @@ impl<'a> Scheduler<'a> {
             });
         }
 
-        trace!("(owned, open, util, low, high, target): {:?}", &records);
+        trace!("(owned, open, util, peak, low, high, target): {:?}", &records);
         targets
     }
 
@@ -5193,6 +5230,83 @@ fn main(opts: Opts) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod peak_util_tests {
+    use super::*;
+
+    #[test]
+    fn test_peak_pins_recent_burst() {
+        let elapsed = Duration::from_millis(100);
+        let half_life = Duration::from_secs(1);
+        let mut peak = 0.0;
+
+        for _ in 0..5 {
+            peak = update_peak_util(peak, 0.1, half_life, elapsed);
+        }
+
+        peak = update_peak_util(peak, 2.0, half_life, elapsed);
+
+        for _ in 0..5 {
+            peak = update_peak_util(peak, 0.1, half_life, elapsed);
+        }
+
+        assert!(
+            peak > 1.3,
+            "peak should still hold the recent burst, got {peak}"
+        );
+    }
+
+    #[test]
+    fn test_peak_decays_after_quiet_period() {
+        let elapsed = Duration::from_millis(100);
+        let half_life = Duration::from_secs(1);
+        let mut peak = 2.0;
+
+        for _ in 0..50 {
+            peak = update_peak_util(peak, 0.0, half_life, elapsed);
+        }
+
+        assert!(
+            peak < 0.1,
+            "peak should decay after a long quiet period, got {peak}"
+        );
+    }
+
+    #[test]
+    fn test_peak_matches_steady_input() {
+        let elapsed = Duration::from_millis(100);
+        let half_life = Duration::from_secs(1);
+        let mut peak = 0.0;
+
+        for _ in 0..30 {
+            peak = update_peak_util(peak, 1.0, half_life, elapsed);
+        }
+
+        assert!(
+            (peak - 1.0).abs() < 1e-9,
+            "peak should match steady-state input, got {peak}"
+        );
+    }
+
+    #[test]
+    fn test_peak_only_changes_shrink_target() {
+        let util_range = (0.7, 0.9);
+        let (low_no_peak, high_no_peak) = calc_peak_aware_target_range(1.8, 1.8, util_range);
+        let (low_with_peak, high_with_peak) = calc_peak_aware_target_range(1.8, 3.1, util_range);
+
+        assert_eq!(low_no_peak, 2);
+        assert_eq!(
+            low_with_peak, low_no_peak,
+            "peak should not affect growth target"
+        );
+        assert_eq!(high_no_peak, 2);
+        assert_eq!(
+            high_with_peak, 4,
+            "peak should only widen the shrink boundary"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION

Add `util_peak_half_life_ms` as an opt-in per-layer config knob for `Confined` and `Grouped` layers. When set, `scx_layered` keeps a decaying peak of the sizing utilization and uses `max(util, peak_util)` only for the upper target bound, so recent bursts can delay shrink while growth remains based on current utilization. The default `0` preserves existing behavior, and the knob is rejected on layers without `util_range`.

