### PR TITLE
docs: update build and developer docs to match current tree

### DIFF
--- a/CARGO_BUILD.md
+++ b/CARGO_BUILD.md
@@ -78,19 +78,22 @@ cargo build --profile=release-tiny -p scx_flash
 
 | Scheduler name | Example build command |
 |----------------|------------------------|
+| `scx_beerland` | `cargo build --release -p scx_beerland` |
 | `scx_bpfland`  | `cargo build --release -p scx_bpfland` |
+| `scx_cake`     | `cargo build --release -p scx_cake` |
 | `scx_chaos`    | `cargo build --release -p scx_chaos` |
 | `scx_cosmos`   | `cargo build --release -p scx_cosmos` |
 | `scx_flash`    | `cargo build --release -p scx_flash` |
+| `scx_flow`     | `cargo build --release -p scx_flow` |
 | `scx_lavd`     | `cargo build --release -p scx_lavd` |
 | `scx_layered`  | `cargo build --release -p scx_layered` |
 | `scx_mitosis`  | `cargo build --release -p scx_mitosis` |
 | `scx_p2dq`     | `cargo build --release -p scx_p2dq` |
+| `scx_pandemonium` | `cargo build --release -p scx_pandemonium` |
 | `scx_rlfifo`   | `cargo build --release -p scx_rlfifo` |
 | `scx_rustland` | `cargo build --release -p scx_rustland` |
 | `scx_rusty`    | `cargo build --release -p scx_rusty` |
 | `scx_tickless` | `cargo build --release -p scx_tickless` |
-| `scx_wd40`     | `cargo build --release -p scx_wd40` |
 
 ---
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -36,33 +36,23 @@ common crate for calculating weights between scheduling domains. See the
 
 ## Development kernels
 
-This repository has a kernel lock file at `./kernel-versions.json` where we track
-several kernels important to development.
+The kernels used by the CI are defined in the job matrices in
+`.github/workflows/ci.yml`, which list the git URL and tag for each tested
+kernel (the `for-next` branch of the `sched_ext` tree, recent stable releases
+and `bpf-next`). The kernels are built with the kernel config at
+`./kernel.config`.
 
-If your change requires a new commit from a branch, you can update this file with:
-    `nix run ./.nix#update-kernels`
-or with:
-    `python3 ./.github/include/update-kernels.py`
-
-Otherwise new changes will be picked up automatically. If the changes that are
-picked up automatically fail CI, you can fix this in a PR separately - the automatic
-updater will kick back in once things are green. Create a branch and PR as normal
-both updating the kernel lock and making necessary fixes to the codebase.
-
-We use `virtme-ng` for testing in the CI environment, and it should be possible
-to reproduce behaviour locally with the same pinned kernels. To get an identical
-kernel to the CI with Nix installed, run:
-    `nix build ./.nix#kernel_sched_ext/for-next`
-And the kernel image will be available at `result/bzImage`. Alternatively you
-can clone the repo/commit from `kernel-versions.json`, but this isn't guaranteed
-to be reproducible.
+We use `virtme-ng` for testing in the CI environment, and it should be
+possible to reproduce behaviour locally with the same kernels: clone the
+repository and tag listed in the matrix, build the kernel with
+`./kernel.config`, and run it with `virtme-ng`.
 
 ## Rust
 
 We use `cargo fmt` to ensure consistency in our `Rust` code. This runs on PRs in
-the CI and will fail with a patch if your code doesn't match. We currently need
-a nightly version of `Rust` to format so have pinned this for consistency. If you
-have `rustup` installed this will use the version in `rust-toolchain.toml`.
+the CI and will fail with a patch if your code doesn't match. The toolchain is
+pinned in `rust-toolchain.toml` (currently stable); if you have `rustup`
+installed, it will pick up the pinned version automatically.
 
     $ cargo fmt
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,15 +23,13 @@ $ sudo apt install -y build-essential cmake cargo rustc clang llvm pkg-config li
 ```
 $ git clone https://github.com/sched-ext/scx.git
 $ cd scx
-$ make all                    # Build C schedulers
-$ cargo build --release       # Build Rust schedulers
+$ cargo build --release
 ```
 
 #### Install the scx schedulers from source
 
 ```
-$ make install INSTALL_DIR=~/bin                                        # Install C schedulers
-$ ls -d scheds/rust/scx_* | xargs -I{} cargo install --path {}          # Install Rust schedulers
+$ ls -d scheds/rust/scx_* | xargs -I{} cargo install --path {}
 ```
 
 ## Arch Linux


### PR DESCRIPTION
Several build/developer documents have fallen behind the tree.

DEVELOPER_GUIDE.md describes the development-kernel workflow around kernel-versions.json and the nix/python update scripts, which were all removed by commit 134d36f0 ("Replace Nix CI with consolidated workflow"). Rewrite the section to describe the current setup, where kernels are defined in the ci.yml job matrices and built with kernel.config under virtme-ng. The same file also says cargo fmt needs a nightly toolchain, but rust-toolchain.toml pins stable these days.

INSTALL.md still tells Ubuntu users to build the C schedulers with make, but there's been no Makefile since commit d1810e62 ("sched: remove C schedulers").

The scheduler table in CARGO_BUILD.md lists scx_wd40, which commit 92356983 ("Cargo: drop scx_wd40") removed from the workspace, so the example command fails. scx_beerland, scx_cake, scx_flow and scx_pandemonium were missing, so sync the table with Cargo.toml.
