### PR TITLE
lib, scx_lavd: fix runnable-task stalls under cpu.max

### DIFF
--- a/lib/atq.bpf.c
+++ b/lib/atq.bpf.c
@@ -205,6 +205,142 @@ u64 scx_atq_pop(scx_atq_t *atq)
 	return taskc_ptr;
 }
 
+/*
+ * Lock two distinct ATQs, lowest address first, to avoid ABBA deadlock with
+ * a concurrent move in the opposite direction. @a and @b must differ;
+ * scx_atq_move_vtime() rejects @src == @dst before calling this. Keeping the
+ * lock count unconditional (always two) also keeps the verifier's
+ * preempt-disable/enable balance provable.
+ */
+static __always_inline
+int scx_atq_lock2(scx_atq_t *a, scx_atq_t *b)
+{
+	scx_atq_t *first, *second;
+	int ret;
+
+	if ((u64)a < (u64)b) {
+		first = a;
+		second = b;
+	} else {
+		first = b;
+		second = a;
+	}
+
+	if ((ret = scx_atq_lock(first)))
+		return ret;
+	if ((ret = scx_atq_lock(second))) {
+		scx_atq_unlock(first);
+		return ret;
+	}
+
+	return 0;
+}
+
+static __always_inline
+void scx_atq_unlock2(scx_atq_t *a, scx_atq_t *b)
+{
+	scx_atq_t *first, *second;
+
+	if ((u64)a < (u64)b) {
+		first = a;
+		second = b;
+	} else {
+		first = b;
+		second = a;
+	}
+
+	scx_atq_unlock(second);
+	scx_atq_unlock(first);
+}
+
+/*
+ * Atomically move the front (min-key) task of @src into @dst, re-keyed by
+ * @vtime. Both ATQ locks are held across the move and the task's ->atq is
+ * updated directly from @src to @dst, so a lockless reader of ->atq never
+ * observes the transient NULL that a separate scx_atq_pop()+insert() would
+ * expose. Locks are taken lowest-address-first (see scx_atq_lock2()).
+ *
+ * On insertion failure the task is left in @src; it is never lost.
+ *
+ * Return the moved task (scx_task_common *) as u64, or (u64)NULL if @src is
+ * empty or the move failed.
+ */
+__hidden
+u64 scx_atq_move_vtime(scx_atq_t *src, scx_atq_t *dst, u64 vtime)
+{
+	scx_task_common *taskc;
+	rbnode_t *node;
+	u64 src_key, taskc_ptr;
+	int ret;
+
+	/*
+	 * Relocation is between distinct ATQs; @src == @dst would self-deadlock
+	 * in scx_atq_lock2(). Reject it before locking.
+	 */
+	if (src == dst)
+		return (u64)NULL;
+
+	ret = scx_atq_lock2(src, dst);
+	if (ret)
+		return (u64)NULL;
+
+	/* Same FIFO/vtime discipline as scx_atq_insert_vtime_unlocked(). */
+	if ((vtime == SCX_ATQ_FIFO) != dst->fifo)
+		goto out_unlock;
+
+	/* Need room in @dst before removing from @src. */
+	if (dst->size == dst->capacity)
+		goto out_unlock;
+
+	if (!scx_atq_nr_queued(src))
+		goto out_unlock;
+
+	ret = rb_pop(src->tree, &src_key, &taskc_ptr);
+	if (ret) {
+		if (ret != -ENOENT)
+			bpf_printk("%s: src error %d", __func__, ret);
+		goto out_unlock;
+	}
+	src->size -= 1;
+
+	taskc = (scx_task_common *)taskc_ptr;
+	node = &taskc->node;
+
+	/* The node still carries value == taskc from @src; only re-key it. */
+	node->key = (vtime == SCX_ATQ_FIFO) ? dst->seq++ : vtime;
+
+	ret = rb_insert_node(dst->tree, node);
+	if (ret) {
+		/*
+		 * Couldn't insert into @dst after popping from @src. Restore
+		 * the task to @src so it is never lost. The capacity check
+		 * above makes this unreachable in practice.
+		 */
+		node->key = src_key;
+		if (!rb_insert_node(src->tree, node))
+			src->size += 1;
+		else
+			bpf_printk("%s: failed to restore task to src", __func__);
+		goto out_unlock;
+	}
+
+	dst->size += 1;
+
+	/*
+	 * Publish the new owner. Both ATQ locks are held, so no concurrent
+	 * pop/cancel/insert can run on @src or @dst; ->atq transitions
+	 * directly from @src to @dst and is never observed as NULL.
+	 */
+	taskc->atq = dst;
+
+	scx_atq_unlock2(src, dst);
+	return taskc_ptr;
+
+out_unlock:
+	scx_atq_unlock2(src, dst);
+	return (u64)NULL;
+}
+
 __hidden
 u64 scx_atq_peek(scx_atq_t *atq)
 {

--- a/lib/atq.bpf.c
+++ b/lib/atq.bpf.c
@@ -341,6 +341,98 @@ out_unlock:
 	return (u64)NULL;
 }
 
+/*
+ * Atomically move a specific @taskc from @src to @dst, re-keyed by @vtime.
+ * Like scx_atq_move_vtime(), both ATQ locks are held across the move and
+ * ->atq transitions directly from @src to @dst, so a lockless reader never
+ * observes the transient NULL that a separate scx_atq_cancel()+insert() would
+ * expose. Unlike scx_atq_move_vtime(), which moves the front (min-key) task,
+ * this moves the given task via rb_remove_node().
+ *
+ * On insertion failure the task is restored to @src so it is never lost.
+ *
+ * Return 0 on success, -EAGAIN if @taskc is no longer queued in @src (a
+ * concurrent pop/cancel won the race), or -errno on other failures.
+ */
+__hidden
+int scx_atq_move_task(scx_atq_t *src, scx_atq_t *dst,
+		      scx_task_common __arg_arena *taskc, u64 vtime)
+{
+	rbnode_t *node = &taskc->node;
+	u64 old_key;
+	int ret;
+
+	/*
+	 * Relocation is between distinct ATQs; @src == @dst would self-deadlock
+	 * in scx_atq_lock2(). Reject it before locking.
+	 */
+	if (src == dst)
+		return -EINVAL;
+
+	ret = scx_atq_lock2(src, dst);
+	if (ret)
+		return ret;
+
+	/* Same FIFO/vtime discipline as scx_atq_insert_vtime_unlocked(). */
+	if ((vtime == SCX_ATQ_FIFO) != dst->fifo) {
+		ret = -EINVAL;
+		goto out_unlock;
+	}
+
+	/* Need room in @dst before removing from @src. */
+	if (dst->size == dst->capacity) {
+		ret = -ENOSPC;
+		goto out_unlock;
+	}
+
+	/*
+	 * The task must still be queued in @src. A concurrent scx_atq_pop() or
+	 * scx_atq_cancel() may have removed it after the caller read ->atq but
+	 * before we took the lock; in that case there is nothing to move.
+	 */
+	if (taskc->atq != src) {
+		ret = -EAGAIN;
+		goto out_unlock;
+	}
+
+	old_key = node->key;
+	ret = rb_remove_node(src->tree, node);
+	if (ret)
+		goto out_unlock;
+	src->size -= 1;
+
+	node->key = (vtime == SCX_ATQ_FIFO) ? dst->seq++ : vtime;
+
+	ret = rb_insert_node(dst->tree, node);
+	if (ret) {
+		/*
+		 * Couldn't insert into @dst after removing from @src. Restore
+		 * the task to @src so it is never lost. The capacity check
+		 * above makes this unreachable in practice.
+		 */
+		node->key = old_key;
+		if (!rb_insert_node(src->tree, node))
+			src->size += 1;
+		else
+			bpf_printk("%s: failed to restore task to src", __func__);
+		goto out_unlock;
+	}
+
+	dst->size += 1;
+
+	/*
+	 * Publish the new owner. Both ATQ locks are held, so no concurrent
+	 * pop/cancel/insert can run on @src or @dst; ->atq transitions
+	 * directly from @src to @dst and is never observed as NULL.
+	 */
+	taskc->atq = dst;
+	ret = 0;
+
+out_unlock:
+	scx_atq_unlock2(src, dst);
+	return ret;
+}
+
 __hidden
 u64 scx_atq_peek(scx_atq_t *atq)
 {

--- a/lib/atq.bpf.c
+++ b/lib/atq.bpf.c
@@ -380,32 +380,54 @@ int scx_atq_cancel(scx_task_common __arg_arena *taskc)
 	int ret;
 
 	/*
-	 * Copy the ATQ pointer over to the stack and use it to avoid
-	 * a racing scx_atq_pop() from overwriting it. Check the
-	 * pointer is valid, as expected by the caller.
+	 * scx_atq_move_vtime() acquires both ATQ locks up front and only drops
+	 * them after publishing the new owner (taskc->atq = dst), so a task's
+	 * ATQ membership changes atomically: ->atq is safe to read locklessly --
+	 * never NULL, never torn. But that does not pin the value across the gap
+	 * between our lockless read and our lock acquisition, so a move can slip
+	 * in between them:
+	 *
+	 *   1. we snapshot atq = taskc->atq, holding no lock yet;
+	 *   2. a move relocates the task out of atq into another ATQ and
+	 *      completes -- it acquired atq's lock before we did;
+	 *   3. we finally acquire atq's lock and observe taskc->atq != atq.
+	 *
+	 * At step 3 we are holding the wrong ATQ's lock and must not touch the
+	 * node, so we re-snapshot ->atq and retry against the ATQ the task now
+	 * lives in. can_loop bounds the retries; in the common, race-free case
+	 * the loop body runs exactly once.
 	 */
-	atq = taskc->atq;
-	if (!atq)
-		return 0;
+	while (can_loop) {
+		/*
+		 * Copy the ATQ pointer over to the stack and use it to avoid
+		 * a racing scx_atq_pop() from overwriting it. Check the
+		 * pointer is valid, as expected by the caller.
+		 */
+		atq = taskc->atq;
+		if (!atq)
+			return 0;
 
-	if ((ret = scx_atq_lock(atq))) {
-		bpf_printk("Failed to lock ATQ for task");
+		if ((ret = scx_atq_lock(atq))) {
+			bpf_printk("Failed to lock ATQ for task");
+			return ret;
+		}
+
+		/* Relocated after our snapshot; retry against the new ATQ. */
+		if (taskc->atq != atq) {
+			scx_atq_unlock(atq);
+			continue;
+		}
+
+		/* Protected from races by the lock. */
+		if ((ret = scx_atq_remove_unlocked(taskc->atq, taskc))) {
+			/* There is an unavoidable race with scx_atq_pop. */
+			bpf_printk("Failed to remove node from task");
+		}
+
+		scx_atq_unlock(atq);
 		return ret;
 	}
 
-	/* We lost the race, assume whoever popped the task will handle it. */
-	if (taskc->atq != atq) {
-		scx_atq_unlock(atq);
-		return 0;
-	}
-
-	/* Protected from races by the lock. */
-	if ((ret = scx_atq_remove_unlocked(taskc->atq, taskc))) {
-		/* There is an unavoidable race with scx_atq_pop. */
-		bpf_printk("Failed to remove node from task");
-	}
-
-	scx_atq_unlock(atq);
-	return ret;
+	return 0;
 }
 

--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -2433,7 +2433,13 @@ int cbw_reenqueue_cgroup(scx_cgroup_ctx_t *cgx, u64 cgrp_id, u64 nuance)
 		idx = (nuance + i) % TOPO_NR(LLC);
 		llcx = cbw_get_llc_ctx_with_id(cgrp_id, idx);
 		if (!llcx) {
-			cbw_err("Failed to lookup an LLC context: cgid%llu", cgrp_id);
+			/*
+			 * After putting the cgroup ID to cbw_throttled_cgroup_ids[],
+			 * the cgroup is exiting, freeing its LLC context
+			 * (cbw_free_llc_ctx). This is expected under cgroup
+			 * churn, not an error; skip it.
+			 */
+			cbw_dbg("LLC context gone (cgroup exiting): cgid%llu", cgrp_id);
 			continue;
 		}
 

--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -893,10 +893,10 @@ static void schedule_atq_destroy(scx_atq_t *btq)
 static __always_inline
 int cbw_free_llc_ctx(scx_cgroup_ctx_t *cgx, u64 cgrp_id)
 {
-	scx_cgroup_llc_ctx_t *llcx;
+	scx_cgroup_llc_ctx_t *llcx, *root_llcx;
 	volatile int nr_moved = 0; /* Add volatile to satisfy the verifier. */
-	int i, ret;
-	scx_atq_t *btq;
+	scx_atq_t *btq, *root_btq;
+	int i;
 	u64 taskc;
 
 	/*
@@ -941,48 +941,32 @@ int cbw_free_llc_ctx(scx_cgroup_ctx_t *cgx, u64 cgrp_id)
 		 */
 
 		/*
-		 * Move all the throttled exiting tasks into the root cgroup.
-		 * Then, delete the LLC context and its associated BTQ.
+		 * Relocate this dying cgroup's throttled tasks into the root
+		 * cgroup's BTQ for the same LLC, then delete the LLC context
+		 * and its BTQ. scx_atq_move_vtime() moves each task under both
+		 * BTQ locks, so its ->atq transitions straight from @btq to
+		 * root's and is never observed as NULL. vtime 0 reaps the
+		 * exiting task at the next replenishment interval.
 		 */
 		if (cgrp_id != ROOT_CGID) {
-			while (can_loop && (taskc = scx_atq_pop(btq))) {
-				scx_task_cgroup_bw_t *t = (scx_task_cgroup_bw_t *)taskc;
-				/*
-				 * Invalidate the per-task cgx/llcx caches before
-				 * moving the task to the root BTQ. The old cgroup
-				 * context will be freed by cbw_del_cgroup_ctx()
-				 * shortly; a stale cgx_raw would cause throttle
-				 * checks to read freed or reallocated memory
-				 * (ABA), potentially throttling the task under
-				 * the wrong cgroup.
-				 *
-				 * No smp_mb() is needed here: cbw_put_aside()
-				 * acquires and releases the BTQ spinlock, whose
-				 * store-release orders these stores before the
-				 * task becomes visible in the BTQ. The drain
-				 * path's lock-acquire provides the matching
-				 * load-acquire.
-				 */
-				WRITE_ONCE(t->cgx_raw, 0);
-				WRITE_ONCE(t->llcx_raw, 0);
-				/*
-				 * Set task's vtime to zero so we can reap the
-				 * the throttled exiting task as soon as possible.
-				 *
-				 * We will try to reenqueue the throttled exiting
-				 * task in the next replenishment interval. This
-				 * is fair since the task was throttled under the
-				 * cgroup, so it has to wait until the next
-				 * replenishment interval anyway.
-				 */
-				ret = cbw_put_aside(taskc, 0, ROOT_CGID);
-				if (likely(!ret)) {
+			root_llcx = cbw_get_llc_ctx_with_id(ROOT_CGID, i);
+			if (root_llcx && (root_btq = READ_ONCE(root_llcx->btq))) {
+				while (can_loop &&
+				       (taskc = scx_atq_move_vtime(btq, root_btq, 0))) {
+					scx_task_cgroup_bw_t *t = (scx_task_cgroup_bw_t *)taskc;
+					/*
+					 * Invalidate the per-task cgx/llcx caches:
+					 * the old cgroup context is about to be freed
+					 * by cbw_del_cgroup_ctx(), and a stale cgx_raw
+					 * would let a later throttle check read freed
+					 * or reallocated memory (ABA).
+					 */
+					WRITE_ONCE(t->cgx_raw, 0);
+					WRITE_ONCE(t->llcx_raw, 0);
 					nr_moved++;
-				} else {
-					cbw_err("Failed to put aside a task "
-						"while exiting cgid%llu: %d",
-						cgrp_id, ret);
 				}
+			} else {
+				cbw_err("Failed to look up root BTQ for LLC %d", i);
 			}
 		}
 

--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -2646,7 +2646,10 @@ int scx_cgroup_bw_move(struct task_struct *p __arg_trusted, u64 taskc,
 		       struct cgroup *to __arg_trusted)
 {
 	volatile scx_task_cgroup_bw_t *tc; /* Add `volatile` to work around the verifier error */
-	int ret;
+	scx_task_common *tcm = (scx_task_common *)taskc;
+	scx_cgroup_llc_ctx_t *to_llcx;
+	scx_atq_t *src_btq, *dst_btq;
+	int llc_id, ret;
 
 	scx_arena_subprog_init();
 	/*
@@ -2665,26 +2668,47 @@ int scx_cgroup_bw_move(struct task_struct *p __arg_trusted, u64 taskc,
 	}
 
 	/*
-	 * If a task is throttled, remove it from the @from cgroup,
-	 * then add it to the BTQ of the @to cgroup.
+	 * If the task is throttled, relocate it from @from's BTQ to @to's BTQ.
 	 *
-	 * We will try to reenqueue it in the next replenishment interval.
-	 * This is fair because the task was throttled under @from cgroup,
-	 * so it has to wait until the next replenishment interval anyway.
+	 * This must be atomic. A cancel-then-put_aside pair would leave
+	 * ->atq == NULL between the two steps; a concurrent task-exit could
+	 * observe that NULL (skipping its own cancel), then free the task
+	 * context while put_aside re-links the node into @to -- leaving a freed
+	 * node in @to's rbtree and corrupting it. scx_atq_move_task() moves the
+	 * task under both BTQ locks, so ->atq is always @from or @to, never NULL.
+	 *
+	 * The task is reenqueued at the next replenishment interval. This is
+	 * fair because it was throttled under @from, so it has to wait anyway.
 	 */
 	if (!scx_cgroup_bw_is_task_throttled(taskc))
 		return 0;
 
-	if ((ret = scx_cgroup_bw_cancel(taskc))) {
-		cbw_err("Fail to cancel a throttled task (%s:%d) from a cgroup (cgid%llu): %d",
-			p->comm, p->pid, cgroup_get_id(from), ret);
-		return ret;
+	/*
+	 * Snapshot the current BTQ. A concurrent pop/cancel may have cleared
+	 * ->atq after the throttle check above; then there is nothing to move.
+	 */
+	src_btq = (scx_atq_t *)READ_ONCE(tcm->atq);
+	if (!src_btq)
+		return 0;
+
+	/* Locate @to's BTQ for the current LLC, as cbw_put_aside() would. */
+	if ((llc_id = cbw_get_current_llc_id()) < 0) {
+		cbw_err("Invalid LLC id: %d", llc_id);
+		return -EINVAL;
+	}
+	to_llcx = cbw_get_llc_ctx_with_id(cgroup_get_id(to), llc_id);
+	if (!to_llcx || !(dst_btq = (scx_atq_t *)READ_ONCE(to_llcx->btq))) {
+		cbw_err("Failed to lookup @to BTQ: cgid%llu llc%d",
+			cgroup_get_id(to), llc_id);
+		return -ESRCH;
 	}
 
-	if ((ret = scx_cgroup_bw_put_aside(p, taskc, p->scx.dsq_vtime, cgroup_get_id(to)))) {
-		cbw_err("Fail to put aside a throttled task (%s:%d) to a cgroup (cgid%llu): %d",
+	ret = scx_atq_move_task(src_btq, dst_btq, tcm, p->scx.dsq_vtime);
+	if (ret == -EAGAIN)
+		return 0;	/* task left @src concurrently; nothing to move */
+	if (ret)
+		cbw_err("Fail to move a throttled task (%s:%d) to a cgroup (cgid%llu): %d",
 			p->comm, p->pid, cgroup_get_id(to), ret);
-	}
 
 	return ret;
 }

--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -193,27 +193,58 @@ void __arena *scx_alloc_from_pool(struct sdt_pool *pool,
 	return ptr;
 }
 
-/* Allocate element from the pool. Must be called with a then pool lock held. */
+/*
+ * Allocate an element from the pool. Takes alloc_lock internally; must be
+ * called WITHOUT it held. Carve under the lock; drop it only for the sleepable
+ * page refill, then re-check before installing, mirroring scx_alloc_stack().
+ */
 static
 void __arena *scx_alloc_from_pool_sleepable(struct sdt_pool *pool)
 {
-	__u64 elem_size, max_elems;
-	void __arena *slab;
+	__u64 elem_size = pool->elem_size;
+	__u64 max_elems = pool->max_elems;
+	__u64 nr_pages;
+	void __arena *slab = NULL;
 	void __arena *ptr;
 
-	elem_size = pool->elem_size;
-	max_elems = pool->max_elems;
+	bpf_spin_lock(&alloc_lock);
 
-	/* If the chunk is spent, get a new one. */
-	if (pool->idx >= max_elems) {
-		slab = bpf_arena_alloc_pages(&arena, NULL,
-			div_round_up(max_elems * elem_size, PAGE_SIZE), NUMA_NO_NODE, 0);
-		pool->slab = slab;
-		pool->idx = 0;
+	/* Fast path: carve the next element from the current slab. */
+	if (pool->idx < max_elems) {
+		ptr = (void __arena *)((__u64)pool->slab + elem_size * pool->idx);
+		pool->idx += 1;
+		bpf_spin_unlock(&alloc_lock);
+		return ptr;
 	}
 
-	ptr = (void __arena *)((__u64) pool->slab + elem_size * pool->idx);
+	/* Slab spent: drop the lock for the sleepable page allocation. */
+	bpf_spin_unlock(&alloc_lock);
+
+	nr_pages = div_round_up(max_elems * elem_size, PAGE_SIZE);
+	slab = bpf_arena_alloc_pages(&arena, NULL, nr_pages, NUMA_NO_NODE, 0);
+	if (!slab)
+		return NULL;
+
+	bpf_spin_lock(&alloc_lock);
+
+	/*
+	 * Re-check: another thread may have installed a fresh slab while we
+	 * slept. If still spent, install ours; otherwise keep the winner's and
+	 * free ours after unlocking.
+	 */
+	if (pool->idx >= max_elems) {
+		pool->slab = slab;
+		pool->idx = 0;
+		slab = NULL;
+	}
+
+	ptr = (void __arena *)((__u64)pool->slab + elem_size * pool->idx);
 	pool->idx += 1;
+
+	bpf_spin_unlock(&alloc_lock);
+
+	if (slab)	/* lost the refill race; release the unused slab */
+		bpf_arena_free_pages(&arena, slab, nr_pages);
 
 	return ptr;
 }

--- a/scheds/include/lib/atq.h
+++ b/scheds/include/lib/atq.h
@@ -57,6 +57,7 @@ int scx_atq_insert_vtime_unlocked(scx_atq_t __arg_arena *atq, scx_task_common __
 int scx_atq_remove_unlocked(scx_atq_t *atq, scx_task_common __arg_arena *taskc);
 int scx_atq_nr_queued(scx_atq_t *atq);
 u64 scx_atq_pop(scx_atq_t *atq);
+u64 scx_atq_move_vtime(scx_atq_t *src, scx_atq_t *dst, u64 vtime);
 u64 scx_atq_peek(scx_atq_t *atq);
 int scx_atq_cancel(scx_task_common *taskc);
 

--- a/scheds/include/lib/atq.h
+++ b/scheds/include/lib/atq.h
@@ -58,6 +58,7 @@ int scx_atq_remove_unlocked(scx_atq_t *atq, scx_task_common __arg_arena *taskc);
 int scx_atq_nr_queued(scx_atq_t *atq);
 u64 scx_atq_pop(scx_atq_t *atq);
 u64 scx_atq_move_vtime(scx_atq_t *src, scx_atq_t *dst, u64 vtime);
+int scx_atq_move_task(scx_atq_t *src, scx_atq_t *dst, scx_task_common *taskc, u64 vtime);
 u64 scx_atq_peek(scx_atq_t *atq);
 int scx_atq_cancel(scx_task_common *taskc);
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -2128,6 +2128,19 @@ s32 BPF_STRUCT_OPS(lavd_exit_task, struct task_struct *p,
 		unaccount_queued_load_pcpu(taskc);
 	}
 
+	/*
+	 * A task's BTQ node lives in the memory scx_task_free() is about to
+	 * release, so it must be unlinked from every BTQ first. lavd_dequeue()
+	 * -> scx_cgroup_bw_cancel() normally does that when the task stops
+	 * running, but a cgroup teardown (cbw_free_llc_ctx) can relocate an
+	 * already-dequeued task into root's BTQ afterward, so it can still be
+	 * queued here. Cancel it before the free; scx_atq_cancel() unlinks it
+	 * wherever teardown moved it.
+	 */
+	if (enable_cpu_bw && taskc &&
+	    scx_cgroup_bw_is_task_throttled((u64)taskc))
+		scx_cgroup_bw_cancel((u64)taskc);
+
 	scx_task_free(p);
 	return 0;
 }


### PR DESCRIPTION
This series fixes runnable-task-stall watchdog timeouts in scx_lavd's
cgroup bandwidth (cpu.max) path, seen under heavy cgroup churn plus a
fork/exit storm. Two independent root causes were found: an allocator
double-allocation (patch 1), which is what stops the reproducer, and a
set of non-atomic backlog-queue relocations (patches 2-7) that corrupt
the queue during cgroup teardown and task migration.

Allocator double-allocation
---------------------------

scx_alloc_internal() reserves a distinct radix-tree index under
alloc_lock, then drops the lock before carving the task's data element
from a shared slab cursor (pool->idx).  ops.init_task is sleepable and
runs concurrently on many CPUs, so under a fork storm two allocations
race on that cursor: both read the same pool->idx and compute the same
element pointer.  The two distinct indices end up bound to one element
-- two tasks share a single task context.  One task's exit then zeroes
the context the other still uses (its ->atq, cgrp_id, and lavd fields
read back zero), orphaning the live task.

The fix carves the element under alloc_lock, dropping the lock only for
the sleepable bpf_arena_alloc_pages() refill and re-checking the cursor
before installing the new slab -- the same lock-drop-allocate-recheck
pattern scx_alloc_stack() already uses for the page stack.

- [1/8] lib/sdt_alloc: carve pool elements under alloc_lock to prevent double allocation

Atomic BTQ relocation
---------------------

A throttled task's backlog-queue (BTQ) membership is the single pointer
taskc->atq, and the BTQ links the rbnode embedded in the task context.
The invariant is that the node must be unlinked from every BTQ before
scx_task_free() zeroes the context it lives in.

Relocating a task with cancel-then-insert briefly leaves ->atq == NULL.
A lockless reader -- a concurrent task exit, or a cgroup teardown
draining the BTQ -- observes that NULL, concludes the task is in no
queue, and skips its unlink; a later free then zeroes a still-linked
node and corrupts the destination rbtree, stranding every task parked
there.

Two move primitives close the window by holding both ATQ locks across
the move, so ->atq transitions directly from source to destination and
is never observed NULL: scx_atq_move_vtime() moves the front task (used
when a dying cgroup's BTQ is drained into root's), and
scx_atq_move_task() moves a specific task (used when a throttled task
migrates between cgroups).  scx_atq_cancel() is made authoritative --
it retries against wherever a concurrent move relocated the task -- and
lavd_exit_task() cancels before freeing, so the node is always unlinked
first.

- [2/8] lib/atq: add scx_atq_move_vtime() to atomically move a task between ATQs
- [3/8] lib/cgroup_bw: move dying-cgroup tasks to the root BTQ atomically
- [4/8] lib/atq: retry scx_atq_cancel() until the task is unlinked
- [5/8] scx_lavd: unlink a throttled task from its BTQ before freeing it
- [6/8] lib/atq: add scx_atq_move_task() to atomically move a specific task between ATQs
- [7/8] lib/cgroup_bw: relocate a migrating throttled task atomically

Benign teardown log
-------------------

The reenqueue path walks a cgroup's per-LLC contexts off a snapshot of
throttled cgroup ids.  A lookup can miss because the cgroup is being
torn down concurrently after its id was recorded -- expected under
churn, not an error.  Downgrade the message from error to debug,
matching the sibling cgroup-context lookup-failure path.

- [8/8] lib/cgroup_bw: downgrade a benign LLC-lookup failure to debug

Signed-off-by: Changwoo Min <changwoo@igalia.com>
