### PR TITLE
chore: fix typos and update codespell rules

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -10,4 +10,7 @@ skip =
     ./rust/scx_utils/src/enums.rs
 
 # Regex of lines to ignore (project-specific terms / proper nouns).
-ignore-regex = .*(ratatui|Affinitized|affinitized).*
+ignore-regex = .*(ratatui|Affinitized|affinitized|nd).*
+
+# Words to ignore.
+ignore-words-list = dota,statics

--- a/scheds/rust/scx_cake/src/topology.rs
+++ b/scheds/rust/scx_cake/src/topology.rs
@@ -241,7 +241,7 @@ pub fn detect() -> Result<TopologyInfo> {
         info.has_hybrid_cores = true;
     } else {
         info.has_hybrid_cores = false;
-        // On Homogenous CPUs (Like 9800X3D), everything is a "Big Phys" core.
+        // On Homogeneous CPUs (Like 9800X3D), everything is a "Big Phys" core.
         // If there's no V-Cache Asymmetry, everything collapses perfectly to prevent extra BPF scans.
     }
 

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -398,7 +398,7 @@ struct Opts {
 
     /// Enable high-resolution timer preemption.
     ///
-    /// By default, the scheduler preempts tasks that exceed their time slice, measuing the time
+    /// By default, the scheduler preempts tasks that exceed their time slice, measuring the time
     /// slice via the tick handler. Add an option to enforce preemption based on the high-precision
     /// timer and CPU occupancy. Enable this option to improve latency-sensitive workloads.
     #[clap(long, action = clap::ArgAction::SetTrue)]

--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -112,7 +112,7 @@ _Static_assert(sizeof(struct cell_llc) >= CACHELINE_SIZE,
 #if !defined(__BINDGEN_RUNNING__)
 #define CELL_LOCK_T struct bpf_spin_lock
 #else
-// When userspaces acceses a cell, this pad is zero.
+// When userspaces accesses a cell, this pad is zero.
 #define CELL_LOCK_T        \
 	struct {           \
 		u32 __pad; \


### PR DESCRIPTION
- Fix 'measuing' to 'measuring' in scx_cosmos/src/main.rs
- Fix 'Homogenous' to 'Homogeneous' in scx_cake/src/topology.rs
- Fix 'acceses' to 'accesses' in scx_mitosis/src/bpf/intf.h
- Add 'dota' and 'statics' to codespell ignore list to fix false positives

── scx/main · 18b99c03034b · 4 file · +7/-4 · 2026-06-03T17:18:25Z