### PR TITLE
common.bpf.h: Make scx_bpf_cpu_rq() weak

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -102,7 +102,7 @@ s32 scx_bpf_pick_any_cpu_node(const cpumask_t *cpus_allowed, int node, u64 flags
 s32 scx_bpf_pick_any_cpu(const cpumask_t *cpus_allowed, u64 flags) __ksym;
 bool scx_bpf_task_running(const struct task_struct *p) __ksym;
 s32 scx_bpf_task_cpu(const struct task_struct *p) __ksym;
-struct rq *scx_bpf_cpu_rq(s32 cpu) __ksym;
+struct rq *scx_bpf_cpu_rq(s32 cpu) __ksym __weak;
 struct rq *scx_bpf_locked_rq(void) __ksym;
 struct task_struct *scx_bpf_cpu_curr(s32 cpu) __ksym __weak;
 u64 scx_bpf_now(void) __ksym __weak;


### PR DESCRIPTION
Recent kernels (for-7.3) removed the deprecated scx_bpf_cpu_rq() kfunc. The helper added by the compatibility layer still references it as the fallback for kernels without scx_bpf_cpu_curr().

Because the declaration was a strong ksym extern, libbpf required the symbol to exist even when bpf_ksym_exists(scx_bpf_cpu_curr) would make the fallback dead on new kernels. This made veristat fail before the verifier ran with:

  libbpf: extern (func ksym) 'scx_bpf_cpu_rq': not found

Mark scx_bpf_cpu_rq() weak so kernels that removed it can load the objects and resolve the fallback to NULL, while older kernels that still export the kfunc can continue using the fallback.