### PR TITLE
scx_lavd: Bound task_clock passed by exec_delta

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -177,6 +177,7 @@ struct task_ctx {
 	u64	last_measured_wall_clk;	/* last time when running time was measured (wall clock) */
 	u64	last_measured_pelt_clk;	/* last time when running time was measured (pelt clock) */
 	u64	last_measured_task_clk;	/* last time when running time was measured (task clock) */
+	u64	last_measured_exec;	/* p->se.sum_exec_runtime at last measurement */
 	/*
 	 * Accumulated runtime from runnable to quiescent state.
 	 * Used to calculate avg_runtime_wall/invr and latency criticality.

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -434,6 +434,7 @@ static void update_stat_for_running(struct task_struct *p,
 	reset_task_flag(taskc, LAVD_FLAG_IS_SYNC_WAKEUP);
 	taskc->last_running_clk = now;
 	taskc->last_measured_wall_clk = now;
+	taskc->last_measured_exec = p->se.sum_exec_runtime;
 
 	/*
 	 * ops.running() can fire while the BPF callback runs on a CPU other
@@ -530,7 +531,7 @@ static void account_task_runtime(struct task_struct *p,
 				 struct cpu_ctx *cpuc,
 				 u64 now)
 {
-	u64 task_time_wall, task_time_iwgt, task_time_invr;
+	u64 task_time_wall, task_time_iwgt, task_time_invr, exec_now, exec_delta;
 	u64 now_task, now_pelt;
 
 	/*
@@ -555,6 +556,20 @@ static void account_task_runtime(struct task_struct *p,
 	task_time_invr = unlikely(!taskc->last_measured_pelt_clk) ? 0 :
 		time_delta(now_pelt, taskc->last_measured_pelt_clk);
 
+	/*
+	 * Synchronizing clock_task for tasks for different CPUs is tricky
+	 * business when our current CPU isn't the CPU that the task is running
+	 * on. Let's use exec_delta where the kernel already does the correct
+	 * accounting for us to bound clock jumps when comparing clock_task
+	 * from different CPUs.
+	 */
+	exec_now = p->se.sum_exec_runtime;
+	exec_delta = unlikely(!taskc->last_measured_exec) ? 0 :
+		time_delta(exec_now, taskc->last_measured_exec);
+
+	if (task_time_wall > exec_delta)
+		task_time_wall = exec_delta;
+
 	task_time_iwgt = task_time_invr / p->scx.weight;
 
 	WRITE_ONCE(cpuc->tot_task_time_wall, cpuc->tot_task_time_wall + task_time_wall);
@@ -574,6 +589,7 @@ static void account_task_runtime(struct task_struct *p,
 	taskc->last_measured_wall_clk = now;
 	taskc->last_measured_task_clk = now_task;
 	taskc->last_measured_pelt_clk = now_pelt;
+	taskc->last_measured_exec = exec_now;
 
 	/*
 	 * Under CPU bandwidth control using cpu.max, we also need to report


### PR DESCRIPTION
I'm still observing large clock_task deltas leading to large negative quotas, example:

account: cgid=11596542 delta=285683503234813 now_task=1193821685872956 last_task=908138182638143 now=1242054054493146 charge: cgid=11596542 consumed_ns=285683503234813 runtime_total=285683529628563 llc=0 account: cgid=11596542 wall=285683503344427 now_task=1193821686158353 last_task=908138182813926 now=1242054054799135 charge: cgid=11596542 consumed_ns=285683503344427 runtime_total=571367033184297 llc=0 cgid=11596542 rt_last=571367054379812 old_pb=17200000000 nq_ub=17200000000 burst=0 debt=571349854379812 newbudget=-571332654379812

Right now, we make the simplifying assumption that most sample points our current cpu's rq == task's rq because sampling remote cpu's clock_task is tricky since we can't acquire remote rq locks when holding our own.

Let's make forward progress to stablize cpu bw limiter by bounding the clock_task delta accounting to exec_time delta where the kernel already handles the proper time accounting for us until we re-think time accounting.