### PR TITLE
scx_utils: Move perf event code to perf crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,15 +2820,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "perf-event-open-sys"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f8d1487a4ffa23c80a1c355dd27235f9b66fb71ba0f261eb417e4fe8451347"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "perfetto_protos"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,7 +3718,6 @@ dependencies = [
  "log",
  "nvml-wrapper",
  "nvml-wrapper-sys",
- "perf-event-open-sys",
  "scx_cargo",
  "scx_stats",
  "scx_stats_derive",

--- a/rust/scx_utils/src/perf.rs
+++ b/rust/scx_utils/src/perf.rs
@@ -60,3 +60,194 @@ pub mod ioctls {
         unsafe { libc::ioctl(fd, perf::bindings::RESET as libc::Ioctl, arg) }
     }
 }
+
+use anyhow::Context as _;
+use anyhow::Result;
+use libbpf_rs::MapCore;
+use libbpf_rs::MapFlags;
+
+/// Must match lib/pmu.bpf.c SCX_PMU_STRIDE for the perf_events map key layout.
+pub const PERF_MAP_STRIDE: u32 = 4096;
+
+/// Perf event specification: either hex (0xN) or a symbolic name (e.g.
+/// cache-misses). `event_id` is the opaque id written to BPF rodata (it must
+/// match between install and read); `type_`/`config` drive perf_event_open.
+#[derive(Clone, Debug)]
+pub struct PerfEventSpec {
+    /// Opaque id for BPF (must match between install and read).
+    pub event_id: u64,
+    /// perf_event_attr.type (PERF_TYPE_RAW, PERF_TYPE_HARDWARE, etc.).
+    pub type_: u32,
+    /// perf_event_attr.config.
+    pub config: u64,
+    /// Original string for error messages.
+    pub display_name: String,
+}
+
+fn parse_hardware_event(s: &str) -> Option<u64> {
+    match s {
+        "cpu-cycles" | "cycles" => Some(0),
+        "instructions" => Some(1),
+        "cache-references" => Some(2),
+        "cache-misses" => Some(3),
+        "branch-instructions" | "branches" => Some(4),
+        "branch-misses" => Some(5),
+        "bus-cycles" => Some(6),
+        "stalled-cycles-frontend" | "idle-cycles-frontend" => Some(7),
+        "stalled-cycles-backend" | "idle-cycles-backend" => Some(8),
+        "ref-cycles" => Some(9),
+        _ => None,
+    }
+}
+
+fn parse_software_event(s: &str) -> Option<u64> {
+    match s {
+        "cpu-clock" => Some(0),
+        "task-clock" => Some(1),
+        "page-faults" | "faults" => Some(2),
+        "context-switches" | "cs" => Some(3),
+        "cpu-migrations" | "migrations" => Some(4),
+        "minor-faults" => Some(5),
+        "major-faults" => Some(6),
+        "alignment-faults" => Some(7),
+        "emulation-faults" => Some(8),
+        "dummy" => Some(9),
+        "bpf-output" => Some(10),
+        _ => None,
+    }
+}
+
+fn parse_hw_cache_event(s: &str) -> Option<u64> {
+    let (cache_id, prefix_len) = if s.starts_with("L1-dcache-") {
+        (0, 10)
+    } else if s.starts_with("L1-icache-") {
+        (1, 10)
+    } else if s.starts_with("LLC-") {
+        (2, 4)
+    } else if s.starts_with("dTLB-") {
+        (3, 5)
+    } else if s.starts_with("iTLB-") {
+        (4, 5)
+    } else if s.starts_with("branch-") {
+        (5, 7)
+    } else if s.starts_with("node-") {
+        (6, 5)
+    } else {
+        return None;
+    };
+
+    let suffix = &s[prefix_len..];
+    let (op_id, result_id) = match suffix {
+        "loads" => (0, 0),
+        "load-misses" => (0, 1),
+        "stores" => (1, 0),
+        "store-misses" => (1, 1),
+        "prefetches" => (2, 0),
+        "prefetch-misses" => (2, 1),
+        _ => return None,
+    };
+
+    Some((result_id << 16) | (op_id << 8) | cache_id)
+}
+
+/// Parse a perf event value: hex (0xN) or a symbolic name (e.g. cache-misses,
+/// LLC-load-misses, page-faults). Intended for use as a clap `value_parser`.
+pub fn parse_perf_event(s: &str) -> Result<PerfEventSpec, String> {
+    let s = s.trim();
+    if s.is_empty() || s == "0" || s.eq_ignore_ascii_case("0x0") {
+        return Ok(PerfEventSpec {
+            event_id: 0,
+            type_: bindings::PERF_TYPE_RAW,
+            config: 0,
+            display_name: s.to_string(),
+        });
+    }
+
+    if let Some(hex_str) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        if let Ok(config) = u64::from_str_radix(hex_str, 16) {
+            return Ok(PerfEventSpec {
+                event_id: config,
+                type_: bindings::PERF_TYPE_RAW,
+                config,
+                display_name: s.to_string(),
+            });
+        }
+    }
+
+    if let Some(config) = parse_hardware_event(s) {
+        let event_id = (bindings::PERF_TYPE_HARDWARE as u64) << 32 | config;
+        return Ok(PerfEventSpec {
+            event_id,
+            type_: bindings::PERF_TYPE_HARDWARE,
+            config,
+            display_name: s.to_string(),
+        });
+    }
+
+    if let Some(config) = parse_software_event(s) {
+        let event_id = (bindings::PERF_TYPE_SOFTWARE as u64) << 32 | config;
+        return Ok(PerfEventSpec {
+            event_id,
+            type_: bindings::PERF_TYPE_SOFTWARE,
+            config,
+            display_name: s.to_string(),
+        });
+    }
+
+    if let Some(config) = parse_hw_cache_event(s) {
+        let event_id = (bindings::PERF_TYPE_HW_CACHE as u64) << 32 | config;
+        return Ok(PerfEventSpec {
+            event_id,
+            type_: bindings::PERF_TYPE_HW_CACHE,
+            config,
+            display_name: s.to_string(),
+        });
+    }
+
+    Err(format!(
+        "Invalid perf event '{}': use hex (0xN) or a symbolic name (e.g. cache-misses, LLC-load-misses, page-faults)",
+        s
+    ))
+}
+
+/// Open a perf event on @cpu and register its fd in the given BPF PMU map (the
+/// scheduler's `scx_pmu_map`) at the slot for (@cpu, @counter_idx). counter_idx
+/// 0 is the migration event, 1 the sticky event, matching the PMU library
+/// install order.
+pub fn setup_perf_events(
+    map: &impl MapCore,
+    cpu: i32,
+    spec: &PerfEventSpec,
+    counter_idx: u32,
+) -> Result<()> {
+    if spec.event_id == 0 {
+        return Ok(());
+    }
+
+    // `disabled` and `inherit` default to 0 via Default::default().
+    let mut attrs = bindings::perf_event_attr {
+        type_: spec.type_,
+        config: spec.config,
+        size: std::mem::size_of::<bindings::perf_event_attr>() as u32,
+        ..Default::default()
+    };
+
+    let fd = unsafe { perf_event_open(&mut attrs, -1, cpu, -1, 0) };
+
+    if fd < 0 {
+        let err = std::io::Error::last_os_error();
+        return Err(anyhow::anyhow!(
+            "Failed to open perf event '{}' on CPU {}: {}",
+            spec.display_name,
+            cpu,
+            err
+        ));
+    }
+
+    let key = cpu as u32 + counter_idx * PERF_MAP_STRIDE;
+
+    map.update(&key.to_ne_bytes(), &fd.to_ne_bytes(), MapFlags::ANY)
+        .with_context(|| "Failed to update perf_events map")?;
+
+    Ok(())
+}

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -15,7 +15,6 @@ libbpf-rs = "=0.26.2"
 log = "0.4"
 nvml-wrapper = "0.12"
 nvml-wrapper-sys = "0.9"
-perf-event-open-sys = "6"
 scx_stats = { path = "../../../rust/scx_stats", version = "1.1.1" }
 scx_stats_derive = { path = "../../../rust/scx_stats/scx_stats_derive", version = "1.1.1" }
 scx_utils = { path = "../../../rust/scx_utils", version = "1.1.1", features = ["autopower", "gpu-topology"] }

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -40,6 +40,9 @@ use scx_utils::build_id;
 use scx_utils::compat;
 use scx_utils::get_primary_cpus;
 use scx_utils::libbpf_clap_opts::LibbpfOpts;
+use scx_utils::perf::parse_perf_event;
+use scx_utils::perf::setup_perf_events;
+use scx_utils::perf::PerfEventSpec;
 use scx_utils::scx_ops_attach;
 use scx_utils::scx_ops_load;
 use scx_utils::scx_ops_open;
@@ -54,197 +57,6 @@ use scx_utils::NR_CPU_IDS;
 use stats::Metrics;
 
 const SCHEDULER_NAME: &str = "scx_cosmos";
-
-/// Perf event specification: either hex (0xN) or symbolic name (e.g. cache-misses).
-/// event_id is written to BPF rodata; type_ and config are used for perf_event_open.
-#[derive(Clone, Debug)]
-struct PerfEventSpec {
-    /// Opaque id for BPF (must match between install and read).
-    event_id: u64,
-    /// perf_event_attr.type (PERF_TYPE_RAW, PERF_TYPE_HARDWARE, etc.).
-    type_: u32,
-    /// perf_event_attr.config.
-    config: u64,
-    /// Original string for error messages.
-    display_name: String,
-}
-
-fn parse_hardware_event(s: &str) -> Option<u64> {
-    match s {
-        "cpu-cycles" | "cycles" => Some(0),
-        "instructions" => Some(1),
-        "cache-references" => Some(2),
-        "cache-misses" => Some(3),
-        "branch-instructions" | "branches" => Some(4),
-        "branch-misses" => Some(5),
-        "bus-cycles" => Some(6),
-        "stalled-cycles-frontend" | "idle-cycles-frontend" => Some(7),
-        "stalled-cycles-backend" | "idle-cycles-backend" => Some(8),
-        "ref-cycles" => Some(9),
-        _ => None,
-    }
-}
-
-fn parse_software_event(s: &str) -> Option<u64> {
-    match s {
-        "cpu-clock" => Some(0),
-        "task-clock" => Some(1),
-        "page-faults" | "faults" => Some(2),
-        "context-switches" | "cs" => Some(3),
-        "cpu-migrations" | "migrations" => Some(4),
-        "minor-faults" => Some(5),
-        "major-faults" => Some(6),
-        "alignment-faults" => Some(7),
-        "emulation-faults" => Some(8),
-        "dummy" => Some(9),
-        "bpf-output" => Some(10),
-        _ => None,
-    }
-}
-
-fn parse_hw_cache_event(s: &str) -> Option<u64> {
-    let (cache_id, prefix_len) = if s.starts_with("L1-dcache-") {
-        (0, 10)
-    } else if s.starts_with("L1-icache-") {
-        (1, 10)
-    } else if s.starts_with("LLC-") {
-        (2, 4)
-    } else if s.starts_with("dTLB-") {
-        (3, 5)
-    } else if s.starts_with("iTLB-") {
-        (4, 5)
-    } else if s.starts_with("branch-") {
-        (5, 7)
-    } else if s.starts_with("node-") {
-        (6, 5)
-    } else {
-        return None;
-    };
-
-    let suffix = &s[prefix_len..];
-    let (op_id, result_id) = match suffix {
-        "loads" => (0, 0),
-        "load-misses" => (0, 1),
-        "stores" => (1, 0),
-        "store-misses" => (1, 1),
-        "prefetches" => (2, 0),
-        "prefetch-misses" => (2, 1),
-        _ => return None,
-    };
-
-    Some((result_id << 16) | (op_id << 8) | cache_id)
-}
-
-/// Parse -e / -y value: hex (0xN) or symbolic name (e.g. cache-misses, LLC-load-misses).
-fn parse_perf_event(s: &str) -> Result<PerfEventSpec, String> {
-    use perf_event_open_sys as sys;
-
-    let s = s.trim();
-    if s.is_empty() || s == "0" || s.eq_ignore_ascii_case("0x0") {
-        return Ok(PerfEventSpec {
-            event_id: 0,
-            type_: sys::bindings::PERF_TYPE_RAW,
-            config: 0,
-            display_name: s.to_string(),
-        });
-    }
-
-    if let Some(hex_str) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
-        if let Ok(config) = u64::from_str_radix(hex_str, 16) {
-            return Ok(PerfEventSpec {
-                event_id: config,
-                type_: sys::bindings::PERF_TYPE_RAW,
-                config,
-                display_name: s.to_string(),
-            });
-        }
-    }
-
-    if let Some(config) = parse_hardware_event(s) {
-        let event_id = (sys::bindings::PERF_TYPE_HARDWARE as u64) << 32 | config;
-        return Ok(PerfEventSpec {
-            event_id,
-            type_: sys::bindings::PERF_TYPE_HARDWARE,
-            config,
-            display_name: s.to_string(),
-        });
-    }
-
-    if let Some(config) = parse_software_event(s) {
-        let event_id = (sys::bindings::PERF_TYPE_SOFTWARE as u64) << 32 | config;
-        return Ok(PerfEventSpec {
-            event_id,
-            type_: sys::bindings::PERF_TYPE_SOFTWARE,
-            config,
-            display_name: s.to_string(),
-        });
-    }
-
-    if let Some(config) = parse_hw_cache_event(s) {
-        let event_id = (sys::bindings::PERF_TYPE_HW_CACHE as u64) << 32 | config;
-        return Ok(PerfEventSpec {
-            event_id,
-            type_: sys::bindings::PERF_TYPE_HW_CACHE,
-            config,
-            display_name: s.to_string(),
-        });
-    }
-
-    Err(format!(
-        "Invalid perf event '{}': use hex (0xN) or symbolic name (e.g. cache-misses, LLC-load-misses, page-faults)",
-        s
-    ))
-}
-
-/// Must match lib/pmu.bpf.c SCX_PMU_STRIDE for perf_events map key layout.
-const PERF_MAP_STRIDE: u32 = 4096;
-
-/// Setup performance counter events for a specific CPU and counter index.
-/// counter_idx 0 = migration event (-e), 1 = sticky event (-y).
-fn setup_perf_events(
-    skel: &mut BpfSkel,
-    cpu: i32,
-    spec: &PerfEventSpec,
-    counter_idx: u32,
-) -> Result<()> {
-    use perf_event_open_sys as sys;
-
-    if spec.event_id == 0 {
-        return Ok(());
-    }
-
-    let map = &skel.maps.scx_pmu_map;
-
-    let mut attrs = sys::bindings::perf_event_attr::default();
-    attrs.type_ = spec.type_;
-    attrs.config = spec.config;
-    attrs.size = std::mem::size_of::<sys::bindings::perf_event_attr>() as u32;
-    attrs.set_disabled(0);
-    attrs.set_inherit(0);
-
-    let fd = unsafe { sys::perf_event_open(&mut attrs, -1, cpu, -1, 0) };
-
-    if fd < 0 {
-        let err = std::io::Error::last_os_error();
-        return Err(anyhow::anyhow!(
-            "Failed to open perf event '{}' on CPU {}: {}",
-            spec.display_name,
-            cpu,
-            err
-        ));
-    }
-
-    let key = cpu as u32 + counter_idx * PERF_MAP_STRIDE;
-
-    map.update(
-        &key.to_ne_bytes(),
-        &fd.to_ne_bytes(),
-        libbpf_rs::MapFlags::ANY,
-    )
-    .with_context(|| "Failed to update perf_events map")?;
-
-    Ok(())
-}
 
 #[derive(Debug, clap::Parser)]
 #[command(
@@ -913,7 +725,9 @@ impl<'a> Scheduler<'a> {
         let sticky_counter_idx = if opts.perf_config.event_id > 0 { 1 } else { 0 };
         for cpu in 0..nr_cpus {
             if opts.perf_config.event_id > 0 {
-                if let Err(e) = setup_perf_events(&mut skel, cpu as i32, &opts.perf_config, 0) {
+                if let Err(e) =
+                    setup_perf_events(&skel.maps.scx_pmu_map, cpu as i32, &opts.perf_config, 0)
+                {
                     if cpu == 0 {
                         let err_str = e.to_string();
                         if err_str.contains("errno 2") || err_str.contains("os error 2") {
@@ -928,9 +742,12 @@ impl<'a> Scheduler<'a> {
                 }
             }
             if opts.perf_sticky.event_id > 0 {
-                if let Err(e) =
-                    setup_perf_events(&mut skel, cpu as i32, &opts.perf_sticky, sticky_counter_idx)
-                {
+                if let Err(e) = setup_perf_events(
+                    &skel.maps.scx_pmu_map,
+                    cpu as i32,
+                    &opts.perf_sticky,
+                    sticky_counter_idx,
+                ) {
                     if cpu == 0 {
                         let err_str = e.to_string();
                         if err_str.contains("errno 2") || err_str.contains("os error 2") {


### PR DESCRIPTION
scx_cosmos implements specific perf event spec parsing and PMU setup code that could be used by other scx schedulers. Move it into the existing scx_utils::perf crate to prevent code duplication.

The shared code uses scx_utils own perf bindings and perf_event_open(), instead of the external perf-event-open-sys crate, which is dropped from scx_cosmos.

setup_perf_events() takes the PMU map directly (&impl MapCore) rather than a crate-specific BpfSkel, so it can live in the shared crate.