### PR TITLE
scx_lavd: dump pending direct-dispatch information in lavd_dump_task

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -2163,6 +2163,14 @@ void BPF_STRUCT_OPS(lavd_dump_task, struct scx_dump_ctx *dctx,
 		     cgrp_name, taskc->cgrp_id,
 		     (cgroup_throttled) ? "throttled" : "not throttled",
 		     (task_throttled) ? "throttled" : "not throttled");
+
+	/*
+	 * Dump the pending direct-dispatch verdict. A non-zero ddsp_dsq_id on a
+	 * stalled task indicates a stale verdict was reused on the do_enqueue_task()
+	 * goto-direct path, bypassing ops.enqueue().
+	 */
+	scx_bpf_dump("  \\_ ddsp_dsq_id: 0x%llx   ddsp_enq_flags: 0x%llx\n",
+		     p->scx.ddsp_dsq_id, p->scx.ddsp_enq_flags);
 }
 
 static s32 init_cpdoms(u64 now)


### PR DESCRIPTION
If a task is stalled with "dsq_id=(n/a)" in a QUEUED state (ops_state == 2/SCX_OPSS_QUEUED), there is no clue why it happened. If the problem didn't stem from the cpu.max library, one possibility is mishandling of the direct dispatch bug from the kernel, fixed by commit 7e0ffb72de8a ("sched_ext: Fix stale direct dispatch state in ddsp_dsq_id"). To recognize this, let's print out p->scx.ddsp_dsq_id and p->scx.ddsp_enq_flags when dumping the task status. ddsp_dsq_id should be SCX_DSQ_INVALID (0x8000000000000000) when a task is throttled and parked to a BTQ normally; any other value on such a stalled task points to a leaked direct-dispatch verdict.

This is a diagnostic-only change; it does not alter scheduling behavior.