### PR TITLE
lib/cgroup_bw: read ->atq with READ_ONCE and treat -EALREADY as benign

### DIFF
--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -1845,14 +1845,14 @@ int cbw_put_aside(u64 ctx, u64 vtime, u64 cgrp_id)
 		return -ESRCH;
 	}
 
-	if (taskc->atq != NULL) {
-		/*
-		 * Not really a bug: The initial .enqueue() may race with
-		 * a pair of .dequeue()/.enqueue() calls, and cause two
-		 * instances of this function to happen simultaneously
-		 * for the task. This should be rare, but possible.
-		 * The spinlock turns the race into a benign one.
-		 */
+	/*
+	 * A task can be claimed by only one BTQ at a time. The atomic cmpxchg
+	 * of ->atq inside scx_atq_insert_vtime_unlocked() elects a single
+	 * winner; the loser sees the task already queued. That benign case is
+	 * detected either here on the fast path or as EALREADY returned by the
+	 * insert below.
+	 */
+	if (READ_ONCE(taskc->atq) != NULL) {
 		cbw_dbg("Possible double enqueue detected.");
 		scx_atq_unlock(btq);
 		cbw_warn("put_aside skipped: already in BTQ; cgid=%llu", cgrp_id);
@@ -1860,10 +1860,14 @@ int cbw_put_aside(u64 ctx, u64 vtime, u64 cgrp_id)
 	}
 
 	ret = scx_atq_insert_vtime_unlocked(btq, taskc, vtime);
-	if (ret)
-		cbw_err("Failed to insert a task to BTQ: %d", ret);
-
 	scx_atq_unlock(btq);
+
+	if (unlikely(ret == -EALREADY)) {
+		cbw_warn("put_aside skipped: already in BTQ; cgid=%llu", cgrp_id);
+		return 0;
+	} else if (unlikely(ret)) {
+		cbw_err("Failed to insert a task to BTQ: %d", ret);
+	}
 
 	return ret;
 }
@@ -2638,7 +2642,7 @@ __hidden
 int scx_cgroup_bw_is_task_throttled(u64 taskc)
 {
 	scx_task_common *ctx = (scx_task_common *)taskc;
-	return ctx && (ctx->atq != NULL);
+	return ctx && (READ_ONCE(ctx->atq) != NULL);
 }
 
 /**


### PR DESCRIPTION
A task's scx_task_common.atq is the pointer that identifies which BTQ currently owns the task, if any. cbw_put_aside() can run concurrently for the same task when an initial .enqueue() races a .dequeue()/ .enqueue() pair, so the same task may be inserted into or deleted from two different BTQs in different LLCs. The ATQ spinlock does not help because the update race on taskc->atq happens across two different ATQs.

Commit 2295cd4cc341 ("lib/atq: Handle insert races to different ATQs") resolves that race by claiming ->atq with an atomic cmpxchg in scx_atq_insert_vtime_unlocked(), so a losing inserter is rejected with -EALREADY rather than corrupting the rbtree.

Update the cgroup_bw consumers of ->atq to match the writer:

- Treat -EALREADY from scx_atq_insert_vtime_unlocked() as the benign "already in BTQ" outcome rather than a hard error, and return 0 so the caller does not also enqueue the task to a DSQ.

- Read ->atq with READ_ONCE() in cbw_put_aside()'s fast-path check and in scx_cgroup_bw_is_task_throttled(). Both are lockless reads of a field now mutated by an atomic writer; READ_ONCE() pairs with it.