### PR TITLE
scx_cosmos: Bump version to 1.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "scx_cosmos"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_cosmos"
-version = "1.1.3"
+version = "1.1.4"
 authors = ["Andrea Righi <arighi@nvidia.com>"]
 edition = "2021"
 description = "Lightweight scheduler optimized for preserving task-to-CPU locality. https://github.com/sched-ext/scx/tree/main"


### PR DESCRIPTION
Bump the version to 1.1.4 to include the recent bug fixes and publish an updated stable release on crates.io.