### PR TITLE
scx_tickless: Start timer from pinned loader thread

### DIFF
--- a/scheds/rust/scx_tickless/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_tickless/src/bpf/main.bpf.c
@@ -45,6 +45,7 @@ volatile u64 nr_direct_dispatches, nr_timer_dispatches, nr_primary_dispatches;
 
 struct cpu_ctx {
 	struct bpf_timer timer;
+	bool timer_initialized;
 };
 
 struct {
@@ -446,26 +447,54 @@ static int sched_timerfn(void *map, int *key, struct bpf_timer *timer)
 }
 
 /*
- * Start the BPF timer on a target CPU.
+ * Initialize the BPF timer on a target CPU.
  */
-static void init_timer(s32 cpu)
+static s32 init_timer(s32 cpu)
 {
 	struct cpu_ctx *cctx;
 	int ret;
 
 	if (!is_primary_cpu(cpu))
-		scx_bpf_error("starting timer on cpu%d, which is not a scheduling CPU", cpu);
+		return -EINVAL;
 
 	cctx = try_lookup_cpu_ctx(cpu);
 	if (!cctx)
-		return;
+		return -ENOENT;
 
-	bpf_timer_init(&cctx->timer, &cpu_ctx_stor, CLOCK_MONOTONIC);
-	bpf_timer_set_callback(&cctx->timer, sched_timerfn);
+	if (cctx->timer_initialized)
+		return 0;
 
-	ret = bpf_timer_start(&cctx->timer, tick_interval_ns(), 0);
+	ret = bpf_timer_init(&cctx->timer, &cpu_ctx_stor, CLOCK_MONOTONIC);
 	if (ret)
-		scx_bpf_error("failed to fire up timer on cpu%d: %d", cpu, ret);
+		return ret;
+
+	ret = bpf_timer_set_callback(&cctx->timer, sched_timerfn);
+	if (ret)
+		return ret;
+
+	cctx->timer_initialized = true;
+
+	return 0;
+}
+
+/*
+ * Start the already-initialized BPF timer on a target CPU.
+ */
+static s32 start_timer_on_cpu(s32 cpu)
+{
+	struct cpu_ctx *cctx;
+
+	if (!is_primary_cpu(cpu))
+		return -EINVAL;
+
+	cctx = try_lookup_cpu_ctx(cpu);
+	if (!cctx)
+		return -ENOENT;
+
+	if (!cctx->timer_initialized)
+		return -EINVAL;
+
+	return bpf_timer_start(&cctx->timer, tick_interval_ns(), 0);
 }
 
 void BPF_STRUCT_OPS(tickless_dispatch, s32 cpu, struct task_struct *prev)
@@ -687,15 +716,33 @@ int enable_primary_cpu(struct cpu_arg *input)
 	return ret;
 }
 
+SEC("syscall")
+int start_timer(struct cpu_arg *input)
+{
+	s32 cpu = input->cpu_id;
+
+	if (cpu != bpf_get_smp_processor_id())
+		return -EINVAL;
+
+	return start_timer_on_cpu(cpu);
+}
+
 s32 BPF_STRUCT_OPS_SLEEPABLE(tickless_init)
 {
-	int ret;
+	s32 cpu, ret;
 
 	ret = scx_bpf_create_dsq(SHARED_DSQ, -1);
 	if (ret < 0)
 		return ret;
 
-	init_timer(bpf_get_smp_processor_id());
+	bpf_for(cpu, 0, nr_cpu_ids) {
+		if (!is_primary_cpu(cpu))
+			continue;
+
+		ret = init_timer(cpu);
+		if (ret)
+			return ret;
+	}
 
 	return 0;
 }

--- a/scheds/rust/scx_tickless/src/main.rs
+++ b/scheds/rust/scx_tickless/src/main.rs
@@ -180,13 +180,15 @@ impl<'a> Scheduler<'a> {
         // Load the BPF program for validation.
         let mut skel = scx_ops_load!(skel, tickless_ops, uei)?;
 
-        // Set task affinity to the first primary CPU: this is required to start the scheduler's
-        // timer on a primary CPU.
+        // Set task affinity to the first primary CPU. The scheduler enable path
+        // runs in a kernel helper thread, so start the BPF timer explicitly
+        // after attach while this thread is still pinned here.
         let timer_cpu = domain.iter().next();
         if timer_cpu.is_none() {
             bail!("primary cpumask is empty");
         }
-        if let Err(e) = set_thread_affinity(&[timer_cpu.unwrap() as usize]) {
+        let timer_cpu = timer_cpu.unwrap();
+        if let Err(e) = set_thread_affinity(&[timer_cpu as usize]) {
             bail!("cannot set central CPU affinity: {}", e);
         }
 
@@ -197,6 +199,13 @@ impl<'a> Scheduler<'a> {
 
         // Attach the scheduler.
         let struct_ops = Some(scx_ops_attach!(skel, tickless_ops)?);
+        if let Err(err) = Self::start_timer(&mut skel, timer_cpu as i32) {
+            bail!(
+                "failed to start scheduling timer on CPU {}: error {}",
+                timer_cpu,
+                err as i32
+            );
+        }
         let stats_server = StatsServer::new(stats::server_data()).launch()?;
 
         // Reset task affinity.
@@ -213,6 +222,28 @@ impl<'a> Scheduler<'a> {
 
     fn enable_primary_cpu(skel: &mut BpfSkel<'_>, cpu: i32) -> Result<(), u32> {
         let prog = &mut skel.progs.enable_primary_cpu;
+        let mut args = cpu_arg {
+            cpu_id: cpu as c_int,
+        };
+        let input = ProgramInput {
+            context_in: Some(unsafe {
+                std::slice::from_raw_parts_mut(
+                    &mut args as *mut _ as *mut u8,
+                    std::mem::size_of_val(&args),
+                )
+            }),
+            ..Default::default()
+        };
+        let out = prog.test_run(input).unwrap();
+        if out.return_value != 0 {
+            return Err(out.return_value);
+        }
+
+        Ok(())
+    }
+
+    fn start_timer(skel: &mut BpfSkel<'_>, cpu: i32) -> Result<(), u32> {
+        let prog = &mut skel.progs.start_timer;
         let mut args = cpu_arg {
             cpu_id: cpu as c_int,
         };


### PR DESCRIPTION
scx_tickless pins the userspace loader to the first primary CPU before attaching so that the scheduler timer is started from a scheduling CPU. That depended on ops.init() running in the attaching task's CPU context, because tickless_init() calls init_timer(bpf_get_smp_processor_id()).

In newer kernels, sched_ext enables schedulers through the scx_enable_helper kthread. As a result, ops.init() can execute on a different CPU than the affinity-pinned loader. If that CPU is not in the primary domain, scx_tickless aborts during attach with:
```
 starting timer on cpuX, which is not a scheduling CPU
```
Move timer startup out of ops.init(). Add a BPF syscall program that starts the timer and verifies that bpf_get_smp_processor_id() matches the requested primary CPU, then invoke it from userspace after struct_ops attach while the loader thread is still pinned to that CPU. Keep a per-CPU initialized bit so repeated startup attempts are harmless.