### PR TITLE
scx_cosmos: Fix GPU-aware scheduling

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -514,7 +514,7 @@ static s32 pick_cpu_on_gpu_node(const struct task_struct *p, int node,
 	if (!mask || !bpf_cpumask_and(mask, cast_mask(nctx->cpumask), p->cpus_ptr))
 		return -ENOENT;
 
-	return scx_bpf_pick_idle_cpu(cast_mask(mask), 0);
+	return __COMPAT_scx_bpf_pick_idle_cpu_node(cast_mask(mask), target_node, 0);
 }
 
 /*


### PR DESCRIPTION
When NUMA optimizations are active, scx_cosmos enables SCX_OPS_BUILTIN_IDLE_PER_NODE, but the GPU-aware placement (`--gpu`) still calls the global scx_bpf_pick_idle_cpu(), which the kernel rejects when per-node idle tracking is enabled, triggering the error:
```
  runtime error (per-node idle tracking is enabled)
```
Fix this using the poper node-aware pick idle CPU compat helper.