### PR TITLE
scx_cosmos: Bump up version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "scx_cosmos"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_cosmos"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["Andrea Righi <arighi@nvidia.com>"]
 edition = "2021"
 description = "Lightweight scheduler optimized for preserving task-to-CPU locality. https://github.com/sched-ext/scx/tree/main"


### PR DESCRIPTION
Since scx_cosmos is in a pretty good state now, let's cut a new version so that we can use this as a baseline for future changes.