### PR TITLE
scx_flow 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "scx_flow"
-version = "3.0.4"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/scheds/experimental/scx_flow/Cargo.toml
+++ b/scheds/experimental/scx_flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_flow"
-version = "3.0.4"
+version = "3.1.0"
 authors = ["Galih Tama <galpt@v.recipes>"]
 edition = "2021"
 description = "A budget-driven sched_ext scheduler with zero heuristic classification. https://github.com/sched-ext/scx/tree/main"

--- a/scheds/experimental/scx_flow/README.md
+++ b/scheds/experimental/scx_flow/README.md
@@ -4,11 +4,11 @@ This is a single user-defined scheduler used within [`sched_ext`](https://github
 
 ## Overview
 
-`scx_flow` is a budget-driven `sched_ext` scheduler with zero heuristic classification. Tasks accumulate budget while sleeping and spend it while running. Non-wakeup re-enqueues enter the **Waiting Room** — per-CPU DSQs where each task receives an ideal CPU time slice computed from the bandwidth model: `(budget / BUDGET_MAX) × (thread_bw / system_total_khz) × window_ns`, adjusted for SMT bandwidth halving, migration cost penalties, and load awareness. Wakeups are dispatched immediately to the target CPU via `SCX_DSQ_LOCAL_ON`.
+`scx_flow` is a budget-driven `sched_ext` scheduler with zero heuristic classification. Tasks accumulate budget while sleeping and spend it while running. Non-wakeup re-enqueues enter the **Waiting Room** — per-CPU vtime-ordered DSQs where each task receives an equal share of its target CPU's bandwidth: `FLOW_CARRIAGE_NS / tasks_on_cpu`, clamped to [50µs, 2ms]. Slices adjust dynamically as tasks arrive on the same core. Wakeups are dispatched immediately to the target CPU via `SCX_DSQ_LOCAL_ON`.
 
 ## Typical Use Case
 
-Systems where scheduling decisions must be deterministic and explainable: embedded control, robotics, avionics, automotive, and other mission-critical workloads. The bandwidth model ensures tasks get slices proportional to their budget and target core frequency, preventing both starvation and priority inversion.
+Systems where scheduling decisions must be deterministic and explainable: embedded control, robotics, avionics, automotive, and other mission-critical workloads. The fair-share slice model ensures each task receives an equal portion of its target core's bandwidth, preventing both starvation and priority inversion.
 
 General-purpose desktop and workstation use is also supported; interactive tasks (longer sleep → higher budget → longer slice) are naturally separated from bulk workers without requiring configuration or heuristics.
 

--- a/scheds/experimental/scx_flow/README.md
+++ b/scheds/experimental/scx_flow/README.md
@@ -4,31 +4,18 @@ This is a single user-defined scheduler used within [`sched_ext`](https://github
 
 ## Overview
 
-`scx_flow` is a budget-driven `sched_ext` scheduler with zero heuristic classification. Tasks accumulate budget while sleeping and spend it while running; non-wakeup re-enqueues are classified into four O(1) FIFO tiers by budget level — PRIORITY (≥ 1.5ms budget), NORMAL (≥ 1ms), LOW (≥ 0.5ms), and DEFICIT (< 0.5ms, bulk workers). The dispatch function rotates the starting tier on every call (gen & 3 selects the phase), so no tier waits longer than 3 dispatch cycles before being serviced first — this prevents both starvation and priority inversion without heuristic tuning. Wakeups are dispatched immediately to the target CPU via `SCX_DSQ_LOCAL_ON`, bypassing the tier system entirely. Non-migratable tasks receive absolute priority over bulk workers via per-CPU FIFO dispatch queues. There are no tunables, no scoring signals, and no adaptive tuning — every scheduling decision is derived from kernel-verified inputs.
+`scx_flow` is a budget-driven `sched_ext` scheduler with zero heuristic classification. Tasks accumulate budget while sleeping and spend it while running. Non-wakeup re-enqueues enter the **Waiting Room** — per-CPU DSQs where each task receives an ideal CPU time slice computed from the bandwidth model: `(budget / BUDGET_MAX) × (thread_bw / system_total_khz) × window_ns`, adjusted for SMT bandwidth halving, migration cost penalties, and load awareness. Wakeups are dispatched immediately to the target CPU via `SCX_DSQ_LOCAL_ON`.
 
 ## Typical Use Case
 
-Systems where scheduling decisions must be deterministic and explainable: embedded control, robotics, avionics, automotive, and other mission-critical workloads. The rotating tier dispatch (cycling start position across all 4 tiers) prevents both starvation and priority inversion without sacrificing O(1) performance. The fixed minimum slice bounds worst-case wakeup latency.
+Systems where scheduling decisions must be deterministic and explainable: embedded control, robotics, avionics, automotive, and other mission-critical workloads. The bandwidth model ensures tasks get slices proportional to their budget and target core frequency, preventing both starvation and priority inversion.
 
-General-purpose desktop and workstation use is also supported; interactive tasks (longer sleep → higher budget → higher tier) are naturally separated from bulk workers without requiring configuration or heuristics.
+General-purpose desktop and workstation use is also supported; interactive tasks (longer sleep → higher budget → longer slice) are naturally separated from bulk workers without requiring configuration or heuristics.
 
 ## Web UI
 
-When scx_flow starts, it automatically serves a live metrics dashboard at [http://localhost:50005](http://localhost:50005). No extra flags needed — open it in any browser.
-
-The dashboard shows:
-- How many dispatches have gone through each tier (Priority / Normal / Low / Exhausted)
-- System information: running tasks, runtime, dispatch counts
-- All values update every second via polling — no page refresh needed
-- If the page doesn't load, the scheduler may have stopped running (the kernel falls back to the built-in EEVDF scheduler)
-
-Disable with `--no-webui` if you don't need it.
+When scx_flow starts, it serves a live dashboard at `http://[::1]:50005/` or via Unix socket at `/tmp/scx_flow.sock`. The dashboard shows per-core cards (CPU ID, max frequency, LLC, SMT status), the Waiting Room carriage pool (producer slot index, filling count, 64-slot grid), and system statistics (on-CPU count, wake/pinned dispatches, budget exhaustions, CPU migrations). Values update every second. Disable with `--no-webui`.
 
 ## Production Ready?
 
-Yes, for the use cases described above. The scheduler has been exercised across combined cyclictest + hackbench + stress-ng workloads.
-
-## Validation
-
-Benchmark scripts and archived result bundles are available at:
-https://github.com/galpt/testing-scx_flow
+Yes, for the use cases described above.

--- a/scheds/experimental/scx_flow/build.rs
+++ b/scheds/experimental/scx_flow/build.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0
 // Copyright (c) 2026 Galih Tama <galpt@v.recipes>
 //
 // This software may be used and distributed according to the terms of the

--- a/scheds/experimental/scx_flow/src/bpf/budget.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/budget.bpf.c
@@ -23,8 +23,11 @@ void BPF_STRUCT_OPS(flow_runnable, struct task_struct *p, u64 enq_flags)
 	 */
 	{
 		s32 cpu = scx_bpf_task_cpu(p);
-		if (cpu >= 0 && (u32)cpu < 1024)
-			__sync_fetch_and_add(&per_cpu_runnable[(u32)cpu], 1);
+		if (cpu >= 0 && (u32)cpu < 1024) {
+			u32 c = (u32)cpu;
+			tctx->runnable_cpu = cpu;
+			__sync_fetch_and_add(&per_cpu_runnable[c], 1);
+		}
 	}
 }
 
@@ -86,14 +89,15 @@ void BPF_STRUCT_OPS(flow_stopping, struct task_struct *p, bool runnable)
 		__sync_fetch_and_add(&on_cpu, 1);
 
 	/*
-	 * Decrement per-CPU runnable count for load awareness on both
-	 * preempt (runnable=true) and sleep (runnable=false) paths.
-	 * Atomic with saturation guard: if it was already zero, restore.
+	 * Decrement per_cpu_runnable on the CPU where flow_runnable
+	 * incremented it (tctx->runnable_cpu), not tctx->last_cpu.
+	 * This ensures correct pairing even when work stealing moves
+	 * the task to a different CPU.  Atomic saturation guard.
 	 */
-	if (tctx && tctx->last_cpu >= 0 && (u32)tctx->last_cpu < 1024) {
-		u32 cpu_idx = (u32)tctx->last_cpu;
-		if (__sync_fetch_and_sub(&per_cpu_runnable[cpu_idx], 1) == 0)
-			__sync_fetch_and_add(&per_cpu_runnable[cpu_idx], 1);
+	if (tctx && tctx->runnable_cpu >= 0 && (u32)tctx->runnable_cpu < 1024) {
+		u32 c = (u32)tctx->runnable_cpu;
+		if (__sync_fetch_and_sub(&per_cpu_runnable[c], 1) == 0)
+			__sync_fetch_and_add(&per_cpu_runnable[c], 1);
 	}
 
 }

--- a/scheds/experimental/scx_flow/src/bpf/budget.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/budget.bpf.c
@@ -13,6 +13,19 @@ void BPF_STRUCT_OPS(flow_runnable, struct task_struct *p, u64 enq_flags)
 	if (tctx->sleep_started_at && now > tctx->sleep_started_at)
 		FLOW_CPUSTAT_INC(lookup_cpu_state(), runnable_wakeups);
 	update_budget_on_wakeup(p, tctx, now);
+
+	/*
+	 * Track per-CPU runnable count for load awareness (heuristic,
+	 * up to 50% slice reduction).  Atomic increment matches the
+	 * atomic decrement in flow_stopping, keeping drift bounded
+	 * to migration-related mismatch between the wakeup CPU and
+	 * the actual execution CPU.
+	 */
+	{
+		s32 cpu = scx_bpf_task_cpu(p);
+		if (cpu >= 0 && (u32)cpu < 1024)
+			__sync_fetch_and_add(&per_cpu_runnable[(u32)cpu], 1);
+	}
 }
 
 void BPF_STRUCT_OPS(flow_running, struct task_struct *p)
@@ -28,6 +41,7 @@ void BPF_STRUCT_OPS(flow_running, struct task_struct *p)
 		if (tctx->last_cpu >= 0 && tctx->last_cpu != current_cpu)
 			FLOW_CPUSTAT_INC(lookup_cpu_state(), cpu_migrations);
 		tctx->last_cpu = current_cpu;
+		tctx->last_llc = (s32)per_cpu_llc_id[current_cpu];
 		tctx->last_run_at = now;
 		tctx->first_run = false;
 	}
@@ -49,7 +63,7 @@ void BPF_STRUCT_OPS(flow_stopping, struct task_struct *p, bool runnable)
 			runtime_ns = now - tctx->last_run_at;
 
 		if (tctx->budget_ns > 0 &&
-		    tctx->budget_ns - (s64)runtime_ns <= 0)
+		    (s64)runtime_ns >= tctx->budget_ns)
 			FLOW_CPUSTAT_INC(lookup_cpu_state(), budget_exhaustions);
 
 		tctx->budget_ns = clamp_budget(tctx->budget_ns - (s64)runtime_ns);
@@ -60,5 +74,26 @@ void BPF_STRUCT_OPS(flow_stopping, struct task_struct *p, bool runnable)
 	}
 
 	__sync_fetch_and_add(&total_runtime, runtime_ns);
-	__sync_fetch_and_sub(&on_cpu, 1);
+
+	/*
+	 * on_cpu diagnostic counter — incremented in flow_running,
+	 * decremented here.  Atomic with saturation guard: if the
+	 * counter was already zero, the guard restores it.  Under
+	 * concurrent access, minor drift is possible but bounded
+	 * (diagnostic only, no scheduling decisions depend on it).
+	 */
+	if (__sync_fetch_and_sub(&on_cpu, 1) == 0)
+		__sync_fetch_and_add(&on_cpu, 1);
+
+	/*
+	 * Decrement per-CPU runnable count for load awareness on both
+	 * preempt (runnable=true) and sleep (runnable=false) paths.
+	 * Atomic with saturation guard: if it was already zero, restore.
+	 */
+	if (tctx && tctx->last_cpu >= 0 && (u32)tctx->last_cpu < 1024) {
+		u32 cpu_idx = (u32)tctx->last_cpu;
+		if (__sync_fetch_and_sub(&per_cpu_runnable[cpu_idx], 1) == 0)
+			__sync_fetch_and_add(&per_cpu_runnable[cpu_idx], 1);
+	}
+
 }

--- a/scheds/experimental/scx_flow/src/bpf/budget.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/budget.bpf.c
@@ -89,15 +89,18 @@ void BPF_STRUCT_OPS(flow_stopping, struct task_struct *p, bool runnable)
 		__sync_fetch_and_add(&on_cpu, 1);
 
 	/*
-	 * Decrement per_cpu_runnable on the CPU where flow_runnable
-	 * incremented it (tctx->runnable_cpu), not tctx->last_cpu.
-	 * This ensures correct pairing even when work stealing moves
-	 * the task to a different CPU.  Atomic saturation guard.
+	 * Decrement per_cpu_runnable only when the task is truly leaving
+	 * the runnable state (runnable == false — going to sleep/block).
+	 * When preempted (runnable == true), the task stays runnable and
+	 * will be re-enqueued — the counter should remain unchanged.
+	 * Clear runnable_cpu after decrement to prevent double-counting.
 	 */
-	if (tctx && tctx->runnable_cpu >= 0 && (u32)tctx->runnable_cpu < 1024) {
+	if (tctx && !runnable && tctx->runnable_cpu >= 0 &&
+	    (u32)tctx->runnable_cpu < 1024) {
 		u32 c = (u32)tctx->runnable_cpu;
 		if (__sync_fetch_and_sub(&per_cpu_runnable[c], 1) == 0)
 			__sync_fetch_and_add(&per_cpu_runnable[c], 1);
+		tctx->runnable_cpu = -1;
 	}
 
 }

--- a/scheds/experimental/scx_flow/src/bpf/carriage.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/carriage.bpf.c
@@ -1,0 +1,104 @@
+/* Waiting Room — included by main.bpf.c via #include
+ *
+ * Non-wakeup tasks are dispatched to per-CPU DSQs
+ * (FLOW_VTIME_DSQ_BASE + target_cpu) via scx_bpf_dsq_insert___v1.
+ * This calls the base kfunc directly (___v1 resolves to type_id 128815
+ * on 7.0.x), bypassing the compat inline which would route to
+ * ___v2___compat (checks task_is_running, returns false at re-enqueue).
+ *
+ * The carriage pool records a rolling window of dispatched PIDs for the
+ * web UI display.  It uses a simple counter (no state machine) so it
+ * never returns -2 — every task is dispatched to a proper DSQ. */
+
+/* Declare the base dsq_insert kfunc directly (bypass compat inline). */
+void scx_bpf_dsq_insert___v1(struct task_struct *p, u64 dsq_id,
+			      u64 slice, u64 enq_flags) __ksym __weak;
+
+static __always_inline u64 compute_base_slice(struct task_ctx *tctx,
+					       s32 target_cpu)
+{
+	u64 slice_ns, budget, core_freq, is_smt, thread_bw, bw_share, wshare;
+	if (!tctx || tctx->budget_ns <= 0 || system_total_khz == 0 ||
+	    target_cpu < 0 || (u32)target_cpu >= 1024)
+		return task_slice_ns(tctx);
+	budget = (u64)tctx->budget_ns;
+	core_freq = per_cpu_max_freq_khz[target_cpu];
+	is_smt = per_cpu_is_smt[target_cpu];
+	thread_bw = is_smt ? core_freq / 2 : core_freq;
+	bw_share = thread_bw * 10000ULL / system_total_khz;
+	wshare = budget * 10000ULL / FLOW_BUDGET_MAX_NS;
+	if (wshare > 10000ULL) wshare = 10000ULL;
+	slice_ns = wshare * bw_share * FLOW_CARRIAGE_NS / 10000ULL / 10000ULL;
+	if (slice_ns < FLOW_SLICE_MIN_NS) slice_ns = FLOW_SLICE_MIN_NS;
+	if (slice_ns > FLOW_BUDGET_MAX_NS) slice_ns = FLOW_BUDGET_MAX_NS;
+	return slice_ns;
+}
+
+static __always_inline u64 apply_slice_adjustments(u64 slice_ns,
+						     struct task_ctx *tctx,
+						     s32 target_cpu)
+{
+	if (tctx && tctx->last_cpu >= 0 && tctx->last_cpu != target_cpu) {
+		s32 last_llc = tctx->last_llc, tllc = -1;
+		if ((u32)target_cpu < 1024)
+			tllc = (s32)per_cpu_llc_id[(u32)target_cpu];
+		if (last_llc >= 0 && tllc >= 0 && last_llc == tllc)
+			slice_ns = slice_ns * 90ULL / 100ULL;
+		else
+			slice_ns = slice_ns * 75ULL / 100ULL;
+		if (slice_ns < FLOW_SLICE_MIN_NS) slice_ns = FLOW_SLICE_MIN_NS;
+	}
+	if ((u32)target_cpu < 1024) {
+		u64 nr_run = per_cpu_runnable[target_cpu];
+		if (nr_run > 0 && nr_cpu_ids > 0) {
+			u64 factor = nr_run * 100ULL / nr_cpu_ids;
+			if (factor > 50) factor = 50;
+			slice_ns = slice_ns * (100ULL - factor) / 100ULL;
+			if (slice_ns < FLOW_SLICE_MIN_NS)
+				slice_ns = FLOW_SLICE_MIN_NS;
+		}
+	}
+	return slice_ns;
+}
+
+static __always_inline u64 compute_task_slice(struct task_ctx *tctx,
+					       s32 target_cpu)
+{
+	return apply_slice_adjustments(compute_base_slice(tctx, target_cpu),
+				       tctx, target_cpu);
+}
+
+/*
+ * Dispatch a non-wakeup task and record its PID for the web UI.
+ * The task is always dispatched (never returned -2).
+ * The carriage pool uses a simple rolling counter — no ring buffer
+ * state machine, no producer/consumer indices, no FILLING/CALCULATING
+ * states.  It always records, never blocks.
+ */
+static __always_inline void carriage_enqueue_task(struct task_struct *p,
+						   struct task_ctx *tctx)
+{
+	u64 slot, slice_ns;
+	s32 target_cpu;
+
+	slot = __sync_fetch_and_add(&carriage_producer, 1)
+		& (FLOW_NR_CARRIAGES - 1);
+
+	target_cpu = (tctx && tctx->last_cpu >= 0) ? tctx->last_cpu
+		     : scx_bpf_task_cpu(p);
+	slice_ns = compute_task_slice(tctx, target_cpu);
+
+	/* Dispatch to the target CPU's per-CPU DSQ via the base kfunc. */
+	{
+		u64 dsq_id; s32 tgt = target_cpu;
+		if (tgt < 0 || (u32)tgt >= 1024)
+			tgt = scx_bpf_task_cpu(p);
+		dsq_id = FLOW_VTIME_DSQ_BASE + (u32)tgt;
+		scx_bpf_dsq_insert___v1(p, dsq_id, slice_ns, 0);
+	}
+
+	/* Record PID (stats-only, simple rolling slot). */
+	carriage_pool[slot].tasks[carriage_pool[slot].count %
+				  FLOW_CARRIAGE_CAPACITY] = (u64)(s32)p->pid;
+	carriage_pool[slot].count++;
+}

--- a/scheds/experimental/scx_flow/src/bpf/carriage.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/carriage.bpf.c
@@ -1,19 +1,21 @@
 /* Waiting Room — included by main.bpf.c via #include
  *
- * Non-wakeup tasks are dispatched to per-CPU DSQs
- * (FLOW_VTIME_DSQ_BASE + target_cpu) via scx_bpf_dsq_insert___v1.
- * This calls the base kfunc directly (___v1 resolves to type_id 128815
- * on 7.0.x), bypassing the compat inline which would route to
- * ___v2___compat (checks task_is_running, returns false at re-enqueue).
+ * Non-wakeup tasks are dispatched to FLOW_BATCH_DSQ, a shared vtime-
+ * ordered DSQ (matching cosmos's global vtime DSQ pattern).  Any idle
+ * CPU drains from FLOW_BATCH_DSQ during ops.dispatch(), naturally
+ * balancing load without per-enqueue CPU scanning.
  *
- * The carriage pool records a rolling window of dispatched PIDs for the
- * web UI display.  It uses a simple counter (no state machine) so it
- * never returns -2 — every task is dispatched to a proper DSQ. */
+ * The bandwidth model computes each task's slice from the task's budget,
+ * the target core's frequency, and the system's total bandwidth:
+ *   slice = (budget / BUDGET_MAX) x (thread_bw / system_total_khz) x window
+ * adjusted for migration cost (same-LLC: -10%, cross-LLC: -25%).
+ *
+ * The carriage pool records PIDs for the web UI (stats-only). */
 
-/* Declare the base dsq_insert kfunc directly (bypass compat inline). */
 void scx_bpf_dsq_insert___v1(struct task_struct *p, u64 dsq_id,
 			      u64 slice, u64 enq_flags) __ksym __weak;
 
+/* Base slice: budget x frequency x window (PRD Phase C). */
 static __always_inline u64 compute_base_slice(struct task_ctx *tctx,
 					       s32 target_cpu)
 {
@@ -34,6 +36,7 @@ static __always_inline u64 compute_base_slice(struct task_ctx *tctx,
 	return slice_ns;
 }
 
+/* Migration penalty: same-LLC -10%, cross-LLC -25%. */
 static __always_inline u64 apply_slice_adjustments(u64 slice_ns,
 						     struct task_ctx *tctx,
 						     s32 target_cpu)
@@ -48,16 +51,6 @@ static __always_inline u64 apply_slice_adjustments(u64 slice_ns,
 			slice_ns = slice_ns * 75ULL / 100ULL;
 		if (slice_ns < FLOW_SLICE_MIN_NS) slice_ns = FLOW_SLICE_MIN_NS;
 	}
-	if ((u32)target_cpu < 1024) {
-		u64 nr_run = per_cpu_runnable[target_cpu];
-		if (nr_run > 0 && nr_cpu_ids > 0) {
-			u64 factor = nr_run * 100ULL / nr_cpu_ids;
-			if (factor > 50) factor = 50;
-			slice_ns = slice_ns * (100ULL - factor) / 100ULL;
-			if (slice_ns < FLOW_SLICE_MIN_NS)
-				slice_ns = FLOW_SLICE_MIN_NS;
-		}
-	}
 	return slice_ns;
 }
 
@@ -69,13 +62,10 @@ static __always_inline u64 compute_task_slice(struct task_ctx *tctx,
 }
 
 /*
- * Dispatch a non-wakeup task and record its PID for the web UI.
- * Target CPU selection (in order of preference):
- *   1. last_cpu — cache warmth (matching bpfland/cosmos pattern)
- *   2. If last_cpu is an SMT secondary, prefer the primary sibling
- *      (avoids sharing the same physical core's execution resources)
- *   3. scx_bpf_task_cpu(p) — fallback (current CPU or wake target)
- * No CPU scanning — O(1) per dispatch, no iterator kfunc calls.
+ * Dispatch a non-wakeup task to the shared FLOW_BATCH_DSQ with vtime
+ * ordering.  The target CPU for the bandwidth model is the task's
+ * last_cpu (cache warmth).  No per-CPU scanning — idle CPUs drain
+ * FLOW_BATCH_DSQ during ops.dispatch().
  */
 static __always_inline void carriage_enqueue_task(struct task_struct *p,
 						   struct task_ctx *tctx)
@@ -86,27 +76,18 @@ static __always_inline void carriage_enqueue_task(struct task_struct *p,
 	slot = __sync_fetch_and_add(&carriage_producer, 1)
 		& (FLOW_NR_CARRIAGES - 1);
 
+	/* Use last_cpu for the bandwidth model (cache warmth).
+	 * The actual dispatch goes to the shared FLOW_BATCH_DSQ. */
 	target_cpu = (tctx && tctx->last_cpu >= 0) ? tctx->last_cpu
 		     : scx_bpf_task_cpu(p);
-	/* SMT-aware: if targeting an SMT secondary, prefer its primary
-	 * sibling to avoid sharing execution resources.  Consecutive
-	 * CPU pairs (0↔1, 2↔3, ...) are typical on x86. */
-	if (target_cpu >= 0 && (u32)target_cpu < 1024 &&
-	    per_cpu_is_smt[target_cpu])
-		target_cpu = target_cpu ^ 1;
 
 	slice_ns = compute_task_slice(tctx, target_cpu);
 
-	/* Dispatch to the target CPU's per-CPU DSQ via the base kfunc. */
-	{
-		u64 dsq_id; s32 tgt = target_cpu;
-		if (tgt < 0 || (u32)tgt >= 1024)
-			tgt = scx_bpf_task_cpu(p);
-		dsq_id = FLOW_VTIME_DSQ_BASE + (u32)tgt;
-		scx_bpf_dsq_insert___v1(p, dsq_id, slice_ns, 0);
-	}
+	/* Shareed vtime-ordered DSQ — idle CPUs drain via ops.dispatch(). */
+	if (!scx_bpf_dsq_insert_vtime(p, FLOW_BATCH_DSQ,
+				      slice_ns, slice_ns, 0))
+		scx_bpf_dsq_insert___v1(p, FLOW_BATCH_DSQ, slice_ns, 0);
 
-	/* Record PID (stats-only, simple rolling slot). */
 	carriage_pool[slot].tasks[carriage_pool[slot].count %
 				  FLOW_CARRIAGE_CAPACITY] = (u64)(s32)p->pid;
 	carriage_pool[slot].count++;

--- a/scheds/experimental/scx_flow/src/bpf/carriage.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/carriage.bpf.c
@@ -17,14 +17,14 @@ void scx_bpf_dsq_insert___v1(struct task_struct *p, u64 dsq_id,
 static __always_inline u64 compute_base_slice(struct task_ctx *tctx,
 					       s32 target_cpu)
 {
-	u64 slice_ns, budget, core_freq, is_smt, thread_bw, bw_share, wshare;
+	u64 slice_ns, budget, core_freq, siblings, thread_bw, bw_share, wshare;
 	if (!tctx || tctx->budget_ns <= 0 || system_total_khz == 0 ||
 	    target_cpu < 0 || (u32)target_cpu >= 1024)
 		return task_slice_ns(tctx);
 	budget = (u64)tctx->budget_ns;
 	core_freq = per_cpu_max_freq_khz[target_cpu];
-	is_smt = per_cpu_is_smt[target_cpu];
-	thread_bw = is_smt ? core_freq / 2 : core_freq;
+	siblings = per_cpu_sibling_count[target_cpu];
+	thread_bw = siblings > 1 ? core_freq / siblings : core_freq;
 	bw_share = thread_bw * 10000ULL / system_total_khz;
 	wshare = budget * 10000ULL / FLOW_BUDGET_MAX_NS;
 	if (wshare > 10000ULL) wshare = 10000ULL;
@@ -70,10 +70,12 @@ static __always_inline u64 compute_task_slice(struct task_ctx *tctx,
 
 /*
  * Dispatch a non-wakeup task and record its PID for the web UI.
- * The task is always dispatched (never returned -2).
- * The carriage pool uses a simple rolling counter — no ring buffer
- * state machine, no producer/consumer indices, no FILLING/CALCULATING
- * states.  It always records, never blocks.
+ * Target CPU selection (in order of preference):
+ *   1. last_cpu — cache warmth (matching bpfland/cosmos pattern)
+ *   2. If last_cpu is an SMT secondary, prefer the primary sibling
+ *      (avoids sharing the same physical core's execution resources)
+ *   3. scx_bpf_task_cpu(p) — fallback (current CPU or wake target)
+ * No CPU scanning — O(1) per dispatch, no iterator kfunc calls.
  */
 static __always_inline void carriage_enqueue_task(struct task_struct *p,
 						   struct task_ctx *tctx)
@@ -86,6 +88,13 @@ static __always_inline void carriage_enqueue_task(struct task_struct *p,
 
 	target_cpu = (tctx && tctx->last_cpu >= 0) ? tctx->last_cpu
 		     : scx_bpf_task_cpu(p);
+	/* SMT-aware: if targeting an SMT secondary, prefer its primary
+	 * sibling to avoid sharing execution resources.  Consecutive
+	 * CPU pairs (0↔1, 2↔3, ...) are typical on x86. */
+	if (target_cpu >= 0 && (u32)target_cpu < 1024 &&
+	    per_cpu_is_smt[target_cpu])
+		target_cpu = target_cpu ^ 1;
+
 	slice_ns = compute_task_slice(tctx, target_cpu);
 
 	/* Dispatch to the target CPU's per-CPU DSQ via the base kfunc. */

--- a/scheds/experimental/scx_flow/src/bpf/carriage.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/carriage.bpf.c
@@ -1,91 +1,63 @@
 /* Waiting Room — included by main.bpf.c via #include
  *
- * Non-wakeup tasks are dispatched to FLOW_BATCH_DSQ, a shared vtime-
- * ordered DSQ (matching cosmos's global vtime DSQ pattern).  Any idle
- * CPU drains from FLOW_BATCH_DSQ during ops.dispatch(), naturally
- * balancing load without per-enqueue CPU scanning.
+ * Per-CPU fair-share dispatch:
+ *   Each task dispatched to a CPU receives a slice of
+ *   FLOW_CARRIAGE_NS / tasks_on_target_cpu, clamped to [50us, 2ms].
+ *   This divides the CPU's bandwidth equally among all tasks currently
+ *   assigned to it — no budget lookups, no frequency ratios.
  *
- * The bandwidth model computes each task's slice from the task's budget,
- * the target core's frequency, and the system's total bandwidth:
- *   slice = (budget / BUDGET_MAX) x (thread_bw / system_total_khz) x window
- * adjusted for migration cost (same-LLC: -10%, cross-LLC: -25%).
+ *   Target CPU is always last_cpu (cache warmth, O(1), no scan).
+ *   When more tasks arrive on a CPU, each automatically gets a
+ *   proportionally smaller slice.
  *
- * The carriage pool records PIDs for the web UI (stats-only). */
+ *   Dispatch uses per-CPU vtime DSQs (FLOW_VTIME_DSQ_BASE + cpu) via
+ *   scx_bpf_dsq_insert_vtime.  ops.dispatch() on the same CPU consumes
+ *   from that CPU's DSQ, and may steal from peer CPUs when idle. */
 
 void scx_bpf_dsq_insert___v1(struct task_struct *p, u64 dsq_id,
 			      u64 slice, u64 enq_flags) __ksym __weak;
 
-/* Base slice: budget x frequency x window (PRD Phase C). */
-static __always_inline u64 compute_base_slice(struct task_ctx *tctx,
-					       s32 target_cpu)
-{
-	u64 slice_ns, budget, core_freq, siblings, thread_bw, bw_share, wshare;
-	if (!tctx || tctx->budget_ns <= 0 || system_total_khz == 0 ||
-	    target_cpu < 0 || (u32)target_cpu >= 1024)
-		return task_slice_ns(tctx);
-	budget = (u64)tctx->budget_ns;
-	core_freq = per_cpu_max_freq_khz[target_cpu];
-	siblings = per_cpu_sibling_count[target_cpu];
-	thread_bw = siblings > 1 ? core_freq / siblings : core_freq;
-	bw_share = thread_bw * 10000ULL / system_total_khz;
-	wshare = budget * 10000ULL / FLOW_BUDGET_MAX_NS;
-	if (wshare > 10000ULL) wshare = 10000ULL;
-	slice_ns = wshare * bw_share * FLOW_CARRIAGE_NS / 10000ULL / 10000ULL;
-	if (slice_ns < FLOW_SLICE_MIN_NS) slice_ns = FLOW_SLICE_MIN_NS;
-	if (slice_ns > FLOW_BUDGET_MAX_NS) slice_ns = FLOW_BUDGET_MAX_NS;
-	return slice_ns;
-}
-
-/* Migration penalty: same-LLC -10%, cross-LLC -25%. */
-static __always_inline u64 apply_slice_adjustments(u64 slice_ns,
-						     struct task_ctx *tctx,
-						     s32 target_cpu)
-{
-	if (tctx && tctx->last_cpu >= 0 && tctx->last_cpu != target_cpu) {
-		s32 last_llc = tctx->last_llc, tllc = -1;
-		if ((u32)target_cpu < 1024)
-			tllc = (s32)per_cpu_llc_id[(u32)target_cpu];
-		if (last_llc >= 0 && tllc >= 0 && last_llc == tllc)
-			slice_ns = slice_ns * 90ULL / 100ULL;
-		else
-			slice_ns = slice_ns * 75ULL / 100ULL;
-		if (slice_ns < FLOW_SLICE_MIN_NS) slice_ns = FLOW_SLICE_MIN_NS;
-	}
-	return slice_ns;
-}
-
+/*
+ * Fair-share slice: window divided equally among tasks on the target CPU.
+ * Clamped to [FLOW_SLICE_MIN_NS, FLOW_BUDGET_MAX_NS].
+ */
 static __always_inline u64 compute_task_slice(struct task_ctx *tctx,
 					       s32 target_cpu)
 {
-	return apply_slice_adjustments(compute_base_slice(tctx, target_cpu),
-				       tctx, target_cpu);
+	u64 tasks, slice;
+
+	if (target_cpu < 0 || (u32)target_cpu >= 1024)
+		return task_slice_ns(tctx);
+
+	tasks = per_cpu_runnable[target_cpu];
+	if (tasks == 0) tasks = 1;
+
+	slice = FLOW_CARRIAGE_NS / tasks;
+	if (slice < FLOW_SLICE_MIN_NS) slice = FLOW_SLICE_MIN_NS;
+	if (slice > FLOW_BUDGET_MAX_NS) slice = FLOW_BUDGET_MAX_NS;
+	return slice;
 }
 
 /*
- * Dispatch a non-wakeup task to the shared FLOW_BATCH_DSQ with vtime
- * ordering.  The target CPU for the bandwidth model is the task's
- * last_cpu (cache warmth).  No per-CPU scanning — idle CPUs drain
- * FLOW_BATCH_DSQ during ops.dispatch().
+ * Dispatch a non-wakeup task to its last_cpu's per-CPU vtime DSQ.
+ * No CPU scan, no budget bandwidth formula — just fair-share slice.
  */
 static __always_inline void carriage_enqueue_task(struct task_struct *p,
 						   struct task_ctx *tctx)
 {
-	u64 slot, slice_ns;
+	u64 slot, slice_ns, dsq_id;
 	s32 target_cpu;
 
 	slot = __sync_fetch_and_add(&carriage_producer, 1)
 		& (FLOW_NR_CARRIAGES - 1);
 
-	/* Use last_cpu for the bandwidth model (cache warmth).
-	 * The actual dispatch goes to the shared FLOW_BATCH_DSQ. */
 	target_cpu = (tctx && tctx->last_cpu >= 0) ? tctx->last_cpu
 		     : scx_bpf_task_cpu(p);
 
 	slice_ns = compute_task_slice(tctx, target_cpu);
+	dsq_id = FLOW_VTIME_DSQ_BASE + (u32)target_cpu;
 
-	/* Shareed vtime-ordered DSQ — idle CPUs drain via ops.dispatch(). */
-	if (!scx_bpf_dsq_insert_vtime(p, FLOW_BATCH_DSQ,
-				      slice_ns, slice_ns, 0))
+	if (!scx_bpf_dsq_insert_vtime(p, dsq_id, slice_ns, slice_ns, 0))
 		scx_bpf_dsq_insert___v1(p, FLOW_BATCH_DSQ, slice_ns, 0);
 
 	carriage_pool[slot].tasks[carriage_pool[slot].count %

--- a/scheds/experimental/scx_flow/src/bpf/carriage.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/carriage.bpf.c
@@ -53,6 +53,8 @@ static __always_inline void carriage_enqueue_task(struct task_struct *p,
 
 	target_cpu = (tctx && tctx->last_cpu >= 0) ? tctx->last_cpu
 		     : scx_bpf_task_cpu(p);
+	if (target_cpu < 0 || (u32)target_cpu >= 1024)
+		target_cpu = 0;
 
 	slice_ns = compute_task_slice(tctx, target_cpu);
 	dsq_id = FLOW_VTIME_DSQ_BASE + (u32)target_cpu;

--- a/scheds/experimental/scx_flow/src/bpf/dispatch.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/dispatch.bpf.c
@@ -1,8 +1,3 @@
-/* Undefine the compat macro so we can declare base kfuncs directly. */
-#ifdef scx_bpf_dsq_move_to_local
-#undef scx_bpf_dsq_move_to_local
-#endif
-
 /* Dispatch hierarchy — included by main.bpf.c via #include
  *
  * 1. Per-CPU pinned DSQ (non-migratable tasks)
@@ -11,23 +6,11 @@
  * 4. Shared FLOW_BATCH_DSQ (fallback)
  * 5. Previous task extension
  *
- * flow_dsq_move_one wraps scx_bpf_dsq_move_to_local with fallback
- * chain for v2/v1/old/base variants. */
-
-bool scx_bpf_dsq_move_to_local___v2(u64 dsq_id, u64 enq_flags) __ksym __weak;
-bool scx_bpf_dsq_move_to_local___v1(u64 dsq_id) __ksym __weak;
-bool scx_bpf_consume___old(u64 dsq_id) __ksym __weak;
-bool scx_bpf_dsq_move_to_local(u64 dsq_id) __ksym __weak;
+ * flow_dsq_move_one wraps scx_bpf_dsq_move_to_local from compat.bpf.h. */
 
 static __always_inline bool flow_dsq_move_one(u64 dsq_id)
 {
-	if (bpf_ksym_exists(scx_bpf_dsq_move_to_local___v2))
-		return scx_bpf_dsq_move_to_local___v2(dsq_id, 0);
-	if (bpf_ksym_exists(scx_bpf_dsq_move_to_local___v1))
-		return scx_bpf_dsq_move_to_local___v1(dsq_id);
-	if (bpf_ksym_exists(scx_bpf_consume___old))
-		return scx_bpf_consume___old(dsq_id);
-	return scx_bpf_dsq_move_to_local(dsq_id);
+	return scx_bpf_dsq_move_to_local(dsq_id, 0);
 }
 
 void BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)

--- a/scheds/experimental/scx_flow/src/bpf/dispatch.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/dispatch.bpf.c
@@ -5,12 +5,14 @@
 
 /* Dispatch hierarchy — included by main.bpf.c via #include
  *
- * Shared FLOW_BATCH_DSQ: non-wakeup tasks with vtime ordering.  Any
- * idle CPU steals from this DSQ, providing natural load balancing.
- * Per-CPU pinned DSQ: non-migratable tasks (nr_cpus_allowed == 1).
+ * 1. Per-CPU pinned DSQ (non-migratable tasks)
+ * 2. Per-CPU vtime DSQ (this CPU's own tasks)
+ * 3. Peer CPU vtime DSQs (work stealing — idle CPU steals from busiest peer)
+ * 4. Shared FLOW_BATCH_DSQ (fallback)
+ * 5. Previous task extension
  *
  * flow_dsq_move_one wraps scx_bpf_dsq_move_to_local with fallback
- * chain for v2/v1/old/base variants across kernel versions. */
+ * chain for v2/v1/old/base variants. */
 
 bool scx_bpf_dsq_move_to_local___v2(u64 dsq_id, u64 enq_flags) __ksym __weak;
 bool scx_bpf_dsq_move_to_local___v1(u64 dsq_id) __ksym __weak;
@@ -25,12 +27,15 @@ static __always_inline bool flow_dsq_move_one(u64 dsq_id)
 		return scx_bpf_dsq_move_to_local___v1(dsq_id);
 	if (bpf_ksym_exists(scx_bpf_consume___old))
 		return scx_bpf_consume___old(dsq_id);
-	/* Fallback: base function (kernel 7.0.x). */
 	return scx_bpf_dsq_move_to_local(dsq_id);
 }
 
 int BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
 {
+	s32 peer;
+	u64 best_load = 0, load;
+	s32 steal_from = -1;
+
 	/* 1. Per-CPU pinned DSQ. */
 	if (scx_bpf_dsq_nr_queued(FLOW_PINNED_DSQ_BASE + (u32)cpu) > 0 &&
 	    flow_dsq_move_one(FLOW_PINNED_DSQ_BASE + (u32)cpu)) {
@@ -38,15 +43,36 @@ int BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
 		return 0;
 	}
 
-	/* 2. Shared FLOW_BATCH_DSQ: non-wakeup tasks with vtime ordering.
-	 *    Any idle CPU steals from this shared DSQ, balancing load
-	 *    without per-enqueue CPU scanning. */
-	if (scx_bpf_dsq_nr_queued(FLOW_BATCH_DSQ) > 0 &&
-	    flow_dsq_move_one(FLOW_BATCH_DSQ)) {
+	/* 2. Per-CPU vtime DSQ (this CPU's own tasks). */
+	if (scx_bpf_dsq_nr_queued(FLOW_VTIME_DSQ_BASE + (u32)cpu) > 0 &&
+	    flow_dsq_move_one(FLOW_VTIME_DSQ_BASE + (u32)cpu))
 		return 0;
-	}
 
-	/* 3. Previous task extension. */
+	/* 3. Work stealing: if this CPU is idle, steal from the busiest peer.
+	 *    Scan peer DSQs (bounded by nr_cpu_ids ≤ 1024). */
+	bpf_for(peer, 0, 1024) {
+		if ((u32)peer >= nr_cpu_ids)
+			break;
+		if (peer == cpu)
+			continue;
+		if (scx_bpf_dsq_nr_queued(FLOW_VTIME_DSQ_BASE + (u32)peer) > 0) {
+			load = scx_bpf_dsq_nr_queued(FLOW_VTIME_DSQ_BASE + (u32)peer);
+			if (load > best_load) {
+				best_load = load;
+				steal_from = peer;
+			}
+		}
+	}
+	if (steal_from >= 0 &&
+	    flow_dsq_move_one(FLOW_VTIME_DSQ_BASE + (u32)steal_from))
+		return 0;
+
+	/* 4. Shared FLOW_BATCH_DSQ fallback. */
+	if (scx_bpf_dsq_nr_queued(FLOW_BATCH_DSQ) > 0 &&
+	    flow_dsq_move_one(FLOW_BATCH_DSQ))
+		return 0;
+
+	/* 5. Previous task extension. */
 	if (!prev || !(prev->scx.flags & SCX_TASK_QUEUED))
 		return 0;
 

--- a/scheds/experimental/scx_flow/src/bpf/dispatch.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/dispatch.bpf.c
@@ -30,7 +30,7 @@ static __always_inline bool flow_dsq_move_one(u64 dsq_id)
 	return scx_bpf_dsq_move_to_local(dsq_id);
 }
 
-int BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
+void BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
 {
 	s32 peer;
 	u64 best_load = 0, load;
@@ -40,13 +40,13 @@ int BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
 	if (scx_bpf_dsq_nr_queued(FLOW_PINNED_DSQ_BASE + (u32)cpu) > 0 &&
 	    flow_dsq_move_one(FLOW_PINNED_DSQ_BASE + (u32)cpu)) {
 		__sync_fetch_and_add(&pinned_dispatches, 1);
-		return 0;
+		return;
 	}
 
 	/* 2. Per-CPU vtime DSQ (this CPU's own tasks). */
 	if (scx_bpf_dsq_nr_queued(FLOW_VTIME_DSQ_BASE + (u32)cpu) > 0 &&
 	    flow_dsq_move_one(FLOW_VTIME_DSQ_BASE + (u32)cpu))
-		return 0;
+		return;
 
 	/* 3. Work stealing: if this CPU is idle, steal from the busiest peer.
 	 *    Scan peer DSQs (bounded by nr_cpu_ids ≤ 1024). */
@@ -65,17 +65,17 @@ int BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
 	}
 	if (steal_from >= 0 &&
 	    flow_dsq_move_one(FLOW_VTIME_DSQ_BASE + (u32)steal_from))
-		return 0;
+		return;
 
 	/* 4. Shared FLOW_BATCH_DSQ fallback. */
 	if (scx_bpf_dsq_nr_queued(FLOW_BATCH_DSQ) > 0 &&
 	    flow_dsq_move_one(FLOW_BATCH_DSQ))
-		return 0;
+		return;
 
 	/* 5. Previous task extension. */
 	if (!prev || !(prev->scx.flags & SCX_TASK_QUEUED))
-		return 0;
+		return;
 
 	prev->scx.slice = task_slice_ns(lookup_task_ctx(prev));
-	return 0;
+	return;
 }

--- a/scheds/experimental/scx_flow/src/bpf/dispatch.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/dispatch.bpf.c
@@ -5,14 +5,12 @@
 
 /* Dispatch hierarchy — included by main.bpf.c via #include
  *
- * Per-CPU DSQ: non-wakeup tasks go to FLOW_VTIME_DSQ_BASE + cpu
- * (user-created).  ops.dispatch() moves tasks from the calling CPU's
- * DSQ to the local DSQ.
+ * Shared FLOW_BATCH_DSQ: non-wakeup tasks with vtime ordering.  Any
+ * idle CPU steals from this DSQ, providing natural load balancing.
+ * Per-CPU pinned DSQ: non-migratable tasks (nr_cpus_allowed == 1).
  *
- * The compat macro scx_bpf_dsq_move_to_local checks v2/v1/old variants,
- * but on kernel 7.0.x only the base scx_bpf_dsq_move_to_local(u64 dsq_id)
- * is registered.  We wrap it with a local fallback to ensure dispatch
- * works across all kernel versions. */
+ * flow_dsq_move_one wraps scx_bpf_dsq_move_to_local with fallback
+ * chain for v2/v1/old/base variants across kernel versions. */
 
 bool scx_bpf_dsq_move_to_local___v2(u64 dsq_id, u64 enq_flags) __ksym __weak;
 bool scx_bpf_dsq_move_to_local___v1(u64 dsq_id) __ksym __weak;
@@ -40,9 +38,11 @@ int BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
 		return 0;
 	}
 
-	/* 2. Per-CPU vtime DSQ. */
-	if (scx_bpf_dsq_nr_queued(FLOW_VTIME_DSQ_BASE + (u32)cpu) > 0 &&
-	    flow_dsq_move_one(FLOW_VTIME_DSQ_BASE + (u32)cpu)) {
+	/* 2. Shared FLOW_BATCH_DSQ: non-wakeup tasks with vtime ordering.
+	 *    Any idle CPU steals from this shared DSQ, balancing load
+	 *    without per-enqueue CPU scanning. */
+	if (scx_bpf_dsq_nr_queued(FLOW_BATCH_DSQ) > 0 &&
+	    flow_dsq_move_one(FLOW_BATCH_DSQ)) {
 		return 0;
 	}
 

--- a/scheds/experimental/scx_flow/src/bpf/dispatch.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/dispatch.bpf.c
@@ -1,92 +1,55 @@
+/* Undefine the compat macro so we can declare base kfuncs directly. */
+#ifdef scx_bpf_dsq_move_to_local
+#undef scx_bpf_dsq_move_to_local
+#endif
+
 /* Dispatch hierarchy — included by main.bpf.c via #include
  *
- * Rotating tier dispatch (Model A):
- *   gen & 3 selects the dispatch phase.  Each phase rotates which tier
- *   is checked FIRST.  Over 4 dispatches every tier starts the cascade
- *   exactly once, guaranteeing that no tier waits longer than 3 dispatch
- *   calls before it is serviced.  Starvation-free by construction.
+ * Per-CPU DSQ: non-wakeup tasks go to FLOW_VTIME_DSQ_BASE + cpu
+ * (user-created).  ops.dispatch() moves tasks from the calling CPU's
+ * DSQ to the local DSQ.
  *
- *   Phase 0:  PRIORITY → NORMAL → LOW → DEFICIT
- *   Phase 1:  NORMAL   → LOW    → DEFICIT → PRIORITY
- *   Phase 2:  LOW      → DEFICIT → PRIORITY → NORMAL
- *   Phase 3:  DEFICIT  → PRIORITY → NORMAL → LOW
- *
- *   The per-CPU pinned DSQ (non-migratable tasks) is always checked first
- *   regardless of phase — it bypasses the tier system entirely. */
+ * The compat macro scx_bpf_dsq_move_to_local checks v2/v1/old variants,
+ * but on kernel 7.0.x only the base scx_bpf_dsq_move_to_local(u64 dsq_id)
+ * is registered.  We wrap it with a local fallback to ensure dispatch
+ * works across all kernel versions. */
 
-void BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
+bool scx_bpf_dsq_move_to_local___v2(u64 dsq_id, u64 enq_flags) __ksym __weak;
+bool scx_bpf_dsq_move_to_local___v1(u64 dsq_id) __ksym __weak;
+bool scx_bpf_consume___old(u64 dsq_id) __ksym __weak;
+bool scx_bpf_dsq_move_to_local(u64 dsq_id) __ksym __weak;
+
+static __always_inline bool flow_dsq_move_one(u64 dsq_id)
 {
-	u64 gen = __sync_fetch_and_add(&dispatch_gen, 1);
+	if (bpf_ksym_exists(scx_bpf_dsq_move_to_local___v2))
+		return scx_bpf_dsq_move_to_local___v2(dsq_id, 0);
+	if (bpf_ksym_exists(scx_bpf_dsq_move_to_local___v1))
+		return scx_bpf_dsq_move_to_local___v1(dsq_id);
+	if (bpf_ksym_exists(scx_bpf_consume___old))
+		return scx_bpf_consume___old(dsq_id);
+	/* Fallback: base function (kernel 7.0.x). */
+	return scx_bpf_dsq_move_to_local(dsq_id);
+}
 
+int BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
+{
+	/* 1. Per-CPU pinned DSQ. */
 	if (scx_bpf_dsq_nr_queued(FLOW_PINNED_DSQ_BASE + (u32)cpu) > 0 &&
-	    scx_bpf_dsq_move_to_local(FLOW_PINNED_DSQ_BASE + (u32)cpu, 0)) {
+	    flow_dsq_move_one(FLOW_PINNED_DSQ_BASE + (u32)cpu)) {
 		__sync_fetch_and_add(&pinned_dispatches, 1);
-		return;
+		return 0;
 	}
 
-	switch (gen & 3) {
-	case 0:
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_PRIORITY_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_PRIORITY_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_priority_dispatches, 1); return; }
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_NORMAL_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_NORMAL_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_normal_dispatches, 1); return; }
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_LOW_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_LOW_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_low_dispatches, 1); return; }
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_DEFICIT_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_DEFICIT_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_deficit_dispatches, 1); return; }
-		break;
-	case 1:
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_NORMAL_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_NORMAL_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_normal_dispatches, 1); return; }
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_LOW_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_LOW_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_low_dispatches, 1); return; }
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_DEFICIT_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_DEFICIT_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_deficit_dispatches, 1); return; }
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_PRIORITY_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_PRIORITY_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_priority_dispatches, 1); return; }
-		break;
-	case 2:
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_LOW_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_LOW_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_low_dispatches, 1); return; }
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_DEFICIT_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_DEFICIT_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_deficit_dispatches, 1); return; }
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_PRIORITY_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_PRIORITY_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_priority_dispatches, 1); return; }
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_NORMAL_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_NORMAL_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_normal_dispatches, 1); return; }
-		break;
-	case 3:
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_DEFICIT_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_DEFICIT_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_deficit_dispatches, 1); return; }
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_PRIORITY_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_PRIORITY_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_priority_dispatches, 1); return; }
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_NORMAL_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_NORMAL_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_normal_dispatches, 1); return; }
-		if (scx_bpf_dsq_nr_queued(FLOW_TIER_LOW_DSQ) > 0 &&
-		    scx_bpf_dsq_move_to_local(FLOW_TIER_LOW_DSQ, 0))
-			{ __sync_fetch_and_add(&tier_low_dispatches, 1); return; }
-		break;
+	/* 2. Per-CPU vtime DSQ. */
+	if (scx_bpf_dsq_nr_queued(FLOW_VTIME_DSQ_BASE + (u32)cpu) > 0 &&
+	    flow_dsq_move_one(FLOW_VTIME_DSQ_BASE + (u32)cpu)) {
+		return 0;
 	}
 
-	/* No tasks in any tier DSQ — check whether prev still has a slice.
-	 * This path is identical across all phases. */
+	/* 3. Previous task extension. */
 	if (!prev || !(prev->scx.flags & SCX_TASK_QUEUED))
-		return;
+		return 0;
 
 	prev->scx.slice = task_slice_ns(lookup_task_ctx(prev));
+	return 0;
 }

--- a/scheds/experimental/scx_flow/src/bpf/enqueue.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/enqueue.bpf.c
@@ -2,8 +2,8 @@
  *
  * Wakeup and pinned tasks bypass the carriage and are dispatched
  * directly to local DSQs.  Non-wakeup tasks go through
- * carriage_enqueue_task() which inserts into per-CPU DSQs
- * (FLOW_VTIME_DSQ_BASE + target_cpu) via scx_bpf_dsq_insert___v1. */
+ * carriage_enqueue_task() which inserts into FLOW_BATCH_DSQ
+ * (shared vtime-ordered DSQ) via scx_bpf_dsq_insert_vtime. */
 
 int BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 {
@@ -13,7 +13,10 @@ int BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 	bool is_wakeup;
 	bool has_wake_target = false;
 
-	/* Scheduler process bypass. */
+	/* Scheduler process bypass: direct dispatch with HEAD+PREEMPT.
+	 * Uses the default slice (not the bandwidth model) since the
+	 * scheduler thread receives HEAD+PREEMPT for immediate dispatch
+	 * regardless of slice duration. */
 	if (flow_scheduler_pid && (u64)(s32)p->pid == flow_scheduler_pid) {
 		s32 sch_cpu = scx_bpf_task_cpu(p);
 		u64 flags = FLOW_ENQ_HEAD | FLOW_ENQ_PREEMPT;
@@ -54,8 +57,9 @@ int BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 	/* Pinned kthread: direct to local DSQ. */
 	if (is_pinned_kthread(p)) {
 		clear_wake_target(tctx);
+		u64 ps = compute_task_slice(tctx, scx_bpf_task_cpu(p));
 		scx_bpf_dsq_insert___v1(p, FLOW_DSQ_LOCAL,
-			FLOW_SLICE_MIN_NS, enq_flags);
+			ps, enq_flags);
 		return 0;
 	}
 
@@ -64,28 +68,37 @@ int BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 		s32 pin_cpu = task_cpu;
 		if (pin_cpu >= 0 && valid_sched_cpu(pin_cpu)) {
 			clear_wake_target(tctx);
+			u64 ps = compute_task_slice(tctx, pin_cpu);
 			scx_bpf_dsq_insert___v1(p,
 				FLOW_PINNED_DSQ_BASE + (u32)pin_cpu,
-				FLOW_SLICE_MIN_NS, enq_flags);
+				ps, enq_flags);
 			return 0;
 		}
 	}
 
-	/* Wakeup fast path — bypass carriage. */
+	/* Wakeup fast path — bypass carriage.
+	 * Use the bandwidth model to compute the slice (matching 3.0.4's
+	 * task_slice_ns pattern), not the fixed minimum.  Tasks that wake
+	 * up often accumulate budget from sleep refills and should receive
+	 * longer slices proportional to their accumulated budget. */
 	if (is_wakeup) {
 		if (has_wake_target && valid_sched_cpu(target_cpu)) {
+			u64 wake_slice = compute_task_slice(tctx, target_cpu);
 			u64 wake_enq_flags;
 			wake_enq_flags = enq_flags | FLOW_ENQ_HEAD;
-			if (tctx && (tctx->first_run ||
-				     tctx->budget_ns >= (s64)FLOW_SLICE_MIN_NS))
+			if (tctx && tctx->budget_ns >= (s64)wake_slice)
 				wake_enq_flags |= FLOW_ENQ_PREEMPT;
 			scx_bpf_cpuperf_set(target_cpu, SCX_CPUPERF_ONE);
 			scx_bpf_dsq_insert___v1(p,
 				FLOW_DSQ_LOCAL_ON | (u32)target_cpu,
-				FLOW_SLICE_MIN_NS, wake_enq_flags);
+				wake_slice, wake_enq_flags);
 		} else {
+			s32 fb_cpu = scx_bpf_task_cpu(p);
+			u64 fb_slice = (fb_cpu >= 0 && (u32)fb_cpu < 1024)
+				? compute_task_slice(tctx, fb_cpu)
+				: task_slice_ns(tctx);
 			scx_bpf_dsq_insert___v1(p, FLOW_DSQ_LOCAL,
-				FLOW_SLICE_MIN_NS, FLOW_ENQ_HEAD);
+				fb_slice, FLOW_ENQ_HEAD);
 		}
 		__sync_fetch_and_add(&prio_dispatches, 1);
 		clear_wake_target(tctx);

--- a/scheds/experimental/scx_flow/src/bpf/enqueue.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/enqueue.bpf.c
@@ -2,10 +2,10 @@
  *
  * Wakeup and pinned tasks bypass the carriage and are dispatched
  * directly to local DSQs.  Non-wakeup tasks go through
- * carriage_enqueue_task() which inserts into FLOW_BATCH_DSQ
- * (shared vtime-ordered DSQ) via scx_bpf_dsq_insert_vtime. */
+ * carriage_enqueue_task() which inserts into per-CPU vtime DSQs
+ * (FLOW_VTIME_DSQ_BASE + cpu) via scx_bpf_dsq_insert_vtime. */
 
-int BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
+void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 {
 	struct task_ctx *tctx;
 	s32 target_cpu = -1;
@@ -27,8 +27,8 @@ int BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 		else
 			scx_bpf_dsq_insert___v1(p, FLOW_DSQ_LOCAL,
 				FLOW_SLICE_MIN_NS, flags);
-		return 0;
-	}
+	return;
+}
 
 	tctx = lookup_task_ctx(p);
 	is_wakeup = enq_flags & FLOW_ENQ_WAKEUP;
@@ -60,7 +60,7 @@ int BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 		u64 ps = compute_task_slice(tctx, scx_bpf_task_cpu(p));
 		scx_bpf_dsq_insert___v1(p, FLOW_DSQ_LOCAL,
 			ps, enq_flags);
-		return 0;
+		return;
 	}
 
 	/* Non-wakeup, non-migratable: per-CPU pinned DSQ. */
@@ -72,7 +72,7 @@ int BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 			scx_bpf_dsq_insert___v1(p,
 				FLOW_PINNED_DSQ_BASE + (u32)pin_cpu,
 				ps, enq_flags);
-			return 0;
+			return;
 		}
 	}
 
@@ -102,7 +102,7 @@ int BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 		}
 		__sync_fetch_and_add(&prio_dispatches, 1);
 		clear_wake_target(tctx);
-		return 0;
+		return;
 	}
 
 	/* Non-wakeup re-enqueue: Waiting Room.
@@ -110,5 +110,5 @@ int BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 	carriage_enqueue_task(p, tctx);
 
 	clear_wake_target(tctx);
-	return 0;
+	return;
 }

--- a/scheds/experimental/scx_flow/src/bpf/enqueue.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/enqueue.bpf.c
@@ -21,11 +21,11 @@ void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 		s32 sch_cpu = scx_bpf_task_cpu(p);
 		u64 flags = FLOW_ENQ_HEAD | FLOW_ENQ_PREEMPT;
 		if (sch_cpu >= 0 && (u32)sch_cpu < 1024)
-			scx_bpf_dsq_insert___v1(p,
+			scx_bpf_dsq_insert(p,
 				FLOW_DSQ_LOCAL_ON | (u32)sch_cpu,
 				FLOW_SLICE_MIN_NS, flags);
 		else
-			scx_bpf_dsq_insert___v1(p, FLOW_DSQ_LOCAL,
+			scx_bpf_dsq_insert(p, FLOW_DSQ_LOCAL,
 				FLOW_SLICE_MIN_NS, flags);
 	return;
 }
@@ -58,7 +58,7 @@ void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 	if (is_pinned_kthread(p)) {
 		clear_wake_target(tctx);
 		u64 ps = compute_task_slice(tctx, scx_bpf_task_cpu(p));
-		scx_bpf_dsq_insert___v1(p, FLOW_DSQ_LOCAL,
+		scx_bpf_dsq_insert(p, FLOW_DSQ_LOCAL,
 			ps, enq_flags);
 		return;
 	}
@@ -69,7 +69,7 @@ void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 		if (pin_cpu >= 0 && valid_sched_cpu(pin_cpu)) {
 			clear_wake_target(tctx);
 			u64 ps = compute_task_slice(tctx, pin_cpu);
-			scx_bpf_dsq_insert___v1(p,
+			scx_bpf_dsq_insert(p,
 				FLOW_PINNED_DSQ_BASE + (u32)pin_cpu,
 				ps, enq_flags);
 			return;
@@ -89,7 +89,7 @@ void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 			if (tctx && tctx->budget_ns >= (s64)wake_slice)
 				wake_enq_flags |= FLOW_ENQ_PREEMPT;
 			scx_bpf_cpuperf_set(target_cpu, SCX_CPUPERF_ONE);
-			scx_bpf_dsq_insert___v1(p,
+			scx_bpf_dsq_insert(p,
 				FLOW_DSQ_LOCAL_ON | (u32)target_cpu,
 				wake_slice, wake_enq_flags);
 		} else {
@@ -97,7 +97,7 @@ void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 			u64 fb_slice = (fb_cpu >= 0 && (u32)fb_cpu < 1024)
 				? compute_task_slice(tctx, fb_cpu)
 				: task_slice_ns(tctx);
-			scx_bpf_dsq_insert___v1(p, FLOW_DSQ_LOCAL,
+			scx_bpf_dsq_insert(p, FLOW_DSQ_LOCAL,
 				fb_slice, FLOW_ENQ_HEAD);
 		}
 		__sync_fetch_and_add(&prio_dispatches, 1);

--- a/scheds/experimental/scx_flow/src/bpf/enqueue.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/enqueue.bpf.c
@@ -1,16 +1,33 @@
-/* Enqueue routing — included by main.bpf.c via #include */
+/* Enqueue routing — included by main.bpf.c via #include
+ *
+ * Wakeup and pinned tasks bypass the carriage and are dispatched
+ * directly to local DSQs.  Non-wakeup tasks go through
+ * carriage_enqueue_task() which inserts into per-CPU DSQs
+ * (FLOW_VTIME_DSQ_BASE + target_cpu) via scx_bpf_dsq_insert___v1. */
 
-void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
+int BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 {
 	struct task_ctx *tctx;
 	s32 target_cpu = -1;
 	s32 task_cpu;
-	u64 slice_ns;
 	bool is_wakeup;
 	bool has_wake_target = false;
 
+	/* Scheduler process bypass. */
+	if (flow_scheduler_pid && (u64)(s32)p->pid == flow_scheduler_pid) {
+		s32 sch_cpu = scx_bpf_task_cpu(p);
+		u64 flags = FLOW_ENQ_HEAD | FLOW_ENQ_PREEMPT;
+		if (sch_cpu >= 0 && (u32)sch_cpu < 1024)
+			scx_bpf_dsq_insert___v1(p,
+				FLOW_DSQ_LOCAL_ON | (u32)sch_cpu,
+				FLOW_SLICE_MIN_NS, flags);
+		else
+			scx_bpf_dsq_insert___v1(p, FLOW_DSQ_LOCAL,
+				FLOW_SLICE_MIN_NS, flags);
+		return 0;
+	}
+
 	tctx = lookup_task_ctx(p);
-	slice_ns = task_slice_ns(tctx);
 	is_wakeup = enq_flags & FLOW_ENQ_WAKEUP;
 
 	if (tctx && tctx->wake_cpu_valid) {
@@ -19,6 +36,8 @@ void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 	}
 
 	task_cpu = scx_bpf_task_cpu(p);
+
+	/* Non-migratable: ensure target matches current CPU. */
 	if (is_non_migratable(p) && task_cpu >= 0 &&
 	    bpf_cpumask_test_cpu(task_cpu, p->cpus_ptr)) {
 		if (!has_wake_target || target_cpu != task_cpu) {
@@ -32,66 +51,51 @@ void BPF_STRUCT_OPS(flow_enqueue, struct task_struct *p, u64 enq_flags)
 		}
 	}
 
+	/* Pinned kthread: direct to local DSQ. */
 	if (is_pinned_kthread(p)) {
 		clear_wake_target(tctx);
-		scx_bpf_dsq_insert(p, FLOW_DSQ_LOCAL, FLOW_SLICE_MIN_NS, enq_flags);
-		return;
+		scx_bpf_dsq_insert___v1(p, FLOW_DSQ_LOCAL,
+			FLOW_SLICE_MIN_NS, enq_flags);
+		return 0;
 	}
 
+	/* Non-wakeup, non-migratable: per-CPU pinned DSQ. */
 	if (!is_wakeup && tctx && is_non_migratable(p)) {
 		s32 pin_cpu = task_cpu;
 		if (pin_cpu >= 0 && valid_sched_cpu(pin_cpu)) {
 			clear_wake_target(tctx);
-			scx_bpf_dsq_insert(p,
+			scx_bpf_dsq_insert___v1(p,
 				FLOW_PINNED_DSQ_BASE + (u32)pin_cpu,
-				task_slice_ns(tctx), enq_flags);
-			return;
+				FLOW_SLICE_MIN_NS, enq_flags);
+			return 0;
 		}
 	}
 
-	if (is_wakeup && has_wake_target && valid_sched_cpu(target_cpu)) {
-		u64 wake_enq_flags;
-		slice_ns = FLOW_SLICE_MIN_NS;
-
-		wake_enq_flags = enq_flags | FLOW_ENQ_HEAD;
-		if (tctx && (tctx->first_run ||
-			     tctx->budget_ns >= (s64)FLOW_SLICE_MIN_NS))
-			wake_enq_flags |= FLOW_ENQ_PREEMPT;
-
-		scx_bpf_cpuperf_set(target_cpu, SCX_CPUPERF_ONE);
-		scx_bpf_dsq_insert(p, FLOW_DSQ_LOCAL_ON | (u32)target_cpu,
-				   slice_ns, wake_enq_flags);
+	/* Wakeup fast path — bypass carriage. */
+	if (is_wakeup) {
+		if (has_wake_target && valid_sched_cpu(target_cpu)) {
+			u64 wake_enq_flags;
+			wake_enq_flags = enq_flags | FLOW_ENQ_HEAD;
+			if (tctx && (tctx->first_run ||
+				     tctx->budget_ns >= (s64)FLOW_SLICE_MIN_NS))
+				wake_enq_flags |= FLOW_ENQ_PREEMPT;
+			scx_bpf_cpuperf_set(target_cpu, SCX_CPUPERF_ONE);
+			scx_bpf_dsq_insert___v1(p,
+				FLOW_DSQ_LOCAL_ON | (u32)target_cpu,
+				FLOW_SLICE_MIN_NS, wake_enq_flags);
+		} else {
+			scx_bpf_dsq_insert___v1(p, FLOW_DSQ_LOCAL,
+				FLOW_SLICE_MIN_NS, FLOW_ENQ_HEAD);
+		}
 		__sync_fetch_and_add(&prio_dispatches, 1);
 		clear_wake_target(tctx);
-		return;
+		return 0;
 	}
 
-	{
-		s64 budget;
+	/* Non-wakeup re-enqueue: Waiting Room.
+	 * carriage_enqueue_task always dispatches (no pool-full blocking). */
+	carriage_enqueue_task(p, tctx);
 
-		if (tctx)
-			budget = tctx->budget_ns;
-		else
-			budget = 0;
-
-		/* Budget is in nanoseconds (s64).  Budget range after clamp is
-	 * [-500 us, 2000 us] = [-500,000 ns, 2,000,000 ns].  Tiers:
-	 *   PRIORITY: budget >= 1500 us (1,500,000 ns)  — long-sleep tasks
-	 *   NORMAL:   budget >= 1000 us (1,000,000 ns)  — tasks with typical budget
-	 *   LOW:      budget >=  500 us (  500,000 ns)  — tasks with modest budget
-	 *   DEFICIT:  budget <   500 us (  500,000 ns)  — exhausted / bulk workers
-	 *
-	 * Tasks need 500 us * 100 = 50 ms of sleep to reach LOW,
-	 * 100 ms for NORMAL, 150 ms for PRIORITY.  Interactive tasks
-	 * that sleep longer earn higher priority. */
-	if (budget >= FLOW_BUDGET_TIER_PRIORITY_NS)
-			scx_bpf_dsq_insert(p, FLOW_TIER_PRIORITY_DSQ, slice_ns, enq_flags);
-		else if (budget >= FLOW_BUDGET_TIER_NORMAL_NS)
-			scx_bpf_dsq_insert(p, FLOW_TIER_NORMAL_DSQ, slice_ns, enq_flags);
-		else if (budget >= FLOW_BUDGET_TIER_LOW_NS)
-			scx_bpf_dsq_insert(p, FLOW_TIER_LOW_DSQ, slice_ns, enq_flags);
-		else
-			scx_bpf_dsq_insert(p, FLOW_TIER_DEFICIT_DSQ, slice_ns, enq_flags);
-	}
 	clear_wake_target(tctx);
+	return 0;
 }

--- a/scheds/experimental/scx_flow/src/bpf/helpers.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/helpers.bpf.c
@@ -101,6 +101,7 @@ static __always_inline void reset_task_ctx(struct task_ctx *tctx, u64 now, bool 
 	tctx->sleep_started_at = sleeping ? now : 0;
 	tctx->last_cpu = -1;
 	tctx->last_llc = -1;
+	tctx->runnable_cpu = -1;
 	tctx->first_run = true;
 	clear_wake_target(tctx);
 }

--- a/scheds/experimental/scx_flow/src/bpf/helpers.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/helpers.bpf.c
@@ -56,7 +56,7 @@ static __always_inline s64 clamp_budget(s64 budget_ns)
 static __always_inline u64 task_slice_ns(const struct task_ctx *tctx)
 {
 	if (tctx && tctx->budget_ns > 0) {
-		u64 budget_ns = (u64)tctx->budget_ns;
+		u64 budget_ns = tctx->budget_ns;
 		u64 reserved_max_ns = tune_reserved_max_ns;
 
 		if (reserved_max_ns < FLOW_SLICE_MIN_NS)
@@ -100,6 +100,7 @@ static __always_inline void reset_task_ctx(struct task_ctx *tctx, u64 now, bool 
 	tctx->last_sleep_ns = 0;
 	tctx->sleep_started_at = sleeping ? now : 0;
 	tctx->last_cpu = -1;
+	tctx->last_llc = -1;
 	tctx->first_run = true;
 	clear_wake_target(tctx);
 }
@@ -158,7 +159,4 @@ static __always_inline void update_budget_on_wakeup(const struct task_struct *p,
 	tctx->last_refill_ns = refill_ns;
 	tctx->last_sleep_ns = sleep_ns;
 	tctx->sleep_started_at = 0;
-
-	if (refill_ns > 0)
-		__sync_fetch_and_add(&budget_refill_events, 1);
 }

--- a/scheds/experimental/scx_flow/src/bpf/intf.h
+++ b/scheds/experimental/scx_flow/src/bpf/intf.h
@@ -27,8 +27,8 @@ enum consts {
 	FLOW_BATCH_DSQ            = 8192ULL,
 
 	/* Carriage pool — stats-only ring buffer for the web UI.
-	 * Non-wakeup tasks are dispatched to SCX_DSQ_LOCAL directly
-	 * from the enqueue callback (matching bpfland/cosmos pattern).
+	 * Non-wakeup tasks are dispatched to per-CPU vtime DSQs
+	 * (FLOW_VTIME_DSQ_BASE + cpu) from the enqueue callback.
 	 * The carriage pool records a rolling sample of dispatched PIDs. */
 	FLOW_NR_CARRIAGES        = 64ULL,
 	FLOW_CARRIAGE_CAPACITY   = 64ULL,

--- a/scheds/experimental/scx_flow/src/bpf/intf.h
+++ b/scheds/experimental/scx_flow/src/bpf/intf.h
@@ -21,8 +21,10 @@ enum consts {
 
 	/* Per-CPU pinned DSQ base. */
 	FLOW_PINNED_DSQ_BASE = 2048ULL,
-	/* Shared vtime-ordered batch DSQ for non-wakeup dispatch. */
-	FLOW_BATCH_DSQ            = 4096ULL,
+	/* Per-CPU vtime DSQ base (per-core bandwidth sharing). */
+	FLOW_VTIME_DSQ_BASE = 4096ULL,
+	/* Shared batch DSQ (fallback when no per-CPU DSQ available). */
+	FLOW_BATCH_DSQ            = 8192ULL,
 
 	/* Carriage pool — stats-only ring buffer for the web UI.
 	 * Non-wakeup tasks are dispatched to SCX_DSQ_LOCAL directly

--- a/scheds/experimental/scx_flow/src/bpf/intf.h
+++ b/scheds/experimental/scx_flow/src/bpf/intf.h
@@ -21,8 +21,8 @@ enum consts {
 
 	/* Per-CPU pinned DSQ base. */
 	FLOW_PINNED_DSQ_BASE = 2048ULL,
-	/* Per-CPU vtime DSQ base (follows bpfland per-CPU-DSQ pattern). */
-	FLOW_VTIME_DSQ_BASE = 4096ULL,
+	/* Shared vtime-ordered batch DSQ for non-wakeup dispatch. */
+	FLOW_BATCH_DSQ            = 4096ULL,
 
 	/* Carriage pool — stats-only ring buffer for the web UI.
 	 * Non-wakeup tasks are dispatched to SCX_DSQ_LOCAL directly

--- a/scheds/experimental/scx_flow/src/bpf/intf.h
+++ b/scheds/experimental/scx_flow/src/bpf/intf.h
@@ -1,16 +1,8 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-/*
- * Copyright (c) 2026 Galih Tama <galpt@v.recipes>
- *
- * This software may be used and distributed according to the terms of the GNU
- * General Public License version 2.
- */
+/* Copyright (c) 2026 Galih Tama <galpt@v.recipes> */
 #ifndef __INTF_H
 #define __INTF_H
 
-/*
- * Shared BPF constants for scx_flow.
- */
 enum consts {
 	NSEC_PER_USEC = 1000ULL,
 	NSEC_PER_MSEC = (1000ULL * NSEC_PER_USEC),
@@ -27,51 +19,31 @@ enum consts {
 	FLOW_INTERACTIVE_FLOOR_MAX_NS = (200ULL * NSEC_PER_USEC),
 	FLOW_REFILL_DIV = 100ULL,
 
-	/* Per-CPU pinned DSQ base: each CPU gets FLOW_PINNED_DSQ_BASE + cpu.
-	 * Non-migratable userspace tasks (nr_cpus_allowed == 1) are routed
-	 * here on non-wakeup re-enqueue, checked first in dispatch so that
-	 * pinned latency-sensitive tasks bypass global vtime DSQ contention.
-	 * The nr_cpus_allowed signal is kernel-enforced, not a heuristic.
-	 * Addition used instead of bitwise-OR to avoid DSQ ID collisions on
-	 * systems with cpu >= FLOW_PINNED_DSQ_BASE (reviewer comment). */
+	/* Per-CPU pinned DSQ base. */
 	FLOW_PINNED_DSQ_BASE = 2048ULL,
+	/* Per-CPU vtime DSQ base (follows bpfland per-CPU-DSQ pattern). */
+	FLOW_VTIME_DSQ_BASE = 4096ULL,
 
-	/* O(1) multi-level FIFO dispatch tiers for non-wakeup re-enqueues.
-	 * Each tier is an independent FIFO DSQ, checked in priority order
-	 * during dispatch.  Tasks are classified by budget at enqueue time:
-	 *   PRIORITY (≥ 1500 us)  — tasks that slept a long time (interactive)
-	 *   NORMAL   (≥ 1000 us)  — tasks with typical budget
-	 *   LOW      (≥  500 us)  — tasks with modest budget
-	 *   DEFICIT  (<  500 us)  — tasks that exhausted their budget (bulk workers)
-	 * Within each tier, tasks dispatch in FIFO order (O(1) per operation).
-	 * The tier boundaries are compile-time constants — no adaptive tuning,
-	 * no scoring signals, no classification heuristics.  Same inputs always
-	 * produce the same tier assignment.
-	 *
-	 * Budget thresholds (in nanoseconds) used by enqueue's select_tier(). */
-	FLOW_BUDGET_TIER_PRIORITY_NS = 1500000ULL,  /* 1500 us */
-	FLOW_BUDGET_TIER_NORMAL_NS   = 1000000ULL,  /* 1000 us */
-	FLOW_BUDGET_TIER_LOW_NS      =  500000ULL,  /*  500 us */
-	FLOW_TIER_PRIORITY_DSQ = 3000ULL,
-	FLOW_TIER_NORMAL_DSQ   = 3001ULL,
-	FLOW_TIER_LOW_DSQ      = 3002ULL,
-	FLOW_TIER_DEFICIT_DSQ  = 3003ULL,
+	/* Carriage pool — stats-only ring buffer for the web UI.
+	 * Non-wakeup tasks are dispatched to SCX_DSQ_LOCAL directly
+	 * from the enqueue callback (matching bpfland/cosmos pattern).
+	 * The carriage pool records a rolling sample of dispatched PIDs. */
+	FLOW_NR_CARRIAGES        = 64ULL,
+	FLOW_CARRIAGE_CAPACITY   = 64ULL,
+	FLOW_CARRIAGE_NS         = 100000ULL,
 
-	/* Enqueue flags (defined directly to bypass weak-volatile compat) */
-	FLOW_ENQ_WAKEUP  = 0x0000000000000001ULL,  /* SCX_ENQ_WAKEUP */
-	FLOW_ENQ_HEAD    = 0x0000000000010000ULL,  /* SCX_ENQ_HEAD */
-	FLOW_ENQ_PREEMPT = 0x0000000100000000ULL,  /* SCX_ENQ_PREEMPT */
+	/* Enqueue flags */
+	FLOW_ENQ_WAKEUP  = 0x0000000000000001ULL,
+	FLOW_ENQ_HEAD    = 0x0000000000010000ULL,
+	FLOW_ENQ_PREEMPT = 0x0000000100000000ULL,
 
 	/* CPU selection flags */
-	FLOW_PICK_IDLE_CORE = 0x01ULL,  /* scx_bpf_pick_idle_cpu: both SMT siblings idle */
+	FLOW_PICK_IDLE_CORE = 0x01ULL,
 
-	/* Built-in DSQ IDs (kernel ABI, stable):
-	 *   SCX_DSQ_LOCAL   = 0x8000000000000002  — per-CPU local DSQ
-	 *   SCX_DSQ_GLOBAL  = 0x8000000000000001  — global FIFO DSQ
-	 *   SCX_DSQ_LOCAL_ON = 0xC000000000000000 | cpu — local DSQ + atomic reschedule */
+	/* Built-in DSQ IDs */
+	FLOW_DSQ_GLOBAL    = 0x8000000000000001ULL,
 	FLOW_DSQ_LOCAL     = 0x8000000000000002ULL,
 	FLOW_DSQ_LOCAL_ON  = 0xC000000000000000ULL,
-
 };
 
 #ifndef __VMLINUX_H__
@@ -79,21 +51,22 @@ typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 typedef unsigned long u64;
-
 typedef signed char s8;
 typedef signed short s16;
 typedef signed int s32;
 typedef signed long s64;
-
 typedef int pid_t;
-#endif /* __VMLINUX_H__ */
+#endif
+
+struct flow_carriage {
+	u64 tasks[FLOW_CARRIAGE_CAPACITY];	/* PIDs for web UI */
+	u32 count;
+};
 
 struct flow_cpu_state {
 	u64 budget_exhaustions;
 	u64 runnable_wakeups;
 	u64 cpu_migrations;
-	/* per-tier dispatch counters are BSS volatiles (not per-CPU),
-	 * read directly by the Rust loader for the web UI. */
 };
 
 #endif /* __INTF_H */

--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -55,7 +55,8 @@ struct {
 /* Per-core topology — populated at init by Rust userspace. */
 volatile u64 per_cpu_max_freq_khz[1024];
 volatile u64 per_cpu_llc_id[1024];
-volatile u64 per_cpu_is_smt[1024];
+volatile u64 per_cpu_is_smt[1024];	/* 1 = SMT secondary (for web UI) */
+volatile u64 per_cpu_sibling_count[1024]; /* threads per core (for bandwidth) */
 volatile u64 per_cpu_runnable[1024];	/* current runnable count per CPU */
 volatile u64 system_total_khz;		/* sum of all core_effective_khz */
 volatile u64 nr_cpu_ids;

--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -118,8 +118,14 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(flow_init)
 		return ret;
 	}
 
-	/* Create per-CPU pinned DSQs for non-migratable tasks. */
+	/* Create per-CPU vtime DSQs and per-CPU pinned DSQs. */
 	bpf_for(cpu, 0, nr_cpu_ids) {
+		ret = scx_bpf_create_dsq(FLOW_VTIME_DSQ_BASE + (u32)cpu, -1);
+		if (ret < 0 && ret != -EEXIST) {
+			scx_bpf_error("failed to create vtime DSQ for CPU %d: %d",
+				      cpu, ret);
+			return ret;
+		}
 		ret = scx_bpf_create_dsq(FLOW_PINNED_DSQ_BASE + (u32)cpu, -1);
 		if (ret < 0 && ret != -EEXIST) {
 			scx_bpf_error("failed to create pinned DSQ for CPU %d: %d",

--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -111,17 +111,18 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(flow_init)
 		return -E2BIG;
 	}
 
-	/* Create per-CPU pinned DSQs and per-CPU vtime DSQs. */
+	/* Create shared vtime-ordered DSQ for non-wakeup traffic. */
+	ret = scx_bpf_create_dsq(FLOW_BATCH_DSQ, -1);
+	if (ret < 0 && ret != -EEXIST) {
+		scx_bpf_error("failed to create batch DSQ: %d", ret);
+		return ret;
+	}
+
+	/* Create per-CPU pinned DSQs for non-migratable tasks. */
 	bpf_for(cpu, 0, nr_cpu_ids) {
 		ret = scx_bpf_create_dsq(FLOW_PINNED_DSQ_BASE + (u32)cpu, -1);
 		if (ret < 0 && ret != -EEXIST) {
 			scx_bpf_error("failed to create pinned DSQ for CPU %d: %d",
-				      cpu, ret);
-			return ret;
-		}
-		ret = scx_bpf_create_dsq(FLOW_VTIME_DSQ_BASE + (u32)cpu, -1);
-		if (ret < 0 && ret != -EEXIST) {
-			scx_bpf_error("failed to create vtime DSQ for CPU %d: %d",
 				      cpu, ret);
 			return ret;
 		}

--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -32,6 +32,7 @@ struct task_ctx {
 	u64 sleep_started_at;
 	s32 last_cpu;
 	s32 last_llc;		/* for migration cost calculation */
+	s32 runnable_cpu;	/* CPU where flow_runnable incremented per_cpu_runnable */
 	s32 wake_cpu;
 	bool wake_cpu_idle;
 	bool wake_cpu_valid;

--- a/scheds/experimental/scx_flow/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/main.bpf.c
@@ -8,10 +8,11 @@
  * The scheduling logic is organized into separate modules included below:
  *   helpers.bpf.c    — utility functions and macros
  *   select_cpu.bpf.c — CPU selection
- *   enqueue.bpf.c    — enqueue routing (pinned -> vtime)
- *   dispatch.bpf.c   — DSQ hierarchy dispatch
+ *   enqueue.bpf.c    — enqueue routing (wakeup fast path / Waiting Room)
+ *   dispatch.bpf.c   — DSQ dispatch (pinned DSQ, FLOW_BATCH_DSQ)
  *   budget.bpf.c     — budget lifecycle (runnable, running, stopping)
  *   task.bpf.c       — task lifecycle (init, enable, exit, yield, cpu_release)
+ *   carriage.bpf.c   — Waiting Room stats window and slice computation
  */
 
 #include <scx/common.bpf.h>
@@ -30,6 +31,7 @@ struct task_ctx {
 	u64 last_sleep_ns;
 	u64 sleep_started_at;
 	s32 last_cpu;
+	s32 last_llc;		/* for migration cost calculation */
 	s32 wake_cpu;
 	bool wake_cpu_idle;
 	bool wake_cpu_valid;
@@ -50,15 +52,31 @@ struct {
 	__type(value, struct flow_cpu_state);
 } cpu_state SEC(".maps");
 
+/* Per-core topology — populated at init by Rust userspace. */
+volatile u64 per_cpu_max_freq_khz[1024];
+volatile u64 per_cpu_llc_id[1024];
+volatile u64 per_cpu_is_smt[1024];
+volatile u64 per_cpu_runnable[1024];	/* current runnable count per CPU */
+volatile u64 system_total_khz;		/* sum of all core_effective_khz */
+volatile u64 nr_cpu_ids;
+
+/* Scheduler PID — set by userspace before attach.
+ * Tasks matching this PID bypass the carriage pool. */
+volatile u64 flow_scheduler_pid;
+
+/* Carriage pool — stats window buffer.
+ * Records recently-dispatched task PIDs for the web UI.
+ * All slots pre-allocated in BSS. */
+struct flow_carriage carriage_pool[FLOW_NR_CARRIAGES];
+volatile u64 carriage_producer;
+
+
+
+/* System-level counters */
 volatile u64 on_cpu;
 volatile u64 total_runtime;
 volatile u64 pinned_dispatches;
-volatile u64 prio_dispatches;
-volatile u64 tier_priority_dispatches;
-volatile u64 tier_normal_dispatches;
-volatile u64 tier_low_dispatches;
-volatile u64 tier_deficit_dispatches;
-volatile u64 budget_refill_events;
+volatile u64 prio_dispatches;	/* wakeup fast path dispatches */
 volatile u64 budget_exhaustions;
 volatile u64 runnable_wakeups;
 volatile u64 cpu_release_reenqueues;
@@ -66,14 +84,14 @@ volatile u64 init_task_events;
 volatile u64 enable_events;
 volatile u64 exit_task_events;
 volatile u64 cpu_migrations;
-volatile u64 dispatch_gen;	/* dispatch phase selector (gen & 3 → rotating tier start) */
+
+/* Tunable bounds (compile-time defaults, no-knobs) */
 volatile u64 tune_reserved_max_ns = FLOW_SLICE_RESERVED_MAX_NS;
 volatile u64 tune_interactive_floor_ns = FLOW_INTERACTIVE_FLOOR_NS;
 
-static u64 nr_cpu_ids;
-
 #include "helpers.bpf.c"
 #include "select_cpu.bpf.c"
+#include "carriage.bpf.c"	/* must precede enqueue/dispatch for function visibility */
 #include "enqueue.bpf.c"
 #include "dispatch.bpf.c"
 #include "budget.bpf.c"
@@ -86,6 +104,13 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(flow_init)
 
 	nr_cpu_ids = scx_bpf_nr_cpu_ids();
 
+	if (nr_cpu_ids > 1024) {
+		scx_bpf_error("nr_cpu_ids (%llu) exceeds max supported (1024)",
+			      nr_cpu_ids);
+		return -E2BIG;
+	}
+
+	/* Create per-CPU pinned DSQs and per-CPU vtime DSQs. */
 	bpf_for(cpu, 0, nr_cpu_ids) {
 		ret = scx_bpf_create_dsq(FLOW_PINNED_DSQ_BASE + (u32)cpu, -1);
 		if (ret < 0 && ret != -EEXIST) {
@@ -93,28 +118,15 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(flow_init)
 				      cpu, ret);
 			return ret;
 		}
+		ret = scx_bpf_create_dsq(FLOW_VTIME_DSQ_BASE + (u32)cpu, -1);
+		if (ret < 0 && ret != -EEXIST) {
+			scx_bpf_error("failed to create vtime DSQ for CPU %d: %d",
+				      cpu, ret);
+			return ret;
+		}
 	}
 
-	ret = scx_bpf_create_dsq(FLOW_TIER_PRIORITY_DSQ, -1);
-	if (ret < 0 && ret != -EEXIST) {
-		scx_bpf_error("failed to create priority DSQ: %d", ret);
-		return ret;
-	}
-	ret = scx_bpf_create_dsq(FLOW_TIER_NORMAL_DSQ, -1);
-	if (ret < 0 && ret != -EEXIST) {
-		scx_bpf_error("failed to create normal DSQ: %d", ret);
-		return ret;
-	}
-	ret = scx_bpf_create_dsq(FLOW_TIER_LOW_DSQ, -1);
-	if (ret < 0 && ret != -EEXIST) {
-		scx_bpf_error("failed to create low DSQ: %d", ret);
-		return ret;
-	}
-	ret = scx_bpf_create_dsq(FLOW_TIER_DEFICIT_DSQ, -1);
-	if (ret < 0 && ret != -EEXIST) {
-		scx_bpf_error("failed to create deficit DSQ: %d", ret);
-		return ret;
-	}
+	carriage_producer = 0;
 
 	return 0;
 }

--- a/scheds/experimental/scx_flow/src/carriage.rs
+++ b/scheds/experimental/scx_flow/src/carriage.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2026 Galih Tama <galpt@v.recipes>
+//
+// Topology discovery: reads per-CPU max frequencies, LLC IDs, and SMT
+// status from sysfs and writes them into BPF BSS arrays.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use log::info;
+
+use scx_utils::Topology;
+
+pub fn init_topology(skel: &mut crate::BpfSkel<'_>) -> Result<()> {
+    let topo = Topology::new().context("Failed to read CPU topology")?;
+    let nr_cpus = topo.all_cpus.len();
+    let bss = skel.maps.bss_data.as_mut()
+        .context("bss_data missing — BPF object has no .bss section")?;
+
+    info!(
+        "Discovered {} CPUs — reading max frequencies, LLC topology, SMT",
+        nr_cpus
+    );
+
+    let mut core_to_cpus: Vec<Vec<usize>> = vec![Vec::new(); 1024];
+    let mut system_total_khz: u64 = 0;
+
+    for (id, cpu) in &topo.all_cpus {
+        let freq_khz = cpu.max_freq as u64;
+        let llc_id = read_cpu_llc_id(*id);
+        let core_id = read_cpu_core_id(*id);
+
+        bss.per_cpu_max_freq_khz[*id] = freq_khz;
+        bss.per_cpu_llc_id[*id] = llc_id;
+
+        if core_id < 1024 {
+            core_to_cpus[core_id].push(*id);
+        }
+
+        info!(
+            "  CPU {:3}: max_freq = {:>6} MHz, LLC = {}, core_id = {}",
+            id, freq_khz / 1000, llc_id, core_id,
+        );
+    }
+
+    let mut seen_cores = HashSet::new();
+    for (core_id, cpus) in core_to_cpus.iter().enumerate() {
+        if cpus.len() > 1 && !seen_cores.contains(&core_id) {
+            seen_cores.insert(core_id);
+            for &cpu_id in cpus {
+                bss.per_cpu_is_smt[cpu_id] = 1;
+                info!("  CPU {:3}: SMT sibling (core {} has {} CPUs)",
+                      cpu_id, core_id, cpus.len());
+            }
+        }
+    }
+
+    for (id, cpu) in &topo.all_cpus {
+        let freq_khz = cpu.max_freq as u64;
+        let core_id = read_cpu_core_id(*id);
+        let siblings = if core_id < 1024 { core_to_cpus[core_id].len() } else { 1 };
+        let thread_bw = if siblings > 1 { freq_khz / siblings as u64 } else { freq_khz };
+        system_total_khz += thread_bw;
+    }
+    bss.system_total_khz = system_total_khz;
+
+    info!(
+        "  System total effective bandwidth: {} MHz ({} cores, SMT halved)",
+        system_total_khz / 1000, nr_cpus,
+    );
+
+    Ok(())
+}
+
+fn read_cpu_llc_id(cpu: usize) -> u64 {
+    let p = format!("/sys/devices/system/cpu/cpu{}/cache/index3/id", cpu);
+    let path = Path::new(&p);
+    if path.exists() {
+        return std::fs::read_to_string(path)
+            .ok().and_then(|s| s.trim().parse::<u64>().ok()).unwrap_or(0);
+    }
+    let fb = format!("/sys/devices/system/cpu/cpu{}/topology/llc_id", cpu);
+    let fb_path = Path::new(&fb);
+    if fb_path.exists() {
+        return std::fs::read_to_string(fb_path)
+            .ok().and_then(|s| s.trim().parse::<u64>().ok()).unwrap_or(0);
+    }
+    0
+}
+
+fn read_cpu_core_id(cpu: usize) -> usize {
+    let p = format!("/sys/devices/system/cpu/cpu{}/topology/core_id", cpu);
+    let path = Path::new(&p);
+    if !path.exists() {
+        log::warn!("CPU {}: topology/core_id not found", cpu);
+        return 0;
+    }
+    std::fs::read_to_string(path)
+        .ok().and_then(|s| s.trim().parse::<usize>().ok()).unwrap_or(0)
+}

--- a/scheds/experimental/scx_flow/src/carriage.rs
+++ b/scheds/experimental/scx_flow/src/carriage.rs
@@ -4,7 +4,6 @@
 // Topology discovery: reads per-CPU max frequencies, LLC IDs, and SMT
 // status from sysfs and writes them into BPF BSS arrays.
 
-use std::collections::HashSet;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -44,15 +43,26 @@ pub fn init_topology(skel: &mut crate::BpfSkel<'_>) -> Result<()> {
         );
     }
 
-    let mut seen_cores = HashSet::new();
+    /* Set per_cpu_sibling_count for all CPUs and mark SMT secondaries.
+     * The first CPU per core_id is primary; subsequent ones are secondary.
+     * sibling_count is set for ALL CPUs (including non-SMT, where it's 1)
+     * so the bandwidth model works correctly for every CPU. */
     for (core_id, cpus) in core_to_cpus.iter().enumerate() {
-        if cpus.len() > 1 && !seen_cores.contains(&core_id) {
-            seen_cores.insert(core_id);
-            for &cpu_id in cpus {
-                bss.per_cpu_is_smt[cpu_id] = 1;
-                info!("  CPU {:3}: SMT sibling (core {} has {} CPUs)",
-                      cpu_id, core_id, cpus.len());
+        let count = cpus.len();
+        if count > 1 {
+            for (j, &cpu_id) in cpus.iter().enumerate() {
+                bss.per_cpu_sibling_count[cpu_id] = count as u64;
+                if j == 0 {
+                    info!("  CPU {:3}: primary (core {}: {} CPUs)",
+                          cpu_id, core_id, count);
+                } else {
+                    bss.per_cpu_is_smt[cpu_id] = 1;
+                    info!("  CPU {:3}: SMT sibling (core {})",
+                          cpu_id, core_id);
+                }
             }
+        } else if count == 1 {
+            bss.per_cpu_sibling_count[cpus[0]] = 1;
         }
     }
 

--- a/scheds/experimental/scx_flow/src/carriage.rs
+++ b/scheds/experimental/scx_flow/src/carriage.rs
@@ -29,6 +29,10 @@ pub fn init_topology(skel: &mut crate::BpfSkel<'_>) -> Result<()> {
     let mut system_total_khz: u64 = 0;
 
     for (id, cpu) in &topo.all_cpus {
+        if *id >= 1024 {
+            log::warn!("CPU {} exceeds max supported (1024), skipping", id);
+            continue;
+        }
         let freq_khz = cpu.max_freq as u64;
         let llc_id = read_cpu_llc_id(*id);
         let core_id = read_cpu_core_id(*id);

--- a/scheds/experimental/scx_flow/src/carriage.rs
+++ b/scheds/experimental/scx_flow/src/carriage.rs
@@ -14,7 +14,10 @@ use scx_utils::Topology;
 pub fn init_topology(skel: &mut crate::BpfSkel<'_>) -> Result<()> {
     let topo = Topology::new().context("Failed to read CPU topology")?;
     let nr_cpus = topo.all_cpus.len();
-    let bss = skel.maps.bss_data.as_mut()
+    let bss = skel
+        .maps
+        .bss_data
+        .as_mut()
         .context("bss_data missing — BPF object has no .bss section")?;
 
     info!(
@@ -39,7 +42,10 @@ pub fn init_topology(skel: &mut crate::BpfSkel<'_>) -> Result<()> {
 
         info!(
             "  CPU {:3}: max_freq = {:>6} MHz, LLC = {}, core_id = {}",
-            id, freq_khz / 1000, llc_id, core_id,
+            id,
+            freq_khz / 1000,
+            llc_id,
+            core_id,
         );
     }
 
@@ -53,12 +59,13 @@ pub fn init_topology(skel: &mut crate::BpfSkel<'_>) -> Result<()> {
             for (j, &cpu_id) in cpus.iter().enumerate() {
                 bss.per_cpu_sibling_count[cpu_id] = count as u64;
                 if j == 0 {
-                    info!("  CPU {:3}: primary (core {}: {} CPUs)",
-                          cpu_id, core_id, count);
+                    info!(
+                        "  CPU {:3}: primary (core {}: {} CPUs)",
+                        cpu_id, core_id, count
+                    );
                 } else {
                     bss.per_cpu_is_smt[cpu_id] = 1;
-                    info!("  CPU {:3}: SMT sibling (core {})",
-                          cpu_id, core_id);
+                    info!("  CPU {:3}: SMT sibling (core {})", cpu_id, core_id);
                 }
             }
         } else if count == 1 {
@@ -69,15 +76,24 @@ pub fn init_topology(skel: &mut crate::BpfSkel<'_>) -> Result<()> {
     for (id, cpu) in &topo.all_cpus {
         let freq_khz = cpu.max_freq as u64;
         let core_id = read_cpu_core_id(*id);
-        let siblings = if core_id < 1024 { core_to_cpus[core_id].len() } else { 1 };
-        let thread_bw = if siblings > 1 { freq_khz / siblings as u64 } else { freq_khz };
+        let siblings = if core_id < 1024 {
+            core_to_cpus[core_id].len()
+        } else {
+            1
+        };
+        let thread_bw = if siblings > 1 {
+            freq_khz / siblings as u64
+        } else {
+            freq_khz
+        };
         system_total_khz += thread_bw;
     }
     bss.system_total_khz = system_total_khz;
 
     info!(
         "  System total effective bandwidth: {} MHz ({} cores, SMT halved)",
-        system_total_khz / 1000, nr_cpus,
+        system_total_khz / 1000,
+        nr_cpus,
     );
 
     Ok(())
@@ -88,13 +104,17 @@ fn read_cpu_llc_id(cpu: usize) -> u64 {
     let path = Path::new(&p);
     if path.exists() {
         return std::fs::read_to_string(path)
-            .ok().and_then(|s| s.trim().parse::<u64>().ok()).unwrap_or(0);
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok())
+            .unwrap_or(0);
     }
     let fb = format!("/sys/devices/system/cpu/cpu{}/topology/llc_id", cpu);
     let fb_path = Path::new(&fb);
     if fb_path.exists() {
         return std::fs::read_to_string(fb_path)
-            .ok().and_then(|s| s.trim().parse::<u64>().ok()).unwrap_or(0);
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok())
+            .unwrap_or(0);
     }
     0
 }
@@ -107,5 +127,7 @@ fn read_cpu_core_id(cpu: usize) -> usize {
         return 0;
     }
     std::fs::read_to_string(path)
-        .ok().and_then(|s| s.trim().parse::<usize>().ok()).unwrap_or(0)
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .unwrap_or(0)
 }

--- a/scheds/experimental/scx_flow/src/main.rs
+++ b/scheds/experimental/scx_flow/src/main.rs
@@ -7,9 +7,11 @@
 
 mod bpf_skel;
 pub use bpf_skel::*;
+pub use bpf_skel::types;
 pub mod bpf_intf;
 pub use bpf_intf::*;
 
+mod carriage;
 mod stats;
 mod webui;
 use std::mem::MaybeUninit;
@@ -49,31 +51,24 @@ fn full_version() -> String {
 #[derive(Debug, Parser)]
 #[command(name = SCHEDULER_NAME, version, disable_version_flag = true)]
 struct Opts {
-    /// Enable stats monitoring with the specified interval.
     #[clap(long)]
     stats: Option<f64>,
 
-    /// Run in stats monitoring mode with the specified interval. Scheduler is not launched.
     #[clap(long)]
     monitor: Option<f64>,
 
-    /// Debug mode
     #[clap(short, long, action = clap::ArgAction::SetTrue)]
     debug: bool,
 
-    /// Print scheduler version and exit.
     #[clap(short = 'V', long, action = clap::ArgAction::SetTrue)]
     version: bool,
 
-    /// Disable the web UI (http://localhost:50005).
     #[clap(long = "no-webui", action = clap::ArgAction::SetTrue)]
     no_webui: bool,
 
-    /// Disable adaptive runtime tuning (no-op, kept for backward compatibility).
     #[clap(long, action = clap::ArgAction::SetTrue)]
     no_autotune: bool,
 
-    /// Generate shell completions for the given shell and exit.
     #[clap(long, value_name = "SHELL", hide = true)]
     completions: Option<Shell>,
 
@@ -85,7 +80,7 @@ struct Scheduler<'a> {
     skel: BpfSkel<'a>,
     struct_ops: Option<libbpf_rs::Link>,
     stats_server: StatsServer<(), Metrics>,
-    webui_tx: Option<crossbeam::channel::Sender<Metrics>>,
+    webui_tx: Option<crossbeam::channel::Sender<stats::WebMetrics>>,
     started_at: std::time::Instant,
 }
 
@@ -150,14 +145,33 @@ impl<'a> Scheduler<'a> {
 
         let mut skel = scx_ops_load!(skel, flow_ops, uei)?;
 
+        // Write scheduler PID to BSS so BPF can bypass the carriage.
+        {
+            let key: u32 = 0;
+            let mut bss_raw = skel.maps.bss
+                .lookup(&key.to_ne_bytes(), libbpf_rs::MapFlags::ANY)
+                .ok()
+                .flatten()
+                .unwrap_or_default();
+            let pid_offset = std::mem::offset_of!(types::bss, flow_scheduler_pid);
+            let pid_bytes = (std::process::id() as u64).to_ne_bytes();
+            let bss_slice = bss_raw.as_mut_slice();
+            if pid_offset + 8 <= bss_slice.len() {
+                bss_slice[pid_offset..pid_offset + 8].copy_from_slice(&pid_bytes);
+            }
+            let _ = skel.maps.bss.update(&key.to_ne_bytes(), &bss_raw,
+                                         libbpf_rs::MapFlags::ANY);
+        }
+
+        // Discover topology and write into BSS.
+        carriage::init_topology(&mut skel)?;
+
         let struct_ops = scx_ops_attach!(skel, flow_ops)?;
 
-        // Expose live metrics for monitor and stats clients.
         let stats_server = StatsServer::new(stats::server_data()).launch()?;
 
-        // Start the web UI thread (unless disabled).
-        let webui_tx: Option<crossbeam::channel::Sender<Metrics>> = if !opts.no_webui {
-            let (tx, rx) = crossbeam::channel::unbounded::<Metrics>();
+        let webui_tx: Option<crossbeam::channel::Sender<stats::WebMetrics>> = if !opts.no_webui {
+            let (tx, rx) = crossbeam::channel::unbounded::<stats::WebMetrics>();
             let shutdown = shutdown.clone();
             std::thread::spawn(move || {
                 webui::start(rx, shutdown);
@@ -177,22 +191,54 @@ impl<'a> Scheduler<'a> {
     }
 
     fn get_metrics(&self) -> Metrics {
-        let bss_data = self.skel.maps.bss_data.as_ref().unwrap();
+        let bss_data = self.skel.maps.bss_data.as_ref().expect("bss_data missing — BPF object has no .bss section");
         let cpu_policy_state = self.read_cpu_policy_state();
         Metrics {
             on_cpu: bss_data.on_cpu,
             total_runtime: bss_data.total_runtime,
+            uptime_ns: self.started_at.elapsed().as_nanos() as u64,
+
             prio_dispatches: bss_data.prio_dispatches,
             pinned_dispatches: bss_data.pinned_dispatches,
-            tier_priority_dispatches: bss_data.tier_priority_dispatches,
-            tier_normal_dispatches: bss_data.tier_normal_dispatches,
-            tier_low_dispatches: bss_data.tier_low_dispatches,
-            tier_deficit_dispatches: bss_data.tier_deficit_dispatches,
-            budget_refill_events: bss_data.budget_refill_events,
+
+            carriage_producer: bss_data.carriage_producer,
+
+
             budget_exhaustions: bss_data.budget_exhaustions + cpu_policy_state.budget_exhaustions,
             runnable_wakeups: bss_data.runnable_wakeups + cpu_policy_state.runnable_wakeups,
             cpu_migrations: bss_data.cpu_migrations + cpu_policy_state.cpu_migrations,
-            uptime_ns: self.started_at.elapsed().as_nanos() as u64,
+        }
+    }
+
+    fn get_web_metrics(&self) -> stats::WebMetrics {
+        let metrics = self.get_metrics();
+        let bss_data = self.skel.maps.bss_data.as_ref().expect("bss_data missing — BPF object has no .bss section");
+
+        let nr_cpus = bss_data.nr_cpu_ids as usize;
+        let mut per_cpu = Vec::with_capacity(nr_cpus);
+        for cpu in 0..nr_cpus {
+            if cpu >= 1024 {
+                break;
+            }
+            per_cpu.push(stats::PerCpuMetrics {
+                id: cpu as u32,
+                freq_khz: bss_data.per_cpu_max_freq_khz[cpu],
+                llc_id: bss_data.per_cpu_llc_id[cpu] as u32,
+                smt: bss_data.per_cpu_is_smt[cpu] != 0,
+            });
+        }
+
+        let closed_slot = (bss_data.carriage_producer.wrapping_sub(1) & 63) as usize;
+        let carriage_filling_count = if closed_slot < 64 {
+            bss_data.carriage_pool[closed_slot].count as u64
+        } else {
+            0
+        };
+
+        stats::WebMetrics {
+            stats: metrics,
+            per_cpu,
+            carriage_filling_count,
         }
     }
 
@@ -208,15 +254,15 @@ impl<'a> Scheduler<'a> {
                 Ok(()) => {
                     let m = self.get_metrics();
                     if let Some(ref tx) = self.webui_tx {
-                        let _ = tx.try_send(m.clone());
+                        let wm = self.get_web_metrics();
+                        let _ = tx.try_send(wm);
                     }
                     res_ch.send(m)?;
                 }
                 Err(RecvTimeoutError::Timeout) => {
-                    // Push metrics to web UI only if someone's listening.
                     if let Some(ref tx) = self.webui_tx {
-                        let m = self.get_metrics();
-                        let _ = tx.try_send(m);
+                        let wm = self.get_web_metrics();
+                        let _ = tx.try_send(wm);
                     }
                 }
                 Err(e) => Err(e)?,

--- a/scheds/experimental/scx_flow/src/main.rs
+++ b/scheds/experimental/scx_flow/src/main.rs
@@ -6,8 +6,8 @@
 // General Public License version 2.
 
 mod bpf_skel;
-pub use bpf_skel::*;
 pub use bpf_skel::types;
+pub use bpf_skel::*;
 pub mod bpf_intf;
 pub use bpf_intf::*;
 
@@ -148,7 +148,9 @@ impl<'a> Scheduler<'a> {
         // Write scheduler PID to BSS so BPF can bypass the carriage.
         {
             let key: u32 = 0;
-            let mut bss_raw = skel.maps.bss
+            let mut bss_raw = skel
+                .maps
+                .bss
                 .lookup(&key.to_ne_bytes(), libbpf_rs::MapFlags::ANY)
                 .ok()
                 .flatten()
@@ -159,8 +161,10 @@ impl<'a> Scheduler<'a> {
             if pid_offset + 8 <= bss_slice.len() {
                 bss_slice[pid_offset..pid_offset + 8].copy_from_slice(&pid_bytes);
             }
-            let _ = skel.maps.bss.update(&key.to_ne_bytes(), &bss_raw,
-                                         libbpf_rs::MapFlags::ANY);
+            let _ = skel
+                .maps
+                .bss
+                .update(&key.to_ne_bytes(), &bss_raw, libbpf_rs::MapFlags::ANY);
         }
 
         // Discover topology and write into BSS.
@@ -191,7 +195,12 @@ impl<'a> Scheduler<'a> {
     }
 
     fn get_metrics(&self) -> Metrics {
-        let bss_data = self.skel.maps.bss_data.as_ref().expect("bss_data missing — BPF object has no .bss section");
+        let bss_data = self
+            .skel
+            .maps
+            .bss_data
+            .as_ref()
+            .expect("bss_data missing — BPF object has no .bss section");
         let cpu_policy_state = self.read_cpu_policy_state();
         Metrics {
             on_cpu: bss_data.on_cpu,
@@ -203,7 +212,6 @@ impl<'a> Scheduler<'a> {
 
             carriage_producer: bss_data.carriage_producer,
 
-
             budget_exhaustions: bss_data.budget_exhaustions + cpu_policy_state.budget_exhaustions,
             runnable_wakeups: bss_data.runnable_wakeups + cpu_policy_state.runnable_wakeups,
             cpu_migrations: bss_data.cpu_migrations + cpu_policy_state.cpu_migrations,
@@ -212,7 +220,12 @@ impl<'a> Scheduler<'a> {
 
     fn get_web_metrics(&self) -> stats::WebMetrics {
         let metrics = self.get_metrics();
-        let bss_data = self.skel.maps.bss_data.as_ref().expect("bss_data missing — BPF object has no .bss section");
+        let bss_data = self
+            .skel
+            .maps
+            .bss_data
+            .as_ref()
+            .expect("bss_data missing — BPF object has no .bss section");
 
         let nr_cpus = bss_data.nr_cpu_ids as usize;
         let mut per_cpu = Vec::with_capacity(nr_cpus);

--- a/scheds/experimental/scx_flow/src/stats.rs
+++ b/scheds/experimental/scx_flow/src/stats.rs
@@ -84,7 +84,7 @@ impl Metrics {
             uptime_ns: self.uptime_ns,
             prio_dispatches: self.prio_dispatches.wrapping_sub(rhs.prio_dispatches),
             pinned_dispatches: self.pinned_dispatches.wrapping_sub(rhs.pinned_dispatches),
-            carriage_producer: self.carriage_producer.wrapping_sub(rhs.carriage_producer),
+            carriage_producer: self.carriage_producer,
 
             budget_exhaustions: self.budget_exhaustions.wrapping_sub(rhs.budget_exhaustions),
             runnable_wakeups: self.runnable_wakeups.wrapping_sub(rhs.runnable_wakeups),

--- a/scheds/experimental/scx_flow/src/stats.rs
+++ b/scheds/experimental/scx_flow/src/stats.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Galih Tama <galpt@v.recipes>
+// SPDX-License-Identifier: GPL-2.0
 //
-// This software may be used and distributed according to the terms of the
-// GNU General Public License version 2.
+// Copyright (c) 2026 Galih Tama <galpt@v.recipes>
 
 use std::io::Write;
 use std::sync::atomic::AtomicBool;
@@ -16,6 +15,21 @@ use scx_stats_derive::Stats;
 use serde::Deserialize;
 use serde::Serialize;
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct PerCpuMetrics {
+    pub id: u32,
+    pub freq_khz: u64,
+    pub llc_id: u32,
+    pub smt: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct WebMetrics {
+    pub stats: Metrics,
+    pub per_cpu: Vec<PerCpuMetrics>,
+    pub carriage_filling_count: u64,
+}
+
 #[stat_doc]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Stats)]
 #[stat(top)]
@@ -26,25 +40,19 @@ pub struct Metrics {
     pub total_runtime: u64,
     #[stat(desc = "Scheduler uptime (wall clock since attach)")]
     pub uptime_ns: u64,
-    #[stat(desc = "Tasks enqueued via the wakeup fast path (FLOW_DSQ_LOCAL_ON)")]
+    #[stat(desc = "Tasks dispatched via the wakeup fast path")]
     pub prio_dispatches: u64,
-    #[stat(desc = "Tasks dispatched from the per-CPU pinned DSQ (non-migratable tasks)")]
+    #[stat(desc = "Tasks dispatched from the per-CPU pinned DSQ")]
     pub pinned_dispatches: u64,
-    #[stat(desc = "Tasks dispatched from the PRIORITY tier (budget >= 1.5 ms)")]
-    pub tier_priority_dispatches: u64,
-    #[stat(desc = "Tasks dispatched from the NORMAL tier (1.0 ms <= budget < 1.5 ms)")]
-    pub tier_normal_dispatches: u64,
-    #[stat(desc = "Tasks dispatched from the LOW tier (0.5 ms <= budget < 1.0 ms)")]
-    pub tier_low_dispatches: u64,
-    #[stat(desc = "Tasks dispatched from the DEFICIT tier (budget < 0.5 ms)")]
-    pub tier_deficit_dispatches: u64,
-    #[stat(desc = "Wakeups that refilled task budget")]
-    pub budget_refill_events: u64,
+
+    #[stat(desc = "Carriage pool slot index")]
+    pub carriage_producer: u64,
+
     #[stat(desc = "Times a task ran its budget down to zero or below")]
     pub budget_exhaustions: u64,
-    #[stat(desc = "Runnable wakeups observed before enqueue/select_cpu decisions")]
+    #[stat(desc = "Runnable wakeups observed")]
     pub runnable_wakeups: u64,
-    #[stat(desc = "Observed task migrations between successive runs")]
+    #[stat(desc = "Observed task migrations")]
     pub cpu_migrations: u64,
 }
 
@@ -52,19 +60,17 @@ impl Metrics {
     fn format<W: Write>(&self, w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "[{}] run={} runtime_ns={} uptime_ns={} quick_disp={} pinned_disp={} tier_P={} tier_N={} tier_L={} tier_D={} refill={} exhaust={} runnable={} migrations={}",
+            "[{}] run={} runtime_ns={} uptime_ns={} quick_disp={} pinned_disp={} \
+             pool: slot={} \
+              exhaust={} runnable={} migrations={}",
             crate::SCHEDULER_NAME,
             self.on_cpu,
             self.total_runtime,
             self.uptime_ns,
             self.prio_dispatches,
             self.pinned_dispatches,
-            self.tier_priority_dispatches,
-            self.tier_normal_dispatches,
-            self.tier_low_dispatches,
-            self.tier_deficit_dispatches,
-            self.budget_refill_events,
-            self.budget_exhaustions,
+             self.carriage_producer & 63,
+             self.budget_exhaustions,
             self.runnable_wakeups,
             self.cpu_migrations,
         )?;
@@ -75,24 +81,11 @@ impl Metrics {
         Self {
             on_cpu: self.on_cpu,
             total_runtime: self.total_runtime.wrapping_sub(rhs.total_runtime),
-            uptime_ns: self.uptime_ns, // absolute, not a counter — no delta
+            uptime_ns: self.uptime_ns,
             prio_dispatches: self.prio_dispatches.wrapping_sub(rhs.prio_dispatches),
             pinned_dispatches: self.pinned_dispatches.wrapping_sub(rhs.pinned_dispatches),
-            tier_priority_dispatches: self
-                .tier_priority_dispatches
-                .wrapping_sub(rhs.tier_priority_dispatches),
-            tier_normal_dispatches: self
-                .tier_normal_dispatches
-                .wrapping_sub(rhs.tier_normal_dispatches),
-            tier_low_dispatches: self
-                .tier_low_dispatches
-                .wrapping_sub(rhs.tier_low_dispatches),
-            tier_deficit_dispatches: self
-                .tier_deficit_dispatches
-                .wrapping_sub(rhs.tier_deficit_dispatches),
-            budget_refill_events: self
-                .budget_refill_events
-                .wrapping_sub(rhs.budget_refill_events),
+            carriage_producer: self.carriage_producer.wrapping_sub(rhs.carriage_producer),
+
             budget_exhaustions: self.budget_exhaustions.wrapping_sub(rhs.budget_exhaustions),
             runnable_wakeups: self.runnable_wakeups.wrapping_sub(rhs.runnable_wakeups),
             cpu_migrations: self.cpu_migrations.wrapping_sub(rhs.cpu_migrations),

--- a/scheds/experimental/scx_flow/src/stats.rs
+++ b/scheds/experimental/scx_flow/src/stats.rs
@@ -69,8 +69,8 @@ impl Metrics {
             self.uptime_ns,
             self.prio_dispatches,
             self.pinned_dispatches,
-             self.carriage_producer & 63,
-             self.budget_exhaustions,
+            self.carriage_producer & 63,
+            self.budget_exhaustions,
             self.runnable_wakeups,
             self.cpu_migrations,
         )?;

--- a/scheds/experimental/scx_flow/src/webui.rs
+++ b/scheds/experimental/scx_flow/src/webui.rs
@@ -1,12 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 //
 // Copyright (c) 2026 Galih Tama <galpt@v.recipes>
-//
-// Web UI — lightweight HTTP server for realtime scx_flow metrics.
-// Uses tiny_http for TCP (when run manually) and falls back to a
-// Unix domain socket (when spawned by scx_loader which blocks TCP
-// via systemd hardening RestrictAddressFamilies/SocketBindDeny).
-// Starts automatically; no CLI flags required.
 
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::fs::FileTypeExt;
@@ -16,63 +10,17 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tiny_http::{Header, Response, Server};
+use serde_json::json;
 
-use crate::stats::Metrics;
+use crate::stats::WebMetrics;
 
 const PORT: u16 = 50005;
 const UNIX_SOCKET_PATH: &str = "/tmp/scx_flow.sock";
 const POLL_INTERVAL: Duration = Duration::from_millis(200);
-const HISTORY_CAP: usize = 300;
-
-// ---------------------------------------------------------------------------
-// Ring buffer
-// ---------------------------------------------------------------------------
-
-struct RingBuf {
-    buf: Vec<Metrics>,
-    head: usize,
-    count: usize,
-}
-
-impl RingBuf {
-    fn new(cap: usize) -> Self {
-        Self {
-            buf: Vec::with_capacity(cap),
-            head: 0,
-            count: 0,
-        }
-    }
-    fn push(&mut self, m: Metrics) {
-        if self.count < self.buf.capacity() {
-            self.buf.push(m);
-            self.count += 1;
-        } else {
-            self.buf[self.head] = m;
-            self.head = (self.head + 1) % self.buf.capacity();
-        }
-    }
-    fn snapshot(&self) -> Vec<Metrics> {
-        let cap = self.buf.capacity();
-        let mut out = Vec::with_capacity(self.count);
-        if self.count == 0 {
-            return out;
-        }
-        let start = if self.count < cap { 0 } else { self.head };
-        for i in 0..self.count {
-            out.push(self.buf[(start + i) % cap].clone());
-        }
-        out
-    }
-}
 
 struct WebState {
-    metrics: Metrics,
-    history: RingBuf,
+    metrics: WebMetrics,
 }
-
-// ---------------------------------------------------------------------------
-// Raw HTTP handler for Unix socket (tiny_http doesn't support Unix sockets)
-// ---------------------------------------------------------------------------
 
 fn unix_handle_client(
     mut stream: std::os::unix::net::UnixStream,
@@ -95,23 +43,25 @@ fn unix_handle_client(
     }
     let path = parts[1];
 
-    // Snapshot state under lock, then release before serialization.
-    let (metrics, history_snap) = {
+    let metrics = {
         let st = match state.lock() {
             Ok(s) => s,
             Err(_) => return,
         };
-        (st.metrics.clone(), st.history.snapshot())
+        st.metrics.clone()
     };
 
     let (body, content_type) = match path {
         "/" => (html.as_bytes().to_vec(), "text/html; charset=utf-8"),
         "/api/stats" => {
-            let j = serde_json::to_string(&metrics).unwrap_or_else(|_| "{}".into());
-            (j.into_bytes(), "application/json")
-        }
-        "/api/history" => {
-            let j = serde_json::to_string(&history_snap).unwrap_or_else(|_| "[]".into());
+            let stats = serde_json::to_value(&metrics.stats).unwrap_or_default();
+            let per_cpu = serde_json::to_value(&metrics.per_cpu).unwrap_or_default();
+            let merged = json!({
+                "stats": stats,
+                "per_cpu": per_cpu,
+                "carriage_filling_count": metrics.carriage_filling_count,
+            });
+            let j = serde_json::to_string(&merged).unwrap_or_else(|_| "{}".into());
             (j.into_bytes(), "application/json")
         }
         _ => {
@@ -132,20 +82,14 @@ fn unix_handle_client(
     let _ = stream.flush();
 }
 
-// ---------------------------------------------------------------------------
-// Entry point
-// ---------------------------------------------------------------------------
-
-pub fn start(metrics_rx: crossbeam::channel::Receiver<Metrics>, shutdown: Arc<AtomicBool>) {
+pub fn start(metrics_rx: crossbeam::channel::Receiver<WebMetrics>, shutdown: Arc<AtomicBool>) {
     log::info!("Web UI thread started");
 
     let html = include_str!("../ui/index.html").to_string();
     let state = Arc::new(Mutex::new(WebState {
-        metrics: Metrics::default(),
-        history: RingBuf::new(HISTORY_CAP),
+        metrics: WebMetrics::default(),
     }));
 
-    // Poller thread
     let state_clone = state.clone();
     let shutdown_clone = shutdown.clone();
     std::thread::spawn(move || {
@@ -153,8 +97,7 @@ pub fn start(metrics_rx: crossbeam::channel::Receiver<Metrics>, shutdown: Arc<At
             match metrics_rx.recv_timeout(POLL_INTERVAL) {
                 Ok(m) => {
                     if let Ok(mut st) = state_clone.lock() {
-                        st.metrics = m.clone();
-                        st.history.push(m);
+                        st.metrics = m;
                     }
                 }
                 Err(crossbeam::channel::RecvTimeoutError::Timeout) => {}
@@ -163,19 +106,15 @@ pub fn start(metrics_rx: crossbeam::channel::Receiver<Metrics>, shutdown: Arc<At
         }
     });
 
-    // Try TCP: IPv6 loopback first, then IPv4.  Falls back to Unix socket
-    // (scx_loader's systemd hardening: RestrictAddressFamilies, SocketBindDeny).
     let html_for_unix = html.to_owned();
     let mut server: Option<tiny_http::Server> = None;
     let mut tcp_addr = String::new();
 
-    // Attempt IPv6
     if let Ok(s) = Server::http(&format!("[::1]:{}", PORT)) {
         tcp_addr = format!("[::1]:{}", PORT);
         server = Some(s);
     }
 
-    // Attempt IPv4 if IPv6 failed
     if server.is_none() {
         if let Ok(s) = Server::http(&format!("127.0.0.1:{}", PORT)) {
             tcp_addr = format!("127.0.0.1:{}", PORT);
@@ -195,13 +134,12 @@ pub fn start(metrics_rx: crossbeam::channel::Receiver<Metrics>, shutdown: Arc<At
 
         while !shutdown.load(Ordering::Relaxed) {
             if let Ok(Some(request)) = server.recv_timeout(Duration::from_millis(200)) {
-                // Snapshot under lock, then release before serialization.
-                let (metrics, history_snap) = {
+                let metrics = {
                     let st = match state.lock() {
                         Ok(s) => s,
                         Err(_) => continue,
                     };
-                    (st.metrics.clone(), st.history.snapshot())
+                    st.metrics.clone()
                 };
                 match request.url() {
                     "/" => {
@@ -211,15 +149,15 @@ pub fn start(metrics_rx: crossbeam::channel::Receiver<Metrics>, shutdown: Arc<At
                         let _ = request.respond(resp);
                     }
                     "/api/stats" => {
-                        let json = serde_json::to_string(&metrics).unwrap_or_else(|_| "{}".into());
-                        let resp = Response::from_string(json)
-                            .with_header(json_type.clone())
-                            .with_header(no_cache.clone());
-                        let _ = request.respond(resp);
-                    }
-                    "/api/history" => {
-                        let json =
-                            serde_json::to_string(&history_snap).unwrap_or_else(|_| "[]".into());
+                        let stats = serde_json::to_value(&metrics.stats).unwrap_or_default();
+                        let per_cpu =
+                            serde_json::to_value(&metrics.per_cpu).unwrap_or_default();
+                        let merged = json!({
+                            "stats": stats,
+                            "per_cpu": per_cpu,
+                            "carriage_filling_count": metrics.carriage_filling_count,
+                        });
+                        let json = serde_json::to_string(&merged).unwrap_or_else(|_| "{}".into());
                         let resp = Response::from_string(json)
                             .with_header(json_type.clone())
                             .with_header(no_cache.clone());
@@ -232,12 +170,10 @@ pub fn start(metrics_rx: crossbeam::channel::Receiver<Metrics>, shutdown: Arc<At
             }
         }
     } else {
-        // TCP blocked — use Unix socket (scx_loader's systemd hardening)
         log::warn!(
             "Web UI: TCP blocked (spawned by scx_loader?), falling back to {}",
             UNIX_SOCKET_PATH
         );
-        // Only remove if it's an existing socket (avoid following symlinks).
         if let Ok(meta) = std::fs::symlink_metadata(UNIX_SOCKET_PATH) {
             if meta.file_type().is_socket() {
                 let _ = std::fs::remove_file(UNIX_SOCKET_PATH);

--- a/scheds/experimental/scx_flow/src/webui.rs
+++ b/scheds/experimental/scx_flow/src/webui.rs
@@ -9,8 +9,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tiny_http::{Header, Response, Server};
 use serde_json::json;
+use tiny_http::{Header, Response, Server};
 
 use crate::stats::WebMetrics;
 
@@ -150,8 +150,7 @@ pub fn start(metrics_rx: crossbeam::channel::Receiver<WebMetrics>, shutdown: Arc
                     }
                     "/api/stats" => {
                         let stats = serde_json::to_value(&metrics.stats).unwrap_or_default();
-                        let per_cpu =
-                            serde_json::to_value(&metrics.per_cpu).unwrap_or_default();
+                        let per_cpu = serde_json::to_value(&metrics.per_cpu).unwrap_or_default();
                         let merged = json!({
                             "stats": stats,
                             "per_cpu": per_cpu,

--- a/scheds/experimental/scx_flow/ui/index.html
+++ b/scheds/experimental/scx_flow/ui/index.html
@@ -17,7 +17,6 @@
       --text-secondary: #888888;
       --text-muted: #6a6a6a;
       --accent: #3f83f8;
-      --accent-hover: #5a9aff;
       --success: #31c48d;
       --warning: #f5a623;
       --error: #ee0000;
@@ -34,7 +33,6 @@
       padding: 16px;
       min-height: 100vh;
       overflow-x: hidden;
-      -webkit-text-size-adjust: 100%;
     }
     @media (min-width: 640px) { body { padding: 24px; } }
 
@@ -46,72 +44,59 @@
       min-width: 0;
       overflow: hidden;
     }
-    .card:hover { border-color: var(--border-hover); }
 
     .stat-value {
       font-family: var(--font-mono);
       font-weight: 600;
       font-feature-settings: "tnum";
     }
-    .tier-P { color: var(--success); }
-    .tier-N { color: var(--accent); }
-    .tier-L { color: var(--warning); }
-    .tier-D { color: var(--error); }
 
-    .tier-bar {
-      height: 20px;
-      border-radius: 4px;
-      min-width: 2px;
+    /* Per-core card grid */
+    .core-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 8px;
+      margin-bottom: 16px;
     }
+    .core-card { padding: 12px; font-size: 0.8125rem; }
+    .core-card .core-id { font-size: 0.75rem; color: var(--text-muted); font-family: var(--font-mono); }
+    .core-card .core-freq { font-size: 0.75rem; color: var(--text-secondary); margin-top: 2px; }
+    .core-card .core-smt { font-size: 0.6875rem; color: var(--warning); }
+    .core-card .core-llc { font-size: 0.6875rem; color: var(--text-muted); }
 
-    .sparkline { display: flex; align-items: flex-end; gap: 1px; height: 32px; padding-top: 6px; }
-    .sparkline-bar { width: 4px; border-radius: 1px; min-height: 1px; flex-shrink: 0; }
+    /* Carriage pool grid */
+    .carriage-grid {
+      display: flex;
+      gap: 4px;
+      flex-wrap: wrap;
+      margin-top: 8px;
+    }
+    .carriage-slot {
+      width: 20px; height: 20px;
+      border-radius: 3px;
+      font-size: 0.5rem;
+      display: flex; align-items: center; justify-content: center;
+      font-family: var(--font-mono);
+    }
+    .carriage-slot.filling { background: var(--accent); color: #fff; }
+    .carriage-slot.calculating { background: var(--warning); color: #000; }
+    .carriage-slot.idle { background: var(--elevated); color: var(--text-muted); }
 
-    .dist-bar-outer { height: 24px; background: var(--elevated); border-radius: 4px; overflow: hidden; display: flex; }
-    .dist-bar { height: 100%; min-width: 4px; }
-
-    button { background: none; border: none; color: inherit; font: inherit; cursor: pointer; }
-    button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-
-    ::-webkit-scrollbar { width: 4px; height: 4px; }
-    ::-webkit-scrollbar-track { background: transparent; }
-    ::-webkit-scrollbar-thumb { background: #333; border-radius: 2px; }
-    ::-webkit-scrollbar-thumb:hover { background: #555; }
-
-    .tier-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; margin-bottom: 16px; }
-    @media (min-width: 640px) { .tier-grid { grid-template-columns: repeat(4, 1fr); } }
-    .sys-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; font-size: 0.8125rem; }
+    /* System stats grid */
+    .sys-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 8px;
+      font-size: 0.8125rem;
+    }
     @media (min-width: 640px) { .sys-grid { grid-template-columns: repeat(4, 1fr); } }
     @media (max-width: 640px) {
       body { padding: 8px; }
       .card { padding: 10px; }
       .stat-value { font-size: 0.875rem !important; word-break: break-all; }
-      .tier-grid { gap: 6px; }
-      .sys-grid { gap: 4px; font-size: 0.75rem; }
-      .modal-content { padding: 12px; margin: 8px; }
-      .sparkline { height: 20px; }
-      .sparkline-bar { width: 3px; }
-      header .text-sm { font-size: 0.75rem; }
+      .core-grid { grid-template-columns: repeat(2, 1fr); gap: 6px; }
+      .carriage-slot { width: 16px; height: 16px; }
     }
-
-    /* Modal overlay */
-    .modal-overlay {
-      position: fixed; inset: 0; z-index: 100;
-      background: rgba(0,0,0,0.8);
-      display: flex; align-items: center; justify-content: center;
-      padding: 16px;
-    }
-    .modal-content {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 24px;
-      max-width: 640px;
-      width: 100%;
-      max-height: 80vh;
-      overflow: auto;
-    }
-    .modal-content h2 { font-size: 1rem; font-weight: 600; margin-bottom: 12px; }
   </style>
 </head>
 <body>
@@ -120,57 +105,29 @@
     <!-- Header -->
     <header class="card" style="margin-bottom:16px;display:flex;align-items:center;justify-content:space-between;gap:12px;">
       <div style="min-width:0;overflow:hidden">
-        <h1 style="font-size:1.25rem;font-weight:700;font-family:var(--font-sans)">scx_flow stats</h1>
-        <p style="font-size:0.8125rem;color:var(--text-secondary);margin-top:2px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">tier dispatches, budget distribution, system stats</p>
+        <h1 style="font-size:1.25rem;font-weight:700">scx_flow stats</h1>
+        <p style="font-size:0.8125rem;color:var(--text-secondary);margin-top:2px">Waiting Room — per-core dispatch, carriage pool</p>
       </div>
       <div id="status-badge" style="font-size:0.75rem;padding:3px 10px;border-radius:999px;border:1px solid var(--success);color:var(--success);font-family:var(--font-mono);white-space:nowrap">
         ● running
       </div>
     </header>
 
-    <!-- Tier metric cards with sparklines -->
-    <div id="tier-cards" class="tier-grid">
-      <div class="card"><button onclick="showHistory('priority')" style="width:100%;text-align:left">
-        <p style="font-size:0.75rem;color:var(--text-muted);font-family:var(--font-sans)">Priority</p>
-        <p class="stat-value tier-P" id="tier-P" style="font-size:1.5rem">0</p>
-        <p style="font-size:0.6875rem;color:var(--text-muted);margin-top:2px">dispatches from priority tier</p>
-        <div class="sparkline" id="spark-P"></div>
-      </button></div>
-      <div class="card"><button onclick="showHistory('normal')" style="width:100%;text-align:left">
-        <p style="font-size:0.75rem;color:var(--text-muted);font-family:var(--font-sans)">Normal</p>
-        <p class="stat-value tier-N" id="tier-N" style="font-size:1.5rem">0</p>
-        <p style="font-size:0.6875rem;color:var(--text-muted);margin-top:2px">dispatches from normal tier</p>
-        <div class="sparkline" id="spark-N"></div>
-      </button></div>
-      <div class="card"><button onclick="showHistory('low')" style="width:100%;text-align:left">
-        <p style="font-size:0.75rem;color:var(--text-muted);font-family:var(--font-sans)">Low</p>
-        <p class="stat-value tier-L" id="tier-L" style="font-size:1.5rem">0</p>
-        <p style="font-size:0.6875rem;color:var(--text-muted);margin-top:2px">dispatches from low tier</p>
-        <div class="sparkline" id="spark-L"></div>
-      </button></div>
-      <div class="card"><button onclick="showHistory('deficit')" style="width:100%;text-align:left">
-        <p style="font-size:0.75rem;color:var(--text-muted);font-family:var(--font-sans)">Exhausted</p>
-        <p class="stat-value tier-D" id="tier-D" style="font-size:1.5rem">0</p>
-        <p style="font-size:0.6875rem;color:var(--text-muted);margin-top:2px">dispatches from deficit tier</p>
-        <div class="sparkline" id="spark-D"></div>
-      </button></div>
-    </div>
+    <!-- Per-core cards -->
+    <div id="core-cards" class="core-grid"></div>
 
-    <!-- Tier distribution bar -->
+    <!-- Carriage pool -->
     <div class="card" style="margin-bottom:16px">
-      <p style="font-size:0.75rem;color:var(--text-muted);margin-bottom:8px">Tier distribution</p>
-      <div class="dist-bar-outer" id="dist-bar">
-        <div class="dist-bar tier-P" id="dist-P" style="background:var(--success)"></div>
-        <div class="dist-bar tier-N" id="dist-N" style="background:var(--accent)"></div>
-        <div class="dist-bar tier-L" id="dist-L" style="background:var(--warning)"></div>
-        <div class="dist-bar tier-D" id="dist-D" style="background:var(--error)"></div>
+      <p style="font-size:0.75rem;color:var(--text-muted);margin-bottom:4px">Waiting Room — Carriage Pool</p>
+      <div style="display:flex;gap:12px;font-size:0.75rem;font-family:var(--font-mono);margin-bottom:8px">
+        <span>prod: <span id="carriage-prod">0</span></span>
+        <span>slot: <span id="carriage-slot">0</span></span>
+
+        <span>fill: <span id="carriage-fill">0</span></span>
+
+
       </div>
-      <div style="display:flex;flex-wrap:wrap;gap:12px;margin-top:8px;font-size:0.6875rem">
-        <span style="color:var(--success)">■ P <span id="dist-pct-P">0</span>%</span>
-        <span style="color:var(--accent)">■ N <span id="dist-pct-N">0</span>%</span>
-        <span style="color:var(--warning)">■ L <span id="dist-pct-L">0</span>%</span>
-        <span style="color:var(--error)">■ D <span id="dist-pct-D">0</span>%</span>
-      </div>
+      <div id="carriage-grid" class="carriage-grid"></div>
     </div>
 
     <!-- System stats -->
@@ -178,13 +135,12 @@
       <p style="font-size:0.75rem;color:var(--text-muted);margin-bottom:8px">System</p>
       <div class="sys-grid">
         <div><span style="color:var(--text-muted)">On CPU:</span> <span class="stat-value" id="on-cpu">0</span></div>
-        <div><span style="color:var(--text-muted)">Uptime:</span> <span class="stat-value" id="total-runtime">0</span></div>
-        <div><span style="color:var(--text-muted)">Quick dispatches:</span> <span class="stat-value" id="quick-disp">0</span></div>
+        <div><span style="color:var(--text-muted)">Uptime:</span> <span class="stat-value" id="uptime">0</span></div>
+        <div><span style="color:var(--text-muted)">Wake dispatches:</span> <span class="stat-value" id="prio-disp">0</span></div>
         <div><span style="color:var(--text-muted)">Pinned dispatches:</span> <span class="stat-value" id="pinned-disp">0</span></div>
-        <div><span style="color:var(--text-muted)">Budget refills:</span> <span class="stat-value" id="budget-refill">0</span></div>
         <div><span style="color:var(--text-muted)">Budget exhaustions:</span> <span class="stat-value" id="budget-exhaust">0</span></div>
-        <div><span style="color:var(--text-muted)">CPU migrations:</span> <span class="stat-value" id="cpu-migrations">0</span></div>
-        <div><span style="color:var(--text-muted)">Wakeups:</span> <span class="stat-value" id="runnable-wakeups">0</span></div>
+        <div><span style="color:var(--text-muted)">CPU migrations:</span> <span class="stat-value" id="cpu-mig">0</span></div>
+        <div><span style="color:var(--text-muted)">Wakeups:</span> <span class="stat-value" id="wakeups">0</span></div>
       </div>
     </div>
 
@@ -194,21 +150,8 @@
     </div>
   </div>
 
-  <!-- Modal placeholder -->
-  <div id="modal-root"></div>
-
   <script>
     const el = (id) => document.getElementById(id);
-    const TIER_COLORS = { P: '#31c48d', N: '#3f83f8', L: '#f5a623', D: '#ee0000' };
-    const TIER_NAMES = { priority: 'Priority', normal: 'Normal', low: 'Low', deficit: 'Exhausted' };
-    const TIER_KEYS = {
-      priority: 'tier_priority_dispatches',
-      normal: 'tier_normal_dispatches',
-      low: 'tier_low_dispatches',
-      deficit: 'tier_deficit_dispatches'
-    };
-
-    let historyData = [];
 
     function clamp(v) { return v < 0 ? 0 : v; }
 
@@ -231,110 +174,72 @@
       var hr = min / 60;
       if (hr < 24) return hr.toFixed(1) + ' hr';
       var day = hr / 24;
-      if (day < 30) return day.toFixed(1) + ' days';
-      if (day < 365) return (day / 30).toFixed(1) + ' months';
-      return (day / 365).toFixed(1) + ' years';
+      return day.toFixed(1) + ' days';
     }
 
-    function renderSparkline(containerId, values, color, maxVal) {
-      const container = el(containerId);
-      if (!container || !values.length) { if (container) container.innerHTML = ''; return; }
-      const h = 26;
-      const m = maxVal || Math.max(...values, 1);
-      container.innerHTML = values.map(function(v) {
-        var bh = Math.max(1, (v / m) * h);
-        return '<div class="sparkline-bar" style="height:' + bh.toFixed(0) + 'px;background:' + color + '"></div>';
+    function renderCoreCards(data) {
+      var container = el('core-cards');
+      var perCpu = data.per_cpu || [];
+      if (!perCpu.length) {
+        container.innerHTML = '<div class="card" style="grid-column:1/-1;text-align:center;color:var(--text-muted)">No CPU data yet</div>';
+        return;
+      }
+      container.innerHTML = perCpu.map(function(cpu) {
+        var freqMhz = Math.round(cpu.freq_khz / 1000);
+        var smtLabel = cpu.smt ? ' <span class="core-smt">SMT</span>' : '';
+        return '<div class="card core-card">' +
+          '<div class="core-id">CPU ' + cpu.id + smtLabel + '</div>' +
+          '<div class="core-freq">' + freqMhz + ' MHz</div>' +
+          '<div class="core-llc">LLC ' + cpu.llc_id + '</div>' +
+          '</div>';
       }).join('');
     }
 
-    function renderDistBar(data) {
-      var p = data.tier_priority_dispatches || 0;
-      var n = data.tier_normal_dispatches || 0;
-      var l = data.tier_low_dispatches || 0;
-      var d = data.tier_deficit_dispatches || 0;
-      var total = p + n + l + d;
-      if (total === 0) {
-        ['dist-P','dist-N','dist-L','dist-D'].forEach(function(id) { el(id).style.width = '0'; });
-        ['dist-pct-P','dist-pct-N','dist-pct-L','dist-pct-D'].forEach(function(id) { el(id).textContent = '0'; });
-        return;
+    function renderCarriagePool(data) {
+      var s = data.stats || {};
+      var prod = s.carriage_producer || 0;
+      var fillCount = data.carriage_filling_count || 0;
+      el('carriage-prod').textContent = fmt(prod);
+      el('carriage-slot').textContent = prod & 63;
+      el('carriage-fill').textContent = fmt(fillCount);
+
+      // Render slot grid from stats API (carriage_pool data not in current API)
+      // Show a simple 64-slot grid based on producer/consumer
+      var grid = el('carriage-grid');
+      var slots = '';
+      for (var i = 0; i < 64; i++) {
+        var cls = 'carriage-slot';
+        if (i === (prod & 63)) cls += ' filling';
+        else cls += ' idle';
+        slots += '<div class="' + cls + '"></div>';
       }
-      el('dist-P').style.width = (p / total * 100) + '%';
-      el('dist-N').style.width = (n / total * 100) + '%';
-      el('dist-L').style.width = (l / total * 100) + '%';
-      el('dist-D').style.width = (d / total * 100) + '%';
-      el('dist-pct-P').textContent = (p / total * 100).toFixed(0);
-      el('dist-pct-N').textContent = (n / total * 100).toFixed(0);
-      el('dist-pct-L').textContent = (l / total * 100).toFixed(0);
-      el('dist-pct-D').textContent = (d / total * 100).toFixed(0);
+      grid.innerHTML = slots;
     }
 
     function updateUI(data) {
-      // Status badge
       el('status-badge').textContent = '● running';
       el('status-badge').style.borderColor = 'var(--success)';
       el('status-badge').style.color = 'var(--success)';
 
-      // Tier counts
-      el('tier-P').textContent = fmt(data.tier_priority_dispatches || 0);
-      el('tier-N').textContent = fmt(data.tier_normal_dispatches || 0);
-      el('tier-L').textContent = fmt(data.tier_low_dispatches || 0);
-      el('tier-D').textContent = fmt(data.tier_deficit_dispatches || 0);
+      var s = data.stats || {};
+      el('on-cpu').textContent = fmt(s.on_cpu || 0);
+      el('uptime').textContent = fmtRuntime(s.uptime_ns || 0);
+      el('prio-disp').textContent = fmt(s.prio_dispatches || 0);
+      el('pinned-disp').textContent = fmt(s.pinned_dispatches || 0);
+      el('budget-exhaust').textContent = fmt(s.budget_exhaustions || 0);
+      el('cpu-mig').textContent = fmt(s.cpu_migrations || 0);
+      el('wakeups').textContent = fmt(s.runnable_wakeups || 0);
 
-      // System stats
-      el('on-cpu').textContent = fmt(data.on_cpu || 0);
-      el('total-runtime').textContent = fmtRuntime(data.uptime_ns || 0);
-      el('quick-disp').textContent = fmt(data.prio_dispatches || 0);
-      el('pinned-disp').textContent = fmt(data.pinned_dispatches || 0);
-      el('budget-refill').textContent = fmt(data.budget_refill_events || 0);
-      el('budget-exhaust').textContent = fmt(data.budget_exhaustions || 0);
-      el('cpu-migrations').textContent = fmt(data.cpu_migrations || 0);
-      el('runnable-wakeups').textContent = fmt(data.runnable_wakeups || 0);
-
-      // Distribution bar
-      renderDistBar(data);
-
-      // Connection status
-      el('conn-status').textContent = 'Live — ' + new Date().toLocaleTimeString();
-    }
-
-    function updateSparklines() {
-      if (historyData.length < 2) return;
-      var keys = [
-        { key: 'tier_priority_dispatches', id: 'spark-P', color: TIER_COLORS.P },
-        { key: 'tier_normal_dispatches',   id: 'spark-N', color: TIER_COLORS.N },
-        { key: 'tier_low_dispatches',      id: 'spark-L', color: TIER_COLORS.L },
-        { key: 'tier_deficit_dispatches',  id: 'spark-D', color: TIER_COLORS.D },
-      ];
-      // Compute per-sample deltas (dispatch rate per interval)
-      var tierKeys = ['tier_priority_dispatches','tier_normal_dispatches','tier_low_dispatches','tier_deficit_dispatches'];
-      var deltas = [];
-      for (var i = 1; i < historyData.length; i++) {
-        var prev = historyData[i - 1];
-        var cur = historyData[i];
-        var d = {};
-        tierKeys.forEach(function(k) { d[k] = Math.max(0, (cur[k] || 0) - (prev[k] || 0)); });
-        deltas.push(d);
-      }
-      var sampleCount = Math.min(deltas.length, 60);
-      var recent = deltas.slice(deltas.length - sampleCount);
-
-      keys.forEach(function(k) {
-        var vals = recent.map(function(d) { return d[k.key] || 0; });
-        if (vals.length > 1) {
-          var max = Math.max(Math.max.apply(null, vals), 1);
-          renderSparkline(k.id, vals, k.color, max);
-        }
-      });
+      renderCoreCards(data);
+      renderCarriagePool(data);
     }
 
     function pollStats() {
       fetch('/api/stats')
         .then(function(r) { return r.json(); })
         .then(function(data) {
-          historyData.push(data);
-          if (historyData.length > 300) historyData.shift();
           updateUI(data);
-          updateSparklines();
+          el('conn-status').textContent = 'Live — ' + new Date().toLocaleTimeString();
         })
         .catch(function() {
           el('status-badge').textContent = '● disconnected';
@@ -344,94 +249,6 @@
         });
     }
 
-    // Load history on page load
-    fetch('/api/history')
-      .then(function(r) { return r.json(); })
-      .then(function(h) {
-        if (Array.isArray(h) && h.length) {
-          historyData = h;
-          updateSparklines();
-          // Update UI with latest history point
-          updateUI(h[h.length - 1]);
-        }
-      })
-      .catch(function() {});
-
-    // Modal — save focus, aria-modal, restore on close.
-    function showHistory(tier) {
-      lastFocused = document.activeElement;
-      var root = el('modal-root');
-      if (!root) return;
-      var key = TIER_KEYS[tier];
-      var name = TIER_NAMES[tier] || tier;
-      var color = TIER_COLORS[tier.charAt(0).toUpperCase()] || '#fff';
-
-      var vals = historyData.map(function(d) { return d[key] || 0; });
-      var values = [];
-      for (var i = 1; i < vals.length; i++) {
-        values.push(Math.max(0, vals[i] - vals[i - 1]));
-      }
-      var max = Math.max.apply(null, values.concat([1]));
-
-      var sampleCount = Math.min(values.length, 120);
-      var recent = values.slice(Math.max(values.length - sampleCount, 0));
-      var barWidth = 640 / Math.max(recent.length, 1);
-
-      var bars = recent.map(function(v) {
-        var h = Math.max(1, (v / max) * 120);
-        return '<div style="width:' + barWidth + 'px;height:' + h.toFixed(0) + 'px;background:' + color + ';display:inline-block;vertical-align:bottom;border-radius:1px"></div>';
-      }).join('');
-
-      var last = recent.length ? recent[recent.length - 1] : 0;
-      var p50 = percentile(recent, 0.5);
-      var p95 = percentile(recent, 0.95);
-      var p99 = percentile(recent, 0.99);
-
-      root.innerHTML =
-        '<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="' + name + ' dispatch history" onclick="onOverlayClick(event)">' +
-        '<div class="modal-content">' +
-        '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px">' +
-        '<h2 id="modal-title">' + name + ' dispatches over time</h2>' +
-        '<button onclick="closeModal()" style="font-size:1.25rem;color:var(--text-muted);padding:4px 8px" aria-label="Close">&times;</button>' +
-        '</div>' +
-        '<div style="overflow-x:auto;white-space:nowrap;height:140px;padding-top:10px">' + bars + '</div>' +
-        '<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-top:12px;font-size:0.75rem">' +
-        '<div><span style="color:var(--text-muted)">Current</span><br><span class="stat-value">' + fmt(last) + '</span></div>' +
-        '<div><span style="color:var(--text-muted)">Median</span><br><span class="stat-value">' + fmt(p50) + '</span></div>' +
-        '<div><span style="color:var(--text-muted)">p95</span><br><span class="stat-value">' + fmt(p95) + '</span></div>' +
-        '<div><span style="color:var(--text-muted)">p99</span><br><span class="stat-value">' + fmt(p99) + '</span></div>' +
-        '</div>' +
-        '</div>' +
-        '</div>';
-      // Focus close button, restore on Esc.
-      var closeBtn = root.querySelector('button[aria-label="Close"]');
-      if (closeBtn) closeBtn.focus();
-    }
-
-    var lastFocused = null;
-
-    document.addEventListener('keydown', function(e) {
-      if (e.key === 'Escape' && el('modal-root').innerHTML) closeModal();
-    });
-
-    function onOverlayClick(e) {
-      if (e.target === e.currentTarget) closeModal();
-    }
-
-    function closeModal() {
-      var root = el('modal-root');
-      if (root) root.innerHTML = '';
-      if (lastFocused && lastFocused.focus) lastFocused.focus();
-    }
-
-    function percentile(arr, p) {
-      if (!arr.length) return 0;
-      var sorted = arr.slice().sort(function(a,b) { return a - b; });
-      var idx = Math.ceil(sorted.length * p) - 1;
-      return sorted[Math.max(0, Math.min(idx, sorted.length - 1))];
-    }
-
-    // Poll immediately and then every second
     pollStats();
     setInterval(pollStats, 1000);
   </script>


### PR DESCRIPTION
## Summary

Per-CPU vtime-ordered DSQs with fair-share bandwidth. Replaces 4-tier FIFO.

## Changes

- `[1/8]` [`7b739201`](https://github.com/galpt/scx/commit/7b739201) **scx_flow: 3.1.0 — Waiting Room with per-CPU DSQs**
- `[2/8]` [`374f2965`](https://github.com/galpt/scx/commit/374f2965) **scx_flow: SMT detection + per_cpu_sibling_count + SMT-aware dispatch**
- `[3/8]` [`982d6253`](https://github.com/galpt/scx/commit/982d6253) **scx_flow: fair-share bandwidth model + shared vtime DSQ (no CPU scan)**
- `[4/8]` [`428acec6`](https://github.com/galpt/scx/commit/428acec6) **scx_flow: per-CPU fair-share DSQs + work stealing**
- `[5/8]` [`bddbed13`](https://github.com/galpt/scx/commit/bddbed13) **scx_flow: fmt fixes for CI lint**
- `[6/8]` [`c433fcf8`](https://github.com/galpt/scx/commit/c433fcf8) **scx_flow: fix review comments — void ops, CPU bounds, runnable tracking, docs**
- `[7/8]` [`41fe3c68`](https://github.com/galpt/scx/commit/41fe3c68) **scx_flow: fix per_cpu_runnable double-decrement in flow_stopping**
- `[8/8]` [`7c27d15`](https://github.com/galpt/scx/commit/7c27d15) **scx_flow: use compat macros for dsq_move_to_local and dsq_insert**