### PR TITLE
scx_mitosis: emit per-cell cgroup path in stats

### DIFF
--- a/scheds/rust/scx_mitosis/src/cell_manager.rs
+++ b/scheds/rust/scx_mitosis/src/cell_manager.rs
@@ -1024,16 +1024,15 @@ impl CellManager {
     }
 
     /// Return the cgroup path for a cell, relative to the cgroup root as it
-    /// appears in `/proc/<pid>/cgroup` (e.g. `/test.slice/foobar`), so
-    /// consumers can map a cell id to its cgroup. Empty for cell 0 (the root
-    /// cell, which has no dedicated cgroup) and for any unknown cell id.
+    /// appears in `/proc/<pid>/cgroup` (e.g. `/test.slice/foobar`), so consumers
+    /// can map a cell id to its cgroup. Cell 0 (the root cell) is `/`.
     pub fn cgroup_path_for_cell(&self, cell_id: u32) -> String {
         self.cell_id_to_cgid
             .get(&cell_id)
             .and_then(|cgid| self.cells.get(cgid))
             .and_then(|info| info.cgroup_path.as_deref())
             .map(cgroup_root_relative)
-            .unwrap_or_default()
+            .unwrap_or_else(|| "/".to_string())
     }
 
     /// Re-read cpuset.cpus for all cells and update stored cpusets.
@@ -1129,9 +1128,8 @@ mod tests {
         )
         .unwrap();
 
-        // Cell 0 (root cell) and unknown ids have no dedicated cgroup -> empty.
-        assert_eq!(mgr.cgroup_path_for_cell(0), "");
-        assert_eq!(mgr.cgroup_path_for_cell(999), "");
+        // Cell 0 is the root cell -> "/".
+        assert_eq!(mgr.cgroup_path_for_cell(0), "/");
 
         // A created cell maps to its cgroup. The TempDir is not under the cgroup
         // mount, so the path is returned as-is (the strip falls back to the

--- a/scheds/rust/scx_mitosis/src/cell_manager.rs
+++ b/scheds/rust/scx_mitosis/src/cell_manager.rs
@@ -20,6 +20,14 @@ use inotify::{Inotify, WatchMask};
 use scx_utils::Cpumask;
 use tracing::{debug, info};
 
+/// Strip the cgroup mount prefix from a stored cell path, yielding the
+/// root-relative cgroup path (e.g. `/sys/fs/cgroup/a/b` -> `/a/b`).
+fn cgroup_root_relative(path: &Path) -> String {
+    path.strip_prefix("/sys/fs/cgroup")
+        .map(|rel| format!("/{}", rel.to_string_lossy()))
+        .unwrap_or_else(|_| path.to_string_lossy().into_owned())
+}
+
 /// Information about a cell created for a cgroup
 #[derive(Debug)]
 pub struct CellInfo {
@@ -1015,6 +1023,19 @@ impl CellManager {
         parts.join(" ")
     }
 
+    /// Return the cgroup path for a cell, relative to the cgroup root as it
+    /// appears in `/proc/<pid>/cgroup` (e.g. `/test.slice/foobar`), so
+    /// consumers can map a cell id to its cgroup. Empty for cell 0 (the root
+    /// cell, which has no dedicated cgroup) and for any unknown cell id.
+    pub fn cgroup_path_for_cell(&self, cell_id: u32) -> String {
+        self.cell_id_to_cgid
+            .get(&cell_id)
+            .and_then(|cgid| self.cells.get(cgid))
+            .and_then(|info| info.cgroup_path.as_deref())
+            .map(cgroup_root_relative)
+            .unwrap_or_default()
+    }
+
     /// Re-read cpuset.cpus for all cells and update stored cpusets.
     /// Returns true if any cell's cpuset changed.
     pub fn refresh_cpusets(&mut self) -> Result<bool> {
@@ -1091,6 +1112,41 @@ mod tests {
             mask.set_cpu(cpu).unwrap();
         }
         mask
+    }
+
+    // ==================== cgroup path mapping tests ====================
+
+    #[test]
+    fn test_cgroup_path_for_cell() {
+        let tmp = TempDir::new().unwrap();
+        let child = tmp.path().join("container-a");
+        std::fs::create_dir(&child).unwrap();
+        let mgr = CellManager::new_with_path(
+            tmp.path().to_path_buf(),
+            256,
+            cpumask_for_range(16),
+            HashSet::new(),
+        )
+        .unwrap();
+
+        // Cell 0 (root cell) and unknown ids have no dedicated cgroup -> empty.
+        assert_eq!(mgr.cgroup_path_for_cell(0), "");
+        assert_eq!(mgr.cgroup_path_for_cell(999), "");
+
+        // A created cell maps to its cgroup. The TempDir is not under the cgroup
+        // mount, so the path is returned as-is (the strip falls back to the
+        // absolute path); the mount-strip itself is covered below.
+        let cell_id = mgr.find_cell_by_name("container-a").unwrap().cell_id;
+        assert_eq!(
+            mgr.cgroup_path_for_cell(cell_id),
+            child.to_string_lossy().into_owned()
+        );
+
+        // A real (mount-absolute) cgroup path is reported relative to the root.
+        assert_eq!(
+            cgroup_root_relative(Path::new("/sys/fs/cgroup/test.slice/foobar")),
+            "/test.slice/foobar"
+        );
     }
 
     // ==================== Cell scanning and creation tests ====================

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -1173,6 +1173,12 @@ impl<'a> Scheduler<'a> {
         }
         self.metrics.num_cells = self.cells.len() as u32;
 
+        // Stamp every cell's cgroup path here in one pass: metrics.cells entries
+        // are created at several sites, and this re-derives on cell-id reuse.
+        for (cell_id, cell_metrics) in self.metrics.cells.iter_mut() {
+            cell_metrics.cgroup_path = self.cell_manager.cgroup_path_for_cell(*cell_id);
+        }
+
         Ok(())
     }
 

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -1169,15 +1169,12 @@ impl<'a> Scheduler<'a> {
             self.metrics
                 .cells
                 .entry(*cell_id)
-                .and_modify(|cell_metrics| cell_metrics.num_cpus = cell.cpus.weight() as u32);
+                .and_modify(|cell_metrics| {
+                    cell_metrics.num_cpus = cell.cpus.weight() as u32;
+                    cell_metrics.cgroup_path = self.cell_manager.cgroup_path_for_cell(*cell_id);
+                });
         }
         self.metrics.num_cells = self.cells.len() as u32;
-
-        // Stamp every cell's cgroup path here in one pass: metrics.cells entries
-        // are created at several sites, and this re-derives on cell-id reuse.
-        for (cell_id, cell_metrics) in self.metrics.cells.iter_mut() {
-            cell_metrics.cgroup_path = self.cell_manager.cgroup_path_for_cell(*cell_id);
-        }
 
         Ok(())
     }

--- a/scheds/rust/scx_mitosis/src/stats.rs
+++ b/scheds/rust/scx_mitosis/src/stats.rs
@@ -22,6 +22,11 @@ use crate::DistributionStats;
 pub struct CellMetrics {
     #[stat(desc = "Number of cpus")]
     pub num_cpus: u32,
+    #[stat(
+        desc = "Cgroup path of this cell, relative to the cgroup root (empty for the root cell)",
+        _om_skip
+    )]
+    pub cgroup_path: String,
     #[stat(desc = "Local queue %")]
     pub local_q_pct: f64,
     #[stat(desc = "CPU queue %")]
@@ -126,7 +131,7 @@ pub struct Metrics {
         desc = "1 if the cell-0 holdout has taken a CPU already claimed by a workload cell, else 0"
     )]
     pub enforced_holdout: u64,
-    #[stat(desc = "Per-cell metrics")] // TODO: cell names
+    #[stat(desc = "Per-cell metrics")]
     pub cells: BTreeMap<u32, CellMetrics>,
 }
 

--- a/scheds/rust/scx_mitosis/src/stats.rs
+++ b/scheds/rust/scx_mitosis/src/stats.rs
@@ -23,7 +23,7 @@ pub struct CellMetrics {
     #[stat(desc = "Number of cpus")]
     pub num_cpus: u32,
     #[stat(
-        desc = "Cgroup path of this cell, relative to the cgroup root (empty for the root cell)",
+        desc = "Cgroup path of this cell, relative to the cgroup root (\"/\" for the root cell)",
         _om_skip
     )]
     pub cgroup_path: String,


### PR DESCRIPTION
Per-cell stats were keyed only by numeric cell id, with no way to map a cell back to its cgroup. 

Add each cell's root-relative cgroup path to CellMetrics for association + add tests.

This adds `"cgroup_path": "/mitosis/web",` to the out below (from `sudo ./target/release/scx_mitosis --cell-parent-cgroup /mitosis --monitor 1` + manually adding a couple cg's):
```
{
  "num_cells": 3,
  "local_q_pct": 85.353585558361,
  "cpu_q_pct": 13.350166007276489,
  "cell_q_pct": 1.2962484343625122,
  "borrowed_pct": 0.0,
  "affn_violations_pct": 0.0,
  "steal_pct": 0.0,
  "drain_cnt": 0,
  "pin_skip_pct": 0.0,
  "slice_shrink": 0,
  "slice_shrink_max": 0,
  "slice_shrink_proportional": 0,
  "slice_shrink_min": 0,
  "share_of_decisions_pct": 100.0,
  "total_decisions": 50299,
  "util_pct": 6.76187939556962,
  "demand_borrow_pct": 0.004564844856589845,
  "lent_pct": 0.0003086693037974684,
  "rebalance_count": 0,
  "enforced_holdout": 0,
  "cells": {
    "0": {
      "num_cpus": 300,
      "cgroup_path": "",
      "local_q_pct": 86.47451004088867,
      "cpu_q_pct": 13.525489959111326,
      "cell_q_pct": 0.0,
      "borrowed_pct": 0.0,
      "affn_violations_pct": 0.0,
      "steal_pct": 0.0,
      "drain_cnt": 0,
      "pin_skip_pct": 0.0,
      "slice_shrink": 0,
      "slice_shrink_max": 0,
      "slice_shrink_proportional": 0,
      "slice_shrink_min": 0,
      "share_of_decisions_pct": 98.70375156563748,
      "total_decisions": 49647,
      "util_pct": 1.6133061923333334,
      "demand_borrow_pct": 0.020153128290943147,
      "lent_pct": 0.0,
      "smoothed_util_pct": 0.0
    },
    "1": {
      "num_cpus": 8,
      "cgroup_path": "/mitosis/web",
      "local_q_pct": 0.0,
      "cpu_q_pct": 0.0,
      "cell_q_pct": 100.0,
      "borrowed_pct": 0.0,
      "affn_violations_pct": 0.0,
      "steal_pct": 0.0,
      "drain_cnt": 0,
      "pin_skip_pct": 0.0,
      "slice_shrink": 0,
      "slice_shrink_max": 0,
      "slice_shrink_proportional": 0,
      "slice_shrink_min": 0,
      "share_of_decisions_pct": 0.646136106085608,
      "total_decisions": 325,
      "util_pct": 102.93410355,
      "demand_borrow_pct": 0.0,
      "lent_pct": 0.006649425,
      "smoothed_util_pct": 0.0
    },
    "2": {
      "num_cpus": 8,
      "cgroup_path": "/mitosis/db",
      "local_q_pct": 0.0,
      "cpu_q_pct": 0.0,
      "cell_q_pct": 100.0,
      "borrowed_pct": 0.0,
      "affn_violations_pct": 0.0,
      "steal_pct": 0.0,
      "drain_cnt": 0,
      "pin_skip_pct": 0.0,
      "slice_shrink": 0,
      "slice_shrink_max": 0,
      "slice_shrink_proportional": 0,
      "slice_shrink_min": 0,
      "share_of_decisions_pct": 0.6501123282769041,
      "total_decisions": 327,
      "util_pct": 103.6611503625,
      "demand_borrow_pct": 0.0,
      "lent_pct": 0.0055430125,
      "smoothed_util_pct": 0.0
    }
  }
}
```