### PR TITLE
cargo: Downgrade sysinfo to 0.38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,17 +2679,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-open-directory"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
-dependencies = [
- "objc2",
- "objc2-core-foundation",
- "objc2-foundation",
-]
-
-[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4477,16 +4466,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.1"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4deba334e1190ba7cb498327affa11e5ece10d26a30ab2f27fcf09504b8d8b6"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "objc2-open-directory",
  "windows",
 ]
 

--- a/scheds/rust/scx_cake/Cargo.toml
+++ b/scheds/rust/scx_cake/Cargo.toml
@@ -20,7 +20,7 @@ arboard = "3"
 
 scx_utils = { path = "../../../rust/scx_utils", version = "1.1.1" }
 scx_arena = { path = "../../../rust/scx_arena/scx_arena", version = "1.1.1" }
-sysinfo = "0.39"
+sysinfo = "0.38"
 core_affinity = "0.8"
 quanta = "0.12"
 crossbeam-utils = "0.8"

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -35,7 +35,7 @@ plain = "0.2"
 walkdir = "2"
 nvml-wrapper = "0.12"
 nix = { version = "0.31", features = ["sched"] }
-sysinfo = "0.39"
+sysinfo = "0.38"
 
 [dev-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.1.1", features = ["testutils"] }

--- a/tools/scxtop/Cargo.toml
+++ b/tools/scxtop/Cargo.toml
@@ -44,7 +44,7 @@ simplelog = "0.12"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 signal-hook = "0.4"
-sysinfo = "0.39"
+sysinfo = "0.38"
 tokio-util = "0.7"
 tokio = { version = "1", features = ["full"] }
 toml = "1"


### PR DESCRIPTION
Ubuntu 24.04 provides rustc up to 1.91, which fails to build sysinfo:

  error: rustc 1.91.1 is not supported by the following package:
    sysinfo@0.39.1 requires rustc 1.95

Downgrade sysinfo dependency to 0.38 to prevent the build failures and properly support Ubuntu 24.04.