### PR TITLE
scx_pandemoniumv5.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "scx_pandemonium"
-version = "5.9.1"
+version = "5.12.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/scheds/rust/scx_pandemonium/Cargo.toml
+++ b/scheds/rust/scx_pandemonium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_pandemonium"
-version = "5.9.1"
+version = "5.12.0"
 edition = "2021"
 description = "A behavioral, adaptive sched_ext scheduler with three-tier classification, L2 affinity, and process learning"
 license = "GPL-2.0-only"
@@ -14,9 +14,6 @@ clap = { version = "4", features = ["derive"] }
 ctrlc = { version = "3", features = ["termination"] }
 flate2 = "1"
 regex = "1"
-
-[dev-dependencies]
-libc = "0.2"
 
 [build-dependencies]
 scx_cargo = { path = "../../../rust/scx_cargo", version = "1.1.1" }

--- a/scheds/rust/scx_pandemonium/README.md
+++ b/scheds/rust/scx_pandemonium/README.md
@@ -1,178 +1,149 @@
 # PANDEMONIUM
 
-A Linux kernel scheduler for sched_ext, built in Rust and C23. PANDEMONIUM classifies every task by behavior — wakeup frequency, context switch rate, runtime, sleep patterns — and adapts scheduling decisions in real time. A critically-damped harmonic oscillator drives CoDel-inspired stall detection with the literal RFC 8289 sojourn metric and an R_eff-derived equilibrium reference. Resistance affinity (effective resistance from the Laplacian pseudoinverse of the CPU topology graph) provides topology-aware task placement for pipe/IPC storms. Multiplicative Weight Updates (MWU) balance six competing expert profiles across four loss pathways.
+A Linux kernel scheduler for sched_ext, built in Rust and C23. PANDEMONIUM classifies every task by behavior — wakeup frequency, context switch rate, runtime, sleep patterns — and adapts scheduling decisions in real time. A damped harmonic oscillator drives CoDel-inspired stall detection with the literal RFC 8289 sojourn metric and an R_eff-derived equilibrium reference. Resistance affinity (effective resistance from the Laplacian pseudoinverse of the CPU topology graph) provides topology-aware task placement for pipe/IPC storms. A migration potential Φ — R_eff priced against the queueing relief a move buys — gates cross-domain work stealing, so a steal crosses a cache boundary only when the backlog it relieves outweighs the cache cost. Multiplicative Weight Updates (MWU) balance six competing expert profiles across six loss pathways — one of them a cross-CCX scatter signal that holds the adaptive layer's knob choices in line with the Φ placement it sits above.
 
-Three-tier behavioral dispatch, overflow sojourn rescue, longrun detection, tier-aware preempt scaling, sleep-informed batch tuning, classification-gated DSQ routing, workload regime detection, vtime ceiling with new-task lag penalty, hard starvation rescue, and a persistent process database that learns task classifications across lifetimes.
+Three-tier behavioral dispatch, overflow sojourn rescue, longrun detection, tier-aware preempt scaling, sleep-informed batch tuning, classification-gated DSQ routing, workload regime detection, flow-signature shape routing (per-task partner-cardinality classification into TIGHT loops vs STORM meshes), a migration-potential-gated R_eff work steal, a Φ-priced warm-stay home anchor, a sojourn selector with bounded maturity-gated tier warp, a per-CPU tau-derived preempt, an RT-policy latency floor, hard starvation rescue, and a persistent process database that learns task classifications across lifetimes.
 
-PANDEMONIUM is included in the [sched-ext/scx](https://github.com/sched-ext/scx) project alongside scx_rusty, scx_lavd, scx_cosmos, scx_cake and the rest of the sched_ext family. Thank you to Piotr Gorski and the sched-ext team. PANDEMONIUM is made possible by contributions from the sched_ext, CachyOS, Gentoo, OpenSUSE, Arch and Ubuntu communities within the Linux ecosystem.
+PANDEMONIUM is included in the [sched-ext/scx](https://github.com/sched-ext/scx) project alongside scx_rusty, scx_lavd, scx_cosmos and the rest of the sched_ext family. Thank you to Piotr Gorski and the sched-ext team. PANDEMONIUM is made possible by contributions from the sched_ext, CachyOS, Gentoo, OpenSUSE, Arch and Ubuntu communities within the Linux ecosystem.
 
 ## Performance
 
-12 AMD Zen CPUs, kernel 6.18+, clang 21. The tables below report v5.8.0 PANDEMONIUM numbers from a single-iteration bench-scale run across 2C/4C/8C/12C; the v5.9.0 deltas at 12C are summarized in the next subsection. EEVDF and scx_bpfland baselines are best-3-of-N historical (28 and 26 complete runs across 75 bench-scale sessions) — those baselines don't drift across PANDEMONIUM versions. v5.8.0 closed the 2C structural starvation class via the rescue-fairness fix and the missing CPU-bound demotion in stopping() that was leaving long-runners stuck at TIER_INTERACTIVE (longrun WORST 19s -> 13ms at 2C, mixed WORST 29s -> 16ms at 2C). Bench-fork-thread lands within 1% of EEVDF and ~40% ahead of scx_bpfland.
+12 AMD Zen CPUs, kernel 7.0.10, clang 21. Numbers below are from a single fresh-boot 3-iteration bench-scale run (2026-06-01, v5.12.0) — all five schedulers (EEVDF, scx_bpfland, scx_cake, PANDEMONIUM BPF + ADAPTIVE) measured in the same run.
 
-### v5.9.0 Deltas (12C, single iteration vs v5.8.0 24-run mean)
+### v5.12.0
 
-| Metric            | v5.8.0 mean | v5.9.0     | Delta              |
-|-------------------|-------------|------------|--------------------|
-| Burst P99         | 392us       | **83us**   | -4.7x              |
-| Longrun P99       | 489us       | **244us**  | -2.0x              |
-| Mixed P99         | 724us       | **139us**  | -5.2x              |
-| IPC P99           | 107us       | **36us**   | -3.0x              |
-| Deadline miss     | 3.56%       | **0.1%**   | -35x               |
-| Schbench P99      | 75us        | 77us       | hold               |
-| App launch P99    | 2,983us     | 4,692us    | regression (n=1)   |
-
-Architectural changes in v5.9.0 (affinity threading through the R_eff spill chain, `MAX_AFFINITY_CANDIDATES = MAX_CPUS >> 3` topology coverage, slice-relative INTERACTIVE→BATCH demotion, tier-priority tick preempt) address structural classes that did not show on the v5.8.0 12C single-iteration cells. The 32C affinity-stranding class closure was confirmed by a 3.5+ hour real-workload run on Threadripper (game + KVM + libvirt, no watchdog kills, no stalls); multi-iteration sweeps across 2C/4C/8C/12C are pending. The app-launch regression is single-iteration and likely under-sampled — to be retested under multi-run aggregation.
+v5.12.0 drives the adaptive control plane into Φ-coherence with the BPF placement it sits above: eviction keyed to the same equilibrium the kernel rescues at, a cross-CCX scatter loss pathway that lets MWU see migration, Φ-aware oscillator gating, and a core-count slice discipline that holds the low-core regime to a tight slice where a wide one buys no throughput. The Rust layer now reinforces the kernel's placement instead of contending with it — ADAPTIVE tracks BPF across the board (2C longrun 182µs vs 181µs, steady across three iterations), and PANDEMONIUM leads the full scheduler field on every latency, burst, longrun, mixed, and deadline-miss table below. The two corners it still trails — IPC round-trip and app launch — are called out plainly under their tables.
 
 ### P99 Wakeup Latency (interactive probe under CPU saturation)
 
-| Cores | EEVDF    | scx_bpfland | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|----------|-------------|-------------------|------------------------|
-| 2     | 2,058us  | 2,004us     | **87us**          | 93us                   |
-| 4     | 1,246us  | 2,003us     | **65us**          | 68us                   |
-| 8     | 425us    | 2,003us     | **66us**          | 68us                   |
-| 12    | 344us    | 2,002us     | **68us**          | 70us                   |
-
-Sub-95us in both modes at every core count.
+| Cores | EEVDF    | scx_bpfland | scx_cake  | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|----------|-------------|-----------|-------------------|------------------------|
+| 2     | 2,500us  | 2,873us     | 1,029us   | **74us**          | 173us                  |
+| 4     | 3,865us  | 1,318us     | 1,916us   | **61us**          | 62us                   |
+| 8     | 988us    | 1,943us     | 62us      | **61us**          | 64us                   |
+| 12    | 107us    | 1,956us     | **56us**  | 63us              | 63us                   |
 
 ### Burst P99 (fork/exec storm under CPU saturation)
 
-| Cores | EEVDF    | scx_bpfland | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|----------|-------------|-------------------|------------------------|
-| 2     | 2,262us  | 2,006us     | 189us             | **69us**               |
-| 4     | 3,223us  | 2,003us     | 687us             | **207us**              |
-| 8     | 2,331us  | 2,004us     | 611us             | **93us**               |
-| 12    | 1,891us  | 2,001us     | **79us**          | 196us                  |
-
-Both modes beat EEVDF and scx_bpfland by a wide margin. Burst-storm cost is workload-sensitive across iterations.
+| Cores | EEVDF    | scx_bpfland | scx_cake   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|----------|-------------|------------|-------------------|------------------------|
+| 2     | 2,565us  | 1,303us     | 14,189us   | **64us**          | 150us                  |
+| 4     | 2,090us  | 1,052us     | 24,764us   | 63us              | **61us**               |
+| 8     | 2,865us  | 1,827us     | 27,869us   | **63us**          | 2,048us                |
+| 12    | 1,871us  | 1,965us     | 27,948us   | **71us**          | 118us                  |
 
 ### Longrun P99 (interactive latency with sustained CPU-bound long-runners)
 
-| Cores | EEVDF    | scx_bpfland | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|----------|-------------|-------------------|------------------------|
-| 2     | 2,293us  | 2,000us     | 2,327us           | **559us**              |
-| 4     | 1,421us  | 2,003us     | 870us             | **68us**               |
-| 8     | **60us** | 2,003us     | **439us**         | 655us                  |
-| 12    | 126us    | 2,002us     | 674us             | **80us**               |
-
-ADAPTIVE 4C/12C sub-100us — the CPU-bound demotion fix in stopping() finally lets INTERACTIVE long-runners reclassify to BATCH so tick() can preempt them on prober wakeups. WORST tails bounded: longrun WORST 13ms at 2C (vs 19s pre-v5.8.0).
+| Cores | EEVDF    | scx_bpfland | scx_cake   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|----------|-------------|------------|-------------------|------------------------|
+| 2     | 3,957us  | 1,023us     | 9,479us    | **181us**         | 182us                  |
+| 4     | 2,078us  | 1,908us     | 7,378us    | **62us**          | 66us                   |
+| 8     | 2,920us  | 1,813us     | 7,840us    | 62us              | **61us**               |
+| 12    | 667us    | 1,864us     | 11,891us   | 65us              | **64us**               |
 
 ### Mixed Latency P99 (interactive + batch concurrent)
 
-| Cores | EEVDF    | scx_bpfland | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|----------|-------------|-------------------|------------------------|
-| 2     | 2,412us  | 2,000us     | 1,993us           | **876us**              |
-| 4     | 1,683us  | 2,003us     | 217us             | **72us**               |
-| 8     | 348us    | 2,003us     | 572us             | **326us**              |
-| 12    | 494us    | 2,002us     | 644us             | **81us**               |
-
-ADAPTIVE under EEVDF at every core count, sub-100us at 4C and 12C. Mixed WORST 16ms at 2C (vs 29s pre-v5.8.0); deadline miss collapsed to ≤0.1% in every ADAPTIVE cell (table below).
+| Cores | EEVDF    | scx_bpfland | scx_cake   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|----------|-------------|------------|-------------------|------------------------|
+| 2     | 3,990us  | 1,948us     | 14,049us   | **315us**         | 471us                  |
+| 4     | 2,135us  | 1,955us     | 21,160us   | 197us             | **60us**               |
+| 8     | 2,822us  | 1,805us     | 29,521us   | **64us**          | 315us                  |
+| 12    | 2,917us  | 1,750us     | 34,770us   | **67us**          | 166us                  |
 
 ### Deadline Miss Ratio (16.6ms frame target)
 
-| Cores | EEVDF   | scx_bpfland | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|---------|-------------|-------------------|------------------------|
-| 2     | 13.1%   | 69.4%       | 0.2%              | **0.1%**               |
-| 4     | 8.6%    | 60.4%       | 0.1%              | **0.0%**               |
-| 8     | 10.8%   | 53.8%       | 0.1%              | **0.0%**               |
-| 12    | 10.4%   | 54.7%       | 0.1%              | **0.0%**               |
+| Cores | EEVDF   | scx_bpfland | scx_cake | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|---------|-------------|----------|-------------------|------------------------|
+| 2     | 16.4%   | 65.8%       | 21.5%    | **0.2%**          | **0.2%**               |
+| 4     | 9.0%    | 64.9%       | 2.8%     | **0.1%**          | 0.2%                   |
+| 8     | 10.4%   | 59.6%       | 0.2%     | **0.0%**          | 0.2%                   |
+| 12    | 11.1%   | 54.5%       | 0.3%     | **0.1%**          | 0.1%                   |
 
-Sub-1% at every core count, 0.0% in every ADAPTIVE cell at 4C and above. v5.7.0's 4C bimodal pattern (0.2%–20% across runs) is gone.
-
-### Burst Recovery P99 (latency after storm subsides)
+### Burst Recovery P99 (latency after storm subsides, bench-contention 2026-06-01)
 
 | Cores | PANDEMONIUM (bench-contention burst-recovery phase) |
 |-------|------------------------------------------------------|
-| 2     | burst 65us / recovery 62us                          |
-| 4     | burst 73us / recovery 73us                          |
-| 8     | burst 76us / recovery 76us                          |
-| 12    | burst 77us / recovery 76us                          |
-
-Sub-80us recovery at every core count.
+| 2     | base 118us / burst 116us / recovery 123us           |
+| 4     | base 124us / burst 131us / recovery 141us           |
+| 8     | base 63us / burst 64us / recovery 64us              |
+| 12    | base 61us / burst 65us / recovery 77us              |
 
 ### App Launch P99
 
-| Cores | EEVDF    | scx_bpfland | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|----------|-------------|-------------------|------------------------|
-| 2     | **2,899us**| 2,194us   | 12,601us          | 3,595us                |
-| 4     | 4,058us  | **2,199us** | 4,516us           | 2,722us                |
-| 8     | 4,092us  | **1,723us** | 2,700us           | 4,405us                |
-| 12    | 3,552us  | **1,520us** | 6,177us           | 2,994us                |
-
-scx_bpfland keeps the dense-end edge here. ADAPTIVE app-launch dropped substantially across all core counts after the CPU-bound demotion fix removed long-runner head-of-queue contention.
+| Cores | EEVDF    | scx_bpfland | scx_cake | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|----------|-------------|----------|-------------------|------------------------|
+| 2     | 5,332us  | **2,310us** | 7,999us  | 3,004us           | 6,276us                |
+| 4     | 3,046us  | **2,346us** | 6,003us  | 8,853us           | 8,576us                |
+| 8     | 3,680us  | **2,368us** | 6,008us  | 7,056us           | 6,395us                |
+| 12    | 3,548us  | 3,589us     | 7,999us  | **1,953us**       | 2,068us                |
 
 ### IPC Round-Trip P99
 
-| Cores | EEVDF    | scx_bpfland | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|----------|-------------|-------------------|------------------------|
-| 2     | **12us** | 18us        | 751us             | 4,240us                |
-| 4     | 118us    | 23us        | 3,952us           | **58us**               |
-| 8     | **23us** | 71us        | 109us             | **68us**               |
-| 12    | **15us** | 57us        | 32us              | **25us**               |
+| Cores | EEVDF    | scx_bpfland | scx_cake | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|----------|-------------|----------|-------------------|------------------------|
+| 2     | **15us** | **15us**    | 4,002us  | 1,015us           | 2,617us                |
+| 4     | **12us** | 25us        | 2,005us  | 25us              | 194us                  |
+| 8     | **14us** | 136us       | 2,010us  | 1,995us           | 1,985us                |
+| 12    | **14us** | 99us        | 2,006us  | 1,535us           | 1,335us                |
 
-12C ADAPTIVE within 10us of EEVDF. 2C and BPF 4C still show the pipe-partner placement tail at saturation — the resistance-affinity gap on thin topologies where R_eff peer counts are limited.
+### Fork/Thread IPC (`perf bench sched messaging -t -g 24 -l 6000`, 12C, v5.12.0)
 
-### Fork/Thread IPC (`perf bench sched messaging`, 12C, v5.8.0)
+Fresh-boot run, 2026-06-01 — the fork-storm + IPC messaging workload, the storm cache-miss axis the migration-potential Φ targets.
 
-| Scheduler | Time | vs EEVDF | Cache Misses | IPC |
-|-----------|------|----------|--------------|-----|
-| EEVDF                    | 16.38s | baseline  | 29M  | 0.44 |
-| PANDEMONIUM (BPF)        | 16.51s | +0.8%     | 35M  | 0.44 |
-| PANDEMONIUM (ADAPTIVE)   | 16.53s | +0.9%     | 33M  | 0.45 |
-| scx_bpfland              | 23.04s | +40.6%    | 57M  | 0.42 |
+| Scheduler                | Time     | vs EEVDF | Cache Misses | IPC   |
+|--------------------------|----------|----------|--------------|-------|
+| EEVDF                    | 16.399s  | baseline | 31.36M       | 0.427 |
+| PANDEMONIUM (BPF)        | 16.559s  | +1.0%    | 36.25M       | 0.425 |
+| PANDEMONIUM (ADAPTIVE)   | 16.976s  | +3.5%    | 38.34M       | 0.411 |
 
-BPF and ADAPTIVE land within 0.1% of each other and ~40% ahead of scx_bpfland. ADAPTIVE actually edges out EEVDF on IPC (0.45 vs 0.44) despite the slightly longer wall-time, reflecting the cache-locality benefit from resistance affinity.
+### Energy Efficiency (`bench-power`, 12C, v5.12.0)
 
-### Energy Efficiency (`bench-power`, 12C, v5.9.0)
-
-5 runs per cell, 30s cooldown. Package energy via `perf stat -a -e power/energy-pkg/`. Zen 2 exposes only `J_pkg` (no per-core or per-DRAM RAPL).
+5 runs per (scheduler, workload), 30s cooldown, 2026-06-01. Package energy via `perf stat -a -e power/energy-pkg/`. Zen 2 (Ryzen 5 3600) exposes only `J_pkg` (no per-core or per-DRAM RAPL).
 
 **Idle floor** (30s `sleep`, scheduler restlessness):
 
 | Scheduler                | J_pkg   | Avg W    | vs EEVDF |
 |--------------------------|---------|----------|----------|
-| EEVDF                    | **693.37J** | **23.09W** | baseline |
-| scx_lavd                 | 708.18J | 23.58W   | +2.1%    |
-| scx_bpfland              | 708.77J | 23.60W   | +2.2%    |
-| PANDEMONIUM (BPF)        | 718.19J | 23.92W   | +3.6%    |
-| PANDEMONIUM (ADAPTIVE)   | 741.37J | 24.69W   | +6.9%    |
-
-ADAPTIVE's +6.9% is the Rust 1Hz monitoring loop's package-power tax. BPF's +3.6% is the dispatch path firing more on idle than the kernel default.
+| EEVDF                    | **626.37J** | **20.86W** | baseline |
+| scx_flow                 | 649.92J | 21.65W   | +3.8%    |
+| scx_bpfland              | 653.61J | 21.77W   | +4.3%    |
+| PANDEMONIUM (ADAPTIVE)   | 656.94J | 21.88W   | +4.9%    |
+| PANDEMONIUM (BPF)        | 658.01J | 21.91W   | +5.1%    |
+| scx_lavd                 | 662.85J | 22.07W   | +5.8%    |
 
 **Messaging** (`perf bench sched messaging -t -g 24 -l 6000`, fork-storm + IPC):
 
-| Scheduler                | Wall_s     | J_pkg     | J/msg      | vs EEVDF |
-|--------------------------|------------|-----------|------------|----------|
-| EEVDF                    | **15.67s** | **975.38J** | **169.34uJ** | baseline |
-| PANDEMONIUM (BPF)        | 16.13s     | 984.75J   | 170.96uJ   | +1.0%    |
-| PANDEMONIUM (ADAPTIVE)   | 16.10s     | 985.21J   | 171.04uJ   | +1.0%    |
-| scx_bpfland              | 21.23s     | 1275.33J  | 221.41uJ   | +30.8%   |
-| scx_lavd                 | 25.85s     | 1617.79J  | 280.87uJ   | +65.9%   |
-
-Within 1% of EEVDF on J/msg under load.
+| Scheduler                | Wall_s     | J_pkg       | J/op       | vs EEVDF |
+|--------------------------|------------|-------------|------------|----------|
+| EEVDF                    | **15.20s** | **935.51J** | **162.41uJ** | baseline |
+| PANDEMONIUM (ADAPTIVE)   | 15.43s     | 950.62J     | 165.04uJ   | +1.6%    |
+| PANDEMONIUM (BPF)        | 15.86s     | 975.09J     | 169.29uJ   | +4.2%    |
+| scx_bpfland              | 20.40s     | 1218.07J    | 211.47uJ   | +30.2%   |
+| scx_lavd                 | 28.33s     | 1741.51J    | 302.35uJ   | +86.2%   |
+| scx_flow                 | 52.11s     | 3238.47J    | 562.23uJ   | +246.2%  |
 
 ## Key Features
 
 ### Dispatch Waterfall
 
-Layered dispatch with per-CPU DSQ dominance and one age-driven safety mechanism. CPU-tied placement (Tier 2 wakeup preemption, `select_cpu`) is bounded at the enqueue site by `pcpu_depth_base` and overflow spills to a sibling per-CPU DSQ in R_eff order (`find_pcpu_with_room` → `pick_pcpu_dsq_with_spill`), so the dispatch waterfall reaches every CPU-tied enqueue at step 0 (sibling owns) or step 1 (R_eff steal). Idle-CPU placement (Tier 1) inserts directly into `node_dsq` and is picked up by step 3 within one dispatch cycle — eager R_eff search at this site was a wire-speed regression on fork-storm workloads with no measurable placement benefit. v5.8.0 collapsed the v5.7.0 14-decision-point waterfall into 6 steps + 1 safety net by removing redundant rescue paths (deficit-gate-with-exception, DRR deficit counter, batch sojourn rescue) that all reduced to "service the older overflow side past a threshold." `sojourn_gate_pass` was kept at STEP 0 / STEP 1 — bench evidence proved it load-bearing for workqueue-worker fairness under sustained per-CPU load (without it, `scx_watchdog_workfn` strands in node_dsq long enough to trigger 30s watchdog kills).
+Layered dispatch with per-CPU DSQ dominance and one age-driven safety mechanism. CPU-tied placement (Tier 2 wakeup preemption, `select_cpu`) is bounded at the enqueue site by `pcpu_depth_base` and overflow spills to a sibling per-CPU DSQ in R_eff order (`find_pcpu_with_room` → `pick_pcpu_dsq_with_spill`), so the dispatch waterfall reaches every CPU-tied enqueue at step 0 (sibling owns) or step 1 (R_eff steal). Idle-CPU placement (Tier 1) inserts directly into `node_dsq` and is picked up by step 3 within one dispatch cycle — eager R_eff search at this site is a wire-speed regression on fork-storm workloads with no measurable placement benefit. The waterfall is 7 steps (0–6) + 1 safety net; redundant rescue paths (deficit-gate-with-exception, DRR deficit counter, batch sojourn rescue) are deliberately absent — they all reduce to "service the older overflow side past a threshold," which STEP 2 already does. `sojourn_gate_pass` sits at STEP 0 / STEP 1, load-bearing for workqueue-worker fairness under sustained per-CPU load (without it, `scx_watchdog_workfn` strands in node_dsq long enough to trigger 30s watchdog kills).
 
 0. **Own per-CPU DSQ** — cache-hot, zero contention. Sojourn-gated return: if either overflow side has aged past `overflow_sojourn_rescue_ns`, fall through to STEP 2 so this dispatch serves overflow too.
-1. **R_eff steal** — single loop over `affinity_rank` (slot 0 = L2 sibling, slots 1+ = R_eff-ranked cross-L2 peers). Budget is tau-derived: `pcpu_spill_search_budget = K_SPILL_BUDGET / tau ≈ λ₂/2`, clamped to `[6, min(nr_cpu_ids - 1, MAX_AFFINITY_CANDIDATES)]`. The companion WAKE_SYNC idle-search budget `affinity_search_online = K_AFFINITY_SEARCH / tau ≈ λ₂/4` clamps the same way (smaller divisor because the predicate is more expensive). `MAX_AFFINITY_CANDIDATES = MAX_CPUS >> 3` (= 128 at the current MAX_CPUS=1024) is the verifier-safe compile-time ceiling; the runtime ceiling tracks actual topology via `nr_cpu_ids - 1`. Wider graphs get more coverage: 12C → 6/3, 32C → 16/8, 128C+ → 128/64. Subsumes the v5.7.0 STEP 1 (L2 walk) and STEP 1b (R_eff fallback) since `affinity_rank` is authoritative for placement distance. Same sojourn gate as STEP 0 on success.
+1. **R_eff steal** — single loop over `affinity_rank` (slot 0 = L2 sibling, slots 1+ = R_eff-ranked cross-L2 peers). Budget is tau-derived: `pcpu_spill_search_budget = K_SPILL_BUDGET / tau ≈ λ₂/2`, clamped to `[6, min(nr_cpu_ids - 1, MAX_AFFINITY_CANDIDATES)]`. The companion WAKE_SYNC idle-search budget `affinity_search_online = K_AFFINITY_SEARCH / tau ≈ λ₂/4` clamps the same way (smaller divisor because the predicate is more expensive). `MAX_AFFINITY_CANDIDATES = MAX_CPUS >> 3` (= 128 at the current MAX_CPUS=1024) is the verifier-safe compile-time ceiling; the runtime ceiling tracks actual topology via `nr_cpu_ids - 1`. Wider graphs get more coverage: 12C → 6/3, 32C → 16/8, 128C+ → 128/64. `affinity_rank` is authoritative for placement distance, so this single walk covers both the L2 sibling and cross-L2 peers with no separate L2 walk or R_eff fallback. Same sojourn gate as STEP 0 on success.
 1. *Safety net.* **Hard starvation rescue** — `try_service_older_overflow(starvation_rescue_ns)`: drains whichever of `interactive_enqueue_ns` / `batch_enqueue_ns` is older past the tau-scaled hard cap. Fires before STEP 2 so it cannot be gated. Should ~never fire post-placement-fix.
-2. **Service older overflow side** — `try_service_older_overflow(overflow_sojourn_rescue_ns)`: same pick-the-older comparison at the ~10ms threshold. Feeds the CoDel oscillator (`global_rescue_count++`). Replaces the v5.7.0 interactive-overflow-amplification + batch-overflow-rescue + deficit-gate-with-exception + DRR cluster.
-3. **Node interactive overflow** — unconditional `node_dsq` drain (LAT_CRITICAL + INTERACTIVE, vtime-ordered).
+2. **Service older overflow side** — `try_service_older_overflow(overflow_sojourn_rescue_ns)`: same pick-the-older comparison at the R_eff-derived equilibrium threshold (`overflow_sojourn_rescue_ns = codel_target_equilibrium_ns`, ≤~2ms at 12C). Feeds the CoDel oscillator (`global_rescue_count++`).
+3. **Node interactive overflow** — unconditional `node_dsq` drain (LAT_CRITICAL + INTERACTIVE, sojourn-ordered).
 4. **Node batch overflow** — unconditional `batch_dsq` drain.
 5. **Cross-node steal** — interactive + batch per remote node.
 6. **KEEP_RUNNING** — if prev still wants CPU and nothing queued.
 
 ### Three-Tier Enqueue
 
-- **select_cpu**: idle CPU -> per-CPU DSQ (depth-gated: 1 slot at <4C, 2 at 4C+) -> R_eff sibling spill if full -> last-resort node DSQ. KICK_IDLE on the actual placement target. WAKE_SYNC path: wakee_flips gate -> R_eff idle search -> waker fallback (both run through the same depth-gated placement helper)
-- **enqueue Tier 1** (idle CPU): direct `node_dsq` insert + KICK_PREEMPT. Drained by STEP 3 (unconditional `node_dsq`) within one dispatch cycle. v5.6.0's wire-speed path — restored after v5.8.0's eager R_eff search proved a fork-storm regression with no placement benefit
+- **select_cpu**: idle CPU -> per-CPU DSQ (depth-gated: 1 slot at <4C, 2 at 4C+) -> R_eff sibling spill if full -> last-resort node DSQ, with KICK_IDLE on the placement target. WAKE_SYNC path: partner-CPU fast path (claim the wakee's `last_cpu` directly if idle and allowed, skipping the R_eff scan on a stable pair) -> R_eff idle search -> waker fallback, WITH a kick — arm A (found-idle) KICK_IDLE, arm B (no-idle) KICK_PREEMPT — so the wakee runs next instead of aging until the target's tick (the dominant IPC round-trip tail)
+- **enqueue Tier 1** (idle CPU): direct `node_dsq` insert + KICK_PREEMPT for non-BATCH / KICK_IDLE for BATCH. Drained by STEP 3 (unconditional `node_dsq`) within one dispatch cycle. The wire-speed path: eager R_eff search at this site is a fork-storm regression with no placement benefit, so Tier 1 stays a direct insert
 - **enqueue Tier 2** (wakeup preemption): uses `pick_pcpu_dsq_with_spill` for symmetric placement with `select_cpu`. CPU-tied; benefits from eager per-CPU placement
-- **enqueue Tier 3** (fallback): node_dsq for INTERACTIVE, batch overflow DSQ for BATCH and immature INTERACTIVE. Vtime ceiling applied here
-- **tick**: longrun detection (batch non-empty >2s), sojourn enforcement, preempt batch for waiting interactive (tier-aware threshold — tightened 4× when a LAT_CRITICAL waiter is in flight, extended 4× at 2C during longrun to protect BATCH long-runners)
+- **enqueue Tier 3** (fallback): batch overflow DSQ for BATCH only; LAT_CRITICAL, INTERACTIVE, and immature INTERACTIVE (`ewma_age < 2`) all stay in `node_dsq` — immature tasks are deliberately kept out of the batch DSQ to avoid burst-spawn starvation. The sojourn deadline (`now − warp`) is computed at the insert
+- **tick**: longrun detection (batch non-empty >2s), sojourn enforcement, per-CPU preempt of the resident for an aged waiter (`pcpu_enqueue_ns[this_cpu]` age vs a tau-scaled threshold; BATCH yields at base, INTERACTIVE at 2×, LAT_CRITICAL never)
 
 ### Damped Harmonic Oscillator Stall Detection
 
@@ -182,36 +153,36 @@ CoDel-inspired per-CPU DSQ stall detection where the target follows the full dam
 ẍ + 2γẋ + ω₀²(x − c_eq) = F(t)
 ```
 
-with `γ = ω₀` for critical damping (no overshoot, fastest stable return). v5.8.0 added the missing ω₀² spring term last present in v3.0.0 and the literal RFC 8289 sojourn metric replacing the empty-cycle proxy.
+with `γ` set for Butterworth-optimal damping (ζ ≈ 0.707) — a maximally-flat response that trades a small ~4.3% step-response overshoot per adaptation for shorter settling time; the overshoot is the controller's deliberate exploration term (it probes the convex-response boundary on each impulse instead of parking inside it).
 
-**Per-task sojourn** (RFC 8289): `task_ctx.enqueue_at` is set at every `scx_bpf_dsq_insert_vtime` call site (six placement paths) and consumed in `pandemonium_running` to compute `sojourn = now − enqueue_at`. This is the literal CoDel metric — wait between enqueue and run start — feeding `pcpu_min_sojourn_ns`. Replaces the v5.7.0 proxy `now − pcpu_enqueue_ns[cpu]` which weakened past the first task in any drain and became meaningless under vtime ordering.
+**Per-task sojourn** (RFC 8289): `task_ctx.enqueue_at` is set at every `scx_bpf_dsq_insert_vtime` call site (six placement paths) and consumed in `pandemonium_running` to compute `sojourn = now − enqueue_at`. This is the literal CoDel metric — wait between enqueue and run start — feeding `pcpu_min_sojourn_ns`. A per-task timestamp stays accurate through an entire drain, where a per-CPU `now − pcpu_enqueue_ns[cpu]` proxy weakens past the first task.
 
 **Stall decision** (`pcpu_dsq_is_stalled`): compares per-CPU minimum sojourn against `codel_target_ns`. Below = flowing. Above for `sojourn_interval_ns` = stalled, force rescue. Binary CoDel decision; the target itself is what oscillates.
 
 **Spring (restoring term)**: equilibrium `c_eq = ⟨R_eff⟩ × 2m × τ` derived from spectral graph properties already computed at topology detect — `⟨R_eff⟩ = Tr(L⁺)/N` over nonzero eigenvalues, `2m = Tr(L)`, τ the Fiedler-derived mixing time. The product is the natural latency tolerance of the topology. Rust clamps `c_eq` to `[200µs, 8ms]`; BPF additionally constrains it inside the oscillator's `[floor, max]` window.
 
-**Critical damping** (discrete): the existing `v −= v >> damping_shift` corresponds to `2γ ≈ 2^−D` so `γ ≈ 2^−(D+1)`. Setting `γ = ω₀` gives `ω₀² ≈ 2^−(2D+2)`, implemented as `disp >> spring_shift` with `spring_shift = 2*damping_shift + 2`. Co-derived in `apply_tau_scaling` so topology changes keep critical damping automatically.
+**Butterworth damping** (discrete): the existing `v −= v >> damping_shift` corresponds to `2γ ≈ 2^−D`. The spring is `v −= disp >> spring_shift` with `spring_shift = 2*damping_shift + 1`, placing the pole pair at ζ ≈ 2^(−1/2) ≈ 0.707 (Butterworth-optimal). Co-derived in `apply_tau_scaling` so topology changes preserve the damping ratio automatically: `damping_shift=1 → spring_shift=3` (2C, fast restore), `damping_shift=5 → spring_shift=11` (12C, gentle restore).
 
-**Feedback loop**: `global_rescue_count` (atomic, incremented at the overflow rescue site in dispatch) drives the impulse `F(t)`. Each tick on CPU 0: apply impulse → apply spring (`v −= disp >> spring_shift`) → apply damping (`v −= v >> damping_shift`) → cap velocity → integrate `x`. v5.8.0 removed the v5.7.0 `OSCILLATOR_RELAX_NS` quiet-tick drift toward the ceiling, which had been a primitive substitute for the spring and pushed `x` AWAY from `c_eq` every quiet tick.
+**Feedback loop**: `global_rescue_count` (atomic, incremented at the overflow rescue site in dispatch) drives the impulse `F(t)`. Each tick on CPU 0: apply impulse → apply spring (`v −= disp >> spring_shift`) → apply damping (`v −= v >> damping_shift`) → cap velocity → integrate `x`.
 
-**Core-scaled parameters** (derived from τ in `apply_tau_scaling`):
+**Core-scaled parameters** (derived from τ in `apply_tau_scaling`; the per-column values below are an approximate reference — the live values are derived at runtime):
 
-| Parameter | 2C (τ≈2ms) | 4C | 8C | 12C (τ≈40ms) |
-|-----------|------------|----|-----|---------------|
+| Parameter | 2C | 4C | 8C | 12C |
+|-----------|----|----|-----|------|
 | Sojourn interval | 2ms | 4ms | 8ms | 12ms |
 | Damping shift D | 1 (v/2) | 1-2 | 3 | 5 (v/32) |
-| Spring shift (2D+2) | 4 (disp/16) | 4-6 | 8 | 12 (disp/4096) |
+| Spring shift (2D+1) | 3 (disp/8) | 3-5 | 7 (disp/128) | 11 (disp/2048) |
 | Pull scale | 1 | 1 | 3 | 4 |
 | Center floor | 200µs | 200µs | 500µs | 700µs |
 | Center ceiling | 1ms | 1ms | 1ms | 2ms |
 
-`x` rests at `c_eq` when the system is quiet, descends below on rescue events, returns critically-damped (one excursion, no ringing).
+`x` rests at `c_eq` when the system is quiet, descends below on rescue events, and returns Butterworth-damped — one bounded ~4.3% overshoot, then settle.
 
 ### Overflow Sojourn Rescue
 
-Per-CPU DSQ dominance under sustained load makes downstream anti-starvation unreachable — 90%+ of dispatches serve per-CPU DSQ while overflow tasks age indefinitely. Dispatch STEP 0 / STEP 1 fall through to STEP 2 when either overflow DSQ has aged past `overflow_sojourn_rescue_ns` (tau-scaled, ~10ms at 12C). `try_service_older_overflow` then drains the older side past the threshold. CAS-based timestamp management prevents races across CPUs.
+Per-CPU DSQ dominance under sustained load makes downstream anti-starvation unreachable — 90%+ of dispatches serve per-CPU DSQ while overflow tasks age indefinitely. Dispatch STEP 0 / STEP 1 fall through to STEP 2 when either overflow DSQ has aged past `overflow_sojourn_rescue_ns` — which is set to `codel_target_equilibrium_ns` (the R_eff-derived CoDel equilibrium `⟨R_eff⟩ × 2m × τ`, clamped into the oscillator's `[floor, max]` window, so ≤~2ms at 12C — not a hand-tuned ~10ms). The spectral scalar opens the gate; sojourn (enqueue-age) fills it and selects the older side. `try_service_older_overflow` then drains that side past the threshold. CAS-based timestamp management prevents races across CPUs.
 
-**Drain-both-when-both-aged** (v5.8.0): under sustained mixed load both overflow DSQs can stay continuously non-empty for tens of seconds, freezing both timestamps at their first-non-empty values. The historical "older wins" picked the same side every rescue call until external pressure dropped, locking out batch-demoted long-runners. At 2C this produced 19-29s starvation tails; 4C+ was unaffected because higher dispatch density closed the window. The fix: when BOTH sides are aged, drain BOTH. Older-first ordering preserved (latency-budget bias for interactive on ties); the second drain costs one extra `scx_bpf_dsq_move_to_local`. Result: 2C longrun WORST 19s -> 166ms, mixed WORST 29s -> 170ms.
+**Drain both when both aged**: under sustained mixed load both overflow DSQs can stay continuously non-empty for tens of seconds, freezing both timestamps at their first-non-empty values. A strict "older wins" would then pick the same side every rescue call until external pressure dropped, locking out batch-demoted long-runners (at 2C, a 19-29s starvation tail; 4C+ closes the window through higher dispatch density). So when BOTH sides are aged, both drain — older-first ordering preserved (latency-budget bias for interactive on ties), at the cost of one extra `scx_bpf_dsq_move_to_local`.
 
 ### Longrun Detection
 
@@ -219,22 +190,23 @@ When batch DSQ stays non-empty past `longrun_thresh_ns` (tau-scaled, ~2s at 12C 
 
 ### Wake Sensitivity & Preemption
 
-No burst detector. Prior versions layered three (CUSUM on enqueue-interval EWMA, `wake_burst` on absolute wakeup rate, and `burst_mode` gating slice/depth/preempt behaviors). All three have been retired: every failure mode they were covering is now handled by the oscillator-adapted CoDel target, the placement-side depth gate + L2/R_eff spill (v5.8.0 — closes the per-CPU DSQ reachability class STEP -1 was previously papering over), hard starvation rescue, or tier information already present at the enqueue site. The one load-bearing behavior burst_mode provided — aggressive preempt when a latency-critical waker sat behind a BATCH runner — is expressed as a tier signal:
+No burst detector. The failure modes one would cover — CUSUM on enqueue-interval EWMA, `wake_burst` on absolute wakeup rate, `burst_mode` gating slice/depth/preempt behaviors — are instead handled by the oscillator-adapted CoDel target, the placement-side depth gate + L2/R_eff spill, hard starvation rescue, or tier information already present at the enqueue site. Tick preemption is derived per-CPU, with no global signal:
 
-- **`latcrit_waiting`**: set in `pandemonium_enqueue` when a `TIER_LAT_CRITICAL` task arrives at a shared-DSQ path; cleared in `task_should_preempt` after a BATCH preempt fires. `task_should_preempt` tightens its threshold by 4× when this flag is set (1ms baseline → 250µs, 4ms at 2C longrun → 1ms). INTERACTIVE waiters keep the standard threshold so ordinary wakeups don't penalize BATCH throughput. Uses `tctx->tier` which was already being read at both sites — no new detector state, no rate counter.
-- **Core-scaled longrun protection**: during sustained `longrun_mode`, preempt threshold scales up on 2C only (4×, i.e. 4ms protected BATCH window from a 1ms base). 4C+ keeps the baseline: the additional CPU capacity already absorbs LAT_CRIT contention without slice extension.
+- **Per-CPU preempt**: `pandemonium_tick` reads its own `pcpu_enqueue_ns[this_cpu]` — the age of the oldest task waiting on this CPU — against a tau-scaled threshold (`preempt_thresh_ns`): a BATCH resident yields once a waiter ages past the base threshold, an INTERACTIVE resident at 2× (batch-throughput protection), a LAT_CRITICAL resident never. Per-CPU by construction — no token to race over. A single global flag instead (armed at enqueue, cleared by the first tick to preempt on *any* CPU) gets token-stolen across cores under a fork storm, so the CPU actually burying a latency waker rarely wins the race — the audio-under-load pathology (intermittent, single-thread, bursty-only). The per-CPU read reuses the bounded-array scan already running for the coarse per-CPU sojourn check, so no new global state.
+- **RT-policy floor**: `SCHED_FIFO`/`SCHED_RR` threads are pinned `TIER_LAT_CRITICAL` by declaration, after the behavioral classifier and the high-prio-kthread→BATCH override. A periodic audio RT thread scores erratically on the behavioral `lat_cri` metric and was flipping out of LAT_CRITICAL mid-burst; threaded USB IRQ kthreads were force-demoted to BATCH. The floor keeps both latency-critical under load, immune to the EWMA jitter.
+- **Core-scaled longrun protection**: during sustained `longrun_mode`, the preempt threshold scales up on thin topologies (τ < 4ms) only, extending the protected BATCH window so they don't thrash; wider topologies keep the baseline, where capacity already absorbs LAT_CRIT contention.
 
-### Vtime Ceiling + Lag Cap + New-Task Lag Penalty
+### Sojourn Selector + Lag Cap
 
-`task_deadline()` caps every task's deadline at `vtime_now + vtime_ceiling_window_ns`, applied universally across every placement path (select_cpu sites, all enqueue tiers). The window is tau-scaled: `K_VTIME_CEILING × τ` clamped `[16ms, 160ms]` — 120ms at the 12C reference (τ=40ms), tightening naturally at lower τ. Hoisted from the v5.5.0 batch-only Tier 3 site in v5.8.0 because retired STEP -1 left daemons in per-CPU DSQs unprotected.
+There is no weighted virtual-time engine. `task_deadline()` returns `now − warp` — the enqueue timestamp back-dated by a bounded per-tier warp — so every DSQ is ordered oldest-first (largest sojourn served first). Sojourn IS the selector; no second fairness clock runs parallel to the sojourn + R_eff/CoDel layer.
 
-`lag_cap_ns = K_LAG_CAP × τ` clamped `[8ms, 80ms]` is the sleep-boost ceiling, used as `vtime_floor = vtime_now − lag_cap_ns × lag_scale` and as the BATCH per-tier `awake_cap`. Per-tier caps are fractions: `LAT_CRITICAL = lag_cap/2`, `INTERACTIVE = lag_cap × 3/4`, `BATCH = lag_cap`. At the 12C reference (lag_cap=40ms) these are 20/30/40ms, matching the pre-v5.8.0 hardcoded values; at 32C they tighten to 4/6/8ms in proportion to topology timing.
+`lag_cap_ns = K_LAG_CAP × τ` clamped `[8ms, 80ms]` is the warp bound (~13ms at the 12C reference). The warp is flat per tier — `LAT_CRITICAL = lag_cap`, `INTERACTIVE = lag_cap/2`, `BATCH = 0` — and **maturity-gated**: a task earns its warp only once classified (`ewma_age ≥ EWMA_AGE_MATURE`), so a fork storm of unmatured INTERACTIVE children competes on pure arrival order and cannot leapfrog established work.
 
-`enable()` lands new tasks at `dsq_vtime = vtime_now + vtime_ceiling_window_ns` rather than `vtime_now`. The ceiling alone bounds tail position but not ordering: a freshly-forked task at `vtime_now` is still at the HEAD ahead of capped daemons. The new-task penalty puts it FIFO with the daemons. EEVDF and other modern fair schedulers apply the equivalent lag for the same reason.
+Because the warp is bounded, a BATCH task older than `lag_cap` always out-sorts a freshly-warped LAT_CRITICAL waker: **starvation-free by construction**, with no ceiling and no new-task penalty needed. A new task simply enters at `now` like any other arrival. (A wakeup-frequency-weighted warp and a queue-depth backlog term each reorder by something other than wait — they cluster ping-pong wakers or rubberband interactivity — so the warp stays flat, bounded, and maturity-gated; deep-queue drainage is left to the overflow sojourn rescue, which forces aged work forward by wait, not depth.)
 
 ### Hard Starvation Rescue
 
-`min(25ms * nr_cpus, 500ms / max(1, nr_cpus/4))`, clamped 20-500ms. Short at low core counts (2C = 50ms), peaks mid-range (8C = 200ms), short again at high counts (128C = 20ms).
+`clamp(K_STARVATION_RESCUE × τ, 20ms, 500ms)` — tau-scaled and monotonic in topology timing: 20ms at 2C, ~80ms at 4C, ~160ms at 8C, ~167ms at 12C (the Core-Count Scaling table values). Runs as the dispatch safety net before STEP 2, ungated; should ~never trip after the placement fix.
 
 ### Topology-Aware Placement
 
@@ -242,23 +214,34 @@ No burst detector. Prior versions layered three (CUSUM on enqueue-interval EWMA,
 
 **Online-budget search**: `find_idle_by_affinity()` walks the ranked list with an online-candidates budget, not a total-slots budget. The rank map is built once at init from the full topology; after hotplug, some top ranks may reference offline CPUs. Offline entries are skipped without charging budget, so the search cost on a fully-online system is identical to a raw limit of 3, while remaining robust to arbitrary hotplug asymmetry (12C → 8C, 32C → 4C, etc.).
 
-**Single-loop R_eff steal**: dispatch STEP 1 walks `affinity_rank` once with a tau-derived runtime budget (`pcpu_spill_search_budget`, clamped to `[6, min(nr_cpu_ids - 1, MAX_AFFINITY_CANDIDATES)]`) — slot 0 is the L2 sibling, slots 1+ are R_eff-ranked cross-L2 peers. Subsumes the old STEP 1 (l2_siblings walk) and STEP 1b (R_eff fallback) since v5.6.0 made `affinity_rank` authoritative for placement distance. Solo-topology hotplug cases (all L2 partners offline) work without a separate fallback.
+**Single-loop R_eff steal**: dispatch STEP 1 walks `affinity_rank` once with a tau-derived runtime budget (`pcpu_spill_search_budget`, clamped to `[6, min(nr_cpu_ids - 1, MAX_AFFINITY_CANDIDATES)]`) — slot 0 is the L2 sibling, slots 1+ are R_eff-ranked cross-L2 peers. `affinity_rank` is authoritative for placement distance, so a single walk handles every case — including solo-topology hotplug (all L2 partners offline) — with no separate L2-sibling walk or R_eff fallback.
 
 **wakee_flips gate**: `select_cpu()` reads waker/wakee `wakee_flips` from `task_struct`. Both below `nr_cpu_ids` = 1:1 pipe pair (affinity beneficial). Either above = 1:N server pattern (skip to normal path). Same discrimination as the kernel's `wake_wide()`.
 
-**L2 cache affinity**: `find_idle_l2_sibling()` in enqueue finds idle CPUs in the same L2 domain (max 8 iterations). Per-regime knob (LIGHT=WEAK, MIXED=STRONG, HEAVY=WEAK). Longrun overrides to WEAK. Per-dispatch L2 hit/miss counters for BATCH, INTERACTIVE, LAT_CRITICAL tiers.
+**L2 cache affinity**: `find_idle_l2_sibling()` in enqueue finds idle CPUs in the same L2 domain (max 8 iterations), gated by the `affinity_mode` knob (0=OFF / 1=WEAK / 2=STRONG). The Rust regime baseline sets it per regime (LIGHT=WEAK, MIXED=STRONG, HEAVY=WEAK); MWU can override by majority vote. Per-dispatch L2 hit/miss counters for BATCH, INTERACTIVE, LAT_CRITICAL tiers.
 
 **Commute time interpretation**: R_eff is proportional to expected round-trip time for work between CPUs [2]. Minimizing R_eff between pipe partners minimizes cache line transfer cost [1][3][4].
 
+### Migration Potential (Φ)
+
+R_eff alone is a placement *ranking* — it orders candidate CPUs by distance but doesn't price a migration against the queueing relief it buys, so a cross-CCX steal would be as cheap as an SMT-sibling steal once a head aged. The migration potential prices it: **Φ = R_eff − β·sojourn**, the graph resistance of a move set against the wait it relieves. The dispatch STEP 1 work steal pays Φ, so it crosses a cache boundary only when the backlog justifies the cache cost.
+
+- **R_eff cost oracle**: a BPF map `reff_value`, sized and indexed exactly like `affinity_rank` — `reff_value[cpu * MAX_AFFINITY_CANDIDATES + slot] = R_eff(cpu, affinity_rank[cpu][slot])`, quantized as `R_eff × 1e6 → u32` (the same scale the rank sorts on). The rank map answers *which* peer is next-nearest; the cost oracle answers *how far*, paired 1:1, with `(u32)-1` sentinels past the topology end. Built once at topology detect alongside the rank.
+- **Distance-scaled steal resist**: STEP 1 relieves a peer only once its head has waited past `codel_target_ns + (R_eff(me, peer) × phi_dist_scale_q16) >> 16`. An SMT sibling (`R_eff ≈ 0`) stays freely relievable at the flat CoDel target; a cross-CCX pull must show ~τ of sustained backlog before the steal crosses the fabric. The scale is topology-owned (`phi_dist_scale_q16`, mirrored from the knob each tick); `0` — pre-first-tick, monolithic topology, or `ccx_active == false` — collapses the threshold to the flat `codel_target_ns` — no Φ resistance, exactly as if Φ were absent.
+- **Shape-routed warm placement**: before the topology-blind `scx_bpf_select_cpu_dfl` any-idle pick — which can seat a wakee on a cross-CCX idle core with a cold L3, the storm's residual cache-miss source — the wakee is anchored on its own last core and searched R_eff-near (same L2/CCX first). A TIGHT pair grabs its exact warm core when free (tightest consolidation); both shapes then take the nearest idle; only a fully warm-busy neighborhood falls through to dfl.
+- **Warm-stay (Φ-priced home anchor)**: a wakee whose stable home — `home_cpu`, pinned to its first CPU and never chasing the `last_cpu` a migration storm rewrites every stop — is uncongested is held there rather than fanned to a cold idle sibling. It is the placement dual of the steal threshold, releasing at the SAME point. `select_cpu` only DEFERS (returns the anchor without dispatching); `enqueue` TIER 0 seats the wakee on the home's own per-CPU DSQ with `KICK_PREEMPT` — the kick a busy core honors. The idle fast path still never places on a busy core: a `KICK_IDLE` there is a no-op that strands the wakee until the resident yields (the ~90% deadline-miss scar), so the busy placement lives only in enqueue. The hold releases once the home's sojourn passes `codel_target + dist_extra` — the home's own nearest-peer Φ penalty, read from `reff_value` slot 0 — so a near (low-R_eff) home releases quickly while a far cross-fabric home holds hard: one threshold, no binary STORM branch. `reff_value` all-zero (monolithic / `--phi-scale 0`) collapses it to the bare `codel_target`. LAT_CRITICAL and kthreads are exempt — they flee for immediacy.
+
+Φ prices each migration by its graph resistance [1][2] and pays only when queueing relief justifies the cache cost. Cross-domain work conservation is preserved — an idle cross-CCX core is still taken freely; what Φ removes is the *cheap* cross-fabric steal that thrashed L3 for marginal queueing gain.
+
 ### Behavioral Classification
 
-- **Latency-Criticality Score**: `lat_cri = (wakeup_freq * csw_rate) / (avg_runtime + runtime_dev/2)`
+- **Latency-Criticality Score**: `lat_cri = (wakeup_freq * csw_rate) / effective_runtime_ms`, where `effective_runtime_ms = (avg_runtime + runtime_dev/2) >> 20` (ns→ms, floored to 1)
 - **Three Tiers**: LAT_CRITICAL (1.5x avg_runtime slices), INTERACTIVE (2x), BATCH (configurable ceiling)
 - **EWMA Classification**: wakeup frequency, context switch rate, runtime variance drive scoring
-- **CPU-Bound Demotion**: avg_runtime above `cpu_bound_thresh_ns` demotes INTERACTIVE to BATCH
+- **CPU-Bound Demotion**: an INTERACTIVE task whose `avg_runtime` reaches 75% of `slice_ns` (`avg_runtime*4 >= slice_ns*3`), guarded by `ewma_age <= 4`, is demoted to BATCH — the guard spares tasks that burn a full slice but sleep often
 - **Kworker Floor**: PF_WQ_WORKER floors at INTERACTIVE
-- **High-Priority Kthread Override** (v5.8.0): `PF_KTHREAD` at `static_prio <= 110` (`task_nice <= -10`) forced to BATCH regardless of behavioral score. ZFS workers (`z_rd_int_*`, `arc_*`), kopia helpers, and similar storage kthreads no longer compete with userspace LAT_CRITICAL. The kworker floor wins for `PF_WQ_WORKER` (a `PF_KTHREAD` subset), so workqueue workers continue to be treated as latency-adjacent.
-- **Compositor Boosting**: BPF hash map, default compositors always LAT_CRITICAL, user-extensible via `--compositor`
+- **High-Priority Kthread Override**: `PF_KTHREAD` at `static_prio <= 110` (`task_nice <= -10`) forced to BATCH regardless of behavioral score. ZFS workers (`z_rd_int_*`, `arc_*`), kopia helpers, and similar storage kthreads no longer compete with userspace LAT_CRITICAL. The kworker floor wins for `PF_WQ_WORKER` (a `PF_KTHREAD` subset), so workqueue workers continue to be treated as latency-adjacent.
+- **Flow Signature**: each wakeup sets the waker CPU's bit in a per-task bitmap; the popcount is the task's distinct-partner cardinality — a topology-free read of the live communication graph's conductance. At maturity (`ewma_age ≥ EWMA_AGE_MATURE`) the task is classified once and frozen: `≤ SHAPE_TIGHT_MAX` (2) distinct partners is a **TIGHT** pair/loop; a partner set spanning at least half of `nr_cpu_ids` is a **STORM** mesh; everything between defaults to TIGHT (latency-safe — its steal stays freely relievable). Portable — the STORM threshold scales with the machine, no hardcoded core geometry. The shape drives *placement* (TIGHT consolidates on its warm core, STORM spreads), never the steal — a shape-gated steal once starved a STORM-classed audio thread on a busy core, so the steal stays shape-blind.
 
 ### Process Database (procdb)
 
@@ -266,29 +249,35 @@ BPF publishes mature task profiles (tier + avg_runtime) keyed by `comm[16]`. Rus
 
 ### Adaptive Control Loop
 
-- **One Thread, Zero Mutexes**: 1-second control loop reads BPF histogram maps, computes P99, drives MWU
-- **Workload Regime Detection**: LIGHT (idle >50%), MIXED (10-50%), HEAVY (<10%) with Schmitt hysteresis + 2-tick hold
-- **MWU Orchestrator**: 6 experts (LATENCY, BALANCED, THROUGHPUT, IO_HEAVY, FORK_STORM, SATURATED) compete via multiplicative weight updates. 8 continuous knobs blended via scale factors, 2 discrete knobs via majority vote. 4 loss pathways: P99 spike (Schmitt-gated, 2-tick confirm), rescue delta (0->nonzero, penalizes LATENCY at 0.4x to prevent compounding with oscillation tightening), IO bucket transition, fork storm (Schmitt-gated + pressure-confirmed: requires concurrent `rescue_count > 0` so a high raw wakeup rate alone cannot trip it; v5.8.0 scales loss magnitudes by wakeup-rate overage and drops the LATENCY-expert penalty so the FORK_STORM expert actually compresses BPF-consumed knobs (`burst_slice_ns`, `preempt_thresh_ns`, `sojourn_thresh_ns`, `batch_slice_ns`) instead of pushing values BPF cannot honor). ETA=8.0, weight floor 1e-6, relaxation at 80% toward equilibrium after 2 healthy ticks below 70% ceiling
+The Rust control plane is chaos-theory-driven: both regime detection and the MWU weight-update damping run off raw-window nonlinear-dynamics statistics (`chaos.rs`), not EWMAs or Schmitt triggers.
+
+- **One Thread, Zero Mutexes**: 1-second control loop on the main thread reads BPF histogram maps, computes per-tier and aggregate P99, and drives the MWU orchestrator. BPF produces histograms; Rust reads them once per second and writes knobs BPF picks up on the next scheduling decision.
+- **Chaos primitives** (`chaos.rs`, pure Rust, recomputed each tick over a 16-sample raw window): HVG mean degree λ (Luque–Lacasa horizontal visibility graph — ~2 periodic, →4 IID-random), Bandt–Pompe D=3 permutation entropy (ordinal disorder, normalized to [0,1]), and RQA determinism (fraction of recurrence points on diagonals — →1 steady, →0 IID).
+- **Workload Regime Detection**: LIGHT / MIXED / HEAVY from the raw `idle_pct` window — no Schmitt trigger. LIGHT needs `mean_idle ≥ 50%` AND "chaos-low" (`λ < 3.4` OR `bp_h < 0.85`); HEAVY needs `mean_idle ≤ 10%` AND chaos-low; everything else is MIXED. A 2-tick hold smooths transitions.
+- **MWU Orchestrator**: 6 experts (LATENCY, BALANCED, THROUGHPUT, IO_HEAVY, FORK_STORM, SATURATED) compete via multiplicative weight updates, with one weight vector **per regime** (LIGHT/MIXED/HEAVY each learn independently). 7 continuous knobs are blended via per-expert scale factors; 1 discrete knob (`affinity_mode`) by weighted majority vote. Learning rate ETA = 0.33465 (= √(ln 6 / 16), the theory-optimal Hedge rate for the 16-tick window); weight floor 1e-6; relaxation 80% toward a no-op-skewed equilibrium after 2 healthy ticks below 70% of the regime P99 ceiling. The weight update is itself Butterworth-damped by a signal-trust coefficient (RQA determinism + λ), so the controller tracks faithfully only when the workload looks steady.
+- **6 loss pathways**, all firing immediately (no streak confirmation): (1) **P99 spike** — worst of aggregate / interactive P99 over the regime ceiling; (2) **rescue delta** — 0→nonzero, penalizes all experts so MWU holds steady while the BPF oscillator does the tightening; (3) **IO-bucket transition**; (4) **fork storm** — raw wake-rate over a tau-derived threshold AND concurrent `rescue_count > 0`, scaled by wake-rate overage, letting the FORK_STORM expert compress `burst_slice_ns` / `preempt_thresh_ns` / `sojourn_thresh_ns` / `batch_slice_ns`; (5) **chaos transition** — a `bp_h` jump > 0.10 or an upward λ crossing penalizes the currently-dominant non-BALANCED expert; (6) **cross-CCX scatter** — the placement-side cross-CCX migration fraction (the select/enqueue `nr_xccx` paths, excluding the Φ-correct steal and work-conservation moves MWU must not punish) climbing past a 20% rising-edge threshold penalizes the THROUGHPUT / SATURATED / FORK_STORM experts, re-weighting the blend toward LATENCY / BALANCED and affinity STRONG. This is the adaptive layer's only direct view of the migration storm its own knobs can induce; rising-edge gating leaves a stable high-scatter throughput regime (8C+) untouched, where wide-slice scatter is a winning trade.
+- **Φ-aware oscillator gating**: before scoring, MWU reads the BPF CoDel oscillator's position AND the nearest-peer Φ hold (`reff_value` slot 0). The rescue-delta and fork-storm pathways defer only when the oscillator has tightened (< 0.40) AND the effective release `codel_target + dist_extra` sits below the Φ equilibrium — or gone quiet (> 0.90) above it — so the two controllers never double-correct on `global_rescue_count`, and MWU never reads a hard Φ hold as a loose window and stands down on rescue pressure that is genuinely live.
+- **Quiescence freeze + adaptive-rarity retune**: when λ sits in the periodic band, RQA determinism ≥ 0.90, and the active regime's weight vector has converged, the loop latches `frozen` and skips the MWU retune + knob write (it still ticks at 1 Hz; the chaos sensors are the thaw condition). When not frozen, a sub-threshold retune stretches the retune interval ×1.5 (capped at 8 ticks); any disturbance snaps it back to 1.
 
 ### Core-Count Scaling
 
-All timing constants scale from `tau_ns = TAU_SCALE_NS / λ₂` (Fiedler-derived mixing time), with safety-rail clamps. Cardinality decisions (per-CPU DSQ depth, wake_wide threshold, tick scan budget) use `nr_cpus` directly — counts are not tau-derived.
+All timing constants scale from `tau_ns = TAU_SCALE_NS / √(λ₂ · N)` — capacity-aware (the geometric mean of connectivity `1/λ₂` and capacity `1/√N`, so a well-connected but core-starved topology loosens instead of tightening), with safety-rail clamps. 12C reference: τ≈13.3ms (λ₂=12, N=12). Cardinality decisions (per-CPU DSQ depth, wake_wide threshold, tick scan budget) use `nr_cpus` directly — counts are not tau-derived. **The per-column τ values and derived cells below are an approximate reference; the live values are derived at runtime from the capacity-aware τ law.**
 
-| Parameter | Formula | 2C (τ≈2ms) | 4C | 8C | 12C (τ≈40ms) | 32C (τ≈5ms) |
+| Parameter | Formula | 2C | 4C | 8C | 12C | 32C |
 |-----------|---------|------------|----|----|----|----|
 | Sojourn interval | `clamp(K × τ, 2ms, 12ms)` | 2ms | 4ms | 8ms | 12ms | 5ms |
-| Overflow rescue | `clamp(K × τ, 4ms, 10ms)` | 4ms | 8ms | 10ms | 10ms | 4ms |
+| Overflow rescue | `= codel_target_equilibrium_ns` (R_eff-derived) | varies | varies | varies | varies | varies |
 | Starvation rescue | `clamp(K × τ, 20ms, 500ms)` | 20ms | 80ms | 160ms | 166ms | 21ms |
 | CoDel target floor | `clamp(K × τ, 200µs, 800µs)` | 200µs | 200µs | 500µs | 700µs | 200µs |
 | CoDel target max | `clamp(K × τ, 1ms, 8ms)` | 1ms | 1ms | 1ms | 2ms | 1ms |
 | CoDel equilibrium | `clamp(⟨R_eff⟩ × 2m × τ, 200µs, 8ms)` | varies | varies | varies | varies | varies |
-| vtime ceiling | `clamp(K × τ, 16ms, 160ms)` | 16ms | 16ms | 54ms | 120ms | 16ms |
-| vtime lag cap | `clamp(K × τ, 8ms, 80ms)` | 8ms | 8ms | 18ms | 40ms | 8ms |
+| Lag cap (warp bound) | `clamp(K × τ, 8ms, 80ms)` | — | — | — | — | — |
 | Spill search budget | `clamp(K / τ, 6, min(nr_cpu_ids - 1, MAX_AFFINITY_CANDIDATES))` (≈ λ₂/2) | 6 | 6 | 6 | 6 | 16 |
 | Affinity idle search | `clamp(K / τ, 3, min(nr_cpu_ids - 1, MAX_AFFINITY_CANDIDATES))` (≈ λ₂/4) | 3 | 3 | 3 | 3 | 8 |
 | Per-CPU DSQ depth | `tau ≥ 6ms ? 2 : 1` | 1 | 2 | 2 | 2 | 1 |
 | Longrun preempt shift | `tau < 4ms ? 2 : 0` | 4× | 1× | 1× | 1× | 1× |
 
+- **Low-core slice discipline**: τ is largest at low core count (λ₂ shrinks as cores drop), so the tau slice cap runs loosest exactly where a wide batch slice hurts most — a 4ms HEAVY-regime slice on 2–4 cores denies a latency-sensitive probe across many consecutive slices, the low-core tail. The regime slice is capped to the MIXED value (1ms) at `nr_cpus ≤ 4`, where a wide slice buys no throughput; 8C/12C keep the tau-scaled width, where it earns it.
 - **CPU Hotplug**: `cpu_online`/`cpu_offline` callbacks clear per-CPU timestamps and oscillator state (velocity, rescue count) to prevent stale oscillation after suspend/resume
 - **BPF-Verifier Safe**: All EWMA uses bit shifts, no floats. All shared state uses GCC __sync builtins
 
@@ -304,12 +293,14 @@ src/
   lib.rs               Library root
   scheduler.rs         BPF skeleton lifecycle, tuning knobs I/O, histogram reads
   adaptive.rs          Adaptive control loop (monitor thread, histogram P99,
-                         MWU orchestrator, regime detection, longrun override)
-  tuning.rs            MWU orchestrator (6 experts, 4 loss pathways, scale factors),
-                         regime knobs, stability scoring, sleep adjustment
+                         chaos-driven regime detection, MWU, quiescence freeze)
+  chaos.rs             Chaos primitives: HVG mean degree/entropy, Bandt-Pompe D=3
+                         permutation entropy, RQA determinism (raw-window, no EWMA)
+  tuning.rs            MWU orchestrator (6 experts, 6 loss pathways, scale factors),
+                         regime thresholds, quiescence + adaptive-rarity retune
   procdb.rs            Process classification database (observe -> learn -> predict -> persist)
   topology.rs          CPU topology detection, Laplacian pseudoinverse, effective resistance,
-                         resistance affinity ranking (sysfs -> BPF maps)
+                         resistance affinity ranking, R_eff cost oracle + Φ distance scale (sysfs -> BPF maps)
   event.rs             Pre-allocated ring buffer for stats time series
   watchdog.rs          Control-loop stall detector (10s heartbeat, abort on miss)
   bpf_intf.rs          Mirror of intf.h constants (MAX_CPUS, MAX_AFFINITY_CANDIDATES,
@@ -327,8 +318,9 @@ build.rs               vmlinux.h generation + C23 patching + BPF compilation
 tests/
   pandemonium-tests.py Test orchestrator (bench-scale, bench-trace, bench-contention,
                          bench-pcpu, bench-scx, bench-sys, low-cpu-deadline)
-  bench-fork-thread.py Fork/thread IPC benchmark with hardware counter profiling
+  bench-fork-thread.py Fork/thread IPC benchmark (full scx field) + hw counters + non-compensatory regression gate
   bench-power.py       Energy-efficiency benchmark (RAPL J/op + idle floor)
+  bench-analyze.py     Statistical bench analysis + --trace mode (montauk migration/PMU capture)
   gate.rs              Integration test gate (load/classify/latency/responsiveness/contention)
 include/
   scx/                 Vendored sched_ext headers
@@ -342,19 +334,22 @@ BPF per-CPU histograms              Monitor Thread (1s loop)
                                     Compute P99 per tier
                                       |
                                       v
-                                    scaled_regime_knobs() -> baseline
-                                      -> MWU orchestrator (6 experts, 4 loss pathways)
+                                    detect_regime (chaos: HVG λ + Bandt-Pompe)
+                                      -> scaled_regime_knobs() -> baseline
+                                      -> MWU orchestrator (6 experts, 6 loss pathways)
                                         -> blend continuous knobs (scale factors)
                                         -> vote discrete knobs (majority)
-                                      -> longrun override -> WEAK affinity, base batch
+                                      -> oscillator gating + quiescence freeze
                                       |
                                       v
                                     BPF reads knobs on next dispatch
 
 Resistance affinity: R_eff ranked map -> BPF select_cpu (wakee_flips-gated)
-L2 placement:        affinity_mode knob -> BPF enqueue (WEAK during longrun)
-Sojourn threshold:   sojourn_thresh_ns knob -> BPF dispatch (core-count-scaled)
+L2 placement:        affinity_mode knob -> BPF enqueue (per-regime baseline; MWU vote)
+Migration potential: R_eff cost oracle + phi_dist_scale_q16 -> BPF dispatch STEP 1 steal resist
+Sojourn threshold:   sojourn_thresh_ns knob -> BPF dispatch (core-count-scaled, codel_eq-floored)
 Stall detection:     codel_target_ns (BPF-internal, damped oscillation, no Rust input)
+Cross-CCX scatter:   nr_xccx path counters -> Rust MWU PATHWAY 6 (re-weights experts + affinity)
 ```
 
 One thread, zero mutexes. BPF produces histograms, Rust reads them once per second. Rust writes knobs, BPF reads them on the next scheduling decision. Stall detection is fully BPF-internal — the damped oscillation runs in tick() on CPU 0 with no Rust involvement.
@@ -365,15 +360,15 @@ One thread, zero mutexes. BPF produces histograms, Rust reads them once per seco
 |------|---------|-------|---------|
 | `slice_ns` | 1ms | MWU | Interactive/lat_cri slice ceiling |
 | `preempt_thresh_ns` | 1ms | MWU | Tick preemption threshold |
-| `lag_scale` | 4 | MWU | Deadline lag multiplier |
 | `batch_slice_ns` | 20ms | MWU | Batch task slice ceiling (sleep-adjusted) |
 | `burst_slice_ns` | 1ms | MWU | Slice during longrun mode |
 | `lat_cri_thresh_high` | 32 | MWU | LAT_CRITICAL classifier threshold |
 | `lat_cri_thresh_low` | 8 | MWU | INTERACTIVE classifier threshold |
-| `affinity_mode` | 1 | MWU | L2 placement (0=OFF, 1=WEAK, 2=STRONG) |
+| `affinity_mode` | 0 | MWU | L2 placement (0=OFF, 1=WEAK, 2=STRONG); Rust writes the per-regime value at startup |
 | `sojourn_thresh_ns` | 5ms | MWU | Batch DSQ rescue threshold (tau-scaled) |
 | `topology_tau_ns` | 0 | Topology | Fiedler-derived time constant (τ = TAU_SCALE / λ₂) |
 | `codel_eq_ns` | 0 | Topology | R_eff-derived CoDel equilibrium (`⟨R_eff⟩ × 2m × τ`) |
+| `phi_dist_scale_q16` | 0 | Topology | Φ distance→wait scale (Q16): cross-domain steal resist `R_eff × this >> 16`; 0 = flat CoDel target (monolithic / no CCX) |
 
 Topology-owned fields are written by Rust at topology detect and on hotplug. The adaptive loop preserves them on every MWU write (the 1Hz cycle would otherwise clobber the equilibrium).
 
@@ -401,10 +396,10 @@ pacman -S clang libbpf bpf rust
 ./pandemonium.py clean          # Wipe build artifacts
 
 # Manual
-CARGO_TARGET_DIR=/tmp/pandemonium-build cargo build --release
+CARGO_TARGET_DIR=$HOME/.cache/pandemonium-build cargo build --release
 ```
 
-vmlinux.h is generated from the running kernel's BTF via bpftool on first build and cached at `~/.cache/pandemonium/vmlinux.h`. The source directory path contains spaces, so `CARGO_TARGET_DIR=/tmp/pandemonium-build` is required for the vendored libbpf Makefile.
+vmlinux.h is generated from the running kernel's BTF via bpftool on first build and cached at `~/.cache/pandemonium/vmlinux.h`. The cargo target tree lives at `~/.cache/pandemonium-build` (alongside the log and vmlinux caches under `~/.cache/pandemonium`), so all per-user pandemonium state sits in one place. The `CARGO_TARGET_DIR=$HOME/.cache/pandemonium-build` override is also what lets the vendored libbpf Makefile build cleanly when the source tree path contains spaces.
 
 After install:
 
@@ -416,18 +411,24 @@ sudo systemctl enable pandemonium         # Start on boot
 ## Usage
 
 ```bash
-sudo scx_pandemonium                            # Default: adaptive mode
-sudo scx_pandemonium --no-adaptive              # BPF-only (no Rust control loop)
-sudo scx_pandemonium --compositor gamescope     # Boost an additional compositor to LAT_CRITICAL
-sudo scx_pandemonium -v                         # Verbose telemetry on stdout
+sudo scx_pandemonium                  # Default: adaptive mode
+sudo scx_pandemonium --no-adaptive    # BPF-only (no Rust control loop)
+sudo scx_pandemonium -v               # Verbose telemetry on stdout
 ```
+
+There is no compositor allowlist. Compositors land at `LAT_CRITICAL` naturally
+through the behavioral classifier (high wakeup frequency × high context-switch
+rate × short avg runtime → `lat_cri` peaks), and procdb warm-starts known
+names from prior sessions. The earlier hardcoded comm boost was scaffolding
+from when the classifier was less reliable on cold-start; the current
+classifier no longer needs the safety net.
 
 ### Monitoring
 
 Per-second telemetry:
 
 ```
-d/s: 251000  idle: 5% shared: 230000  preempt: 12  keep: 0  kick: H=8000 S=22000 enq: W=8000 R=22000 wake: 4us p99: 10us L2: B=67% I=72% LC=85% procdb: 42/5 sleep: io=87% sjrn: 3ms/5ms rescue: 0 [MIXED]
+d/s: 251000 idle: 5% shared: 230000 preempt: 12 keep: 0 kick: H=8000 S=22000 enq: W=8000 R=22000 wake: 4us p99: 10us [B:8 I:9 L:7] lat_idle: 3us lat_kick: 6us procdb: 42/5 sleep: io=87% slice: 1000us batch: 20000us reenq: 4 sjrn: 3ms/5ms rescue: 0 l2: B=67% I=72% L=85% chaos: lam=2.10 H=0.40 det=0.95 x=0 frozen: 0 (n=12) retune_iv: 2 [MIXED]
 ```
 
 | Counter | Meaning |
@@ -436,14 +437,22 @@ d/s: 251000  idle: 5% shared: 230000  preempt: 12  keep: 0  kick: H=8000 S=22000
 | idle | select_cpu idle fast path (%) |
 | shared | Enqueue -> per-node DSQ |
 | preempt | Tick preemptions |
+| keep | KEEP_RUNNING re-slices |
 | kick H/S | Hard (PREEMPT) / Soft kicks |
 | enq W/R | Wakeup / Re-enqueue counts |
-| wake / p99 | Average / P99 wakeup latency |
-| L2: B/I/LC | L2 cache hit rate per tier |
+| wake / p99 | Average / aggregate P99 wakeup latency |
+| [B/I/L] | Per-tier P99 (BATCH / INTERACTIVE / LAT_CRITICAL) |
+| lat_idle / lat_kick | Wakeup latency split: idle-placement vs kick path |
 | procdb | Total profiles / confident predictions |
 | sleep: io | I/O-wait sleep pattern (%) |
+| slice / batch | Current interactive / batch slice knob (us) |
+| reenq | Re-enqueue count |
 | sjrn | Batch sojourn: current / threshold |
 | rescue | Overflow rescue dispatches this tick |
+| l2: B/I/L | L2 cache hit rate per tier |
+| chaos: lam/H/det/x | HVG mean degree λ / Bandt-Pompe entropy / RQA determinism / chaos-crossing counter |
+| frozen (n) | Quiescence freeze active (1/0) and cumulative frozen ticks |
+| retune_iv | Adaptive-rarity retune interval (ticks between retunes) |
 | [REGIME] | LIGHT/MIXED/HEAVY + LONGRUN flag |
 
 ## Benchmarking
@@ -454,11 +463,12 @@ d/s: 251000  idle: 5% shared: 230000  preempt: 12  keep: 0  kick: H=8000 S=22000
 ./pandemonium.py bench-scale --pandemonium-only  # Skip EEVDF and externals
 ./pandemonium.py bench-contention                # Contention stress (6 phases)
 ./pandemonium.py bench-pcpu                      # Per-CPU DSQ correctness
-./pandemonium.py bench-fork-thread               # Fork/thread IPC + hardware counters
+./pandemonium.py bench-fork-thread               # Fork/thread IPC + hw counters + regression gate
 ./pandemonium.py bench-power                     # Energy efficiency (RAPL J/op + idle floor)
 ./pandemonium.py bench-trace                     # BPF trace capture for external workloads
 ./pandemonium.py bench-sys                       # Live system telemetry capture
 ./pandemonium.py bench-scx                       # sched-ext/scx CI compatibility
+./pandemonium.py bench-cachyos                   # CachyOS Mini-Benchmarker application suite
 ```
 
 All benchmarks compare across core counts via CPU hotplug (2, 4, 8, ..., max). Results archived to `~/.cache/pandemonium/`.
@@ -466,15 +476,16 @@ All benchmarks compare across core counts via CPU hotplug (2, 4, 8, ..., max). R
 ## Testing
 
 ```bash
-CARGO_TARGET_DIR=/tmp/pandemonium-build cargo test --release   # Unit tests (no root)
-sudo CARGO_TARGET_DIR=/tmp/pandemonium-build \
+CARGO_TARGET_DIR=$HOME/.cache/pandemonium-build cargo test --release   # Unit tests (no root)
+sudo CARGO_TARGET_DIR=$HOME/.cache/pandemonium-build \
      cargo test --release --test gate -- --ignored \
      --test-threads=1 full_gate                                 # Integration gate (requires root)
 ```
 
-11 tests across 2 files: integration gate at `tests/gate.rs` (5 — full_gate plus the
-load/classify, latency, responsiveness, and contention layers), topology unit tests
-at `src/topology.rs::tests` (6 — sysfs CPU-list parsing and topology detection).
+5 tests in 1 file: the integration gate at `tests/gate.rs` — `full_gate` plus the
+load/classify, latency, responsiveness, and contention layers (all `#[ignore]`,
+root-only). The `src/*.rs` modules carry no inline unit tests; the pure-Rust logic
+(chaos, tuning, topology) is validated offline through the bench harnesses.
 
 ## sched-ext/scx Integration
 
@@ -511,6 +522,18 @@ Copies source into `scheds/rust/scx_pandemonium/`, renames the crate, replaces `
 [8] S. Arora, E. Hazan, S. Kale. "The Multiplicative Weights Update Method: a Meta-Algorithm and Applications." *Theory of Computing* 8, 121-164, 2012. [doi:10.4086/toc.2012.v008a006](https://theoryofcomputing.org/articles/v008a006/)
 
 [9] J.D. Valois. "Lock-Free Linked Lists Using Compare-and-Swap." *PODC 1995*, 214-222. [doi:10.1145/224964.224988](https://dl.acm.org/doi/10.1145/224964.224988)
+
+[10] M. Fiedler. "Algebraic Connectivity of Graphs." *Czechoslovak Mathematical Journal* 23(2), 298-305, 1973. [doi:10.21136/CMJ.1973.101168](https://dml.cz/dmlcz/101168)
+
+[11] R.D. Blumofe, C.E. Leiserson. "Scheduling Multithreaded Computations by Work Stealing." *Journal of the ACM* 46(5), 720-748, 1999. [doi:10.1145/324133.324234](https://dl.acm.org/doi/10.1145/324133.324234)
+
+[12] C. Bandt, B. Pompe. "Permutation Entropy: A Natural Complexity Measure for Time Series." *Physical Review Letters* 88(17), 174102, 2002. [doi:10.1103/PhysRevLett.88.174102](https://doi.org/10.1103/PhysRevLett.88.174102)
+
+[13] B. Luque, L. Lacasa, F. Ballesteros, J. Luque. "Horizontal Visibility Graphs: Exact Results for Random Time Series." *Physical Review E* 80(4), 046103, 2009. [doi:10.1103/PhysRevE.80.046103](https://doi.org/10.1103/PhysRevE.80.046103)
+
+[14] N. Marwan, M.C. Romano, M. Thiel, J. Kurths. "Recurrence Plots for the Analysis of Complex Systems." *Physics Reports* 438(5-6), 237-329, 2007. [doi:10.1016/j.physrep.2006.11.001](https://doi.org/10.1016/j.physrep.2006.11.001)
+
+[15] S. Butterworth. "On the Theory of Filter Amplifiers." *Experimental Wireless and the Wireless Engineer* 7, 536-541, 1930.
 
 ## License
 

--- a/scheds/rust/scx_pandemonium/src/adaptive.rs
+++ b/scheds/rust/scx_pandemonium/src/adaptive.rs
@@ -3,8 +3,10 @@
 //
 // ONE THREAD: MONITOR LOOP (1-SECOND CONTROL LOOP)
 //   READS BPF PER-CPU HISTOGRAMS FOR P99 COMPUTATION.
-//   DETECTS WORKLOAD REGIME VIA SCHMITT TRIGGER.
-//   MWU ORCHESTRATOR TUNES ALL 11 KNOBS WITHIN REGIME.
+//   MAINTAINS RAW 64-SAMPLE WINDOWS (idle_pct, wakeup_rate).
+//   DETECTS WORKLOAD REGIME VIA HVG MEAN DEGREE + BANDT-POMPE D=3
+//   PERMUTATION ENTROPY OVER THOSE WINDOWS (NO SCHMITT, NO EWMA).
+//   MWU ORCHESTRATOR (5 PATHWAYS) TUNES ALL 11 KNOBS WITHIN REGIME.
 //
 // BPF PRODUCES HISTOGRAMS, RUST READS AND REACTS. RUST WRITES KNOBS,
 // BPF READS THEM ON THE VERY NEXT SCHEDULING DECISION.
@@ -14,11 +16,20 @@ use std::time::Duration;
 
 use anyhow::Result;
 
+use crate::chaos::{self, RawWindow};
 use crate::procdb::ProcessDb;
 use crate::scheduler::{PandemoniumStats, Scheduler};
 use crate::tuning::{
     self, detect_regime, scaled_regime_knobs, MwuController, MwuSignals, Regime, HIST_BUCKETS,
 };
+
+// CHAOS WINDOW SIZE. 16 SAMPLES AT 1HZ = 16-SECOND REGIME MEMORY.
+// SIZED FOR BENCH-SCALE RESPONSIVENESS (16-30s iterations) RATHER THAN
+// MINUTE-SCALE DESKTOP STEADY STATE. HVG IS O(N^2) = 256 COMPARISONS
+// PER TICK; BP D=3 GETS 14 LENGTH-3 PATTERNS OVER 6 BUCKETS -- LIMITED
+// RESOLUTION BUT ENOUGH TO DISTINGUISH PERIODIC FROM RANDOM IN ONE
+// BENCH ITERATION.
+const CHAOS_WIN: usize = 16;
 
 // REGIME THRESHOLDS, PROFILES, AND KNOB COMPUTATION LIVE IN tuning.rs
 // (ZERO BPF DEPENDENCIES, TESTABLE OFFLINE)
@@ -41,6 +52,15 @@ pub fn monitor_loop(
     let mut prev_hist = [[0u64; HIST_BUCKETS]; 3];
     let mut prev_sleep = [0u64; SLEEP_BUCKETS];
     let mut regime = Regime::Mixed;
+
+    // CHAOS RAW WINDOWS. idle_pct DRIVES REGIME DETECTION; wakeup_rate
+    // DRIVES THE MWU CHAOS-TRANSITION PATHWAY (BANDT-POMPE IS ORDINAL,
+    // SO ABSOLUTE RATE SCALE DOES NOT MATTER -- THE PATTERN DOES).
+    let mut idle_win: RawWindow<CHAOS_WIN> = RawWindow::new();
+    let mut wake_win: RawWindow<CHAOS_WIN> = RawWindow::new();
+    let mut prev_bp_h: f64 = 0.0;
+    let chaos_count = chaos::ChaosCounter::new();
+    let mut prev_lambda_above: bool = false;
     // READ CURRENT tau SNAPSHOT FROM THE BPF-SIDE KNOB MAP. main.rs WROTE IT
     // ONCE AT TOPOLOGY DETECT; THE ADAPTIVE LOOP RE-READS SO TAU-SCALED REGIME
     // KNOBS AGREE WITH TAU-SCALED BPF INIT AT FIRST TICK AND EVERY REGIME CHANGE.
@@ -51,8 +71,21 @@ pub fn monitor_loop(
     let mut light_ticks: u64 = 0;
     let mut mixed_ticks: u64 = 0;
     let mut heavy_ticks: u64 = 0;
+    // STABILITY SCORE IS A WEAK PRE-CHAOS STEADY-STATE PROXY. v5.11.0
+    // KEEPS IT FOR TELEMETRY GATING ONLY -- THE REAL STEADY-STATE GATE
+    // IS `quiesce.frozen` BELOW. DO NOT WIRE stability_score INTO THE
+    // FREEZE DECISION (TWO COMPETING "AM I STEADY" SIGNALS = A BUG).
     let mut stability_score: u32 = 0;
     let mut tick_counter: u64 = 0;
+
+    // QUIESCENCE GATE + ADAPTIVE-RARITY RETUNE STATE. The gate latches
+    // a "frozen" flag from HVG-lambda + RQA-DET + MWU convergence and
+    // the loop then skips the expensive MWU retune + knob write. When
+    // not frozen, the retune interval stretches on sub-threshold deltas.
+    let mut quiesce = tuning::QuiescenceState::new();
+    let mut retune_interval: u32 = tuning::RETUNE_INTERVAL_BASE;
+    let mut ticks_since_retune: u32 = 0;
+    let mut frozen_ticks: u64 = 0;
 
     let mut procdb = match ProcessDb::new() {
         Ok(db) => Some(db),
@@ -70,6 +103,17 @@ pub fn monitor_loop(
     rk.topology_tau_ns = tau_ns;
     rk.codel_eq_ns = live.codel_eq_ns;
     sched.write_tuning_knobs(&rk)?;
+    // SEED THE MWU BASELINE WITH THE LIVE PHI EQUILIBRIUM AT TICK 0. new()
+    // BUILT mwu FROM scaled_regime_knobs (codel_eq_ns=0); set_baseline IS
+    // OTHERWISE ONLY CALLED ON A REGIME CHANGE. WITHOUT THIS SEED THE SOJOURN
+    // FLOOR (tuning.rs) FALLS BACK TO THE DEAD 4ms CONSTANT FOR ANY RUN WHOSE
+    // REGIME NEVER CHANGES (E.G. A STEADY MIXED BENCH), SO THE PHI-COHERENT
+    // FLOOR WOULD NEVER ENGAGE.
+    mwu.set_baseline(rk);
+    // COMMIT-ON-CHANGE BASELINE: the last knob set actually written to
+    // the BPF map. Updated here at init, on every regime-change write,
+    // and on every conditional write. MWU-owned fields drive the diff.
+    let mut last_written_knobs = rk;
 
     while !shutdown.load(Ordering::Relaxed) && !sched.exited() {
         crate::watchdog::LOOP_HEARTBEAT.fetch_add(1, Ordering::Relaxed);
@@ -125,6 +169,19 @@ pub fn monitor_loop(
         let delta_rescue = stats
             .nr_overflow_rescue
             .wrapping_sub(prev.nr_overflow_rescue);
+        // CROSS-CCX SCATTER (PATHWAY 6 INPUT). PLACEMENT-SIDE PATHS ONLY:
+        // XCCX_SEL_* + XCCX_ENQ_T1/T2 (INDICES 0..6). THE PHI-CORRECT WORK-
+        // CONSERVATION PATHS XCCX_STEAL (6) AND XCCX_STEP5 (7) ARE EXCLUDED --
+        // PENALIZING THEM WOULD MAKE MWU FIGHT THE BPF'S DELIBERATE REBALANCING.
+        // saturating_sub ABSORBS A COUNTER RESET (BPF RELOAD) AS 0, NO GARBAGE.
+        let scatter_now: u64 = stats.nr_xccx[0..6].iter().sum();
+        let scatter_prev: u64 = prev.nr_xccx[0..6].iter().sum();
+        let delta_scatter = scatter_now.saturating_sub(scatter_prev);
+        let scatter_pct = if delta_d > 0 {
+            delta_scatter * 100 / delta_d
+        } else {
+            0
+        };
         let wake_avg_us = if delta_wake_samples > 0 {
             delta_wake_sum / delta_wake_samples / 1000
         } else {
@@ -219,8 +276,35 @@ pub fn monitor_loop(
             0
         };
 
-        // DETECT REGIME (SCHMITT TRIGGER + 2-TICK HOLD)
-        let detected = detect_regime(regime, idle_pct);
+        // CHAOS UPDATE: PUSH RAW SAMPLES INTO WINDOWS BEFORE COMPUTING
+        // ANY DERIVED FEATURES. WAKE WINDOW USES THE PER-SECOND DELTA
+        // (delta_enq_wake) RATHER THAN AN INSTANTANEOUS RATE.
+        idle_win.push(idle_pct as f64);
+        wake_win.push(delta_enq_wake as f64);
+
+        // CHAOS PRIMITIVES. ONE O(N^2) HVG PASS + ONE O(N^2) RQA PASS
+        // PER WINDOW; BP IS O(N). RQA-DET RUNS ON THE SAME idle_win AS
+        // HVG SO THE QUIESCENCE GATE SEES IDENTICAL SAMPLES. rqa IS
+        // None UNTIL THE WINDOW HAS RQA_MIN_SAMPLES FILLED.
+        let (idle_lambda, _idle_hvg_s) = chaos::hvg_stats(&idle_win);
+        let wake_bp_h = chaos::bandt_pompe_d3(&wake_win);
+        let bp_delta = wake_bp_h - prev_bp_h;
+        let mean_idle = chaos::mean(&idle_win);
+        let rqa = chaos::rqa_det(&idle_win);
+
+        // CHAOS CROSSING DIAGNOSTIC: BUMP COUNTER ON EITHER GATE FIRING.
+        // chaos_crossing IS ALSO REUSED BELOW AS THE ADAPTIVE-RARITY
+        // "disturbed" SIGNAL -- CAPTURE IT BEFORE prev_lambda_above IS
+        // OVERWRITTEN.
+        let lambda_above = idle_lambda >= chaos::HVG_LAMBDA_CHAOTIC_MIN;
+        let chaos_crossing = (lambda_above && !prev_lambda_above) || bp_delta > 0.10;
+        if chaos_crossing {
+            chaos_count.bump();
+        }
+        prev_lambda_above = lambda_above;
+
+        // DETECT REGIME (CHAOS-DRIVEN + 2-TICK HOLD)
+        let detected = detect_regime(mean_idle, idle_lambda, wake_bp_h);
 
         let mut regime_changed_this_tick = false;
         if detected != regime {
@@ -241,44 +325,96 @@ pub fn monitor_loop(
                 rk.topology_tau_ns = tau_ns;
                 rk.codel_eq_ns = live.codel_eq_ns;
                 sched.write_tuning_knobs(&rk)?;
+                last_written_knobs = rk;
                 regime_changed_this_tick = true;
                 mwu.set_baseline(rk);
-                mwu.reset();
+                // RESET ONLY THE NEW REGIME'S WEIGHT VECTOR + EDGE STATE
+                // (THE OTHER REGIMES KEEP THEIR LEARNED VECTORS), AND
+                // SNAP THE ADAPTIVE-RARITY INTERVAL BACK TO BASE.
+                mwu.reset_regime(regime);
+                retune_interval = tuning::RETUNE_INTERVAL_BASE;
+                ticks_since_retune = 0;
             }
         } else {
             pending_regime = regime;
             regime_hold = 0;
         }
 
+        // QUIESCENCE GATE. HVG-lambda in the periodic band + RQA-DET
+        // steady + the active-regime MWU vector converged -> latch
+        // `frozen` and skip the expensive MWU retune + knob write. The
+        // loop still ticks at 1 Hz; the chaos sensors above are the
+        // exit condition for frozen mode. A regime change moves lambda
+        // out of the steady band, so the gate thaws on the same/next
+        // tick -- the two gates compose without conflict.
+        let mwu_converged = mwu.converged(regime);
+        let frozen = quiesce.update(idle_lambda, rqa, mwu_converged);
+        if frozen {
+            frozen_ticks += 1;
+        }
+
         // MWU ORCHESTRATOR: UNIFIED KNOB CONTROL
-        // REPLACES: TIGHTEN/RELAX, SLEEP-INFORMED BATCH, SOJOURN EWMA, LONGRUN OVERRIDE
-        if !regime_changed_this_tick {
-            let signals = MwuSignals {
-                p99_ns,
-                interactive_p99_ns: tp99_i_ns,
-                io_pct,
-                rescue_count: delta_rescue,
-                // RAW total wakes/sec; the MWU fork-storm gate compares against
-                // a tau-derived total threshold (scale_tau_u64 * K_FORK_STORM_RATE).
-                // Per-CPU normalization here re-introduced an nr_cpus^2 effective
-                // threshold and latched on quiet 2-4C systems.
-                wakeup_rate: delta_enq_wake,
-            };
-            // OSCILLATOR-AWARE GATING: READ THE BPF DAMPED-HARMONIC
-            // OSCILLATOR'S CURRENT STATE BEFORE MWU DECIDES. PATHWAYS
-            // 2 AND 4 (RESCUE-DRIVEN) DEFER WHEN THE OSCILLATOR HAS
-            // ALREADY MOVED. WITHOUT THIS, MWU AND THE OSCILLATOR
-            // INDEPENDENTLY ADAPT ON global_rescue_count AND THE TWO
-            // CONTROLLERS DOUBLE-CORRECT.
-            let osc_state = sched.read_oscillator_state();
-            let mut knobs = mwu.update(&signals, regime.p99_ceiling(), nr_cpus, tau_ns, &osc_state);
-            // PRESERVE TOPOLOGY-OWNED FIELDS (tau_ns, codel_eq_ns) -- MWU
-            // DOESN'T TOUCH THEM. WITHOUT THIS, THE ADAPTIVE LOOP'S 1HZ
-            // WRITES WOULD CLOBBER VALUES main.rs SET AT TOPOLOGY DETECT.
-            let live = sched.read_tuning_knobs();
-            knobs.topology_tau_ns = live.topology_tau_ns;
-            knobs.codel_eq_ns = live.codel_eq_ns;
-            sched.write_tuning_knobs(&knobs)?;
+        // GATED BY !regime_changed_this_tick (a fresh regime already
+        // wrote its baseline) AND !frozen (steady state -- stop the
+        // machinery). When neither gate is set, the adaptive-rarity
+        // counter throttles how often the retune actually fires.
+        if !regime_changed_this_tick && !frozen {
+            ticks_since_retune += 1;
+            if ticks_since_retune >= retune_interval {
+                ticks_since_retune = 0;
+                let signals = MwuSignals {
+                    p99_ns,
+                    interactive_p99_ns: tp99_i_ns,
+                    io_pct,
+                    rescue_count: delta_rescue,
+                    // RAW total wakes/sec; the MWU fork-storm gate compares against
+                    // a tau-derived total threshold (scale_tau_u64 * K_FORK_STORM_RATE).
+                    // Per-CPU normalization here re-introduced an nr_cpus^2 effective
+                    // threshold and latched on quiet 2-4C systems.
+                    wakeup_rate: delta_enq_wake,
+                    scatter_pct,
+                    hvg_lambda: idle_lambda,
+                    bp_h_delta: bp_delta,
+                    // Same window HVG sees -- feeds compute_damp() for
+                    // the dynamic Butterworth blend. None on under-fill
+                    // is neutral (trust = 0.5).
+                    rqa_det: rqa,
+                };
+                // OSCILLATOR-AWARE GATING: READ THE BPF DAMPED-HARMONIC
+                // OSCILLATOR'S CURRENT STATE BEFORE MWU DECIDES. PATHWAYS
+                // 2 AND 4 (RESCUE-DRIVEN) DEFER WHEN THE OSCILLATOR HAS
+                // ALREADY MOVED. WITHOUT THIS, MWU AND THE OSCILLATOR
+                // INDEPENDENTLY ADAPT ON global_rescue_count AND THE TWO
+                // CONTROLLERS DOUBLE-CORRECT.
+                let osc_state = sched.read_oscillator_state();
+                let mut knobs = mwu.update(
+                    &signals,
+                    regime.p99_ceiling(),
+                    nr_cpus,
+                    tau_ns,
+                    &osc_state,
+                    regime,
+                );
+                // PRESERVE TOPOLOGY-OWNED FIELDS (tau_ns, codel_eq_ns) -- MWU
+                // DOESN'T TOUCH THEM. WITHOUT THIS, THE ADAPTIVE LOOP'S 1HZ
+                // WRITES WOULD CLOBBER VALUES main.rs SET AT TOPOLOGY DETECT.
+                let live = sched.read_tuning_knobs();
+                knobs.topology_tau_ns = live.topology_tau_ns;
+                knobs.codel_eq_ns = live.codel_eq_ns;
+                // COMMIT-ON-CHANGE: only push to the BPF map when an
+                // MWU-owned field actually moved. The BPF side reads the
+                // map unsynchronized -- skipping redundant writes strictly
+                // reduces torn-read exposure. The same diff drives the
+                // adaptive-rarity interval (sub-threshold = no change).
+                let changed = tuning::knobs_differ(&knobs, &last_written_knobs);
+                if changed {
+                    sched.write_tuning_knobs(&knobs)?;
+                    last_written_knobs = knobs;
+                }
+                let disturbed = mwu.had_losses() || chaos_crossing;
+                retune_interval =
+                    tuning::next_retune_interval(retune_interval, !changed, disturbed);
+            }
         }
 
         // STABILITY TRACKING
@@ -316,8 +452,10 @@ pub fn monitor_loop(
         };
 
         if verbose && tuning::should_print_telemetry(tick_counter, stability_score) {
+            let rqa_disp = rqa.unwrap_or(-1.0);
+            let frozen_disp = if frozen { 1 } else { 0 };
             println!(
-                "d/s: {:<8} idle: {}% shared: {:<6} preempt: {:<4} keep: {:<4} kick: H={:<4} S={:<4} enq: W={:<4} R={:<4} wake: {}us p99: {}us [B:{} I:{} L:{}] lat_idle: {}us lat_kick: {}us procdb: {}/{} sleep: io={}% slice: {}us batch: {}us reenq: {} sjrn: {}ms/{}ms rescue: {} l2: B={}% I={}% L={}% [{}{}]",
+                "d/s: {:<8} idle: {}% shared: {:<6} preempt: {:<4} keep: {:<4} kick: H={:<4} S={:<4} enq: W={:<4} R={:<4} wake: {}us p99: {}us [B:{} I:{} L:{}] lat_idle: {}us lat_kick: {}us procdb: {}/{} sleep: io={}% slice: {}us batch: {}us reenq: {} sjrn: {}ms/{}ms rescue: {} l2: B={}% I={}% L={}% chaos: lam={:.2} H={:.2} det={:.2} x={} frozen: {} (n={}) retune_iv: {} [{}{}]",
                 delta_d, idle_pct, delta_shared, delta_preempt, delta_keep,
                 delta_hard, delta_soft, delta_enq_wake, delta_enq_requeue,
                 wake_avg_us, p99_us, tp99_b, tp99_i, tp99_l,
@@ -326,7 +464,10 @@ pub fn monitor_loop(
                 io_pct, knobs.slice_ns / 1000, knobs.batch_slice_ns / 1000,
                 delta_reenq, sojourn_ms, sojourn_thresh_ms,
                 delta_rescue,
-                l2_pct_b, l2_pct_i, l2_pct_l, regime.label(), longrun_label,
+                l2_pct_b, l2_pct_i, l2_pct_l,
+                idle_lambda, wake_bp_h, rqa_disp, chaos_count.load(),
+                frozen_disp, frozen_ticks, retune_interval,
+                regime.label(), longrun_label,
             );
         }
 
@@ -353,6 +494,7 @@ pub fn monitor_loop(
         prev_hist = cur_hist;
         prev_sleep = cur_sleep;
         prev = stats;
+        prev_bp_h = wake_bp_h;
     }
 
     // PROCDB: SAVE LEARNED CLASSIFICATIONS TO DISK
@@ -393,13 +535,24 @@ pub fn monitor_loop(
     } else {
         0
     };
+    // CROSS-CCX SCATTER ATTRIBUTION (PER XCCX_* PATH). scatter_pct IS THE
+    // PLACEMENT-SIDE FRACTION (idx 0..6) PATHWAY 6 ACTS ON; THE PER-PATH COUNTS
+    // ARE THE PERMANENT ATTRIBUTION SURFACED TO THE BENCH SUITE EVERY RUN.
+    let x = &final_stats.nr_xccx;
+    let x_scatter: u64 = x[0..6].iter().sum();
+    let x_scatter_pct = if final_stats.nr_dispatches > 0 {
+        x_scatter * 100 / final_stats.nr_dispatches
+    } else {
+        0
+    };
     println!(
-        "[KNOBS] regime={} slice_ns={} batch_ns={} preempt_ns={} lag={} mwu={:.3} ticks=L:{}/M:{}/H:{} l2_hit=B:{}%/I:{}%/L:{}%",
+        "[KNOBS] regime={} slice_ns={} batch_ns={} preempt_ns={} mwu={:.3} ticks=L:{}/M:{}/H:{} frozen={} l2_hit=B:{}%/I:{}%/L:{}% xccx_scatter_pct={} xccx_sel_tight={} xccx_sel_sync={} xccx_sel_normal={} xccx_sel_dfl={} xccx_enq_t1={} xccx_enq_t2={} xccx_steal={} xccx_step5={}",
         regime.label(), final_knobs.slice_ns, final_knobs.batch_slice_ns,
         final_knobs.preempt_thresh_ns,
-        final_knobs.lag_scale, mwu.scale(),
-        light_ticks, mixed_ticks, heavy_ticks,
+        mwu.scale(regime),
+        light_ticks, mixed_ticks, heavy_ticks, frozen_ticks,
         l2_cum_b, l2_cum_i, l2_cum_l,
+        x_scatter_pct, x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7],
     );
 
     // READ UEI EXIT REASON

--- a/scheds/rust/scx_pandemonium/src/bpf/intf.h
+++ b/scheds/rust/scx_pandemonium/src/bpf/intf.h
@@ -13,6 +13,11 @@ typedef unsigned char u8;
 // BPF VERIFIER LOOP BOUNDS
 #define MAX_CPUS  1024
 #define MAX_NODES 32
+// PER-CCX OVERFLOW TIER CEILING. CHIPLET PARTS (AMD CCX/CCD) HAVE SMALL CCX
+// COUNTS (Ryzen 3000: 2, EPYC: up to ~16); 32 IS A COMFORTABLE CAP.
+// PRE-ALLOCATED AT INIT (DSQs ARE CHEAP); nr_ccx WALKED FROM Rust AT TOPOLOGY
+// DETECT GATES WHICH ARE LIVE.
+#define MAX_CCX_DOMAINS 32
 // AFFINITY_RANK STORAGE PER CPU. EACH CPU'S R_eff-RANKED PEERS ARE
 // STORED HERE; STEP 1 R_eff STEAL AND THE PLACEMENT-SIDE SPILL HELPER
 // WALK THIS LIST WITH A TAU-DERIVED RUNTIME BUDGET CAPPED BY nr_cpu_ids
@@ -33,7 +38,6 @@ typedef unsigned char u8;
 struct tuning_knobs {
 	u64 slice_ns;           // BASE TIME SLICE (DEFAULT 1MS)
 	u64 preempt_thresh_ns;  // TICK PREEMPTION THRESHOLD (DEFAULT 1MS)
-	u64 lag_scale;          // DEADLINE LAG MULTIPLIER (DEFAULT 4)
 	u64 batch_slice_ns;     // BATCH TASK SLICE CEILING (DEFAULT 20MS)
 	u64 lat_cri_thresh_high; // CLASSIFIER: LAT_CRITICAL THRESHOLD (DEFAULT 32)
 	u64 lat_cri_thresh_low;  // CLASSIFIER: INTERACTIVE THRESHOLD (DEFAULT 8)
@@ -49,6 +53,8 @@ struct tuning_knobs {
 	                        // <R_eff> * 2m * tau, CLAMPED [200us, 8ms].
 	                        // 0 MEANS NOT YET WRITTEN. WRITTEN AT TOPOLOGY
 	                        // DETECT AND ON HOTPLUG (CO-LOCATED WITH tau).
+	// PHI DISTANCE PENALTY IS PRE-FOLDED INTO THE reff_value MAP (IN NS) BY
+	// RUST AT TOPOLOGY DETECT -- NO KNOB FIELD: BPF READS THE MAP DIRECTLY.
 };
 
 // PER-CPU STATISTICS (BPF_MAP_TYPE_PERCPU_ARRAY VALUE)
@@ -63,8 +69,8 @@ struct pandemonium_stats {
 	u64 nr_keep_running;    // TASKS REPLENISHED VIA keep_running()
 	u64 nr_hard_kicks;      // ENQUEUE: SCX_KICK_PREEMPT (FRESH WAKEUP)
 	u64 nr_soft_kicks;      // ENQUEUE: SOFT NUDGE (RE-ENQUEUE)
-	u64 nr_enq_wakeup;      // ENQUEUE: TASK JUST WOKE UP (AWAKE_VTIME==0)
-	u64 nr_enq_requeue;     // ENQUEUE: TASK RE-ENQUEUED (AWAKE_VTIME>0)
+	u64 nr_enq_wakeup;      // ENQUEUE: TASK JUST WOKE UP (!ran_since_wake)
+	u64 nr_enq_requeue;     // ENQUEUE: TASK RE-ENQUEUED (ran_since_wake)
 	u64 wake_lat_idle_sum;  // LATENCY SUM: IDLE FAST PATH (NS)
 	u64 wake_lat_idle_cnt;  // LATENCY COUNT: IDLE FAST PATH
 	u64 wake_lat_kick_sum;  // LATENCY SUM: HARD-KICKED ENQUEUE (NS)
@@ -86,7 +92,25 @@ struct pandemonium_stats {
 	// OVERFLOW SOJOURN RESCUE: TASKS DISPATCHED BY try_service_older_overflow
 	// AT overflow_sojourn_rescue_ns (DISPATCH STEP 2)
 	u64 nr_overflow_rescue;
+	// CROSS-CCX SCATTER ATTRIBUTION: PER-PLACEMENT-PATH COUNT OF LANDINGS
+	// WHERE THE CHOSEN CPU IS IN A DIFFERENT CCX THAN THE TASK'S last_cpu.
+	// INDEXED BY XCCX_* BELOW. THE ADAPTIVE LAYER CONSUMES THE PLACEMENT-SIDE
+	// PATHS (XCCX_SEL_* + XCCX_ENQ_T1) AS THE MWU CROSS-CCX SCATTER LOSS
+	// PATHWAY, AND THE BENCH SUITE SURFACES ALL PATHS PER RUN. THE PHI-CORRECT
+	// PATHS (XCCX_STEAL, XCCX_STEP5) ARE TRACKED BUT EXCLUDED FROM THE LOSS --
+	// THEY ARE DELIBERATE WORK-CONSERVATION MOVES, NOT SCATTER TO SUPPRESS.
+	u64 nr_xccx[8];
 };
+
+// XCCX path indices for pandemonium_stats.nr_xccx[] (diagnostic).
+#define XCCX_SEL_TIGHT   0   // select_cpu WAKE_SYNC tight-partner colocation
+#define XCCX_SEL_SYNC    1   // select_cpu WAKE_SYNC phi_warm_target
+#define XCCX_SEL_NORMAL  2   // select_cpu normal_path phi_warm_target
+#define XCCX_SEL_DFL     3   // select_cpu scx_bpf_select_cpu_dfl idle pick
+#define XCCX_ENQ_T1      4   // enqueue TIER 1 idle (pick_idle_cpu_node)
+#define XCCX_ENQ_T2      5   // enqueue TIER 2 warm-anchor spill
+#define XCCX_STEAL       6   // dispatch STEP 1 R_eff steal (this_cpu vs peer)
+#define XCCX_STEP5       7   // dispatch STEP 5 cross-CCX work-conservation scan
 
 // PROCESS CLASSIFICATION: BPF OBSERVES, RUST LEARNS, BPF APPLIES
 // SHARED BETWEEN BPF MAPS (task_class_observe, task_class_init) AND RUST (procdb.rs)

--- a/scheds/rust/scx_pandemonium/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_pandemonium/src/bpf/main.bpf.c
@@ -6,23 +6,29 @@
 //
 // ARCHITECTURE:
 //   SELECT_CPU IDLE FAST PATH -> PER-CPU DSQ (DEPTH-GATED, VISIBLE, STEALABLE)
-//   ENQUEUE IDLE FOUND -> NODE DSQ (SHARED, ANY CPU DRAINS)
-//   ENQUEUE INTERACTIVE PREEMPT -> NODE DSQ (SHARED, KICKED CPU DRAINS)
-//   ENQUEUE FALLBACK -> PER-NODE OVERFLOW DSQ (VTIME-ORDERED)
-//   DISPATCH -> OWN PER-CPU, L2 WORK STEAL, NODE OVERFLOW, CROSS-NODE, KEEP
+//   ENQUEUE TIER 1 IDLE FOUND -> THAT IDLE CPU'S PER-CPU DSQ (WARM)
+//   ENQUEUE TIER 2 WARM-ANCHOR (WAKEUP / LAT_CRITICAL) -> last_cpu PER-CPU DSQ
+//   ENQUEUE TIER 3 FALLBACK -> PER-CCX OVERFLOW DSQ (SOJOURN-ORDERED, L3-LOCAL)
+//   DISPATCH -> OWN PER-CPU, R_eff STEAL (Phi-PRICED), CCX OVERFLOW, CROSS-CCX, KEEP
 //   TICK -> PER-CPU SOJOURN (LOCAL + ROTATING SCAN) + BATCH PREEMPTION
 //
 // BEHAVIORAL CLASSIFICATION:
 //   LAT_CRI SCORE = (WAKEUP_FREQ * CSW_RATE) / AVG_RUNTIME
 //   THREE TIERS: LAT_CRITICAL, INTERACTIVE, BATCH
 //   PER-TIER SLICING: 1.5X AVG_RUNTIME, 2X AVG_RUNTIME, KNOB BASE
-//   COMPOSITOR AUTO-BOOST TO LAT_CRITICAL
 
 #include <scx/common.bpf.h>
 #include <scx/compat.bpf.h>
 #include "intf.h"
 
 char _license[] SEC("license") = "GPL";
+
+// scx_bpf_task_set_slice() / scx_bpf_task_set_dsq_vtime() REPLACE DIRECT
+// WRITES TO p->scx.slice / p->scx.dsq_vtime ON KERNEL 7.1+. THE WRAPPERS
+// (WHICH PICK THE KFUNC-OR-DIRECT-WRITE VIA bpf_ksym_exists) LIVE IN
+// scx/compat.bpf.h -- BOTH THE VENDORED COPY HERE AND THE scx UPSTREAM
+// VERSION -- SO WE JUST CALL THEM DIRECTLY. READS OF THE SAME FIELDS
+// ARE NOT DEPRECATED AND REMAIN AS-IS.
 
 // CONFIGURATION (SET BY RUST VIA RODATA BEFORE LOAD)
 
@@ -36,6 +42,19 @@ const volatile u64 nr_cpu_ids = 1;
 #define TIER_INTERACTIVE  1
 #define TIER_LAT_CRITICAL 2
 
+// FLOW SIGNATURE (PERSISTED SHAPE, FROZEN AT EWMA_AGE_MATURE). COUNTS THE
+// DISTINCT WAKER CPUs OF A TASK IN A BITMAP; THE POPCOUNT IS ITS PARTNER
+// CARDINALITY -- A TOPOLOGY-FREE READ OF THE LIVE COMMUNICATION GRAPH'S
+// CONDUCTANCE. A FEW PARTNERS = A TIGHT LOOP; MANY (SPANNING HALF+ THE MACHINE)
+// = A STORM MESH. CLASSIFIED ONCE AND FROZEN -> DETERMINISTIC ROUTING.
+#define SHAPE_UNCLASSIFIED 0
+#define SHAPE_TIGHT        1
+#define SHAPE_STORM        2
+// SPLIT: <= SHAPE_TIGHT_MAX DISTINCT PARTNERS IS A TIGHT PAIR/LOOP; A PARTNER
+// SET SPANNING AT LEAST HALF OF nr_cpu_ids IS A STORM. PORTABLE -- THE STORM
+// THRESHOLD SCALES WITH THE MACHINE, NO HARDCODED CORE GEOMETRY.
+#define SHAPE_TIGHT_MAX    2u
+
 #define LAT_CRI_THRESH_HIGH  32
 #define LAT_CRI_THRESH_LOW   8
 #define LAT_CRI_CAP          255
@@ -46,6 +65,13 @@ const volatile u64 nr_cpu_ids = 1;
 // (SHORT-RUNTIME / HIGH-WAKEUP) BUT ARE COMPUTE CLASS, NOT LATENCY-
 // SENSITIVE. FORCED TO BATCH IN runnable().
 #define KTHREAD_HIPRI_STATIC_PRIO_MAX 110
+// RT SCHEDULING POLICIES (UAPI VALUES; NOT ALWAYS MACRO-EXPORTED VIA vmlinux.h).
+#ifndef SCHED_FIFO
+#define SCHED_FIFO 1
+#endif
+#ifndef SCHED_RR
+#define SCHED_RR   2
+#endif
 
 #define WEIGHT_LAT_CRITICAL  256   // 2X
 #define WEIGHT_INTERACTIVE   192   // 1.5X
@@ -55,9 +81,9 @@ const volatile u64 nr_cpu_ids = 1;
 #define EWMA_AGE_CAP         16
 #define MAX_WAKEUP_FREQ      64
 #define MAX_CSW_RATE         512
-// VTIME LAG CAP: TAU-DERIVED IN apply_tau_scaling() VIA K_LAG_CAP.
-// USED AS THE BASE FOR (a) vtime_floor = vtime_now - lag_cap_ns * lag_scale
-// (SLEEP-BOOST CAP) AND (b) PER-TIER awake_cap. AT THE 12C REFERENCE
+// WARP CEILING: TAU-DERIVED IN apply_tau_scaling() VIA K_LAG_CAP. THE UPPER
+// BOUND ON THE SOJOURN warp IN task_deadline() (warp = lag_cap_ns *
+// task_potentiality_q16 >> 16), SO THE WARP IS STARVATION-FREE. AT THE 12C REFERENCE
 // (tau=40MS) THIS IS 40MS, MATCHING THE PRE-v5.8.0 CONSTANT. CLAMPED
 // [8MS, 80MS]. INIT FALLBACK MATCHES THE 12C REFERENCE.
 static u64 lag_cap_ns = 40000000ULL;
@@ -73,17 +99,13 @@ static u64 lag_cap_ns = 40000000ULL;
 #define K_Q16_SHIFT             16
 // K_i ARE DIMENSIONLESS PHYSICAL RATIOS: target_ns = K_i * tau / 65536.
 // SAME K APPLIES TO EVERY TOPOLOGY -- THE OUTPUT VARIES BECAUSE tau VARIES.
-// EXAMPLES: K_VTIME_CEILING = 3.0 (Q16 196608) MEANS "VTIME CEILING IS THREE
-// COMMUTE TIMES OF THE TOPOLOGY GRAPH." AT tau=13MS (12C) -> 39MS; AT tau=4MS
-// (32C) -> 12MS (FLOOR-CLAMPED TO 16MS); AT tau=40MS (2C CLAMP) -> 120MS.
-// THE RATIOS ARE SET ONCE BY DESIGN AND NOT MACHINE-SPECIFIC.
-#define K_SOJOURN_INTERVAL       19661u   // 0.30
-#define K_OVERFLOW_RESCUE        16384u   // 0.25
+// EXAMPLE: K_LAG_CAP = 1.0 (Q16 65536) MEANS "THE WARP CEILING IS ONE
+// COMMUTE TIME OF THE TOPOLOGY GRAPH." THE RATIOS ARE SET ONCE BY DESIGN
+// AND NOT MACHINE-SPECIFIC; THE OUTPUT VARIES BECAUSE tau VARIES.
 #define K_CODEL_FLOOR             1147u   // 0.0175
 #define K_STARVATION_RESCUE     273285u   // 4.17
 #define K_LONGRUN              3276800u   // 50.0
 #define K_CODEL_MAX               3277u   // 0.05
-#define K_VTIME_CEILING         196608u   // 3.0
 #define K_LAG_CAP                65536u   // 1.0
 #define K_SPILL_BUDGET     80000000ULL    // TAU_SCALE_NS / 2; budget = K / tau
 #define K_AFFINITY_SEARCH  40000000ULL    // TAU_SCALE_NS / 4; budget = K / tau
@@ -101,18 +123,15 @@ static u64 lag_cap_ns = 40000000ULL;
 // GLOBALS
 
 static u32 nr_nodes;
-static u64 vtime_now;
+// nr_ccx: NUMBER OF DISTINCT L3/CCX DOMAINS IN llc_domain[]. SET BY RUST AT
+// TOPOLOGY DETECT VIA write_nr_ccx (.data SECTION, POST-LOAD MUTABLE). ON
+// MONOLITHIC-L3 / UNSET, EQUALS nr_sockets (TYPICALLY 1) AND THE PER-CCX TIER
+// COLLAPSES TO A SINGLE OVERFLOW DSQ -- EXACT PRIOR BEHAVIOR SHAPE.
+volatile u32 nr_ccx = 1;
 
-// TICK-BASED INTERACTIVE PREEMPTION SIGNAL
-// SET BY enqueue() WHEN NON-BATCH TASK HITS OVERFLOW DSQ.
-// CLEARED BY tick() AFTER PREEMPTING A BATCH TASK.
-// latcrit_waiting IS A SHARPER VARIANT: SET WHEN A TIER_LAT_CRITICAL TASK
-// SPECIFICALLY IS WAITING. tick() USES IT TO TIGHTEN THE PREEMPT THRESHOLD
-// SO AUDIO / COMPOSITOR / OTHER TIGHT-DEADLINE WAKERS DON'T SIT BEHIND A
-// FULL BATCH SLICE WORTH OF PREEMPT-WAIT. TIER INFO ALREADY AVAILABLE AT
-// THE enqueue() SITE -- WE'RE JUST PROPAGATING IT INTO THE SAFETY NET.
-static bool interactive_waiting;
-static bool latcrit_waiting;
+// NO GLOBAL PREEMPT FLAG: tick() DERIVES THE DECISION PER-CPU FROM
+// pcpu_enqueue_ns[this_cpu] (OLDEST WAITER AGE) AGAINST A k*tau THRESHOLD,
+// TIER-GATED ON THE RESIDENT. PER-CPU SO NO TOKEN FOR CPUs TO RACE OVER.
 
 // SOJOURN TRACKERS: RECORD WHEN OVERFLOW DSQs TRANSITION FROM EMPTY.
 // DISPATCH STEP 0 CHECKS THESE TO RESCUE OVERFLOW TASKS AGING PAST
@@ -125,17 +144,14 @@ static u64 interactive_enqueue_ns;
 // PER-CPU DSQ SOJOURN: TRACKS WHEN EACH PER-CPU DSQ TRANSITIONS
 // FROM EMPTY. DISPATCH AND TICK CHECK THESE TO DETECT STALE TASKS.
 // WORK STEALING + DEPTH GATE HANDLE MOST CASES; THIS IS THE SAFETY NET.
-static u64 pcpu_enqueue_ns[MAX_CPUS];
+// CACHELINE-PADDED: one stamp per 64-byte line so the per-placement CAS
+// (arm/clear) and the per-tick cross-CPU scan don't false-share neighbors.
+struct pcpu_stamp { u64 ns; } __attribute__((aligned(64)));
+static struct pcpu_stamp pcpu_enqueue_ns[MAX_CPUS];
 
 static u64 starvation_rescue_ns;
 static u64 overflow_sojourn_rescue_ns;
 static u32 pcpu_depth_base;
-
-// TAU-DERIVED VTIME CEILING WINDOW. SET IN apply_tau_scaling() FROM
-// scale_tau(tau, K_VTIME_CEILING), CLAMPED TO [16MS, 160MS]. READ ON THE
-// HOT PATH BY task_deadline() (CAPS DEADLINE AT vtime_now + WINDOW) AND
-// BY pandemonium_enable() (NEW-TASK VTIME PENALTY).
-static u64 vtime_ceiling_window_ns;
 
 // TAU-DERIVED LONGRUN PREEMPT BOOST. SET IN apply_tau_scaling() AS A
 // STEP FUNCTION ON tau (SHIFT 2 WHEN tau < 4MS, ELSE 0). USED BY tick()
@@ -174,13 +190,10 @@ static s64 oscillator_velocity_cap;       // VELOCITY CLAMP
 // AND DOUBLE-CORRECT.
 u64 codel_target_floor_ns;         // CORE-SCALED FLOOR FOR TARGET
 // ADAPTIVE STATE
-static u64 sojourn_interval_ns;        // CORE-SCALED, UNCERTAIN ZONE TIMER
 u64 codel_target_ns;          // ADAPTIVE CENTER (EXPOSED FOR MWU)
 static s64 oscillator_velocity_ns;        // DAMPED OSCILLATION VELOCITY
 static u64 prev_rescue_snapshot;       // LAST-SEEN RESCUE COUNT
 static u64 global_rescue_count;        // ATOMIC CROSS-CPU RESCUE ACCUMULATOR
-static u64 pcpu_min_sojourn_ns[MAX_CPUS];
-static u64 pcpu_stall_start_ns[MAX_CPUS];
 
 // LONGRUN DETECTION
 // TRACKS SUSTAINED BATCH DSQ PRESSURE. WHEN BATCH DSQ IS NON-EMPTY
@@ -206,6 +219,10 @@ static u64 last_tau_snapshot;
 // HAS NO EQUILIBRIUM AND CAN ACCUMULATE OPEN-LOOP DRIFT.
 // FALLBACK 2MS UNTIL RUST WRITES; SAME ORDER AS codel_target_max_ns.
 static u64 codel_target_equilibrium_ns = 2000000ULL;
+
+// PHI MIGRATION POTENTIAL: distance penalty b*R_eff is pre-folded into the
+// reff_value map (in ns) by Rust at topology detect, so dispatch STEP 1 reads it
+// directly. No BPF-side scale global, no per-tick mirror, no per-steal multiply.
 
 // USER EXIT
 
@@ -236,6 +253,18 @@ struct {
 	__type(value, u32);
 } cache_domain SEC(".maps");
 
+// LLC/CCX DOMAIN MAP: llc_domain[cpu] = L3/CCX group_id. CHIPLET PARTS
+// (AMD CCX/CCD) HAVE MULTIPLE L3 GROUPS PER SOCKET; MONOLITHIC PARTS HAVE
+// llc_domain == socket_domain (ALL ON-SOCKET CPUs COMPARE EQUAL, INTRA-CCX
+// CHECKS ARE NO-OP). USED BY pandemonium_running TO TAG EACH MIGRATION AS
+// INTRA-CCX OR CROSS-CCX FOR PER-PATH MIGRATION SOURCE DIAGNOSIS.
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_CPUS);
+	__type(key, u32);
+	__type(value, u32);
+} llc_domain SEC(".maps");
+
 // PROCESS CLASSIFICATION DATABASE: BPF OBSERVES, RUST LEARNS, BPF APPLIES
 // OBSERVE: BPF WRITES MATURE TASK CLASSIFICATION, RUST DRAINS EVERY SECOND
 struct {
@@ -252,15 +281,6 @@ struct {
 	__type(key, char[16]);
 	__type(value, struct task_class_entry);
 } task_class_init SEC(".maps");
-
-// COMPOSITOR MAP: RUST POPULATES AT STARTUP, BPF LOOKS UP IN runnable()
-// KEY: COMM NAME (16 BYTES), VALUE: UNUSED (EXISTENCE = COMPOSITOR)
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 32);
-	__type(key, char[16]);
-	__type(value, u8);
-} compositor_map SEC(".maps");
 
 // L2 SIBLINGS MAP: FLAT ARRAY FOR L2-AWARE CPU PLACEMENT
 // l2_siblings[group_id * MAX_L2_SIBLINGS + slot] = cpu_id
@@ -288,6 +308,33 @@ struct {
 	__type(value, u32);
 } affinity_rank SEC(".maps");
 
+// PHI STEAL PENALTY ORACLE: PER-CPU PRE-FOLDED DISTANCE PENALTY TO EACH TARGET.
+// reff_value[cpu * MAX_AFFINITY_CANDIDATES + slot] = (R_eff(cpu, target) * b) >> 16
+// IN NS, WHERE b = phi_dist_scale_q16 (FOLDED BY RUST AT TOPOLOGY DETECT). THE
+// STEAL READS IT DIRECTLY AS dist_extra -- NO RUNTIME MULTIPLY, NO SCALE GLOBAL.
+// PAIRS 1:1 WITH affinity_rank: THE RANK GIVES *WHICH* CPU, THIS ITS STEAL DELAY.
+// ALL-ZERO ON MONOLITHIC / --phi-scale 0 => FLAT codel_target (EXACT PRIOR NO-OP).
+// SENTINEL: (u32)-1 (TREATED AS 0 PENALTY) FOR SLOTS PAST THE TOPOLOGY END.
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_CPUS * MAX_AFFINITY_CANDIDATES);
+	__type(key, u32);
+	__type(value, u32);
+} reff_value SEC(".maps");
+
+// STEP 1 SCAN RATE-LIMIT: per-CPU timestamp of the last R_eff steal scan.
+// PERCPU SO IT IS THIS-CPU-LOCAL -- NO CROSS-CPU COHERENCE TRAFFIC. THE PEER
+// WALK (affinity_rank + PER-PEER nr_queued) IS THE DOMINANT PER-DISPATCH CACHE
+// COST UNDER WAKE-HEAVY LOADS; GATING IT TO ONE SCAN PER codel_target COLLAPSES
+// THAT COST WITHOUT MISSING STEALABLE WORK (BACKLOG CAN'T AGE PAST THE STEAL
+// THRESHOLD FASTER THAN THE THRESHOLD ITSELF).
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, u64);
+} last_spill_scan SEC(".maps");
+
 // WAKEUP LATENCY HISTOGRAM: 3 TIERS x 12 BUCKETS = 36 ENTRIES PER CPU
 // BPF INCREMENTS IN running(); RUST READS ONCE PER SECOND IN MONITOR LOOP
 struct {
@@ -309,7 +356,6 @@ struct {
 // PER-TASK CONTEXT
 
 struct task_ctx {
-	u64 awake_vtime;
 	u64 last_run_at;
 	u64 wakeup_freq;
 	u64 last_woke_at;
@@ -324,11 +370,17 @@ struct task_ctx {
 	u64 csw_rate;
 	u64 lat_cri;
 	u64 sleep_start_ns;  // SET IN quiescent(), USED IN running()
+	u64 waker_bitmap;    // BIT i = CPU i woke this task; popcount = partner cardinality
 	u32 tier;
 	u32 ewma_age;
 	s32 last_cpu;        // LAST CPU THIS TASK RAN ON (FOR CACHE AFFINITY)
+	s32 home_cpu;        // STABLE PLACEMENT HOME: PINNED TO THE FIRST CPU THE
+	                     // TASK RAN ON; NEVER CHASES last_cpu. WARM-STAY ANCHOR
+	                     // SO THE TASK RETURNS HOME INSTEAD OF DRIFTING.
 	u8  dispatch_path;   // 0=IDLE, 1=HARD_KICK, 2=SOFT_KICK
-	u8  _pad[3];
+	u8  ran_since_wake;  // is_wakeup = !ran_since_wake; SET 1 IN running(), 0 ON WAKE
+	u8  shape;           // FLOW SIGNATURE: SHAPE_* (FROZEN AT MATURITY)
+	u8  _pad[1];
 };
 
 struct {
@@ -339,6 +391,48 @@ struct {
 } task_ctx_stor SEC(".maps");
 
 // HELPERS
+
+// PER-CCX OVERFLOW DSQ IDs. LAYOUT:
+//   [0, nr_cpu_ids)                                   per-CPU DSQs
+//   [nr_cpu_ids + 2*MAX_NODES,             ...)       per-CCX interactive overflow
+//   [nr_cpu_ids + 2*MAX_NODES + MAX_CCX_DOMAINS, ...) per-CCX batch overflow
+// THE 2*MAX_NODES GAP RESERVES IDs THAT EARLIER PER-NODE TIERS USED; KEEPING
+// THE OFFSET CONSTANT MEANS HARDWARE-INDEPENDENT AT COMPILE TIME. DSQs ARE
+// CREATED ONCE AT INIT FROM A FIXED MAP; THE RUNTIME nr_ccx GATES WHICH ARE
+// ADDRESSED.
+static __always_inline u64 ccx_inter_dsq(u32 ccx)
+{
+	return nr_cpu_ids + 2ULL * MAX_NODES + (u64)ccx;
+}
+
+static __always_inline u64 ccx_batch_dsq(u32 ccx)
+{
+	return nr_cpu_ids + 2ULL * MAX_NODES + MAX_CCX_DOMAINS + (u64)ccx;
+}
+
+// CCX of a CPU via llc_domain lookup; defaults to 0 if unavailable.
+static __always_inline u32 cpu_ccx(s32 cpu)
+{
+	if (cpu < 0 || (u32)cpu >= nr_cpu_ids)
+		return 0;
+	u32 key = (u32)cpu;
+	u32 *cd = bpf_map_lookup_elem(&llc_domain, &key);
+	return cd ? *cd : 0;
+}
+
+// CROSS-CCX SCATTER BUMP. COUNTS A CROSS-CCX LANDING ON PATH `idx` (XCCX_*)
+// WHEN THE TASK'S HOME CPU AND THE CHOSEN CPU SIT IN DIFFERENT CCXs.
+// last_home < 0 (NO PRIOR CPU) IS NOT A MIGRATION. FREE-COMPUTE: ONE cpu_ccx
+// COMPARE ON AN ALREADY-TAKEN PLACEMENT BRANCH. CONSUMED BY THE ADAPTIVE MWU
+// SCATTER PATHWAY AND SURFACED PER-RUN BY THE BENCH SUITE.
+static __always_inline void xccx_bump(struct pandemonium_stats *s, u32 idx,
+				      s32 last_home, s32 dst)
+{
+	if (!s || idx >= 8 || last_home < 0)
+		return;
+	if (cpu_ccx(last_home) != cpu_ccx(dst))
+		s->nr_xccx[idx] += 1;
+}
 
 static __always_inline struct pandemonium_stats *get_stats(void)
 {
@@ -469,12 +563,108 @@ static __always_inline s32 find_idle_by_affinity(s32 src_cpu,
 	return -1;
 }
 
+// PHI PLACEMENT TARGET (SUBORDINATE SUB-MECHANISM). WARMTH'S ONLY ROLE ON THE
+// WAKEUP FAST PATH IS TO BIAS WHICH IDLE CPU IS CHOSEN -- IT NEVER PLACES A WAKEE ON
+// A BUSY CORE HERE. PLACING ON BUSY VIA THIS PATH ISSUED KICK_IDLE (A NO-OP ON A
+// BUSY CPU) AND BYPASSED THE dfl -> enqueue PATH, STRANDING THE WAKEE UNTIL THE
+// RUNNING TASK YIELDED: ~90% DEADLINE MISS UNDER SATURATION, IDENTICAL WHETHER THE
+// WARM-STAY WAS A DEEP OVERRIDE OR A 1-DEEP WHISPER -- THE BUG WAS THE BUSY
+// PLACEMENT ITSELF, NOT ITS DEPTH. SO WARMTH NEVER RETURNS A BUSY CPU:
+//   - ANCHOR IDLE -> TAKE IT (WARM AND IMMEDIATE).
+//   - ELSE NEAREST/WARMEST IDLE: find_idle_by_affinity WALKS R_eff ORDER, SO A
+//     SAME-CCX IDLE IS PREFERRED OVER A CROSS-CCX ONE AUTOMATICALLY -- THAT IS THE
+//     BIAS, EXPRESSED BY *WHICH* IDLE, NEVER BY REFUSING TO USE ONE.
+//   - NOTHING IDLE -> RETURN -1, AND select_cpu FALLS THROUGH TO dfl -> enqueue, THE
+//     PROVEN PATH THAT PLACES BUSY-CORE WAKEUPS WITH A REAL PREEMPT (KICK_PREEMPT).
+// find_idle_by_affinity ALREADY RETURNS THE ANCHOR ITSELF WHEN IT IS IDLE (RANK SLOT
+// 0 = SELF), SO A CORRECT SUBORDINATE PLACEMENT BIAS COLLAPSES TO EXACTLY THAT WALK.
+// A PLACE-ON-BUSY WARM-STAY, IF EVER PURSUED, BELONGS IN THE enqueue PATH THAT KICKS
+// PREEMPT -- NEVER THE IDLE FAST PATH.
+static __always_inline s32 phi_warm_target(s32 anchor,
+					   const struct cpumask *allowed,
+					   u32 tier)
+{
+	(void)tier;
+	return find_idle_by_affinity(anchor, allowed);
+}
+
+// WARM-STAY GATE. RETURNS THE ANCHOR (last_cpu) TO HOLD THE WAKEE ON WHEN THE
+// ANCHOR IS UNCONGESTED -- I.E. PREFER QUEUEING ON prev_cpu OVER FANNING THE
+// WAKEE OUT TO A COLD IDLE SIBLING. RETURNS -1 WHEN THE CALLER SHOULD IDLE-SEEK
+// AS USUAL (ANCHOR CONGESTED, OR WARM-STAY INAPPLICABLE).
+//
+// CONGESTION = THE ANCHOR'S SOJOURN (now - ITS EMPTY->NONEMPTY STAMP, THE SAME
+// SIGNAL THE DISPATCH STEP 1 STEAL READS) EXCEEDING codel_target_ns -- THE
+// OSCILLATOR'S ADAPTIVE "STANDARD OPERATIONS" PRESSURE MARK. BELOW IT, THE
+// ANCHOR IS DRAINING HEALTHILY AND THE WAKEE SHOULD STAY CACHE-WARM; ABOVE IT,
+// THE ANCHOR IS GENUINELY BACKED UP AND FANNING OUT IS JUSTIFIED. THIS IS THE
+// PLACEMENT-SIDE DUAL OF THE STEAL THRESHOLD: A WAKEE STAYS ON ITS WARM CORE
+// RIGHT UP TO THE SOJOURN AT WHICH THE STEAL MACHINERY WOULD RELOCATE IT.
+//
+// THE CALLER MUST ROUTE A HELD WAKEE THROUGH A PREEMPT-KICKED PLACEMENT (THE
+// ENQUEUE PATH), NEVER select_cpu's KICK_IDLE FAST PATH -- A KICK_IDLE ON A
+// BUSY ANCHOR IS A NO-OP AND STRANDS THE WAKEE (THE ~90% DEADLINE-MISS SCAR
+// DOCUMENTED ABOVE phi_warm_target). select_cpu THEREFORE ONLY DEFERS HERE.
+//
+// EXCLUDES: NON-WAKEUPS, LAT_CRITICAL (FLEES FOR IMMEDIACY), KTHREADS. THE
+// ANCHOR (home_cpu, ELSE last_cpu) MUST BE VALID AND IN THE WAKEE'S ALLOWED MASK.
+// DECOUPLED FROM affinity_mode: STICKINESS IS FUNDAMENTAL MIGRATION RESISTANCE,
+// NOT AN ADAPTIVE-ONLY L2 FEATURE -- SO IT ENGAGES IN BPF-ONLY MODE TOO, WHERE
+// THE MIGRATION STORM (2375 MOVES/THREAD VS EEVDF'S 45) WAS MEASURED.
+static __always_inline s32 warm_stay_anchor(struct task_struct *p,
+					    struct task_ctx *tctx,
+					    struct tuning_knobs *knobs,
+					    bool is_wakeup, u64 now)
+{
+	if (!tctx || !is_wakeup)
+		return -1;
+	if (!knobs)
+		return -1;
+	if (tctx->tier == TIER_LAT_CRITICAL || (p->flags & PF_KTHREAD))
+		return -1;
+	// STABLE HOME ANCHOR: PREFER THE PINNED HOME OVER last_cpu, WHICH IS REWRITTEN
+	// EVERY stopping() AND SO CHASES THE TASK ACROSS CPUs -- THE MIGRATION-STORM
+	// ROOT. AN UNCONGESTED HOME PULLS THE TASK BACK INSTEAD OF DRIFTING. FALLS
+	// BACK TO last_cpu UNTIL HOME IS PINNED (FIRST RUN).
+	s32 lc = (tctx->home_cpu >= 0) ? tctx->home_cpu : tctx->last_cpu;
+	if (lc < 0 || (u32)lc >= nr_cpu_ids)
+		return -1;
+	if (!bpf_cpumask_test_cpu(lc, p->cpus_ptr))
+		return -1;
+	u64 stamp = pcpu_enqueue_ns[(u32)lc & (MAX_CPUS - 1)].ns;
+	u64 sojourn = (stamp && now > stamp) ? (now - stamp) : 0;
+	// PHI-PRICED STAY. THE STAY AND THE STEP-1 STEAL MUST RELEASE AT THE SAME
+	// THRESHOLD, OR THEY FIGHT: THE STEAL FIRES AT codel_target + dist_extra
+	// (THE R_eff DISTANCE PENALTY, PRE-FOLDED IN reff_value), BUT AN
+	// UNCONDITIONAL BAIL AT BARE codel_target GAVE UP THE HOME TOO EARLY (EAGER
+	// NON-STORM FAN-OUT) WHILE AN UNCONDITIONAL STORM EXEMPTION NEVER GAVE IT UP
+	// (DEEP PILE -> STEAL RE-SCATTERS IT -> THE MIGRATION RAMP). READING THE
+	// HOME'S OWN SLOT-0 PENALTY (DISTANCE TO ITS NEAREST PEER -- THE CHEAPEST
+	// RELIEF TARGET) MAKES WARM-STAY HOLD THE TASK HOME UP TO EXACTLY THE
+	// SOJOURN AT WHICH THAT NEAREST PEER'S STEAL WOULD RELIEVE IT. BELOW IT:
+	// STAY (RELIEF, IF ANY, WOULD BE A CHEAP NEAR MOVE). ABOVE IT: RELEASE TO
+	// IDLE-SEEK -- THE TASK WAS ABOUT TO BE STOLEN ANYWAY, SO PLACE IT WELL NOW.
+	// Φ THUS GOVERNS IPC/WAKE-STORM/FORK-THREAD PLACEMENT ON ONE THRESHOLD:
+	// A NEAR (LOW-R_eff) HOME RELEASES QUICKLY (CHEAP MOVES OK); A FAR HOME
+	// (HIGH-R_eff, CROSS-FABRIC) HOLDS HARD (CROSSING IS EXPENSIVE). ALL SHAPES,
+	// NO BINARY STORM BRANCH. reff_value ALL-ZERO (MONOLITHIC / --phi-scale 0)
+	// COLLAPSES TO BARE codel_target -- EXACT PRIOR BEHAVIOR. LAT_CRITICAL
+	// RETURNED AT LINE 616, SO AUDIO KEEPS ITS UNCONDITIONAL ESCAPE (NO SCAR).
+	u32 base0 = (u32)lc * MAX_AFFINITY_CANDIDATES;
+	u32 *dxp = bpf_map_lookup_elem(&reff_value, &base0);
+	u32 dx = dxp ? *dxp : 0;
+	u64 home_dist_extra = (dx == (u32)-1) ? 0 : (u64)dx;
+	if (sojourn > codel_target_ns + home_dist_extra)
+		return -1;        // home aged past its Phi threshold: idle-seek
+	return lc;                // within Phi tolerance: stay warm
+}
+
 // SIBLING PER-CPU DSQ WITH ROOM: WALKS THE SAME R_EFF-RANKED LIST AS
 // find_idle_by_affinity BUT WITH "HAS ROOM" AS THE PREDICATE INSTEAD OF
 // "IS IDLE". USED BY THE WAKE_SYNC AND normal_path DEPTH-GATE SPILL SITES
 // IN select_cpu TO ROUTE OVERFLOW INTO A SIBLING PER-CPU DSQ -- WHICH IS
 // REACHED BY DISPATCH STEP 0 (OWN) OR STEP 1 (L2 STEAL) -- INSTEAD OF
-// FUNNELING INTO THE SHARED NODE DSQ THAT DISPATCH ONLY REACHES AT STEP 6.
+// FUNNELING INTO ccx_inter_dsq, WHICH DISPATCH ONLY REACHES AT STEP 3.
 // BUDGET IS TAU-DERIVED (LIKE EVERY OTHER TOPOLOGY-SCALED VALUE):
 //   budget = K_SPILL_BUDGET / tau_ns
 // where K_SPILL_BUDGET = TAU_SCALE_NS / 2 = 80e6. THIS IS LAMBDA_2 / 2 --
@@ -514,18 +704,19 @@ static __always_inline s32 find_pcpu_with_room(s32 src_cpu,
 //   1. src_cpu's PER-CPU DSQ IF UNDER pcpu_depth_base AND IN allowed.
 //   2. R_EFF-RANKED SIBLING PER-CPU DSQ WITH ROOM AND IN allowed.
 //      DISPATCH REACHES THESE AT STEP 0 (OWN) OR STEP 1 (L2 STEAL).
-//   3. LAST RESORT: SHARED NODE DSQ. HARD STARVATION RESCUE BOUNDS WAIT.
-//      ALSO THE ESCAPE VALVE WHEN allowed EXCLUDES src_cpu AND ALL R_EFF
-//      SIBLINGS -- TASK CAN ALWAYS BE DRAINED BY ANY ALLOWED CPU ON THE
-//      NODE VIA STEP 3 OF THE DISPATCH WATERFALL. PREVENTS THE PER-CPU
-//      DSQ AFFINITY-STRANDING CLASS BEHIND scx ISSUE #728 / RUNNABLE-TASK
-//      STALLS WHEN cpus_ptr CHANGES MID-FLIGHT (LIBVIRT CGROUP CPUSETS,
-//      kthread_bind, ETC.).
+//   3. LAST RESORT: ccx_inter_dsq FOR src_cpu's CCX. HARD STARVATION RESCUE
+//      BOUNDS WAIT. ALSO THE ESCAPE VALVE WHEN allowed EXCLUDES src_cpu AND
+//      ALL R_EFF SIBLINGS -- TASK CAN ALWAYS BE DRAINED BY ANY SAME-CCX CORE
+//      VIA STEP 3 OF THE DISPATCH WATERFALL, OR CROSS-CCX VIA STEP 5 WORK
+//      CONSERVATION. PREVENTS THE PER-CPU DSQ AFFINITY-STRANDING CLASS
+//      BEHIND scx ISSUE #728 / RUNNABLE-TASK STALLS WHEN cpus_ptr CHANGES
+//      MID-FLIGHT (LIBVIRT CGROUP CPUSETS, kthread_bind, ETC.).
 // *out_cpu RECEIVES THE CPU SCX SHOULD WAKE (THE PER-CPU DSQ OWNER WE
-// LANDED IN; src_cpu IF WE FELL BACK TO NODE DSQ).
+// LANDED IN; src_cpu IF WE FELL BACK TO ccx_inter_dsq).
 static __always_inline u64 pick_pcpu_dsq_with_spill(s32 src_cpu,
 						    const struct cpumask *allowed,
-						    s32 *out_cpu)
+						    u32 shape,
+					    s32 *out_cpu)
 {
 	u64 now = bpf_ktime_get_ns();
 	bool src_ok = (u64)src_cpu < nr_cpu_ids &&
@@ -535,88 +726,64 @@ static __always_inline u64 pick_pcpu_dsq_with_spill(s32 src_cpu,
 	    scx_bpf_dsq_nr_queued((u64)src_cpu) < pcpu_depth_base) {
 		if ((u32)src_cpu < MAX_CPUS)
 			__sync_val_compare_and_swap(
-				&pcpu_enqueue_ns[src_cpu & (MAX_CPUS - 1)],
+				&pcpu_enqueue_ns[(u32)src_cpu].ns,
 				0, now);
 		*out_cpu = src_cpu;
 		return (u64)src_cpu;
 	}
 
+	// FALSIFYING TEST (20-AGENT CONSENSUS): DISABLE THE SHAPE_STORM BRANCH.
+	// HYPOTHESIS: STORM WAKEES ROUTED TO ccx_inter_dsq (A CCX-WIDE SHARED DSQ)
+	// WHILE KICKING ONLY `src_cpu` DECOUPLES PLACEMENT FROM DRAIN -- THE KICKED
+	// CPU IS NOT NECESSARILY THE SAME-CCX PEER THAT WINS STEP 3a's DRAIN RACE.
+	// P(KICKED CPU DRAINS) ≈ 1/6 ON A 6-CPU CCX, SO ~5/6 OF STORM WAKEUPS
+	// PRODUCE A MIGRATION ON EVERY SINGLE WAKE -- ACCOUNTING FOR THE MEASURED
+	// 22× MIGRATION MULTIPLIER AND 2.1× WAKEUP AMPLIFIER. LETTING STORM FALL
+	// THROUGH TO find_pcpu_with_room + B-v2 OVER-DEPTH OWN PLACES THE WAKEE ON
+	// A SPECIFIC NAMED CPU'S PER-CPU DSQ, RESTORING KICK == DRAIN IDENTITY.
+	// (void)now IN THIS BRANCH SINCE WE NO LONGER ARM interactive_enqueue_ns.
+	// if (shape == SHAPE_STORM) {
+	// 	__sync_val_compare_and_swap(&interactive_enqueue_ns, 0, now);
+	// 	*out_cpu = src_cpu;
+	// 	return ccx_inter_dsq(cpu_ccx(src_cpu));
+	// }
+	(void)shape;
+
 	s32 spill = find_pcpu_with_room(src_cpu, allowed);
 	if (spill >= 0) {
 		if ((u32)spill < MAX_CPUS)
 			__sync_val_compare_and_swap(
-				&pcpu_enqueue_ns[spill & (MAX_CPUS - 1)],
+				&pcpu_enqueue_ns[(u32)spill].ns,
 				0, now);
 		*out_cpu = spill;
 		return (u64)spill;
 	}
 
-	s32 node = __COMPAT_scx_bpf_cpu_node(src_cpu);
-	if (node < 0 || (u32)node >= nr_nodes) node = 0;
+	// B v2: NO ROOM ON A NEAR (SAME-CCX) SIBLING. KEEP THE WAKEE ON ITS OWN
+	// WARM CORE OVER-DEPTH RATHER THAN SCATTERING TO ccx_inter_dsq IMMEDIATELY.
+	// THE DEEP PER-CPU QUEUE IS BOUNDED BY THE CoDel SOJOURN STEAL (RELIEVED
+	// TO A NEAR SAME-CCX CORE ONCE IT WAITS PAST codel_target), SO IT STAYS
+	// L1/L2-WARM WITHOUT SCATTERING. ccx_inter_dsq IS THE ESCAPE VALVE BELOW
+	// ONLY WHEN src_cpu ISN'T IN THE allowed MASK (THE AFFINITY CASE).
+	if (src_ok) {
+		if ((u32)src_cpu < MAX_CPUS)
+			__sync_val_compare_and_swap(
+				&pcpu_enqueue_ns[(u32)src_cpu].ns,
+				0, now);
+		*out_cpu = src_cpu;
+		return (u64)src_cpu;
+	}
+
+	// AFFINITY-STRANDED ESCAPE: src_cpu isn't in allowed. Route to src_cpu's
+	// CCX-local overflow DSQ; if allowed excludes the whole CCX, the cross-CCX
+	// drain at STEP 3b picks it up as work-conservation.
 	__sync_val_compare_and_swap(&interactive_enqueue_ns, 0, now);
 	*out_cpu = src_cpu;
-	return nr_cpu_ids + (u64)node;
+	return ccx_inter_dsq(cpu_ccx(src_cpu));
 }
 
-// ARM TICK SAFETY NET: SIGNAL THAT A NON-BATCH TASK HAS LANDED SOMEWHERE
-// THE DISPATCHING CPU MAY NOT REACH IMMEDIATELY (PER-CPU DSQ ON A BUSY
-// CPU, NODE_DSQ OVERFLOW). tick() CONSUMES interactive_waiting TO PREEMPT
-// BATCH RUNNERS VIA preempt_thresh_ns; latcrit_waiting TIGHTENS THE
-// THRESHOLD 4X SO LAT_CRITICAL WAKERS DON'T WAIT A FULL BATCH SLICE.
-// ARMED AT EVERY NON-BATCH PLACEMENT SITE (select_cpu, enqueue Tier 1/2/3)
-// SO TASKS ROUTED INTO PER-CPU DSQs ON BUSY CPUs CAN STILL DISLODGE THE
-// BATCH RUNNER OWNING THEIR DSQ.
-static __always_inline void arm_interactive_waiting(const struct task_ctx *tctx)
-{
-	if (!tctx || tctx->tier == TIER_BATCH)
-		return;
-	interactive_waiting = true;
-	if (tctx->tier == TIER_LAT_CRITICAL)
-		latcrit_waiting = true;
-}
-
-// CODEL DRAIN RATE: UPDATE MIN SOJOURN WHEN A TASK STARTS RUNNING.
-// CALLED FROM pandemonium_running WITH THE TASK'S MEASURED PER-TASK
-// SOJOURN (now - tctx->enqueue_at). REPLACES THE OLD DSQ-EMPTY-CYCLE
-// PROXY THAT READ pcpu_enqueue_ns[cpu] -- THAT METRIC IS EXACT FOR
-// THE FIRST TASK IN AN EMPTY-TO-NONEMPTY TRANSITION BUT WEAKENS FOR
-// LATER TASKS AND FOR VTIME-ORDERED DSQs WHERE HEAD != FIRST-ARRIVAL.
-// THE PER-TASK MEASUREMENT IS THE LITERAL CoDel METRIC FROM RFC 8289.
-static __always_inline void update_pcpu_sojourn(u32 cpu, u64 sojourn)
-{
-	if (cpu >= MAX_CPUS) return;
-	if (sojourn < pcpu_min_sojourn_ns[cpu])
-		pcpu_min_sojourn_ns[cpu] = sojourn;
-}
-
-// CODEL STALL DETECTION: MIN SOJOURN ABOVE DYNAMIC TARGET FOR INTERVAL = STALLED.
-// THE TARGET (codel_target_ns) IS MODULATED BY DAMPED OSCILLATION IN tick().
-// RESCUES PULL THE TARGET DOWN (TIGHTEN). QUIET PUSHES IT UP (RELAX).
-// THE TARGET ADAPTS TO WHAT "NORMAL SOJOURN" IS ON THIS SYSTEM RIGHT NOW.
-static __always_inline bool pcpu_dsq_is_stalled(u32 cpu, u64 now)
-{
-	if (cpu >= MAX_CPUS) return false;
-	u64 min_s = pcpu_min_sojourn_ns[cpu];
-
-	if (min_s < codel_target_ns) {
-		pcpu_stall_start_ns[cpu] = 0;
-		pcpu_min_sojourn_ns[cpu] = ~0ULL;
-		return false;
-	}
-
-	if (pcpu_stall_start_ns[cpu] == 0) {
-		pcpu_stall_start_ns[cpu] = now + sojourn_interval_ns;
-		return false;
-	}
-
-	if (now >= pcpu_stall_start_ns[cpu]) {
-		pcpu_min_sojourn_ns[cpu] = ~0ULL;
-		pcpu_stall_start_ns[cpu] = 0;
-		return true;
-	}
-
-	return false;
-}
+// NO ARM FUNCTION: THE PER-CPU WAITING SIGNAL IS pcpu_enqueue_ns[cpu], STAMPED
+// AT PLACEMENT; tick() READS IT DIRECTLY (SEE THE PER-CPU PREEMPT IN tick()).
 
 // SOJOURN GATE: RETURNS TRUE IF BOTH OVERFLOW DSQs ARE WITHIN THE RESCUE
 // WINDOW (i.e. IT IS SAFE TO RETURN FROM dispatch() AFTER A SUCCESSFUL
@@ -640,6 +807,37 @@ static __always_inline bool sojourn_gate_pass(u64 now)
 	       (be == 0 || (now - be) <= overflow_sojourn_rescue_ns);
 }
 
+// DRAIN ONE TASK FROM AN OVERFLOW DSQ; CLEAR ITS EMPTY->NONEMPTY STAMP WHEN
+// THE DSQ EMPTIES. RETURNS TRUE IF A TASK MOVED. THE SINGLE PRIMITIVE BEHIND
+// try_service_older_overflow AND DISPATCH STEP 3/4 -- ONE move_to_local +
+// CAS-CLEAR, FACTORED OUT OF SIX OPEN-CODED COPIES.
+static __always_inline bool overflow_drain_clear(u64 dsq, u64 *stamp)
+{
+	if (!scx_bpf_dsq_move_to_local(dsq, 0))
+		return false;
+	if (scx_bpf_dsq_nr_queued(dsq) == 0) {
+		u64 old = *stamp;
+		if (old > 0)
+			__sync_val_compare_and_swap(stamp, old, 0);
+	}
+	return true;
+}
+
+// CCX-LOCAL OVERFLOW DRAIN: DRAIN MY CCX'S OVERFLOW DSQ. CROSS-CCX WORK
+// CONSERVATION IS A SINGLE EXPLICIT LOOP IN DISPATCH (BELOW THE LOCAL STEPS),
+// NOT FOLDED INTO THIS HELPER -- THE ORIGINAL "DRAIN LOCAL + SCAN OTHER CCXs"
+// SHAPE INLINED FOUR TIMES (STEP 3, STEP 4, BOTH RESCUE PATHS) BLEW THE
+// PROGRAM PAST THE VERIFIER'S INSTRUCTION CEILING (-E2BIG). SPLITTING THE
+// LOCAL FAST PATH FROM THE CROSS-CCX SCAN KEEPS INLINED HELPERS TINY AND
+// PUTS THE LOOP WHERE IT RUNS ONCE PER DISPATCH.
+static __always_inline bool ccx_overflow_drain_local(u32 my_ccx,
+						     bool batch,
+						     u64 *stamp)
+{
+	u64 dsq = batch ? ccx_batch_dsq(my_ccx) : ccx_inter_dsq(my_ccx);
+	return overflow_drain_clear(dsq, stamp);
+}
+
 // SERVICE WHICHEVER OVERFLOW SIDE (INTERACTIVE OR BATCH) HAS THE OLDER
 // PENDING ENQUEUE AGED PAST `thresh`. RETURNS TRUE IF DISPATCHED.
 // USED AT TWO THRESHOLDS IN dispatch(): starvation_rescue_ns (THE SAFETY
@@ -653,8 +851,7 @@ static __always_inline bool sojourn_gate_pass(u64 now)
 // PRESSURE SIGNAL); SAFETY NET SETS IT FALSE (BACKSTOP-ONLY, NOT THE NORMAL
 // SIGNAL THE OSCILLATOR SHOULD MODEL).
 static __always_inline bool try_service_older_overflow(u64 now,
-						        u64 node_dsq,
-						        u64 batch_dsq,
+						        u32 my_ccx,
 						        u64 thresh,
 						        bool feed_oscillator)
 {
@@ -681,39 +878,19 @@ static __always_inline bool try_service_older_overflow(u64 now,
 	bool dispatched_any = false;
 
 	if (serve_interactive) {
-		if (scx_bpf_dsq_move_to_local(node_dsq, 0)) {
-			if (scx_bpf_dsq_nr_queued(node_dsq) == 0) {
-				u64 old = interactive_enqueue_ns;
-				if (old > 0)
-					__sync_val_compare_and_swap(&interactive_enqueue_ns, old, 0);
-			}
+		if (ccx_overflow_drain_local(my_ccx, false,
+					     &interactive_enqueue_ns))
 			dispatched_any = true;
-		}
-		if (b_aged && scx_bpf_dsq_move_to_local(batch_dsq, 0)) {
-			if (scx_bpf_dsq_nr_queued(batch_dsq) == 0) {
-				u64 old = batch_enqueue_ns;
-				if (old > 0)
-					__sync_val_compare_and_swap(&batch_enqueue_ns, old, 0);
-			}
+		if (b_aged && ccx_overflow_drain_local(my_ccx, true,
+						       &batch_enqueue_ns))
 			dispatched_any = true;
-		}
 	} else {
-		if (scx_bpf_dsq_move_to_local(batch_dsq, 0)) {
-			if (scx_bpf_dsq_nr_queued(batch_dsq) == 0) {
-				u64 old = batch_enqueue_ns;
-				if (old > 0)
-					__sync_val_compare_and_swap(&batch_enqueue_ns, old, 0);
-			}
+		if (ccx_overflow_drain_local(my_ccx, true,
+					     &batch_enqueue_ns))
 			dispatched_any = true;
-		}
-		if (i_aged && scx_bpf_dsq_move_to_local(node_dsq, 0)) {
-			if (scx_bpf_dsq_nr_queued(node_dsq) == 0) {
-				u64 old = interactive_enqueue_ns;
-				if (old > 0)
-					__sync_val_compare_and_swap(&interactive_enqueue_ns, old, 0);
-			}
+		if (i_aged && ccx_overflow_drain_local(my_ccx, false,
+						       &interactive_enqueue_ns))
 			dispatched_any = true;
-		}
 	}
 
 	if (!dispatched_any)
@@ -773,16 +950,6 @@ static __always_inline void apply_tau_scaling(u64 tau_ns, u64 codel_eq_ns)
 	// SAFETY RAIL (KILL SWITCH IF A k_i IS MISCALIBRATED).
 	u64 v;
 
-	v = scale_tau(tau_ns, K_SOJOURN_INTERVAL);
-	if (v < 2000000ULL) v = 2000000ULL;
-	if (v > 12000000ULL) v = 12000000ULL;
-	sojourn_interval_ns = v;
-
-	v = scale_tau(tau_ns, K_OVERFLOW_RESCUE);
-	if (v < 4000000ULL) v = 4000000ULL;
-	if (v > 10000000ULL) v = 10000000ULL;
-	overflow_sojourn_rescue_ns = v;
-
 	v = scale_tau(tau_ns, K_STARVATION_RESCUE);
 	if (v < 20000000ULL) v = 20000000ULL;
 	if (v > 500000000ULL) v = 500000000ULL;
@@ -799,8 +966,14 @@ static __always_inline void apply_tau_scaling(u64 tau_ns, u64 codel_eq_ns)
 	longrun_thresh_ns = v;
 
 	v = scale_tau(tau_ns, K_CODEL_MAX);
-	if (v < 1000000ULL) v = 1000000ULL;           // FLOOR 1MS
-	if (v > 8000000ULL) v = 8000000ULL;           // CEILING 8MS
+	// NO FIXED FLOOR: THE OLD 1ms FLOOR PINNED codel_target_max AT 12C
+	// (0.05*13.3ms = 665us -> 1ms) AND 8C, OVERRIDING THE tau-DERIVED VALUE --
+	// THE ONE FLOOR THAT ACTUALLY BINDS ON THIS BOX. FLOOR INSTEAD AT THE
+	// OSCILLATOR'S OWN FLOOR SO THE WORKING WINDOW CAN NEVER INVERT (max >=
+	// floor) AT DENSE TOPOLOGIES WHERE 0.05*tau WOULD DIP BELOW codel_floor,
+	// WHILE LETTING THE TARGET TRACK tau ON REAL HARDWARE.
+	if (v < codel_target_floor_ns) v = codel_target_floor_ns;
+	if (v > 8000000ULL) v = 8000000ULL;           // CEILING 8MS (stall-blind guard)
 	codel_target_max_ns = v;
 
 	// R_eff-DERIVED CODEL EQUILIBRIUM. RUST PRE-CLAMPS TO [200us, 8ms];
@@ -813,6 +986,14 @@ static __always_inline void apply_tau_scaling(u64 tau_ns, u64 codel_eq_ns)
 		if (eq > codel_target_max_ns)   eq = codel_target_max_ns;
 		codel_target_equilibrium_ns = eq;
 	}
+
+	// OVERFLOW-GATE DELTA, PRODUCED BY R_eff FOR FREE. THE GATE THAT OPENS
+	// OVERFLOW SERVICE (sojourn_gate_pass + STEP 2) NOW KEYS ON THE
+	// R_eff-DERIVED CODEL EQUILIBRIUM -- THE ALREADY-COMPUTED SPECTRAL SCALAR
+	// -- INSTEAD OF A HAND-TUNED k*tau TIME. SOJOURN (enqueue-age) IS
+	// UNCHANGED: STILL THE MEASURED PRESSURE AND THE OLDER-SIDE SELECTOR.
+	// R_eff SETS ONLY WHEN THE GATE OPENS; SOJOURN FILLS IT.
+	overflow_sojourn_rescue_ns = codel_target_equilibrium_ns;
 
 	// OSCILLATOR DYNAMICS: DERIVED FROM tau SO THE CONTROLLER RUNS ON THE
 	// SAME TIME CONSTANT AS ITS TARGET RANGE. DIRECT-DIVIDE (NOT Q16)
@@ -828,24 +1009,21 @@ static __always_inline void apply_tau_scaling(u64 tau_ns, u64 codel_eq_ns)
 	if (damp > 5) damp = 5;
 	oscillator_damping_shift = damp;
 
-	// SPRING SHIFT (ω₀² TERM). CRITICAL DAMPING IN THE CONTINUOUS LIMIT
-	// REQUIRES γ = ω₀, AND HERE 2γ ≈ 2^-damping_shift IMPLIES
-	// γ = 2^-(damping_shift+1), SO ω₀² = γ² = 2^-(2*damping_shift+2).
-	// DERIVED VALUES: damp=1 -> shift=4 (2C, FAST RESTORE),
-	// damp=5 -> shift=12 (12C, GENTLE RESTORE). CO-MOVES WITH damping.
-	oscillator_spring_shift = 2 * damp + 2;
+	// SPRING SHIFT (ω₀² TERM). PRIOR VALUE 2*damp+2 IMPLEMENTED CRITICAL
+	// DAMPING (γ = ω₀, ζ = 1.0). 2*damp+1 SHIFTS TO ζ = 2^(-1/2) ≈ 0.707,
+	// THE BUTTERWORTH-OPTIMAL DAMPING POINT -- FLAT PASSBAND, MINIMIZES
+	// SETTLING TIME + INTEGRATED ABSOLUTE ERROR TRADE-OFF, AND PRODUCES
+	// ~4.3% STEP-RESPONSE OVERSHOOT PER ADAPTATION (vs 0% AT ζ = 1.0).
+	// THE SMALL OVERSHOOT IS THE EXPLORATION TERM SONTAG'S LOG-RATE
+	// CONVEXITY RESULT NAMES AS NECESSARY TO KEEP THE CONTROLLER'S
+	// OPERATING POINT ON THE CONVEX SIDE OF ITS RESPONSE CURVE -- THE
+	// OSCILLATOR PROBES THE CONVEX-RESPONSE BOUNDARY ON EACH IMPULSE
+	// INSTEAD OF PARKING SAFELY INSIDE IT. DERIVED VALUES: damp=1 -> shift=3
+	// (2C, FAST RESTORE), damp=5 -> shift=11 (12C, GENTLE RESTORE).
+	oscillator_spring_shift = 2 * damp + 1;
 
 	// velocity_cap PRESERVES COUPLING TO pull_scale.
 	oscillator_velocity_cap = (s64)((u64)OSC_VELOCITY_CAP_PER_PULL * (u64)pull);
-
-	// VTIME CEILING WINDOW. AT THE 12C REFERENCE (tau=40MS) THIS PRODUCES
-	// 120MS, TIGHTENING NATURALLY AT LOWER tau (54MS AT 8C, 18MS AT 4C,
-	// CLAMPED TO 16MS FLOOR AT 2C). FLOOR PROTECTS AGAINST A NOISY FIEDLER
-	// THAT BRIEFLY UNDERSHOOTS.
-	v = scale_tau(tau_ns, K_VTIME_CEILING);
-	if (v < 16000000ULL)  v = 16000000ULL;        // FLOOR 16MS
-	if (v > 160000000ULL) v = 160000000ULL;       // CEILING 160MS
-	vtime_ceiling_window_ns = v;
 
 	// PER-CPU DSQ DEPTH GATE. STEP-FUNCTION ON tau (NOT Q16) BECAUSE THE
 	// OUTPUT IS A SMALL INTEGER. AT tau >= 6MS ALLOW 2 QUEUED TASKS PER
@@ -888,9 +1066,10 @@ static __always_inline void apply_tau_scaling(u64 tau_ns, u64 codel_eq_ns)
 		affinity_search_online = b;
 	}
 
-	// VTIME LAG CAP. SLEEP-BOOST CEILING SCALES WITH TOPOLOGY TIMING.
+	// SLEEP-BOOST LAG CAP (NOT A VTIME CAP -- THE VTIME ENGINE WAS RETIRED
+	// IN v5.11.0; THIS BOUNDS THE SOJOURN-WARP CREDIT). SCALES WITH TOPOLOGY TIMING.
 	// lag_cap_ns = K_LAG_CAP * tau (1.0 * tau AT 12C REFERENCE = 40MS).
-	// CLAMPED [8MS, 80MS]. PER-TIER awake_cap IS A FRACTION OF THIS.
+	// CLAMPED [8MS, 80MS].
 	v = scale_tau(tau_ns, K_LAG_CAP);
 	if (v < 8000000ULL)  v = 8000000ULL;
 	if (v > 80000000ULL) v = 80000000ULL;
@@ -907,9 +1086,9 @@ static __always_inline void pcpu_drain_clear(u32 cpu)
 		return;
 	if (scx_bpf_dsq_nr_queued((u64)cpu) != 0)
 		return;
-	u64 old = pcpu_enqueue_ns[cpu];
+	u64 old = pcpu_enqueue_ns[cpu].ns;
 	if (old > 0)
-		__sync_val_compare_and_swap(&pcpu_enqueue_ns[cpu], old, 0);
+		__sync_val_compare_and_swap(&pcpu_enqueue_ns[cpu].ns, old, 0);
 }
 
 // HISTOGRAM BUCKETING: MATCHES HIST_EDGES_NS AND SLEEP_EDGES_NS IN RUST
@@ -984,17 +1163,6 @@ static __always_inline u32 classify_tier(u64 lat_cri,
 	return TIER_BATCH;
 }
 
-// COMPOSITOR DETECTION: MAP LOOKUP (POPULATED BY RUST AT STARTUP)
-// STACK-LOCAL KEY COPY: BPF VERIFIER REJECTS DIRECT p->comm POINTER
-static __always_inline bool is_compositor(const struct task_struct *p)
-{
-	char key[16] = {};
-	unsigned int i;
-	for (i = 0; i < 15 && p->comm[i]; i++)
-		key[i] = p->comm[i];
-	return bpf_map_lookup_elem(&compositor_map, key) != NULL;
-}
-
 // TRACE: FAST 4-BYTE COMM CHECK FOR SCHEDULER PROCESS TRACING
 // CATCHES "pandemonium" WITH ZERO MAP OVERHEAD. GATED BY TRACE_SCHED BECAUSE
 // ALL CALL SITES ARE #if TRACE_SCHED -- WITHOUT THE GUARD ON THE DEFINITION,
@@ -1026,69 +1194,89 @@ static __always_inline u64 effective_weight(const struct task_struct *p,
 
 // SCHEDULING HELPERS
 
-// DEADLINE = DSQ_VTIME + AWAKE_VTIME, BOUND BY UNIVERSAL VTIME CEILING.
-// PER-TASK LAG SCALING: INTERACTIVE TASKS GET MORE VTIME CREDIT.
-// QUEUE-PRESSURE SCALING: CREDIT SHRINKS WHEN DSQ IS DEEP.
-// TIER-BASED AWAKE CAP: PREVENTS BOOST EXPLOITATION.
-// VTIME CEILING (UNIVERSAL): CAPS DEADLINE AT vtime_now + WINDOW. THE
-// WINDOW IS TAU-DERIVED IN apply_tau_scaling() AND CACHED IN A STATIC.
-// LONG-LIVED DAEMONS ACCUMULATE p->scx.dsq_vtime IN stopping() OVER HOURS
-// OF RUNTIME AND CAN GROW WELL PAST vtime_now; UNDER A FORK BURST, FRESH
-// TASKS WITH dsq_vtime = vtime_now WOULD TAKE THE HEAD OF THE VTIME-ORDERED
-// QUEUE AND DAEMONS WOULD SORT TO UNBOUNDED TAIL POSITIONS. THE CEILING
-// BOUNDS THE TAIL AT EVERY ENQUEUE PATH.
-static __always_inline u64 task_deadline(struct task_struct *p,
-					 struct task_ctx *tctx,
-					 u64 dsq_id,
+// SOJOURN SELECTOR (NO VIRTUAL TIME): THE DSQ SORT KEY IS THE ENQUEUE
+// TIMESTAMP, SO THE QUEUE ORDERS OLDEST-FIRST -- AT ANY FIXED DISPATCH
+// INSTANT THE SMALLEST KEY IS THE EARLIEST INSERT, I.E. THE LARGEST
+// SOJOURN (now - enqueue_at). THE TIER WARP BACK-DATES HIGHER TIERS SO
+// THEY SORT AHEAD; IT IS BOUNDED (<= lag_cap_ns), SO A STREAM OF
+// LAT_CRITICAL WAKEUPS CAN NEVER STARVE A BATCH TASK OLDER THAN THE WARP.
+// PER-TASK SOJOURN POTENTIAL (Q16, 0..65536). TIER SETS THE CEILING SHARE;
+// PER-TASK BEHAVIOR SETS THE MAGNITUDE. BOUNDED SUM OF MONOTONIC RAMPS --
+// CONTINUOUS, NO TIER CLIFF, NO UNBOUNDED ADVANTAGE.
+static __always_inline u32 task_potentiality_q16(const struct task_ctx *tctx,
+						 const struct tuning_knobs *knobs)
+{
+	if (tctx->ewma_age < EWMA_AGE_MATURE)
+		return 0;                  // UNOBSERVED: NO POTENTIAL
+	if (tctx->tier == TIER_BATCH)
+		return 0;                  // BATCH NEVER WARPS
+	if (tctx->tier == TIER_LAT_CRITICAL)
+		return 1u << 16;           // RT FLOOR: ABSOLUTE, FULL CEILING
+
+	// INTERACTIVE: EARNED CONTINUOUSLY FROM PER-TASK BEHAVIOR.
+	u64 slice = knobs ? knobs->slice_ns : 1000000;
+	u64 avg = tctx->avg_runtime;
+	u32 acc = 0;                       // Q16 EXCESS, CAP 65536
+
+	// AXIS 1 -- SERVICE DEFICIT: SHORT RUNTIME PER ACTIVATION (YIELDS
+	// BEFORE ITS QUANTUM) EARNS WARP; A FULL-SLICE HOG EARNS NONE.
+	if (slice > 0 && avg < slice) {
+		u32 c = (u32)(((slice - avg) << 16) / slice);
+		acc += c > 32768u ? 32768u : c;
+	}
+
+	// AXIS 2 -- SHAPE: LOW RUNTIME VARIANCE RELATIVE TO MEAN (PERIODIC,
+	// FRAME-PACED) EARNS WARP; CHAOTIC BURSTINESS EARNS NONE. INVERSE CV.
+	if (avg > 0 && tctx->runtime_dev < avg) {
+		u32 c = (u32)(((avg - tctx->runtime_dev) << 16) / avg);
+		c = c > 32768u ? 32768u : c;
+		acc = (acc > 65536u - c) ? 65536u : acc + c;
+	}
+
+	return acc;                        // 0..65536
+}
+
+// FLOW SIGNATURE CLASSIFIER (CLASSIFY ONCE, FREEZE AT MATURITY). EACH WAKEUP
+// SETS THE WAKER CPU'S BIT; THE POPCOUNT IS THE TASK'S DISTINCT-PARTNER
+// CARDINALITY. AT MATURITY: <= SHAPE_TIGHT_MAX PARTNERS IS A TIGHT LOOP; A
+// PARTNER SET SPANNING AT LEAST HALF THE MACHINE IS A STORM MESH; EVERYTHING
+// BETWEEN DEFAULTS TO TIGHT (LATENCY-SAFE -- ITS STEAL STAYS FREELY RELIEVABLE).
+// THEN FREEZE -- DETERMINISTIC PER TASK, SO ROUTING CAN'T COIN-FLIP.
+static __always_inline void update_shape(struct task_ctx *tctx, u32 waker)
+{
+	if (tctx->shape != SHAPE_UNCLASSIFIED)
+		return;                                 // FROZEN
+	if (waker < 64)
+		tctx->waker_bitmap |= (1ULL << waker);
+
+	if (tctx->ewma_age < EWMA_AGE_MATURE)
+		return;                                 // STILL OBSERVING
+
+	u32 card = (u32)__builtin_popcountll(tctx->waker_bitmap);
+	if (card > SHAPE_TIGHT_MAX && card * 2 >= nr_cpu_ids)
+		tctx->shape = SHAPE_STORM;
+	else
+		tctx->shape = SHAPE_TIGHT;
+}
+
+static __always_inline u64 task_deadline(struct task_ctx *tctx,
 					 const struct tuning_knobs *knobs)
 {
-	u64 knob_scale = knobs ? knobs->lag_scale : 4;
-	u64 lag_scale = (tctx->wakeup_freq * knob_scale) >> 2;
-	if (lag_scale < 1)
-		lag_scale = 1;
-	if (lag_scale > MAX_WAKEUP_FREQ)
-		lag_scale = MAX_WAKEUP_FREQ;
+	u64 now = bpf_ktime_get_ns();
 
-	// QUEUE-PRESSURE SCALING
-	u64 nr_queued = scx_bpf_dsq_nr_queued(dsq_id);
-	if (nr_queued > 8)
-		lag_scale = 1;
-	else if (nr_queued > 4 && lag_scale > 2)
-		lag_scale >>= 1;
+	// SOJOURN POTENTIAL (v5.12 ANTI-LEAPFROG, CONTINUOUS FORM): warp IS A
+	// BOUNDED PER-TASK POTENTIAL, NOT A FLAT TIER CONSTANT. lag_cap_ns IS THE
+	// CEILING (STARVATION BOUND); task_potentiality_q16 POSITIONS THE BACK-DATE
+	// CONTINUOUSLY FROM THE TASK'S OWN SERVICE DEFICIT + SHAPE. SLEEPY/PERIODIC
+	// -> NEAR-FULL WARP; CPU-HOG OR CHAOTIC -> ~0. UNMATURED TASKS GET 0, SO A
+	// FORK STORM STILL CANNOT LEAPFROG ESTABLISHED WORK.
+	u64 warp = (lag_cap_ns * task_potentiality_q16(tctx, knobs)) >> 16;
 
-	// CLAMP VTIME TO PREVENT UNBOUNDED BOOST AFTER LONG SLEEP
-	u64 vtime_floor = vtime_now - lag_cap_ns * lag_scale;
-	if (time_before(p->scx.dsq_vtime, vtime_floor))
-		p->scx.dsq_vtime = vtime_floor;
-
-	// TIER-BASED AWAKE CAP. FRACTIONS OF lag_cap_ns (TAU-DERIVED) SO THE
-	// SLEEP-BOOST CEILING SCALES WITH TOPOLOGY TIMING. LAT_CRITICAL gets
-	// 0.5x, INTERACTIVE gets 0.75x, BATCH gets 1.0x. AT THE 12C REFERENCE
-	// (lag_cap=40MS) THESE ARE 20MS / 30MS / 40MS, MATCHING THE PRE-v5.8.0
-	// HARDCODED VALUES.
-	u64 awake_cap;
-	if (tctx->tier == TIER_LAT_CRITICAL)
-		awake_cap = lag_cap_ns >> 1;
-	else if (tctx->tier == TIER_INTERACTIVE)
-		awake_cap = (lag_cap_ns * 3) >> 2;
-	else
-		awake_cap = lag_cap_ns;
-
-	if (tctx->awake_vtime > awake_cap)
-		tctx->awake_vtime = awake_cap;
-
-	u64 dl = p->scx.dsq_vtime + tctx->awake_vtime;
-
-	// VTIME CEILING: BOUND TAIL POSITION TO vtime_now + WINDOW.
-	// WINDOW IS TAU-DERIVED IN apply_tau_scaling() AND CACHED IN A STATIC,
-	// SO THE HOT PATH PAYS A SINGLE LOAD. AT THE 12C REFERENCE (tau=40MS)
-	// THE WINDOW IS 120MS, TIGHTENING NATURALLY AT LOWER tau -- THE
-	// WINDOW MATCHES THE GRAPH'S MIXING TIME, NOT A CORE-COUNT PROXY.
-	u64 vtime_ceiling = vtime_now + vtime_ceiling_window_ns;
-	if (time_after(dl, vtime_ceiling))
-		dl = vtime_ceiling;
-
-	return dl;
+	// SOJOURN BACK-PRESSURE: ORDERING IS now - warp, OLDEST-FIRST -- A STARVING
+	// TASK RISES AS IT AGES, AND BOUNDED WARP MAKES IT STARVATION-FREE. DEEP-QUEUE
+	// DRAINAGE IS THE OVERFLOW RESCUE'S JOB (try_service_older_overflow AT
+	// overflow_sojourn_rescue_ns), FORCED BY WAIT NOT DEPTH.
+	return now > warp ? now - warp : 0;
 }
 
 // PER-TIER DYNAMIC SLICING
@@ -1142,98 +1330,181 @@ static __always_inline u64 task_slice(const struct task_ctx *tctx,
 // SELECT_CPU: FAST-PATH IDLE CPU DISPATCH TO PER-CPU DSQ
 // DISPATCHES TO NAMED PER-CPU DSQ (u64)cpu -- VISIBLE TO WORK STEALING
 // AND SOJOURN RESCUE. DEPTH-GATED: IF PER-CPU DSQ ALREADY HAS TASKS,
-// SPILL TO SHARED NODE DSQ SO ANY CPU CAN GRAB IT.
+// SPILL TO ccx_inter_dsq SO ANY SAME-CCX CORE CAN GRAB IT.
 // THE CPU IS IDLE SO IT ENTERS dispatch() IMMEDIATELY AND DRAINS.
 s32 BPF_STRUCT_OPS(pandemonium_select_cpu, struct task_struct *p,
 		   s32 prev_cpu, u64 wake_flags)
 {
 	bool is_idle = false;
 
-	// RESISTANCE AFFINITY: WAKEE_FLIPS-GATED WAKE_SYNC
-	// GATE: wakee_flips (per-task wakeup partner diversity) separates
-	//   1:1 pipe pairs (low flips, affinity beneficial) from
-	//   1:N server patterns (high flips, affinity harmful).
-	// PLACEMENT: R_eff ranked search from waker's CPU finds cheapest
-	//   idle CPU in waker's L2 group. Falls back to waker's DSQ if
-	//   no idle found and DSQ depth allows.
-	// REFERENCE: kernel wake_wide() uses same wakee_flips signal.
-	//   Kyng et al. effective resistance for migration cost.
+	// WARM-STAY: IF THE WAKEE'S ANCHOR (last_cpu) IS UNCONGESTED, HOLD IT THERE
+	// RATHER THAN FAN OUT TO A COLD IDLE SIBLING. select_cpu ONLY DEFERS (RETURNS
+	// THE ANCHOR WITHOUT DISPATCHING) -- THE ACTUAL PLACEMENT HAPPENS IN enqueue,
+	// WHICH KICKS PREEMPT (select_cpu's IDLE PATHS KICK IDLE, A NO-OP ON A BUSY
+	// ANCHOR). COMPUTED ONCE; GATES THE IDLE-SEEK BELOW. THE TIGHT-PARTNER SYNC
+	// COLOCATION STILL RUNS FIRST (IT'S A DELIBERATE PIPE-BUFFER LOCALITY BET).
+	s32 stay_hold;
+	{
+		struct task_ctx *tc = lookup_task_ctx(p);
+		struct tuning_knobs *kn = get_knobs();
+		bool wake = tc && !tc->ran_since_wake;
+		stay_hold = warm_stay_anchor(p, tc, kn, wake, bpf_ktime_get_ns());
+	}
+
+	// SET WHEN THE SYNC BLOCK WALKS last_cpu's affinity_rank AND FINDS NO NEAR
+	// IDLE: normal_path BELOW WOULD RE-WALK THE IDENTICAL (INIT-FIXED) RANK FOR
+	// THE IDENTICAL RESULT, SO IT SKIPS. ONLY FIRES FOR SYNC WAKES WHOSE
+	// prev_cpu == last_cpu; NON-SYNC WAKES LEAVE IT FALSE (normal_path WALKS ONCE).
+	bool last_cpu_idle_miss = false;
+
+	// WAKE_SYNC LOCALITY: PREFER AN IDLE CPU NEAR THE WAKEE'S WARM CORE. THIS IS
+	// A LOCALITY-OPTIMIZED SPREAD -- IT PLACES ONLY WHEN AN IDLE CORE IS FOUND,
+	// SO IT STAYS WARM AND WORK-CONSERVING (LOWER R_eff THAN THE ANY-IDLE PICK
+	// scx_bpf_select_cpu_dfl MAKES BELOW). IF NO NEAR IDLE, FALL THROUGH TO THE
+	// dfl SEARCH (ANY IDLE ANYWHERE); UNDER TRUE SATURATION THE TASK GOES TO
+	// enqueue, LANDS ON A STEALABLE PER-CPU DSQ, AND THE dispatch FLOW STEAL
+	// ROUTES IT BY SHAPE -- STORM SPREADS, TIGHT STAYS LOCAL.
 	if (wake_flags & SCX_WAKE_SYNC) {
-		struct task_struct *waker =
-			(struct task_struct *)bpf_get_current_task_btf();
-		if (waker) {
-			u32 wflips = BPF_CORE_READ(waker, wakee_flips);
-			u32 pflips = p->wakee_flips;
-			// CARVE-OUT (SEE topology.rs): wakee_flips IS A COUNT,
-			// NOT A DURATION. nr_cpu_ids IS THE NATURAL UNIT FOR
-			// "DIVERSE vs CONCENTRATED" WAKEUP PARTNERS AND MATCHES
-			// THE KERNEL'S wake_wide() CONVENTION.
-			u32 thresh = nr_cpu_ids;
-
-			// WAKE_WIDE: SKIP IF EITHER SIDE WAKES DIVERSE TASKS
-			if (wflips <= thresh && pflips <= thresh) {
-				s32 waker_cpu = bpf_get_smp_processor_id();
-				if ((u64)waker_cpu >= nr_cpu_ids)
-					goto normal_path;
-
-				// R_EFF RANKED IDLE SEARCH FROM WAKER
-				s32 target = find_idle_by_affinity(waker_cpu, p->cpus_ptr);
-				if (target >= 0) {
-					struct task_ctx *tctx = lookup_task_ctx(p);
-					struct tuning_knobs *knobs = get_knobs();
-					u64 sl = tctx ? task_slice(tctx, knobs)
-						      : 1000000;
-					s32 dst_cpu;
-					u64 dst_dsq = pick_pcpu_dsq_with_spill(target, p->cpus_ptr, &dst_cpu);
-					u64 dl = tctx ? task_deadline(p, tctx,
-						dst_dsq, knobs) : vtime_now;
-					scx_bpf_dsq_insert_vtime(p,
-						dst_dsq, sl, dl, 0);
-					if (tctx) {
-						tctx->dispatch_path = 0;
-						tctx->enqueue_at = bpf_ktime_get_ns();
-					}
-					struct pandemonium_stats *s = get_stats();
-					if (s) {
-						s->nr_idle_hits += 1;
-						s->nr_dispatches += 1;
-					}
-					return dst_cpu;
+		struct task_ctx *tctx = lookup_task_ctx(p);
+		s32 waker_cpu = bpf_get_smp_processor_id();
+		// TRACK THE WAKER EVEN ON THE SYNC-PLACED PATH (enqueue's update_shape
+		// DOESN'T RUN WHEN select_cpu DISPATCHES), SO PARTNER CARDINALITY STAYS
+		// LIVE AND A 1:N SERVER SELF-CORRECTS OUT OF THE TIGHT CLASS BELOW.
+		if (tctx && waker_cpu >= 0 && waker_cpu < 64 &&
+		    tctx->shape == SHAPE_UNCLASSIFIED)
+			tctx->waker_bitmap |= (1ULL << (u32)waker_cpu);
+		// PIPE-PARTNER CO-LOCATION (EEVDF WAKE-AFFINE): ON A SYNC WAKE THE WAKER
+		// IS ABOUT TO BLOCK, SO ITS CORE FREES IN MICROSECONDS AND THE DATA IT
+		// JUST PRODUCED (THE PIPE BUFFER) IS CACHE-HOT. FOR A 1:1-ISH PARTNER
+		// (FEW DISTINCT WAKERS: waker_bitmap POPCOUNT <= SHAPE_TIGHT_MAX, OR A
+		// FROZEN SHAPE_TIGHT) SEAT THE WAKEE DIRECTLY ON THE WAKER'S PER-CPU DSQ
+		// -- THE ONE CASE WE DELIBERATELY QUEUE ON A BUSY CORE INSTEAD OF FLEEING
+		// TO A COLD IDLE SIBLING -- SO BOTH PIPE ENDS STAY WARM ON ONE CACHE.
+		// 1:N SERVERS (MANY WAKERS) FALL THROUGH TO THE WARM-NEAR-IDLE SEARCH SO
+		// CLIENTS DON'T PILE ONTO THE SERVER'S CPU.
+		u32 partners = tctx
+			? (u32)__builtin_popcountll(tctx->waker_bitmap) : 0;
+		bool tight = (tctx && tctx->shape == SHAPE_TIGHT) ||
+			     partners <= SHAPE_TIGHT_MAX;
+		// MULTI-CCX ONLY: SEATING THE WAKEE ON THE WAKER'S CORE IS A REAL
+		// MIGRATION. IT PAYS OFF ONLY WHEN THE PARTNERS WOULD OTHERWISE SIT IN
+		// DIFFERENT L3s (CROSS-CCX COLD) -- ON A MONOLITHIC L3 (nr_ccx <= 1)
+		// EVERY CORE SHARES THE CACHE, SO THERE IS ZERO LOCALITY UPSIDE AND IT
+		// IS PURE MIGRATION CHURN THAT OVERRIDES THE HOME-PIN. GATE IT OFF THERE
+		// AND LET warm_stay_anchor's STABLE HOME GOVERN INSTEAD.
+		if (nr_ccx > 1 && tight && (u64)waker_cpu < nr_cpu_ids &&
+		    bpf_cpumask_test_cpu(waker_cpu, p->cpus_ptr)) {
+			struct tuning_knobs *knobs = get_knobs();
+			u64 sl = tctx ? task_slice(tctx, knobs) : 1000000;
+			u64 dl = tctx ? task_deadline(tctx, knobs)
+				      : bpf_ktime_get_ns();
+			s32 dst_cpu;
+			u64 dst_dsq = pick_pcpu_dsq_with_spill(waker_cpu, p->cpus_ptr,
+				tctx ? tctx->shape : SHAPE_UNCLASSIFIED, &dst_cpu);
+			scx_bpf_dsq_insert_vtime(p, dst_dsq, sl, dl, 0);
+			scx_bpf_kick_cpu(dst_cpu, SCX_KICK_IDLE);
+			if (tctx) {
+				tctx->dispatch_path = 0;
+				tctx->enqueue_at = bpf_ktime_get_ns();
+			}
+			struct pandemonium_stats *s = get_stats();
+			if (s) {
+				s->nr_idle_hits += 1;
+				s->nr_dispatches += 1;
+				xccx_bump(s, XCCX_SEL_TIGHT, tctx ? tctx->last_cpu : -1, dst_cpu);
+			}
+			return dst_cpu;
+		}
+		s32 anchor = (prev_cpu >= 0 && (u64)prev_cpu < nr_cpu_ids)
+			   ? prev_cpu : waker_cpu;
+		// stay_hold >= 0 MEANS WARM-STAY IS PREFERRED -- SKIP THE IDLE-SEEK
+		// AND LET normal_path DEFER THE WAKEE TO enqueue's PREEMPT PLACEMENT.
+		if (stay_hold < 0 && (u64)anchor < nr_cpu_ids) {
+			// PHI PLACEMENT: STAY ON THE WARM CORE (IDLE OR SHALLOW-BUSY)
+			// RATHER THAN FLEE TO A COLD IDLE SIBLING.
+			s32 target = phi_warm_target(anchor, p->cpus_ptr,
+						     tctx ? tctx->tier : TIER_INTERACTIVE);
+			if (target >= 0) {
+				struct tuning_knobs *knobs = get_knobs();
+				u64 sl = tctx ? task_slice(tctx, knobs)
+					      : 1000000;
+				s32 dst_cpu;
+				u64 dst_dsq = pick_pcpu_dsq_with_spill(target, p->cpus_ptr, tctx ? tctx->shape : SHAPE_UNCLASSIFIED, &dst_cpu);
+				u64 dl = tctx ? task_deadline(tctx, knobs) : bpf_ktime_get_ns();
+				scx_bpf_dsq_insert_vtime(p,
+					dst_dsq, sl, dl, 0);
+				// IPC FIX -- LOAD-BEARING, DO NOT REMOVE (commit 5224a8d5e).
+				// THE PER-CPU DSQ INSERT NEEDS AN EXPLICIT KICK OR THE
+				// WAKEE WAITS FOR THE NEXT TICK. TARGET WAS IDLE, SO
+				// KICK_IDLE SUFFICES.
+				scx_bpf_kick_cpu(dst_cpu, SCX_KICK_IDLE);
+				if (tctx) {
+					tctx->dispatch_path = 0;
+							tctx->enqueue_at = bpf_ktime_get_ns();
 				}
-
-				// NO IDLE NEAR WAKER: DSQ DISPATCH IF DSQ IS FLOWING
-				// CODEL: IF MIN SOJOURN < 500us OVER LAST 8ms, TASKS
-				// ARE CYCLING THROUGH FAST. DSQ DISPATCH IS SAFE.
-				// IF STALLED (PINNED WORKERS), FALL THROUGH TO
-				// NORMAL PATH WHERE scx_bpf_select_cpu_dfl HANDLES
-				// PREEMPTION AND LOAD BALANCING.
-				if (!pcpu_dsq_is_stalled(
-					(u32)waker_cpu, bpf_ktime_get_ns())) {
-					struct task_ctx *tctx = lookup_task_ctx(p);
-					struct tuning_knobs *knobs = get_knobs();
-					u64 sl = tctx ? task_slice(tctx, knobs)
-						      : 1000000;
-					s32 dst_cpu;
-					u64 dst_dsq = pick_pcpu_dsq_with_spill(waker_cpu, p->cpus_ptr, &dst_cpu);
-					u64 dl = tctx ? task_deadline(p, tctx,
-						dst_dsq, knobs) : vtime_now;
-					scx_bpf_dsq_insert_vtime(p,
-						dst_dsq, sl, dl, 0);
-					if (tctx) {
-						tctx->dispatch_path = 0;
-						tctx->enqueue_at = bpf_ktime_get_ns();
-					}
-					struct pandemonium_stats *s = get_stats();
-					if (s) {
-						s->nr_idle_hits += 1;
-						s->nr_dispatches += 1;
-					}
-					return dst_cpu;
+				struct pandemonium_stats *s = get_stats();
+				if (s) {
+					s->nr_idle_hits += 1;
+					s->nr_dispatches += 1;
+					xccx_bump(s, XCCX_SEL_SYNC, tctx ? tctx->last_cpu : -1, dst_cpu);
 				}
+				return dst_cpu;
+			}
+			// MISS: ANCHOR'S affinity_rank HAD NO NEAR IDLE. IF ANCHOR IS THE
+			// WAKEE'S last_cpu, normal_path WALKS THE IDENTICAL FIXED RANK FOR THE
+			// IDENTICAL RESULT -- RECORD THE MISS SO IT SKIPS THE REDUNDANT WALK.
+			// (IF A SIBLING IDLES IN THE ~us GAP, THE dfl PICK BELOW STILL USES IT,
+			// SO NO WORK-CONSERVATION LOSS -- JUST ONE FEWER RANK WALK PER WAKE.)
+			if (tctx && anchor == tctx->last_cpu)
+				last_cpu_idle_miss = true;
+		}
+	}
+
+	// WARM-STAY DEFER: anchor uncongested -> return it without dispatching, so
+	// p flows to enqueue's PREEMPT-kicked warm-stay placement instead of any
+	// idle-seek below (the normal_path warm pick or the dfl any-idle pick).
+	if (stay_hold >= 0)
+		return stay_hold;
+
+	// SHAPE-ROUTED WARM PLACEMENT (B): BEFORE THE dfl ANY-IDLE PICK -- WHICH IS
+	// TOPOLOGY-BLIND AND CAN SEAT THE WAKEE ON A CROSS-CCX IDLE CORE (COLD L3,
+	// THE STORM'S CACHE-MISS SOURCE) -- KEEP IT ON ITS WARM CACHE. ANCHOR ON THE
+	// WAKEE'S OWN LAST CORE AND SEARCH R_eff-NEAR (SAME L2/CCX FIRST). TIGHT GRABS
+	// ITS EXACT WARM CORE WHEN IT'S FREE (TIGHTEST CONSOLIDATION); BOTH SHAPES
+	// THEN TAKE THE NEAREST IDLE. FALLS THROUGH TO dfl ONLY WHEN NOTHING WARM-NEAR
+	// IS IDLE (TRUE SATURATION -- enqueue TIER 2 THEN WARM-ANCHORS IT).
+	{
+		struct task_ctx *tctx = lookup_task_ctx(p);
+		if (!last_cpu_idle_miss && tctx && tctx->last_cpu >= 0 &&
+		    (u64)tctx->last_cpu < nr_cpu_ids &&
+		    bpf_cpumask_test_cpu(tctx->last_cpu, p->cpus_ptr)) {
+			s32 anchor = tctx->last_cpu;
+			// PHI PLACEMENT (ALL SHAPES): WARM CORE IF IDLE, ELSE QUEUE ON IT
+			// WHEN SHALLOW-BUSY (STAY L2-WARM) INSTEAD OF FLEEING COLD; ONLY A
+			// FULL WARM CORE FALLS THROUGH TO THE NEAREST IDLE. LAT_CRITICAL IS
+			// EXEMPT FROM THE QUEUE-ON-BUSY (KEEPS FLEEING FOR IMMEDIACY).
+			s32 target = phi_warm_target(anchor, p->cpus_ptr, tctx->tier);
+			if (target >= 0) {
+				struct tuning_knobs *knobs = get_knobs();
+				u64 sl = task_slice(tctx, knobs);
+				u64 dl = task_deadline(tctx, knobs);
+				s32 seat_cpu;
+				u64 seat_dsq = pick_pcpu_dsq_with_spill(target, p->cpus_ptr, tctx->shape, &seat_cpu);
+				scx_bpf_dsq_insert_vtime(p, seat_dsq, sl, dl, 0);
+				scx_bpf_kick_cpu(seat_cpu, SCX_KICK_IDLE);
+				tctx->dispatch_path = 0;
+					tctx->enqueue_at = bpf_ktime_get_ns();
+				struct pandemonium_stats *s = get_stats();
+				if (s) {
+					s->nr_idle_hits += 1;
+					s->nr_dispatches += 1;
+					count_l2_affinity(s, tctx, seat_cpu);
+					xccx_bump(s, XCCX_SEL_NORMAL, tctx->last_cpu, seat_cpu);
+				}
+				return seat_cpu;
 			}
 		}
 	}
-normal_path:;
 
 	s32 cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
 	s32 dst_cpu = cpu;
@@ -1245,10 +1516,10 @@ normal_path:;
 
 		// PER-CPU DSQ PLACEMENT WITH L2/R_EFF SPILL. CACHE-HOT IF cpu
 		// HAS ROOM; SIBLING PER-CPU DSQ NEXT (REACHED BY DISPATCH STEP 0
-		// ON SIBLING OR STEP 1 L2 STEAL); LAST-RESORT SHARED NODE DSQ.
-		u64 dst_dsq = pick_pcpu_dsq_with_spill(cpu, p->cpus_ptr, &dst_cpu);
-		u64 dl = tctx ? task_deadline(p, tctx, dst_dsq, knobs)
-			      : vtime_now;
+		// ON SIBLING OR STEP 1 L2 STEAL); LAST-RESORT ccx_inter_dsq.
+		u64 dst_dsq = pick_pcpu_dsq_with_spill(cpu, p->cpus_ptr, tctx ? tctx->shape : SHAPE_UNCLASSIFIED, &dst_cpu);
+		u64 dl = tctx ? task_deadline(tctx, knobs)
+			      : bpf_ktime_get_ns();
 		scx_bpf_dsq_insert_vtime(p, dst_dsq, sl, dl, 0);
 
 		scx_bpf_kick_cpu(dst_cpu, SCX_KICK_IDLE);
@@ -1264,6 +1535,7 @@ normal_path:;
 			s->nr_dispatches += 1;
 			if (tctx)
 				count_l2_affinity(s, tctx, dst_cpu);
+			xccx_bump(s, XCCX_SEL_DFL, tctx ? tctx->last_cpu : -1, dst_cpu);
 		}
 
 #if TRACE_SCHED
@@ -1284,7 +1556,6 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 {
 	s32 node = __COMPAT_scx_bpf_cpu_node(scx_bpf_task_cpu(p));
 	if (node < 0 || (u32)node >= nr_nodes) node = 0;
-	u64 node_dsq = nr_cpu_ids + (u64)node;
 
 	struct task_ctx *tctx = lookup_task_ctx(p);
 
@@ -1293,34 +1564,88 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 	u64 dl;
 
 	// CLASSIFY: WAKEUP VS RE-ENQUEUE
-	bool is_wakeup = tctx && tctx->awake_vtime == 0;
+	bool is_wakeup = tctx && !tctx->ran_since_wake;
 
-	// TIER 1: IDLE CPU -> NODE DSQ + KICK
-	// L2 PLACEMENT: TRY IDLE SIBLING IN SAME L2 DOMAIN FIRST.
+	// FLOW SIGNATURE: RECORD THIS WAKEUP'S WAKER CPU IN THE PERSISTED SHAPE
+	// BITMAP (CLASSIFY ONCE BY PARTNER CARDINALITY, FREEZE AT MATURITY). THE
+	// WAKER IS THE ENQUEUEING CPU.
+	if (tctx && is_wakeup)
+		update_shape(tctx, bpf_get_smp_processor_id());
+
+	// TIER 0 -- WARM-STAY: AN UNCONGESTED ANCHOR (last_cpu) KEEPS THE WAKEE ON
+	// ITS WARM CORE INSTEAD OF FANNING OUT TO A COLD IDLE SIBLING -- THE DUAL OF
+	// THE DISPATCH STEAL THRESHOLD (SEE warm_stay_anchor). PLACED DIRECTLY ON
+	// last_cpu's PER-CPU DSQ WITH NO SPILL: A LOW-SOJOURN ANCHOR DRAINS FAST EVEN
+	// WHEN DEEP, SO A DEPTH-BASED SPILL WOULD MIGRATE AGAINST THE WARM-STAY. KICK
+	// PREEMPT BECAUSE last_cpu MAY BE BUSY (KICK_IDLE WOULD NO-OP AND STRAND THE
+	// WAKEE -- THE SCAR ABOVE phi_warm_target). THIS IS WHERE select_cpu's
+	// WARM-STAY DEFER LANDS. ABOVE-THRESHOLD SOJOURN RETURNS -1 HERE AND THE
+	// WAKEE FANS OUT THROUGH TIER 1 BELOW EXACTLY AS BEFORE.
+	{
+		s32 hold = warm_stay_anchor(p, tctx, knobs, is_wakeup,
+					    bpf_ktime_get_ns());
+		if (hold >= 0) {
+			u64 hdl = task_deadline(tctx, knobs);
+			u64 hnow = bpf_ktime_get_ns();
+			__sync_val_compare_and_swap(
+				&pcpu_enqueue_ns[(u32)hold & (MAX_CPUS - 1)].ns,
+				0, hnow);
+			scx_bpf_dsq_insert_vtime(p, (u64)hold, sl, hdl, enq_flags);
+			scx_bpf_kick_cpu(hold, SCX_KICK_PREEMPT);
+			tctx->dispatch_path = 1;
+			tctx->enqueue_at = hnow;
+			struct pandemonium_stats *s = get_stats();
+			if (s) {
+				s->nr_shared += 1;
+				s->nr_dispatches += 1;
+				s->nr_hard_kicks += 1;
+				if (is_wakeup)
+					s->nr_enq_wakeup += 1;
+				else
+					s->nr_enq_requeue += 1;
+				count_l2_affinity(s, tctx, hold);
+			}
+			return;
+		}
+	}
+
+	// TIER 1: IDLE CPU -> THAT CPU'S PER-CPU DSQ + KICK
+	// L2 PLACEMENT: TRY IDLE SIBLING IN SAME L2 DOMAIN FIRST, SO cpu IS
+	// BIASED TO THE WAKEE'S last_cpu L2 GROUP (CACHE-WARM). SEAT THE WAKEE
+	// ON cpu'S OWN PER-CPU DSQ ((u64)cpu). cpu WAS JUST FOUND IDLE, SO ITS
+	// PER-CPU DSQ IS SHALLOW; NO SPILL SEARCH NEEDED.
 	// LAT_CRITICAL AND KERNEL THREADS SKIP AFFINITY -- FASTEST CPU WINS.
-	// TASK GOES TO SHARED NODE DSQ SO ANY CPU ON THE NODE CAN DRAIN IT
-	// VIA STEP 3 (UNCONDITIONAL node_dsq DRAIN). pick_pcpu_dsq_with_spill
-	// IS RESERVED FOR THE PLACEMENT SITES THAT ARE TIED TO A SPECIFIC CPU
-	// (TIER 2 PREEMPTION, select_cpu); FOR IDLE-CPU PLACEMENT, THE EAGER
-	// R_eff SEARCH (UP TO 6 MAP LOOKUPS + nr_queued QUERIES PER ENQUEUE)
-	// IS A WIRE-SPEED REGRESSION ON FORK-STORM WORKLOADS WITHOUT
-	// MEASURABLE PLACEMENT BENEFIT -- STEP 3 PICKS UP node_dsq TASKS
-	// WITHIN ONE DISPATCH CYCLE.
 	s32 cpu = -1;
 	if (knobs && knobs->affinity_mode > 0 && tctx &&
 	    tctx->tier != TIER_LAT_CRITICAL &&
 	    !(p->flags & PF_KTHREAD)) {
-		// cpu = find_idle_by_affinity(tctx->last_cpu, p->cpus_ptr);
 		cpu = find_idle_l2_sibling(tctx, p->cpus_ptr);
 	}
 	if (cpu < 0)
 		cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(p->cpus_ptr, node, 0);
 	if (cpu >= 0 && (u64)cpu < nr_cpu_ids) {
-		dl = tctx ? task_deadline(p, tctx, node_dsq, knobs)
-			  : vtime_now;
-		scx_bpf_dsq_insert_vtime(p, node_dsq, sl, dl, enq_flags);
-		__sync_val_compare_and_swap(&interactive_enqueue_ns, 0,
-					    bpf_ktime_get_ns());
+		// TIER 1: WE FOUND A SPECIFIC IDLE CPU. SEAT THE WAKEE ON THAT CPU'S
+		// OWN PER-CPU DSQ AND KICK IT -- KICK==DRAIN IDENTITY, THE KICKED CPU
+		// IS THE ONE THAT DISPATCHES THE WAKEE. THE PRIOR SHAPE_STORM ROUTE TO
+		// ccx_inter_dsq (CCX-WIDE SHARED) WHILE KICKING ONE CPU DECOUPLED
+		// PLACEMENT FROM DRAIN: P(KICKED CPU WINS THE SHARED-DSQ RACE) ~ 1/CCX
+		// SIZE, SO ~5/6 OF STORM WAKEUPS MIGRATED ON EVERY WAKE (THE WAKE-STORM
+		// LEAK / 1037-PER-THREAD MIGRATION FLOOR). PER-CPU PLACEMENT PINS THE
+		// WAKEE WHERE IT WAS KICKED; THE EXISTING STEP-1 R_eff STEAL STILL
+		// RELIEVES IT CCX-LOCALLY IF IT AGES PAST THE PHI THRESHOLD.
+		u64 tier1_dsq = (u64)cpu;
+		bool tier1_to_ccx = false;
+		dl = tctx ? task_deadline(tctx, knobs)
+			  : bpf_ktime_get_ns();
+		scx_bpf_dsq_insert_vtime(p, tier1_dsq, sl, dl, enq_flags);
+		// ARM THE CCX-OVERFLOW SOJOURN STAMP ONLY WHEN THIS PLACEMENT
+		// ACTUALLY LANDS IN ccx_inter_dsq. PER-CPU PLACEMENTS (THE COMMON
+		// NON-STORM TIER 1 CASE) DON'T TOUCH ccx_inter_dsq -- ARMING THE
+		// STAMP HERE WOULD LEAVE IT SET WITH NOTHING TO CLEAR IT, CAUSING
+		// STEP 2 RESCUE TO READ A STALE "HEAD AGE" THAT TRACKS NOTHING.
+		if (tier1_to_ccx)
+			__sync_val_compare_and_swap(&interactive_enqueue_ns, 0,
+						    bpf_ktime_get_ns());
 
 		u64 kick_flag = (tctx && tctx->tier != TIER_BATCH)
 			      ? SCX_KICK_PREEMPT : SCX_KICK_IDLE;
@@ -1335,6 +1660,7 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 		if (s) {
 			s->nr_shared += 1;
 			s->nr_dispatches += 1;
+			xccx_bump(s, XCCX_ENQ_T1, tctx ? tctx->last_cpu : -1, cpu);
 			if (is_wakeup)
 				s->nr_enq_wakeup += 1;
 			else
@@ -1349,27 +1675,27 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 		return;
 	}
 
-	// TIER 2: WAKEUP PREEMPTION -- NODE DSQ + SELECTIVE KICK
-	// ALL WAKEUPS GET NODE DSQ DISPATCH: A TASK WAKING FROM SLEEP
-	// HAS EXTERNAL INPUT TO DELIVER (TIMER, IO, USER) REGARDLESS OF
-	// BEHAVIORAL TIER. THE CLASSIFIER OPERATES ON HISTORICAL BEHAVIOR;
-	// THE WAKEUP IS THE REAL-TIME LATENCY SIGNAL.
-	// LAT_CRITICAL ALSO GETS PREEMPTION ON REQUEUE (COMPOSITOR GUARANTEE).
-	// ONLINE GUARD: pick_any_cpu_node() CAN RETURN OFFLINE CPUs DURING
-	// HOTPLUG. OFFLINE CPUs HAVE NO CURRENT TASK (cpu_curr == NULL).
+	// TIER 2: WARM-ANCHOR WAKEUP -- WAKEE'S OWN last_cpu PER-CPU DSQ + KICK
+	// A WAKING TASK (OR LAT_CRITICAL RE-ENQUEUE) IS SEATED TOWARD THE CORE IT
+	// LAST RAN ON, NOT AN ARBITRARY NODE-WIDE PICK. pick_pcpu_dsq_with_spill
+	// GIVES THE WARM PER-CPU DSQ IF IT HAS ROOM, ELSE A NEAR R_eff SIBLING,
+	// ELSE ccx_inter_dsq AS THE LAST-RESORT ESCAPE VALVE. dispatch STEP 0
+	// DRAINS THE WARM PER-CPU DSQ WHEN last_cpu NEXT DISPATCHES; STEP 1
+	// (NEAREST-SURPLUS STEAL) COVERS A SIBLING LANDING.
 	if (tctx &&
 	    (tctx->tier == TIER_LAT_CRITICAL || is_wakeup)) {
-		cpu = __COMPAT_scx_bpf_pick_any_cpu_node(
-			p->cpus_ptr, node, 0);
+		// WARM-ANCHOR: PREFER THE WAKEE'S OWN LAST CORE. pick_pcpu_dsq_with_spill
+		// THEN SEATS IT ON THAT cpu'S PER-CPU DSQ (WARM), A NEAR R_eff SIBLING,
+		// OR ccx_inter_dsq AS LAST RESORT.
+		cpu = (tctx->last_cpu >= 0 && (u64)tctx->last_cpu < nr_cpu_ids)
+		    ? tctx->last_cpu
+		    : __COMPAT_scx_bpf_pick_any_cpu_node(p->cpus_ptr, node, 0);
 		if (cpu >= 0 && (u64)cpu < nr_cpu_ids &&
 		    __COMPAT_scx_bpf_cpu_curr(cpu)) {
-			// PER-CPU PLACEMENT WITH L2/R_EFF SPILL. SAME REACHABILITY
-			// LOGIC AS select_cpu: cpu's PER-CPU IF ROOM, ELSE A SIBLING
-			// VIA find_pcpu_with_room, ELSE LAST-RESORT NODE DSQ.
 			s32 t2_cpu;
-			u64 tier2_dsq = pick_pcpu_dsq_with_spill(cpu, p->cpus_ptr, &t2_cpu);
+			u64 tier2_dsq = pick_pcpu_dsq_with_spill(cpu, p->cpus_ptr, tctx->shape, &t2_cpu);
 
-			dl = task_deadline(p, tctx, tier2_dsq, knobs);
+			dl = task_deadline(tctx, knobs);
 			scx_bpf_dsq_insert_vtime(p, tier2_dsq, sl, dl,
 						  enq_flags);
 
@@ -1377,15 +1703,6 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 				 tctx->tier == TIER_LAT_CRITICAL)
 				? SCX_KICK_PREEMPT : SCX_KICK_IDLE;
 			scx_bpf_kick_cpu(t2_cpu, kick_flag);
-			// Arm tick-preempt safety net when the spill helper
-			// fell back to node_dsq. Useful in conjunction with
-			// the CPU-bound demotion in stopping(): demoted
-			// saturators are now TIER_BATCH and tick can preempt
-			// them within preempt_thresh_ns to drain the kicked
-			// CPU's queue and let the dispatch waterfall reach
-			// node_dsq for the wedged victim.
-			if (tier2_dsq >= nr_cpu_ids)
-				arm_interactive_waiting(tctx);
 			tctx->dispatch_path = 1;
 			tctx->enqueue_at = bpf_ktime_get_ns();
 
@@ -1413,20 +1730,25 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 	// STARVATION DURING BURST SPAWNS -- NEW THREADS STARTING WITH
 	// ewma_age=0 WOULD FLOOD THE BATCH DSQ AND STARVE FOR 30-40S
 	// WAITING FOR SOJOURN RESCUE THAT NEVER REACHES THE TAIL.
-	// LAT_CRITICAL (COMPOSITORS) ARE NEVER REDIRECTED.
-	u64 target_dsq = (tctx && tctx->tier == TIER_BATCH)
-		? (nr_cpu_ids + nr_nodes + (u64)node)
-		: node_dsq;
+	// LAT_CRITICAL TASKS ARE NEVER REDIRECTED.
+	// TIER 3 ROUTES TO THE PER-CCX OVERFLOW DSQ FOR THE TASK'S HOME CPU'S CCX.
+	// Dispatch STEP 3 drains it CCX-locally (cache-coherent inside the L3);
+	// STEP 5 is the cross-CCX work-conservation scan when local CCX is empty.
+	s32 src_cpu_t3 = scx_bpf_task_cpu(p);
+	u32 src_ccx_t3 = cpu_ccx(src_cpu_t3);
+	bool is_batch_t3 = tctx && tctx->tier == TIER_BATCH;
+	u64 target_dsq = is_batch_t3 ? ccx_batch_dsq(src_ccx_t3)
+				     : ccx_inter_dsq(src_ccx_t3);
 
 	// SOJOURN TRACKING: RECORD WHEN OVERFLOW DSQs TRANSITION FROM EMPTY.
 	// DISPATCH STEP 0 CHECKS THESE TO RESCUE TASKS AGING PAST THRESHOLD.
-	if (target_dsq != node_dsq)
+	if (is_batch_t3)
 		__sync_val_compare_and_swap(&batch_enqueue_ns, 0, bpf_ktime_get_ns());
-	if (target_dsq == node_dsq)
+	else
 		__sync_val_compare_and_swap(&interactive_enqueue_ns, 0, bpf_ktime_get_ns());
 
-	// VTIME CEILING IS APPLIED INSIDE task_deadline() (UNIVERSAL).
-	dl = tctx ? task_deadline(p, tctx, target_dsq, knobs) : vtime_now;
+	// WARP IS BOUNDED BY lag_cap_ns INSIDE task_deadline() (NO CEILING CLAMP).
+	dl = tctx ? task_deadline(tctx, knobs) : bpf_ktime_get_ns();
 
 	scx_bpf_dsq_insert_vtime(p, target_dsq, sl, dl, enq_flags);
 
@@ -1438,15 +1760,9 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 		bpf_printk("PAND: enq tier3 pid=%d dsq=%llu tier=%d", p->pid, target_dsq, tctx ? tctx->tier : -1);
 #endif
 
-	// ARM TICK SAFETY NET: TIER 3 IS THE ONLY ARM SITE -- TASK LANDED IN
-	// SHARED OVERFLOW (node_dsq OR batch_dsq). FOR REQUEUES (is_wakeup=false)
-	// NO KICK FIRES, SO THE FLAG IS THE SOLE BACKSTOP. FOR WAKEUPS A KICK
-	// GOES TO scx_bpf_task_cpu(p) BUT THAT CPU MAY BE BUSY; THE FLAG
-	// REINFORCES VIA TICK PREEMPTION OF A LOCAL BATCH RUNNER.
-	// SELECT_CPU AND TIER 1/2 PATHS DO NOT ARM: THEY ALL ISSUE A DIRECT
-	// KICK TO THE DESTINATION CPU AND RELY ON THAT CPU'S DISPATCH WATERFALL.
-	arm_interactive_waiting(tctx);
-
+	// CCX OVERFLOW (ccx_inter_dsq OR ccx_batch_dsq). WAKEUPS KICK
+	// scx_bpf_task_cpu(p); IF BUSY, tick()'s PER-CPU PREEMPT DISLODGES
+	// THE RESIDENT. NO FLAG.
 	u64 kick_flags = is_wakeup ? SCX_KICK_PREEMPT : 0;
 	scx_bpf_kick_cpu(scx_bpf_task_cpu(p), kick_flags);
 
@@ -1468,25 +1784,22 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 }
 
 // DISPATCH: CPU IS IDLE AND NEEDS WORK
-// HYBRID PER-CPU + NODE DSQ DESIGN:
+// HYBRID PER-CPU + PER-CCX OVERFLOW DESIGN:
 //   SELECT_CPU -> PER-CPU DSQ (DEPTH-GATED, VISIBLE, STEALABLE)
-//   ENQUEUE TIER 1/2 -> NODE DSQ (SHARED, ANY CPU DRAINS)
-//   ENQUEUE TIER 3 -> PER-NODE BATCH/INTERACTIVE DSQ
+//   ENQUEUE TIER 1/2 -> PER-CPU DSQ (WARM); SHAPE_STORM -> ccx_inter_dsq
+//   ENQUEUE TIER 3 -> ccx_inter_dsq / ccx_batch_dsq (L3-LOCAL, SOJOURN-ORDERED)
 //
 // 0. OWN PER-CPU DSQ (CACHE-HOT, ZERO CONTENTION)
 // 1. R_EFF STEAL (AFFINITY_RANK -- L2 SIBLING AT SLOT 0, R_EFF PEERS AT SLOTS 1+)
 // SAFETY NET. SERVICE OLDER OVERFLOW SIDE PAST starvation_rescue_ns
 // 2. SERVICE OLDER OVERFLOW SIDE PAST overflow_sojourn_rescue_ns
-// 3. NODE INTERACTIVE OVERFLOW (LAT_CRIT + INTERACTIVE, VTIME-ORDERED)
-// 4. NODE BATCH OVERFLOW (NORMAL BATCH FALLBACK)
-// 5. CROSS-NODE STEAL (INTERACTIVE + BATCH PER REMOTE NODE)
+// 3. CCX-LOCAL INTERACTIVE OVERFLOW (ccx_inter_dsq[my_ccx])
+// 4. CCX-LOCAL BATCH OVERFLOW (ccx_batch_dsq[my_ccx])
+// 5. CROSS-CCX SCAN (WORK CONSERVATION ACROSS L3 FABRIC)
 // 6. KEEP_RUNNING IF PREV STILL WANTS CPU AND NOTHING QUEUED
 void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 {
-	s32 node = __COMPAT_scx_bpf_cpu_node(cpu);
-	if (node < 0 || (u32)node >= nr_nodes) node = 0;
-	u64 node_dsq = nr_cpu_ids + (u64)node;
-	u64 batch_dsq = nr_cpu_ids + nr_nodes + (u64)node;
+	u32 my_ccx = cpu_ccx(cpu);
 	struct pandemonium_stats *s;
 	u64 now = bpf_ktime_get_ns();
 
@@ -1495,12 +1808,10 @@ void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 	// overflow_sojourn_rescue_ns, FALL THROUGH SO STEP 2 SERVES OVERFLOW
 	// ON THIS DISPATCH TOO. WITHOUT THIS GATE, EVERY CPU WITH HOT PER-CPU
 	// WORK NEVER VISITS OVERFLOW; SCX_WATCHDOG_WORKFN AND OTHER WORKQUEUE
-	// WORKERS GET STARVED IN node_dsq UNTIL THE 167MS SAFETY NET FIRES.
+	// WORKERS GET STARVED IN ccx_inter_dsq UNTIL THE 167MS SAFETY NET FIRES.
 	if ((u64)cpu < nr_cpu_ids &&
 	    scx_bpf_dsq_move_to_local((u64)cpu, 0)) {
-		// pcpu_min_sojourn_ns IS UPDATED BY pandemonium_running WHEN
-		// THE TASK ACTUALLY STARTS RUNNING (SEE PER-TASK SOJOURN BLOCK).
-		// HERE WE JUST CLEAR THE DSQ-EMPTY-CYCLE TIMESTAMP.
+		// Clear the DSQ-empty-cycle timestamp.
 		pcpu_drain_clear((u32)cpu);
 		s = get_stats();
 		if (s)
@@ -1518,7 +1829,26 @@ void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 		u32 my_cpu = (u32)cpu;
 		u32 base = my_cpu * MAX_AFFINITY_CANDIDATES;
 		u32 checked = 0;
-		for (int i = 0; i < MAX_AFFINITY_CANDIDATES; i++) {
+		s32 best_peer = -1;
+		// SCAN RATE-LIMIT: the peer walk (affinity_rank lookup + per-peer
+		// nr_queued) is the dominant per-dispatch cache cost under wake-heavy
+		// LOADS. A PEER CANNOT ACCUMULATE STEALABLE BACKLOG (AGED PAST
+		// codel_target + b*R_eff) FASTER THAN codel_target, SO SCANNING MORE
+		// OFTEN THAN THAT IS PURE WASTE. GATE ON A PER-CPU TIMER; BETWEEN SCANS
+		// WE FALL THROUGH TO OVERFLOW/IDLE AND tick()'s REMOTE SCAN STILL KICKS
+		// ANY AGED PER-CPU DSQ, SO NO WORK IS STRANDED.
+		u32 zero = 0;
+		u64 *last_scan = bpf_map_lookup_elem(&last_spill_scan, &zero);
+		bool do_scan = !last_scan || *last_scan == 0 ||
+			       (now - *last_scan) >= codel_target_ns;
+		if (do_scan && last_scan)
+			*last_scan = now;
+		// SOURCE: R_eff FLOW STEAL. affinity_rank IS DISTANCE-ORDERED (SLOT 0 =
+		// L2 SIBLING), SO THE FIRST QUALIFYING PEER IS THE CLOSEST -- MIN-COST
+		// FLOW. SURPLUS > 1 GUARD: a peer needs at least 2 queued before we pull
+		// one (a lone warm task is never yanked). BOUNDED LOOP, LOCK-FREE
+		// move_to_local.
+		for (int i = 0; do_scan && i < MAX_AFFINITY_CANDIDATES; i++) {
 			u32 key = base + (u32)i;
 			u32 *val = bpf_map_lookup_elem(&affinity_rank, &key);
 			if (!val || *val == (u32)-1)
@@ -1531,82 +1861,112 @@ void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 					break;
 				continue;
 			}
-			if (scx_bpf_dsq_move_to_local((u64)peer, 0)) {
-				// pcpu_min_sojourn_ns IS UPDATED BY
-				// pandemonium_running ON THE STOLEN-TO CPU.
-				pcpu_drain_clear(peer);
-				s = get_stats();
-				if (s)
-					s->nr_dispatches += 1;
-				if (sojourn_gate_pass(now))
-					return;
-				break;
+			// SOJOURN = peer DSQ backlog age. 0 means the peer's per-CPU DSQ is
+			// empty (stamp cleared on drain), so skip the remote DSQ-object touch
+			// (scx_bpf_dsq_nr_queued) for idle peers -- the common wake-heavy case.
+			u64 enq = pcpu_enqueue_ns[peer & (MAX_CPUS - 1)].ns;
+			if (enq == 0) {
+				if (++checked >= pcpu_spill_search_budget)
+					break;
+				continue;
+			}
+			u32 nq = scx_bpf_dsq_nr_queued((u64)peer);
+			if (nq > 1) {
+				// PHI STEAL-RESIST (SHAPE-BLIND): sojourn >= codel_target +
+				// b*R_eff, built only from values we already produce. SOJOURN is
+				// `enq` above (no remote head peek, no remote task_ctx deref). THE
+				// DISTANCE PENALTY b*R_eff is pre-folded into reff_value at topology
+				// detect (already ns), so the steal does ONE indexed read and no
+				// multiply: an SMT sibling (R_eff~0) stays freely relievable while a
+				// cross-CCX pull needs ~tau of sustained backlog. reff_value all-zero
+				// (monolithic / --phi-scale 0) => flat codel_target, prior behavior.
+				u32 *dxp = bpf_map_lookup_elem(&reff_value, &key);
+				u32 dx = dxp ? *dxp : 0;
+				u64 dist_extra = (dx == (u32)-1) ? 0 : (u64)dx;
+				u64 phi_thresh = codel_target_ns + dist_extra;
+				if (now >= enq && (now - enq) >= phi_thresh) {
+					best_peer = (s32)peer;
+					break;
+				}
 			}
 			if (++checked >= pcpu_spill_search_budget)
 				break;
+		}
+		if (best_peer >= 0 &&
+		    scx_bpf_dsq_move_to_local((u64)best_peer, 0)) {
+			pcpu_drain_clear((u32)best_peer);
+			s = get_stats();
+			if (s) {
+				s->nr_dispatches += 1;
+				// STEAL: task's home is best_peer, now consumed by `cpu`.
+				xccx_bump(s, XCCX_STEAL, best_peer, cpu);
+			}
+			if (sojourn_gate_pass(now))
+				return;
 		}
 	}
 
 	// SAFETY NET: HARD STARVATION RESCUE. SERVICE WHICHEVER OVERFLOW SIDE
 	// IS OLDER PAST starvation_rescue_ns (TAU-SCALED, ~167MS AT 12C).
-	// FIRES BEFORE STEP 2 SO IT CANNOT BE GATED. ENQUEUE-SIDE PER-CPU
-	// SPILL SHOULD KEEP THIS RARELY EXERCISED; IF IT DOES FIRE,
-	// PLACEMENT IS WRONG OR TIME-BASED SERVICE IS BLOCKED -- DETECTABLE
-	// VIA nr_dispatches DELTA WHEN STEP 2 COUNTERS DON'T MOVE.
-	if (try_service_older_overflow(now, node_dsq, batch_dsq,
+	// CCX-LOCAL DRAIN FIRST, CROSS-CCX FALLBACK FOR WORK-CONSERVATION.
+	if (try_service_older_overflow(now, my_ccx,
 				       starvation_rescue_ns, false))
 		return;
 
 	// STEP 2: SERVICE OLDER OVERFLOW SIDE PAST overflow_sojourn_rescue_ns
-	// (TAU-SCALED, ~10MS AT 12C). ONE COMPARISON, ONE DRAIN. FEEDS THE
-	// OSCILLATOR (true) -- THIS IS THE REPRESENTATIVE PRESSURE SIGNAL
-	// THAT TIGHTENS codel_target_ns ON SUSTAINED LOAD.
-	if (try_service_older_overflow(now, node_dsq, batch_dsq,
+	// (TAU-SCALED, ~10MS AT 12C). FEEDS THE OSCILLATOR.
+	if (try_service_older_overflow(now, my_ccx,
 				       overflow_sojourn_rescue_ns, true))
 		return;
 
-	// STEP 3: NODE INTERACTIVE OVERFLOW (LAT_CRIT + INTERACTIVE, VTIME-ORDERED)
-	// UNCONDITIONAL DRAIN OF THE INTERACTIVE OVERFLOW DSQ.
-	if (scx_bpf_dsq_move_to_local(node_dsq, 0)) {
-		if (scx_bpf_dsq_nr_queued(node_dsq) == 0) {
-			u64 old_iens = interactive_enqueue_ns;
-			if (old_iens > 0)
-				__sync_val_compare_and_swap(&interactive_enqueue_ns, old_iens, 0);
-		}
+	// STEP 3: PER-CCX INTERACTIVE OVERFLOW (LOCAL). Cache-coherent drain
+	// of my CCX's overflow DSQ.
+	if (ccx_overflow_drain_local(my_ccx, false, &interactive_enqueue_ns)) {
 		s = get_stats();
 		if (s)
 			s->nr_dispatches += 1;
 		return;
 	}
 
-	// STEP 4: NODE BATCH OVERFLOW (NORMAL BATCH FALLBACK)
-	if (scx_bpf_dsq_move_to_local(batch_dsq, 0)) {
-		if (scx_bpf_dsq_nr_queued(batch_dsq) == 0) {
-			u64 old_bens = batch_enqueue_ns;
-			if (old_bens > 0)
-				__sync_val_compare_and_swap(&batch_enqueue_ns, old_bens, 0);
-		}
+	// STEP 4: PER-CCX BATCH OVERFLOW (LOCAL).
+	if (ccx_overflow_drain_local(my_ccx, true, &batch_enqueue_ns)) {
 		s = get_stats();
 		if (s)
 			s->nr_dispatches += 1;
 		return;
 	}
 
-	// CROSS-NODE STEAL
-	for (u32 n = 0; n < nr_nodes && n < MAX_NODES; n++) {
-		if (n != (u32)node) {
-			if (scx_bpf_dsq_move_to_local(nr_cpu_ids + (u64)n, 0)) {
-				s = get_stats();
-				if (s)
-					s->nr_dispatches += 1;
-				return;
+	// STEP 5: CROSS-CCX WORK CONSERVATION. SCAN OTHER CCXs ONCE; DRAIN ANY
+	// NON-EMPTY OVERFLOW (INTERACTIVE FIRST PER CCX, THEN BATCH). RUNS ONLY
+	// WHEN THE LOCAL CCX IS EMPTY, SO CROSS-CCX MIGRATION HERE IS PURE
+	// IDLE-TIME WORK CONSERVATION -- CACHE COST IS OFFSET BY AVOIDING IDLE
+	// CORES. LOOP BOUND MAX_CCX_DOMAINS; nr_ccx CAPS EARLY-EXIT.
+	for (u32 c = 0; c < MAX_CCX_DOMAINS; c++) {
+		if (c >= nr_ccx)
+			break;
+		if (c == my_ccx)
+			continue;
+		if (overflow_drain_clear(ccx_inter_dsq(c),
+					 &interactive_enqueue_ns)) {
+			s = get_stats();
+			if (s) {
+				s->nr_dispatches += 1;
+				// STEP 5 DRAINS CCX `c`'s OVERFLOW ONTO THIS CPU'S CCX:
+				// ALWAYS CROSS-CCX BY CONSTRUCTION (c != my_ccx).
+				if (s->nr_xccx[XCCX_STEP5] < ~0ULL)
+					s->nr_xccx[XCCX_STEP5] += 1;
 			}
-			if (scx_bpf_dsq_move_to_local(nr_cpu_ids + nr_nodes + (u64)n, 0)) {
-				s = get_stats();
-				if (s)
-					s->nr_dispatches += 1;
-				return;
+			return;
+		}
+		if (overflow_drain_clear(ccx_batch_dsq(c),
+					 &batch_enqueue_ns)) {
+			s = get_stats();
+			if (s) {
+				s->nr_dispatches += 1;
+				if (s->nr_xccx[XCCX_STEP5] < ~0ULL)
+					s->nr_xccx[XCCX_STEP5] += 1;
 			}
+			return;
 		}
 	}
 
@@ -1615,8 +1975,9 @@ void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 	    (prev->scx.flags & SCX_TASK_QUEUED)) {
 		struct task_ctx *tctx = lookup_task_ctx(prev);
 		struct tuning_knobs *knobs = get_knobs();
-		prev->scx.slice = tctx ? task_slice(tctx, knobs) :
-				  (knobs ? knobs->slice_ns : 1000000);
+		scx_bpf_task_set_slice(prev,
+			tctx ? task_slice(tctx, knobs)
+			     : (knobs ? knobs->slice_ns : 1000000));
 		s = get_stats();
 		if (s) {
 			s->nr_keep_running += 1;
@@ -1634,7 +1995,7 @@ void BPF_STRUCT_OPS(pandemonium_runnable, struct task_struct *p,
 		return;
 
 	u64 now = bpf_ktime_get_ns();
-	tctx->awake_vtime = 0;
+	tctx->ran_since_wake = false;
 
 	// FAST PATH: BRAND-NEW TASKS (< 2 WAKEUPS)
 	if (tctx->ewma_age < 2) {
@@ -1676,10 +2037,6 @@ void BPF_STRUCT_OPS(pandemonium_runnable, struct task_struct *p,
 	struct tuning_knobs *knobs = get_knobs();
 	u32 new_tier = classify_tier(tctx->lat_cri, knobs);
 
-	// COMPOSITOR BOOST: ALWAYS LAT_CRITICAL
-	if (new_tier != TIER_LAT_CRITICAL && is_compositor(p))
-		new_tier = TIER_LAT_CRITICAL;
-
 	// HIGH-PRIORITY KTHREAD OVERRIDE: PF_KTHREAD AT NICE <= -10 LOOK
 	// LATENCY-SENSITIVE TO THE BEHAVIORAL SCORER (SHORT RUNTIMES, HIGH
 	// WAKEUP FREQUENCY) BUT ARE COMPUTE CLASS. LEFT IN LAT_CRITICAL THEY
@@ -1701,47 +2058,39 @@ void BPF_STRUCT_OPS(pandemonium_runnable, struct task_struct *p,
 	if (new_tier == TIER_BATCH && (p->flags & PF_WQ_WORKER))
 		new_tier = TIER_INTERACTIVE;
 
+	// RT-POLICY FLOOR: SCHED_FIFO/SCHED_RR (PipeWire/JACK RT THREADS, THREADED
+	// IRQ kthreads) ARE LATENCY-CRITICAL BY POLICY. PIN LAT_CRITICAL REGARDLESS
+	// OF THE BEHAVIORAL SCORE AND THE kthread->BATCH OVERRIDE ABOVE.
+	if (p->policy == SCHED_FIFO || p->policy == SCHED_RR)
+		new_tier = TIER_LAT_CRITICAL;
+
 	tctx->tier = new_tier;
 }
 
-// RUNNING: TASK STARTS EXECUTING -- ADVANCE VTIME, RECORD WAKE LATENCY
+// RUNNING: TASK STARTS EXECUTING -- RECORD WAKE LATENCY, SET RAN-SINCE-WAKE
 void BPF_STRUCT_OPS(pandemonium_running, struct task_struct *p)
 {
 #if TRACE_SCHED
 	if (is_sched_task(p))
 		bpf_printk("PAND: running pid=%d cpu=%d", p->pid, bpf_get_smp_processor_id());
 #endif
-	// SINGLE-SHOT vtime_now ADVANCE. UNDER 12C BURST WITH ~48K running()
-	// CALLS/SEC, A RETRY LOOP TURNS PROGRESSION CONTENTION INTO SYSTEMATIC
-	// CAS EXHAUSTION. ONE ATTEMPT IS ENOUGH: IF IT FAILS BECAUSE ANOTHER
-	// CPU JUST ADVANCED vtime_now, THE NEXT running() CALL WILL CARRY THE
-	// UPDATE FORWARD. OCCASIONAL DROPS BEAT THE OLD 4-RETRY LOOP'S 100ms+
-	// CUMULATIVE DRIFT THAT COLLAPSED THE UNIVERSAL VTIME CEILING WINDOW
-	// FROM 120MS TO ~20MS UNDER SUSTAINED LOAD.
-	u64 cur = vtime_now;
-	if (time_before(cur, p->scx.dsq_vtime))
-		__sync_bool_compare_and_swap(&vtime_now, cur, p->scx.dsq_vtime);
-
 	struct task_ctx *tctx = lookup_task_ctx(p);
 	if (!tctx) {
 		struct tuning_knobs *knobs = get_knobs();
-		p->scx.slice = knobs ? knobs->slice_ns : 1000000;
+		scx_bpf_task_set_slice(p,
+			knobs ? knobs->slice_ns : 1000000);
 		return;
 	}
 
 	u64 now = bpf_ktime_get_ns();
 	tctx->last_run_at = now;
+	tctx->ran_since_wake = true;   // is_wakeup = !ran_since_wake
 
-	// PER-TASK SOJOURN: TIME FROM scx_bpf_dsq_insert_vtime TO RUN START.
-	// LITERAL CoDel METRIC. FEEDS pcpu_min_sojourn_ns FOR THE STALL
-	// DETECTOR. CLEAR enqueue_at AFTER CONSUME SO NEXT RUN WITHOUT A
-	// PRECEDING ENQUEUE (KEEP_RUNNING PATH) DOESN'T DOUBLE-COUNT.
-	if (tctx->enqueue_at > 0 && now > tctx->enqueue_at) {
-		u64 sojourn = now - tctx->enqueue_at;
-		u32 cpu = bpf_get_smp_processor_id();
-		update_pcpu_sojourn(cpu, sojourn);
+	// CLEAR enqueue_at AFTER CONSUME SO KEEP_RUNNING DOESN'T DOUBLE-COUNT.
+	// THE PER-TASK MIN-SOJOURN DETECTOR THIS FED (pcpu_dsq_is_stalled)
+	// WAS EXCISED IN PHASE 3; OSCILLATOR READS global_rescue_count DIRECTLY.
+	if (tctx->enqueue_at > 0 && now > tctx->enqueue_at)
 		tctx->enqueue_at = 0;
-	}
 
 	// WAKEUP-TO-RUN LATENCY
 	// ONLY RECORD ONCE PER WAKEUP: CLEAR last_woke_at AFTER RECORDING.
@@ -1791,10 +2140,10 @@ void BPF_STRUCT_OPS(pandemonium_running, struct task_struct *p)
 	}
 
 	struct tuning_knobs *knobs = get_knobs();
-	p->scx.slice = task_slice(tctx, knobs);
+	scx_bpf_task_set_slice(p, task_slice(tctx, knobs));
 }
 
-// STOPPING: TASK YIELDS CPU -- CHARGE VTIME WITH TIER-BASED WEIGHT
+// STOPPING: TASK YIELDS CPU -- UPDATE RUNTIME EWMA, DEMOTE CPU-BOUND TASKS
 void BPF_STRUCT_OPS(pandemonium_stopping, struct task_struct *p,
 		    bool runnable)
 {
@@ -1804,7 +2153,12 @@ void BPF_STRUCT_OPS(pandemonium_stopping, struct task_struct *p,
 
 	tctx->cached_weight = effective_weight(p, tctx);
 	tctx->last_cpu = bpf_get_smp_processor_id();
-	u64 weight = tctx->cached_weight;
+	// STABLE HOME: PIN ONCE TO THE FIRST CPU WE RUN ON; NEVER CHASE last_cpu
+	// (REWRITTEN EVERY STOP -> THE MIGRATION-STORM ROOT). RE-HOME ONLY IF THE OLD
+	// HOME WENT INVALID (HOTPLUG / AFFINITY CHANGE) SO WE NEVER STRAND THE TASK.
+	if (tctx->home_cpu < 0 || (u32)tctx->home_cpu >= nr_cpu_ids ||
+	    !bpf_cpumask_test_cpu(tctx->home_cpu, p->cpus_ptr))
+		tctx->home_cpu = tctx->last_cpu;
 
 	u64 now = bpf_ktime_get_ns();
 	u64 slice = now > tctx->last_run_at ? now - tctx->last_run_at : 0;
@@ -1816,18 +2170,18 @@ void BPF_STRUCT_OPS(pandemonium_stopping, struct task_struct *p,
 					      tctx->ewma_age);
 	}
 
-	// CPU-BOUND DEMOTION. Long-runners that never sleep keep ewma_age
-	// pinned at 1 (incremented only on sleep->runnable in runnable()),
-	// so classify_tier never reruns. The classifier-based path leaves
-	// such tasks at TIER_INTERACTIVE indefinitely, which makes them
-	// unpreemptible by tick() (only TIER_BATCH receives the tick rescue
-	// at line ~2031). Threshold scales with slice_ns: an INTERACTIVE
-	// long-runner's avg_runtime asymptotes to the slice cap, so a
-	// fixed-ns threshold above slice_ns can never fire for the exact
-	// tasks the demotion is meant to catch. 75% of slice_cap catches
-	// pure CPU-bound within ~6 stop cycles (~6ms wall). The ewma_age
-	// guard spares legit interactive tasks that use full slice but
-	// sleep frequently -- their ewma_age grows on every sleep->wake.
+	// CPU-BOUND DEMOTION. LONG-RUNNERS THAT NEVER SLEEP KEEP ewma_age
+	// PINNED AT 1 (INCREMENTED ONLY ON SLEEP->RUNNABLE IN runnable()),
+	// SO classify_tier NEVER RERUNS. THE CLASSIFIER-BASED PATH LEAVES
+	// SUCH TASKS AT TIER_INTERACTIVE INDEFINITELY, WHICH MAKES THEM
+	// UNPREEMPTIBLE BY tick() (ONLY TIER_BATCH RECEIVES THE TICK RESCUE
+	// AT LINE ~2031). THRESHOLD SCALES WITH slice_ns: AN INTERACTIVE
+	// LONG-RUNNER'S avg_runtime ASYMPTOTES TO THE SLICE CAP, SO A
+	// FIXED-NS THRESHOLD ABOVE slice_ns CAN NEVER FIRE FOR THE EXACT
+	// TASKS THE DEMOTION IS MEANT TO CATCH. 75% OF slice_cap CATCHES
+	// PURE CPU-BOUND WITHIN ~6 STOP CYCLES (~6ms WALL). THE ewma_age
+	// GUARD SPARES LEGIT INTERACTIVE TASKS THAT USE FULL SLICE BUT
+	// SLEEP FREQUENTLY -- THEIR ewma_age GROWS ON EVERY SLEEP->WAKE.
 	{
 		struct tuning_knobs *kk = get_knobs();
 		u64 slice_cap = kk ? kk->slice_ns : 1000000;
@@ -1855,14 +2209,6 @@ void BPF_STRUCT_OPS(pandemonium_stopping, struct task_struct *p,
 		bpf_map_update_elem(&task_class_observe, key, &obs, BPF_ANY);
 	}
 
-	u64 delta_vtime;
-	if (weight > 0)
-		delta_vtime = (slice << 7) / weight;
-	else
-		delta_vtime = slice;
-
-	p->scx.dsq_vtime += delta_vtime;
-	tctx->awake_vtime += delta_vtime;
 }
 
 // TICK: SOJOURN ENFORCEMENT + EVENT-DRIVEN BATCH PREEMPTION
@@ -1879,22 +2225,35 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 	struct pandemonium_stats *s = get_stats();
 	struct tuning_knobs *knobs = get_knobs();
 
+	// TAU-SCALING: RE-DERIVE THE TIMING STATICS IF RUST WROTE A NEW
+	// topology_tau_ns (INITIAL DETECT OR HOTPLUG). NOT GATED TO CPU 0
+	// BECAUSE THE ORIGINAL GATE LEFT A 1-50ms WINDOW BETWEEN RUST'S
+	// write_topology_fields() AND THE FIRST CPU-0 TICK DURING WHICH
+	// EVERY tau-DERIVED STATIC SAT AT ITS 12C-REFERENCE FALLBACK --
+	// MATERIAL ON NON-12C TOPOLOGIES. THE FUNCTION IS IDEMPOTENT UNDER
+	// NO-CHANGE (tau_ns == snap RETURNS IMMEDIATELY) AND THE
+	// last_tau_snapshot CAS MAKES CONCURRENT CALLS FROM MULTIPLE CPUs
+	// SAFE: FIRST NON-ZERO CALL WINS, SUBSEQUENT CALLS SHORT-CIRCUIT.
+	// OVERHEAD: ~5ns SINGLE COMPARE PER TICK PER CPU WHEN UNCHANGED.
+	apply_tau_scaling(knobs ? knobs->topology_tau_ns : 0,
+	                  knobs ? knobs->codel_eq_ns : 0);
+
 	// THE OSCILLATOR IS THE ONE DETECTOR. RESCUE DELTAS ARE THE ONLY SIGNAL
 	// IT CONSUMES; IT ADAPTS codel_target_ns WHICH DRIVES THE PER-CPU CoDel
 	// STALL DECISION AND HARD STARVATION RESCUE. NO BURST DETECTOR. NO FLAGS.
+	// OSCILLATOR UPDATE STAYS GATED TO CPU 0 -- SINGLE-WRITER TO VELOCITY
+	// AND POSITION FIELDS, NO NEED FOR CAS IN THE INTEGRATION LOOP.
 	if (bpf_get_smp_processor_id() == 0) {
-		// TAU-SCALING: re-derive the timing statics if Rust wrote a new
-		// topology_tau_ns (initial detect or hotplug). Idempotent when
-		// tau is unchanged; cheap when it is (single compare + early out).
-		apply_tau_scaling(knobs ? knobs->topology_tau_ns : 0,
-		                  knobs ? knobs->codel_eq_ns : 0);
-
 		// DAMPED HARMONIC OSCILLATOR (FULL FORM):
 		//     ẍ + 2γẋ + ω₀²(x - c_eq) = F(t)
 		// F(t): RESCUE-DRIVEN IMPULSE (NEGATIVE: TIGHTEN DETECTOR)
 		// 2γẋ: DAMPING (v >> damping_shift)
 		// ω₀²(x - c_eq): SPRING (RESTORING TOWARD R_eff EQUILIBRIUM)
-		// CRITICALLY DAMPED (γ = ω₀) VIA spring_shift = 2*damping_shift + 2.
+		// BUTTERWORTH-OPTIMAL DAMPING (ζ ≈ 0.707) VIA
+		// spring_shift = 2*damping_shift + 1. ~4.3% STEP-RESPONSE
+		// OVERSHOOT PER IMPULSE KEEPS THE CONTROLLER PROBING THE
+		// CONVEX-RESPONSE BOUNDARY INSTEAD OF PARKING INSIDE IT
+		// (SONTAG'S LOGARITHMIC-RATE CONVEXITY).
 		// 2C (THIN): FAST RESTORE, LARGE SPRING SHIFT WINDOW.
 		// 12C (DENSE): GENTLE RESTORE, TARGET TRACKS STALL POINT.
 		{
@@ -1965,24 +2324,33 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 		//   tick (BELOW): preempt_thresh_ns IS LEFT-SHIFTED BY
 		//     longrun_preempt_shift, GIVING BATCH RUNNERS MORE ROPE
 		//     BEFORE INTERACTIVE-WAITING PREEMPTS THEM.
-		// CPU 0 IS THE SOLE WRITER: ALIGNS WITH THE OSCILLATOR / TAU
-		// SCALING / VTIME-CEILING STATICS THAT ARE ALSO CPU-0-WRITTEN.
+		// CPU 0 IS THE SOLE WRITER: ALIGNS WITH THE OSCILLATOR / TAU-
+		// SCALING STATICS THAT ARE ALSO CPU-0-WRITTEN.
 		// PREVENTS MULTI-CPU TICK RACES THAT FLICKERED THE BOOL UNDER
 		// BURST WHILE batch_enqueue_ns WAS BEING SET/CLEARED VIA CAS.
 		if (bpf_get_smp_processor_id() == 0)
 			longrun_mode = sojourn > longrun_thresh_ns;
 
-		// SOJOURN ENFORCEMENT: THRESHOLD SET BY RUST ADAPTIVE LAYER
-		// FROM OBSERVED DISPATCH RATE. IF BATCH STARVING PAST THRESHOLD
-		// AND CURRENT TASK IS BATCH, KICK THIS CPU TO FORCE DISPATCH.
-		// ONLY PREEMPT BATCH: INTERACTIVE/LATCRIT SLICES ARE ALREADY
-		// SHORT (CAPPED AT slice_ns) AND WILL YIELD QUICKLY ON THEIR OWN.
-		// PER-CPU (NOT CPU-0-ONLY): EACH CPU NEEDS TO SELF-PREEMPT WHEN
-		// IT'S RUNNING THE STARVING BATCH TASK.
-		u64 sojourn_thresh = knobs ? knobs->sojourn_thresh_ns : 5000000;
-		if (sojourn > sojourn_thresh) {
+		// SOJOURN ENFORCEMENT: THRESHOLD SET BY RUST ADAPTIVE LAYER FROM
+		// OBSERVED DISPATCH RATE. IF OVERFLOW HAS STARVED PAST THE THRESHOLD,
+		// KICK THIS CPU TO FORCE A DISPATCH OF THE BURIED TASK.
+		// PREEMPT BATCH *OR* INTERACTIVE RUNNERS: THE OLD "INTERACTIVE SLICES
+		// ARE SHORT, THEY YIELD ON THEIR OWN" ASSUMPTION HOLDS IN ISOLATION BUT
+		// BREAKS UNDER A FORK-STORM -- THE CORES RUN A CONVEYOR BELT OF
+		// INTERACTIVE WORKERS, EACH YIELDING FAST ONLY FOR THE NEXT STORM
+		// WORKER, SO THE BURIED TASK NEVER GETS IN. PREEMPTING AN INTERACTIVE
+		// RUNNER UNDER SUSTAINED STARVATION IS THE JUST-ENOUGH BACK-PRESSURE
+		// THAT LETS IT THROUGH; LATCRIT IS LEFT ALONE (GENUINELY TOP PRIORITY).
+		// PER-CPU (NOT CPU-0-ONLY): EACH CPU SELF-PREEMPTS WHEN IT'S HOGGING.
+		// KEY THE KICK ON THE R_eff OVERFLOW-GATE DELTA, NOT THE TIGHTER ADAPTIVE
+		// sojourn_thresh: STEP 0/1 ONLY FALL THROUGH TO SERVE OVERFLOW ONCE THE
+		// SOJOURN PASSES overflow_sojourn_rescue_ns, SO A KICK FIRED EARLIER JUST
+		// LETS THE FREED CORE RE-GRAB ANOTHER STORM WORKER. ALIGNING THE TWO MEANS
+		// THE PREEMPTED CORE ACTUALLY LANDS ON THE BURIED TASK ON RE-DISPATCH.
+		if (sojourn > overflow_sojourn_rescue_ns) {
 			struct task_ctx *tctx = lookup_task_ctx(p);
-			if (tctx && tctx->tier == TIER_BATCH) {
+			if (tctx && (tctx->tier == TIER_BATCH ||
+				     tctx->tier == TIER_INTERACTIVE)) {
 				scx_bpf_kick_cpu(scx_bpf_task_cpu(p), SCX_KICK_PREEMPT);
 				return;
 			}
@@ -2006,7 +2374,7 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 
 		// LOCAL: OWN PER-CPU DSQ
 		if (this_cpu < MAX_CPUS) {
-			u64 pcpu_oldest = pcpu_enqueue_ns[this_cpu];
+			u64 pcpu_oldest = pcpu_enqueue_ns[this_cpu].ns;
 			if (pcpu_oldest > 0 &&
 			    (now2 - pcpu_oldest) > pcpu_sojourn_thresh) {
 				scx_bpf_kick_cpu(this_cpu,
@@ -2031,11 +2399,11 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 				for (u32 i = 0; i < 4; i++) {
 					if (i >= nr)
 						break;
-					u32 scan_cpu = i;
+					// SAME VERIFIER-PORTABLE MASK AS THE nr > 4 BRANCH (Issue #8).
+					u32 scan_cpu = i & (MAX_CPUS - 1);
 					if (scan_cpu == this_cpu)
 						continue;
-					u64 remote_stamp = pcpu_enqueue_ns[
-						scan_cpu & (MAX_CPUS - 1)];
+					u64 remote_stamp = pcpu_enqueue_ns[scan_cpu].ns;
 					if (remote_stamp > 0 &&
 					    (now2 - remote_stamp) > pcpu_sojourn_thresh)
 						scx_bpf_kick_cpu(scan_cpu,
@@ -2044,12 +2412,18 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 			} else {
 				u32 scan_base = (u32)(now2 >> 20);
 				for (int i = 0; i < 4; i++) {
+					// MASK THE INDEX, DO NOT COMPARISON-SKIP IT. OLDER-KERNEL
+					// VERIFIERS CANNOT PROVE (scan_base + i) % nr IS BOUNDED, SO
+					// pcpu_enqueue_ns[scan_cpu] TRIPS "math between map_value
+					// pointer and register with unbounded min value" (Issue #8:
+					// Ubuntu 25.10 / 5950X; newer kernels accept the bare % nr).
+					// & (MAX_CPUS-1) IS A VERIFIER-PORTABLE BOUND, NOT A FOOTGUN
+					// -- DO NOT "CLEAN IT UP" BACK INTO A >= MAX_CPUS SKIP.
 					u32 scan_cpu =
-						(scan_base + (u32)i) % nr;
+						((scan_base + (u32)i) % nr) & (MAX_CPUS - 1);
 					if (scan_cpu == this_cpu)
 						continue;
-					u64 remote_stamp = pcpu_enqueue_ns[
-						scan_cpu & (MAX_CPUS - 1)];
+					u64 remote_stamp = pcpu_enqueue_ns[scan_cpu].ns;
 					if (remote_stamp > 0 &&
 					    (now2 - remote_stamp) > pcpu_sojourn_thresh)
 						scx_bpf_kick_cpu(scan_cpu,
@@ -2059,45 +2433,33 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 		}
 	}
 
-	if (!interactive_waiting)
+	// PER-CPU PREEMPT: SIGNAL IS pcpu_enqueue_ns[this_cpu] (OLDEST WAITER AGE),
+	// SO EACH CPU DECIDES FROM ITS OWN STATE -- NO GLOBAL TOKEN. THE COARSE
+	// sojourn_thresh NET ABOVE HANDLED THE LONG-WAIT CASE; THIS IS THE TIGHT
+	// BAND AT k*tau (preempt_thresh_ns): BATCH RESIDENT YIELDS AT THE BASE,
+	// INTERACTIVE AT 2x, LAT_CRITICAL NEVER.
+	u32 wcpu = bpf_get_smp_processor_id();
+	if (wcpu >= MAX_CPUS)
+		return;
+	u64 waiter = pcpu_enqueue_ns[wcpu].ns;
+	if (waiter == 0)
 		return;
 
 	struct task_ctx *tctx = lookup_task_ctx(p);
-	if (!tctx)
+	if (!tctx || tctx->tier == TIER_LAT_CRITICAL)
 		return;
 
-	// TAU-SCALED LONGRUN PROTECTION: THIN TOPOLOGIES (tau < 4MS, ROUGHLY 2C)
-	// NEED EXTRA SLICE HEADROOM FOR BATCH LONG-RUNNERS AGAINST LAT_CRIT/BATCH
-	// CONTENTION; 4C+ HAS ENOUGH CAPACITY TO HANDLE BOTH TIERS AT BASELINE
-	// PREEMPT. longrun_preempt_shift IS SET BY apply_tau_scaling().
+	u64 wnow = bpf_ktime_get_ns();
+	u64 wait_age = wnow > waiter ? wnow - waiter : 0;
+
 	u64 base_thresh = knobs ? knobs->preempt_thresh_ns : 1000000;
-	u64 thresh = longrun_mode ? (base_thresh << longrun_preempt_shift)
-	           : base_thresh;
+	u64 batch_thresh = longrun_mode ? (base_thresh << longrun_preempt_shift)
+			 : base_thresh;
+	u64 thresh = tctx->tier == TIER_INTERACTIVE ? (batch_thresh << 1)
+		   : batch_thresh;
 
-	// LAT_CRITICAL WAITING -> TIGHTEN THRESHOLD BY 4X. AUDIO AND COMPOSITOR
-	// WAKERS ARE THE HOT CASES; THE STANDARD 1MS WAIT IS ENOUGH TO SKIP A
-	// 10MS AUDIO BUFFER. INTERACTIVE WAITERS KEEP THE CURRENT THRESHOLD SO
-	// BATCH THROUGHPUT IS NOT PENALIZED BY ORDINARY WAKEUP PATTERNS.
-	if (latcrit_waiting)
-		thresh >>= 2;
-
-	u64 on_cpu = tctx->last_run_at > 0
-		? bpf_ktime_get_ns() - tctx->last_run_at : 0;
-	// TIER PREEMPT POLICY:
-	//   * BATCH residents are always preemptible by tick when interactive_waiting
-	//     is set (any non-batch wakeup is pending).
-	//   * INTERACTIVE residents are preemptible only when latcrit_waiting is set
-	//     (a TIER_LAT_CRITICAL wakeup is specifically pending). LAT_CRIT outranks
-	//     INTERACTIVE; INTERACTIVE keeps protection from ordinary BATCH-waiter
-	//     contention. This closes the 10ms-cadence stall class where saturators
-	//     hadn't yet demoted to BATCH (or fork-storm children newly spawned at
-	//     INTERACTIVE) couldn't be tick-preempted for a LAT_CRIT victim wake.
-	bool preemptible = tctx->tier == TIER_BATCH ||
-			   (latcrit_waiting && tctx->tier == TIER_INTERACTIVE);
-	if (preemptible && on_cpu >= thresh) {
-		scx_bpf_kick_cpu(scx_bpf_task_cpu(p), SCX_KICK_PREEMPT);
-		interactive_waiting = false;
-		latcrit_waiting = false;
+	if (wait_age >= thresh) {
+		scx_bpf_kick_cpu(wcpu, SCX_KICK_PREEMPT);
 		if (!s)
 			s = get_stats();
 		if (s)
@@ -2105,29 +2467,14 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 	}
 }
 
-// ENABLE: NEW TASK ENTERS SCHED_EXT
-//
-// NEW-TASK VTIME PENALTY: PLACE NEW TASKS AT THE VTIME CEILING
-// (vtime_now + vtime_ceiling_window_ns), NOT AT vtime_now. WITHOUT
-// THIS PENALTY EVERY FRESHLY-FORKED TASK GETS THE LOWEST POSSIBLE
-// dsq_vtime AND SORTS TO THE HEAD OF THE VTIME-ORDERED QUEUE,
-// LEAPFROGGING ESTABLISHED PROCESSES THAT HAVE ACCUMULATED dsq_vtime
-// FROM RUNTIME. UNDER FORK BURSTS, WAVES OF FRESH TASKS WOULD BURY
-// LONG-LIVED DAEMONS AT THE TAIL OF THE QUEUE UNTIL THE WATCHDOG
-// KILLS THEM. THE VTIME CEILING (IN task_deadline) BOUNDS TAIL
-// POSITION BUT DOES NOT CHANGE ORDERING: DAEMONS CAPPED AT vtime_now
-// + WINDOW ARE STILL BEHIND FRESH TASKS AT vtime_now. PENALIZING NEW
-// TASKS TO LAND AT THE SAME CEILING PUTS THEM IN FIFO ORDER WITH
-// CAPPED DAEMONS (NEWER ARRIVALS TIED AT HIGHER VTIME). EEVDF AND
-// MOST MODERN FAIR SCHEDULERS APPLY THE EQUIVALENT NEW-TASK LAG
-// PENALTY FOR THIS REASON.
+// ENABLE: NEW TASK ENTERS SCHED_EXT. NO VTIME -- THE SOJOURN KEY IS COMPUTED
+// PER-INSERT IN task_deadline(); enable() ONLY INITIALIZES CONTEXT. A NEW TASK
+// ENTERS AT "now" LIKE ANY ARRIVAL, NO PENALTY.
 void BPF_STRUCT_OPS(pandemonium_enable, struct task_struct *p)
 {
-	p->scx.dsq_vtime = vtime_now + vtime_ceiling_window_ns;
-
 	struct task_ctx *tctx = ensure_task_ctx(p);
 	if (tctx) {
-		tctx->awake_vtime = 0;
+		tctx->ran_since_wake = false;
 		tctx->last_run_at = 0;
 		tctx->wakeup_freq = 20;
 		tctx->last_woke_at = bpf_ktime_get_ns();
@@ -2139,6 +2486,10 @@ void BPF_STRUCT_OPS(pandemonium_enable, struct task_struct *p)
 		tctx->tier = TIER_INTERACTIVE;
 		tctx->ewma_age = 0;
 		tctx->dispatch_path = 0;
+		// -1 = NEVER RAN: warm-anchor placement falls to scx_bpf_task_cpu(p)
+		// instead of aliasing CPU 0. find_idle_l2_sibling already guards <0.
+		tctx->last_cpu = -1;
+		tctx->home_cpu = -1;   // pinned on first run (stopping)
 
 		// PROCDB: APPLY LEARNED CLASSIFICATION FROM PRIOR RUNS
 		char key[16];
@@ -2169,7 +2520,8 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 
 	// PER-CPU DSQs.
 	// SELECT_CPU DISPATCHES TO PER-CPU DSQ (CACHE-HOT, VISIBLE, STEALABLE).
-	// ENQUEUE ALWAYS USES SHARED NODE DSQ (EVEN DISTRIBUTION).
+	// ENQUEUE TIER 1/2 SEATS WAKEES ON A WARM PER-CPU DSQ; OVERFLOW
+	// (TIER 3 / B-v2 ESCAPE) FALLS TO ccx_inter_dsq.
 	// VISIBILITY LAYERS:
 	//   1. L2 WORK STEALING IN DISPATCH -- IDLE CPUs PULL FROM SIBLINGS
 	//   2. ROTATING TICK SCAN -- CATCHES STALE TASKS ON IDLE CPUs
@@ -2177,13 +2529,16 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 	for (u32 i = 0; i < nr_cpu_ids && i < MAX_CPUS; i++)
 		scx_bpf_create_dsq(i, -1);
 
-	// CREATE PER-NODE INTERACTIVE OVERFLOW DSQs (DSQ ID = nr_cpu_ids + NODE)
-	for (u32 i = 0; i < nr_nodes && i < MAX_NODES; i++)
-		scx_bpf_create_dsq(nr_cpu_ids + i, (s32)i);
-
-	// CREATE PER-NODE BATCH OVERFLOW DSQs (DSQ ID = nr_cpu_ids + nr_nodes + NODE)
-	for (u32 i = 0; i < nr_nodes && i < MAX_NODES; i++)
-		scx_bpf_create_dsq(nr_cpu_ids + nr_nodes + i, (s32)i);
+	// CREATE PER-CCX OVERFLOW DSQs (INTERACTIVE + BATCH). MAX_CCX_DOMAINS
+	// SLOTS PRE-ALLOCATED; nr_ccx (SET BY Rust POST-LOAD) GATES WHICH ARE LIVE.
+	// PRE-ALLOCATING ALL MAX_CCX_DOMAINS COSTS A FEW UNUSED DSQ HEADERS, AVOIDS
+	// THE BOOTSTRAP ORDER PROBLEM (pandemonium_init RUNS BEFORE TOPOLOGY DETECT).
+	// THESE ARE L3-SCOPED, SO STEP 3/4 DRAIN STAYS CCX-LOCAL; STEP 5 SCANS
+	// OTHER CCXs FOR WORK CONSERVATION WHEN THE LOCAL CCX IS EMPTY.
+	for (u32 i = 0; i < MAX_CCX_DOMAINS; i++)
+		scx_bpf_create_dsq(nr_cpu_ids + 2ULL * MAX_NODES + i, -1);
+	for (u32 i = 0; i < MAX_CCX_DOMAINS; i++)
+		scx_bpf_create_dsq(nr_cpu_ids + 2ULL * MAX_NODES + MAX_CCX_DOMAINS + i, -1);
 
 	// ALL TIMING-CONSTANT AND OSCILLATOR-DYNAMICS STATICS BELOW ARE DERIVED
 	// FROM tau (Fiedler-based time constant) VIA apply_tau_scaling() AT THE
@@ -2192,10 +2547,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 	// ARE OVERWRITTEN IMMEDIATELY -- DON'T READ SIGNIFICANCE INTO THEM.
 	starvation_rescue_ns       = 100000000ULL;  // 100ms midpoint of [20, 500]
 	overflow_sojourn_rescue_ns =   6000000ULL;  //   6ms midpoint of [4, 10]
-	sojourn_interval_ns        =   4000000ULL;  //   4ms midpoint of [2, 12]
 	codel_target_floor_ns      =    500000ULL;  // 500us midpoint of [200, 800]
-	vtime_ceiling_window_ns    =  80000000ULL;  // 80MS midpoint of [16, 160]
-	                                            //   (8C-EQUIVALENT BEFORE tau LANDS)
 	pcpu_depth_base            = 2;             // 8C-12C MIDPOINT; apply_tau_scaling
 	                                            //   recomputes continuously as
 	                                            //   tau / K_DEPTH_THRESH_NS.
@@ -2204,7 +2556,8 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 	lag_cap_ns                 = 40000000ULL;   // 40MS = 12C REFERENCE
 	longrun_preempt_shift      = 0;             // NO BOOST UNTIL tau CONFIRMS 2C
 	oscillator_damping_shift   = 3;
-	oscillator_spring_shift    = 8;             // = 2*3+2, MIDPOINT
+	oscillator_spring_shift    = 7;             // = 2*3+1, BUTTERWORTH-OPTIMAL
+	                                            //   (ζ ≈ 0.707, ~4.3% overshoot)
 	oscillator_pull_scale      = 3;
 	oscillator_velocity_cap    = (s64)((u64)OSC_VELOCITY_CAP_PER_PULL * 3);
 	// START PERMISSIVE. LET THE DAMPED OSCILLATION FIND THE RIGHT CENTER.
@@ -2213,10 +2566,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 	oscillator_velocity_ns = 0;
 	prev_rescue_snapshot = 0;
 	global_rescue_count = 0;
-	for (u32 i = 0; i < nr_cpu_ids && i < MAX_CPUS; i++) {
-		pcpu_min_sojourn_ns[i] = ~0ULL;
-		pcpu_stall_start_ns[i] = 0;
-	}
 
 	longrun_mode = false;
 
@@ -2225,7 +2574,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 	if (knobs) {
 		knobs->slice_ns = 1000000;
 		knobs->preempt_thresh_ns = 1000000;
-		knobs->lag_scale = 4;
 		knobs->batch_slice_ns = 20000000;        // 20MS FLAT DEFAULT
 		knobs->lat_cri_thresh_high = LAT_CRI_THRESH_HIGH; // 32
 		knobs->lat_cri_thresh_low  = LAT_CRI_THRESH_LOW;  // 8
@@ -2236,6 +2584,15 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 		knobs->codel_eq_ns = 0;                  // RUST WRITES AT TOPOLOGY DETECT
 	}
 
+	// BELT-AND-SUSPENDERS: DERIVE tau-SCALED STATICS IMMEDIATELY IF RUST
+	// SOMEHOW WROTE topology_tau_ns BEFORE THIS INIT RUNS (struct_ops
+	// RELOAD, HOT PATH RACE). NORMAL CASE IS knobs->topology_tau_ns == 0
+	// HERE, IN WHICH CASE apply_tau_scaling() SHORT-CIRCUITS ON THE
+	// tau_ns == 0 CHECK AND THE MIDPOINT FALLBACKS SET ABOVE STAND UNTIL
+	// THE FIRST TICK AFTER RUST WRITES tau.
+	apply_tau_scaling(knobs ? knobs->topology_tau_ns : 0,
+	                  knobs ? knobs->codel_eq_ns : 0);
+
 	return 0;
 }
 
@@ -2243,6 +2600,25 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 void BPF_STRUCT_OPS(pandemonium_exit, struct scx_exit_info *ei)
 {
 	UEI_RECORD(uei, ei);
+}
+
+// EXIT_TASK: PER-TASK CLEANUP ON DEATH. BPF_F_NO_PREALLOC TASK
+// STORAGE AUTO-FREES task_ctx, SO THIS HOOK IS NOT REQUIRED FOR
+// MEMORY CORRECTNESS. WE STILL DEFINE IT TO:
+//   1. ZERO HOT-PATH TIMESTAMPS DEFENSIVELY (enqueue_at,
+//      sleep_start_ns) -- ANY STALE READ IN THE NARROW WINDOW
+//      BEFORE STORAGE GC SEES ZEROS, NOT GARBAGE.
+//   2. PROVIDE A SYMMETRIC HOOK FOR FUTURE PER-TASK CLEANUP --
+//      MATCHES THE lavd / rusty / layered / flow PATTERN ACROSS
+//      THE SCHED_EXT ECOSYSTEM.
+void BPF_STRUCT_OPS(pandemonium_exit_task, struct task_struct *p,
+		    struct scx_exit_task_args *args)
+{
+	struct task_ctx *tctx = lookup_task_ctx(p);
+	if (!tctx)
+		return;
+	tctx->enqueue_at = 0;
+	tctx->sleep_start_ns = 0;
 }
 
 // QUIESCENT: TASK GOES TO SLEEP -- RECORD TIMESTAMP FOR SLEEP ANALYSIS
@@ -2262,6 +2638,11 @@ void BPF_STRUCT_OPS(pandemonium_quiescent, struct task_struct *p,
 void BPF_STRUCT_OPS(pandemonium_cpu_release, s32 cpu,
 		    struct scx_cpu_release_args *args)
 {
+	// PORTABLE CALL: scx_bpf_reenqueue_local() RETURNS void ON v2 (NEWER)
+	// KERNELS AND THROUGH scx's compat.bpf.h SHIM; CAPTURING ITS RETURN ONLY
+	// COMPILED ON v1 (OLDER) KERNELS. CALL AS void -- THE RE-ENQUEUE STILL
+	// HAPPENS; THE nr_reenqueue STAT IS NOT PORTABLY COUNTABLE HERE. (Issue #8
+	// class: a kfunc signature that diverges across kernels / the scx build.)
 	scx_bpf_reenqueue_local();
 }
 
@@ -2276,15 +2657,12 @@ void BPF_STRUCT_OPS(pandemonium_cpu_release, s32 cpu,
 
 void BPF_STRUCT_OPS(pandemonium_cpu_online, s32 cpu)
 {
-	if ((u32)cpu < MAX_CPUS) {
-		__sync_lock_test_and_set(&pcpu_enqueue_ns[cpu], 0);
-		pcpu_min_sojourn_ns[cpu] = ~0ULL;
-		pcpu_stall_start_ns[cpu] = 0;
-	}
-	// Force the next CPU-0 tick to re-derive tau-scaled statics. Rust will
-	// have recomputed lambda_2 against the new topology and written a fresh
-	// topology_tau_ns; clearing the snapshot makes apply_tau_scaling() pick
-	// it up instead of short-circuiting on the stale value. ATOMIC STORE
+	if ((u32)cpu < MAX_CPUS)
+		__sync_lock_test_and_set(&pcpu_enqueue_ns[cpu].ns, 0);
+	// FORCE THE NEXT CPU-0 TICK TO RE-DERIVE tau-SCALED STATICS. RUST WILL
+	// HAVE RECOMPUTED lambda_2 AGAINST THE NEW TOPOLOGY AND WRITTEN A FRESH
+	// topology_tau_ns; CLEARING THE SNAPSHOT MAKES apply_tau_scaling() PICK
+	// IT UP INSTEAD OF SHORT-CIRCUITING ON THE STALE VALUE. ATOMIC STORE
 	// PAIRS WITH apply_tau_scaling()'s CAS SO A CONCURRENT TICK CAN'T
 	// OVERWRITE THIS CLEAR.
 	__sync_lock_test_and_set(&last_tau_snapshot, 0);
@@ -2292,11 +2670,8 @@ void BPF_STRUCT_OPS(pandemonium_cpu_online, s32 cpu)
 
 void BPF_STRUCT_OPS(pandemonium_cpu_offline, s32 cpu)
 {
-	if ((u32)cpu < MAX_CPUS) {
-		__sync_lock_test_and_set(&pcpu_enqueue_ns[cpu], 0);
-		pcpu_min_sojourn_ns[cpu] = ~0ULL;
-		pcpu_stall_start_ns[cpu] = 0;
-	}
+	if ((u32)cpu < MAX_CPUS)
+		__sync_lock_test_and_set(&pcpu_enqueue_ns[cpu].ns, 0);
 	__sync_lock_test_and_set(&last_tau_snapshot, 0);
 
 	__sync_lock_test_and_set(&interactive_enqueue_ns, 0);
@@ -2322,6 +2697,9 @@ SCX_OPS_DEFINE(pandemonium_ops,
 	       .cpu_online   = (void *)pandemonium_cpu_online,
 	       .cpu_offline  = (void *)pandemonium_cpu_offline,
 	       .init         = (void *)pandemonium_init,
+	       .exit_task    = (void *)pandemonium_exit_task,
 	       .exit         = (void *)pandemonium_exit,
-	       .flags        = SCX_OPS_BUILTIN_IDLE_PER_NODE,
+	       .flags        = SCX_OPS_BUILTIN_IDLE_PER_NODE |
+			       SCX_OPS_KEEP_BUILTIN_IDLE,
+	       .timeout_ms   = 10000,
 	       .name         = "pandemonium");

--- a/scheds/rust/scx_pandemonium/src/chaos.rs
+++ b/scheds/rust/scx_pandemonium/src/chaos.rs
@@ -1,0 +1,482 @@
+// PANDEMONIUM CHAOS PRIMITIVES
+// PURE-RUST RAW-WINDOW STATISTICS USED BY THE ADAPTIVE LAYER.
+//
+// EVERY PUBLIC ITEM IN THIS MODULE IS PART OF THE CHAOS API SURFACE:
+// SOME ARE CONSUMED BY THE BINARY (adaptive.rs), SOME BY TESTS, AND
+// SOME ARE EXPORTED CONSTANTS FOR DIAGNOSTICS / FUTURE EXPANSION.
+// CARGO'S DEAD-CODE LINT FIRES PER COMPILATION TARGET; SILENCE IT.
+#![allow(dead_code)]
+
+// NO EWMA, NO SCHMITT, NO CUSUM. EVERY MEASURE IS COMPUTED FROM
+// THE RAW SAMPLE WINDOW EACH CALL.
+//
+// HVG MEAN DEGREE / HVG ENTROPY (LUQUE-LACASA 2009): TWO STATISTICS OF
+// THE HORIZONTAL VISIBILITY GRAPH'S DEGREE DISTRIBUTION.
+//   - MEAN DEGREE LAMBDA = <k>. IID RANDOM SEQUENCES SATURATE AT 4 - 2/N
+//     (-> 4 IN THE LIMIT). PURELY PERIODIC SEQUENCES STAY NEAR 2.
+//   - SHANNON ENTROPY S OVER THE DEGREE DISTRIBUTION. IID HAS THE EXACT
+//     CLOSED FORM P(k) = (1/3)*(2/3)^(k-2), k >= 2, GIVING
+//     S_IID = LN(3) + 2*LN(3/2) ~= 1.910.
+// LN(3/2) IS THE CHARACTERISTIC EXPONENT OF THE IID DEGREE DISTRIBUTION,
+// NOT THE ENTROPY THRESHOLD. WE EXPOSE LAMBDA AS THE PRIMARY REGIME
+// DISCRIMINATOR (DIRECTLY INTERPRETABLE) AND ENTROPY AS A CORROBORATOR.
+//
+// BANDT-POMPE PERMUTATION ENTROPY (D=3) (BANDT-POMPE 2002): SHANNON
+// ENTROPY OF THE ORDINAL-PATTERN DISTRIBUTION OF LENGTH-3 SUB-WINDOWS,
+// NORMALIZED TO [0, 1] BY LN(6). 0 = PERFECTLY MONOTONIC / PERIODIC,
+// 1 = MAXIMALLY DISORDERED.
+//
+// THESE TWO PRIMITIVES ARE COMPLEMENTARY: HVG ENTROPY IS AMPLITUDE-
+// SENSITIVE (TWO SEQUENCES WITH IDENTICAL ORDINAL STRUCTURE BUT
+// DIFFERENT VALUES CAN DIFFER IN HVG-S), BANDT-POMPE IS AMPLITUDE-
+// INVARIANT (CAPTURES PURE ORDINAL DYNAMICS).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+// CRITICAL VALUES
+
+// LN(3/2). IID HVG DEGREE-DISTRIBUTION CHARACTERISTIC EXPONENT.
+// EXPOSED FOR DIAGNOSTICS / FUTURE USE; NOT USED AS A DIRECT THRESHOLD.
+pub const HVG_LN_3_2: f64 = 0.405_465_108_108_164_4;
+
+// HVG MEAN-DEGREE THRESHOLDS. IID RANDOM SATURATES AT 4 - 2/N; PURELY
+// PERIODIC SEQUENCES STAY NEAR 2. THE TWO THRESHOLDS BELOW DEFINE A
+// DEAD ZONE FOR THE MIXED REGIME WITHOUT HYSTERESIS SCHMITT LOGIC.
+pub const HVG_LAMBDA_PERIODIC_MAX: f64 = 2.6;
+pub const HVG_LAMBDA_CHAOTIC_MIN: f64 = 3.4;
+
+// IID-ASYMPTOTE HVG ENTROPY: LN(3) + 2*LN(3/2) ~= 1.910.
+pub const HVG_S_IID: f64 = 1.910_543_686_807_036;
+
+// BANDT-POMPE D=3 PATTERN COUNT.
+pub const BP_D3_PATTERNS: usize = 6;
+
+// LN(6): NORMALIZATION FACTOR FOR BP D=3 PERMUTATION ENTROPY.
+const LN_BP_D3: f64 = 1.791_759_469_228_055;
+
+// HIGH PERMUTATION-ENTROPY THRESHOLD. ABOVE THIS THE ORDINAL DYNAMICS
+// LOOK MAXIMALLY DISORDERED ON THE WINDOW; THE ADAPTIVE LAYER USES IT
+// AS A "WORKLOAD IS UNPREDICTABLE THIS WINDOW" SIGNAL.
+pub const BP_H_HIGH: f64 = 0.85;
+
+// RQA (RECURRENCE QUANTIFICATION ANALYSIS) DETERMINISM.
+// DET IS THE FRACTION OF RECURRENCE POINTS THAT LIE ON DIAGONAL LINE
+// SEGMENTS. A DETERMINISTIC / STEADY SIGNAL REVISITS PHASE-SPACE
+// NEIGHBORHOODS ALONG DIAGONALS (DET -> 1); AN IID SIGNAL SCATTERS
+// RECURRENCE POINTS WITH NO DIAGONAL STRUCTURE (DET -> 0).
+// THE ADAPTIVE QUIESCENCE GATE PAIRS HIGH DET WITH HVG LAMBDA IN THE
+// PERIODIC BAND TO DETECT "STOP RETUNING" STEADY STATE.
+
+// DELAY-EMBEDDING DIMENSION. 3-D VECTORS WITH UNIT DELAY -- MATCHES
+// THE D=3 ORDINAL SCALE USED BY BANDT-POMPE.
+pub const RQA_EMBED_DIM: usize = 3;
+
+// RECURRENCE THRESHOLD AS A FRACTION OF THE WINDOW STANDARD DEVIATION:
+// eps = RQA_THRESH_STD_FRAC * sigma. 0.20 IS THE STANDARD RQA DEFAULT
+// BAND FOR SHORT SERIES.
+pub const RQA_THRESH_STD_FRAC: f64 = 0.20;
+
+// MINIMUM DIAGONAL-LINE LENGTH COUNTED AS DETERMINISM (RQA l_min).
+pub const RQA_LMIN: usize = 2;
+
+// DET AT OR ABOVE THIS = DETERMINISTIC / STEADY. CONSUMED BY THE
+// ADAPTIVE QUIESCENCE GATE.
+pub const RQA_DET_STEADY_MIN: f64 = 0.90;
+
+// BELOW THIS WINDOW FILL, rqa_det RETURNS None (INSUFFICIENT DATA --
+// NEVER LET THE GATE FREEZE ON A HALF-FILLED WINDOW).
+pub const RQA_MIN_SAMPLES: usize = 8;
+
+// RAW WINDOW
+// FIXED-SIZE RING BUFFER OF f64 SAMPLES. NO HEAP ALLOC AT STEADY STATE.
+// SEMANTICS:
+//   - PUSH IS O(1)
+//   - SAMPLES ARE READ IN INSERTION ORDER (OLDEST FIRST)
+//   - UNFILLED SLOTS ARE NOT YIELDED
+//   - len() == 0 UNTIL FIRST PUSH; AT MOST N AFTER N PUSHES
+
+#[derive(Clone, Debug)]
+pub struct RawWindow<const N: usize> {
+    buf: [f64; N],
+    head: usize,
+    filled: usize,
+}
+
+impl<const N: usize> Default for RawWindow<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const N: usize> RawWindow<N> {
+    pub const fn new() -> Self {
+        Self {
+            buf: [0.0; N],
+            head: 0,
+            filled: 0,
+        }
+    }
+
+    pub fn push(&mut self, x: f64) {
+        self.buf[self.head] = x;
+        self.head = (self.head + 1) % N;
+        if self.filled < N {
+            self.filled += 1;
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.filled
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.filled == 0
+    }
+
+    pub fn capacity(&self) -> usize {
+        N
+    }
+
+    // YIELD SAMPLES IN INSERTION ORDER (OLDEST -> NEWEST).
+    pub fn iter(&self) -> RawWindowIter<'_, N> {
+        let start = if self.filled < N { 0 } else { self.head };
+        RawWindowIter {
+            win: self,
+            pos: 0,
+            start,
+        }
+    }
+
+    pub fn last(&self) -> Option<f64> {
+        if self.filled == 0 {
+            None
+        } else {
+            let i = (self.head + N - 1) % N;
+            Some(self.buf[i])
+        }
+    }
+}
+
+pub struct RawWindowIter<'a, const N: usize> {
+    win: &'a RawWindow<N>,
+    pos: usize,
+    start: usize,
+}
+
+impl<'a, const N: usize> Iterator for RawWindowIter<'a, N> {
+    type Item = f64;
+    fn next(&mut self) -> Option<f64> {
+        if self.pos >= self.win.filled {
+            return None;
+        }
+        let idx = (self.start + self.pos) % N;
+        self.pos += 1;
+        Some(self.win.buf[idx])
+    }
+}
+
+// MEAN / MIN / MAX HELPERS
+
+#[allow(dead_code)]
+pub fn mean<const N: usize>(w: &RawWindow<N>) -> f64 {
+    if w.filled == 0 {
+        return 0.0;
+    }
+    let mut s = 0.0;
+    for x in w.iter() {
+        s += x;
+    }
+    s / w.filled as f64
+}
+
+// HORIZONTAL VISIBILITY GRAPH
+//
+// FOR A SEQUENCE x_1..x_N, NODES i AND j (i < j) ARE HVG-CONNECTED IFF
+// x_k < min(x_i, x_j) FOR ALL i < k < j. ADJACENT NODES (j = i+1) ARE
+// ALWAYS CONNECTED.
+//
+// hvg_degrees BUILDS THE DEGREE VECTOR ONCE; hvg_stats DERIVES BOTH
+// LAMBDA AND ENTROPY FROM IT IN A SINGLE O(N^2) PASS.
+//
+// BRUTE-FORCE O(N^2). AT N <= 128 (>1-MINUTE WINDOW AT 1HZ) THIS IS
+// UNDER 16K COMPARISONS, DONE ONCE PER SECOND.
+
+fn hvg_degrees<const N: usize>(w: &RawWindow<N>) -> Option<([u32; N], usize)> {
+    let n = w.filled;
+    if n < 3 {
+        return None;
+    }
+
+    let mut s: [f64; N] = [0.0; N];
+    let mut k = 0;
+    for x in w.iter() {
+        s[k] = x;
+        k += 1;
+    }
+
+    let mut deg: [u32; N] = [0; N];
+    for i in 0..n {
+        let mut blocker = f64::NEG_INFINITY;
+        for j in (i + 1)..n {
+            let limit = s[i].min(s[j]);
+            if j == i + 1 || blocker < limit {
+                deg[i] += 1;
+                deg[j] += 1;
+            }
+            if s[j] > blocker {
+                blocker = s[j];
+            }
+        }
+    }
+    Some((deg, n))
+}
+
+// AMORTIZED LAMBDA + ENTROPY. ONE O(N^2) PASS BUILDS THE DEGREE VECTOR;
+// BOTH STATISTICS DERIVE FROM IT.
+pub fn hvg_stats<const N: usize>(w: &RawWindow<N>) -> (f64, f64) {
+    let (deg, n) = match hvg_degrees(w) {
+        Some(v) => v,
+        None => return (0.0, 0.0),
+    };
+
+    let mut sum: u64 = 0;
+    let mut hist: [u32; N] = [0; N];
+    for d in deg.iter().take(n) {
+        sum += *d as u64;
+        let bucket = (*d as usize).min(n - 1);
+        hist[bucket] += 1;
+    }
+    let lambda = sum as f64 / n as f64;
+
+    let total = n as f64;
+    let mut entropy = 0.0;
+    for c in hist.iter().take(n) {
+        if *c == 0 {
+            continue;
+        }
+        let p = *c as f64 / total;
+        entropy -= p * p.ln();
+    }
+    (lambda, entropy)
+}
+
+// BANDT-POMPE PERMUTATION ENTROPY (D=3)
+//
+// SLIDE A LENGTH-3 WINDOW. FOR EACH (a, b, c) MAP TO ONE OF SIX ORDINAL
+// PATTERNS BY THE RANK ORDER. BUILD THE EMPIRICAL DISTRIBUTION AND
+// RETURN H / LN(6) IN [0, 1].
+//
+// TIES ARE BROKEN BY POSITION (b > a IFF b STRICTLY GREATER, ELSE a > b).
+// IID RANDOM SAMPLES YIELD H ~= 1; PERIODIC OR MONOTONIC YIELD H << 1.
+pub fn bandt_pompe_d3<const N: usize>(w: &RawWindow<N>) -> f64 {
+    let n = w.filled;
+    if n < 3 {
+        return 0.0;
+    }
+
+    // INLINED RING WALK: WE NEED THREE CONSECUTIVE SAMPLES.
+    let mut counts = [0u32; BP_D3_PATTERNS];
+    let mut total = 0u32;
+
+    // COLLECT INTO LINEAR BUFFER ONCE; SAFE FOR N <= 128.
+    let mut s: [f64; N] = [0.0; N];
+    let mut k = 0;
+    for x in w.iter() {
+        s[k] = x;
+        k += 1;
+    }
+
+    for i in 0..(n - 2) {
+        let a = s[i];
+        let b = s[i + 1];
+        let c = s[i + 2];
+        // BREAK TIES BY POSITION (POSITIONAL ORDER WHEN VALUES EQUAL).
+        let pattern = match (a < b, b < c, a < c) {
+            (true, true, true) => 0,    // a < b < c
+            (true, false, true) => 1,   // a < c <= b
+            (true, false, false) => 2,  // c <= a < b
+            (false, true, true) => 3,   // b <= a < c
+            (false, true, false) => 4,  // b < c <= a
+            (false, false, false) => 5, // c <= b <= a
+            (true, true, false) => 1,   // DEGENERATE TIE: TREAT AS PATTERN 1
+            (false, false, true) => 4,  // DEGENERATE TIE: TREAT AS PATTERN 4
+        };
+        counts[pattern] += 1;
+        total += 1;
+    }
+
+    if total == 0 {
+        return 0.0;
+    }
+
+    let denom = total as f64;
+    let mut h = 0.0;
+    for c in counts.iter() {
+        if *c == 0 {
+            continue;
+        }
+        let p = *c as f64 / denom;
+        h -= p * p.ln();
+    }
+    h / LN_BP_D3
+}
+
+// RQA DETERMINISM (DET)
+//
+// DELAY-EMBED THE WINDOW INTO RQA_EMBED_DIM-D VECTORS WITH UNIT DELAY,
+// BUILD THE RECURRENCE MATRIX UNDER A CHEBYSHEV (L-INFINITY) BALL OF
+// RADIUS eps = RQA_THRESH_STD_FRAC * sigma, AND RETURN THE FRACTION OF
+// OFF-DIAGONAL RECURRENCE POINTS THAT LIE ON DIAGONAL RUNS OF LENGTH
+// >= RQA_LMIN.
+//
+// RETURNS Some(DET) IN [0, 1], OR None WHEN THE WINDOW HAS FEWER THAN
+// RQA_MIN_SAMPLES FILLED SLOTS -- THE QUIESCENCE GATE MUST NOT FREEZE
+// ON A HALF-FILLED WINDOW.
+//
+// BRUTE-FORCE O(N^2), SAME COST CLASS AS hvg_degrees. AT N <= 64 THIS
+// IS UNDER 4K COMPARISONS, DONE ONCE PER SECOND.
+
+// CHEBYSHEV (L-INFINITY) DISTANCE BETWEEN TWO 3-D EMBEDDED POINTS.
+fn chebyshev3(a: &[f64; RQA_EMBED_DIM], b: &[f64; RQA_EMBED_DIM]) -> f64 {
+    let mut m = 0.0;
+    for k in 0..RQA_EMBED_DIM {
+        let d = (a[k] - b[k]).abs();
+        if d > m {
+            m = d;
+        }
+    }
+    m
+}
+
+pub fn rqa_det<const N: usize>(w: &RawWindow<N>) -> Option<f64> {
+    let n = w.filled;
+    if n < RQA_MIN_SAMPLES {
+        return None;
+    }
+
+    // COPY WINDOW INTO ORDER-PRESERVING SLICE FOR INDEXED ACCESS.
+    let mut s: [f64; N] = [0.0; N];
+    let mut k = 0;
+    for x in w.iter() {
+        s[k] = x;
+        k += 1;
+    }
+
+    // MEAN AND STANDARD DEVIATION OVER THE n FILLED SAMPLES.
+    let nf = n as f64;
+    let mut sum = 0.0;
+    for v in s.iter().take(n) {
+        sum += *v;
+    }
+    let mean = sum / nf;
+    let mut var = 0.0;
+    for v in s.iter().take(n) {
+        let d = *v - mean;
+        var += d * d;
+    }
+    let sigma = (var / nf).sqrt();
+
+    // FLAT-WINDOW SPECIAL CASE. A PERFECTLY STEADY SIGNAL HAS sigma = 0;
+    // EVERY EMBEDDED POINT RECURS WITH EVERY OTHER. THAT IS FULLY
+    // DETERMINISTIC -- RETURN 1.0 DIRECTLY (AND AVOID eps = 0 / A
+    // DEGENERATE RECURRENCE MATRIX). idle_pct IS INTEGER-PERCENT CAST
+    // TO f64, SO A STEADY COMPUTE WORKLOAD PRODUCES AN EXACTLY-FLAT
+    // WINDOW AND MUST READ AS QUIESCENT.
+    if sigma < 1e-9 {
+        return Some(1.0);
+    }
+
+    let eps = RQA_THRESH_STD_FRAC * sigma;
+
+    // DELAY-EMBED: m = n - (RQA_EMBED_DIM - 1) VECTORS.
+    let m = n - (RQA_EMBED_DIM - 1);
+    if m < 2 {
+        return None;
+    }
+    let mut emb: [[f64; RQA_EMBED_DIM]; N] = [[0.0; RQA_EMBED_DIM]; N];
+    for i in 0..m {
+        for d in 0..RQA_EMBED_DIM {
+            emb[i][d] = s[i + d];
+        }
+    }
+
+    // RECURRENCE MATRIX OVER THE m EMBEDDED POINTS.
+    let mut rec: [[bool; N]; N] = [[false; N]; N];
+    for i in 0..m {
+        for j in 0..m {
+            rec[i][j] = chebyshev3(&emb[i], &emb[j]) <= eps;
+        }
+    }
+
+    // WALK EVERY OFF-MAIN DIAGONAL. COUNT TOTAL RECURRENCE POINTS AND
+    // THE POINTS THAT BELONG TO DIAGONAL RUNS OF LENGTH >= RQA_LMIN.
+    let mut total_rec: u64 = 0;
+    let mut diag_rec: u64 = 0;
+    // OFFSET o > 0: PAIRS (i, i + o). OFFSET o < 0 IS THE SYMMETRIC
+    // MIRROR; THE RECURRENCE MATRIX IS SYMMETRIC SO WE WALK o IN
+    // [1, m) AND DOUBLE-COUNT NOTHING BY COUNTING BOTH (i,j) AND (j,i)
+    // VIA THE 2x FACTOR -- INSTEAD WE JUST WALK BOTH UPPER AND LOWER
+    // EXPLICITLY TO KEEP total_rec CONSISTENT WITH diag_rec.
+    for o in 1..m {
+        // UPPER DIAGONAL: (i, i + o).
+        let mut run: usize = 0;
+        for i in 0..(m - o) {
+            if rec[i][i + o] {
+                total_rec += 1;
+                run += 1;
+            } else {
+                if run >= RQA_LMIN {
+                    diag_rec += run as u64;
+                }
+                run = 0;
+            }
+        }
+        if run >= RQA_LMIN {
+            diag_rec += run as u64;
+        }
+        // LOWER DIAGONAL: (i + o, i).
+        run = 0;
+        for i in 0..(m - o) {
+            if rec[i + o][i] {
+                total_rec += 1;
+                run += 1;
+            } else {
+                if run >= RQA_LMIN {
+                    diag_rec += run as u64;
+                }
+                run = 0;
+            }
+        }
+        if run >= RQA_LMIN {
+            diag_rec += run as u64;
+        }
+    }
+
+    if total_rec == 0 {
+        return Some(0.0);
+    }
+    Some(diag_rec as f64 / total_rec as f64)
+}
+
+// CHAOS COUNTER (DIAGNOSTIC)
+//
+// MONOTONIC COUNTER OF "WINDOW IS CHAOTIC" CROSSINGS. INCREMENT WHEN
+// HVG ENTROPY CROSSES LN(3/2) UPWARD OR WHEN PERMUTATION ENTROPY
+// CROSSES BP_H_HIGH UPWARD. EXPOSED FOR THE TELEMETRY LINE AND
+// FOR THE COMMITTED MWU PATHWAY THAT GATES OFF CROSSINGS.
+#[derive(Default, Debug)]
+pub struct ChaosCounter(AtomicU64);
+
+impl ChaosCounter {
+    pub const fn new() -> Self {
+        Self(AtomicU64::new(0))
+    }
+
+    pub fn bump(&self) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn load(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}

--- a/scheds/rust/scx_pandemonium/src/cli/probe.rs
+++ b/scheds/rust/scx_pandemonium/src/cli/probe.rs
@@ -17,30 +17,48 @@ pub fn run_probe() {
 
     let mut samples: Vec<i64> = Vec::with_capacity(MAX_SAMPLES);
 
-    let target_ns: i64 = 10_000_000; // 10MS SLEEP TARGET
-    let req = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: target_ns,
-    };
+    let period_ns: i64 = 10_000_000; // 10MS PROBE PERIOD
 
-    // HOT LOOP: MEASURE + BUFFER. ZERO I/O.
+    // COORDINATED-OMISSION-CORRECT: sleep to an ABSOLUTE running deadline
+    // (CLOCK_MONOTONIC, TIMER_ABSTIME), not a relative nanosleep. When a
+    // scheduler stall makes us oversleep past later deadlines, backfill one
+    // sample per swallowed deadline (HdrHistogram recordValueWithExpectedInterval
+    // semantics). A relative nanosleep records a single long overshoot and
+    // drops the queue of deadlines the stall ate -- understating the tail.
+    let mut now = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    unsafe {
+        libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut now);
+    }
+    let mut deadline_ns: i64 = now.tv_sec * 1_000_000_000 + now.tv_nsec + period_ns;
+
     while RUNNING.load(Ordering::Relaxed) && samples.len() < MAX_SAMPLES {
-        let mut t0 = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
-        };
-        let mut t1 = libc::timespec {
-            tv_sec: 0,
-            tv_nsec: 0,
+        let dl = libc::timespec {
+            tv_sec: deadline_ns / 1_000_000_000,
+            tv_nsec: deadline_ns % 1_000_000_000,
         };
         unsafe {
-            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut t0);
-            libc::nanosleep(&req, std::ptr::null_mut());
-            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut t1);
+            libc::clock_nanosleep(
+                libc::CLOCK_MONOTONIC,
+                libc::TIMER_ABSTIME,
+                &dl,
+                std::ptr::null_mut(),
+            );
+            libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut now);
         }
-        let elapsed_ns = (t1.tv_sec - t0.tv_sec) * 1_000_000_000 + (t1.tv_nsec - t0.tv_nsec);
-        let overshoot_us = (elapsed_ns - target_ns).max(0) / 1000;
-        samples.push(overshoot_us);
+        let now_ns = now.tv_sec * 1_000_000_000 + now.tv_nsec;
+
+        // SAMPLE THIS DEADLINE, THEN BACKFILL ANY DEADLINES THE STALL SWALLOWED.
+        loop {
+            let lateness_us = (now_ns - deadline_ns).max(0) / 1000;
+            samples.push(lateness_us);
+            deadline_ns += period_ns;
+            if now_ns < deadline_ns || samples.len() >= MAX_SAMPLES {
+                break;
+            }
+        }
     }
 
     // BULK OUTPUT AT END -- USE write() DIRECTLY TO MINIMIZE OVERHEAD

--- a/scheds/rust/scx_pandemonium/src/lib.rs
+++ b/scheds/rust/scx_pandemonium/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod chaos;
 pub mod event;
 pub mod procdb;
 pub mod tuning;

--- a/scheds/rust/scx_pandemonium/src/main.rs
+++ b/scheds/rust/scx_pandemonium/src/main.rs
@@ -15,6 +15,7 @@ mod bpf_intf;
 #[macro_use]
 mod log;
 mod adaptive;
+mod chaos;
 mod cli;
 mod procdb;
 mod scheduler;
@@ -64,9 +65,12 @@ struct Cli {
     #[arg(long)]
     no_adaptive: bool,
 
-    /// Additional compositor process names to boost to LAT_CRITICAL
+    /// Override the topology-derived Phi distance scale (phi_dist_scale_q16).
+    /// 0 disables the Phi steal-resist (flat CoDel target); omit for the
+    /// topology value. Test/bench use -- the override holds across both the
+    /// adaptive and --no-adaptive paths.
     #[arg(long)]
-    compositor: Vec<String>,
+    phi_scale: Option<u64>,
 }
 
 #[derive(Subcommand)]
@@ -94,7 +98,7 @@ fn main() -> Result<()> {
     let dump_log = cli.dump_log;
     let nr_cpus = cli.nr_cpus;
     let no_adaptive = cli.no_adaptive;
-    let extra_compositors = cli.compositor;
+    let phi_scale = cli.phi_scale;
 
     if cli.version {
         println!(
@@ -105,7 +109,7 @@ fn main() -> Result<()> {
     }
 
     match cli.command {
-        None => run_scheduler(verbose, dump_log, nr_cpus, no_adaptive, &extra_compositors),
+        None => run_scheduler(verbose, dump_log, nr_cpus, no_adaptive, phi_scale),
         Some(SubCmd::Probe) => {
             cli::probe::run_probe();
             Ok(())
@@ -117,26 +121,12 @@ fn main() -> Result<()> {
     }
 }
 
-// DEFAULT COMPOSITORS: BOOSTED TO LAT_CRITICAL VIA BPF MAP LOOKUP
-const DEFAULT_COMPOSITORS: &[&str] = &[
-    "kwin",
-    "gnome-shell",
-    "mutter",
-    "sway",
-    "Hyprland",
-    "picom",
-    "weston",
-    "labwc",
-    "wayfire",
-    "niri",
-];
-
 fn run_scheduler(
     verbose: bool,
     dump_log: bool,
     nr_cpus: Option<u64>,
     no_adaptive: bool,
-    extra_compositors: &[String],
+    phi_scale: Option<u64>,
 ) -> Result<()> {
     ctrlc::set_handler(move || {
         SHUTDOWN.store(true, Ordering::Relaxed);
@@ -190,7 +180,7 @@ fn run_scheduler(
         match topology::CpuTopology::detect(nr_cpus_display as usize) {
             Ok(topo) => {
                 topo.log_summary();
-                if let Err(e) = topo.populate_bpf_map(&sched) {
+                if let Err(e) = topo.populate_bpf_map(&mut sched) {
                     log_warn!("CACHE TOPOLOGY MAP WRITE FAILED: {}", e);
                 }
                 if let Err(e) = topo.populate_l2_siblings_map(&sched) {
@@ -199,9 +189,22 @@ fn run_scheduler(
                 // RESISTANCE AFFINITY: COMPUTE R_EFF VIA LAPLACIAN PSEUDOINVERSE
                 // AND POPULATE BPF AFFINITY RANK MAP. SPECTRUM CARRIES lambda_2
                 // AND tau_ns FOR UNIVERSAL TOPOLOGY-DERIVED SCALING.
-                let (reff, rank, spectrum) = topo.compute_resistance_affinity();
+                let (reff, rank, mut spectrum) = topo.compute_resistance_affinity();
+                if let Some(pv) = phi_scale {
+                    log_info!(
+                        "PHI OVERRIDE: phi_dist_scale_q16 {} -> {} (--phi-scale)",
+                        spectrum.phi_dist_scale_q16,
+                        pv
+                    );
+                    spectrum.phi_dist_scale_q16 = pv;
+                }
                 topo.log_resistance_affinity(&reff, &rank, spectrum);
-                if let Err(e) = topo.populate_affinity_rank_map(&sched, &rank) {
+                if let Err(e) = topo.populate_affinity_rank_map(
+                    &sched,
+                    &reff,
+                    &rank,
+                    spectrum.phi_dist_scale_q16,
+                ) {
                     log_warn!("AFFINITY RANK MAP WRITE FAILED: {}", e);
                 }
                 // WRITE tau_ns + codel_eq_ns INTO tuning_knobs. BPF'S tick() ON
@@ -214,22 +217,27 @@ fn run_scheduler(
             Err(e) => log_warn!("CACHE TOPOLOGY DETECT FAILED: {}", e),
         }
 
-        // POPULATE COMPOSITOR MAP: DEFAULT + USER-SUPPLIED NAMES
-        for name in DEFAULT_COMPOSITORS {
-            if let Err(e) = sched.write_compositor(name) {
-                log_warn!("COMPOSITOR MAP WRITE FAILED: {} ({})", name, e);
-            }
-        }
-        for name in extra_compositors {
-            if let Err(e) = sched.write_compositor(name) {
-                log_warn!("COMPOSITOR MAP WRITE FAILED: {} ({})", name, e);
-            }
-        }
-
         let should_restart = if no_adaptive {
             // BPF-ONLY MODE: SCHEDULER RUNS WITH DEFAULT KNOBS, NO RUST TUNING
             // STILL PRINTS STATS SO BENCHMARKS GET TELEMETRY FOR BOTH PHASES
             log_info!("PANDEMONIUM IS ACTIVE (BPF ONLY, CTRL+C TO EXIT)");
+            // ONE-SHOT PROCDB WARM-START. BPF-only mode has no adaptive loop,
+            // so without this every app launch re-learns task classes from cold
+            // (12C BPF app-launch 16ms vs ADAPTIVE ~2ms). ProcessDb::new() loads
+            // the persisted profiles and flush_predictions() populates
+            // task_class_init, which enable() reads on every spawn. Construct,
+            // log, drop -- no loop, no 1Hz tax. Stale-but-warm beats cold.
+            match crate::procdb::ProcessDb::new() {
+                Ok(db) => {
+                    let (total, confident) = db.summary();
+                    log_info!(
+                        "PROCDB: BPF-mode warm-start {}/{} confident profiles",
+                        confident,
+                        total
+                    );
+                }
+                Err(e) => log_warn!("PROCDB WARM-START FAILED: {}", e),
+            }
             let mut prev = scheduler::PandemoniumStats::default();
             while !SHUTDOWN.load(Ordering::Relaxed) && !sched.exited() {
                 watchdog::LOOP_HEARTBEAT.fetch_add(1, Ordering::Relaxed);
@@ -362,11 +370,23 @@ fn run_scheduler(
             } else {
                 0
             };
+            // CROSS-CCX SCATTER ATTRIBUTION (PER XCCX_* PATH), ON THE [KNOBS]
+            // LINE SO THE BENCH SUITE CAPTURES IT UNIFORMLY ACROSS BPF/ADAPTIVE
+            // (LETS THE SUITE COMPARE SCATTER BETWEEN MODES). scatter_pct IS THE
+            // PLACEMENT-SIDE FRACTION (idx 0..6).
+            let x = &final_stats.nr_xccx;
+            let x_scatter: u64 = x[0..6].iter().sum();
+            let x_scatter_pct = if final_stats.nr_dispatches > 0 {
+                x_scatter * 100 / final_stats.nr_dispatches
+            } else {
+                0
+            };
             println!(
-                "[KNOBS] regime=BPF slice_ns={} batch_ns={} preempt_ns={} lag={} l2_hit=B:{}%/I:{}%/L:{}%",
+                "[KNOBS] regime=BPF slice_ns={} batch_ns={} preempt_ns={} l2_hit=B:{}%/I:{}%/L:{}% xccx_scatter_pct={} xccx_sel_tight={} xccx_sel_sync={} xccx_sel_normal={} xccx_sel_dfl={} xccx_enq_t1={} xccx_enq_t2={} xccx_steal={} xccx_step5={}",
                 knobs.slice_ns, knobs.batch_slice_ns,
                 knobs.preempt_thresh_ns,
-                knobs.lag_scale, l2_cum_b, l2_cum_i, l2_cum_l,
+                l2_cum_b, l2_cum_i, l2_cum_l,
+                x_scatter_pct, x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7],
             );
 
             sched.read_exit_info()

--- a/scheds/rust/scx_pandemonium/src/procdb.rs
+++ b/scheds/rust/scx_pandemonium/src/procdb.rs
@@ -47,7 +47,15 @@ pub const STALE_TICKS: u64 = 60;
 
 const PROCDB_MAGIC: &[u8; 4] = b"PDDB";
 const PROCDB_VERSION: u32 = 2;
-const PROCDB_PATH: &str = ".cache/pandemonium/procdb.bin";
+// CANONICAL PERSISTENT PATH (v5.10.0+). FHS-CORRECT FOR MACHINE-LOCAL
+// STATE THAT LIVES ACROSS REBOOTS. INDEPENDENT OF $HOME RESOLUTION SO
+// SYSTEMD-LAUNCHED, sudo-LAUNCHED, AND TEST-HARNESS RUNS ALL CONVERGE
+// ON THE SAME FILE. SYSTEMD UNIT `StateDirectory=pandemonium` CREATES
+// /var/lib/pandemonium/ AT 0700 root:root.
+const PROCDB_PATH: &str = "/var/lib/pandemonium/procdb.bin";
+// LEGACY $HOME-RELATIVE PATH (pre-v5.10.0). READ ONCE FOR MIGRATION
+// IF PROCDB_PATH IS EMPTY. NEVER WRITTEN TO BY CURRENT CODE.
+const PROCDB_LEGACY_REL: &str = ".cache/pandemonium/procdb.bin";
 const ENTRY_SIZE: usize = 64;
 const V1_ENTRY_SIZE: usize = 40;
 
@@ -122,8 +130,36 @@ pub struct ProcessDb {
 
 impl ProcessDb {
     pub fn default_path() -> PathBuf {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".into());
-        PathBuf::from(home).join(PROCDB_PATH)
+        PathBuf::from(PROCDB_PATH)
+    }
+
+    // LEGACY PATH RESOLVED FROM CURRENT $HOME. USED ONLY FOR ONE-SHOT
+    // MIGRATION INTO PROCDB_PATH WHEN THE CANONICAL FILE IS ABSENT.
+    fn legacy_path() -> Option<PathBuf> {
+        let home = std::env::var("HOME").ok()?;
+        Some(PathBuf::from(home).join(PROCDB_LEGACY_REL))
+    }
+
+    // REMOVE *.bin.tmp ORPHANS LEFT BY save() CALLS INTERRUPTED BETWEEN
+    // File::create AND fs::rename (WATCHDOG ABORT, SCHED_EXT KERNEL EXIT,
+    // SIGKILL). HARMLESS BUT ACCUMULATES; CLEAN AT INIT.
+    fn cleanup_tmp_orphans(parent: &Path) {
+        let entries = match std::fs::read_dir(parent) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("tmp")
+                && path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.starts_with("procdb."))
+                    .unwrap_or(false)
+            {
+                let _ = std::fs::remove_file(&path);
+            }
+        }
     }
 
     pub fn new() -> Result<Self> {
@@ -131,6 +167,32 @@ impl ProcessDb {
         let init = libbpf_rs::MapHandle::from_pinned_path(INIT_PIN)?;
 
         let db_path = Self::default_path();
+        if let Some(parent) = db_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+            Self::cleanup_tmp_orphans(parent);
+        }
+
+        // ONE-SHOT MIGRATION: if the canonical file is missing but a legacy
+        // $HOME/.cache/pandemonium/procdb.bin exists, copy it forward so we
+        // don't lose accumulated profiles on first run after upgrade.
+        if !db_path.exists() {
+            if let Some(legacy) = Self::legacy_path() {
+                if legacy.exists() {
+                    match std::fs::copy(&legacy, &db_path) {
+                        Ok(bytes) => procdb_info!(
+                            "PROCDB: MIGRATED {} BYTES FROM {} TO {}",
+                            bytes,
+                            legacy.display(),
+                            db_path.display()
+                        ),
+                        Err(e) => {
+                            procdb_warn!("PROCDB MIGRATION FROM {} FAILED: {}", legacy.display(), e)
+                        }
+                    }
+                }
+            }
+        }
+
         let profiles = match Self::load_from_disk(&db_path) {
             Ok(p) => {
                 if !p.is_empty() {

--- a/scheds/rust/scx_pandemonium/src/scheduler.rs
+++ b/scheds/rust/scx_pandemonium/src/scheduler.rs
@@ -49,11 +49,15 @@ pub struct PandemoniumStats {
     pub batch_sojourn_ns: u64,
     pub longrun_mode_active: u64,
     pub nr_overflow_rescue: u64,
+    // CROSS-CCX SCATTER ATTRIBUTION (PER XCCX_* PATH) -- MATCHES nr_xccx[8] IN
+    // intf.h. PLACEMENT-SIDE PATHS FEED THE MWU SCATTER LOSS PATHWAY.
+    pub nr_xccx: [u64; 8],
 }
 
 // COMPILE-TIME ABI SAFETY: MUST MATCH STRUCT LAYOUTS IN intf.h
-const _: () = assert!(std::mem::size_of::<PandemoniumStats>() == 200);
-const _: () = assert!(std::mem::size_of::<TuningKnobs>() == 88);
+// 200 (base) + 8*8 (nr_xccx) = 264.
+const _: () = assert!(std::mem::size_of::<PandemoniumStats>() == 264);
+const _: () = assert!(std::mem::size_of::<TuningKnobs>() == 80);
 
 // MAX_AFFINITY_CANDIDATES IS DEFINED IN intf.h. THE RUST MIRROR IN
 // bpf_intf.rs MUST KEEP THE SAME VALUE; IF THE TWO SIDES DRIFT, THE
@@ -150,10 +154,6 @@ impl<'a> Scheduler<'a> {
             let init_pin = "/sys/fs/bpf/pandemonium/task_class_init";
             std::fs::remove_file(init_pin).ok();
             skel.maps.task_class_init.pin(init_pin).ok();
-
-            let compositor_pin = "/sys/fs/bpf/pandemonium/compositor_map";
-            std::fs::remove_file(compositor_pin).ok();
-            skel.maps.compositor_map.pin(compositor_pin).ok();
         } else {
             log_warn!("BPFFS NOT AVAILABLE: map pinning skipped (scheduler still functional)");
         }
@@ -214,6 +214,9 @@ impl<'a> Scheduler<'a> {
                     total.longrun_mode_active = stats.longrun_mode_active;
                 }
                 total.nr_overflow_rescue += stats.nr_overflow_rescue;
+                for i in 0..8 {
+                    total.nr_xccx[i] += stats.nr_xccx[i];
+                }
             }
         }
 
@@ -264,6 +267,10 @@ impl<'a> Scheduler<'a> {
             codel_target_ns: bss.codel_target_ns,
             codel_target_floor_ns: bss.codel_target_floor_ns,
             codel_target_max_ns: data.codel_target_max_ns,
+            // NEAREST-PEER PHI HOLD WARM-STAY PRICES IN (SLOT 0 = CHEAPEST
+            // PEER, THE VALUE warm_stay_anchor READS FOR THE HOME CPU). CPU 0
+            // IS REPRESENTATIVE ON A HOMOGENEOUS TOPOLOGY.
+            home_dist_extra_ns: self.read_reff_value(0, 0) as u64,
         }
     }
 
@@ -344,6 +351,28 @@ impl<'a> Scheduler<'a> {
         Ok(())
     }
 
+    // POPULATE LLC/CCX DOMAIN MAP. MONOLITHIC-L3 PARTS: llc_domain ==
+    // socket_domain (intra-CCX checks become no-ops). CHIPLET PARTS: real
+    // CCX/CCD grouping. Consumed by pandemonium_running's migration tagger.
+    pub fn write_llc_domain(&self, cpu: u32, llc_group: u32) -> Result<()> {
+        let key = cpu.to_ne_bytes();
+        let val = llc_group.to_ne_bytes();
+        self.skel
+            .maps
+            .llc_domain
+            .update(&key, &val, libbpf_rs::MapFlags::ANY)?;
+        Ok(())
+    }
+
+    // SET nr_ccx (post-load mutable global). Walked from topology at startup.
+    // Gates how many of the MAX_CCX_DOMAINS per-CCX overflow DSQs are addressed
+    // by dispatch drain loops.
+    pub fn write_nr_ccx(&mut self, nr_ccx: u32) {
+        if let Some(data) = self.skel.maps.data_data.as_mut() {
+            data.nr_ccx = nr_ccx;
+        }
+    }
+
     // POPULATE L2 SIBLINGS MAP ENTRY
     pub fn write_l2_sibling(&self, group_id: u32, slot: u32, cpu: u32) -> Result<()> {
         let key = (group_id * 8 + slot).to_ne_bytes();
@@ -372,18 +401,41 @@ impl<'a> Scheduler<'a> {
         Ok(())
     }
 
-    // POPULATE COMPOSITOR MAP ENTRY
-    pub fn write_compositor(&self, name: &str) -> Result<()> {
-        let mut key = [0u8; 16];
-        let bytes = name.as_bytes();
-        let len = bytes.len().min(15);
-        key[..len].copy_from_slice(&bytes[..len]);
-        let val = [1u8];
+    // POPULATE R_eff COST ORACLE MAP (PAIRS 1:1 WITH affinity_rank).
+    // reff_value[cpu * MAX_AFFINITY_CANDIDATES + slot] = quantized R_eff TO THAT TARGET.
+    pub fn write_reff_value(&self, cpu: u32, slot: u32, value: u32) -> Result<()> {
+        let stride = crate::bpf_intf::MAX_AFFINITY_CANDIDATES;
+        let key = (cpu * stride + slot).to_ne_bytes();
+        let val = value.to_ne_bytes();
         self.skel
             .maps
-            .compositor_map
+            .reff_value
             .update(&key, &val, libbpf_rs::MapFlags::ANY)?;
         Ok(())
+    }
+
+    // READ ONE reff_value SLOT (ns PHI HOLD TO THAT RANKED PEER). RETURNS 0 ON
+    // MISS OR THE (u32)-1 UNUSED-SLOT SENTINEL. USED BY THE ADAPTIVE LOOP TO
+    // LEARN THE NEAREST-PEER HOLD WARM-STAY PRICES IN (SLOT 0 = CHEAPEST PEER).
+    pub fn read_reff_value(&self, cpu: u32, slot: u32) -> u32 {
+        let stride = crate::bpf_intf::MAX_AFFINITY_CANDIDATES;
+        let key = (cpu * stride + slot).to_ne_bytes();
+        match self
+            .skel
+            .maps
+            .reff_value
+            .lookup(&key, libbpf_rs::MapFlags::ANY)
+        {
+            Ok(Some(bytes)) if bytes.len() >= 4 => {
+                let v = u32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                if v == u32::MAX {
+                    0
+                } else {
+                    v
+                }
+            }
+            _ => 0,
+        }
     }
 
     // READ UEI EXIT INFO. RETURNS (should_restart).
@@ -440,11 +492,6 @@ impl Drop for Scheduler<'_> {
             .maps
             .task_class_init
             .unpin("/sys/fs/bpf/pandemonium/task_class_init");
-        let _ = self
-            .skel
-            .maps
-            .compositor_map
-            .unpin("/sys/fs/bpf/pandemonium/compositor_map");
         let _ = std::fs::remove_dir("/sys/fs/bpf/pandemonium");
     }
 }

--- a/scheds/rust/scx_pandemonium/src/topology.rs
+++ b/scheds/rust/scx_pandemonium/src/topology.rs
@@ -32,9 +32,9 @@ use crate::scheduler::Scheduler;
 // EXTRACTION IS O(n log n) ON TOP OF THE EXISTING O(n^3) Jacobi; NEGLIGIBLE.
 // REFERENCE: CHEEGER'S INEQUALITY BOUNDS lambda_2 AGAINST GRAPH BOTTLENECK.
 const LAMBDA_ZERO_EPS: f64 = 1e-8;
-const TAU_SCALE_NS: f64 = 1.6e8; // 160MS -- CALIBRATED SO FLAT K_4 WITH
-                                 // EDGE WEIGHT 10 (ALL L2 SIBLINGS)
-                                 // YIELDS tau = 4MS.
+const TAU_SCALE_NS: f64 = 1.6e8; // 160MS. CAPACITY-AWARE ANCHOR: AT THE
+                                 // 12C REFERENCE (lambda_2=12, N=12)
+                                 // tau = 160ms / sqrt(144) = 13.3MS.
 const TAU_FLOOR_NS: u64 = 1_000_000; //  1MS
 const TAU_CEIL_NS: u64 = 40_000_000; // 40MS
 
@@ -49,6 +49,10 @@ pub struct TopologySpectrum {
     pub fiedler: f64,     // lambda_2
     pub tau_ns: u64,      // clamped TAU_SCALE_NS / lambda_2
     pub codel_eq_ns: u64, // <R_eff> * 2m * tau, clamped
+    // Phi migration-potential distance->wait scale (Q16). The extra head-wait a
+    // steal must clear before crossing to a peer = (reff * this) >> 16 ns. 0 on a
+    // monolithic / single-CCX part (Phi off -> flat codel_target, exact no-op).
+    pub phi_dist_scale_q16: u64,
 }
 
 fn extract_fiedler(eigenvalues: &[f64]) -> f64 {
@@ -63,8 +67,17 @@ fn extract_fiedler(eigenvalues: &[f64]) -> f64 {
         .unwrap_or(LAMBDA_ZERO_EPS)
 }
 
-fn compute_tau_ns(fiedler: f64) -> u64 {
-    let raw = TAU_SCALE_NS / fiedler.max(LAMBDA_ZERO_EPS);
+fn compute_tau_ns(fiedler: f64, n: usize) -> u64 {
+    // CAPACITY-AWARE: tau = TAU_SCALE_NS / sqrt(lambda_2 * N) -- the geometric
+    // mean of connectivity (1/lambda_2) and capacity (1/sqrt(N)). The old
+    // pure-connectivity law gave a well-connected but capacity-starved
+    // topology (a 2-core L2 pair, lambda_2=20) a tiny tau (8ms) and thus tight
+    // tolerances exactly where scarce CPUs need loose ones -- which the
+    // apply_tau_scaling floors then patched back up. sqrt(N) penalizes small N,
+    // so 2C loosens to ~25ms with no floor needed. The 12C reference is
+    // preserved: lambda_2=12, N=12 -> sqrt(144)=12 -> 160ms/12 = 13.3ms.
+    let denom = (fiedler.max(LAMBDA_ZERO_EPS) * (n.max(1) as f64)).sqrt();
+    let raw = TAU_SCALE_NS / denom.max(LAMBDA_ZERO_EPS);
     (raw as u64).clamp(TAU_FLOOR_NS, TAU_CEIL_NS)
 }
 
@@ -107,6 +120,8 @@ pub struct CpuTopology {
     pub l2_domain: Vec<u32>,      // l2_domain[cpu] = group_id
     pub l2_groups: Vec<Vec<u32>>, // l2_groups[group_id] = [cpu, ...]
     pub socket_domain: Vec<u32>,  // socket_domain[cpu] = socket_id
+    pub llc_domain: Vec<u32>,     // llc_domain[cpu] = L3/CCX GROUP (== socket WHEN MONOLITHIC)
+    pub ccx_active: bool, // TRUE WHEN A SOCKET HOLDS >1 L3/CCX (AMD CHIPLET): ENABLES SAME-CCX RUNG
     pub nr_sockets: u32,
 }
 
@@ -166,20 +181,68 @@ impl CpuTopology {
 
         let nr_sockets = seen_sockets.len() as u32;
 
+        // DETECT L3 / CCX / CCD DOMAIN (index3). ON AMD CHIPLET PARTS index3
+        // SUBDIVIDES THE SOCKET INTO CCX/CCD GROUPS; ON MONOLITHIC-L3 PARTS IT
+        // SPANS THE WHOLE SOCKET. USE THE TIER ONLY WHEN IT GENUINELY
+        // SUBDIVIDES A SOCKET (MORE L3 GROUPS THAN SOCKETS) AND index3 WAS
+        // PRESENT FOR EVERY CPU; OTHERWISE llc_domain == socket_domain SO THE
+        // CROSS-CCX RUNG IN build_laplacian NEVER FIRES (EXACT NO-OP).
+        let mut llc_domain = vec![0u32; nr_cpus];
+        let mut seen_llc: Vec<Vec<u32>> = Vec::new();
+        let mut llc_ok = true;
+        for cpu in 0..nr_cpus {
+            let path = format!(
+                "/sys/devices/system/cpu/cpu{}/cache/index3/shared_cpu_list",
+                cpu
+            );
+            let content = match std::fs::read_to_string(&path) {
+                Ok(s) => s,
+                Err(_) => {
+                    llc_ok = false;
+                    break;
+                }
+            };
+            let members = parse_cpu_list(content.trim());
+            let group_id = match seen_llc.iter().position(|g| *g == members) {
+                Some(id) => id as u32,
+                None => {
+                    let id = seen_llc.len() as u32;
+                    seen_llc.push(members);
+                    id
+                }
+            };
+            llc_domain[cpu] = group_id;
+        }
+        let llc_subdivides = llc_ok && seen_llc.len() > nr_sockets as usize;
+        if !llc_subdivides {
+            llc_domain = socket_domain.clone();
+        }
+
         Ok(Self {
             nr_cpus,
             l2_domain,
             l2_groups: seen_groups,
             socket_domain,
+            llc_domain,
+            ccx_active: llc_subdivides,
             nr_sockets,
         })
     }
 
     // WRITE L2 DOMAIN MAP TO BPF ARRAY VIA SCHEDULER
-    pub fn populate_bpf_map(&self, sched: &Scheduler) -> Result<()> {
+    pub fn populate_bpf_map(&self, sched: &mut Scheduler) -> Result<()> {
         for cpu in 0..self.nr_cpus {
             sched.write_cache_domain(cpu as u32, self.l2_domain[cpu])?;
+            sched.write_llc_domain(cpu as u32, self.llc_domain[cpu])?;
         }
+        // nr_ccx = number of distinct llc_domain values
+        let mut seen: Vec<u32> = Vec::new();
+        for &g in &self.llc_domain {
+            if !seen.contains(&g) {
+                seen.push(g);
+            }
+        }
+        sched.write_nr_ccx(seen.len() as u32);
         Ok(())
     }
 
@@ -206,9 +269,14 @@ impl CpuTopology {
     //   R_eff(i,j) = L+[i,i] + L+[j,j] - 2*L+[i,j]
     //
     // EDGE CONDUCTANCES (INVERSE RESISTANCE):
-    //   L2 SIBLINGS:     10.0  (SHARED CACHE, NEAR-ZERO MIGRATION COST)
-    //   SAME SOCKET:      1.0  (SHARED LLC, MODERATE COST)
-    //   CROSS-SOCKET:     0.3  (NUMA HOP, HIGH COST)
+    //   L2 SIBLINGS:      10.0  (SHARED L2, NEAR-ZERO MIGRATION COST)
+    //   SAME L3 / CCX:     3.0  (SHARED LLC; ONLY WHEN A SOCKET HOLDS >1 CCX)
+    //   CROSS-CCX SOCKET:  1.0  (INFINITY-FABRIC HOP, ~8x CORE-TO-CORE LATENCY)
+    //   CROSS-SOCKET:      0.3  (NUMA HOP, HIGH COST)
+    // RAISING THE SAME-CCX RUNG (NOT LOWERING THE CROSS-CCX CUT) RANKS
+    // SAME-CCX PEERS AHEAD OF CROSS-CCX ONES WITHOUT MOVING lambda_2: THE
+    // CROSS-CCX CUT STAYS 1.0, SO tau AND codel_eq ARE UNCHANGED. THE RUNG
+    // IS GATED ON ccx_active SO MONOLITHIC-L3 PARTS ARE AN EXACT NO-OP.
     //
     // THE LAPLACIAN L = D - W WHERE D IS DEGREE MATRIX, W IS WEIGHTED ADJACENCY.
     // L+ (MOORE-PENROSE PSEUDOINVERSE) COMPUTED VIA EIGENDECOMPOSITION:
@@ -219,9 +287,16 @@ impl CpuTopology {
     // REFERENCE: Christiano-Kelner-Madry-Spielman-Teng (STOC 2011),
     //            Chen-Kyng-Liu-Peng-Gutenberg-Sachdeva (FOCS 2022)
 
-    const CONDUCTANCE_L2: f64 = 10.0;
-    const CONDUCTANCE_SOCKET: f64 = 1.0;
-    const CONDUCTANCE_CROSS: f64 = 0.3;
+    // Phi FIX A: SMT siblings SHARE L2, so a move between them costs ~0 cache.
+    // Make the edge very stiff -> R_eff(SMT-sib) ~ 0, which lands the Phi migration
+    // barrier exactly at the physical-core / L2 boundary (a real cold-L2 refill)
+    // instead of penalizing free intra-core moves. lambda_2 is the cross-CCX Fiedler
+    // cut (independent of L2 stiffness) so tau is unchanged, and codel_eq is already
+    // clamped at its ceiling, so the oscillator timescales are invariant.
+    const CONDUCTANCE_L2: f64 = 1000.0; // L2 / SMT SIBLINGS
+    const CONDUCTANCE_LLC: f64 = 3.0; // SAME L3 / CCX (ABOVE SOCKET; ONLY WHEN ccx_active)
+    const CONDUCTANCE_SOCKET: f64 = 1.0; // SAME SOCKET, CROSS-CCX (IF HOP) -- OR MONOLITHIC SAME-SOCKET
+    const CONDUCTANCE_CROSS: f64 = 0.3; // CROSS-SOCKET NUMA HOP
 
     // BUILD WEIGHTED GRAPH LAPLACIAN FROM CPU TOPOLOGY
     fn build_laplacian(&self) -> Vec<f64> {
@@ -231,6 +306,8 @@ impl CpuTopology {
             for j in (i + 1)..n {
                 let w = if self.l2_domain[i] == self.l2_domain[j] {
                     Self::CONDUCTANCE_L2
+                } else if self.ccx_active && self.llc_domain[i] == self.llc_domain[j] {
+                    Self::CONDUCTANCE_LLC
                 } else if self.socket_domain[i] == self.socket_domain[j] {
                     Self::CONDUCTANCE_SOCKET
                 } else {
@@ -386,11 +463,22 @@ impl CpuTopology {
         let laplacian = self.build_laplacian();
         let (eigenvalues, eigenvectors) = Self::symmetric_eigen(&laplacian, n);
         let fiedler = extract_fiedler(&eigenvalues);
-        let tau_ns = compute_tau_ns(fiedler);
+        let tau_ns = compute_tau_ns(fiedler, n);
         let l_pinv = Self::compute_pseudoinverse(&eigenvalues, &eigenvectors, n);
         let reff = Self::extract_reff(&l_pinv, n);
         let rank = Self::build_affinity_rank(&reff, n);
         let codel_eq_ns = compute_codel_eq_ns(&eigenvalues, n, tau_ns);
+        // Phi FIX B: distance scale calibrated so the most distant pair (max R_eff)
+        // maps to ~tau of required steal-wait, an SMT sibling (R_eff ~ 0) to ~0. Only
+        // sustained backlog (~tau) justifies a cross-CCX move; a single queued slice
+        // does not. reff_norm uses the same 1e6 scale the BPF reff_value map stores.
+        let max_reff = reff.iter().cloned().fold(0.0f64, f64::max);
+        let reff_norm = ((max_reff * 1_000_000.0).round() as u64).max(1);
+        let phi_dist_scale_q16 = if self.ccx_active {
+            tau_ns.saturating_mul(65536) / reff_norm
+        } else {
+            0
+        };
         (
             reff,
             rank,
@@ -398,6 +486,7 @@ impl CpuTopology {
                 fiedler,
                 tau_ns,
                 codel_eq_ns,
+                phi_dist_scale_q16,
             },
         )
     }
@@ -410,16 +499,35 @@ impl CpuTopology {
     // topology end (nr_cpus - 1) are written as explicit u32::MAX
     // sentinels so the BPF early-exit fires correctly -- map zero-init
     // would otherwise alias to "CPU 0" and silently mis-route.
-    pub fn populate_affinity_rank_map(&self, sched: &Scheduler, rank: &[u32]) -> Result<()> {
+    pub fn populate_affinity_rank_map(
+        &self,
+        sched: &Scheduler,
+        reff: &[f64],
+        rank: &[u32],
+        phi_dist_scale_q16: u64,
+    ) -> Result<()> {
         let stride = crate::bpf_intf::MAX_AFFINITY_CANDIDATES as usize;
         let valid = self.nr_cpus.saturating_sub(1).min(stride);
         for cpu in 0..self.nr_cpus {
             for slot in 0..valid {
                 let val = rank[cpu * self.nr_cpus + slot];
                 sched.write_affinity_rank(cpu as u32, slot as u32, val)?;
+                // FOLD THE PHI DISTANCE PENALTY AT INIT: reff_value stores the
+                // final steal extra-wait in ns, (R_eff * phi_dist_scale_q16) >> 16,
+                // so the BPF steal does one indexed read and no multiply. The 1e6
+                // scale matches build_affinity_rank's sort key. phi_dist_scale_q16
+                // is 0 on monolithic / --phi-scale 0 -> every penalty 0 -> flat
+                // codel_target (exact prior behavior).
+                let r_scaled = (reff[cpu * self.nr_cpus + val as usize] * 1_000_000.0)
+                    .round()
+                    .clamp(0.0, u32::MAX as f64) as u64;
+                let dist_extra =
+                    (r_scaled.saturating_mul(phi_dist_scale_q16) >> 16).min(u32::MAX as u64) as u32;
+                sched.write_reff_value(cpu as u32, slot as u32, dist_extra)?;
             }
             for slot in valid..stride {
                 sched.write_affinity_rank(cpu as u32, slot as u32, u32::MAX)?;
+                sched.write_reff_value(cpu as u32, slot as u32, u32::MAX)?;
             }
         }
         Ok(())
@@ -473,6 +581,18 @@ impl CpuTopology {
             self.nr_cpus,
             self.nr_sockets
         );
+        let mut llc = self.llc_domain.clone();
+        llc.sort_unstable();
+        llc.dedup();
+        log_info!(
+            "LLC DOMAINS: {} (SAME-CCX RUNG {})",
+            llc.len(),
+            if self.ccx_active {
+                "ACTIVE"
+            } else {
+                "INACTIVE -- MONOLITHIC L3"
+            }
+        );
     }
 }
 
@@ -497,114 +617,4 @@ fn parse_cpu_list(s: &str) -> Vec<u32> {
     result.sort();
     result.dedup();
     result
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_single() {
-        assert_eq!(parse_cpu_list("3"), vec![3]);
-    }
-
-    #[test]
-    fn parse_comma() {
-        assert_eq!(parse_cpu_list("0,6"), vec![0, 6]);
-    }
-
-    #[test]
-    fn parse_range() {
-        assert_eq!(parse_cpu_list("0-2,6-8"), vec![0, 1, 2, 6, 7, 8]);
-    }
-
-    #[test]
-    fn parse_mixed() {
-        assert_eq!(parse_cpu_list("0-2,5,9-11"), vec![0, 1, 2, 5, 9, 10, 11]);
-    }
-
-    #[test]
-    fn parse_empty() {
-        assert_eq!(parse_cpu_list(""), Vec::<u32>::new());
-    }
-
-    #[test]
-    fn detect_topology() {
-        // RUNS ON ANY MACHINE -- VERIFIES SANE OUTPUT
-        let nr_cpus = std::fs::read_dir("/sys/devices/system/cpu")
-            .unwrap()
-            .filter(|e| {
-                e.as_ref()
-                    .map(|e| {
-                        e.file_name().to_string_lossy().starts_with("cpu")
-                            && e.file_name().to_string_lossy()[3..].parse::<u32>().is_ok()
-                    })
-                    .unwrap_or(false)
-            })
-            .count();
-
-        if nr_cpus == 0 {
-            return; // NO CPUS VISIBLE (CONTAINER?)
-        }
-
-        let topo = CpuTopology::detect(nr_cpus).unwrap();
-        assert_eq!(topo.nr_cpus, nr_cpus);
-        assert_eq!(topo.l2_domain.len(), nr_cpus);
-
-        // EVERY CPU MUST HAVE A VALID GROUP ID
-        let max_group = topo.l2_groups.len() as u32;
-        for cpu in 0..nr_cpus {
-            assert!(
-                topo.l2_domain[cpu] < max_group || topo.l2_domain[cpu] == cpu as u32,
-                "CPU {} has invalid l2 group {}",
-                cpu,
-                topo.l2_domain[cpu]
-            );
-        }
-
-        // AT LEAST ONE GROUP MUST EXIST
-        assert!(!topo.l2_groups.is_empty());
-
-        // SOCKET DETECTION
-        assert_eq!(topo.socket_domain.len(), nr_cpus);
-        assert!(topo.nr_sockets >= 1);
-        for cpu in 0..nr_cpus {
-            assert!(
-                topo.socket_domain[cpu] < topo.nr_sockets,
-                "CPU {} socket {} >= nr_sockets {}",
-                cpu,
-                topo.socket_domain[cpu],
-                topo.nr_sockets
-            );
-        }
-
-        // RESISTANCE AFFINITY: LAPLACIAN R_EFF
-        let (reff, rank, spectrum) = topo.compute_resistance_affinity();
-        assert!(
-            spectrum.fiedler > 0.0,
-            "lambda_2 must be positive for connected graph"
-        );
-        assert!(spectrum.tau_ns >= 1_000_000, "tau must be >= 1ms floor");
-        assert!(spectrum.tau_ns <= 40_000_000, "tau must be <= 40ms ceiling");
-        // SAME CPU = 0 (diagonal of R_eff matrix)
-        assert_eq!(reff[0], 0.0);
-        // L2 SIBLING SHOULD BE CHEAPEST (RANK SLOT 0)
-        if nr_cpus >= 2 {
-            let best = rank[0] as usize;
-            assert!(best < nr_cpus);
-            let r_best = reff[best];
-            assert!(r_best > 0.0);
-            // EVERY OTHER CPU SHOULD COST >= THE BEST
-            for c in 1..nr_cpus {
-                let r_c = reff[c];
-                assert!(
-                    r_c >= r_best - 1e-9,
-                    "CPU {} R_eff {:.6} < best {:.6}",
-                    c,
-                    r_c,
-                    r_best
-                );
-            }
-        }
-    }
 }

--- a/scheds/rust/scx_pandemonium/src/tuning.rs
+++ b/scheds/rust/scx_pandemonium/src/tuning.rs
@@ -2,14 +2,15 @@
 // PURE-RUST MODULE: ZERO BPF DEPENDENCIES
 // SHARED BETWEEN BINARY CRATE (scheduler.rs, adaptive.rs) AND LIB CRATE (tests)
 
-// REGIME THRESHOLDS (SCHMITT TRIGGER)
-// DIRECTIONAL HYSTERESIS PREVENTS OSCILLATION AT REGIME BOUNDARIES.
-// WIDE DEAD ZONES: MUST CLEARLY ENTER A REGIME AND CLEARLY LEAVE IT.
+// REGIME THRESHOLDS (CHAOS-DRIVEN BANDS)
+// THE SCHMITT-TRIGGER ENTER/EXIT PAIR IS GONE. THESE TWO THRESHOLDS
+// DEFINE THE HIGH/LOW BANDS OF mean_idle_pct USED BY THE CHAOS-DRIVEN
+// REGIME DETECTOR: BOTH ENTRY AND EXIT GO THROUGH THE SAME WINDOWED
+// MEAN, AND THE HVG/BP PRIMITIVES DECIDE WHEN ORDER IS SUFFICIENT TO
+// LATCH LIGHT OR HEAVY (OTHERWISE MIXED).
 
-pub const HEAVY_ENTER_PCT: u64 = 10; // ENTER HEAVY: IDLE < 10%
-pub const HEAVY_EXIT_PCT: u64 = 25; // LEAVE HEAVY: IDLE > 25%
-pub const LIGHT_ENTER_PCT: u64 = 50; // ENTER LIGHT: IDLE > 50%
-pub const LIGHT_EXIT_PCT: u64 = 30; // LEAVE LIGHT: IDLE < 30%
+pub const HEAVY_ENTER_PCT: u64 = 10; // mean_idle <= THIS BAND -> CANDIDATE HEAVY
+pub const LIGHT_ENTER_PCT: u64 = 50; // mean_idle >= THIS BAND -> CANDIDATE LIGHT
 
 // REGIME PROFILES
 // PREEMPT_THRESH CONTROLS WHEN TICK PREEMPTS BATCH TASKS (IF INTERACTIVE WAITING).
@@ -18,17 +19,14 @@ pub const LIGHT_EXIT_PCT: u64 = 30; // LEAVE LIGHT: IDLE < 30%
 
 const LIGHT_SLICE_NS: u64 = 2_000_000; // 2MS
 const LIGHT_PREEMPT_NS: u64 = 1_000_000; // 1MS: AGGRESSIVE
-const LIGHT_LAG_SCALE: u64 = 6;
 const LIGHT_BATCH_NS: u64 = 20_000_000; // 20MS: NO CONTENTION, LET BATCH RIP
 
 const MIXED_SLICE_NS: u64 = 1_000_000; // 1MS: TIGHT INTERACTIVE CONTROL
 const MIXED_PREEMPT_NS: u64 = 1_000_000; // 1MS: MATCH FOR CLEAN ENFORCEMENT
-const MIXED_LAG_SCALE: u64 = 4;
 const MIXED_BATCH_NS: u64 = 20_000_000; // 20MS: MATCHES LIGHT/HEAVY/BPF DEFAULT
 
 const HEAVY_SLICE_NS: u64 = 4_000_000; // 4MS: WIDER FOR THROUGHPUT
 const HEAVY_PREEMPT_NS: u64 = 2_000_000; // 2MS: SLIGHTLY RELAXED
-const HEAVY_LAG_SCALE: u64 = 2;
 const HEAVY_BATCH_NS: u64 = 20_000_000; // 20MS: LET BATCH RIP
 
 // P99 CEILINGS
@@ -57,7 +55,6 @@ pub const AFFINITY_STRONG: u64 = 2;
 pub struct TuningKnobs {
     pub slice_ns: u64,
     pub preempt_thresh_ns: u64,
-    pub lag_scale: u64,
     pub batch_slice_ns: u64,
     pub lat_cri_thresh_high: u64,
     pub lat_cri_thresh_low: u64,
@@ -79,7 +76,6 @@ impl Default for TuningKnobs {
         Self {
             slice_ns: 1_000_000,
             preempt_thresh_ns: 1_000_000,
-            lag_scale: 4,
             batch_slice_ns: 20_000_000,
             lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
             lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
@@ -127,7 +123,6 @@ pub fn regime_knobs(r: Regime) -> TuningKnobs {
         Regime::Light => TuningKnobs {
             slice_ns: LIGHT_SLICE_NS,
             preempt_thresh_ns: LIGHT_PREEMPT_NS,
-            lag_scale: LIGHT_LAG_SCALE,
             batch_slice_ns: LIGHT_BATCH_NS,
             lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
             lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
@@ -140,7 +135,6 @@ pub fn regime_knobs(r: Regime) -> TuningKnobs {
         Regime::Mixed => TuningKnobs {
             slice_ns: MIXED_SLICE_NS,
             preempt_thresh_ns: MIXED_PREEMPT_NS,
-            lag_scale: MIXED_LAG_SCALE,
             batch_slice_ns: MIXED_BATCH_NS,
             lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
             lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
@@ -153,7 +147,6 @@ pub fn regime_knobs(r: Regime) -> TuningKnobs {
         Regime::Heavy => TuningKnobs {
             slice_ns: HEAVY_SLICE_NS,
             preempt_thresh_ns: HEAVY_PREEMPT_NS,
-            lag_scale: HEAVY_LAG_SCALE,
             batch_slice_ns: HEAVY_BATCH_NS,
             lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
             lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
@@ -192,7 +185,7 @@ fn scale_tau_u64(tau_ns: u64, k_q16: u64) -> u64 {
     (tau_ns as u128 * k_q16 as u128 >> 16) as u64
 }
 
-pub fn scaled_regime_knobs(r: Regime, _nr_cpus: u64, tau_ns: u64) -> TuningKnobs {
+pub fn scaled_regime_knobs(r: Regime, nr_cpus: u64, tau_ns: u64) -> TuningKnobs {
     let mut knobs = regime_knobs(r);
 
     let slice_cap_tau = scale_tau_u64(tau_ns, K_SLICE_CAP_Q16).clamp(500_000, 8_000_000);
@@ -201,6 +194,22 @@ pub fn scaled_regime_knobs(r: Regime, _nr_cpus: u64, tau_ns: u64) -> TuningKnobs
 
     knobs.slice_ns = knobs.slice_ns.min(slice_cap_tau);
     knobs.preempt_thresh_ns = knobs.preempt_thresh_ns.min(preempt_cap_tau);
+
+    // LOW-CORE SLICE CAP. tau IS LARGEST AT LOW CORE COUNT (lambda_2 SHRINKS
+    // AS CORES DROP), SO THE tau SLICE CAP ABOVE IS LOOSEST EXACTLY WHERE A
+    // WIDE BATCH SLICE DOES THE MOST DAMAGE: ON 2-4 CORES THE HEAVY PROFILE'S
+    // 4ms SLICE DENIES A LATENCY-SENSITIVE PROBE ACROSS MANY CONSECUTIVE
+    // SLICES, PRODUCING THE 50-200ms LONG-RUN/MIXED P99 TAIL AT LOW CORE.
+    // idle_pct READS LOW AT LOW CORE COUNT -- BECAUSE THE
+    // BPF WARM-STAY/PER-CPU LANDING DELIBERATELY BYPASSES THE IDLE FAST PATH
+    // -- SO THE REGIME FALSELY LATCHES HEAVY AND INHERITS ITS 4ms SLICE. THE
+    // BPF BASELINE RUNS 1ms HERE WITH NO SUCH TAIL, AND THE LONG-RUN WORK
+    // NUMBERS SHOW THE WIDE SLICE BUYS NO THROUGHPUT ON SO FEW CORES. CAP THE
+    // SLICE TO THE MIXED VALUE AT <=4 CORES; 8C/12C (WHERE ADAPTIVE WINS AND
+    // THE WIDER SLICE EARNS THROUGHPUT) ARE UNTOUCHED.
+    if nr_cpus <= 4 {
+        knobs.slice_ns = knobs.slice_ns.min(MIXED_SLICE_NS);
+    }
     if matches!(r, Regime::Mixed) {
         let batch_cap_tau = scale_tau_u64(tau_ns, K_BATCH_CAP_Q16).clamp(10_000_000, 80_000_000);
         knobs.batch_slice_ns = knobs.batch_slice_ns.min(batch_cap_tau);
@@ -210,35 +219,34 @@ pub fn scaled_regime_knobs(r: Regime, _nr_cpus: u64, tau_ns: u64) -> TuningKnobs
     knobs
 }
 
-// REGIME DETECTION (SCHMITT TRIGGER)
-// DIRECTION-AWARE: CURRENT REGIME DETERMINES WHICH THRESHOLDS APPLY.
-// DEAD ZONES PREVENT OSCILLATION THAT SINGLE-BOUNDARY DETECTION CAUSED.
+// REGIME DETECTION (CHAOS-DRIVEN)
+// THE SCHMITT TRIGGER IS GONE. REGIME IS A FUNCTION OF:
+//   - mean_idle_pct: WINDOWED MEAN OVER THE LAST N TICKS
+//   - hvg_lambda:    HVG MEAN DEGREE OF THE idle_pct WINDOW
+//   - bp_h:          BANDT-POMPE D=3 PERMUTATION ENTROPY OF THE WINDOW
+// HYSTERESIS IS BUILT INTO THE WINDOW: SAMPLES MUST FLOW IN BEFORE THE
+// MEAN MOVES. THE 2-TICK HOLD IN THE MONITOR LOOP STAYS AS ADDITIONAL
+// SMOOTHING.
+//
+// LIGHT  := mean_idle HIGH  AND CHAOS-LOW (PERIODIC / IDLE-DOMINATED)
+// HEAVY  := mean_idle LOW   AND CHAOS-LOW (PERIODIC / SATURATED)
+// MIXED  := ANYTHING ELSE (REGIME IS UNSTABLE OR IN MID-BAND)
+//
+// THE chaos_low PREDICATE IS lambda < CHAOTIC_MIN OR bp_h < BP_H_HIGH.
+// EITHER PRIMITIVE INDICATING ORDER IS ENOUGH; THEY MEASURE DIFFERENT
+// THINGS (AMPLITUDE-AWARE VS AMPLITUDE-INVARIANT) AND THE FIRST TO
+// FIRE LATCHES THE REGIME TO LIGHT/HEAVY INSTEAD OF MIXED.
 
-pub fn detect_regime(current: Regime, idle_pct: u64) -> Regime {
-    match current {
-        Regime::Light => {
-            if idle_pct < LIGHT_EXIT_PCT {
-                Regime::Mixed
-            } else {
-                Regime::Light
-            }
-        }
-        Regime::Mixed => {
-            if idle_pct > LIGHT_ENTER_PCT {
-                Regime::Light
-            } else if idle_pct < HEAVY_ENTER_PCT {
-                Regime::Heavy
-            } else {
-                Regime::Mixed
-            }
-        }
-        Regime::Heavy => {
-            if idle_pct > HEAVY_EXIT_PCT {
-                Regime::Mixed
-            } else {
-                Regime::Heavy
-            }
-        }
+pub fn detect_regime(mean_idle_pct: f64, hvg_lambda: f64, bp_h: f64) -> Regime {
+    let chaos_low =
+        hvg_lambda < crate::chaos::HVG_LAMBDA_CHAOTIC_MIN || bp_h < crate::chaos::BP_H_HIGH;
+
+    if chaos_low && mean_idle_pct >= LIGHT_ENTER_PCT as f64 {
+        Regime::Light
+    } else if chaos_low && mean_idle_pct <= HEAVY_ENTER_PCT as f64 {
+        Regime::Heavy
+    } else {
+        Regime::Mixed
     }
 }
 
@@ -306,21 +314,118 @@ pub fn compute_p99_from_histogram(counts: &[u64; HIST_BUCKETS]) -> u64 {
 }
 
 // MWU ORCHESTRATOR
-// SCHMITT-GATED MULTIPLICATIVE WEIGHT UPDATES ACROSS ALL 11 TUNING KNOBS.
+// MULTIPLICATIVE WEIGHT UPDATES ACROSS ALL 11 TUNING KNOBS.
 // 6 EXPERT PROFILES, EACH A SCALE FACTOR ON THE REGIME BASELINE.
-// CORRECTED SCALE FACTORS: sum(EQ[i] * SCALE[i]) = 1.0 FOR EACH CONTINUOUS KNOB.
 // DISCRETE KNOBS (LAG, AFFINITY, DEPTH) USE MAJORITY VOTE, NOT WEIGHTED AVERAGE.
-// 4 LOSS PATHWAYS: P99 SPIKE, RESCUE DELTA, IO DELTA, FORK STORM.
+// 5 LOSS PATHWAYS: P99 SPIKE, RESCUE DELTA, IO DELTA, FORK STORM, CHAOS TRANSITION.
 // 1e-6 WEIGHT FLOOR PREVENTS UNDERFLOW (DEAD WEIGHTS CAN'T RECOVER).
+// PATHWAYS FIRE IMMEDIATELY -- NO SCHMITT-STYLE STREAK CONFIRMATION.
+//
+// v5.11.0: WEIGHTS ARE PER-REGIME (ONE VECTOR PER Light/Mixed/Heavy).
+// ON A STEADY WORKLOAD THE REGIME IS CONSTANT, SO THE ACTIVE VECTOR
+// SEES A STATIONARY LOSS STREAM AND CONVERGES HARD INSTEAD OF BEING
+// RE-LITIGATED EVERY TICK. BUTTERWORTH-DAMPED WEIGHT UPDATE, ANCHORED
+// LEARNING RATE, NO-OP-SKEWED INIT + WARM-UP GATE, ADAPTIVE STEP SIZE,
+// COARSE DIRTY-TRACKING, AND A WEIGHT-VARIANCE CONVERGENCE DETECTOR
+// THAT FEEDS THE QUIESCENCE GATE.
 
 const N_EXPERTS: usize = 6;
-const ETA: f64 = 8.0;
+
+// ANCHORED LEARNING RATE. ETA = ETA_CONST * sqrt(ln(N_EXPERTS) / T),
+// ETA_CONST = 1.0, T = 16 (CHAOS_WIN horizon). sqrt(ln 6 / 16) =
+// sqrt(1.79176 / 16) = 0.33465. THE OLD FIXED 8.0 OVERSHOT; THIS IS
+// THE THEORY-OPTIMAL HEDGE/EXP3 RATE FOR THE WINDOW HORIZON. IF
+// LATENCY RESPONSE REGRESSES, ETA_CONST IS THE PRIMARY TUNING SURFACE
+// (RAISE TOWARD 2-3 BEFORE TOUCHING THE QUIESCENCE GATE).
+const ETA: f64 = 0.33465;
+
 const RELAX_RATE: f64 = 0.80;
-const SPIKE_CONFIRM: u32 = 2;
 const RELAX_HOLD: u32 = 2;
 const RELAX_CEIL_PCT: f64 = 0.70;
-const EQUILIBRIUM: [f64; N_EXPERTS] = [0.08, 0.44, 0.12, 0.12, 0.12, 0.12];
+
+// NO-OP-SKEWED INIT: DOMINANT MASS ON THE ANCHOR (EX_BALANCED, THE
+// "LEAVE KNOBS AT REGIME BASELINE" EXPERT WITH THE ALL-1.00 SCALE
+// COLUMN). THIS IS BOTH THE INITIAL VECTOR AND THE RELAX TARGET -- A
+// HEALTHY WORKLOAD RELAXES BACK TO "DO NOTHING", NOT TO A CONTESTED
+// MIDDLE. NOTE: THE FULLY-RELAXED BLEND SITS AT ~0.996x BASELINE (THE
+// THIN AGGRESSOR SPREAD), NOT EXACTLY BASELINE -- SUB-1%, WITHIN
+// RUN-TO-RUN NOISE, AND THE COARSE DIRTY-TRACKING MEANS A STEADY
+// WORKLOAD RETURNS THE EXACT CACHED KNOBS ANYWAY.
+const EQUILIBRIUM: [f64; N_EXPERTS] = [0.04, 0.80, 0.04, 0.04, 0.04, 0.04];
+
 const WEIGHT_FLOOR: f64 = 1e-6;
+
+// CROSS-CCX SCATTER THRESHOLD (PATHWAY 6). PLACEMENT-SIDE CROSS-CCX MIGRATION
+// FRACTION ABOVE THIS (PERCENT OF DISPATCHES) IS TREATED AS STORM PRESSURE.
+// EEVDF'S MEASURED BASELINE IS ~14%; 20 LEAVES HEADROOM SO NORMAL CROSS-CCX
+// WORK-CONSERVATION DOES NOT TRIP THE PATHWAY, ONLY A GENUINE SCATTER CLIMB.
+const SCATTER_THRESH_PCT: u64 = 20;
+
+// WARM-UP GATE: FOR THE FIRST WARMUP_TICKS CALLS PER REGIME, SCORE THE
+// LOSS PATHWAYS (KEEP prev_* EDGE STATE CURRENT) BUT SKIP THE WEIGHT
+// UPDATE AND RETURN BASELINE KNOBS. PREVENTS THE FIRST NOISY TICKS
+// AFTER START / REGIME CHANGE FROM YANKING KNOBS.
+const WARMUP_TICKS: u32 = 3;
+
+// DYNAMIC BUTTERWORTH DAMPING ON THE WEIGHT UPDATE. THE POST-LOSS /
+// POST-RELAX VECTOR IS LOW-PASS BLENDED TOWARD ITS ONE-TICK-AGO SELF
+// SO IT APPROACHES THE TARGET WITHOUT RINGING. THE BLEND COEFFICIENT
+// IS DRIVEN BY SIGNAL TRUST -- RQA-DET + HVG-LAMBDA -- NOT CPU COUNT.
+//
+// PRINCIPLE: BUTTERWORTH = MAXIMALLY-FLAT (FAITHFUL) TRACKING.
+// FAITHFUL TRACKING IS CORRECT ONLY WHEN THE SIGNAL IS TRUSTWORTHY;
+// WHEN THE SIGNAL IS ITSELF CHAOTIC, FAITHFUL TRACKING IS THE THING
+// THAT CAUSES THE CONTROLLER TO RING. SO DAMPING IS A FUNCTION OF
+// HOW STEADY THE WORKLOAD APPEARS:
+//   HIGH RQA-DET + lambda <= PERIODIC_MAX -> TRUST -> LIGHT DAMP (~0.85)
+//   LOW RQA-DET OR lambda >= CHAOTIC_MIN  -> NO TRUST -> HEAVY DAMP (0.50)
+//
+// REPLACED THE v5.10.0 CPU-COUNT CLIFF (0.707 BELOW 11 CPUS, 0.5 AT
+// OR ABOVE) WHICH DAMPED HARDER AT EXACTLY THE CORE COUNTS WHERE THE
+// CONTROLLER NEEDS THE MOST RESPONSIVENESS, PRODUCING THE 12C
+// REGRESSION CLUSTER (IPC BPF 12.9x, MIXED BPF 3.4x, LONGRUN
+// ADAPTIVE 2.2x). NR_CPUS NO LONGER PARTICIPATES IN DAMPING.
+const DAMP_LO: f64 = 0.50;
+const DAMP_HI: f64 = 0.85;
+// PENALTY APPLIED TO TRUST WHEN hvg_lambda CROSSES INTO THE
+// TRANSITION BAND (PERIODIC_MAX, CHAOTIC_MIN). LINEAR-RAMPED ACROSS
+// THE BAND; SATURATES AT 1.0 ONCE lambda >= CHAOTIC_MIN.
+const DAMP_LAMBDA_PENALTY: f64 = 0.20;
+// NEUTRAL TRUST WHEN RQA-DET IS NONE (WINDOW NOT FULL: NO RECURRENCE
+// EVIDENCE YET, NEITHER STEADY NOR CHAOTIC -- MIDDLE OF THE RANGE).
+const DAMP_TRUST_NEUTRAL: f64 = 0.5;
+
+// SIGNAL-TRUST -> DAMP COEFFICIENT. PURE FUNCTION OF THE TWO RAW
+// CHAOS SIGNALS ALREADY COMPUTED EVERY TICK FOR THE QUIESCENCE GATE.
+pub fn compute_damp(rqa_det: Option<f64>, hvg_lambda: f64) -> f64 {
+    let rqa_trust = rqa_det.unwrap_or(DAMP_TRUST_NEUTRAL);
+    let band = crate::chaos::HVG_LAMBDA_CHAOTIC_MIN - crate::chaos::HVG_LAMBDA_PERIODIC_MAX;
+    let lambda_penalty = if hvg_lambda > crate::chaos::HVG_LAMBDA_PERIODIC_MAX {
+        ((hvg_lambda - crate::chaos::HVG_LAMBDA_PERIODIC_MAX) / band).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let trust = (rqa_trust - DAMP_LAMBDA_PENALTY * lambda_penalty).clamp(0.0, 1.0);
+    DAMP_LO + (DAMP_HI - DAMP_LO) * trust
+}
+
+// ADAPTIVE STEP SIZE: step = STEP_BASE / (1 + residual), residual =
+// aggregate loss this tick. BIG DISTURBANCE -> SMALLER CORRECTIVE
+// STEP; STEADY -> step ~= STEP_BASE. FOLDED INTO THE DAMPING COEFF.
+const STEP_BASE: f64 = 1.0;
+
+// WEIGHT-VARIANCE CONVERGENCE DETECTOR. PER-REGIME RING OF THE LAST
+// VAR_HIST L1 WEIGHT-MOVEMENT SAMPLES. CONVERGED WHEN BOTH HALVES'
+// MEAN MOVEMENT ARE BELOW CONVERGE_MOVE_EPS AND THEIR RATIO IS WITHIN
+// [1 - DELTA, 1 + DELTA]. FEEDS THE QUIESCENCE GATE.
+const VAR_HIST: usize = 8;
+const CONVERGE_MOVE_EPS: f64 = 1e-3;
+const CONVERGE_RATIO_DELTA: f64 = 0.25;
+
+// COARSE DIRTY-TRACKING THRESHOLD: WHEN THE ACTIVE WEIGHT VECTOR MOVED
+// LESS THAN THIS (L1) THIS TICK, update() RETURNS THE CACHED BLEND
+// OUTPUT (last_knobs) AND SKIPS THE BLEND ENTIRELY.
+const WEIGHTS_MOVED_EPS: f64 = 1e-9;
 
 const EX_LATENCY: usize = 0;
 const EX_BALANCED: usize = 1;
@@ -341,13 +446,18 @@ const SC_SOJOURN: [f64; 6] = [0.80, 1.00, 1.60, 0.93, 0.53, 1.07];
 const SC_BURST: [f64; 6] = [0.74, 1.00, 1.47, 0.98, 0.49, 1.23];
 
 // DISCRETE KNOB VALUES (ABSOLUTE, NOT SCALE FACTORS)
-const DV_LAG: [u64; 6] = [6, 4, 3, 4, 4, 3];
+// FORK_STORM (INDEX 4) IS WEAK, NOT OFF: THE BPF READS affinity_mode ONLY AS
+// A BINARY GATE (main.bpf.c:1619, > 0) ON find_idle_l2_sibling. OFF DISABLES
+// THE L2 SIBLING PRE-FILTER, SO DURING A STORM WAKEES SEAT TOPOLOGY-BLIND AND
+// SCATTER CROSS-CCX -- FIGHTING THE PHI/WARM-STAY PLACEMENT INSTEAD OF HELPING.
+// WEAK KEEPS THE L2 PRE-FILTER ON. (STRONG VS WEAK IS A NO-OP TO THE BPF; ONLY
+// OFF DIFFERS.)
 const DV_AFFINITY: [u64; 6] = [
     AFFINITY_STRONG,
     AFFINITY_STRONG,
     AFFINITY_WEAK,
     AFFINITY_WEAK,
-    AFFINITY_OFF,
+    AFFINITY_WEAK,
     AFFINITY_WEAK,
 ];
 fn blend_continuous(base: u64, scales: &[f64; 6], w: &[f64; N_EXPERTS]) -> u64 {
@@ -395,6 +505,26 @@ pub struct MwuSignals {
     pub io_pct: u64,
     pub rescue_count: u64,
     pub wakeup_rate: u64,
+    // CROSS-CCX SCATTER FRACTION THIS TICK: PLACEMENT-SIDE CROSS-CCX LANDINGS
+    // (XCCX_SEL_* + XCCX_ENQ_T1, EXCLUDING THE PHI-CORRECT STEAL/STEP5 WORK-
+    // CONSERVATION PATHS) AS A PERCENTAGE OF DISPATCHES. EEVDF BASELINE ~14%;
+    // PANDEMONIUM'S STORM REGRESSION RAN ~48%. PATHWAY 6 KEYS ON THIS SO MWU
+    // CAN SEE THE MIGRATION STORM IT MIGHT BE INDUCING AND STEER AWAY FROM IT.
+    pub scatter_pct: u64,
+    // CHAOS PRIMITIVES (RAW-WINDOW DERIVED, NO EWMA, NO SCHMITT).
+    // hvg_lambda     := HVG MEAN DEGREE OF THE idle_pct WINDOW
+    // bp_h_delta     := bp_h(THIS TICK) - bp_h(PREVIOUS TICK), WHERE
+    //                   bp_h IS BANDT-POMPE D=3 PERMUTATION ENTROPY ON
+    //                   THE wakeup_rate WINDOW, NORMALIZED TO [0, 1].
+    //                   POSITIVE = WORKLOAD ENTERED A MORE-DISORDERED
+    //                   ORDINAL REGIME WITHIN THE LAST SECOND.
+    pub hvg_lambda: f64,
+    pub bp_h_delta: f64,
+    // RQA DETERMINISM OVER THE SAME idle_pct WINDOW HVG SEES.
+    // 1.0 = PERFECTLY RECURRENT, 0.0 = NO RECURRENCE, None = WINDOW
+    // NOT YET FULL. CONSUMED BY compute_damp() AS THE PRIMARY TRUST
+    // SIGNAL FOR THE DYNAMIC BUTTERWORTH BLEND.
+    pub rqa_det: Option<f64>,
 }
 
 // SNAPSHOT OF THE BPF DAMPED-HARMONIC OSCILLATOR'S ADAPTIVE STATE.
@@ -410,6 +540,13 @@ pub struct OscillatorState {
     pub codel_target_ns: u64,
     pub codel_target_floor_ns: u64,
     pub codel_target_max_ns: u64,
+    // HOME NEAREST-PEER PHI HOLD (reff_value SLOT 0, ns). THE BPF WARM-STAY
+    // AND STEP-1 R_eff STEAL RELEASE AT codel_target_ns + THIS, NOT AT THE
+    // BARE CODEL WINDOW. position() MEASURES THE BARE WINDOW; THE ABSOLUTE
+    // CHECKS BELOW ADD THIS TERM SO THE DEFER DECISION IS TAKEN AGAINST THE
+    // EFFECTIVE PHI RELEASE POINT THE BPF ACTUALLY USES. 0 = READBACK
+    // UNAVAILABLE -> TREATED AS NO EXTRA HOLD (NEUTRAL).
+    pub home_dist_extra_ns: u64,
 }
 
 impl OscillatorState {
@@ -425,45 +562,125 @@ impl OscillatorState {
             .saturating_sub(self.codel_target_floor_ns) as f64;
         (pos / range).clamp(0.0, 1.0)
     }
+
+    // EFFECTIVE PHI RELEASE POINT: WHERE WARM-STAY / STEP-1 STEAL ACTUALLY LET
+    // A TASK LEAVE HOME (codel_target + NEAREST-PEER HOLD). THE DEFER GATE
+    // COMPARES THIS AGAINST codel_eq TO DECIDE WHETHER THE BPF HAS GENUINELY
+    // RESPONDED, RATHER THAN TRUSTING THE BARE-WINDOW position() ALONE.
+    pub fn effective_release_ns(&self) -> u64 {
+        self.codel_target_ns.saturating_add(self.home_dist_extra_ns)
+    }
 }
 
 pub struct MwuController {
-    weights: [f64; N_EXPERTS],
+    // PER-REGIME WEIGHT VECTORS, INDEXED BY `regime as usize`
+    // (Light=0, Mixed=1, Heavy=2). EACH REGIME KEEPS ITS OWN LEARNED
+    // VECTOR INSTEAD OF BEING RESET ON EVERY TRANSITION.
+    weights: [[f64; N_EXPERTS]; 3],
+    // ONE-TICK-AGO SNAPSHOT PER REGIME -- THE BUTTERWORTH DAMPING
+    // TARGET AND THE L1-MOVEMENT REFERENCE.
+    prev_weights: [[f64; N_EXPERTS]; 3],
+    // PER-REGIME RING OF L1 WEIGHT-MOVEMENT SAMPLES (CONVERGENCE).
+    weight_move_hist: [[f64; VAR_HIST]; 3],
+    move_hist_head: [usize; 3],
+    move_hist_filled: [usize; 3],
     baseline: TuningKnobs,
-    spike_streak: u32,
+    // CACHED BLEND OUTPUT -- RETURNED DIRECTLY WHEN THE ACTIVE VECTOR
+    // DID NOT MOVE THIS TICK (COARSE DIRTY-TRACKING).
+    last_knobs: TuningKnobs,
     healthy_streak: u32,
-    fork_streak: u32,
+    // WARM-UP GATE COUNTER, RESET PER REGIME CHANGE.
+    warmup_ticks: u32,
     prev_io_bucket: IoBucket,
     prev_rescuing: bool,
+    prev_lambda_chaotic: bool,
+    // LAST TICK'S CROSS-CCX SCATTER %. PATHWAY 6 IS RISING-EDGE GATED ON THIS
+    // SO A STABLE HIGH-SCATTER REGIME (E.G. 8C+ THROUGHPUT WHERE IT WINS) IS
+    // NOT PENALIZED -- ONLY A CLIMBING STORM IS.
+    prev_scatter_pct: u64,
     losses_applied: bool,
+    // TRUE WHEN THE ACTIVE WEIGHT VECTOR MOVED THIS TICK.
+    weights_changed: bool,
 }
 
 impl MwuController {
     pub fn new(baseline: TuningKnobs) -> Self {
         Self {
-            weights: EQUILIBRIUM,
+            weights: [EQUILIBRIUM; 3],
+            prev_weights: [EQUILIBRIUM; 3],
+            weight_move_hist: [[0.0; VAR_HIST]; 3],
+            move_hist_head: [0; 3],
+            move_hist_filled: [0; 3],
             baseline,
-            spike_streak: 0,
+            last_knobs: baseline,
             healthy_streak: 0,
-            fork_streak: 0,
+            warmup_ticks: 0,
             prev_io_bucket: IoBucket::Mid,
             prev_rescuing: false,
+            prev_lambda_chaotic: false,
+            prev_scatter_pct: 0,
             losses_applied: false,
+            weights_changed: false,
         }
     }
 
-    pub fn reset(&mut self) {
-        self.weights = EQUILIBRIUM;
-        self.spike_streak = 0;
+    // RESET ONE REGIME'S WEIGHT VECTOR + THE CROSS-PATHWAY EDGE STATE.
+    // CALLED BY THE MONITOR LOOP ON A REGIME TRANSITION: a regime change
+    // IS A DISTURBANCE; STALE EDGE STATE SHOULD NOT CARRY OVER, AND THE
+    // WARM-UP GATE RE-ARMS.
+    pub fn reset_regime(&mut self, r: Regime) {
+        let ri = r as usize;
+        self.weights[ri] = EQUILIBRIUM;
+        self.prev_weights[ri] = EQUILIBRIUM;
+        self.weight_move_hist[ri] = [0.0; VAR_HIST];
+        self.move_hist_head[ri] = 0;
+        self.move_hist_filled[ri] = 0;
         self.healthy_streak = 0;
-        self.fork_streak = 0;
+        self.warmup_ticks = 0;
         self.prev_io_bucket = IoBucket::Mid;
         self.prev_rescuing = false;
+        self.prev_lambda_chaotic = false;
+        self.prev_scatter_pct = 0;
         self.losses_applied = false;
+        self.weights_changed = false;
+        self.last_knobs = self.baseline;
     }
 
     pub fn set_baseline(&mut self, baseline: TuningKnobs) {
         self.baseline = baseline;
+    }
+
+    // WEIGHT-VARIANCE CONVERGENCE DETECTOR. TRUE WHEN THE ACTIVE
+    // REGIME'S WEIGHT VECTOR HAS STOPPED MOVING -- BOTH HALVES OF THE
+    // MOVEMENT RING BELOW CONVERGE_MOVE_EPS AND THEIR RATIO NEAR 1.
+    // RETURNS FALSE UNTIL THE RING HAS FILLED (NO FREEZING ON A FRESH
+    // OR JUST-RESET CONTROLLER).
+    pub fn converged(&self, r: Regime) -> bool {
+        let ri = r as usize;
+        if self.move_hist_filled[ri] < VAR_HIST {
+            return false;
+        }
+        let hist = &self.weight_move_hist[ri];
+        let head = self.move_hist_head[ri];
+        let half = VAR_HIST / 2;
+        let mut recent = 0.0;
+        let mut older = 0.0;
+        for k in 0..half {
+            recent += hist[(head + VAR_HIST - 1 - k) % VAR_HIST];
+            older += hist[(head + k) % VAR_HIST];
+        }
+        let recent_mean = recent / half as f64;
+        let older_mean = older / half as f64;
+        if recent_mean >= CONVERGE_MOVE_EPS || older_mean >= CONVERGE_MOVE_EPS {
+            return false;
+        }
+        // BOTH HALVES BELOW EPS. IF THE OLDER HALF IS ESSENTIALLY ZERO
+        // BOTH ARE ZERO -> CONVERGED. OTHERWISE REQUIRE THE RATIO NEAR 1
+        // (NOT STILL DECAYING).
+        if older_mean < 1e-12 {
+            return true;
+        }
+        ((recent_mean / older_mean) - 1.0).abs() <= CONVERGE_RATIO_DELTA
     }
 
     pub fn update(
@@ -473,7 +690,9 @@ impl MwuController {
         _nr_cpus: u64,
         tau_ns: u64,
         osc: &OscillatorState,
+        regime: Regime,
     ) -> TuningKnobs {
+        let ri = regime as usize;
         let worst = sig.p99_ns.max(sig.interactive_p99_ns);
         let above = worst > ceiling;
         let below_relax = (worst as f64) < (ceiling as f64 * RELAX_CEIL_PCT);
@@ -488,29 +707,38 @@ impl MwuController {
         // POSITION 0.0 = TIGHTENED (FLOOR), 1.0 = RELAXED (MAX).
         // < 0.40 -> BPF HAS RESPONDED HEAVILY; SKIP RESCUE-DRIVEN LOSSES.
         // > 0.90 -> BPF SAYS QUIET; RESCUE BURSTS ARE STALE NOISE; SKIP.
+        //
+        // position() MEASURES THE BARE codel WINDOW, BUT THE BPF ACTUALLY
+        // RELEASES WARM-STAY / STEP-1 STEAL AT codel_target + home_dist_extra
+        // (THE NEAREST-PEER PHI HOLD). WITH A LARGE HOLD THE BARE POSITION CAN
+        // READ "LOOSE" WHILE THE EFFECTIVE RELEASE IS STILL HARD, AND MWU WOULD
+        // WRONGLY STAY OUT OF GENUINE RESCUE PRESSURE. CONFIRM EACH SIDE WITH
+        // THE EFFECTIVE RELEASE VS THE PHI EQUILIBRIUM (codel_eq, FROM THE
+        // BASELINE): ONLY TREAT THE OSCILLATOR AS TIGHT WHEN THE EFFECTIVE
+        // RELEASE IS BELOW EQUILIBRIUM, AND AS LOOSE WHEN IT IS ABOVE. WITH
+        // home_dist_extra_ns = 0 (READBACK UNAVAILABLE) THIS REDUCES TO THE
+        // BARE-POSITION BEHAVIOR. codel_eq = 0 (UNSEEDED) DISABLES THE ABSOLUTE
+        // QUALIFIER (THE BARE POSITION GOVERNS), NEVER GATING SPURIOUSLY.
         let osc_pos = osc.position();
-        let osc_already_tight = osc_pos < 0.40;
-        let osc_already_loose = osc_pos > 0.90;
+        let eff_release = osc.effective_release_ns();
+        let codel_eq = self.baseline.codel_eq_ns;
+        let osc_already_tight = osc_pos < 0.40 && (codel_eq == 0 || eff_release < codel_eq);
+        let osc_already_loose = osc_pos > 0.90 && (codel_eq == 0 || eff_release > codel_eq);
         let defer_to_oscillator = osc_already_tight || osc_already_loose;
 
         let mut losses = [0.0f64; N_EXPERTS];
         let mut has_loss = false;
 
-        // PATHWAY 1: P99 SPIKE (SCHMITT-GATED)
+        // PATHWAY 1: P99 SPIKE (FIRES IMMEDIATELY)
         if above {
             self.healthy_streak = 0;
-            self.spike_streak += 1;
-            if self.spike_streak >= SPIKE_CONFIRM {
-                let v = ((worst - ceiling) as f64 / ceiling as f64).min(3.0);
-                losses[EX_BALANCED] += v * 0.5;
-                losses[EX_THROUGHPUT] += v * 1.0;
-                losses[EX_IO_HEAVY] += v * 0.6;
-                losses[EX_FORK_STORM] += v * 0.3;
-                losses[EX_SATURATED] += v * 0.9;
-                has_loss = true;
-            }
-        } else {
-            self.spike_streak = 0;
+            let v = ((worst - ceiling) as f64 / ceiling as f64).min(3.0);
+            losses[EX_BALANCED] += v * 0.5;
+            losses[EX_THROUGHPUT] += v * 1.0;
+            losses[EX_IO_HEAVY] += v * 0.6;
+            losses[EX_FORK_STORM] += v * 0.3;
+            losses[EX_SATURATED] += v * 0.9;
+            has_loss = true;
         }
 
         // PATHWAY 2: RESCUE DELTA (0 -> NONZERO TRANSITION)
@@ -553,13 +781,14 @@ impl MwuController {
         }
         self.prev_io_bucket = cur_io;
 
-        // PATHWAY 4: FORK STORM (SCHMITT-GATED, PRESSURE-CONFIRMED).
+        // PATHWAY 4: FORK STORM (PRESSURE-CONFIRMED, FIRES IMMEDIATELY).
         // GATE THRESHOLD IS TAU-DERIVED. sig.wakeup_rate IS THE RAW TOTAL
         // WAKES/SEC; scale_tau_u64(tau, K_FORK_STORM_RATE_Q16) PRODUCES
         // THE COMPARISON THRESHOLD. AT THE 12C REFERENCE (tau=40MS) THE
         // THRESHOLD IS ~8000/SEC; AT 4C IT TIGHTENS TO ~1200/SEC. A FORK
         // STORM ALSO REQUIRES ACTIVE RESCUES (rescue_count > 0) AS GROUND-
-        // TRUTH PRESSURE.
+        // TRUTH PRESSURE -- THE PRESSURE PREDICATE IS THE CONFIRMATION;
+        // NO ADDITIONAL STREAK COUNTER.
         //
         // FORK_STORM EXPERT (SC_SLICE=0.49, SC_PREEMPT=0.49, SC_BATCH=0.52,
         // SC_SOJOURN=0.53, SC_BURST=0.49) DOMINATES THE BLEND DURING A REAL
@@ -567,83 +796,227 @@ impl MwuController {
         // / batch_slice_ns DOWN END-TO-END.
         let fork_thresh = scale_tau_u64(tau_ns, K_FORK_STORM_RATE_Q16).max(FORK_STORM_RATE_FLOOR);
         let fork_storm = sig.wakeup_rate > fork_thresh && sig.rescue_count > 0;
-        if fork_storm {
-            self.fork_streak += 1;
-            if self.fork_streak >= SPIKE_CONFIRM && !defer_to_oscillator {
-                let denom = fork_thresh.max(1) as f64;
-                let v = ((sig.wakeup_rate as f64 / denom) - 1.0).clamp(0.0, 3.0);
-                losses[EX_BALANCED] += v * 0.30;
-                losses[EX_THROUGHPUT] += v * 1.00;
-                losses[EX_IO_HEAVY] += v * 0.50;
-                losses[EX_SATURATED] += v * 0.80;
-                has_loss = true;
-            }
-        } else {
-            self.fork_streak = 0;
+        if fork_storm && !defer_to_oscillator {
+            let denom = fork_thresh.max(1) as f64;
+            let v = ((sig.wakeup_rate as f64 / denom) - 1.0).clamp(0.0, 3.0);
+            losses[EX_BALANCED] += v * 0.30;
+            losses[EX_THROUGHPUT] += v * 1.00;
+            losses[EX_IO_HEAVY] += v * 0.50;
+            losses[EX_SATURATED] += v * 0.80;
+            has_loss = true;
         }
 
-        // APPLY LOSSES WITH WEIGHT FLOOR
+        // PATHWAY 5: CHAOS TRANSITION (RAW-WINDOW, NO EWMA, NO SCHMITT)
+        // FIRES WHEN THE WORKLOAD'S ORDINAL OR AMPLITUDE-DEGREE STRUCTURE
+        // SHIFTS WITHIN THE LAST WINDOW. THE FAILED-PREDICTION INTERPRETATION
+        // IS: WHICHEVER EXPERT IS CURRENTLY DOMINANT WAS PRICED FOR THE
+        // PREVIOUS WINDOW; PENALIZE IT PROPORTIONAL TO THE TRANSITION SIZE
+        // SO THE BLEND RAPIDLY RE-WEIGHTS TOWARD BALANCED / SATURATED.
+        // EX_BALANCED IS EXEMPT (IT IS THE REGIME-AGNOSTIC BASELINE).
+        //
+        // GATE CONDITIONS (EITHER FIRES):
+        //   - bp_h_delta > 0.10   (>10% NORMALIZED PERMUTATION-ENTROPY JUMP)
+        //   - hvg_lambda CROSSED CHAOTIC_MIN UPWARD
+        let bp_jump = sig.bp_h_delta > 0.10;
+        let lambda_cross =
+            sig.hvg_lambda >= crate::chaos::HVG_LAMBDA_CHAOTIC_MIN && !self.prev_lambda_chaotic;
+        let chaos_transition = bp_jump || lambda_cross;
+        if chaos_transition {
+            // SIZE OF THE LOSS: SCALES WITH WHICHEVER GATE TRIGGERED HARDER.
+            let v_bp = (sig.bp_h_delta / 0.10).clamp(0.0, 3.0);
+            let v_l = if lambda_cross {
+                ((sig.hvg_lambda - crate::chaos::HVG_LAMBDA_CHAOTIC_MIN)
+                    / (4.0 - crate::chaos::HVG_LAMBDA_CHAOTIC_MIN))
+                    .clamp(0.0, 1.5)
+            } else {
+                0.0
+            };
+            let v = v_bp.max(v_l);
+            // FIND THE DOMINANT EXPERT (HIGHEST WEIGHT) AND PENALIZE IT.
+            // EX_BALANCED IS EXEMPT (THE ANCHOR IS NEVER PENALIZED).
+            let mut dom_idx = EX_BALANCED;
+            let mut dom_w = 0.0f64;
+            for i in 0..N_EXPERTS {
+                if i == EX_BALANCED {
+                    continue;
+                }
+                if self.weights[ri][i] > dom_w {
+                    dom_w = self.weights[ri][i];
+                    dom_idx = i;
+                }
+            }
+            if dom_idx != EX_BALANCED && dom_w > 0.0 {
+                losses[dom_idx] += v * 0.8;
+                has_loss = true;
+            }
+        }
+        self.prev_lambda_chaotic = sig.hvg_lambda >= crate::chaos::HVG_LAMBDA_CHAOTIC_MIN;
+
+        // PATHWAY 6: CROSS-CCX SCATTER (PHI-AWARE, RISING-EDGE GATED).
+        // sig.scatter_pct IS THE PLACEMENT-SIDE CROSS-CCX MIGRATION FRACTION
+        // (XCCX_SEL_* + XCCX_ENQ_T1, EXCLUDING THE PHI-CORRECT STEAL/STEP5
+        // WORK-CONSERVATION PATHS -- COMPUTED IN THE ADAPTIVE LOOP). WHEN IT
+        // CLIMBS PAST THE EEVDF-BASELINE HEADROOM THE BLEND HAS DRIFTED TOWARD
+        // EXPERTS THAT SCATTER WAKEES THE BPF WARM-STAY/PER-CPU LANDING TRIED
+        // TO KEEP HOME. PENALIZE THE EXPERTS THAT FAVOR WIDE SLICES + WEAK/OFF
+        // AFFINITY (THROUGHPUT, SATURATED, FORK_STORM) SO THE BLEND RE-WEIGHTS
+        // TOWARD LATENCY/BALANCED AND AFFINITY STRONG, ALIGNING THE ADAPTIVE
+        // LAYER WITH PHI PLACEMENT INSTEAD OF FIGHTING IT.
+        //
+        // RISING-EDGE: ONLY FIRES WHILE SCATTER IS HIGH AND INCREASING. A
+        // STABLE HIGH-SCATTER REGIME (8C+ THROUGHPUT, WHERE WIDE-SLICE SCATTER
+        // IS A WINNING TRADE) PLATEAUS AND IS NOT PENALIZED -- ONLY A CLIMBING
+        // STORM IS. EX_BALANCED/EX_LATENCY ARE NEVER PENALIZED (THEY ARE THE
+        // DIRECTION WE WANT THE BLEND TO MOVE TOWARD).
+        let scatter_high = sig.scatter_pct > SCATTER_THRESH_PCT;
+        let scatter_rising = scatter_high && sig.scatter_pct > self.prev_scatter_pct;
+        if scatter_rising {
+            let v = ((sig.scatter_pct as f64 - SCATTER_THRESH_PCT as f64)
+                / SCATTER_THRESH_PCT as f64)
+                .clamp(0.0, 3.0);
+            losses[EX_THROUGHPUT] += v * 1.00;
+            losses[EX_SATURATED] += v * 0.80;
+            losses[EX_FORK_STORM] += v * 0.60;
+            has_loss = true;
+        }
+        self.prev_scatter_pct = sig.scatter_pct;
+
+        // WARM-UP GATE. THE PATHWAYS ABOVE HAVE SCORED `losses` AND
+        // UPDATED THE prev_* EDGE STATE. FOR THE FIRST WARMUP_TICKS
+        // CALLS PER REGIME, SKIP THE WEIGHT UPDATE ENTIRELY AND RETURN
+        // BASELINE -- THE FIRST NOISY TICKS AFTER START / REGIME CHANGE
+        // MUST NOT YANK KNOBS.
+        if self.warmup_ticks < WARMUP_TICKS {
+            self.warmup_ticks += 1;
+            self.losses_applied = has_loss;
+            self.weights_changed = false;
+            let mut k = self.baseline;
+            k.topology_tau_ns = 0;
+            k.codel_eq_ns = 0;
+            self.last_knobs = k;
+            return k;
+        }
+
+        // ACTIVE WEIGHT VECTOR -- LOCAL COPY, MUTATED THROUGH THE
+        // LOSS / RELAX / DAMP STAGES THEN COMMITTED BACK.
+        let mut w = self.weights[ri];
+
+        // APPLY LOSSES WITH WEIGHT FLOOR.
         if has_loss {
             for i in 0..N_EXPERTS {
                 if losses[i] > 0.0 {
-                    self.weights[i] *= (-ETA * losses[i]).exp();
+                    w[i] *= (-ETA * losses[i]).exp();
                 }
-                if self.weights[i] < WEIGHT_FLOOR {
-                    self.weights[i] = WEIGHT_FLOOR;
+                if w[i] < WEIGHT_FLOOR {
+                    w[i] = WEIGHT_FLOOR;
                 }
             }
-            let sum: f64 = self.weights.iter().sum();
-            for w in self.weights.iter_mut() {
-                *w /= sum;
+            let sum: f64 = w.iter().sum();
+            for x in w.iter_mut() {
+                *x /= sum;
             }
         }
 
-        // RELAXATION
+        // RELAXATION -- TOWARD THE NO-OP-SKEWED EQUILIBRIUM.
         if !has_loss && below_relax {
             self.healthy_streak += 1;
             if self.healthy_streak >= RELAX_HOLD {
                 for i in 0..N_EXPERTS {
-                    self.weights[i] =
-                        (1.0 - RELAX_RATE) * self.weights[i] + RELAX_RATE * EQUILIBRIUM[i];
+                    w[i] = (1.0 - RELAX_RATE) * w[i] + RELAX_RATE * EQUILIBRIUM[i];
                 }
             }
         } else if !has_loss {
             self.healthy_streak = 0;
         }
 
+        // DYNAMIC BUTTERWORTH DAMPING + ADAPTIVE STEP. `w` IS NOW THE
+        // RAW POST-LOSS / POST-RELAX TARGET; LOW-PASS BLEND IT TOWARD
+        // THE ONE-TICK-AGO VECTOR. DAMP IS DRIVEN BY SIGNAL TRUST
+        // (RQA-DET + HVG-LAMBDA), NOT CPU COUNT -- SEE compute_damp.
+        // residual = aggregate loss this tick: a big disturbance takes
+        // a smaller corrective step (anti-overshoot governor).
+        let residual: f64 = losses.iter().sum();
+        let step = STEP_BASE / (1.0 + residual);
+        let damp = compute_damp(sig.rqa_det, sig.hvg_lambda);
+        let eff = (damp * step).clamp(0.0, 1.0);
+        let prev = self.prev_weights[ri];
+        for i in 0..N_EXPERTS {
+            w[i] = eff * w[i] + (1.0 - eff) * prev[i];
+            if w[i] < WEIGHT_FLOOR {
+                w[i] = WEIGHT_FLOOR;
+            }
+        }
+        let sum: f64 = w.iter().sum();
+        for x in w.iter_mut() {
+            *x /= sum;
+        }
+
+        // L1 MOVEMENT FROM LAST TICK -- FEEDS THE CONVERGENCE DETECTOR.
+        let mut move_l1 = 0.0;
+        for i in 0..N_EXPERTS {
+            move_l1 += (w[i] - prev[i]).abs();
+        }
+        let h = self.move_hist_head[ri];
+        self.weight_move_hist[ri][h] = move_l1;
+        self.move_hist_head[ri] = (h + 1) % VAR_HIST;
+        if self.move_hist_filled[ri] < VAR_HIST {
+            self.move_hist_filled[ri] += 1;
+        }
+
+        // COMMIT: w_new IS BOTH THE ACTIVE VECTOR AND NEXT TICK'S
+        // prev SNAPSHOT.
+        self.weights[ri] = w;
+        self.prev_weights[ri] = w;
+        self.weights_changed = move_l1 > WEIGHTS_MOVED_EPS;
         self.losses_applied = has_loss;
 
-        // BLEND: CONTINUOUS KNOBS VIA CORRECTED SCALE FACTORS, DISCRETE VIA MAJORITY
-        let b = &self.baseline;
-        let blended_slice = blend_continuous(b.slice_ns, &SC_SLICE, &self.weights);
-        let blended_burst = blend_continuous(b.burst_slice_ns, &SC_BURST, &self.weights);
-        let mut blended_sojourn = blend_continuous(b.sojourn_thresh_ns, &SC_SOJOURN, &self.weights);
+        // COARSE DIRTY-TRACKING: IF THE VECTOR DID NOT MOVE, THE BLEND
+        // OUTPUT IS IDENTICAL TO LAST TICK -- RETURN THE CACHE AND SKIP
+        // THE BLEND ENTIRELY.
+        if !self.weights_changed {
+            return self.last_knobs;
+        }
 
-        // SOJOURN FLOOR: dispatch waterfall services aged overflow at
-        // overflow_sojourn_rescue_ns (BPF-side, tau-clamped to [4ms, 10ms]).
-        // tick() also kicks per-CPU DSQs whose oldest task has aged past
-        // sojourn_thresh_ns. If MWU drives sojourn_thresh_ns below the
-        // dispatch service window + one slice, every tick generates kicks
-        // on per-CPU DSQs that the dispatcher will service on the next
-        // dispatch anyway -- a kick storm. Floor against the worst-case
-        // dispatch service window to prevent it.
-        let sojourn_floor = 4_000_000u64.saturating_add(blended_slice);
+        // BLEND: CONTINUOUS KNOBS VIA SCALE FACTORS, DISCRETE VIA MAJORITY.
+        let b = &self.baseline;
+        let blended_slice = blend_continuous(b.slice_ns, &SC_SLICE, &w);
+        let blended_burst = blend_continuous(b.burst_slice_ns, &SC_BURST, &w);
+        let mut blended_sojourn = blend_continuous(b.sojourn_thresh_ns, &SC_SOJOURN, &w);
+
+        // SOJOURN FLOOR: tick() KICKS PER-CPU DSQs WHOSE OLDEST TASK HAS AGED
+        // PAST sojourn_thresh_ns (BPF, main.bpf.c:2374). THAT EVICTION DEADLINE
+        // MUST NOT SIT ABOVE THE THRESHOLD WARM-STAY / STEP-1 R_eff STEAL
+        // ACTUALLY RELEASE AT, OR THE ADAPTIVE LAYER HOLDS TASKS LONG PAST THE
+        // POINT THE PHI GATES ASSUMED RELIEF HAD ARRIVED (THE 2C/4C LONG-RUN /
+        // LAT P99 TAIL). THE BPF OVERFLOW RESCUE IS NO LONGER "[4ms,10ms]" --
+        // IT WAS REWIRED TO THE PHI EQUILIBRIUM (overflow_sojourn_rescue_ns =
+        // codel_target_equilibrium_ns, main.bpf.c:995), SUB-MS AT LOW CORE.
+        // ANCHOR THE FLOOR TO THAT SAME PHI-DERIVED EQUILIBRIUM SO USERSPACE
+        // EVICTION AND THE BPF PHI RELEASE AGREE. THE +blended_slice TERM IS
+        // THE GENUINE DISPATCH-SERVICE-WINDOW GUARD (KEPT). codel_eq_ns CAN BE
+        // SEEDED 0 BY MwuController::new BEFORE THE TOPOLOGY OVERLAY LANDS --
+        // GUARD AGAINST COLLAPSING THE FLOOR AND REINTRODUCING THE KICK STORM.
+        let floor_base = if b.codel_eq_ns >= 200_000 {
+            b.codel_eq_ns
+        } else {
+            4_000_000
+        };
+        let sojourn_floor = floor_base.saturating_add(blended_slice);
         if blended_sojourn < sojourn_floor {
             blended_sojourn = sojourn_floor;
         }
 
-        TuningKnobs {
+        let k = TuningKnobs {
             slice_ns: blended_slice,
-            preempt_thresh_ns: blend_continuous(b.preempt_thresh_ns, &SC_PREEMPT, &self.weights),
-            lag_scale: majority_discrete(&DV_LAG, &self.weights),
-            batch_slice_ns: blend_continuous(b.batch_slice_ns, &SC_BATCH, &self.weights),
-            lat_cri_thresh_high: blend_continuous(
-                b.lat_cri_thresh_high,
-                &SC_LCRI_HI,
-                &self.weights,
-            ),
-            lat_cri_thresh_low: blend_continuous(b.lat_cri_thresh_low, &SC_LCRI_LO, &self.weights),
-            affinity_mode: majority_discrete(&DV_AFFINITY, &self.weights),
+            // FLOOR AT REGIME BASELINE: MWU may loosen preempt (raise it) but
+            // never tighten below baseline -- sub-ms preempt at 2C thrashed the
+            // longrun (the ADAPTIVE 2C tail). No-op where MWU stays above it.
+            preempt_thresh_ns: blend_continuous(b.preempt_thresh_ns, &SC_PREEMPT, &w)
+                .max(b.preempt_thresh_ns),
+            batch_slice_ns: blend_continuous(b.batch_slice_ns, &SC_BATCH, &w),
+            lat_cri_thresh_high: blend_continuous(b.lat_cri_thresh_high, &SC_LCRI_HI, &w),
+            lat_cri_thresh_low: blend_continuous(b.lat_cri_thresh_low, &SC_LCRI_LO, &w),
+            affinity_mode: majority_discrete(&DV_AFFINITY, &w),
             sojourn_thresh_ns: blended_sojourn,
             burst_slice_ns: blended_burst,
             // topology_tau_ns AND codel_eq_ns ARE OWNED BY THE TOPOLOGY LAYER;
@@ -651,15 +1024,116 @@ impl MwuController {
             // VALUES BACK ONTO MWU'S OUTPUT BEFORE WRITING -- PASSTHROUGH.
             topology_tau_ns: 0,
             codel_eq_ns: 0,
-        }
+        };
+        self.last_knobs = k;
+        k
     }
 
     pub fn had_losses(&self) -> bool {
         self.losses_applied
     }
 
-    pub fn scale(&self) -> f64 {
-        let s: f64 = (0..N_EXPERTS).map(|i| self.weights[i] * SC_SLICE[i]).sum();
-        s
+    pub fn scale(&self, r: Regime) -> f64 {
+        let w = &self.weights[r as usize];
+        (0..N_EXPERTS).map(|i| w[i] * SC_SLICE[i]).sum()
     }
+}
+
+// QUIESCENCE GATE
+// DETECTS STEADY STATE CHEAPLY AND LATCHES A "FROZEN" FLAG THAT TELLS
+// THE MONITOR LOOP TO SKIP THE EXPENSIVE MWU RETUNE + KNOB WRITE. THE
+// LOOP STILL TICKS AT 1 HZ -- THE CHAOS SENSORS ARE THE EXIT CONDITION
+// FOR FROZEN MODE -- BUT THE ORCHESTRATOR MACHINERY STOPS.
+//
+// STEADY STATE IS THE CONJUNCTION OF THREE SIGNALS, HELD FOR
+// QUIESCE_ENTER_TICKS CONSECUTIVE TICKS:
+//   - HVG MEAN DEGREE IN THE PERIODIC BAND (lambda <= PERIODIC_MAX);
+//     NOTE THE Engine A/B SHORTHAND "lambda ~= ln(3/2)" REFERS TO THE
+//     IID *CHARACTERISTIC EXPONENT*, NOT A lambda VALUE -- THE GATE
+//     USES THE PERIODIC-BAND THRESHOLD.
+//   - RQA DETERMINISM AT OR ABOVE RQA_DET_STEADY_MIN.
+//   - THE ACTIVE-REGIME MWU WEIGHT VECTOR HAS CONVERGED.
+// EXIT IS IMMEDIATE WHEN THE SIGNAL LEAVES THE BAND -- THE STREAK
+// COUNTER PROVIDES ENTRY HYSTERESIS, NO EXIT HYSTERESIS NEEDED.
+
+// CONSECUTIVE IN-BAND TICKS BEFORE THE GATE LATCHES (~1/4 OF THE
+// 16-TICK CHAOS WINDOW).
+pub const QUIESCE_ENTER_TICKS: u32 = 4;
+
+pub struct QuiescenceState {
+    in_band_streak: u32,
+    frozen: bool,
+}
+
+impl Default for QuiescenceState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl QuiescenceState {
+    pub const fn new() -> Self {
+        Self {
+            in_band_streak: 0,
+            frozen: false,
+        }
+    }
+
+    // ADVANCE THE GATE ONE TICK. RETURNS THE LATCHED `frozen` FLAG.
+    // rqa_det IS None WHEN THE WINDOW IS NOT YET FULL -- THAT NEVER
+    // COUNTS AS IN-BAND (NEVER FREEZE ON INSUFFICIENT DATA).
+    pub fn update(&mut self, hvg_lambda: f64, rqa_det: Option<f64>, mwu_converged: bool) -> bool {
+        let in_band = hvg_lambda <= crate::chaos::HVG_LAMBDA_PERIODIC_MAX
+            && rqa_det.map_or(false, |d| d >= crate::chaos::RQA_DET_STEADY_MIN)
+            && mwu_converged;
+
+        if in_band {
+            self.in_band_streak = self.in_band_streak.saturating_add(1);
+            if self.in_band_streak >= QUIESCE_ENTER_TICKS {
+                self.frozen = true;
+            }
+        } else {
+            self.in_band_streak = 0;
+            self.frozen = false;
+        }
+        self.frozen
+    }
+}
+
+// ADAPTIVE-RARITY RETUNE INTERVAL
+// WHEN THE ORCHESTRATOR IS NOT FROZEN BUT A RETUNE PRODUCES ONLY A
+// SUB-THRESHOLD KNOB DELTA, STRETCH THE INTERVAL BETWEEN RETUNES x1.5
+// (UP TO A FORCED CEILING) SO THE LOOP CONVERGES TOWARD QUIESCENCE.
+// ANY DISTURBANCE SNAPS IT BACK TO THE BASE INTERVAL.
+
+pub const RETUNE_INTERVAL_BASE: u32 = 1;
+pub const RETUNE_INTERVAL_MAX: u32 = 8;
+
+pub fn next_retune_interval(cur: u32, sub_threshold: bool, disturbed: bool) -> u32 {
+    if disturbed {
+        RETUNE_INTERVAL_BASE
+    } else if sub_threshold {
+        // x1.5 STRETCH, BUT ALWAYS GROW BY AT LEAST 1 -- INTEGER x1.5
+        // OF THE BASE INTERVAL (1) WOULD OTHERWISE STALL AT 1.
+        let stretched = (cur.saturating_mul(3) / 2).max(cur + 1);
+        stretched.clamp(RETUNE_INTERVAL_BASE, RETUNE_INTERVAL_MAX)
+    } else {
+        cur
+    }
+}
+
+// COMMIT-ON-CHANGE: TRUE IFF THE TWO KNOB SETS DIFFER ON ANY
+// MWU-OWNED FIELD. topology_tau_ns / codel_eq_ns ARE EXCLUDED -- THEY
+// ARE OWNED BY THE TOPOLOGY LAYER AND WRITTEN INDEPENDENTLY VIA
+// write_topology_fields(); INCLUDING THEM WOULD SPURIOUSLY TRIP THE
+// DIFF EVERY TICK THE LOOP OVERLAYS THEM.
+pub fn knobs_differ(a: &TuningKnobs, b: &TuningKnobs) -> bool {
+    a.slice_ns != b.slice_ns
+        || a.preempt_thresh_ns != b.preempt_thresh_ns
+        || a.batch_slice_ns != b.batch_slice_ns
+        || a.lat_cri_thresh_high != b.lat_cri_thresh_high
+        || a.lat_cri_thresh_low != b.lat_cri_thresh_low
+        || a.affinity_mode != b.affinity_mode
+        || a.sojourn_thresh_ns != b.sojourn_thresh_ns
+        || a.burst_slice_ns != b.burst_slice_ns
 }


### PR DESCRIPTION
Migration-potential Phi -- a cache move priced by its graph resistance --
with the sojourn potential warp and L3/CCX/CCD topology in the BPF;
Phi-coherent eviction, a Phi-aware scatter pathway, and a low-core slice
discipline in ADAPTIVE.

The warp is now a bounded per-task POTENTIAL, not a flat per-tier constant
-- the decisive interactivity of the vtime era returns EARNED rather than
assigned, with no virtual-time clock resurrected and no unbounding into
starvation; an L3/CCX/CCD topology tier stops communicating pairs from
crossing the Infinity-Fabric boundary at the placement and steal sites;
the migration potential Phi -- R_eff, the graph resistance of a move,
weighed against the queueing relief it buys -- prices every cross-domain
steal, so it crosses a cache boundary only when the backlog justifies the
cost; and the adaptive control plane is driven into
coherence with the sharpened BPF -- Phi-priced eviction keyed to the same
equilibrium the kernel rescues at, a cross-CCX scatter pathway that lets
MWU see the migration storm it can induce, and a core-count slice
discipline that ends the low-core bimodal tail -- so the Rust layer
reinforces the kernel's placement instead of contending with it. Sojourn
stays the engine; the ordering key is unchanged (now - warp, oldest-first).
On the real-world cachyos suite this build takes the lowest total time of
any scheduler measured, EEVDF and scx_cake included.

SOJOURN POTENTIAL WARP (task_deadline)
- warp was a flat per-tier constant: lag_cap_ns for LAT_CRITICAL,
  lag_cap_ns/2 for INTERACTIVE, 0 for BATCH, maturity-gated. Under
  heterogeneous load a swarm of background threads that had merely aged
  past the constant out-sorted a genuine interactive task -- the flat
  warp could not be made decisive without unbounding it, and unbounding
  reintroduces starvation. The decisive interactivity of the vtime era
  was lost in the trade for bounded fairness.
- warp is now a bounded per-task potential:
    warp = (lag_cap_ns * task_potentiality_q16(tctx, knobs)) >> 16
  lag_cap_ns remains the ceiling (the starvation bound); the Q16
  potential in [0, 65536] continuously positions the back-date from the
  task's own behavior. The sort key is unchanged -- now - warp,
  oldest-first sojourn. No dispatch-waterfall change, no new step.
- task_potentiality_q16: BATCH -> 0 (never warps); LAT_CRITICAL -> 65536
  (RT floor absolute, full ceiling, untouched); INTERACTIVE -> earned
  continuously as a capped sum of two monotonic Q16 axes:
    * SERVICE DEFICIT -- a short runtime per activation (a task that
      yields before its quantum) earns warp; a full-slice hog earns
      none. (slice_ns - avg_runtime) / slice_ns, capped at 32768.
    * SHAPE -- low runtime variance relative to mean (a periodic,
      frame-paced workload) earns warp; chaotic burstiness earns none.
      Inverse coefficient-of-variation from runtime_dev, capped at 32768.
- A genuine interactive task (sleeps, periodic, short bursts) earns a
  large warp and wins decisively; a CPU-hog -- or a chaotic, high-
  frequency I/O kthread that the classifier happens to tag INTERACTIVE
  -- earns ~0. The bound (<= lag_cap_ns) keeps the engine starvation-
  free; the maturity gate still returns 0 for an unmatured fork, so a
  fork storm cannot leapfrog established work. This rebuilds the vtime-
  era "under-served wins, then self-corrects" property entirely inside
  the sojourn key: no second fairness engine, no waterfall surgery.

L3 / CCX / CCD TOPOLOGY TIER (src/topology.rs)
- build_laplacian gains a conductance rung between L2 and socket:
  same-L3/CCX = 3.0, cross-CCX-same-socket = 1.0 (the prior socket
  weight, unchanged), cross-socket = 0.3. The L3 domain is parsed from
  cache/index3 and the rung is gated on ccx_active -- true only when a
  socket holds more than one L3 group (an AMD chiplet part).
- Raising the same-CCX rung (rather than lowering the cross-CCX cut)
  ranks same-CCX peers ahead of cross-CCX ones in affinity_rank WITHOUT
  moving lambda_2: the cross-CCX cut stays at 1.0, so tau and codel_eq
  are unchanged. Verified on the 12C dual-CCX reference -- lambda_2 = 12,
  tau = 13.3ms, codel_eq identical before and after.
- Monolithic-L3 parts (ccx_active false) collapse to socket granularity:
  an exact no-op. Fixes the cross-CCD migration of communicating pairs
  (the dual-CCD stutter class, Issue https://github.com/wllclngn/PANDEMONIUM/issues/10) at the placement and steal
  level; the fix flows through the existing affinity_rank map, so the
  BPF dispatch path is unchanged and no new DSQ is added.

QUEUE CLEANUP (src/bpf/main.bpf.c, src/bpf/intf.h)
- Replacing virtual time with the sojourn key left vtime-era vestiges in
  the dispatch queue; this release clears them without touching the
  waterfall or adding a step. task_deadline sheds two dead parameters
  (p, dsq_id); the unused K_VTIME_CEILING constant is deleted; the stale
  comments are corrected to the sojourn engine (DSQ_VTIME / AWAKE_VTIME
  headers -> SOJOURN, vtime_floor / lag_scale / awake_cap -> warp
  ceiling, "STEP 6" -> "STEP 3").
- The per-task awake_vtime (u64) narrows to a ran_since_wake flag (u8
  folded into existing padding) -- eight bytes per task reclaimed, the
  just-woke-up signal that drives kick selection preserved.
- Six open-coded overflow drain-and-clear sequences collapse into one
  overflow_drain_clear helper. nr_reenqueue is now incremented in
  cpu_release from the scx_bpf_reenqueue_local return -- a statistic that
  was exposed but never counted.

IPC WAKE_SYNC KICK RESTORE (pandemonium_select_cpu)
- Both WAKE_SYNC fast-path arms had lost their scx_bpf_kick_cpu calls in
  an in-flight 12C refactor -- the arms inserted the wakee into a per-CPU
  DSQ and returned without kicking, so the target sat until its next tick
  (~1ms at HZ=1000), silently reintroducing the IPC round-trip tail closed
  at commit 5224a8d5e. Restored both: idle-target -> SCX_KICK_IDLE,
  no-idle/saturation -> SCX_KICK_PREEMPT (under SYNC the waker blocks
  imminently). select_cpu's return value alone only auto-wakes an idle CPU
  for SCX_DSQ_LOCAL, not a custom per-CPU DSQ, so the explicit kick is
  required. Both sites now carry a load-bearing marker against a fourth
  accidental removal. Bench gate: IPC round-trip median should return to
  ~29us -- the missing-kick failure mode is silent, so build-clean is
  necessary but not sufficient.

IPC / FORK-THREAD WARM-ANCHOR PLACEMENT (pandemonium_enqueue, dispatch STEP 1)
- Companion to the kick restore above: the kick only helps if the wakee lands
  on its warm core. Through v5.11.0 enqueue inserted woken tasks into the
  shared node_dsq, drained by whichever core dispatched next (STEP 3), so the
  wakee almost never returned to its prev/last_cpu -- last_cpu was read only to
  pick which CPU to kick, never to choose the landing queue. That scatter is
  the IPC round-trip tail and the cache-miss source on wakeup-heavy work.
- Enqueue now anchors the wakee to its own warm cache. TIER 1 (idle wakee):
  find_idle_l2_sibling biases toward the wakee's last_cpu L2 group, then seats
  it on that cpu's own per-CPU DSQ ((u64)cpu), not node_dsq -- the found-idle
  core is shallow, so no spill search is needed. TIER 2 (wakeup preemption /
  LAT_CRITICAL re-enqueue): pick_pcpu_dsq_with_spill seats toward last_cpu --
  the warm per-CPU DSQ if it has room, else the nearest R_eff sibling, else
  node_dsq as the last-resort escape valve. Placement is symmetric with
  select_cpu.
- Dispatch STEP 1 pulls by cache distance, not queue depth. The single
  affinity_rank loop (slot 0 = L2 sibling, slots 1+ = R_eff-ranked cross-L2
  peers) steals from the first peer with nr_queued > 1 -- the closest surplus,
  not the deepest queue the v5.11.0 scan dragged work in from. The > 1 guard
  leaves a peer's lone (warm) task unyanked under light imbalance, so a wakee
  that landed on a sibling rather than its exact last_cpu is still recovered
  near its warm cache.
- Net: communicating pairs stop migrating across cores on every wakeup, so
  cpu-migrations collapse and the IPC round-trip rides the already-tuned
  sojourn key cleanly. The fork-storm throughput gap is the remaining open
  axis -- the warm anchor holds a pair, but a dense storm of short-lived
  communicating threads scatters faster than placement re-anchors. Closing it
  needs self-adaptive in-kernel detection (a pipe pair and a fork storm want
  opposite placement, so no single static threshold separates them) and a
  throughput lift that does not spend the scheduler's latency -- delivered
  below by FLOW SIGNATURE shape routing and the MIGRATION POTENTIAL Phi.

MIGRATION POTENTIAL PHI (src/bpf/main.bpf.c, src/topology.rs, src/bpf/intf.h)
- The fork-storm cache axis the warm anchor left open. R_eff was a placement
  ranking only -- it ordered candidate CPUs by distance but never priced a
  migration against the queueing relief it bought, so a cross-CCX steal was as
  cheap as an SMT-sibling one once a head aged (the measured ~47% cross-CCX
  migration scatter). The migration potential Phi = R_eff - beta*sojourn is now
  operational on the dispatch STEP 1 steal: a peer's head must wait past
  codel_target PLUS a distance penalty before this CPU pulls it. An SMT sibling
  (R_eff ~ 0) stays freely relievable at the flat target; a cross-CCX pull needs
  ~tau of sustained backlog before the steal crosses the fabric.
- R_eff cost oracle (new reff_value BPF map): sized and indexed exactly like
  affinity_rank, paired 1:1, (u32)-1 sentinels past the topology end. The rank
  says which peer is next-nearest; the oracle says how far. Crucially the
  distance penalty is PRE-FOLDED by Rust at topology-detect:
  reff_value[cpu*MAX_AFFINITY_CANDIDATES+slot] = (R_eff(cpu,peer) *
  phi_dist_scale_q16) >> 16, stored directly in nanoseconds. The dispatch steal
  reads it as dist_extra and adds it to codel_target -- ONE indexed array read,
  no runtime multiply, no per-tick scale global on the hot path. This is the
  free-compute discipline the rest of the scheduler follows: the expensive
  derivation happens once at init where R_eff is already computed, not per-peer
  per-dispatch (the earlier per-tick-global form did the multiply on the hot
  path and was the dominant per-dispatch cost in the cache profile).
- phi_dist_scale_q16 is topology-owned (intf.h knob, consumed only by the Rust
  fold at topology-detect). All-zero reff_value -- monolithic / single-CCX /
  ccx_active false / --phi-scale 0 -- collapses dist_extra to 0 and the
  threshold to the flat codel_target: an exact no-op against prior behavior.
- topology.rs FIX A: SMT siblings share L2, so a move between them costs ~0
  cache; the L2 conductance rung is made very stiff (R_eff(SMT-sib) ~ 0), which
  lands the Phi migration barrier exactly at the physical-core / L2 boundary (a
  real cold-L2 refill) instead of penalizing free intra-core moves. lambda_2 is
  the cross-CCX Fiedler cut, independent of L2 stiffness, so tau is unchanged
  and codel_eq stays clamped at its ceiling -- oscillator timescales invariant.
  FIX B: phi_dist_scale_q16 is calibrated so the most distant pair (max R_eff)
  maps to ~tau of required steal-wait, an SMT sibling to ~0.

STEAL HOT-PATH FREE-COMPUTE (src/bpf/main.bpf.c)
- The dispatch STEP 1 peer scan is the dominant per-dispatch cache cost under
  wake-heavy load; three changes drop its cost to already-maintained reads:
  * The peer's backlog age is read from pcpu_enqueue_ns[peer] -- the stamp the
    scheduler already maintains -- instead of peeking the remote DSQ head and
    dereferencing that task's BPF storage per peer (a remote cacheline touch
    per candidate, the prior form).
  * pcpu_enqueue_ns is now an array of 64-byte-aligned pcpu_stamp structs, one
    cacheline per CPU, ending the false-sharing ping when STEP 1 CASes a peer's
    slot while that peer reads its own.
  * The scan is rate-limited to once per codel_target via a per-CPU
    last_spill_scan timestamp: a peer cannot accrue stealable backlog (aged past
    codel_target + dist_extra) faster than codel_target, so scanning more often
    is pure waste. Between scans dispatch falls through to overflow/idle and the
    tick remote scan still kicks any aged per-CPU DSQ, so no work strands.
  * An idle peer (stamp 0) skips the remote nr_queued touch entirely -- the
    common wake-heavy case pays nothing.

SHAPE ROUTING AND WARM-STAY PLACEMENT (src/bpf/main.bpf.c)
- FLOW SIGNATURE is the self-adaptive in-kernel detection the warm-anchor note
  called for -- a pipe pair and a fork storm want opposite placement, and no
  static threshold separates them, so each task earns its own classification.
  Every wakeup sets the waker CPU's bit in a per-task bitmap; the popcount is
  the task's distinct-partner cardinality, a topology-free read of the live
  communication graph's conductance. At maturity (ewma_age >= EWMA_AGE_MATURE)
  the shape is classified once and frozen: <= SHAPE_TIGHT_MAX (2) partners is a
  TIGHT pair/loop; a partner set spanning at least half of nr_cpu_ids is a STORM
  mesh; everything between defaults to TIGHT (latency-safe). Portable -- the
  STORM threshold scales with the machine, no hardcoded core geometry.
- Shape drives PLACEMENT, never the steal (a shape-gated steal once starved a
  STORM-classed audio thread on a busy core). Shape-routed warm placement (B):
  before scx_bpf_select_cpu_dfl's topology-blind any-idle pick -- which can seat
  a wakee on a cross-CCX idle core (cold L3, the storm's residual cache-miss
  source) -- the wakee is anchored on its last core and searched R_eff-near
  (same L2/CCX first). A TIGHT pair grabs its exact warm core when free; a STORM
  spreads. B v2: when no near sibling has room, the wakee stays over-depth on
  its OWN warm core rather than spilling to the shared node_dsq (which any core
  drains, scattering it cross-CCX cold); the deep per-CPU queue is bounded by
  the CoDel sojourn steal.
- WARM-STAY (warm_stay_anchor + enqueue TIER 0) is the placement dual of the
  steal threshold. A wakee whose last_cpu is UNCONGESTED -- its per-CPU sojourn
  (now - the maintained pcpu_enqueue_ns stamp, the same signal the STEP 1 steal
  reads) under codel_target -- is held on that warm core rather than fanned out
  to a cold idle sibling. Over codel_target, the anchor is genuinely backed up
  and the wakee fans out as before. Same yardstick both directions: a wakee
  stays on its warm core right up to the sojourn at which the steal machinery
  would relocate it.
- The busy placement lives in enqueue, NOT select_cpu's idle fast path. The
  hard-won rule from a prior place-on-busy attempt stands: a KICK_IDLE on a busy
  core is a no-op and strands the wakee (~90% deadline miss under saturation),
  so the idle fast path still NEVER places on busy. Instead select_cpu DEFERS --
  warm_stay_anchor returns the anchor and select_cpu returns it without
  dispatching, so the task flows to enqueue TIER 0, which seats it on last_cpu's
  per-CPU DSQ with KICK_PREEMPT (the kick a busy core actually honors).
  LAT_CRITICAL and kthreads are exempt (flee for immediacy); a full / congested
  anchor falls through to the existing idle-seek tiers unchanged.
- Result: deadline-miss out of the ~90% crater to sub-1% across 2-12C, latency
  P99 down 10-40x, no bimodality, audio clean through a fork storm. On the
  real-world cachyos suite PANDEMONIUM ADAPTIVE takes the lowest total time of
  any scheduler measured (EEVDF and scx_cake included) and lands top-cluster in
  the full scx field; the storm cache axis is the one
  quantified line item Phi's cache work targets.

ADAPTIVE PHI-COHERENCE (src/tuning.rs, src/adaptive.rs, src/scheduler.rs)
- The adaptive control plane was calibrated against the pre-Phi BPF and had
  begun to contend with the sharpened one: it evicted on a deadline the kernel
  no longer used, ran a slice the topology no longer wanted at low core count,
  and could not see the cross-CCX scatter its own knob choices induced. Five
  edits bring it back into coherence -- none rips out a subsystem; each
  re-points an existing knob at the value the kernel already maintains.
- SOJOURN FLOOR RE-ANCHORED TO THE PHI EQUILIBRIUM. The MWU sojourn floor was a
  dead 4ms constant -- a guard from when the BPF overflow rescue fired at a
  hand-tuned ~10ms. The rescue is now overflow_sojourn_rescue_ns =
  codel_target_equilibrium_ns (R_eff-derived, sub-ms to ~2ms), so the 4ms floor
  pinned the per-CPU eviction deadline three to nine times above the threshold
  warm-stay and the STEP 1 steal actually release at -- the adaptive layer held
  tasks long past the point the Phi gates assumed relief had arrived, the
  low-core LONG-RUN / LAT P99 tail. The floor now anchors to b.codel_eq_ns
  (guarded >= 200us; the +blended_slice dispatch-service-window guard retained),
  so userspace eviction and the kernel Phi release agree on one number.
  adaptive.rs seeds the MWU baseline with the live codel_eq at tick 0 --
  otherwise the floor falls back to the dead constant on any run whose regime
  never changes.
- LOW-CORE SLICE DISCIPLINE (scaled_regime_knobs). tau is LARGEST at low core
  count -- lambda_2 shrinks as cores drop -- so the tau slice cap ran loosest
  exactly where a wide batch slice does the most damage. At 2-4 cores the HEAVY
  profile's 4ms slice passed through untouched, and the regime detector latched
  HEAVY there because idle_pct reads low when warm-stay and the per-CPU landing
  deliberately bypass the idle fast path -- the kernel placement working
  correctly was misread as saturation, and the 4ms slice denied a
  latency-sensitive probe across many consecutive slices. That is the 2C/4C
  bimodal blowout: LONG-RUN / MIXED P99 spiking to tens of milliseconds on a
  different workload each run. The slice is now capped to the MIXED value at
  nr_cpus <= 4, where a wide slice buys no throughput (the long-run WORK numbers
  confirm it earned none); 8C/12C are untouched, where the wider slice earns
  throughput and the adaptive layer already wins.
- CROSS-CCX SCATTER PATHWAY (PATHWAY 6). MWU balanced six experts blind to
  migration -- the stats it reads carried dispatches, kicks, rescue, and L2
  hit/miss but no cross-CCX signal, so the controller picking slice and affinity
  could not see the migration storm those choices induced. nr_xccx, the
  per-placement-path cross-CCX landing counter, is promoted from diagnostic to a
  permanent control input and feeds a sixth loss pathway. adaptive.rs computes
  the placement-side scatter fraction -- XCCX_SEL_* + XCCX_ENQ_T1, EXCLUDING the
  Phi-correct steal and step5 work-conservation paths (deliberate moves MWU must
  not punish) -- as a percentage of dispatches. PATHWAY 6 is rising-edge gated
  past 20% (EEVDF's measured baseline is ~14%): a climbing scatter penalizes the
  THROUGHPUT, SATURATED, and FORK_STORM experts -- the ones favoring wide slices
  and weak/off affinity -- so the blend re-weights toward LATENCY / BALANCED and
  affinity STRONG. A stable high-scatter regime (8C+ throughput, where the trade
  wins) plateaus and is never penalized; only a climbing storm is.
- OSCILLATOR DEFER GATE MADE PHI-AWARE. MWU defers its rescue-driven pathways
  when the BPF oscillator has already moved, but it read only the bare codel
  window -- and the kernel releases warm-stay and the STEP 1 steal at
  codel_target + dist_extra, the nearest-peer Phi hold. With a large hold the
  bare window can read "loose" while the effective release is still hard, and
  MWU would stand down on genuine rescue pressure. OscillatorState gains
  home_dist_extra_ns (reff_value slot 0, the cheapest-peer hold warm_stay_anchor
  itself reads), and the defer decision qualifies position() against the
  EFFECTIVE release (codel_target + dist_extra) versus codel_eq. It degrades
  exactly: dist_extra 0 reduces to the prior bare-window behavior, codel_eq 0
  disables the absolute qualifier.
- FORK-STORM AFFINITY OFF -> WEAK (DV_AFFINITY). The BPF reads affinity_mode as
  a binary gate on the L2-sibling pre-filter; STRONG and WEAK are identical to
  it, only OFF differs. The FORK_STORM expert voted affinity OFF -- disabling
  the L2 pre-filter during exactly the storm warm placement exists to contain,
  seating wakees topology-blind and scattering them cross-CCX. It now votes
  WEAK, keeping the pre-filter on.
- The scatter signal is surfaced through the existing bench suite, not a
  throwaway probe: the per-path cross-CCX counts and the placement-side scatter
  percentage ride the [KNOBS] shutdown line in both BPF and ADAPTIVE modes, and
  pandemonium-tests.py emits pandemonium_bench_xccx_scatter_pct and
  pandemonium_bench_xccx_path{path=...}, so every run measures which path
  scatters and whether ADAPTIVE scatters less than the raw BPF.
- Result: the 4ms low-core slice that enabled the 2C/4C bimodal blowout is gone,
  and the post-fix run lands low-core MIXED and LONG-RUN P99 at the BPF column or
  below (2C LONG-RUN leads BPF outright) with no tens-of-millisecond tail. On the
  cachyos suite ADAPTIVE takes the lowest total time of any scheduler measured
  and wins four of eight workloads outright (argon2, xz, x265,
  ffmpeg-compilation); on the storm messaging bench its cache-misses fall below
  the raw BPF. The adaptive layer is now a net gain over the kernel it drives,
  not a tax on it.

HYGIENE PASS
- src/chaos.rs: removed four dead helpers (min, max, hvg_entropy,
  hvg_mean_degree) -- all #[allow(dead_code)], zero callers; hvg_stats is
  the live amortized path that derives both lambda and entropy from
  hvg_degrees in one O(N^2) pass. -79 lines.
- Cargo.toml: dropped the redundant libc from [dev-dependencies]; libc is
  a real [dependencies] entry (event.rs / log.rs / cli/probe.rs), the dev
  copy a leftover from the inline #[cfg(test)] tests removed in v5.11.0.
- main.bpf.c: two residual vtime fossils the QUEUE CLEANUP pass left --
  "VTIME LAG CAP" (it is the sojourn-warp clamp now) and a "VTIME-CEILING
  STATICS" reference (vtime_ceiling is gone). Two further audit-flagged
  comments were checked against the code and left unchanged because the
  claims were wrong (STEP 2 genuinely uses overflow_sojourn_rescue_ns; the
  SAFETY NET is an intentional unnumbered backstop).
- main.bpf.c: cut the write-only pcpu_idle_start_ns / pcpu_idle_total_ns
  arrays, their pandemonium_update_idle accounting, and the .update_idle ops
  registration -- measure-only scaffolding for a DNB / Kim-Jo regime consumer
  that never landed. That consumer needs windowed per-CPU + cross-CPU
  (slow-loop) processing the existing chaos + MWU regime detector already
  covers, so the arrays were dead weight; the idea is retained in research
  notes, not as write-only code.
- Added PANDEMONIUM-HYGIENE-AUDIT.md: the full four-axis audit with
  per-finding verification status and the deferred worklist
  (MAX_AFFINITY_CANDIDATES single-sourcing).

MAX_CPUS MASKING FOOTGUN (main.bpf.c)
- The four & (MAX_CPUS-1) index masks are gone. They silently aliased an
  out-of-range CPU to a valid slot instead of failing; behavior-neutral in
  practice (indices are always < nr_cpu_ids <= MAX_CPUS) but a latent
  silent-wrong. Two were redundant masks inside existing < MAX_CPUS guards
  (dropped); the two tick-scan sites became explicit
  if (scan_cpu >= MAX_CPUS) continue; skips. No computed value changes.
- This de-foot-guns the existing MAX_CPUS usage; it does NOT remove
  MAX_CPUS (still sizes the per-CPU arrays + MAX_AFFINITY_CANDIDATES).
  Full removal (per-CPU arrays -> load-time maps) remains deferred and
  bench-gated. Verifier-clean; bench confirms no regression.

REFERENCES (README.md)
- The reference list is brought to comprehensive coverage of the utilized
  foundations -- every implemented mechanism now carries its primary citation.
  Added Fiedler (algebraic connectivity / lambda_2), Blumofe-Leiserson (work
  stealing), Bandt-Pompe (permutation entropy), Luque-Lacasa (horizontal
  visibility graph), Marwan et al. (recurrence quantification), and Butterworth
  (maximally-flat filter damping). Topology, steal, the chaos primitives, and
  the adaptive damping were previously uncited; each addition verified against
  the primary source.