### PR TITLE
lib/atq: Fix error paths, size accounting, insert races

### DIFF
--- a/lib/atq.bpf.c
+++ b/lib/atq.bpf.c
@@ -129,9 +129,14 @@ int scx_atq_remove_unlocked(scx_atq_t *atq, scx_task_common __arg_arena *taskc)
 	       return -EINVAL;
 
        ret = rb_remove_node(atq->tree, &taskc->node);
+       if (ret)
+	       return ret;
+
        taskc->atq = NULL;
 
-       return ret;
+       atq->size -= 1;
+
+       return 0;
 }
 
 __hidden
@@ -167,19 +172,20 @@ u64 scx_atq_pop(scx_atq_t *atq)
 	}
 
 	ret = rb_pop(atq->tree, &vtime, &taskc_ptr);
-	if (!ret)
-		atq->size -= 1;
+	if (ret) {
+		scx_atq_unlock(atq);
+
+		if (ret != -ENOENT)
+			bpf_printk("%s: error %d", __func__, ret);
+		return (u64)NULL;
+	}
+
+	atq->size -= 1;
 
 	taskc = (scx_task_common *)taskc_ptr;
 	taskc->atq = NULL;
 
 	scx_atq_unlock(atq);
-
-	if (ret) {
-		if (ret != -ENOENT)
-			bpf_printk("%s: error %d", __func__, ret);
-		return (u64)NULL;
-	}
 
 	return taskc_ptr;
 }

--- a/lib/atq.bpf.c
+++ b/lib/atq.bpf.c
@@ -68,6 +68,15 @@ int scx_atq_insert_vtime_unlocked(scx_atq_t __arg_arena *atq, scx_task_common __
 		return -EINVAL;
 
 	/*
+	 * The ->atq field is not protected by the ATQ
+	 * lock, since multiple callers may be trying to
+	 * add the same task to differnt ATQs. Use atomic
+	 * cmpxchg so that races have a single winner.
+	 */
+	if (cmpxchg(&taskc->atq, 0, atq))
+		return -EALREADY;
+
+	/*
 	 * For FIFO, "Leak" the seq on error. We only want
 	 * sequence numbers to be monotonic, not
 	 * consecutive.
@@ -76,10 +85,11 @@ int scx_atq_insert_vtime_unlocked(scx_atq_t __arg_arena *atq, scx_task_common __
 	node->value = (u64)taskc;
 
 	ret = rb_insert_node(atq->tree, node);
-	if (ret)
+	if (ret) {
+		taskc->atq = NULL;
 		return ret;
+	}
 
-	taskc->atq = atq;
 	atq->size += 1;
 
 	return 0;
@@ -124,7 +134,12 @@ int scx_atq_remove_unlocked(scx_atq_t *atq, scx_task_common __arg_arena *taskc)
 {
 	int ret;
 
-       /* Are we in this ATQ in the first place? */
+       /*
+	* Are we in this ATQ in the first place?
+	*
+	* Note: Unlike in the insert path, the ATQ
+	* lock is valid enough protection here.
+	*/
        if (taskc->atq != atq)
 	       return -EINVAL;
 


### PR DESCRIPTION
Address three possible sources of bugs in ATQs:

- Size accounting was incomplete for direct ATQ removals, like in the case of dequeues. Properly decrement the queue size when we remove an item as opposed to popping.
- Atomically set the owner ATQ of a task. The ->atq field of a taskc is not actually protected by the ATQ lock, because different threads may try to enqueue the same task to different ATQs at the same time. Atomically set the owner ATQ so those races have a single winner.
- Do not unset the atq field of a task if the removal fails.