### PR TITLE
scx_lavd: avoid a stray CPU pick in pick_idle_cpu() error paths

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/idle.bpf.c
@@ -676,6 +676,7 @@ s32 pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle)
 	 *    (if it exists) will be resolved by the load balancing mechanism.
 	 */
 	bpf_rcu_read_lock();
+	ctx->a_mask = ctx->o_mask = NULL;
 
 	/*
 	 * If a task can run only on a single CPU (e.g., per-CPU kworker),
@@ -683,8 +684,16 @@ s32 pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle)
 	 * Note that do not extend the overflow set for a unpinned,
 	 * non-migratable task since disabling task migration is temporary.
 	 */
-	if (!init_active_ovrflw_masks(ctx))
-		goto err_out;
+	if (!init_active_ovrflw_masks(ctx)) {
+		/*
+		 * ctx->a_mask and ctx->o_mask haven't been initialized yet,
+		 * so we cannot rely on pick_random_cpu(). Hence, fall back to
+		 * the prev_cpu and go out.
+		 */
+		cpu = ctx->prev_cpu;
+		goto unlock_out;
+	}
+
 	/*
 	 * Use effective pinning here so we cover both permanent pinning
 	 * (nr_cpus_allowed == 1) and transient migrate_disable narrowing
@@ -710,8 +719,15 @@ s32 pick_idle_cpu(struct pick_ctx *ctx, bool *is_idle)
 	 * If @p cannot run on either active or overflow set, extend the
 	 * overflow set, respecting the cpu preference order.
 	 */
-	if (!init_ao_masks(ctx))
-		goto err_out;
+	if (!init_ao_masks(ctx)) {
+		/*
+		 * ctx->a_mask and ctx->o_mask haven't been initialized yet,
+		 * so we cannot rely on pick_random_cpu(). Hence, fall back to
+		 * the prev_cpu and go out.
+		 */
+		cpu = ctx->prev_cpu;
+		goto unlock_out;
+	}
 	if (ctx->a_empty && ctx->o_empty) {
 		cpu = find_cpu_in(ctx->p->cpus_ptr, ctx->cpuc_cur);
 		if (cpu >= 0) {


### PR DESCRIPTION
If an error occurs in pick_idle_cpu(), we rely on pick_random_cpu() to choose an arbitrary CPU from ctx->{a_mask, o_mask}, which is already filtered by p->cpus_ptr. However, if the error occurs before ctx->{a_mask, o_mask} are initialized, we end up choosing a CPU from garbage {a_mask, o_mask}, which may not be in p->cpus_ptr.

We harden this case by choosing prev_cpu, which is already in p->cpus_ptr. Note that such an error cannot happen in reality -- the per-CPU scratch masks always exist and the failure handling is only there to satisfy the BPF verifier -- so this is for completeness.