### PR TITLE
scx_pandemoniumv5.16.0:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6358,7 +6358,7 @@ dependencies = [
 
 [[package]]
 name = "scx_pandemonium"
-version = "5.15.0"
+version = "5.16.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6358,7 +6358,7 @@ dependencies = [
 
 [[package]]
 name = "scx_pandemonium"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/scheds/rust/scx_pandemonium/Cargo.toml
+++ b/scheds/rust/scx_pandemonium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_pandemonium"
-version = "5.15.0"
+version = "5.16.0"
 edition = "2021"
 description = "A behavioral, adaptive sched_ext scheduler with three-tier classification, L2 affinity, and process learning"
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_pandemonium/Cargo.toml
+++ b/scheds/rust/scx_pandemonium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scx_pandemonium"
-version = "5.14.0"
+version = "5.15.0"
 edition = "2021"
 description = "A behavioral, adaptive sched_ext scheduler with three-tier classification, L2 affinity, and process learning"
 license = "GPL-2.0-only"

--- a/scheds/rust/scx_pandemonium/README.md
+++ b/scheds/rust/scx_pandemonium/README.md
@@ -1,8 +1,8 @@
 # PANDEMONIUM
 
-A Linux kernel scheduler for sched_ext, built in Rust and C23. PANDEMONIUM classifies every task by behavior — wakeup frequency, context switch rate, runtime, sleep patterns — and adapts scheduling decisions in real time. A damped harmonic oscillator drives CoDel-inspired stall detection with the literal RFC 8289 sojourn metric and an R_eff-derived equilibrium reference. Resistance affinity (effective resistance from the Laplacian pseudoinverse of the CPU topology graph) provides topology-aware task placement for pipe/IPC storms. A migration potential Φ — R_eff priced against the queueing relief a move buys — gates cross-domain work stealing, so a steal crosses a cache boundary only when the backlog it relieves outweighs the cache cost. Multiplicative Weight Updates (MWU) balance six competing expert profiles across six loss pathways — one of them a cross-domain scatter signal that holds the adaptive layer's knob choices in line with the Φ placement it sits above.
+A Linux kernel scheduler for sched_ext, built in Rust and C23. PANDEMONIUM assigns every task a latency tier by scheduling role and adapts scheduling decisions in real time. A damped harmonic oscillator drives CoDel-inspired stall detection with the literal RFC 8289 sojourn metric and an R_eff-derived equilibrium reference. Resistance affinity (effective resistance from the Laplacian pseudoinverse of the CPU topology graph) provides topology-aware task placement for pipe/IPC storms. A migration potential Φ — R_eff priced against the queueing relief a move buys — prices both cross-domain work stealing and enqueue-time placement spill, so a task crosses a cache boundary only when the backlog it relieves outweighs the cache cost. The steal applies Φ as a delay on the backlog age; the spill as a per-peer depth threshold Rust folds from R_eff at topology detect and the kernel reads with one indexed lookup — the computation in the adaptive layer, the application in the kernel. Multiplicative Weight Updates (MWU) balance six competing expert profiles across six loss pathways — one of them a cross-domain scatter signal that holds the adaptive layer's knob choices in line with the Φ placement it sits above.
 
-Three-tier behavioral dispatch, overflow sojourn rescue, longrun detection, tier-aware preempt scaling, sleep-informed batch tuning, classification-gated DSQ routing, workload regime detection, flow-signature shape routing (per-task partner-cardinality classification into TIGHT loops vs STORM meshes), a migration-potential-gated R_eff work steal, a Φ-priced warm-stay home anchor, a sojourn selector with bounded maturity-gated tier warp, a per-CPU tau-derived preempt, an RT-policy latency floor, hard starvation rescue and a persistent process database that learns task classifications across lifetimes.
+Three-tier role-based dispatch, overflow sojourn rescue, longrun detection, sleep-informed batch tuning, tier-gated DSQ routing, workload regime detection, a migration-potential-gated R_eff work steal, a Φ-priced placement spill, a Φ-priced warm-stay home anchor, a sojourn selector with a bounded flat per-tier warp, an off-tick unified sojourn bound, an RT-policy latency floor, hard starvation rescue and a persistent process database that learns task classifications across lifetimes.
 
 See the [New User Guide](NEW-USER-GUIDE.md) for an introduction — the ideas behind PANDEMONIUM in plain language.
 
@@ -10,124 +10,124 @@ PANDEMONIUM is included in the [sched-ext/scx](https://github.com/sched-ext/scx)
 
 ## Performance
 
-12 AMD Zen CPUs (Ryzen 5 3600), kernel 7.0.13-arch1-1, clang 21. v5.15.0 numbers are from a prism-scale run (2026-06-27, 3 iterations): EEVDF baseline vs PANDEMONIUM (BPF and ADAPTIVE). External schedulers are omitted from this comparison.
+12 AMD Zen CPUs (Ryzen 5 3600), kernel 7.0.14-arch1-1, clang 21. v5.16.0 numbers are from prism-scale, prism-power and prism-fork-thread runs (2026-06-30, 3 iterations): EEVDF baseline vs PANDEMONIUM (BPF and ADAPTIVE). External schedulers are omitted from this comparison.
 
 ### P99 Wakeup Latency (interactive probe under CPU saturation)
 
 | Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
 |-------|---------|-------------------|------------------------|
-| 2     | 3,009us | **105us**         | 136us                  |
-| 4     | 1,996us | 1,059us           | **77us**               |
-| 8     | 728us   | **66us**          | 67us                   |
-| 12    | 313us   | **68us**          | **68us**               |
+| 2     | 3,856us | **1,050us**       | 1,303us                |
+| 4     | 3,606us | **98us**          | 278us                  |
+| 8     | 193us   | 108us             | **79us**               |
+| 12    | 388us   | **72us**          | 76us                   |
 
 ### Burst P99 (fork/exec storm under CPU saturation)
 
 | Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
 |-------|---------|-------------------|------------------------|
-| 2     | 2,731us | **175us**         | 204us                  |
-| 4     | 2,080us | 70us              | **68us**               |
-| 8     | 2,067us | 76us              | **74us**               |
-| 12    | 2,226us | 80us              | **77us**               |
+| 2     | 3,868us | **1,251us**       | 2,373us                |
+| 4     | 2,921us | 1,043us           | **261us**              |
+| 8     | 2,066us | **76us**          | 96us                   |
+| 12    | 2,867us | **78us**          | **78us**               |
 
 ### Longrun P99 (interactive latency with sustained CPU-bound long-runners)
 
 | Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
 |-------|---------|-------------------|------------------------|
-| 2     | 2,967us | **905us**         | 998us                  |
-| 4     | 871us   | **152us**         | 946us                  |
-| 8     | 71us    | **68us**          | 633us                  |
-| 12    | **92us**| 347us             | 634us                  |
+| 2     | 4,091us | **1,955us**       | 3,548us                |
+| 4     | 2,986us | **1,534us**       | 4,932us                |
+| 8     | **60us**| 1,990us           | 3,212us                |
+| 12    | **1,689us** | 1,737us       | 2,188us                |
 
 ### Mixed Latency P99 (interactive + batch concurrent)
 
 | Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
 |-------|---------|-------------------|------------------------|
-| 2     | 2,486us | **989us**         | 1,832us                |
-| 4     | 2,987us | **197us**         | 1,461us                |
-| 8     | 1,965us | 1,038us           | **722us**              |
-| 12    | 875us   | **75us**          | 919us                  |
+| 2     | 3,741us | **1,607us**       | 3,747us                |
+| 4     | 2,986us | **1,861us**       | 4,270us                |
+| 8     | 2,065us | **1,928us**       | 3,378us                |
+| 12    | 7,255us | **1,196us**       | 2,678us                |
 
 ### Deadline Miss Ratio (16.6ms frame target)
 
 | Cores | EEVDF | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
 |-------|-------|-------------------|------------------------|
-| 2     | 13.7% | **0.3%**          | **0.3%**               |
-| 4     | 10.3% | 0.3%              | **0.2%**               |
-| 8     | 9.6%  | **0.1%**          | 0.3%                   |
-| 12    | 11.3% | 0.3%              | **0.2%**               |
+| 2     | 14.0% | **1.6%**          | 2.5%                   |
+| 4     | 10.2% | **0.5%**          | 1.1%                   |
+| 8     | 10.8% | **0.4%**          | 0.6%                   |
+| 12    | 11.8% | **0.2%**          | **0.2%**               |
 
 ### Burst Recovery P99 (latency after storm subsides)
 
 | Cores | PANDEMONIUM (BPF) (prism-scale burst-recovery phase) |
 |-------|------------------------------------------------------|
-| 2     | base 96us / burst 175us / recovery 62us             |
-| 4     | base 63us / burst 70us / recovery 65us              |
-| 8     | base 65us / burst 76us / recovery 67us              |
-| 12    | base 67us / burst 80us / recovery 69us              |
+| 2     | base 604us / burst 1,251us / recovery 1,910us       |
+| 4     | base 76us / burst 1,043us / recovery 123us          |
+| 8     | base 515us / burst 76us / recovery 69us             |
+| 12    | base 69us / burst 78us / recovery 118us             |
 
 ### App Launch (`fork()`+`exec()` under load, mean / p99 us)
 
 | Cores | EEVDF         | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
 |-------|---------------|-------------------|------------------------|
-| 2     | 1,617 / 2,342 | **1,098** / 2,909 | 1,421 / 3,721          |
-| 4     | 2,189 / 3,664 | 782 / 2,304       | **770** / 2,601        |
-| 8     | 1,298 / 3,075 | **698** / 1,893   | 1,046 / 16,477         |
-| 12    | 1,258 / 2,992 | 2,955 / 16,536    | **602** / 1,850        |
+| 2     | 1,577 / 7,130 | **1,459** / 5,658 | 2,113 / 11,254         |
+| 4     | 1,938 / 5,708 | **811** / 2,395   | 1,729 / 13,551         |
+| 8     | 1,688 / 3,360 | **731** / 2,094   | 747 / 2,332            |
+| 12    | 1,722 / 5,592 | 628 / 1,851       | **592** / 1,647        |
 
-The *typical* app launch under the better PANDEMONIUM arm beats EEVDF at every width — mean 0.6–1.1ms vs EEVDF's 1.3–2.2ms. The p99 carries occasional cold-launch outliers from the fork/exec dispatch waterfall (BPF 12C and ADAPTIVE 8C each show one ~16ms launch in 100; BPF 12C also runs a high mean there). Reported as mean / p99 so the typical-case win isn't masked by the tail. IPC is PANDEMONIUM's weak workload — broken out by primitive below.
+The *typical* app launch under the better PANDEMONIUM arm beats EEVDF at every width — mean 0.6–1.5ms vs EEVDF's 1.6–1.9ms. The p99 carries occasional cold-launch outliers from the fork/exec dispatch waterfall (ADAPTIVE shows ~11–14ms launches at 2C/4C). Reported as mean / p99 so the typical-case win isn't masked by the tail. IPC is PANDEMONIUM's weak workload — broken out by primitive below.
 
 ### IPC Round-Trip by Primitive (12C, p50 / p99 us)
 
 | Primitive | EEVDF      | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
 |-----------|------------|-------------------|------------------------|
-| pipe      | 12 / 15    | 11 / 1,370        | 11 / 1,369             |
-| socket    | 17 / 24    | 14 / 1,371        | 14 / 1,371             |
-| eventfd   | 9 / 15     | 27 / 1,333        | 27 / 1,398             |
-| sem       | 10 / 13    | 27 / 1,393        | 28 / 1,402             |
-| fanout    | 68 / 3,423 | 1,999 / 2,987     | 1,999 / 2,989          |
+| pipe      | 9 / 14     | 11 / 1,409        | 11 / 2,396             |
+| socket    | 15 / 25    | 13 / 1,433        | 13 / 2,423             |
+| eventfd   | 11 / 16    | 27 / 1,616        | 27 / 1,024             |
+| sem       | 8 / 15     | 27 / 1,672        | 27 / 1,037             |
+| fanout    | 50 / 3,373 | 12,462 / 15,999   | 12,221 / 15,013        |
 
-IPC is PANDEMONIUM's weakest workload and EEVDF leads it decisively. The *median* round-trip is microsecond-tight on pipe and socket (p50 11–14us, on par with EEVDF), but every primitive's p99 sits at ~1.3–1.4ms under busy-waker co-location versus EEVDF's ~15–24us, and the 1:N fanout runs ~2ms at the median. montauk names the cause: under IPC saturation a CPU-bound hog holds the core for multiple seconds while the round-trip partner spills cross-domain and never preempts it (51k floored wakes, 100% held, worst single hold ~7.8s, against EEVDF's ~240ms). Closing this saturation strand is the standing v5.16.0 IPC item.
+IPC is PANDEMONIUM's weakest workload and EEVDF leads it decisively. The *median* round-trip stays microsecond-tight on pipe and socket (p50 11–13us, on par with EEVDF), but p99 sits at ~1.4–2.4ms under busy-waker co-location versus EEVDF's ~14–25us, and the 1:N fanout regressed this release to ~12–16ms. Under sustained saturation the round-trip wake2run tick-floors to ~13ms p99 against EEVDF's ~40us — montauk names the cause: a CPU-bound hog holds the core while the round-trip partner spills cross-domain and is not preempted. Restoring IPC is the top post-v5.16.0 item.
 
-### Fork/Thread IPC (`perf bench sched messaging -t -g 24 -l 6000`, 12C, v5.15.0)
+### Fork/Thread IPC (`perf bench sched messaging -t -g 24 -l 6000`, 12C, v5.16.0)
 
 | Scheduler                | Time        | vs EEVDF | Cache Misses | Cache Refs | IPC       |
 |--------------------------|-------------|----------|--------------|------------|-----------|
-| EEVDF                    | **15.398s** | baseline | **3.48G**    | 24.35G     | **0.477** |
-| PANDEMONIUM (BPF)        | 15.735s     | +2.2%    | 3.88G        | 22.60G     | 0.456     |
-| PANDEMONIUM (ADAPTIVE)   | 15.799s     | +2.6%    | 3.88G        | 22.62G     | 0.456     |
+| EEVDF                    | **16.158s** | baseline | **3.66G**    | 26.58G     | **0.474** |
+| PANDEMONIUM (BPF)        | 16.678s     | +3.2%    | 4.14G        | 26.27G     | 0.449     |
+| PANDEMONIUM (ADAPTIVE)   | 16.721s     | +3.5%    | 4.19G        | 26.50G     | 0.448     |
 
-The fork/exec storm is PANDEMONIUM's hardest case for cache locality: ~11% more cache-misses (17.2% vs EEVDF's 14.3% miss rate) and ~5× the cpu-migrations (895K vs 170K, 43% cross-domain vs EEVDF's 0.7%) — the cost of the aggressive rebalancing that buys the latency, burst and deadline wins above. Wall time trails EEVDF only slightly (+2.2 / +2.6%) and IPC is near parity (0.456 vs 0.477); PANDEMONIUM even edges EEVDF on wake2run p99 here (53ms vs 60ms). Cutting the cross-domain migration rate without giving back the tail is standing v5.16.0 work.
+The fork/exec storm is PANDEMONIUM's hardest case for cache locality: ~2pp more cache-misses (15.8% vs EEVDF's 13.8% miss rate) and ~7× the cpu-migrations (1.38M vs 192K, 44% cross-domain vs EEVDF's 0.9%) — the cost of the aggressive rebalancing that buys the latency, burst and deadline wins above. Wall time trails EEVDF only slightly (+3.2 / +3.5%) and IPC is near parity (0.449 vs 0.474); the rebalancing buys a 2.5× better wake2run p99 here (23ms vs EEVDF's 69ms). Cutting the cross-domain migration rate without giving back the tail is standing post-v5.16.0 work.
 
-### Energy Efficiency (`prism-power`, 12C, v5.15.0)
+### Energy Efficiency (`prism-power`, 12C, v5.16.0)
 
-5 runs per (scheduler, workload), 30s cooldown between runs (2026-06-27). Package energy via `perf stat -a -e power/energy-pkg/`. Zen 2 (Ryzen 5 3600) exposes only `J_pkg` (no per-core or per-DRAM RAPL).
+5 runs per (scheduler, workload), 30s cooldown between runs (2026-06-30). Package energy via `perf stat -a -e power/energy-pkg/`. Zen 2 (Ryzen 5 3600) exposes only `J_pkg` (no per-core or per-DRAM RAPL). This run was on a working desktop under active application load, which lifts the absolute wattage of both schedulers and inflates the idle floor below.
 
 **Idle floor** (30s `sleep`, scheduler restlessness):
 
-| Scheduler                | J_pkg       | Avg W      | vs EEVDF   |
-|--------------------------|-------------|------------|------------|
-| PANDEMONIUM (ADAPTIVE)   | **510.24J** | **16.99W** | **-13.1%** |
-| PANDEMONIUM (BPF)        | 511.59J     | 17.04W     | -12.9%     |
-| EEVDF                    | 587.03J     | 19.55W     | baseline   |
+| Scheduler                | J_pkg   | Avg W    | vs EEVDF |
+|--------------------------|---------|----------|----------|
+| EEVDF                    | 679.44J | 22.63W   | baseline |
+| PANDEMONIUM (BPF)        | 710.75J | 23.67W   | +4.6%    |
+| PANDEMONIUM (ADAPTIVE)   | 711.71J | 23.70W   | +4.7%    |
 
-PANDEMONIUM now idles well below EEVDF (−12.9 / −13.1% package power, 17.0W vs 19.6W) — the scheduler is markedly quiet at rest.
+Measured under active desktop load on this run (note the elevated baseline wattage), PANDEMONIUM idles slightly above EEVDF (+4.6 / +4.7%); the idle floor is sensitive to background work, so a quiet-box run is the honest measure of scheduler restlessness at rest.
 
 **Messaging** (`perf bench sched messaging`, fork-storm + IPC):
 
 | Scheduler                | Wall_s  | J_pkg       | J/op         | vs EEVDF  |
 |--------------------------|---------|-------------|--------------|-----------|
-| EEVDF                    | 14.81s  | 902.49J     | 156.68uJ     | baseline  |
-| PANDEMONIUM (BPF)        | 15.08s  | 896.38J     | 155.62uJ     | -0.7%     |
-| PANDEMONIUM (ADAPTIVE)   | 15.12s  | **895.50J** | **155.47uJ** | **-0.8%** |
+| EEVDF                    | 15.53s  | 962.77J     | 167.15uJ     | baseline  |
+| PANDEMONIUM (BPF)        | 15.70s  | **955.77J** | **165.93uJ** | **-0.7%** |
+| PANDEMONIUM (ADAPTIVE)   | 15.74s  | 958.37J     | 166.38uJ     | -0.5%     |
 
-On the fork-storm messaging mix PANDEMONIUM matches EEVDF on energy (−0.7 / −0.8% J/op) at a small wall-time cost (+1.8 / +2.1%) — the package-energy delta the cross-domain rebalancing once carried is now within noise.
+On the fork-storm messaging mix PANDEMONIUM matches EEVDF on energy (−0.5 / −0.7% J/op) at a small wall-time cost (+1.1 / +1.3%) — the package-energy delta the cross-domain rebalancing once carried is within noise.
 
 ## Key Features
 
 ### Dispatch Waterfall
 
-Layered dispatch with per-CPU DSQ dominance and one age-driven safety mechanism. CPU-tied placement (Tier 2 wakeup preemption, `select_cpu`) is bounded at the enqueue site by `pcpu_depth_base` and overflow spills to a sibling per-CPU DSQ in R_eff order (`find_pcpu_with_room` → `pick_pcpu_dsq_with_spill`), so the dispatch waterfall reaches every CPU-tied enqueue at STEP 0 (sibling owns) or STEP 1 (near R_eff steal). Idle-CPU placement (Tier 1) inserts directly into the per-domain overflow DSQ and is picked up by STEP 3 within one dispatch cycle — eager R_eff search at this site is a wire-speed regression on fork-storm workloads with no measurable placement benefit. The steal is **one Φ-priced walk**: STEP 1 walks `affinity_rank` (the per-CPU R_eff-ascending list, cross-domain peers included) with no near/far tier boundary — Φ (the `reff_value` penalty) alone prices the move, so nearer relief is always preferred without a structural same/different-domain gate (the CCX/CCD-removal end state, THE FLAG). The waterfall is 7 steps (0, 1, 2, 3, 4, 5, KEEP_RUNNING) + 1 safety net; redundant rescue paths (deficit-gate-with-exception, DRR deficit counter, batch sojourn rescue) are deliberately absent — they all reduce to "service the older overflow side past a threshold," which STEP 2 already does. `sojourn_gate_pass` sits at STEP 0 / STEP 1, load-bearing for workqueue-worker fairness under sustained per-CPU load (without it, `scx_watchdog_workfn` strands in the overflow DSQ long enough to trigger 30s watchdog kills).
+Layered dispatch with per-CPU DSQ dominance and one age-driven safety mechanism. CPU-tied placement (Tier 2 wakeup preemption, `select_cpu`) is bounded at the enqueue site by `pcpu_depth_base` and overflow spills to a sibling per-CPU DSQ in R_eff order (`find_pcpu_with_room` → `pick_pcpu_dsq_with_spill`), each candidate gated by a per-peer `spill_depth` threshold Rust folds from R_eff at topology detect — near peers accept at higher depth, distant peers only when near-empty; flat on a monolithic L3, so the dispatch waterfall reaches every CPU-tied enqueue at STEP 0 (sibling owns) or STEP 1 (near R_eff steal). Idle-CPU placement (Tier 1) inserts directly into the per-domain overflow DSQ and is picked up by STEP 3 within one dispatch cycle — eager R_eff search at this site is a wire-speed regression on fork-storm workloads with no measurable placement benefit. The steal is **one Φ-priced walk**: STEP 1 walks `affinity_rank` (the per-CPU R_eff-ascending list, cross-domain peers included) with no near/far tier boundary — Φ (the `reff_value` penalty) alone prices the move, so nearer relief is always preferred without a structural same/different-domain gate (the CCX/CCD-removal end state, THE FLAG). The waterfall is 7 steps (0, 1, 2, 3, 4, 5, KEEP_RUNNING) + 1 safety net; redundant rescue paths (deficit-gate-with-exception, DRR deficit counter, batch sojourn rescue) are deliberately absent — they all reduce to "service the older overflow side past a threshold," which STEP 2 already does. `sojourn_gate_pass` sits at STEP 0 / STEP 1, load-bearing for workqueue-worker fairness under sustained per-CPU load (without it, `scx_watchdog_workfn` strands in the overflow DSQ long enough to trigger 30s watchdog kills).
 
 0. **Own per-CPU DSQ** — cache-hot, zero contention. Sojourn-gated return: if either overflow side has aged past `codel_target_ns`, fall through to STEP 2 so this dispatch serves overflow too.
 1. **R_eff steal** — single loop over `affinity_rank`, the per-CPU R_eff-ascending peer list (slot 0 = nearest sibling, cross-domain peers included, no tier boundary). Budget is tau-derived: `pcpu_spill_search_budget ≈ λ₂/2`, clamped to `[6, MAX_AFFINITY_CANDIDATES]`. The companion WAKE_SYNC idle-search budget `affinity_search_online ≈ λ₂/4` clamps the same way (smaller divisor because the predicate is more expensive). A peer is relieved only with `nr_queued > 1` and its head aged past the Φ threshold `codel_target_ns + dist_extra`, where `dist_extra = b·R_eff` is pre-folded in ns into the `reff_value` map (one indexed read, no multiply), so an SMT sibling (R_eff≈0) stays freely relievable while a cross-domain pull must show ~τ of backlog. A confirmed tight pair (`is_handoff_partner`) adds a `domain_phi`-scaled hold so a near steal does not split it. A per-CPU scan rate-limit (`last_spill_scan`) gates the walk to once per `codel_target_ns`. Same sojourn gate as STEP 0 on success.
@@ -143,7 +143,7 @@ Layered dispatch with per-CPU DSQ dominance and one age-driven safety mechanism.
 - **select_cpu**: idle CPU -> per-CPU DSQ (depth-gated: 1 slot at <4C, 2 at 4C+) -> R_eff sibling spill if full -> last-resort node DSQ, with KICK_IDLE on the placement target. WAKE_SYNC path: partner-CPU fast path (claim the wakee's `last_cpu` directly if idle and allowed, skipping the R_eff scan on a stable pair) -> R_eff idle search -> waker fallback, WITH a kick — arm A (found-idle) KICK_IDLE, arm B (no-idle) KICK_PREEMPT — so the wakee runs next instead of aging until the target's tick (the dominant IPC round-trip tail)
 - **enqueue Tier 1** (idle CPU): direct `node_dsq` insert + KICK_PREEMPT for non-BATCH / KICK_IDLE for BATCH. Drained by STEP 3 (unconditional `node_dsq`) within one dispatch cycle. The wire-speed path: eager R_eff search at this site is a fork-storm regression with no placement benefit, so Tier 1 stays a direct insert
 - **enqueue Tier 2** (wakeup preemption): uses `pick_pcpu_dsq_with_spill` for symmetric placement with `select_cpu`. CPU-tied; benefits from eager per-CPU placement
-- **enqueue Tier 3** (fallback): batch overflow DSQ for BATCH only; LAT_CRITICAL, INTERACTIVE and immature INTERACTIVE (`ewma_age < 2`) all stay in `node_dsq` — immature tasks are deliberately kept out of the batch DSQ to avoid burst-spawn starvation. The sojourn deadline (`now − warp`) is computed at the insert
+- **enqueue Tier 3** (fallback): batch overflow DSQ for BATCH only; LAT_CRITICAL and INTERACTIVE all stay in `node_dsq` — the batch DSQ is for BATCH-tier work only, so a burst of fresh INTERACTIVE threads cannot flood it and starve. The sojourn deadline (`now − warp`) is computed at the insert
 - **tick**: longrun detection (batch non-empty >2s), sojourn enforcement, per-CPU preempt of the resident for an aged waiter (`sojourn_stamp_pcpu[this_cpu]` age vs a tau-scaled threshold; BATCH yields at base, INTERACTIVE at 2×, LAT_CRITICAL never)
 
 ### Damped Harmonic Oscillator Stall Detection
@@ -196,7 +196,7 @@ When batch DSQ stays non-empty past `longrun_thresh_ns` (tau-scaled, ~2s at 12C 
 No burst detector. The failure modes one would cover — CUSUM on enqueue-interval EWMA, `wake_burst` on absolute wakeup rate, `burst_mode` gating slice/depth/preempt behaviors — are instead handled by the oscillator-adapted CoDel target, the placement-side depth gate + L2/R_eff spill, hard starvation rescue or tier information already present at the enqueue site. Tick preemption is derived per-CPU, with no global signal:
 
 - **Per-CPU preempt**: `pandemonium_tick` reads its own `sojourn_stamp_pcpu[this_cpu]` — the age of the oldest task waiting on this CPU — against a tau-scaled threshold (`preempt_thresh_ns`): a BATCH resident yields once a waiter ages past the base threshold, an INTERACTIVE resident at 2× (batch-throughput protection), a LAT_CRITICAL resident never. Per-CPU by construction — no token to race over. A single global flag instead (armed at enqueue, cleared by the first tick to preempt on *any* CPU) gets token-stolen across cores under a fork storm, so the CPU actually burying a latency waker rarely wins the race — the audio-under-load pathology (intermittent, single-thread, bursty-only). The per-CPU read reuses the bounded-array scan already running for the coarse per-CPU sojourn check, so no new global state.
-- **RT-policy floor**: `SCHED_FIFO`/`SCHED_RR` threads are pinned `TIER_LAT_CRITICAL` by declaration, after the behavioral classifier and the high-prio-kthread→BATCH override. A periodic audio RT thread scores erratically on the behavioral `lat_cri` metric and was flipping out of LAT_CRITICAL mid-burst; threaded USB IRQ kthreads were force-demoted to BATCH. The floor keeps both latency-critical under load, immune to the EWMA jitter.
+- **RT-policy floor**: `SCHED_FIFO`/`SCHED_RR` threads are pinned `TIER_LAT_CRITICAL` by declaration, after the high-prio-kthread→BATCH override. Pinning by policy rather than by a measured score keeps a periodic audio RT thread from flipping out of LAT_CRITICAL mid-burst and stops threaded USB IRQ kthreads being force-demoted to BATCH. The floor keeps both latency-critical under load.
 - **Core-scaled longrun protection**: during sustained `longrun_mode`, the preempt threshold scales up on thin topologies (τ < 4ms) only, extending the protected BATCH window so they don't thrash; wider topologies keep the baseline, where capacity already absorbs LAT_CRIT contention.
 - **Powersave kick-storm damping**: under powersave on a multi-domain part, `cpu_release` (an RT task seizing a core) floods `scx_bpf_reenqueue_local()` on every preemption — a self-feeding loop where each re-enqueue displaces a resident whose own release re-enqueues again, storming ~96% of intervals (montauk defines a storm as reenq/s ≥ 50k). The fix is NOT on the kick: a forced-soft experiment drove preempt-kicks down with the storm untouched — the kick was never the engine, the unconditional reenqueue flood was. A per-CPU leaky time-budget rate-limits `scx_bpf_reenqueue_local()` itself (≥1ms between reenqueues, a short burst allowed): a brief RT preemption leaves local tasks home to dispatch when RT yields, while sparse preemption reenqueues freely. Continuous budget, no gate, placement (Tier 0/1/2/3) untouched (THE FLAG). montauk A/B: storm 96.5% → 0.0%, reenq 166k → 16k/s.
 
@@ -204,9 +204,9 @@ No burst detector. The failure modes one would cover — CUSUM on enqueue-interv
 
 There is no weighted virtual-time engine. `task_deadline()` returns `now − warp` — the enqueue timestamp back-dated by a bounded per-tier warp — so every DSQ is ordered oldest-first (largest sojourn served first). Sojourn IS the selector; no second fairness clock runs parallel to the sojourn + R_eff/CoDel layer.
 
-`lag_cap_ns = K_LAG_CAP × τ` clamped `[8ms, 80ms]` is the warp bound (~13ms at the 12C reference). The warp is flat per tier — `LAT_CRITICAL = lag_cap`, `INTERACTIVE = lag_cap/2`, `BATCH = 0` — and **maturity-gated**: a task earns its warp only once classified (`ewma_age ≥ EWMA_AGE_MATURE`), so a fork storm of unmatured INTERACTIVE children competes on pure arrival order and cannot leapfrog established work.
+`lag_cap_ns = K_LAG_CAP × τ` clamped `[8ms, 80ms]` is the warp bound (~13ms at the 12C reference). The warp is flat per tier — `LAT_CRITICAL = lag_cap`, `INTERACTIVE = lag_cap/2`, `BATCH = 0` — a pure function of tier. Because it is bounded, a fork storm of INTERACTIVE children competes within `lag_cap` and the unified sojourn bound guarantees none can leapfrog established work past the bound.
 
-Because the warp is bounded, a BATCH task older than `lag_cap` always out-sorts a freshly-warped LAT_CRITICAL waker: **starvation-free by construction**, with no ceiling and no new-task penalty needed. A new task simply enters at `now` like any other arrival. (A wakeup-frequency-weighted warp and a queue-depth backlog term each reorder by something other than wait — they cluster ping-pong wakers or rubberband interactivity — so the warp stays flat, bounded and maturity-gated; deep-queue drainage is left to the overflow sojourn rescue, which forces aged work forward by wait, not depth.)
+Because the warp is bounded, a BATCH task older than `lag_cap` always out-sorts a freshly-warped LAT_CRITICAL waker: **starvation-free by construction**, with no ceiling and no new-task penalty needed. A new task simply enters at `now` like any other arrival. (A wakeup-frequency-weighted warp and a queue-depth backlog term each reorder by something other than wait — they cluster ping-pong wakers or rubberband interactivity — so the warp stays flat and bounded; deep-queue drainage is left to the overflow sojourn rescue, which forces aged work forward by wait, not depth.)
 
 ### Hard Starvation Rescue
 
@@ -237,15 +237,13 @@ R_eff alone is a placement *ranking* — it orders candidate CPUs by distance bu
 
 Φ prices each migration by its graph resistance [1][2] and pays only when queueing relief justifies the cache cost. Cross-domain work conservation is preserved — an idle cross-domain core is still taken freely; what Φ removes is the *cheap* cross-domain steal that thrashed L3 for marginal queueing gain.
 
-### Behavioral Classification
+### Tier Classification
 
-- **Latency-Criticality Score**: `lat_cri = (wakeup_freq * csw_rate) / effective_runtime_ms`, where `effective_runtime_ms = (avg_runtime + runtime_dev/2) >> 20` (ns→ms, floored to 1)
-- **Three Tiers**: LAT_CRITICAL (1.5x avg_runtime slices), INTERACTIVE (2x), BATCH (configurable ceiling)
-- **EWMA Classification**: wakeup frequency, context switch rate, runtime variance drive scoring
-- **CPU-Bound Demotion**: an INTERACTIVE task whose `avg_runtime` reaches 75% of `slice_ns` (`avg_runtime*4 >= slice_ns*3`), guarded by `ewma_age <= 4`, is demoted to BATCH — the guard spares tasks that burn a full slice but sleep often
+- **Role-based tier**: scheduling policy decides — `SCHED_FIFO`/`SCHED_RR` → LAT_CRITICAL, all other userspace → INTERACTIVE. No per-task behavioral scoring, no maturity gate; the tier is a pure function of policy plus the kthread floors below.
+- **Three Tiers**: LAT_CRITICAL and INTERACTIVE take a flat knob base slice as a max-quantum cap; BATCH takes the adaptive-layer ceiling.
 - **Kworker Floor**: PF_WQ_WORKER floors at INTERACTIVE
-- **High-Priority Kthread Override**: `PF_KTHREAD` at `static_prio <= 110` (`task_nice <= -10`) forced to BATCH regardless of behavioral score. ZFS workers (`z_rd_int_*`, `arc_*`), kopia helpers and similar storage kthreads no longer compete with userspace LAT_CRITICAL. The kworker floor wins for `PF_WQ_WORKER` (a `PF_KTHREAD` subset), so workqueue workers continue to be treated as latency-adjacent.
-- **Flow Signature**: each wakeup sets the waker CPU's bit in a per-task bitmap; the popcount is the task's distinct-partner cardinality — a topology-free read of the live communication graph's conductance. At maturity (`ewma_age ≥ EWMA_AGE_MATURE`) the task is classified once and frozen: `≤ SHAPE_TIGHT_MAX` (2) distinct partners is a **TIGHT** pair/loop; a partner set spanning at least half of `nr_cpu_ids` is a **STORM** mesh; everything between defaults to TIGHT (latency-safe — its steal stays freely relievable). Portable — the STORM threshold scales with the machine, no hardcoded core geometry. The shape drives *placement* (TIGHT consolidates on its warm core, STORM spreads), never the steal — a shape-gated steal once starved a STORM-classed audio thread on a busy core, so the steal stays shape-blind.
+- **High-Priority Kthread Override**: `PF_KTHREAD` at `static_prio <= 110` (`task_nice <= -10`) forced to BATCH regardless of the role tier. ZFS workers (`z_rd_int_*`, `arc_*`), kopia helpers and similar storage kthreads no longer compete with userspace LAT_CRITICAL. The kworker floor wins for `PF_WQ_WORKER` (a `PF_KTHREAD` subset), so workqueue workers continue to be treated as latency-adjacent.
+- **Flow Signature**: each wakeup sets the waker CPU's bit in a per-task bitmap; the popcount is the task's distinct-partner cardinality — a topology-free read of the live communication graph's conductance. Once the partner set is stable the task is classified once and frozen: `≤ SHAPE_TIGHT_MAX` (2) distinct partners is a **TIGHT** pair/loop; a partner set spanning at least half of `nr_cpu_ids` is a **STORM** mesh; everything between defaults to TIGHT (latency-safe — its steal stays freely relievable). Portable — the STORM threshold scales with the machine, no hardcoded core geometry. The shape drives *placement* (TIGHT consolidates on its warm core, STORM spreads), never the steal — a shape-gated steal once starved a STORM-classed audio thread on a busy core, so the steal stays shape-blind.
 
 ### Process Database (procdb)
 
@@ -283,7 +281,7 @@ All timing constants scale from `tau_ns = TAU_SCALE_NS / √(λ₂ · N)` — ca
 
 - **Low-core slice discipline**: τ is largest at low core count (λ₂ shrinks as cores drop), so the tau slice cap runs loosest exactly where a wide batch slice hurts most — a 4ms HEAVY-regime slice on 2–4 cores denies a latency-sensitive probe across many consecutive slices, the low-core tail. The regime slice is capped to the MIXED value (1ms) at `nr_cpus ≤ 4`, where a wide slice buys no throughput; 8C/12C keep the tau-scaled width, where it earns it.
 - **CPU Hotplug**: `cpu_online`/`cpu_offline` callbacks clear per-CPU timestamps and oscillator state (velocity, rescue count) to prevent stale oscillation after suspend/resume
-- **BPF-Verifier Safe**: All EWMA uses bit shifts, no floats. All shared state uses GCC __sync builtins
+- **BPF-Verifier Safe**: No floats in the BPF path; integer-only arithmetic throughout. All shared state uses GCC __sync builtins
 
 ## Architecture
 
@@ -362,12 +360,10 @@ One thread, zero mutexes. BPF produces histograms, Rust reads them once per seco
 
 | Knob | Default | Owner | Purpose |
 |------|---------|-------|---------|
-| `slice_ns` | 1ms | MWU | Interactive/lat_cri slice ceiling |
+| `slice_ns` | 1ms | MWU | Interactive slice ceiling |
 | `preempt_thresh_ns` | 1ms | MWU | Tick preemption threshold |
 | `batch_slice_ns` | 20ms | MWU | Batch task slice ceiling (sleep-adjusted) |
 | `burst_slice_ns` | 1ms | MWU | Slice during longrun mode |
-| `lat_cri_thresh_high` | 32 | MWU | LAT_CRITICAL classifier threshold |
-| `lat_cri_thresh_low` | 8 | MWU | INTERACTIVE classifier threshold |
 | `affinity_mode` | 0 | MWU | L2 placement (0=OFF, 1=WEAK, 2=STRONG); Rust writes the per-regime value at startup |
 | `sojourn_thresh_ns` | 5ms | MWU | Batch DSQ rescue threshold (tau-scaled) |
 | `topology_tau_ns` | 0 | Topology | Fiedler-derived time constant (τ = TAU_SCALE / λ₂) |
@@ -420,10 +416,8 @@ sudo scx_pandemonium --no-adaptive    # BPF-only (no Rust control loop)
 sudo scx_pandemonium -v               # Verbose telemetry on stdout
 ```
 
-There is no compositor allowlist. Compositors land at `LAT_CRITICAL` naturally
-through the behavioral classifier (high wakeup frequency × high context-switch
-rate × short avg runtime → `lat_cri` peaks), and procdb warm-starts known
-names from prior sessions. The earlier hardcoded comm boost was scaffolding
+There is no compositor allowlist. Compositors run at `INTERACTIVE` by role
+(non-RT userspace), and procdb warm-starts known names from prior sessions. The earlier hardcoded comm boost was scaffolding
 from when the classifier was less reliable on cold-start; the current
 classifier no longer needs the safety net.
 

--- a/scheds/rust/scx_pandemonium/README.md
+++ b/scheds/rust/scx_pandemonium/README.md
@@ -10,136 +10,131 @@ PANDEMONIUM is included in the [sched-ext/scx](https://github.com/sched-ext/scx)
 
 ## Performance
 
-12 AMD Zen CPUs (Ryzen 5 3600), kernel 7.0.12.arch1, clang 21. v5.14.0, EEVDF, scx_cosmos, scx_lavd are from a fresh-boot full-field bench-scale (2026-06-17, 3 iterations). All five schedulers completed every cell; no crash or hotplug insta-exit contamination.
+12 AMD Zen CPUs (Ryzen 5 3600), kernel 7.0.13-arch1-1, clang 21. v5.15.0 numbers are from a prism-scale run (2026-06-27, 3 iterations): EEVDF baseline vs PANDEMONIUM (BPF and ADAPTIVE). External schedulers are omitted from this comparison.
 
 ### P99 Wakeup Latency (interactive probe under CPU saturation)
 
-| Cores | EEVDF    | scx_cosmos | scx_lavd  | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|----------|------------|-----------|-------------------|------------------------|
-| 2     | 72,740us | 11,847us   | 11,561us  | 612us             | **463us**              |
-| 4     | 6,020us  | 2,274us    | 5,957us   | 108us             | **66us**               |
-| 8     | 1,305us  | 1,705us    | 3,291us   | **67us**          | **67us**               |
-| 12    | 694us    | 1,902us    | 1,789us   | 69us              | **68us**               |
+| Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|---------|-------------------|------------------------|
+| 2     | 3,009us | **105us**         | 136us                  |
+| 4     | 1,996us | 1,059us           | **77us**               |
+| 8     | 728us   | **66us**          | 67us                   |
+| 12    | 313us   | **68us**          | **68us**               |
 
 ### Burst P99 (fork/exec storm under CPU saturation)
 
-| Cores | EEVDF    | scx_cosmos | scx_lavd  | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|----------|------------|-----------|-------------------|------------------------|
-| 2     | 5,809us  | 10,336us   | 13,934us  | **266us**         | 924us                  |
-| 4     | 5,066us  | 2,328us    | 6,849us   | **146us**         | 919us                  |
-| 8     | 2,175us  | 1,896us    | 4,845us   | 66us              | **34us**               |
-| 12    | 2,870us  | 853us      | 2,103us   | **72us**          | 164us                  |
+| Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|---------|-------------------|------------------------|
+| 2     | 2,731us | **175us**         | 204us                  |
+| 4     | 2,080us | 70us              | **68us**               |
+| 8     | 2,067us | 76us              | **74us**               |
+| 12    | 2,226us | 80us              | **77us**               |
 
 ### Longrun P99 (interactive latency with sustained CPU-bound long-runners)
 
-| Cores | EEVDF    | scx_cosmos | scx_lavd  | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|----------|------------|-----------|-------------------|------------------------|
-| 2     | 11,073us | 7,093us    | 13,527us  | **775us**         | 1,527us                |
-| 4     | 4,526us  | 1,985us    | 5,965us   | **532us**         | 1,818us                |
-| 8     | 689us    | 1,946us    | 4,954us   | 824us             | **225us**              |
-| 12    | 814us    | 1,745us    | 4,693us   | **67us**          | 71us                   |
+| Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|---------|-------------------|------------------------|
+| 2     | 2,967us | **905us**         | 998us                  |
+| 4     | 871us   | **152us**         | 946us                  |
+| 8     | 71us    | **68us**          | 633us                  |
+| 12    | **92us**| 347us             | 634us                  |
 
 ### Mixed Latency P99 (interactive + batch concurrent)
 
-| Cores | EEVDF    | scx_cosmos | scx_lavd  | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|----------|------------|-----------|-------------------|------------------------|
-| 2     | 16,989us | 8,652us    | 13,937us  | 1,147us           | **1,011us**            |
-| 4     | 3,020us  | 2,003us    | 6,293us   | **773us**         | 1,138us                |
-| 8     | 2,424us  | 1,478us    | 4,681us   | **67us**          | 668us                  |
-| 12    | 1,436us  | 1,772us    | 4,826us   | **70us**          | 673us                  |
+| Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|---------|-------------------|------------------------|
+| 2     | 2,486us | **989us**         | 1,832us                |
+| 4     | 2,987us | **197us**         | 1,461us                |
+| 8     | 1,965us | 1,038us           | **722us**              |
+| 12    | 875us   | **75us**          | 919us                  |
 
 ### Deadline Miss Ratio (16.6ms frame target)
 
-| Cores | EEVDF   | scx_cosmos | scx_lavd | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|---------|------------|----------|-------------------|------------------------|
-| 2     | 20.9%   | 72.8%      | 86.9%    | 3.0%              | **2.8%**               |
-| 4     | 13.9%   | 67.4%      | 79.5%    | 0.5%              | **0.2%**               |
-| 8     | 13.0%   | 54.7%      | 53.3%    | **0.2%**          | **0.2%**               |
-| 12    | 11.8%   | 51.7%      | 49.8%    | **0.2%**          | 0.4%                   |
+| Cores | EEVDF | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|-------|-------------------|------------------------|
+| 2     | 13.7% | **0.3%**          | **0.3%**               |
+| 4     | 10.3% | 0.3%              | **0.2%**               |
+| 8     | 9.6%  | **0.1%**          | 0.3%                   |
+| 12    | 11.3% | 0.3%              | **0.2%**               |
 
 ### Burst Recovery P99 (latency after storm subsides)
 
-| Cores | PANDEMONIUM (BPF) (bench-scale burst-recovery phase) |
+| Cores | PANDEMONIUM (BPF) (prism-scale burst-recovery phase) |
 |-------|------------------------------------------------------|
-| 2     | base 517us / burst 266us / recovery 696us           |
-| 4     | base 63us / burst 146us / recovery 165us            |
-| 8     | base 66us / burst 66us / recovery 66us              |
-| 12    | base 67us / burst 72us / recovery 74us              |
+| 2     | base 96us / burst 175us / recovery 62us             |
+| 4     | base 63us / burst 70us / recovery 65us              |
+| 8     | base 65us / burst 76us / recovery 67us              |
+| 12    | base 67us / burst 80us / recovery 69us              |
 
 ### App Launch (`fork()`+`exec()` under load, mean / p99 us)
 
-| Cores | EEVDF         | scx_cosmos    | scx_lavd       | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|---------------|---------------|----------------|-------------------|------------------------|
-| 2     | 1,639 / 5,050 | 759 / 2,549   | 1,939 / 21,080 | 1,508 / 6,560     | 1,501 / 4,674          |
-| 4     | 1,947 / 4,689 | 1,033 / 2,668 | 715 / 6,172    | **828** / 2,774   | 1,145 / 4,007          |
-| 8     | 1,488 / 3,124 | 1,007 / 2,631 | 781 / 3,986    | **732** / 2,297   | 971 / 5,609            |
-| 12    | 1,575 / 3,153 | 898 / 2,043   | 720 / 2,959    | 968 / 15,187      | **670** / 1,850        |
+| Cores | EEVDF         | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|---------------|-------------------|------------------------|
+| 2     | 1,617 / 2,342 | **1,098** / 2,909 | 1,421 / 3,721          |
+| 4     | 2,189 / 3,664 | 782 / 2,304       | **770** / 2,601        |
+| 8     | 1,298 / 3,075 | **698** / 1,893   | 1,046 / 16,477         |
+| 12    | 1,258 / 2,992 | 2,955 / 16,536    | **602** / 1,850        |
 
-The *typical* app launch under PANDEMONIUM is faster than EEVDF — mean 0.7–1.0ms vs EEVDF's ~1.5ms at 4C and up. The p99 carries occasional cold-launch outliers from the fork/exec dispatch waterfall (the BPF 12C 15ms is one slow launch in 100, not the norm — mean there is 968us). Reported as mean / p99 so the typical-case win isn't masked by the tail. IPC is likewise nuanced — broken out by primitive below.
+The *typical* app launch under the better PANDEMONIUM arm beats EEVDF at every width — mean 0.6–1.1ms vs EEVDF's 1.3–2.2ms. The p99 carries occasional cold-launch outliers from the fork/exec dispatch waterfall (BPF 12C and ADAPTIVE 8C each show one ~16ms launch in 100; BPF 12C also runs a high mean there). Reported as mean / p99 so the typical-case win isn't masked by the tail. IPC is PANDEMONIUM's weak workload — broken out by primitive below.
 
 ### IPC Round-Trip by Primitive (12C, p50 / p99 us)
 
-| Primitive | EEVDF       | scx_cosmos | scx_lavd    | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-----------|-------------|------------|-------------|-------------------|------------------------|
-| pipe      | 10 / 14     | 12 / 49    | 13 / 477    | 10 / 1,335        | 10 / 1,335             |
-| socket    | 17 / 321    | 14 / 30    | 16 / 191    | 13 / 1,337        | 13 / 1,338             |
-| eventfd   | 9 / 16      | 11 / 55    | 13 / 1,008  | 21 / **137**      | 22 / **30**            |
-| sem       | 12 / 18     | 11 / 76    | 14 / 1,000  | 17 / **25**       | 17 / **48**            |
-| fanout    | 102 / 3,578 | 93 / 198   | 130 / 2,251 | 1,007 / 2,246     | 998 / 2,008            |
+| Primitive | EEVDF      | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-----------|------------|-------------------|------------------------|
+| pipe      | 12 / 15    | 11 / 1,370        | 11 / 1,369             |
+| socket    | 17 / 24    | 14 / 1,371        | 14 / 1,371             |
+| eventfd   | 9 / 15     | 27 / 1,333        | 27 / 1,398             |
+| sem       | 10 / 13    | 27 / 1,393        | 28 / 1,402             |
+| fanout    | 68 / 3,423 | 1,999 / 2,987     | 1,999 / 2,989          |
 
-PANDEMONIUM dispatches the typical IPC wake in tens of microseconds on every primitive except the 1:N fan-out (pipe p50 10us, socket 13us). The sem and eventfd *tails* are resolved too — p99 25us and 137us (BPF), ~40× under scx_lavd's ~1ms. The remaining gaps are honest: pipe and socket p99 sit on the CONFIG_HZ=1000 tick floor (~1.3ms) under busy-waker co-location even though their median is microsecond-tight, and the 1:N fanout (~1ms p50) is where cosmos, purpose-built for it, leads. Closing the pipe/socket busy-waker tail is the top v5.15.0 item.
+IPC is PANDEMONIUM's weakest workload and EEVDF leads it decisively. The *median* round-trip is microsecond-tight on pipe and socket (p50 11–14us, on par with EEVDF), but every primitive's p99 sits at ~1.3–1.4ms under busy-waker co-location versus EEVDF's ~15–24us, and the 1:N fanout runs ~2ms at the median. montauk names the cause: under IPC saturation a CPU-bound hog holds the core for multiple seconds while the round-trip partner spills cross-domain and never preempts it (51k floored wakes, 100% held, worst single hold ~7.8s, against EEVDF's ~240ms). Closing this saturation strand is the standing v5.16.0 IPC item.
 
-### Fork/Thread IPC (`perf bench sched messaging -t -g 24 -l 6000`, 12C, v5.14.0)
+### Fork/Thread IPC (`perf bench sched messaging -t -g 24 -l 6000`, 12C, v5.15.0)
 
-| Scheduler                | Time        | vs EEVDF  | Cache Misses | Cache Refs | IPC   |
-|--------------------------|-------------|-----------|--------------|------------|-------|
-| EEVDF                    | **16.837s** | baseline  | **36.94M**   | 1,150M     | 0.411 |
-| PANDEMONIUM (BPF)        | 19.020s     | +13.0%    | 51.14M       | 1,160M     | 0.411 |
-| PANDEMONIUM (ADAPTIVE)   | 18.759s     | +11.4%    | 53.41M       | 1,150M     | 0.413 |
+| Scheduler                | Time        | vs EEVDF | Cache Misses | Cache Refs | IPC       |
+|--------------------------|-------------|----------|--------------|------------|-----------|
+| EEVDF                    | **15.398s** | baseline | **3.48G**    | 24.35G     | **0.477** |
+| PANDEMONIUM (BPF)        | 15.735s     | +2.2%    | 3.88G        | 22.60G     | 0.456     |
+| PANDEMONIUM (ADAPTIVE)   | 15.799s     | +2.6%    | 3.88G        | 22.62G     | 0.456     |
 
-The fork/exec storm is PANDEMONIUM's hardest case: it trails fresh-boot EEVDF by ~11–13% on wall time and takes ~40% more cache-misses (3.2% vs ~4.5% miss rate) — the cross-domain migration cost of the aggressive rebalancing that buys the latency, burst and deadline wins above. IPC is at parity (0.41). Tightening the storm-cache without giving back the tail is standing v5.15.0 work.
+The fork/exec storm is PANDEMONIUM's hardest case for cache locality: ~11% more cache-misses (17.2% vs EEVDF's 14.3% miss rate) and ~5× the cpu-migrations (895K vs 170K, 43% cross-domain vs EEVDF's 0.7%) — the cost of the aggressive rebalancing that buys the latency, burst and deadline wins above. Wall time trails EEVDF only slightly (+2.2 / +2.6%) and IPC is near parity (0.456 vs 0.477); PANDEMONIUM even edges EEVDF on wake2run p99 here (53ms vs 60ms). Cutting the cross-domain migration rate without giving back the tail is standing v5.16.0 work.
 
-### Energy Efficiency (`bench-power`, 12C, v5.14.0)
+### Energy Efficiency (`prism-power`, 12C, v5.15.0)
 
-5 runs per (scheduler, workload), 30s cooldown, off a fresh reboot (2026-06-17). Package energy via `perf stat -a -e power/energy-pkg/`. Zen 2 (Ryzen 5 3600) exposes only `J_pkg` (no per-core or per-DRAM RAPL).
+5 runs per (scheduler, workload), 30s cooldown between runs (2026-06-27). Package energy via `perf stat -a -e power/energy-pkg/`. Zen 2 (Ryzen 5 3600) exposes only `J_pkg` (no per-core or per-DRAM RAPL).
 
 **Idle floor** (30s `sleep`, scheduler restlessness):
 
-| Scheduler                | J_pkg   | Avg W    | vs EEVDF |
-|--------------------------|---------|----------|----------|
-| scx_cosmos               | **517.33J** | **17.22W** | **-1.3%** |
-| PANDEMONIUM (ADAPTIVE)   | 518.61J | 17.27W   | -1.1%    |
-| PANDEMONIUM (BPF)        | 519.31J | 17.29W   | -0.9%    |
-| EEVDF                    | 524.26J | 17.36W   | baseline |
-| scx_lavd                 | 528.44J | 17.59W   | +0.8%    |
+| Scheduler                | J_pkg       | Avg W      | vs EEVDF   |
+|--------------------------|-------------|------------|------------|
+| PANDEMONIUM (ADAPTIVE)   | **510.24J** | **16.99W** | **-13.1%** |
+| PANDEMONIUM (BPF)        | 511.59J     | 17.04W     | -12.9%     |
+| EEVDF                    | 587.03J     | 19.55W     | baseline   |
 
-PANDEMONIUM now idles *below* EEVDF (−0.9 / −1.1%), second only to cosmos — the scheduler is quiet at rest.
+PANDEMONIUM now idles well below EEVDF (−12.9 / −13.1% package power, 17.0W vs 19.6W) — the scheduler is markedly quiet at rest.
 
 **Messaging** (`perf bench sched messaging`, fork-storm + IPC):
 
-| Scheduler                | Wall_s     | J_pkg       | J/op       | vs EEVDF |
-|--------------------------|------------|-------------|------------|----------|
-| EEVDF                    | **14.72s** | **882.77J** | **153.26uJ** | baseline |
-| PANDEMONIUM (BPF)        | 15.77s     | 957.83J     | 166.29uJ   | +8.5%    |
-| PANDEMONIUM (ADAPTIVE)   | 15.88s     | 959.98J     | 166.66uJ   | +8.7%    |
-| scx_cosmos               | 25.10s     | 1470.48J    | 255.29uJ   | +66.6%   |
-| scx_lavd                 | 27.28s     | 1650.12J    | 286.48uJ   | +86.9%   |
+| Scheduler                | Wall_s  | J_pkg       | J/op         | vs EEVDF  |
+|--------------------------|---------|-------------|--------------|-----------|
+| EEVDF                    | 14.81s  | 902.49J     | 156.68uJ     | baseline  |
+| PANDEMONIUM (BPF)        | 15.08s  | 896.38J     | 155.62uJ     | -0.7%     |
+| PANDEMONIUM (ADAPTIVE)   | 15.12s  | **895.50J** | **155.47uJ** | **-0.8%** |
 
-On the fork-storm PANDEMONIUM trails EEVDF ~8% on energy (the cross-domain rebalancing cost, same source as the cache-miss delta) but undercuts the scx field by 60–87% — lavd and cosmos burn far more energy for the same messaging work.
+On the fork-storm messaging mix PANDEMONIUM matches EEVDF on energy (−0.7 / −0.8% J/op) at a small wall-time cost (+1.8 / +2.1%) — the package-energy delta the cross-domain rebalancing once carried is now within noise.
 
 ## Key Features
 
 ### Dispatch Waterfall
 
-Layered dispatch with per-CPU DSQ dominance and one age-driven safety mechanism. CPU-tied placement (Tier 2 wakeup preemption, `select_cpu`) is bounded at the enqueue site by `pcpu_depth_base` and overflow spills to a sibling per-CPU DSQ in R_eff order (`find_pcpu_with_room` → `pick_pcpu_dsq_with_spill`), so the dispatch waterfall reaches every CPU-tied enqueue at STEP 0 (sibling owns) or STEP 1 (near R_eff steal). Idle-CPU placement (Tier 1) inserts directly into the per-domain overflow DSQ and is picked up by STEP 3 within one dispatch cycle — eager R_eff search at this site is a wire-speed regression on fork-storm workloads with no measurable placement benefit. The steal is **near-before-far tiered**: STEP 1 walks same-domain peers only, the cross-domain tier (STEP 4b) is reached only after the home domain — peers *and* local overflow — is fully exhausted, so a working set never scatters off its home L3 while same-domain or local work remains. The cache-domain boundary is structural ordering *between* tiers; Φ still prices the steal *within* each tier. The waterfall is 8 steps (0, 1, 2, 3, 4, 4b, 5, KEEP_RUNNING) + 1 safety net; redundant rescue paths (deficit-gate-with-exception, DRR deficit counter, batch sojourn rescue) are deliberately absent — they all reduce to "service the older overflow side past a threshold," which STEP 2 already does. `sojourn_gate_pass` sits at STEP 0 / STEP 1, load-bearing for workqueue-worker fairness under sustained per-CPU load (without it, `scx_watchdog_workfn` strands in the overflow DSQ long enough to trigger 30s watchdog kills).
+Layered dispatch with per-CPU DSQ dominance and one age-driven safety mechanism. CPU-tied placement (Tier 2 wakeup preemption, `select_cpu`) is bounded at the enqueue site by `pcpu_depth_base` and overflow spills to a sibling per-CPU DSQ in R_eff order (`find_pcpu_with_room` → `pick_pcpu_dsq_with_spill`), so the dispatch waterfall reaches every CPU-tied enqueue at STEP 0 (sibling owns) or STEP 1 (near R_eff steal). Idle-CPU placement (Tier 1) inserts directly into the per-domain overflow DSQ and is picked up by STEP 3 within one dispatch cycle — eager R_eff search at this site is a wire-speed regression on fork-storm workloads with no measurable placement benefit. The steal is **one Φ-priced walk**: STEP 1 walks `affinity_rank` (the per-CPU R_eff-ascending list, cross-domain peers included) with no near/far tier boundary — Φ (the `reff_value` penalty) alone prices the move, so nearer relief is always preferred without a structural same/different-domain gate (the CCX/CCD-removal end state, THE FLAG). The waterfall is 7 steps (0, 1, 2, 3, 4, 5, KEEP_RUNNING) + 1 safety net; redundant rescue paths (deficit-gate-with-exception, DRR deficit counter, batch sojourn rescue) are deliberately absent — they all reduce to "service the older overflow side past a threshold," which STEP 2 already does. `sojourn_gate_pass` sits at STEP 0 / STEP 1, load-bearing for workqueue-worker fairness under sustained per-CPU load (without it, `scx_watchdog_workfn` strands in the overflow DSQ long enough to trigger 30s watchdog kills).
 
-0. **Own per-CPU DSQ** — cache-hot, zero contention. Sojourn-gated return: if either overflow side has aged past `overflow_sojourn_rescue_ns`, fall through to STEP 2 so this dispatch serves overflow too.
-1. **Near R_eff steal (same-domain tier)** — single loop over `near_tbl`, the same-domain prefix of the R_eff rank packed by Rust at topology detect: slot 0 = L2 sibling, each u64 entry packs the peer CPU (low 32 bits) and the pre-folded Φ distance penalty in ns (high 32). Budget is tau-derived: `pcpu_spill_search_budget = K_SPILL_BUDGET / tau ≈ λ₂/2`, clamped to `[6, min(nr_cpu_ids - 1, MAX_AFFINITY_CANDIDATES)]`. The companion WAKE_SYNC idle-search budget `affinity_search_online = K_AFFINITY_SEARCH / tau ≈ λ₂/4` clamps the same way (smaller divisor because the predicate is more expensive). A peer is relieved only with `nr_queued > 1` and its head aged past the Φ threshold `codel_target_ns + (penalty >> 32)` — the penalty read straight from the entry's high bits, no second map lookup and no multiply, so an SMT sibling (R_eff≈0) stays freely relievable while a far peer must show ~τ of backlog. A per-CPU scan rate-limit (`last_spill_scan`, one stamp shared with STEP 4b) gates the walk to once per `codel_target_ns`. Same sojourn gate as STEP 0 on success.
-1. *Safety net.* **Hard starvation rescue** — `try_service_older_overflow(starvation_rescue_ns)`: drains whichever of `interactive_enqueue_ns` / `batch_enqueue_ns` is older past the tau-scaled hard cap. Fires before STEP 2 so it cannot be gated. Should ~never fire post-placement-fix.
-2. **Service older overflow side** — `try_service_older_overflow(overflow_sojourn_rescue_ns)`: same pick-the-older comparison at the R_eff-derived equilibrium threshold (`overflow_sojourn_rescue_ns = codel_target_equilibrium_ns`). Feeds the CoDel oscillator (`global_rescue_count++`).
+0. **Own per-CPU DSQ** — cache-hot, zero contention. Sojourn-gated return: if either overflow side has aged past `codel_target_ns`, fall through to STEP 2 so this dispatch serves overflow too.
+1. **R_eff steal** — single loop over `affinity_rank`, the per-CPU R_eff-ascending peer list (slot 0 = nearest sibling, cross-domain peers included, no tier boundary). Budget is tau-derived: `pcpu_spill_search_budget ≈ λ₂/2`, clamped to `[6, MAX_AFFINITY_CANDIDATES]`. The companion WAKE_SYNC idle-search budget `affinity_search_online ≈ λ₂/4` clamps the same way (smaller divisor because the predicate is more expensive). A peer is relieved only with `nr_queued > 1` and its head aged past the Φ threshold `codel_target_ns + dist_extra`, where `dist_extra = b·R_eff` is pre-folded in ns into the `reff_value` map (one indexed read, no multiply), so an SMT sibling (R_eff≈0) stays freely relievable while a cross-domain pull must show ~τ of backlog. A confirmed tight pair (`is_handoff_partner`) adds a `domain_phi`-scaled hold so a near steal does not split it. A per-CPU scan rate-limit (`last_spill_scan`) gates the walk to once per `codel_target_ns`. Same sojourn gate as STEP 0 on success.
+1. *Safety net.* **Hard starvation rescue** — `try_service_older_overflow(codel_starve_ns)`: drains whichever overflow side (`sojourn_stamp_overflow[].inter` / `.batch`) is older past the tau-scaled hard cap. Fires before STEP 2 so it cannot be gated. Should ~never fire post-placement-fix.
+2. **Service older overflow side** — `try_service_older_overflow(codel_target_ns)`: same pick-the-older comparison at the live CoDel target (the R_eff×τ equilibrium the oscillator parks at is `codel_seed_ns`; the vestigial second writer `overflow_sojourn_rescue_ns` is deleted, reads key off `codel_target_ns` directly). Feeds the CoDel oscillator.
 3. **Per-cache domain interactive overflow (local)** — cache-coherent drain of this cache domain's interactive overflow DSQ (`node_dsq`; LAT_CRITICAL + INTERACTIVE, sojourn-ordered).
-4. **Per-cache domain batch overflow (local)** — this cache domain's batch overflow DSQ.
-4. **STEP 4b — Far R_eff steal (cross-domain tier)** — reached only with the home domain fully exhausted (no own work, no qualifying near peer, no local overflow). Walks `far_tbl`, the `FAR_CANDIDATES = 8` nearest cross-domain peers (dense from slot 0, constant bound, sentinel-terminated), under the same scan window STEP 1 stamped and the same Φ price: a cross-domain pull still needs ~τ of sustained backlog via the pre-folded penalty. v5.7.0's far-steal-last ordering expressed inside the Φ-priced walk. All-sentinel on a monolithic box — instant break.
+4. **Per-cache-domain batch overflow (local)** — this cache domain's batch overflow DSQ.
 5. **Cross-domain work conservation** — scan other domains once; drain any non-empty overflow (interactive first per domain, then batch). Runs only when the local domain is empty, so cross-domain migration here is pure idle-time work conservation.
 6. **KEEP_RUNNING** — if prev still wants CPU and nothing queued.
 
@@ -149,7 +144,7 @@ Layered dispatch with per-CPU DSQ dominance and one age-driven safety mechanism.
 - **enqueue Tier 1** (idle CPU): direct `node_dsq` insert + KICK_PREEMPT for non-BATCH / KICK_IDLE for BATCH. Drained by STEP 3 (unconditional `node_dsq`) within one dispatch cycle. The wire-speed path: eager R_eff search at this site is a fork-storm regression with no placement benefit, so Tier 1 stays a direct insert
 - **enqueue Tier 2** (wakeup preemption): uses `pick_pcpu_dsq_with_spill` for symmetric placement with `select_cpu`. CPU-tied; benefits from eager per-CPU placement
 - **enqueue Tier 3** (fallback): batch overflow DSQ for BATCH only; LAT_CRITICAL, INTERACTIVE and immature INTERACTIVE (`ewma_age < 2`) all stay in `node_dsq` — immature tasks are deliberately kept out of the batch DSQ to avoid burst-spawn starvation. The sojourn deadline (`now − warp`) is computed at the insert
-- **tick**: longrun detection (batch non-empty >2s), sojourn enforcement, per-CPU preempt of the resident for an aged waiter (`pcpu_enqueue_ns[this_cpu]` age vs a tau-scaled threshold; BATCH yields at base, INTERACTIVE at 2×, LAT_CRITICAL never)
+- **tick**: longrun detection (batch non-empty >2s), sojourn enforcement, per-CPU preempt of the resident for an aged waiter (`sojourn_stamp_pcpu[this_cpu]` age vs a tau-scaled threshold; BATCH yields at base, INTERACTIVE at 2×, LAT_CRITICAL never)
 
 ### Damped Harmonic Oscillator Stall Detection
 
@@ -161,7 +156,7 @@ CoDel-inspired per-CPU DSQ stall detection where the target follows the full dam
 
 with `γ` set for Butterworth-optimal damping (ζ ≈ 0.707) — a maximally-flat response that trades a small ~4.3% step-response overshoot per adaptation for shorter settling time; the overshoot is the controller's deliberate exploration term (it probes the convex-response boundary on each impulse instead of parking inside it).
 
-**Per-task sojourn** (RFC 8289): `task_ctx.enqueue_at` is set at every `scx_bpf_dsq_insert_vtime` call site (six placement paths) and consumed in `pandemonium_running` to compute `sojourn = now − enqueue_at`. This is the literal CoDel metric — wait between enqueue and run start — feeding `pcpu_min_sojourn_ns`. A per-task timestamp stays accurate through an entire drain, where a per-CPU `now − pcpu_enqueue_ns[cpu]` proxy weakens past the first task.
+**Per-task sojourn** (RFC 8289): `task_ctx.enqueue_at` is set at every `scx_bpf_dsq_insert_vtime` call site (six placement paths) and consumed in `pandemonium_running` to compute `sojourn = now − enqueue_at`. This is the literal CoDel metric — wait between enqueue and run start — feeding `pcpu_min_sojourn_ns`. A per-task timestamp stays accurate through an entire drain, where a per-CPU `now − sojourn_stamp_pcpu[cpu]` proxy weakens past the first task.
 
 **Stall decision** (`pcpu_dsq_is_stalled`): compares per-CPU minimum sojourn against `codel_target_ns`. Below = flowing. Above for `sojourn_interval_ns` = stalled, force rescue. Binary CoDel decision; the target itself is what oscillates.
 
@@ -184,11 +179,11 @@ with `γ` set for Butterworth-optimal damping (ζ ≈ 0.707) — a maximally-fla
 
 `x` rests at `c_eq` when the system is quiet, descends below on rescue events and returns Butterworth-damped — one bounded ~4.3% overshoot, then settle.
 
-**Oscillator envelope (idle quiescence)**: the control effort obeys the same damping law as the system it controls, so the oscillator goes quiet when the system does. A decayed energy reservoir (`osc_env_energy -= osc_env_energy >> 3`, then `+= disp² + v²`, built only from values the recompute already maintains) drives the recompute cadence down as the oscillator contracts. Below the RELEASE threshold the oscillator recomputes every 4th tick (graded band); below PARK it pins `codel_target_ns` at `codel_target_equilibrium_ns` (the closed-form fixed point, one store), freezes the velocity integrator (anti-windup, so it cannot accumulate across the band and slingshot at wake) and stops the arithmetic. Thresholds derive from the spring/damp dead-band quanta pre-scaled by the reservoir gain, with RELEASE 2× above PARK — multiplicative hysteresis, a Schmitt trigger on energy, not a change-point accumulator. While parked, three compares per tick arm the detector: a rescue event (a discrete count, so no epsilon floor), the equilibrium moving under the parked value (MWU/τ retune) or a 1024-tick max-park heartbeat. On any of these the oscillator does a full recompute in the same tick — before any dispatch prices against the target — and re-primes the reservoir above RELEASE so a bursty wake cannot immediately re-park. Every burst begins from an identical controller state. `nr_osc_park` (in the stats struct, surfaced as TOTAL OSC PARKS) counts parks; zero parks after an idle-heavy run is the minimum-attention-collapse failure mode the counter exists to detect.
+**Oscillator envelope (idle quiescence)**: the control effort obeys the same damping law as the system it controls, so the oscillator goes quiet when the system does. A decayed energy reservoir (`osc_env_energy -= osc_env_energy >> 3`, then `+= disp² + v²`, built only from values the recompute already maintains) drives the recompute cadence down as the oscillator contracts. Below the RELEASE threshold the oscillator recomputes every 4th tick (graded band); below PARK it pins `codel_target_ns` at `codel_seed_ns` (the closed-form fixed point, one store), freezes the velocity integrator (anti-windup, so it cannot accumulate across the band and slingshot at wake) and stops the arithmetic. Thresholds derive from the spring/damp dead-band quanta pre-scaled by the reservoir gain, with RELEASE 2× above PARK — multiplicative hysteresis, a Schmitt trigger on energy, not a change-point accumulator. While parked, three compares per tick arm the detector: a rescue event (a discrete count, so no epsilon floor), the equilibrium moving under the parked value (MWU/τ retune) or a 1024-tick max-park heartbeat. On any of these the oscillator does a full recompute in the same tick — before any dispatch prices against the target — and re-primes the reservoir above RELEASE so a bursty wake cannot immediately re-park. Every burst begins from an identical controller state. `nr_osc_park` (in the stats struct, surfaced as TOTAL OSC PARKS) counts parks; zero parks after an idle-heavy run is the minimum-attention-collapse failure mode the counter exists to detect.
 
 ### Overflow Sojourn Rescue
 
-Per-CPU DSQ dominance under sustained load makes downstream anti-starvation unreachable — 90%+ of dispatches serve per-CPU DSQ while overflow tasks age indefinitely. Dispatch STEP 0 / STEP 1 fall through to STEP 2 when either overflow DSQ has aged past `overflow_sojourn_rescue_ns` — which is set to `codel_target_equilibrium_ns` (the R_eff-derived CoDel equilibrium `⟨R_eff⟩ × 2m × τ`, clamped into the oscillator's `[floor, max]` window, so ≤~2ms at 12C — not a hand-tuned ~10ms). The spectral scalar opens the gate; sojourn (enqueue-age) fills it and selects the older side. `try_service_older_overflow` then drains that side past the threshold. CAS-based timestamp management prevents races across CPUs.
+Per-CPU DSQ dominance under sustained load makes downstream anti-starvation unreachable — 90%+ of dispatches serve per-CPU DSQ while overflow tasks age indefinitely. Dispatch STEP 0 / STEP 1 fall through to STEP 2 when either overflow DSQ has aged past `codel_target_ns` — the live CoDel target the oscillator drives around its R_eff-derived equilibrium `codel_seed_ns` (`⟨R_eff⟩ × 2m × τ`, clamped into the oscillator's `[floor, max]` window, so ≤~2ms at 12C — not a hand-tuned ~10ms). The spectral scalar opens the gate; sojourn (enqueue-age) fills it and selects the older side. `try_service_older_overflow` then drains that side past the threshold. CAS-based timestamp management prevents races across CPUs.
 
 **Drain both when both aged**: under sustained mixed load both overflow DSQs can stay continuously non-empty for tens of seconds, freezing both timestamps at their first-non-empty values. A strict "older wins" would then pick the same side every rescue call until external pressure dropped, locking out batch-demoted long-runners (at 2C, a 19-29s starvation tail; 4C+ closes the window through higher dispatch density). So when BOTH sides are aged, both drain — older-first ordering preserved (latency-budget bias for interactive on ties), at the cost of one extra `scx_bpf_dsq_move_to_local`.
 
@@ -200,9 +195,10 @@ When batch DSQ stays non-empty past `longrun_thresh_ns` (tau-scaled, ~2s at 12C 
 
 No burst detector. The failure modes one would cover — CUSUM on enqueue-interval EWMA, `wake_burst` on absolute wakeup rate, `burst_mode` gating slice/depth/preempt behaviors — are instead handled by the oscillator-adapted CoDel target, the placement-side depth gate + L2/R_eff spill, hard starvation rescue or tier information already present at the enqueue site. Tick preemption is derived per-CPU, with no global signal:
 
-- **Per-CPU preempt**: `pandemonium_tick` reads its own `pcpu_enqueue_ns[this_cpu]` — the age of the oldest task waiting on this CPU — against a tau-scaled threshold (`preempt_thresh_ns`): a BATCH resident yields once a waiter ages past the base threshold, an INTERACTIVE resident at 2× (batch-throughput protection), a LAT_CRITICAL resident never. Per-CPU by construction — no token to race over. A single global flag instead (armed at enqueue, cleared by the first tick to preempt on *any* CPU) gets token-stolen across cores under a fork storm, so the CPU actually burying a latency waker rarely wins the race — the audio-under-load pathology (intermittent, single-thread, bursty-only). The per-CPU read reuses the bounded-array scan already running for the coarse per-CPU sojourn check, so no new global state.
+- **Per-CPU preempt**: `pandemonium_tick` reads its own `sojourn_stamp_pcpu[this_cpu]` — the age of the oldest task waiting on this CPU — against a tau-scaled threshold (`preempt_thresh_ns`): a BATCH resident yields once a waiter ages past the base threshold, an INTERACTIVE resident at 2× (batch-throughput protection), a LAT_CRITICAL resident never. Per-CPU by construction — no token to race over. A single global flag instead (armed at enqueue, cleared by the first tick to preempt on *any* CPU) gets token-stolen across cores under a fork storm, so the CPU actually burying a latency waker rarely wins the race — the audio-under-load pathology (intermittent, single-thread, bursty-only). The per-CPU read reuses the bounded-array scan already running for the coarse per-CPU sojourn check, so no new global state.
 - **RT-policy floor**: `SCHED_FIFO`/`SCHED_RR` threads are pinned `TIER_LAT_CRITICAL` by declaration, after the behavioral classifier and the high-prio-kthread→BATCH override. A periodic audio RT thread scores erratically on the behavioral `lat_cri` metric and was flipping out of LAT_CRITICAL mid-burst; threaded USB IRQ kthreads were force-demoted to BATCH. The floor keeps both latency-critical under load, immune to the EWMA jitter.
 - **Core-scaled longrun protection**: during sustained `longrun_mode`, the preempt threshold scales up on thin topologies (τ < 4ms) only, extending the protected BATCH window so they don't thrash; wider topologies keep the baseline, where capacity already absorbs LAT_CRIT contention.
+- **Powersave kick-storm damping**: under powersave on a multi-domain part, `cpu_release` (an RT task seizing a core) floods `scx_bpf_reenqueue_local()` on every preemption — a self-feeding loop where each re-enqueue displaces a resident whose own release re-enqueues again, storming ~96% of intervals (montauk defines a storm as reenq/s ≥ 50k). The fix is NOT on the kick: a forced-soft experiment drove preempt-kicks down with the storm untouched — the kick was never the engine, the unconditional reenqueue flood was. A per-CPU leaky time-budget rate-limits `scx_bpf_reenqueue_local()` itself (≥1ms between reenqueues, a short burst allowed): a brief RT preemption leaves local tasks home to dispatch when RT yields, while sparse preemption reenqueues freely. Continuous budget, no gate, placement (Tier 0/1/2/3) untouched (THE FLAG). montauk A/B: storm 96.5% → 0.0%, reenq 166k → 16k/s.
 
 ### Sojourn Selector + Lag Cap
 
@@ -214,17 +210,17 @@ Because the warp is bounded, a BATCH task older than `lag_cap` always out-sorts 
 
 ### Hard Starvation Rescue
 
-`clamp(K_STARVATION_RESCUE × τ, 20ms, 500ms)` — tau-scaled and monotonic in topology timing: 20ms at 2C, ~80ms at 4C, ~160ms at 8C, ~167ms at 12C (the Core-Count Scaling table values). Runs as the dispatch safety net before STEP 2, ungated; should ~never trip after the placement fix.
+`clamp(K_STARVATION_RESCUE × τ, 20ms, 500ms)` — tau-scaled and monotonic in topology timing: 20ms at 2C, ~80ms at 4C, ~160ms at 8C, ~167ms at 12C (the Core-Count Scaling table values). Runs as the dispatch safety net before STEP 2, ungated; should ~never trip after the placement fix. A pinned single-CPU task (per-CPU kworker, IRQ thread, cpuset) is a separate hazard: it can only run on its one CPU, and if that CPU is idle it never ticks, so the in-tick rescue scan never fires and the task strands until the 30s scx watchdog disables the scheduler. A tick-independent guard on the enqueue path seats a pinned task on its own CPU and `SCX_KICK_IDLE`s it at enqueue (an event scx guarantees runs), closing the watchdog-disable the tick-driven rescue cannot reach.
 
 ### Topology-Aware Placement
 
-**Resistance affinity**: The CPU topology is modeled as a weighted electrical network (L2 siblings = 10.0, same socket = 1.0, cross-socket = 0.3). The Laplacian pseudoinverse (Jacobi eigendecomposition, O(n^3), pure Rust) gives all-pairs migration costs accounting for every path through the graph, not just direct connections. `R_eff(i,j) = L+[i,i] + L+[j,j] - 2*L+[i,j]` — a true metric satisfying the triangle inequality. Per-CPU ranked lists stored in a BPF map sized at `MAX_AFFINITY_CANDIDATES = MAX_CPUS >> 3` slots per CPU (= 128 at MAX_CPUS=1024); the runtime walk is bounded by `nr_cpu_ids - 1`, with `(u32)-1` sentinels marking unused slots so loops early-exit on small N.
+**Resistance affinity**: The CPU topology is modeled as a weighted electrical network (L2/SMT siblings = 1000.0, same L3 = 3.0, same socket = 1.0, cross-socket = 0.3). The Laplacian pseudoinverse (Jacobi eigendecomposition, O(n^3), pure Rust) gives all-pairs migration costs accounting for every path through the graph, not just direct connections. `R_eff(i,j) = L+[i,i] + L+[j,j] - 2*L+[i,j]` — a true metric satisfying the triangle inequality. Per-CPU ranked lists stored in a BPF map sized at `MAX_AFFINITY_CANDIDATES = MAX_CPUS >> 3` slots per CPU (= 128 at MAX_CPUS=1024); the runtime walk is bounded by `nr_cpu_ids - 1`, with `(u32)-1` sentinels marking unused slots so loops early-exit on small N.
 
 **Online-budget search**: `find_idle_by_affinity()` walks the ranked list with an online-candidates budget, not a total-slots budget. The rank map is built once at init from the full topology; after hotplug, some top ranks may reference offline CPUs. Offline entries are skipped without charging budget, so the search cost on a fully-online system is identical to a raw limit of 3, while remaining robust to arbitrary hotplug asymmetry (12C → 8C, 32C → 4C, etc.).
 
-**Tiered R_eff steal (near-before-far)**: the R_eff rank is split once, in Rust at topology detect, into two packed tables — `near_tbl` (same-domain peers, R_eff-ascending) and `far_tbl` (the `FAR_CANDIDATES = 8` nearest cross-domain peers). Each slot is a u64 packing the peer CPU (low 32) and the pre-folded Φ distance penalty in ns (high 32), so one lookup yields both distance and price — strictly fewer map reads than the prior `affinity_rank` + `reff_value` pair. Dispatch STEP 1 walks `near_tbl` under the tau-derived `pcpu_spill_search_budget` (clamped to `[6, min(nr_cpu_ids - 1, MAX_AFFINITY_CANDIDATES)]`); STEP 4b walks `far_tbl` under a constant 8-slot bound, reached only with the home domain exhausted. The split is computed once (topology-static, never a per-dispatch or variable-loop-bound cost) — two earlier inline-loop attempts hit verifier E2BIG path-state explosion, which moving the boundary to Rust-side static tables eliminates. On a monolithic single-domain box `near_tbl` is the full rank and `far_tbl` is all-sentinel — bit-identical prior behavior.
+**R_eff steal (Φ-priced, near-before-far)**: dispatch STEP 1 walks `affinity_rank` — the per-CPU R_eff-ascending peer list (slot 0 = nearest sibling, cross-domain peers included, no tier boundary) — under the tau-derived `pcpu_spill_search_budget` (clamped to `[6, MAX_AFFINITY_CANDIDATES]`). The distance price `b·R_eff` is pre-folded in ns into the `reff_value` map at topology detect, so the steal does one indexed read and no runtime multiply: an SMT sibling (R_eff≈0) relieves freely while a cross-domain pull needs ~τ of sustained backlog. `reff_value` all-zero (monolithic part / `--phi-scale 0`) collapses to a flat `codel_target` — bit-identical prior behavior. This is the CCX/CCD-removal end state: Φ prices cache distance continuously over the whole hierarchy, never a binary same/different-domain gate (THE FLAG).
 
-**wakee_flips gate**: `select_cpu()` reads waker/wakee `wakee_flips` from `task_struct`. Both below `nr_cpu_ids` = 1:1 pipe pair (affinity beneficial). Either above = 1:N server pattern (skip to normal path). Same discrimination as the kernel's `wake_wide()`.
+**Tight-pair gate (`is_handoff_partner`)**: each task's distinct wakers are recorded in a persisted `waker_bitmap`. `popcount(waker_bitmap) <= SHAPE_TIGHT_MAX` marks a 1:1-ish handoff pair (warm co-location beneficial); a high popcount marks a 1:N server (skip to the normal path so clients don't pile on the server's CPU). Same discrimination as the kernel's `wake_wide()`, but persisted and frozen at classification rather than re-derived per wake. The wake placement also tests the wakee's own anchor for idle FIRST (the `affinity_rank` walk excludes self), so a returning wakee re-takes its warm home instead of scattering to a sibling — a per-wake prev_cpu preference, self-limiting under load.
 
 **L2 cache affinity**: `find_idle_l2_sibling()` in enqueue finds idle CPUs in the same L2 domain (max 8 iterations), gated by the `affinity_mode` knob (0=OFF / 1=WEAK / 2=STRONG). The Rust regime baseline sets it per regime (LIGHT=WEAK, MIXED=STRONG, HEAVY=WEAK); MWU can override by majority vote. Per-dispatch L2 hit/miss counters for BATCH, INTERACTIVE, LAT_CRITICAL tiers.
 
@@ -234,7 +230,7 @@ Because the warp is bounded, a BATCH task older than `lag_cap` always out-sorts 
 
 R_eff alone is a placement *ranking* — it orders candidate CPUs by distance but doesn't price a migration against the queueing relief it buys, so a cross-domain steal would be as cheap as an SMT-sibling steal once a head aged. The migration potential prices it: **Φ = R_eff − β·sojourn**, the graph resistance of a move set against the wait it relieves. The dispatch STEP 1 work steal pays Φ, so it crosses a cache boundary only when the backlog justifies the cache cost.
 
-- **R_eff cost oracle**: the per-tier steal penalty `b·R_eff` is pre-folded by Rust into the high 32 bits of each `near_tbl` / `far_tbl` entry at topology detect (`b = phi_dist_scale_q16`), so the dispatch steal reads peer and price from one u64 — no second lookup, no multiply. A companion `reff_value` map — sized and indexed like the rank, `reff_value[cpu * MAX_AFFINITY_CANDIDATES + slot] = (R_eff(cpu, target) × b) >> 16` in ns, `(u32)-1` past the topology end — remains the price source for the warm-stay home anchor (slot 0) and the MWU oscillator gating, which need a CPU's nearest-peer penalty outside the steal walk.
+- **R_eff cost oracle**: the steal distance penalty `b·R_eff` is pre-folded by Rust into the `reff_value` map at topology detect (`b = phi_dist_scale_q16`), so the dispatch steal reads the price with one indexed lookup — no runtime multiply. `reff_value[cpu * MAX_AFFINITY_CANDIDATES + slot] = (R_eff(cpu, target) × b) >> 16` in ns, paired 1:1 with `affinity_rank`, `(u32)-1` past the topology end. The same map sources the warm-stay home anchor's slot-0 penalty and the steal's per-peer price; `domain_phi` (the min-conductance cut price between a CPU and each ranked peer, also 1:1 with the rank) is its companion, read by the tight-pair steal hold. All-zero on a monolithic part / `--phi-scale 0` — flat `codel_target`, prior behavior.
 - **Distance-scaled steal resist**: STEP 1 / STEP 4b relieve a peer only once its head has waited past `codel_target_ns + (penalty >> 32)`, the penalty read straight from the tier-table entry's high bits. An SMT sibling (`R_eff ≈ 0`) stays freely relievable at the flat CoDel target; a cross-domain pull must show ~τ of sustained backlog before the steal crosses the domain boundary. The scale is topology-owned (`phi_dist_scale_q16`, folded in at detect) and is always computed now (T1): on a single-domain part it calibrates to the L2 boundary instead of vanishing, so the continuous metric prices distance on every processor with no binary topology gate. Penalties are all-zero only pre-first-tick or under `--phi-scale 0`, which collapses the threshold to the flat `codel_target_ns` as if Φ were absent.
 - **Shape-routed warm placement**: before the topology-blind `scx_bpf_select_cpu_dfl` any-idle pick — which can seat a wakee on a cross-domain idle core with a cold L3, the storm's residual cache-miss source — the wakee is anchored on its own last core and searched R_eff-near (same L2/cache domain first). A TIGHT pair grabs its exact warm core when free (tightest consolidation); both shapes then take the nearest idle; only a fully warm-busy neighborhood falls through to dfl.
 - **Warm-stay (Φ-priced home anchor)**: a wakee whose stable home — `home_cpu`, pinned to its first CPU and never chasing the `last_cpu` a migration storm rewrites every stop — is uncongested is held there rather than fanned to a cold idle sibling. It is the placement dual of the steal threshold, releasing at the SAME point. `select_cpu` only DEFERS (returns the anchor without dispatching); `enqueue` TIER 0 seats the wakee on the home's own per-CPU DSQ with `KICK_PREEMPT` — the kick a busy core honors. The idle fast path still never places on a busy core: a `KICK_IDLE` there is a no-op that strands the wakee until the resident yields (the ~90% deadline-miss scar), so the busy placement lives only in enqueue. The hold releases once the home's sojourn passes `codel_target + dist_extra` — the home's own nearest-peer Φ penalty, read from `reff_value` slot 0 — so a near (low-R_eff) home releases quickly while a far cross-domain home holds hard: one threshold, no binary STORM branch. `reff_value` all-zero (monolithic / `--phi-scale 0`) collapses it to the bare `codel_target`. LAT_CRITICAL and kthreads are exempt — they flee for immediacy.
@@ -274,7 +270,7 @@ All timing constants scale from `tau_ns = TAU_SCALE_NS / √(λ₂ · N)` — ca
 | Parameter | Formula | 2C | 4C | 8C | 12C | 32C |
 |-----------|---------|------------|----|----|----|----|
 | Sojourn interval | `clamp(K × τ, 2ms, 12ms)` | 2ms | 4ms | 8ms | 12ms | 5ms |
-| Overflow rescue | `= codel_target_equilibrium_ns` (R_eff-derived) | varies | varies | varies | varies | varies |
+| Overflow rescue | `= codel_seed_ns` (R_eff-derived) | varies | varies | varies | varies | varies |
 | Starvation rescue | `clamp(K × τ, 20ms, 500ms)` | 20ms | 80ms | 160ms | 166ms | 21ms |
 | CoDel target floor | `clamp(K × τ, 200µs, 800µs)` | 200µs | 200µs | 500µs | 700µs | 200µs |
 | CoDel target max | `clamp(K × τ, 1ms, 8ms)` | 1ms | 1ms | 1ms | 2ms | 1ms |
@@ -324,11 +320,11 @@ src/
     stress.rs          CPU-pinned stress worker (Python test harness hook)
 build.rs               vmlinux.h generation + C23 patching + BPF compilation
 tests/
-  pandemonium-tests.py Test orchestrator (bench-scale, bench-contention,
-                         bench-pcpu, bench-scx, bench-sys, low-cpu-deadline)
-  bench-fork-thread.py Fork/thread IPC benchmark (full scx field) + hw counters + non-compensatory regression gate
-  bench-power.py       Energy-efficiency benchmark (RAPL J/op + idle floor)
-  bench-enduser.py     One-command shareable report (montauk digest: specs + ranked offenders + metrics, redacted)
+  pandemonium-tests.py Test orchestrator (prism-scale, prism-contention,
+                         prism-pcpu, prism-scx, prism-sys, low-cpu-deadline)
+  prism-fork-thread.py Fork/thread IPC benchmark (full scx field) + hw counters + non-compensatory regression gate
+  prism-power.py       Energy-efficiency benchmark (RAPL J/op + idle floor)
+  prism.py     One-command shareable report (montauk digest: specs + ranked offenders + metrics, redacted)
   gate.rs              Integration test gate (load/classify/latency/responsiveness/contention)
 include/
   scx/                 Vendored sched_ext headers
@@ -352,7 +348,7 @@ BPF per-CPU histograms              Monitor Thread (1s loop)
                                       v
                                     BPF reads knobs on next dispatch
 
-Resistance affinity: R_eff ranked map -> BPF select_cpu (wakee_flips-gated)
+Resistance affinity: R_eff ranked map -> BPF select_cpu (is_handoff_partner-gated)
 L2 placement:        affinity_mode knob -> BPF enqueue (per-regime baseline; MWU vote)
 Migration potential: R_eff cost oracle + phi_dist_scale_q16 -> BPF dispatch STEP 1 steal resist
 Sojourn threshold:   sojourn_thresh_ns knob -> BPF dispatch (core-count-scaled, codel_eq-floored)
@@ -466,26 +462,26 @@ d/s: 251000 idle: 5% shared: 230000 preempt: 12 keep: 0 kick: H=8000 S=22000 enq
 ## Benchmarking
 
 ```bash
-./pandemonium.py bench-scale                     # Full suite (throughput, latency, burst, longrun, mixed, deadline, IPC, launch)
-./pandemonium.py bench-scale --iterations 3      # Multi-iteration
-./pandemonium.py bench-scale --pandemonium-only  # Skip EEVDF and externals
-./pandemonium.py bench-contention                # Contention stress (6 phases)
-./pandemonium.py bench-pcpu                      # Per-CPU DSQ correctness
-./pandemonium.py bench-fork-thread               # Fork/thread IPC + hw counters + regression gate
-./pandemonium.py bench-power                     # Energy efficiency (RAPL J/op + idle floor)
-./pandemonium.py bench-sys                       # Live system telemetry capture
-./pandemonium.py bench-scx                       # sched-ext/scx CI compatibility
-./pandemonium.py bench-cachyos                   # CachyOS Mini-Benchmarker application suite
-./pandemonium.py bench-enduser                   # One-command shareable report (specs + ranked misbehaving items + metrics)
-./pandemonium.py bench-enduser --schedulers scx_rusty,scx_lavd  # Add named scx schedulers to the cachyos field (EEVDF + PANDEMONIUM always in)
-./pandemonium.py bench-enduser --all-scx         # Add the full installed scx field instead (mutually exclusive with --schedulers)
-./pandemonium.py bench-enduser --workload "ffmpeg -i in.mkv out.mp4"   # Trace YOUR isolated workload instead of the fixed profile
-./pandemonium.py bench-enduser --attach chrome --duration 30           # Trace an already-running program for 30s
+./pandemonium.py prism-scale                     # Full suite (throughput, latency, burst, longrun, mixed, deadline, IPC, launch)
+./pandemonium.py prism-scale --iterations 3      # Multi-iteration
+./pandemonium.py prism-scale --pandemonium-only  # Skip EEVDF and externals
+./pandemonium.py prism-contention                # Contention stress (6 phases)
+./pandemonium.py prism-pcpu                      # Per-CPU DSQ correctness
+./pandemonium.py prism-fork-thread               # Fork/thread IPC + hw counters + regression gate
+./pandemonium.py prism-power                     # Energy efficiency (RAPL J/op + idle floor)
+./pandemonium.py prism-sys                       # Live system telemetry capture
+./pandemonium.py prism-scx                       # sched-ext/scx CI compatibility
+./pandemonium.py prism-cachyos                   # CachyOS Mini-Benchmarker application suite
+./pandemonium.py prism                   # One-command shareable report (specs + ranked misbehaving items + metrics)
+./pandemonium.py prism --schedulers scx_rusty,scx_lavd  # Compare EEVDF against the named scx schedulers (add 'pandemonium' to the list to include the PANDEMONIUM arms)
+./pandemonium.py prism --all-scx         # Add the full installed scx field instead (mutually exclusive with --schedulers)
+./pandemonium.py prism --workload "ffmpeg -i in.mkv out.mp4"   # Trace YOUR isolated workload instead of the fixed profile
+./pandemonium.py prism --attach chrome --duration 30           # Trace an already-running program for 30s
 ```
 
 All benchmarks compare across core counts via CPU hotplug (2, 4, 8, ..., max). Results archived to `~/.cache/pandemonium/`.
 
-`bench-enduser` is the one command a user runs to send a report. It runs a short
+`prism` is the one command a user runs to send a report. It runs a short
 fixed profile — the cachyos application workloads, a fork/exec storm, an IPC
 round-trip and capped (20s) burst-starvation and contention captures — under
 your scheduler and EEVDF as a neutral reference, traces each with montauk, and
@@ -495,13 +491,13 @@ a thermal/power block, then the key wake-to-run metrics. Process names are
 hashed and the raw traces stay local — you share only the report. montauk is the
 only data source; the script orchestrates and assembles, nothing more.
 
-If montauk isn't installed, bench-enduser clones it from its repo and drives
+If montauk isn't installed, prism clones it from its repo and drives
 montauk's own installer: two prompts up front decide whether it installs montauk
 permanently (capped so `--trace` needs no sudo) or builds it just for the run and
 removes it after. It self-elevates for the trace, ejects any scheduler it loaded
 if you Ctrl+C, and when a build dependency is missing it prints the exact install
 command for your distro (CachyOS, Arch, Gentoo, OpenSUSE, Ubuntu, NixOS). Share
-the resulting `enduser-report-*.txt`.
+the resulting `prism-report-*.txt`.
 
 If you have already isolated the problem to one program, skip the fixed profile
 and capture that program directly: `--workload "<command>"` launches your

--- a/scheds/rust/scx_pandemonium/src/adaptive.rs
+++ b/scheds/rust/scx_pandemonium/src/adaptive.rs
@@ -269,6 +269,7 @@ pub fn monitor_loop(
         // None UNTIL THE WINDOW HAS RQA_MIN_SAMPLES FILLED.
         let (idle_lambda, _idle_hvg_s) = chaos::hvg_stats(&idle_win);
         let wake_bp_h = chaos::bandt_pompe_d3(&wake_win);
+        let spill_temp_q16 = tuning::spill_temp_q16(wake_bp_h);
         let bp_delta = wake_bp_h - prev_bp_h;
         let mean_idle = chaos::mean(&idle_win);
         let rqa = chaos::rqa_det(&idle_win);
@@ -305,6 +306,7 @@ pub fn monitor_loop(
                 let mut rk = scaled_regime_knobs(regime, nr_cpus, tau_ns);
                 rk.topology_tau_ns = tau_ns;
                 rk.codel_eq_ns = live.codel_eq_ns;
+                rk.spill_temp_q16 = spill_temp_q16;
                 sched.write_tuning_knobs(&rk)?;
                 last_written_knobs = rk;
                 regime_changed_this_tick = true;
@@ -381,6 +383,7 @@ pub fn monitor_loop(
                 let live = sched.read_tuning_knobs();
                 knobs.topology_tau_ns = live.topology_tau_ns;
                 knobs.codel_eq_ns = live.codel_eq_ns;
+                knobs.spill_temp_q16 = spill_temp_q16;
                 // COMMIT-ON-CHANGE: only push to the BPF map when an
                 // MWU-owned field actually moved. The BPF side reads the
                 // map unsynchronized -- skipping redundant writes strictly

--- a/scheds/rust/scx_pandemonium/src/adaptive.rs
+++ b/scheds/rust/scx_pandemonium/src/adaptive.rs
@@ -103,13 +103,6 @@ pub fn monitor_loop(
     rk.topology_tau_ns = tau_ns;
     rk.codel_eq_ns = live.codel_eq_ns;
     sched.write_tuning_knobs(&rk)?;
-    // SEED THE MWU BASELINE WITH THE LIVE PHI EQUILIBRIUM AT TICK 0. new()
-    // BUILT mwu FROM scaled_regime_knobs (codel_eq_ns=0); set_baseline IS
-    // OTHERWISE ONLY CALLED ON A REGIME CHANGE. WITHOUT THIS SEED THE SOJOURN
-    // FLOOR (tuning.rs) FALLS BACK TO THE DEAD 4ms CONSTANT FOR ANY RUN WHOSE
-    // REGIME NEVER CHANGES (E.G. A STEADY MIXED BENCH), SO THE PHI-COHERENT
-    // FLOOR WOULD NEVER ENGAGE.
-    mwu.set_baseline(rk);
     // COMMIT-ON-CHANGE BASELINE: the last knob set actually written to
     // the BPF map. Updated here at init, on every regime-change write,
     // and on every conditional write. MWU-owned fields drive the diff.
@@ -160,7 +153,6 @@ pub fn monitor_loop(
         let delta_shared = stats.nr_shared.wrapping_sub(prev.nr_shared);
         let delta_preempt = stats.nr_preempt.wrapping_sub(prev.nr_preempt);
         let delta_keep = stats.nr_keep_running.wrapping_sub(prev.nr_keep_running);
-        let delta_parks = stats.nr_osc_park.wrapping_sub(prev.nr_osc_park);
         let delta_wake_sum = stats.wake_lat_sum.wrapping_sub(prev.wake_lat_sum);
         let delta_wake_samples = stats.wake_lat_samples.wrapping_sub(prev.wake_lat_samples);
         let delta_hard = stats.nr_hard_kicks.wrapping_sub(prev.nr_hard_kicks);
@@ -170,19 +162,7 @@ pub fn monitor_loop(
         let delta_rescue = stats
             .nr_overflow_rescue
             .wrapping_sub(prev.nr_overflow_rescue);
-        // CROSS-DOMAIN SCATTER (PATHWAY 6 INPUT). PLACEMENT-SIDE PATHS ONLY:
-        // XDOM_SEL_* + XDOM_ENQ_T1/T2 (INDICES 0..6). THE PHI-CORRECT WORK-
-        // CONSERVATION PATHS XDOM_STEAL (6) AND XDOM_STEP5 (7) ARE EXCLUDED --
-        // PENALIZING THEM WOULD MAKE MWU FIGHT THE BPF'S DELIBERATE REBALANCING.
-        // saturating_sub ABSORBS A COUNTER RESET (BPF RELOAD) AS 0, NO GARBAGE.
-        let scatter_now: u64 = stats.nr_cross_domain[0..6].iter().sum();
-        let scatter_prev: u64 = prev.nr_cross_domain[0..6].iter().sum();
-        let delta_scatter = scatter_now.saturating_sub(scatter_prev);
-        let scatter_pct = if delta_d > 0 {
-            delta_scatter * 100 / delta_d
-        } else {
-            0
-        };
+        let delta_parks = stats.nr_osc_park.wrapping_sub(prev.nr_osc_park);
         let wake_avg_us = if delta_wake_samples > 0 {
             delta_wake_sum / delta_wake_samples / 1000
         } else {
@@ -373,7 +353,6 @@ pub fn monitor_loop(
                     // Per-CPU normalization here re-introduced an nr_cpus^2 effective
                     // threshold and latched on quiet 2-4C systems.
                     wakeup_rate: delta_enq_wake,
-                    scatter_pct,
                     hvg_lambda: idle_lambda,
                     bp_h_delta: bp_delta,
                     // Same window HVG sees -- feeds compute_damp() for
@@ -445,7 +424,7 @@ pub fn monitor_loop(
         let knobs = sched.read_tuning_knobs();
 
         let sojourn_ms = stats.batch_sojourn_ns / 1_000_000;
-        let sojourn_thresh_ms = knobs.sojourn_thresh_ns / 1_000_000;
+        let sojourn_thresh_ms = knobs.codel_thresh_ns / 1_000_000;
         let longrun_label = if stats.longrun_mode_active > 0 {
             " LONGRUN"
         } else {
@@ -456,7 +435,7 @@ pub fn monitor_loop(
             let rqa_disp = rqa.unwrap_or(-1.0);
             let frozen_disp = if frozen { 1 } else { 0 };
             println!(
-                "d/s: {:<8} idle: {}% shared: {:<6} preempt: {:<4} keep: {:<4} kick: H={:<4} S={:<4} enq: W={:<4} R={:<4} wake: {}us p99: {}us [B:{} I:{} L:{}] lat_idle: {}us lat_kick: {}us procdb: {}/{} sleep: io={}% slice: {}us batch: {}us reenq: {} sjrn: {}ms/{}ms rescue: {} l2: B={}% I={}% L={}% chaos: lam={:.2} H={:.2} det={:.2} x={} frozen: {} (n={}) retune_iv: {} [{}{}]",
+                "d/s: {:<8} idle: {}% shared: {:<6} preempt: {:<4} keep: {:<4} kick: H={:<4} S={:<4} enq: W={:<4} R={:<4} wake: {}us p99: {}us [B:{} I:{} L:{}] lat_idle: {}us lat_kick: {}us procdb: {}/{} sleep: io={}% slice: {}us batch: {}us reenq: {} sjrn: {}ms/{}ms rescue: {} park: {} l2: B={}% I={}% L={}% chaos: lam={:.2} H={:.2} det={:.2} x={} frozen: {} (n={}) retune_iv: {} [{}{}]",
                 delta_d, idle_pct, delta_shared, delta_preempt, delta_keep,
                 delta_hard, delta_soft, delta_enq_wake, delta_enq_requeue,
                 wake_avg_us, p99_us, tp99_b, tp99_i, tp99_l,
@@ -464,7 +443,7 @@ pub fn monitor_loop(
                 db_total, db_confident,
                 io_pct, knobs.slice_ns / 1000, knobs.batch_slice_ns / 1000,
                 delta_reenq, sojourn_ms, sojourn_thresh_ms,
-                delta_rescue,
+                delta_rescue, delta_parks,
                 l2_pct_b, l2_pct_i, l2_pct_l,
                 idle_lambda, wake_bp_h, rqa_disp, chaos_count.load(),
                 frozen_disp, frozen_ticks, retune_interval,
@@ -478,7 +457,6 @@ pub fn monitor_loop(
             delta_shared,
             delta_preempt,
             delta_keep,
-            delta_parks,
             wake_avg_us,
             delta_hard,
             delta_soft,
@@ -537,24 +515,13 @@ pub fn monitor_loop(
     } else {
         0
     };
-    // CROSS-DOMAIN SCATTER ATTRIBUTION (PER XDOM_* PATH). scatter_pct IS THE
-    // PLACEMENT-SIDE FRACTION (idx 0..6) PATHWAY 6 ACTS ON; THE PER-PATH COUNTS
-    // ARE THE PERMANENT ATTRIBUTION SURFACED TO THE BENCH SUITE EVERY RUN.
-    let x = &final_stats.nr_cross_domain;
-    let x_scatter: u64 = x[0..6].iter().sum();
-    let x_scatter_pct = if final_stats.nr_dispatches > 0 {
-        x_scatter * 100 / final_stats.nr_dispatches
-    } else {
-        0
-    };
     println!(
-        "[KNOBS] regime={} slice_ns={} batch_ns={} preempt_ns={} mwu={:.3} ticks=L:{}/M:{}/H:{} frozen={} l2_hit=B:{}%/I:{}%/L:{}% cross_domain_scatter_pct={} cross_domain_sel_tight={} cross_domain_sel_sync={} cross_domain_sel_normal={} cross_domain_sel_dfl={} cross_domain_enq_t1={} cross_domain_enq_t2={} cross_domain_steal={} cross_domain_step5={}",
+        "[KNOBS] regime={} slice_ns={} batch_ns={} preempt_ns={} mwu={:.3} ticks=L:{}/M:{}/H:{} frozen={} l2_hit=B:{}%/I:{}%/L:{}%",
         regime.label(), final_knobs.slice_ns, final_knobs.batch_slice_ns,
         final_knobs.preempt_thresh_ns,
         mwu.scale(regime),
         light_ticks, mixed_ticks, heavy_ticks, frozen_ticks,
         l2_cum_b, l2_cum_i, l2_cum_l,
-        x_scatter_pct, x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7],
     );
 
     // READ UEI EXIT REASON

--- a/scheds/rust/scx_pandemonium/src/bpf/intf.h
+++ b/scheds/rust/scx_pandemonium/src/bpf/intf.h
@@ -13,11 +13,6 @@ typedef unsigned char u8;
 // BPF VERIFIER LOOP BOUNDS
 #define MAX_CPUS  1024
 #define MAX_NODES 32
-// EMERGENT OVERFLOW-DOMAIN CEILING. The min-conductance partition yields small
-// domain counts (Ryzen 3000: 2, EPYC: up to ~16); 32 is a comfortable cap. The
-// overflow DSQs are pre-allocated at init (DSQs are cheap); nr_overflow_domains,
-// walked from Rust at topology detect, gates which are live.
-#define MAX_OVERFLOW_DOMAINS 32
 // AFFINITY_RANK STORAGE PER CPU. EACH CPU'S R_eff-RANKED PEERS ARE
 // STORED HERE; STEP 1 R_eff STEAL AND THE PLACEMENT-SIDE SPILL HELPER
 // WALK THIS LIST WITH A TAU-DERIVED RUNTIME BUDGET CAPPED BY nr_cpu_ids
@@ -42,7 +37,7 @@ struct tuning_knobs {
 	u64 lat_cri_thresh_high; // CLASSIFIER: LAT_CRITICAL THRESHOLD (DEFAULT 32)
 	u64 lat_cri_thresh_low;  // CLASSIFIER: INTERACTIVE THRESHOLD (DEFAULT 8)
 	u64 affinity_mode;      // L2 PLACEMENT: 0=OFF, 1=WEAK, 2=STRONG
-	u64 sojourn_thresh_ns;  // BATCH DSQ RESCUE THRESHOLD (SET BY RUST)
+	u64 codel_thresh_ns;    // BATCH DSQ RESCUE THRESHOLD (SET BY RUST)
 	u64 burst_slice_ns;     // SLICE CEILING DURING BURST/LONGRUN (SET BY RUST, DEFAULT 1MS)
 	u64 topology_tau_ns;    // FIEDLER-DERIVED TIME CONSTANT (1/lambda_2).
 	                        // 0 MEANS RUST HAS NOT YET WRITTEN tau; BPF
@@ -53,8 +48,6 @@ struct tuning_knobs {
 	                        // <R_eff> * 2m * tau, CLAMPED [200us, 8ms].
 	                        // 0 MEANS NOT YET WRITTEN. WRITTEN AT TOPOLOGY
 	                        // DETECT AND ON HOTPLUG (CO-LOCATED WITH tau).
-	// PHI DISTANCE PENALTY IS PRE-FOLDED INTO THE reff_value MAP (IN NS) BY
-	// RUST AT TOPOLOGY DETECT -- NO KNOB FIELD: BPF READS THE MAP DIRECTLY.
 };
 
 // PER-CPU STATISTICS (BPF_MAP_TYPE_PERCPU_ARRAY VALUE)
@@ -90,37 +83,11 @@ struct pandemonium_stats {
 	// LONGRUN: 1 IF SUSTAINED BATCH PRESSURE DETECTED, 0 OTHERWISE, WRITTEN BY tick()
 	u64 longrun_mode_active;
 	// OVERFLOW SOJOURN RESCUE: TASKS DISPATCHED BY try_service_older_overflow
-	// AT overflow_sojourn_rescue_ns (DISPATCH STEP 2)
+	// AT codel_target_ns (DISPATCH STEP 2)
 	u64 nr_overflow_rescue;
-	// CROSS-DOMAIN SCATTER ATTRIBUTION: PER-PLACEMENT-PATH COUNT OF LANDINGS
-	// WHERE THE CHOSEN CPU IS IN A DIFFERENT cache domain THAN THE TASK'S last_cpu.
-	// INDEXED BY XDOM_* BELOW. THE ADAPTIVE LAYER CONSUMES THE PLACEMENT-SIDE
-	// PATHS (XDOM_SEL_* + XDOM_ENQ_T1) AS THE MWU CROSS-DOMAIN SCATTER LOSS
-	// PATHWAY, AND THE BENCH SUITE SURFACES ALL PATHS PER RUN. THE PHI-CORRECT
-	// PATHS (XDOM_STEAL, XDOM_STEP5) ARE TRACKED BUT EXCLUDED FROM THE LOSS --
-	// THEY ARE DELIBERATE WORK-CONSERVATION MOVES, NOT SCATTER TO SUPPRESS.
-	u64 nr_cross_domain[8];
-	// OSCILLATOR ENVELOPE: PARK ENTRIES (CPU-0 TICK WRITER). ZERO AFTER AN
-	// IDLE-HEAVY RUN MEANS THE ENVELOPE NEVER PARKED -- THE MIET-COLLAPSE
-	// FAILURE MODE THE BENCH MUST BE ABLE TO DETECT.
+	// IDLE QUIESCENCE ENVELOPE: TIMES THE OSCILLATOR PARKED AT EQUILIBRIUM
 	u64 nr_osc_park;
-	// SPILL-KICK ATTRIBUTION: select_cpu wakeups whose seat was redirected off
-	// the verified-idle pick onto a busy spill CPU, kicked with SCX_KICK_PREEMPT
-	// instead of the no-op SCX_KICK_IDLE. The signal that confirms the tick-floor
-	// strand fix -- it should track the formerly tick-floored burst wakes while
-	// the >=900us wake2run bucket collapses.
-	u64 nr_spill_kick_preempt;
 };
-
-// XDOM path indices for pandemonium_stats.nr_cross_domain[] (diagnostic).
-#define XDOM_SEL_TIGHT   0   // select_cpu WAKE_SYNC tight-partner colocation
-#define XDOM_SEL_SYNC    1   // select_cpu WAKE_SYNC phi_warm_target
-#define XDOM_SEL_NORMAL  2   // select_cpu normal_path phi_warm_target
-#define XDOM_SEL_DFL     3   // select_cpu scx_bpf_select_cpu_dfl idle pick
-#define XDOM_ENQ_T1      4   // enqueue TIER 1 idle (pick_idle_cpu_node)
-#define XDOM_ENQ_T2      5   // enqueue TIER 2 warm-anchor spill
-#define XDOM_STEAL       6   // dispatch STEP 1 R_eff steal (this_cpu vs peer)
-#define XDOM_STEP5       7   // dispatch STEP 5 cross-domain work-conservation scan
 
 // PROCESS CLASSIFICATION: BPF OBSERVES, RUST LEARNS, BPF APPLIES
 // SHARED BETWEEN BPF MAPS (task_class_observe, task_class_init) AND RUST (procdb.rs)

--- a/scheds/rust/scx_pandemonium/src/bpf/intf.h
+++ b/scheds/rust/scx_pandemonium/src/bpf/intf.h
@@ -34,8 +34,6 @@ struct tuning_knobs {
 	u64 slice_ns;           // BASE TIME SLICE (DEFAULT 1MS)
 	u64 preempt_thresh_ns;  // TICK PREEMPTION THRESHOLD (DEFAULT 1MS)
 	u64 batch_slice_ns;     // BATCH TASK SLICE CEILING (DEFAULT 20MS)
-	u64 lat_cri_thresh_high; // CLASSIFIER: LAT_CRITICAL THRESHOLD (DEFAULT 32)
-	u64 lat_cri_thresh_low;  // CLASSIFIER: INTERACTIVE THRESHOLD (DEFAULT 8)
 	u64 affinity_mode;      // L2 PLACEMENT: 0=OFF, 1=WEAK, 2=STRONG
 	u64 codel_thresh_ns;    // BATCH DSQ RESCUE THRESHOLD (SET BY RUST)
 	u64 burst_slice_ns;     // SLICE CEILING DURING BURST/LONGRUN (SET BY RUST, DEFAULT 1MS)
@@ -48,6 +46,7 @@ struct tuning_knobs {
 	                        // <R_eff> * 2m * tau, CLAMPED [200us, 8ms].
 	                        // 0 MEANS NOT YET WRITTEN. WRITTEN AT TOPOLOGY
 	                        // DETECT AND ON HOTPLUG (CO-LOCATED WITH tau).
+	u64 spill_temp_q16;     // SPILL-Phi #69: T_base*(1+kappa*H) Q16, from perm-entropy
 };
 
 // PER-CPU STATISTICS (BPF_MAP_TYPE_PERCPU_ARRAY VALUE)

--- a/scheds/rust/scx_pandemonium/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_pandemonium/src/bpf/main.bpf.c
@@ -42,10 +42,6 @@ const volatile u64 nr_cpu_ids = 1;
 #define TIER_INTERACTIVE  1
 #define TIER_LAT_CRITICAL 2
 
-#define LAT_CRI_THRESH_HIGH  32
-#define LAT_CRI_THRESH_LOW   8
-#define LAT_CRI_CAP          255
-
 // HIGH-PRIORITY KTHREAD THRESHOLD: NICE <= -10 EQUIVALENT.
 // static_prio = nice + 120, SO nice <= -10 IS static_prio <= 110.
 // PF_KTHREAD AT NICE -20 OFTEN SCORE LAT_CRITICAL BEHAVIORALLY
@@ -64,10 +60,6 @@ const volatile u64 nr_cpu_ids = 1;
 #define WEIGHT_INTERACTIVE   192   // 1.5X
 #define WEIGHT_BATCH         128   // 1X
 
-#define EWMA_AGE_MATURE      8
-#define EWMA_AGE_CAP         16
-#define MAX_WAKEUP_FREQ      64
-#define MAX_CSW_RATE         512
 // WARP CEILING: TAU-DERIVED IN apply_tau_scaling() VIA K_LAG_CAP. THE UPPER
 // BOUND ON THE SOJOURN warp IN task_deadline() (warp = lag_cap_ns *
 // task_potentiality_q16 >> 16), SO THE WARP IS STARVATION-FREE. AT THE 12C REFERENCE
@@ -129,10 +121,6 @@ static struct { u64 inter; u64 batch; } sojourn_stamp_overflow;
 // FROM EMPTY. DISPATCH AND TICK CHECK THESE TO DETECT STALE TASKS.
 // WORK STEALING + DEPTH GATE HANDLE MOST CASES; THIS IS THE SAFETY NET.
 static u64 sojourn_stamp_pcpu[MAX_CPUS];
-// PINNED KERNEL-SERVICE per-CPU rescue stamp: set when a pinned_service kthread
-// (ksoftirqd/N, kworker/N) is enqueued to its home CPU, read by tick() to preempt
-// a held hog at the tight floor, cleared when the kthread runs.
-static u64 pcpu_pinned_strand_ns[MAX_CPUS];
 
 static u64 codel_starve_ns;
 static u32 pcpu_depth_base;
@@ -316,6 +304,19 @@ struct {
 	__type(value, u32);
 } reff_value SEC(".maps");
 
+// PHI SPILL DEPTH ORACLE: PER-CPU PRE-FOLDED PLACEMENT THRESHOLD TO EACH TARGET.
+// spill_depth[cpu * MAX_AFFINITY_CANDIDATES + slot] = THE MAX PEER DSQ DEPTH AT
+// WHICH A SPILL TO affinity_rank[cpu][slot] IS STILL WORTH ITS R_eff DISTANCE,
+// FOLDED BY RUST AT TOPOLOGY DETECT. THE PLACEMENT SPILL READS IT DIRECTLY -- ONE
+// INDEXED READ, NO MULTIPLY, MIRRORING THE STEAL reff_value READ. PAIRS 1:1 WITH
+// affinity_rank. NEAR PEERS HIGH, FAR PEERS NEAR-EMPTY-ONLY; FLAT ON MONOLITHIC.
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_CPUS * MAX_AFFINITY_CANDIDATES);
+	__type(key, u32);
+	__type(value, u32);
+} spill_depth SEC(".maps");
+
 // STEP 1 SCAN RATE-LIMIT: per-CPU timestamp of the last R_eff steal scan.
 // PERCPU SO IT IS THIS-CPU-LOCAL -- NO CROSS-CPU COHERENCE TRAFFIC. THE PEER
 // WALK (affinity_rank + PER-PEER nr_queued) IS THE DOMINANT PER-DISPATCH CACHE
@@ -351,21 +352,14 @@ struct {
 
 struct task_ctx {
 	u64 last_run_at;
-	u64 wakeup_freq;
 	u64 last_woke_at;
 	u64 enqueue_at;      // SET AT EVERY scx_bpf_dsq_insert_vtime SITE;
 	                     // CONSUMED IN pandemonium_running TO COMPUTE
 	                     // PER-TASK SOJOURN (LITERAL CoDel METRIC).
 	                     // CLEARED AFTER CONSUME TO AVOID STALE READS.
-	u64 avg_runtime;
-	u64 runtime_dev;     // EWMA OF |RUNTIME - AVG_RUNTIME| (VARIANCE SIGNAL)
 	u64 cached_weight;
-	u64 prev_nvcsw;
-	u64 csw_rate;
-	u64 lat_cri;
 	u64 sleep_start_ns;  // SET IN quiescent(), USED IN running()
 	u32 tier;
-	u32 ewma_age;
 	s32 last_cpu;        // LAST CPU THIS TASK RAN ON (FOR CACHE AFFINITY)
 	u8  dispatch_path;   // 0=IDLE, 1=HARD_KICK, 2=SOFT_KICK
 	u8  ran_since_wake;  // is_wakeup = !ran_since_wake; SET 1 IN running(), 0 ON WAKE
@@ -545,7 +539,14 @@ static __always_inline s32 find_pcpu_with_room(s32 src_cpu,
 			continue;
 		if (allowed && !bpf_cpumask_test_cpu((s32)*val, allowed))
 			continue;
-		if (scx_bpf_dsq_nr_queued((u64)*val) < pcpu_depth_base)
+		// PHI SPILL PRICE (apply-only, #70): Rust pre-folded R_eff into a
+		// per-peer depth threshold at topology detect; the BPF does one indexed
+		// read and compares -- near peers accept at higher depth, far peers
+		// near-empty only. Mirrors the STEAL reff_value read. spill_depth 0
+		// (pre-populate / unfilled slot) falls back to the flat pcpu_depth_base.
+		u32 *sdp = bpf_map_lookup_elem(&spill_depth, &key);
+		u32 sd = (sdp && *sdp) ? *sdp : pcpu_depth_base;
+		if (scx_bpf_dsq_nr_queued((u64)*val) < sd)
 			return (s32)*val;
 		if (++checked >= pcpu_spill_search_budget)
 			break;
@@ -936,8 +937,6 @@ static __always_inline void pcpu_drain_clear(u32 cpu)
 	u64 old = sojourn_stamp_pcpu[cpu];
 	if (old > 0)
 		__sync_val_compare_and_swap(&sojourn_stamp_pcpu[cpu], old, 0);
-	if (pcpu_pinned_strand_ns[cpu] > 0)
-		pcpu_pinned_strand_ns[cpu] = 0;
 }
 
 // HISTOGRAM BUCKETING: MATCHES HIST_EDGES_NS AND SLEEP_EDGES_NS IN RUST
@@ -966,52 +965,6 @@ static __always_inline u32 sleep_bucket(u64 sleep_ns)
 	return 3;
 }
 
-// EWMA
-
-static __always_inline u64 calc_avg(u64 old_val, u64 new_val, u32 age)
-{
-	if (age < EWMA_AGE_MATURE)
-		return (old_val >> 1) + (new_val >> 1);
-	return old_val - (old_val >> 3) + (new_val >> 3);
-}
-
-static __always_inline u64 update_freq(u64 freq, u64 interval_ns, u32 age)
-{
-	if (interval_ns == 0)
-		interval_ns = 1;
-	u64 new_freq = (100ULL * 1000000ULL) / interval_ns;
-	return calc_avg(freq, new_freq, age);
-}
-
-// BEHAVIORAL CLASSIFICATION
-
-// LAT_CRI SCORE: HIGH WAKEUP FREQ + HIGH CSW RATE + SHORT RUNTIME = CRITICAL
-static __always_inline u64 compute_lat_cri(u64 wakeup_freq, u64 csw_rate,
-					    u64 avg_runtime_ns,
-					    u64 runtime_dev_ns)
-{
-	u64 effective_runtime_ns = avg_runtime_ns + (runtime_dev_ns >> 1);
-	u64 avg_runtime_ms = effective_runtime_ns >> 20;
-	if (avg_runtime_ms == 0)
-		avg_runtime_ms = 1;
-	u64 score = (wakeup_freq * csw_rate) / avg_runtime_ms;
-	if (score > LAT_CRI_CAP)
-		score = LAT_CRI_CAP;
-	return score;
-}
-
-static __always_inline u32 classify_tier(u64 lat_cri,
-					  const struct tuning_knobs *knobs)
-{
-	u64 thresh_high = knobs ? knobs->lat_cri_thresh_high : LAT_CRI_THRESH_HIGH;
-	u64 thresh_low  = knobs ? knobs->lat_cri_thresh_low  : LAT_CRI_THRESH_LOW;
-	if (lat_cri >= thresh_high)
-		return TIER_LAT_CRITICAL;
-	if (lat_cri >= thresh_low)
-		return TIER_INTERACTIVE;
-	return TIER_BATCH;
-}
-
 // TRACE: FAST 4-BYTE COMM CHECK FOR SCHEDULER PROCESS TRACING
 // CATCHES "pandemonium" WITH ZERO MAP OVERHEAD. GATED BY TRACE_SCHED BECAUSE
 // ALL CALL SITES ARE #if TRACE_SCHED -- WITHOUT THE GUARD ON THE DEFINITION,
@@ -1029,16 +982,16 @@ static __always_inline u64 effective_weight(const struct task_struct *p,
 					     const struct task_ctx *tctx)
 {
 	u64 weight = p->scx.weight;
-	u64 behavioral;
+	u64 tier_weight;
 
 	if (tctx->tier == TIER_LAT_CRITICAL)
-		behavioral = WEIGHT_LAT_CRITICAL;
+		tier_weight = WEIGHT_LAT_CRITICAL;
 	else if (tctx->tier == TIER_INTERACTIVE)
-		behavioral = WEIGHT_INTERACTIVE;
+		tier_weight = WEIGHT_INTERACTIVE;
 	else
-		behavioral = WEIGHT_BATCH;
+		tier_weight = WEIGHT_BATCH;
 
-	return weight * behavioral >> 7;
+	return weight * tier_weight >> 7;
 }
 
 // SCHEDULING HELPERS
@@ -1049,49 +1002,23 @@ static __always_inline u64 effective_weight(const struct task_struct *p,
 // sojourn (now - enqueue_at). The tier warp back-dates higher tiers so
 // they sort ahead; it is BOUNDED (<= lag_cap_ns), so a stream of
 // LAT_CRITICAL wakeups can never starve a BATCH task older than the warp.
-// PER-TASK SOJOURN POTENTIAL (Q16, 0..65536). TIER SETS THE CEILING SHARE;
-// PER-TASK BEHAVIOR SETS THE MAGNITUDE. BOUNDED SUM OF MONOTONIC RAMPS --
-// CONTINUOUS, NO TIER CLIFF, NO UNBOUNDED ADVANTAGE.
+// PER-TASK SOJOURN POTENTIAL (Q16, 0..65536). TIER ALONE SETS IT -- A FLAT
+// PER-TIER CONSTANT BOUNDED BY lag_cap_ns, NO PER-TASK MAGNITUDE.
 static __always_inline u32 task_potentiality_q16(const struct task_ctx *tctx,
 						 const struct tuning_knobs *knobs)
 {
-	if (tctx->ewma_age < EWMA_AGE_MATURE)
-		return 0;                  // UNOBSERVED: NO POTENTIAL
+	// FLAT TIER WARP: ROLE sets the warp -- a flat per-tier constant, no earning,
+	// no maturity gate. The unified sojourn bound (sweep_bound_preempt), not the warp,
+	// guarantees starvation-freedom, so the warp is pure ordering preference, never a
+	// rescue lever. LAT_CRITICAL full ceiling; BATCH none; everything else --
+	// INTERACTIVE, including the pinned per-CPU kservice bumped to TIER_INTERACTIVE in
+	// runnable() -- the v5.11.0 half-ceiling. The warp is a pure function of tier.
+	(void)knobs;
+	if (tctx->tier == TIER_LAT_CRITICAL)
+		return 1u << 16;           // RT: ABSOLUTE FULL CEILING
 	if (tctx->tier == TIER_BATCH)
 		return 0;                  // BATCH NEVER WARPS
-	if (tctx->tier == TIER_LAT_CRITICAL)
-		return 1u << 16;           // RT FLOOR: ABSOLUTE, FULL CEILING
-
-	// PINNED KERNEL-SERVICE FLOOR: the welded per-CPU kworker userspace blocks
-	// on earns its back-date by ROLE, not interactive shape. Its bursty I/O work
-	// scores ~0 on both axes below, so the behavioral earner would strand it
-	// behind a LAT_CRITICAL holder until the ~167ms codel net instead of the
-	// ~20ms warp. A pure read of the ONE pinned_service judgement set in
-	// runnable() -- no PF_KTHREAD/cpumask re-test. BELOW the LAT_CRITICAL ceiling.
-	if (tctx->pinned_service)
-		return 1u << 15;           // == lag_cap_ns>>1, the v5.11.0 INTERACTIVE value
-
-	// INTERACTIVE: EARNED CONTINUOUSLY FROM PER-TASK BEHAVIOR.
-	u64 slice = knobs ? knobs->slice_ns : 1000000;
-	u64 avg = tctx->avg_runtime;
-	u32 acc = 0;                       // Q16 EXCESS, CAP 65536
-
-	// AXIS 1 -- SERVICE DEFICIT: SHORT RUNTIME PER ACTIVATION (YIELDS
-	// BEFORE ITS QUANTUM) EARNS WARP; A FULL-SLICE HOG EARNS NONE.
-	if (slice > 0 && avg < slice) {
-		u32 c = (u32)(((slice - avg) << 16) / slice);
-		acc += c > 32768u ? 32768u : c;
-	}
-
-	// AXIS 2 -- SHAPE: LOW RUNTIME VARIANCE RELATIVE TO MEAN (PERIODIC,
-	// FRAME-PACED) EARNS WARP; CHAOTIC BURSTINESS EARNS NONE. INVERSE CV.
-	if (avg > 0 && tctx->runtime_dev < avg) {
-		u32 c = (u32)(((avg - tctx->runtime_dev) << 16) / avg);
-		c = c > 32768u ? 32768u : c;
-		acc = (acc > 65536u - c) ? 65536u : acc + c;
-	}
-
-	return acc;                        // 0..65536
+	return 1u << 15;                   // INTERACTIVE + pinned kservice == lag_cap_ns>>1
 }
 
 static __always_inline u64 task_deadline(struct task_ctx *tctx,
@@ -1099,12 +1026,10 @@ static __always_inline u64 task_deadline(struct task_ctx *tctx,
 {
 	u64 now = bpf_ktime_get_ns();
 
-	// SOJOURN POTENTIAL (v5.12 ANTI-LEAPFROG, CONTINUOUS FORM): warp IS A
-	// BOUNDED PER-TASK POTENTIAL, NOT A FLAT TIER CONSTANT. lag_cap_ns IS THE
-	// CEILING (STARVATION BOUND); task_potentiality_q16 POSITIONS THE BACK-DATE
-	// CONTINUOUSLY FROM THE TASK'S OWN SERVICE DEFICIT + SHAPE. SLEEPY/PERIODIC
-	// -> NEAR-FULL WARP; CPU-HOG OR CHAOTIC -> ~0. UNMATURED TASKS GET 0, SO A
-	// FORK STORM STILL CANNOT LEAPFROG ESTABLISHED WORK.
+	// SOJOURN WARP: ordering is now - warp. The warp is a flat per-tier constant
+	// scaled by lag_cap_ns (the starvation ceiling); task_potentiality_q16 returns
+	// the tier's share. The bound, not the warp, guarantees starvation-freedom, so
+	// a fork storm competes on arrival order and cannot leapfrog established work.
 	u64 warp = (lag_cap_ns * task_potentiality_q16(tctx, knobs)) >> 16;
 
 	// SOJOURN BACK-PRESSURE: ORDERING IS now - warp, OLDEST-FIRST -- A STARVING
@@ -1114,10 +1039,8 @@ static __always_inline u64 task_deadline(struct task_ctx *tctx,
 	return now > warp ? now - warp : 0;
 }
 
-// PER-TIER DYNAMIC SLICING
-// LAT_CRITICAL: 1.5X AVG_RUNTIME (TIGHT -- FAST PREEMPTION)
-// INTERACTIVE:  2X AVG_RUNTIME (RESPONSIVE)
-// BATCH:        KNOB BASE SLICE (CONTROLLED BY ADAPTIVE LAYER)
+// PER-TIER SLICING: LAT_CRITICAL and INTERACTIVE get the knob base slice as a
+// flat max-quantum cap; BATCH gets the adaptive-layer base slice.
 static __always_inline u64 task_slice(const struct task_ctx *tctx,
 				      const struct tuning_knobs *knobs)
 {
@@ -1127,19 +1050,11 @@ static __always_inline u64 task_slice(const struct task_ctx *tctx,
 		? knobs->burst_slice_ns : knobs->slice_ns) : 1000000;
 	u64 base;
 
-	if (tctx->tier == TIER_LAT_CRITICAL) {
-		base = tctx->avg_runtime + (tctx->avg_runtime >> 1);
-		if (base > base_slice)
-			base = base_slice;
-		if (base < SLICE_MIN_NS)
-			base = SLICE_MIN_NS;
-		return base;
-	}
-
-	if (tctx->tier == TIER_INTERACTIVE) {
-		base = tctx->avg_runtime << 1;
-		if (base > base_slice)
-			base = base_slice;
+	// FLAT SLICE: LAT_CRITICAL and INTERACTIVE get the knob base_slice as a flat
+	// max-quantum cap -- these tiers yield early on sleep, so the slice is a
+	// ceiling, not a target, a pure function of tier and the knobs.
+	if (tctx->tier == TIER_LAT_CRITICAL || tctx->tier == TIER_INTERACTIVE) {
+		base = base_slice;
 		if (base < SLICE_MIN_NS)
 			base = SLICE_MIN_NS;
 		return base;
@@ -1330,15 +1245,9 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 		if (home >= 0 && (u64)home < nr_cpu_ids) {
 			dl = task_deadline(tctx, knobs);
 			scx_bpf_dsq_insert_vtime(p, (u64)home, sl, dl, enq_flags);
-			// Mark this CPU as carrying a welded waiter so tick() can rescue it
-			// at the tight preempt floor if this PREEMPT-kick does not take. Stamp
-			// BOTH the pinned-strand stamp AND the generic per-CPU waiter stamp:
-			// tick() returns early when sojourn_stamp_pcpu[cpu]==0, so without this
-			// second stamp the pinned rescue is unreachable when the welded kworker
-			// waits alone behind a LAT_CRITICAL hog -- the 122s kworker strand.
+			// Stamp the per-CPU waiter age so the dispatch sweep sees a stranded
+			// pinned kthread and preempts the holder at the bound, off-tick.
 			u64 pin_now = bpf_ktime_get_ns();
-			__sync_val_compare_and_swap(
-				&pcpu_pinned_strand_ns[home & (MAX_CPUS - 1)], 0, pin_now);
 			__sync_val_compare_and_swap(
 				&sojourn_stamp_pcpu[home & (MAX_CPUS - 1)], 0, pin_now);
 			scx_bpf_kick_cpu(home, SCX_KICK_PREEMPT);
@@ -1464,12 +1373,9 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 	}
 
 	// TIER 3: NODE OVERFLOW DSQ + SELECTIVE KICK
-	// ONLY BATCH-CLASSIFIED TASKS GO TO BATCH DSQ.
-	// IMMATURE TASKS (ewma_age < 2) STAY IN INTERACTIVE DSQ TO PREVENT
-	// STARVATION DURING BURST SPAWNS -- NEW THREADS STARTING WITH
-	// ewma_age=0 WOULD FLOOD THE BATCH DSQ AND STARVE FOR 30-40S
-	// WAITING FOR SOJOURN RESCUE THAT NEVER REACHES THE TAIL.
-	// LAT_CRITICAL TASKS ARE NEVER REDIRECTED.
+	// ONLY BATCH-TIER TASKS GO TO THE BATCH DSQ. INTERACTIVE AND LAT_CRITICAL
+	// STAY IN node_dsq -- THE BATCH DSQ IS FOR COMPUTE-CLASS WORK ONLY, SO A
+	// BURST OF FRESH INTERACTIVE THREADS CANNOT FLOOD IT AND STARVE THE TAIL.
 	u64 target_dsq = (tctx && tctx->tier == TIER_BATCH)
 		? (nr_cpu_ids + nr_nodes + (u64)node)
 		: node_dsq;
@@ -1530,6 +1436,44 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 // 4. NODE BATCH OVERFLOW (NORMAL BATCH FALLBACK)
 // 5. CROSS-NODE STEAL (INTERACTIVE + BATCH PER REMOTE NODE)
 // 6. KEEP_RUNNING IF PREV STILL WANTS CPU AND NOTHING QUEUED
+#define BOUND_SWEEP_BUDGET 8
+// UNIFIED SOJOURN BOUND SWEEP (v5.16.0 -- the single starvation enforcer). Any CPU
+// whose per-CPU DSQ head has waited >= lag_cap_ns -- the bound the sort key already
+// promises, since warp <= lag_cap_ns -- gets a PREEMPT kick, ANY tier, no exemption.
+// It runs from dispatch on every CPU, so a CPU walled off by a non-yielding resident
+// is rescued by ANY OTHER CPU's dispatch -- off the held CPU's own tick, so NO_HZ_FULL
+// cannot suppress it. Rotating budget window: O(1) per dispatch, flat as N grows.
+static __always_inline void sweep_bound_preempt(u64 now, u32 self)
+{
+	u32 nr = nr_cpu_ids;
+	if (nr == 0)
+		return;
+	u32 base = (u32)(now >> 20);
+	#pragma unroll
+	for (u32 i = 0; i < BOUND_SWEEP_BUDGET; i++) {
+		u32 c = (base + (u32)i) % nr;
+		if (c == self)
+			continue;
+		u64 stamp = sojourn_stamp_pcpu[c & (MAX_CPUS - 1)];
+		if (stamp == 0)
+			continue;
+		if (now > stamp && (now - stamp) >= lag_cap_ns)
+			scx_bpf_kick_cpu(c, SCX_KICK_PREEMPT);
+	}
+	// OVERFLOW BOUND: a node/batch overflow head aged past lag_cap is drained by
+	// any CPU's dispatch (STEP 3/4); if every CPU is held, force one off-tick by
+	// preempting a rotating CPU so it re-enters dispatch and drains the aged head.
+	// Rare -- overflow normally drains within the codel band, far below lag_cap.
+	u64 ie = sojourn_stamp_overflow.inter;
+	u64 be = sojourn_stamp_overflow.batch;
+	if ((ie != 0 && now > ie && (now - ie) >= lag_cap_ns) ||
+	    (be != 0 && now > be && (now - be) >= lag_cap_ns)) {
+		u32 k = base % nr;
+		if (k != self)
+			scx_bpf_kick_cpu(k, SCX_KICK_PREEMPT);
+	}
+}
+
 void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 {
 	s32 node = __COMPAT_scx_bpf_cpu_node(cpu);
@@ -1538,6 +1482,11 @@ void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 	u64 batch_dsq = nr_cpu_ids + nr_nodes + (u64)node;
 	struct pandemonium_stats *s;
 	u64 now = bpf_ktime_get_ns();
+
+	// UNIFIED BOUND, FIRST: rescue any CPU whose per-CPU DSQ head has waited past
+	// lag_cap_ns before this CPU runs its own placement waterfall. Hard invariant
+	// ahead of placement, off the held CPU's tick (this is another CPU's dispatch).
+	sweep_bound_preempt(now, (u32)cpu);
 
 	// STEP 0: OWN PER-CPU DSQ -- HIGHEST PRIORITY, CACHE-HOT.
 	// SOJOURN GATE AT EXIT: IF EITHER OVERFLOW SIDE HAS AGED PAST
@@ -1723,65 +1672,31 @@ void BPF_STRUCT_OPS(pandemonium_runnable, struct task_struct *p,
 	if (!tctx)
 		return;
 
-	u64 now = bpf_ktime_get_ns();
 	tctx->ran_since_wake = false;
-
-	// FAST PATH: BRAND-NEW TASKS (< 2 WAKEUPS)
-	if (tctx->ewma_age < 2) {
-		tctx->last_woke_at = now;
-		tctx->prev_nvcsw = p->nvcsw;
-		tctx->ewma_age += 1;
-		return;
-	}
-
-	// WAKEUP FREQUENCY
-	u64 delta_t = now > tctx->last_woke_at ? now - tctx->last_woke_at : 1;
-	tctx->wakeup_freq = update_freq(tctx->wakeup_freq, delta_t,
-					 tctx->ewma_age);
-	if (tctx->wakeup_freq > MAX_WAKEUP_FREQ)
-		tctx->wakeup_freq = MAX_WAKEUP_FREQ;
-	tctx->last_woke_at = now;
-
-	if (tctx->ewma_age < EWMA_AGE_CAP)
-		tctx->ewma_age += 1;
-
-	// VOLUNTARY CONTEXT SWITCH RATE
-	u64 nvcsw = p->nvcsw;
-	u64 csw_delta = nvcsw > tctx->prev_nvcsw ? nvcsw - tctx->prev_nvcsw : 0;
-	tctx->prev_nvcsw = nvcsw;
-
-	if (csw_delta > 0 && delta_t > 0) {
-		u64 csw_freq = csw_delta * (100ULL * 1000000ULL) / delta_t;
-		tctx->csw_rate = calc_avg(tctx->csw_rate, csw_freq,
-					   tctx->ewma_age);
-	} else {
-		tctx->csw_rate = calc_avg(tctx->csw_rate, 0, tctx->ewma_age);
-	}
-	if (tctx->csw_rate > MAX_CSW_RATE)
-		tctx->csw_rate = MAX_CSW_RATE;
-
-	// BEHAVIORAL CLASSIFICATION
-	tctx->lat_cri = compute_lat_cri(tctx->wakeup_freq, tctx->csw_rate,
-					 tctx->avg_runtime, tctx->runtime_dev);
+	tctx->last_woke_at = bpf_ktime_get_ns();
 	struct tuning_knobs *knobs = get_knobs();
-	u32 new_tier = classify_tier(tctx->lat_cri, knobs);
+	(void)knobs;
 
-	// HIGH-PRIORITY KTHREAD OVERRIDE: PF_KTHREAD AT NICE <= -10 LOOK
-	// LATENCY-SENSITIVE TO THE BEHAVIORAL SCORER (SHORT RUNTIMES, HIGH
-	// WAKEUP FREQUENCY) BUT ARE COMPUTE CLASS. LEFT IN LAT_CRITICAL THEY
-	// DOMINATE DISPATCH OVER LEGITIMATE USERSPACE INTERACTIVE WORK UNDER
-	// HEAVY KERNEL LOAD. FORCED TO BATCH SO THEY STILL GET WEIGHTED
-	// PREFERENCE WITHIN BATCH BUT DO NOT MIX WITH USER LAT_CRITICAL.
-	// PF_WQ_WORKER IS A PF_KTHREAD SUBSET HANDLED BY THE FLOOR BELOW
-	// (WORKQUEUE WORKERS STAY INTERACTIVE).
+	// ROLE-BASED TIER (v5.16.0): no EWMA, no maturity gate, no behavioral model.
+	// Scheduling policy decides; the kthread floors below refine kernel threads,
+	// and stopping() demotes a userspace hog by consecutive full slices.
+	u32 new_tier = (p->policy == SCHED_FIFO || p->policy == SCHED_RR)
+		? TIER_LAT_CRITICAL : TIER_INTERACTIVE;
+
+	// HIGH-PRIORITY KTHREAD OVERRIDE: PF_KTHREAD AT NICE <= -10 IS COMPUTE
+	// CLASS. LEFT IN LAT_CRITICAL THEY DOMINATE DISPATCH OVER LEGITIMATE
+	// USERSPACE INTERACTIVE WORK UNDER HEAVY KERNEL LOAD. FORCED TO BATCH SO
+	// THEY STILL GET WEIGHTED PREFERENCE WITHIN BATCH BUT DO NOT MIX WITH USER
+	// LAT_CRITICAL. PF_WQ_WORKER IS A PF_KTHREAD SUBSET HANDLED BY THE FLOOR
+	// BELOW (WORKQUEUE WORKERS STAY INTERACTIVE).
 	if (p->flags & PF_KTHREAD &&
 	    p->static_prio <= KTHREAD_HIPRI_STATIC_PRIO_MAX)
 		new_tier = TIER_BATCH;
 
 	// KERNEL-INFRASTRUCTURE FLOOR: WORKQUEUE WORKERS HANDLE I/O COMPLETIONS,
 	// TIMER CALLBACKS, AND DEFERRED INTERRUPT WORK. USERSPACE BLOCKS ON THESE.
-	// THEIR LOW EWMA SCORES (INFREQUENT WAKEUPS, LONG RUNTIMES) PUSH THEM TO
-	// BATCH, BUT THEY ARE LATENCY-CRITICAL KERNEL INFRASTRUCTURE. EXTENDED TO THE
+	// A NAIVE BY-ACTIVITY TIERING WOULD UNDERWEIGHT THEM, BUT THEY ARE
+	// LATENCY-CRITICAL KERNEL INFRASTRUCTURE. EXTENDED TO THE
 	// PER-CPU SOFTIRQ DAEMONS (ksoftirqd/N -- PF_KTHREAD, ONE ALLOWED CPU, NOT A
 	// PF_WQ_WORKER): THEY RUN THE SAME DEFERRED WORK (softirqs) USERSPACE BLOCKS
 	// ON BUT MISSED THE PF_WQ_WORKER FLOOR AND BURIED IN BATCH node_dsq, FALLING
@@ -1790,7 +1705,7 @@ void BPF_STRUCT_OPS(pandemonium_runnable, struct task_struct *p,
 	// PINNED KERNEL-SERVICE: the ONE kthread judgement, computed here and nowhere
 	// else. A per-CPU kthread (ksoftirqd/N, kworker/N) welded to its home CPU that
 	// userspace blocks on. enqueue() reads pinned_service for forced home-CPU
-	// placement; tick() reads it for the preempt backstop. WQ workers that are NOT
+	// placement and to stamp the sweep's sojourn signal. WQ workers that are NOT
 	// pinned (unbound, nr_cpus_allowed>1) still get the INTERACTIVE floor below but
 	// not the home-CPU forcing -- they can run anywhere, so steal/spill applies.
 	bool pinned_kservice =
@@ -1803,7 +1718,7 @@ void BPF_STRUCT_OPS(pandemonium_runnable, struct task_struct *p,
 
 	// RT-POLICY FLOOR: SCHED_FIFO/SCHED_RR (PipeWire/JACK RT THREADS, THREADED
 	// IRQ kthreads) ARE LATENCY-CRITICAL BY POLICY. PIN LAT_CRITICAL REGARDLESS
-	// OF THE BEHAVIORAL SCORE AND THE kthread->BATCH OVERRIDE ABOVE.
+	// OF THE kthread->BATCH OVERRIDE ABOVE.
 	if (p->policy == SCHED_FIFO || p->policy == SCHED_RR)
 		new_tier = TIER_LAT_CRITICAL;
 
@@ -1826,13 +1741,7 @@ void BPF_STRUCT_OPS(pandemonium_running, struct task_struct *p)
 		return;
 	}
 
-	// PINNED KERNEL-SERVICE: this CPU's welded waiter is now running -- clear the
-	// rescue stamp so tick() stops preempting the resident for it.
-	if (tctx->pinned_service) {
-		u32 rcpu = bpf_get_smp_processor_id();
-		if (rcpu < MAX_CPUS)
-			pcpu_pinned_strand_ns[rcpu] = 0;
-	}
+	// (pinned strand stamp removed v5.16.0 -- the dispatch sweep needs no clear)
 
 	u64 now = bpf_ktime_get_ns();
 	tctx->last_run_at = now;
@@ -1900,7 +1809,7 @@ void BPF_STRUCT_OPS(pandemonium_running, struct task_struct *p)
 	scx_bpf_task_set_slice(p, task_slice(tctx, knobs));
 }
 
-// STOPPING: TASK YIELDS CPU -- UPDATE RUNTIME EWMA, DEMOTE CPU-BOUND TASKS
+// STOPPING: TASK YIELDS CPU -- REFRESH CACHED WEIGHT AND LAST CPU
 void BPF_STRUCT_OPS(pandemonium_stopping, struct task_struct *p,
 		    bool runnable)
 {
@@ -1911,54 +1820,10 @@ void BPF_STRUCT_OPS(pandemonium_stopping, struct task_struct *p,
 	tctx->cached_weight = effective_weight(p, tctx);
 	tctx->last_cpu = bpf_get_smp_processor_id();
 
-	u64 now = bpf_ktime_get_ns();
-	u64 slice = now > tctx->last_run_at ? now - tctx->last_run_at : 0;
-	{
-		u64 avg = tctx->avg_runtime;
-		u64 diff = slice > avg ? slice - avg : avg - slice;
-		tctx->avg_runtime = calc_avg(avg, slice, tctx->ewma_age);
-		tctx->runtime_dev = calc_avg(tctx->runtime_dev, diff,
-					      tctx->ewma_age);
-	}
-
-	// CPU-BOUND DEMOTION. Long-runners that never sleep keep ewma_age
-	// pinned at 1 (incremented only on sleep->runnable in runnable()),
-	// so classify_tier never reruns. The classifier-based path leaves
-	// such tasks at TIER_INTERACTIVE indefinitely, which makes them
-	// unpreemptible by tick() (only TIER_BATCH receives the tick rescue
-	// at line ~2031). Threshold scales with slice_ns: an INTERACTIVE
-	// long-runner's avg_runtime asymptotes to the slice cap, so a
-	// fixed-ns threshold above slice_ns can never fire for the exact
-	// tasks the demotion is meant to catch. 75% of slice_cap catches
-	// pure CPU-bound within ~6 stop cycles (~6ms wall). The ewma_age
-	// guard spares legit interactive tasks that use full slice but
-	// sleep frequently -- their ewma_age grows on every sleep->wake.
-	{
-		struct tuning_knobs *kk = get_knobs();
-		u64 slice_cap = kk ? kk->slice_ns : 1000000;
-		if (tctx->tier == TIER_INTERACTIVE &&
-		    tctx->avg_runtime * 4 >= slice_cap * 3 &&
-		    tctx->ewma_age <= 4) {
-			tctx->tier = TIER_BATCH;
-			tctx->cached_weight = effective_weight(p, tctx);
-		}
-	}
-
-	// PROCDB: PUBLISH TASK CLASSIFICATION FOR USERSPACE
-	// INITIAL AT EWMA MATURITY, THEN EVERY 64 SCHEDULING EVENTS
-	// RE-PUBLISHING KEEPS PROCDB FRESH FOR LONG-LIVED TASKS
-	if (tctx->ewma_age == EWMA_AGE_MATURE ||
-	    (tctx->ewma_age > EWMA_AGE_MATURE && tctx->ewma_age % 64 == 0)) {
-		struct task_class_entry obs = {};
-		obs.tier = (u8)tctx->tier;
-		obs.avg_runtime = tctx->avg_runtime;
-		obs.runtime_dev = tctx->runtime_dev;
-		obs.wakeup_freq = tctx->wakeup_freq;
-		obs.csw_rate = tctx->csw_rate;
-		char key[16];
-		__builtin_memcpy(key, p->comm, 16);
-		bpf_map_update_elem(&task_class_observe, key, &obs, BPF_ANY);
-	}
+	// stopping() only refreshes cached state now. The unified sweep preempts any
+	// tier at the bound, so there is no hog demotion and no per-task runtime
+	// maintenance here. If a userspace INTERACTIVE hog ever needs demotion, gate
+	// it on a consecutive-full-slice counter.
 
 }
 
@@ -2145,30 +2010,8 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 		if (bpf_get_smp_processor_id() == 0)
 			longrun_mode = sojourn > longrun_thresh_ns;
 
-		// SOJOURN ENFORCEMENT: THRESHOLD SET BY RUST ADAPTIVE LAYER FROM
-		// OBSERVED DISPATCH RATE. IF OVERFLOW HAS STARVED PAST THE THRESHOLD,
-		// KICK THIS CPU TO FORCE A DISPATCH OF THE BURIED TASK.
-		// PREEMPT BATCH *OR* INTERACTIVE RUNNERS: the old "interactive slices
-		// are short, they yield on their own" assumption holds in isolation but
-		// breaks under a fork-storm -- the cores run a conveyor belt of
-		// interactive workers, each yielding fast only for the NEXT storm
-		// worker, so the buried task never gets in. Preempting an interactive
-		// runner under sustained starvation is the just-enough back-pressure
-		// that lets it through; LATCRIT is left alone (genuinely top priority).
-		// PER-CPU (NOT CPU-0-ONLY): EACH CPU SELF-PREEMPTS WHEN IT'S HOGGING.
-		// Key the kick on the R_eff overflow-gate delta, NOT the tighter adaptive
-		// sojourn_thresh: STEP 0/1 only fall through to serve overflow once the
-		// sojourn passes codel_target_ns, so a kick fired earlier just
-		// lets the freed core re-grab another storm worker. Aligning the two means
-		// the preempted core actually lands on the buried task on re-dispatch.
-		if (sojourn > codel_target_ns) {
-			struct task_ctx *tctx = lookup_task_ctx(p);
-			if (tctx && (tctx->tier == TIER_BATCH ||
-				     tctx->tier == TIER_INTERACTIVE)) {
-				scx_bpf_kick_cpu(scx_bpf_task_cpu(p), SCX_KICK_PREEMPT);
-				return;
-			}
-		}
+		// OVERFLOW PREEMPT REMOVED (v5.16.0): the dispatch sweep preempts a
+		// stranded overflow/per-CPU head at the bound, off-tick. No tick kick.
 	} else {
 		if (bpf_get_smp_processor_id() == 0)
 			longrun_mode = false;
@@ -2176,159 +2019,16 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 			s->batch_sojourn_ns = 0;
 	}
 
-	// PER-CPU DSQ SOJOURN: CHECK OWN DSQ + ROTATING GLOBAL SCAN.
-	// LOCAL CHECK: CATCHES STALE TASKS ON THIS CPU.
-	// GLOBAL SCAN: CATCHES STALE TASKS ON IDLE CPUS WHERE tick() NEVER
-	// FIRES. ROTATES 4 CPUS PER TICK SO ALL CPUS GET COVERED OVER TIME.
-	{
-		u32 this_cpu = bpf_get_smp_processor_id();
-		u64 now2 = bpf_ktime_get_ns();
-		u64 codel_thresh_ns = knobs
-			? knobs->codel_thresh_ns : 5000000;
+	// PER-CPU TICK SCAN REMOVED (v5.16.0): the interactive rescue, the local
+	// per-CPU kick and the rotating remote scan all preempted a stranded waiter
+	// from the tick -- sweep_bound_preempt() does this off-tick now, at the bound,
+	// for any tier on any CPU, so the tick no longer touches preemption at all.
 
-		// INTERACTIVE RESCUE: PREEMPT A BATCH HOG PAST preempt_thresh
-		if (sojourn_stamp_overflow.inter && this_cpu < MAX_CPUS) {
-			struct task_ctx *rtctx = lookup_task_ctx(p);
-			if (rtctx && rtctx->tier == TIER_BATCH) {
-				u64 pbase = knobs
-					? knobs->preempt_thresh_ns : 1000000;
-				u64 pthr = longrun_mode
-					? (pbase << longrun_preempt_shift) : pbase;
-				u64 on_cpu = rtctx->last_run_at > 0
-					? now2 - rtctx->last_run_at : 0;
-				if (on_cpu >= pthr) {
-					scx_bpf_kick_cpu(this_cpu,
-							 SCX_KICK_PREEMPT);
-					return;
-				}
-			}
-		}
-
-		// LOCAL: OWN PER-CPU DSQ
-		if (this_cpu < MAX_CPUS) {
-			u64 pcpu_oldest = sojourn_stamp_pcpu[this_cpu];
-			if (pcpu_oldest > 0 &&
-			    (now2 - pcpu_oldest) > codel_thresh_ns) {
-				scx_bpf_kick_cpu(this_cpu,
-						 SCX_KICK_PREEMPT);
-				return;
-			}
-		}
-
-		// REMOTE PER-CPU DSQ SCAN.
-		// CARVE-OUT (SEE topology.rs): THIS IS A COVERAGE BUDGET OVER
-		// THE ACTIVE CPU RANGE, NOT A TIMING DECISION -- nr_cpu_ids IS
-		// THE NATURAL UNIT, NOT tau.
-		// AT nr_cpu_ids <= 4 THE BUDGET OF 4 ALREADY FITS THE WHOLE
-		// TOPOLOGY, SO COVER EVERY ACTIVE CPU EACH TICK; UNCONDITIONAL
-		// ROTATION OVER MAX_CPUS=64 WOULD WASTE 94-97% OF SCAN SLOTS
-		// ON NONEXISTENT CPUs.
-		// AT nr_cpu_ids > 4, ROTATE 4 CPUs PER TICK; WRAP WITHIN THE
-		// ACTIVE RANGE VIA MODULO SO THE BUDGET IS SPENT ON REAL CPUs.
-		if (nr_cpu_ids > 0) {
-			u32 nr = nr_cpu_ids;
-			if (nr <= 4) {
-				for (u32 i = 0; i < 4; i++) {
-					if (i >= nr)
-						break;
-					u32 scan_cpu = i;
-					if (scan_cpu == this_cpu)
-						continue;
-					u64 remote_stamp = sojourn_stamp_pcpu[
-						scan_cpu & (MAX_CPUS - 1)];
-					if (remote_stamp > 0 &&
-					    (now2 - remote_stamp) > codel_thresh_ns)
-						scx_bpf_kick_cpu(scan_cpu,
-								 SCX_KICK_PREEMPT);
-				}
-			} else {
-				u32 scan_base = (u32)(now2 >> 20);
-				for (int i = 0; i < 4; i++) {
-					u32 scan_cpu =
-						(scan_base + (u32)i) % nr;
-					if (scan_cpu == this_cpu)
-						continue;
-					u64 remote_stamp = sojourn_stamp_pcpu[
-						scan_cpu & (MAX_CPUS - 1)];
-					if (remote_stamp > 0 &&
-					    (now2 - remote_stamp) > codel_thresh_ns)
-						scx_bpf_kick_cpu(scan_cpu,
-								 SCX_KICK_PREEMPT);
-				}
-			}
-		}
-	}
-
-	// PER-CPU PREEMPT: SIGNAL IS sojourn_stamp_pcpu[this_cpu] (OLDEST WAITER AGE),
-	// SO EACH CPU DECIDES FROM ITS OWN STATE -- NO GLOBAL TOKEN. THE COARSE
-	// sojourn_thresh NET ABOVE HANDLED THE LONG-WAIT CASE; THIS IS THE TIGHT
-	// BAND AT k*tau (preempt_thresh_ns): BATCH RESIDENT YIELDS AT THE BASE,
-	// INTERACTIVE AT 2x, LAT_CRITICAL NEVER.
-	u32 wcpu = bpf_get_smp_processor_id();
-	if (wcpu >= MAX_CPUS)
-		return;
-	u64 waiter = sojourn_stamp_pcpu[wcpu];
-	if (waiter == 0)
-		return;
-
-	u64 wnow = bpf_ktime_get_ns();
-	u64 wait_age = wnow > waiter ? wnow - waiter : 0;
-	struct task_ctx *tctx = lookup_task_ctx(p);
-
-	// PINNED KERNEL-SERVICE RESCUE: a welded ksoftirqd/kworker waiter whose enqueue
-	// PREEMPT-kick did not take (LAT_CRITICAL holder) must not age to the generic 2x
-	// codel_target backstop -- it is softirq/workqueue work userspace blocks on.
-	// Rescue at the tight preempt floor. Stamp set in enqueue(), cleared in running().
-	u64 pin_wait = pcpu_pinned_strand_ns[wcpu];
-	if (pin_wait > 0) {
-		u64 pin_age = wnow > pin_wait ? wnow - pin_wait : 0;
-		u64 pin_thresh = knobs ? knobs->preempt_thresh_ns : 1000000;
-		if (pin_age >= pin_thresh) {
-			scx_bpf_kick_cpu(wcpu, SCX_KICK_PREEMPT);
-			if (!s)
-				s = get_stats();
-			if (s)
-				s->nr_preempt += 1;
-			return;
-		}
-	}
-
-	// PINNED-WAITER BACKSTOP: a per-CPU DSQ waiter aged past 2x codel_target
-	// preempts the holder even when the resident is LAT_CRITICAL or ctxless.
-	// This is the pinned kernel-service rescue (the enqueue PREEMPT-kick is the
-	// primary; this catches the case where it did not take, e.g. the holder is
-	// LAT_CRITICAL and the tight-band exemption below would otherwise let it
-	// strand the welded ksoftirqd/kworker indefinitely -- steal cannot rescue a
-	// pinned task). Sits just above the steal beat and far below the ~167ms net,
-	// so it only fires for the no-rescue strand. A price on the exemption, not
-	// its removal -- a genuinely short task never ages this far.
-	if (wait_age >= (codel_target_ns << 1)) {
-		scx_bpf_kick_cpu(wcpu, SCX_KICK_PREEMPT);
-		if (!s)
-			s = get_stats();
-		if (s)
-			s->nr_preempt += 1;
-		return;
-	}
-
-	// TIGHT-BAND PREEMPT: BATCH yields at the base, INTERACTIVE at 2x,
-	// LAT_CRITICAL exempt (the backstop above is its only override).
-	if (!tctx || tctx->tier == TIER_LAT_CRITICAL)
-		return;
-
-	u64 base_thresh = knobs ? knobs->preempt_thresh_ns : 1000000;
-	u64 batch_thresh = longrun_mode ? (base_thresh << longrun_preempt_shift)
-			 : base_thresh;
-	u64 thresh = tctx->tier == TIER_INTERACTIVE ? (batch_thresh << 1)
-		   : batch_thresh;
-
-	if (wait_age >= thresh) {
-		scx_bpf_kick_cpu(wcpu, SCX_KICK_PREEMPT);
-		if (!s)
-			s = get_stats();
-		if (s)
-			s->nr_preempt += 1;
-	}
+	// PER-CPU PREEMPT TOWER REMOVED (v5.16.0). The pinned-service rescue, the
+	// 2x-codel backstop and the tier-tiered tight-band with its LAT_CRITICAL
+	// exemption are all subsumed by sweep_bound_preempt() at dispatch entry: the
+	// unified bound preempts a stranded per-CPU DSQ head of ANY tier, off-tick, at
+	// lag_cap_ns -- no per-class stamp, no exemption, no tick dependency.
 }
 
 // ENABLE: NEW TASK ENTERS SCHED_EXT. NO VTIME -- THE SOJOURN KEY IS COMPUTED
@@ -2340,31 +2040,11 @@ void BPF_STRUCT_OPS(pandemonium_enable, struct task_struct *p)
 	if (tctx) {
 		tctx->ran_since_wake = false;
 		tctx->last_run_at = 0;
-		tctx->wakeup_freq = 20;
 		tctx->last_woke_at = bpf_ktime_get_ns();
-		tctx->avg_runtime = 100000;
 		tctx->cached_weight = WEIGHT_INTERACTIVE;
-		tctx->prev_nvcsw = p->nvcsw;
-		tctx->csw_rate = 0;
-		tctx->lat_cri = 0;
 		tctx->tier = TIER_INTERACTIVE;
-		tctx->ewma_age = 0;
 		tctx->dispatch_path = 0;
 		tctx->pinned_service = 0;
-
-		// PROCDB: APPLY LEARNED CLASSIFICATION FROM PRIOR RUNS
-		char key[16];
-		__builtin_memcpy(key, p->comm, 16);
-		struct task_class_entry *init_entry =
-		    bpf_map_lookup_elem(&task_class_init, key);
-		if (init_entry) {
-			tctx->tier = (u32)init_entry->tier;
-			tctx->avg_runtime = init_entry->avg_runtime;
-			tctx->runtime_dev = init_entry->runtime_dev;
-			tctx->wakeup_freq = init_entry->wakeup_freq;
-			tctx->csw_rate = init_entry->csw_rate;
-			tctx->cached_weight = effective_weight(p, tctx);
-		}
 	}
 }
 
@@ -2436,8 +2116,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 		knobs->slice_ns = 1000000;
 		knobs->preempt_thresh_ns = 1000000;
 		knobs->batch_slice_ns = 20000000;        // 20MS FLAT DEFAULT
-		knobs->lat_cri_thresh_high = LAT_CRI_THRESH_HIGH; // 32
-		knobs->lat_cri_thresh_low  = LAT_CRI_THRESH_LOW;  // 8
 		knobs->affinity_mode = 0;                // OFF BY DEFAULT (RUST SETS PER REGIME)
 		knobs->codel_thresh_ns = 5000000;      // 5MS DEFAULT (RUST OVERRIDES)
 		knobs->burst_slice_ns = 1000000;         // 1MS DEFAULT (BURST/LONGRUN CEILING)

--- a/scheds/rust/scx_pandemonium/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_pandemonium/src/bpf/main.bpf.c
@@ -6,10 +6,10 @@
 //
 // ARCHITECTURE:
 //   SELECT_CPU IDLE FAST PATH -> PER-CPU DSQ (DEPTH-GATED, VISIBLE, STEALABLE)
-//   ENQUEUE TIER 1 IDLE FOUND -> THAT IDLE CPU'S PER-CPU DSQ (WARM)
-//   ENQUEUE TIER 2 WARM-ANCHOR (WAKEUP / LAT_CRITICAL) -> last_cpu PER-CPU DSQ
-//   ENQUEUE TIER 3 FALLBACK -> per-domain OVERFLOW DSQ (SOJOURN-ORDERED, L3-LOCAL)
-//   DISPATCH -> OWN PER-CPU, R_eff STEAL (Phi-PRICED), cache domain OVERFLOW, CROSS-DOMAIN, KEEP
+//   ENQUEUE IDLE FOUND -> NODE DSQ (SHARED, ANY CPU DRAINS)
+//   ENQUEUE INTERACTIVE PREEMPT -> NODE DSQ (SHARED, KICKED CPU DRAINS)
+//   ENQUEUE FALLBACK -> PER-NODE OVERFLOW DSQ (SOJOURN-ORDERED)
+//   DISPATCH -> OWN PER-CPU, L2 WORK STEAL, NODE OVERFLOW, CROSS-NODE, KEEP
 //   TICK -> PER-CPU SOJOURN (LOCAL + ROTATING SCAN) + BATCH PREEMPTION
 //
 // BEHAVIORAL CLASSIFICATION:
@@ -23,12 +23,12 @@
 
 char _license[] SEC("license") = "GPL";
 
-// scx_bpf_task_set_slice() / scx_bpf_task_set_dsq_vtime() REPLACE DIRECT
-// WRITES TO p->scx.slice / p->scx.dsq_vtime ON KERNEL 7.1+. THE WRAPPERS
-// (WHICH PICK THE KFUNC-OR-DIRECT-WRITE VIA bpf_ksym_exists) LIVE IN
-// scx/compat.bpf.h -- BOTH THE VENDORED COPY HERE AND THE scx UPSTREAM
-// VERSION -- SO WE JUST CALL THEM DIRECTLY. READS OF THE SAME FIELDS
-// ARE NOT DEPRECATED AND REMAIN AS-IS.
+// scx_bpf_task_set_slice() / scx_bpf_task_set_dsq_vtime() replace direct
+// writes to p->scx.slice / p->scx.dsq_vtime on kernel 7.1+. The wrappers
+// (which pick the kfunc-or-direct-write via bpf_ksym_exists) live in
+// scx/compat.bpf.h -- both the vendored copy here and the scx upstream
+// version -- so we just call them directly. Reads of the same fields
+// are not deprecated and remain as-is.
 
 // CONFIGURATION (SET BY RUST VIA RODATA BEFORE LOAD)
 
@@ -41,19 +41,6 @@ const volatile u64 nr_cpu_ids = 1;
 #define TIER_BATCH        0
 #define TIER_INTERACTIVE  1
 #define TIER_LAT_CRITICAL 2
-
-// FLOW SIGNATURE (PERSISTED SHAPE, FROZEN AT EWMA_AGE_MATURE). COUNTS THE
-// DISTINCT WAKER CPUs OF A TASK IN A BITMAP; THE POPCOUNT IS ITS PARTNER
-// CARDINALITY -- A TOPOLOGY-FREE READ OF THE LIVE COMMUNICATION GRAPH'S
-// CONDUCTANCE. A FEW PARTNERS = A TIGHT LOOP; MANY (SPANNING HALF+ THE MACHINE)
-// = A STORM MESH. CLASSIFIED ONCE AND FROZEN -> DETERMINISTIC ROUTING.
-#define SHAPE_UNCLASSIFIED 0
-#define SHAPE_TIGHT        1
-#define SHAPE_STORM        2
-// SPLIT: <= SHAPE_TIGHT_MAX DISTINCT PARTNERS IS A TIGHT PAIR/LOOP; A PARTNER
-// SET SPANNING AT LEAST HALF OF nr_cpu_ids IS A STORM. PORTABLE -- THE STORM
-// THRESHOLD SCALES WITH THE MACHINE, NO HARDCODED CORE GEOMETRY.
-#define SHAPE_TIGHT_MAX    2u
 
 #define LAT_CRI_THRESH_HIGH  32
 #define LAT_CRI_THRESH_LOW   8
@@ -79,15 +66,6 @@ const volatile u64 nr_cpu_ids = 1;
 
 #define EWMA_AGE_MATURE      8
 #define EWMA_AGE_CAP         16
-// FRESH-FORK COLD-START PRIME (Q16): A SMALL BOUNDED BACK-DATE FOR AN
-// UNOBSERVED INTERACTIVE TASK SO IT IS NOT SORTED DEAD-LAST (LIKE BATCH) AND
-// LOSING THE DISPATCH RACE DURING ITS LAUNCH WINDOW -- THE app-launch ms
-// BLOWOUT. 1/16 OF FULL: A MATURED INTERACTIVE/LAT_CRITICAL TASK (UP TO 65536)
-// ALWAYS SORTS AHEAD, SO DEADLINE WORK IS UNTOUCHED. DECAYS TO 0 BY
-// EWMA_AGE_MATURE, WHERE THE EARNED WARP TAKES OVER. lag_cap_ns BOUNDS THE
-// RESULTING BACK-DATE (STARVATION-FREE). ORDERING ONLY -- NEVER A PREEMPT.
-#define PRIME_FRESH_Q16      4096u
-#define MAX_WAKEUP_FREQ      64
 #define MAX_WAKEUP_FREQ      64
 #define MAX_CSW_RATE         512
 // WARP CEILING: TAU-DERIVED IN apply_tau_scaling() VIA K_LAG_CAP. THE UPPER
@@ -98,7 +76,7 @@ const volatile u64 nr_cpu_ids = 1;
 static u64 lag_cap_ns = 40000000ULL;
 
 #define SLICE_MIN_NS 100000     // 100US FLOOR
-// starvation_rescue_ns AND overflow_sojourn_rescue_ns ARE DERIVED FROM
+// codel_starve_ns AND codel_target_ns ARE DERIVED FROM
 // knobs->topology_tau_ns VIA scale_tau() AT THE FIRST CPU-0 TICK. SEE
 // apply_tau_scaling() AND pandemonium_init().
 
@@ -111,6 +89,7 @@ static u64 lag_cap_ns = 40000000ULL;
 // EXAMPLE: K_LAG_CAP = 1.0 (Q16 65536) MEANS "THE WARP CEILING IS ONE
 // COMMUTE TIME OF THE TOPOLOGY GRAPH." THE RATIOS ARE SET ONCE BY DESIGN
 // AND NOT MACHINE-SPECIFIC; THE OUTPUT VARIES BECAUSE tau VARIES.
+#define K_SOJOURN_INTERVAL       19661u   // 0.30
 #define K_CODEL_FLOOR             1147u   // 0.0175
 #define K_STARVATION_RESCUE     273285u   // 4.17
 #define K_LONGRUN              3276800u   // 50.0
@@ -132,39 +111,30 @@ static u64 lag_cap_ns = 40000000ULL;
 // GLOBALS
 
 static u32 nr_nodes;
-// nr_overflow_domains: NUMBER OF DISTINCT L3 cache DOMAINS IN llc_domain[]. SET BY RUST AT
-// TOPOLOGY DETECT VIA write_nr_overflow_domains (.data SECTION, POST-LOAD MUTABLE). ON
-// MONOLITHIC-L3 / UNSET, EQUALS nr_sockets (TYPICALLY 1) AND THE per-domain TIER
-// COLLAPSES TO A SINGLE OVERFLOW DSQ -- EXACT PRIOR BEHAVIOR SHAPE.
-volatile u32 nr_overflow_domains = 1;
 
 // NO GLOBAL PREEMPT FLAG: tick() DERIVES THE DECISION PER-CPU FROM
-// pcpu_enqueue_ns[this_cpu] (OLDEST WAITER AGE) AGAINST A k*tau THRESHOLD,
+// sojourn_stamp_pcpu[this_cpu] (OLDEST WAITER AGE) AGAINST A k*tau THRESHOLD,
 // TIER-GATED ON THE RESIDENT. PER-CPU SO NO TOKEN FOR CPUs TO RACE OVER.
 
 // SOJOURN TRACKERS: RECORD WHEN OVERFLOW DSQs TRANSITION FROM EMPTY.
 // DISPATCH STEP 0 CHECKS THESE TO RESCUE OVERFLOW TASKS AGING PAST
-// overflow_sojourn_rescue_ns. WITHOUT THIS, PER-CPU DSQ DOMINANCE
+// codel_target_ns. WITHOUT THIS, PER-CPU DSQ DOMINANCE
 // UNDER SUSTAINED LOAD MAKES ALL DOWNSTREAM ANTI-STARVATION LOGIC
 // (DEFICIT, SOJOURN, STARVATION_RESCUE) UNREACHABLE.
-// per-domain (v5.14.0 F3): the overflow DSQs are per-domain (domain_inter_dsq /
-// domain_batch_dsq), so their sojourn stamps must be too. A single global scalar
-// let one cache domain's stamp mask another cache domain's aging -- a task buried on the
-// unmonitored cache domain was invisible to STEP 2 / the safety net and aged to the 30s
-// watchdog -> ejection on multi-cache domain parts. Indexed by dom at every arm/clear/read.
-static u64 batch_enqueue_ns[MAX_OVERFLOW_DOMAINS];
-static u64 interactive_enqueue_ns[MAX_OVERFLOW_DOMAINS];
+// Two per-domain overflow stamps (interactive node_dsq, batch batch_dsq) folded
+// onto one cacheline -- both tiers preserved, dispatch keys off .inter / .batch.
+static struct { u64 inter; u64 batch; } sojourn_stamp_overflow;
 
 // PER-CPU DSQ SOJOURN: TRACKS WHEN EACH PER-CPU DSQ TRANSITIONS
 // FROM EMPTY. DISPATCH AND TICK CHECK THESE TO DETECT STALE TASKS.
 // WORK STEALING + DEPTH GATE HANDLE MOST CASES; THIS IS THE SAFETY NET.
-// CACHELINE-PADDED: one stamp per 64-byte line so the per-placement CAS
-// (arm/clear) and the per-tick cross-CPU scan don't false-share neighbors.
-struct pcpu_stamp { u64 ns; } __attribute__((aligned(64)));
-static struct pcpu_stamp pcpu_enqueue_ns[MAX_CPUS];
+static u64 sojourn_stamp_pcpu[MAX_CPUS];
+// PINNED KERNEL-SERVICE per-CPU rescue stamp: set when a pinned_service kthread
+// (ksoftirqd/N, kworker/N) is enqueued to its home CPU, read by tick() to preempt
+// a held hog at the tight floor, cleared when the kthread runs.
+static u64 pcpu_pinned_strand_ns[MAX_CPUS];
 
-static u64 starvation_rescue_ns;
-static u64 overflow_sojourn_rescue_ns;
+static u64 codel_starve_ns;
 static u32 pcpu_depth_base;
 
 // TAU-DERIVED LONGRUN PREEMPT BOOST. SET IN apply_tau_scaling() AS A
@@ -204,49 +174,22 @@ static s64 oscillator_velocity_cap;       // VELOCITY CLAMP
 // AND DOUBLE-CORRECT.
 u64 codel_target_floor_ns;         // CORE-SCALED FLOOR FOR TARGET
 // ADAPTIVE STATE
+static u64 sojourn_interval_ns;        // CORE-SCALED, UNCERTAIN ZONE TIMER
 u64 codel_target_ns;          // ADAPTIVE CENTER (EXPOSED FOR MWU)
 static s64 oscillator_velocity_ns;        // DAMPED OSCILLATION VELOCITY
 static u64 prev_rescue_snapshot;       // LAST-SEEN RESCUE COUNT
 static u64 global_rescue_count;        // ATOMIC CROSS-CPU RESCUE ACCUMULATOR
+static u64 pcpu_min_sojourn_ns[MAX_CPUS];
+static u64 pcpu_stall_start_ns[MAX_CPUS];
 
-// OSCILLATOR ENVELOPE: THE CONTROL EFFORT OBEYS THE SAME DAMPING LAW AS THE
-// SYSTEM IT CONTROLS. A DECAYED ENERGY RESERVOIR (GIRARD'S DYNAMIC-TRIGGER
-// eta) DRIVES THE OSCILLATOR'S OWN RECOMPUTE CADENCE: FULL EVERY-TICK WHEN
-// HOT, A SHORT GRADED BAND BELOW THE RELEASE THRESHOLD, A TRUE PARK (ZERO
-// ARITHMETIC, TARGET PINNED AT ITS CLOSED-FORM FIXED POINT) BELOW THE PARK
-// THRESHOLD. CPU-0 TICK IS THE SINGLE WRITER; DISPATCH READS codel_target_ns
-// WITH NO KNOWLEDGE THE ENVELOPE EXISTS. SEE MAYBE-5.13.0.md (Idle) AND
-// ENVELOPE-RESEARCH.md FOR THE DESIGN RECORD.
-#define OSC_ENV_DECAY_SHIFT     3    // RESERVOIR DECAY: env -= env >> 3 PER UPDATE
-#define OSC_ENV_GRADED_DIV      4    // GRADED BAND: RECOMPUTE EVERY 4TH TICK
-#define OSC_ENV_HEARTBEAT_TICKS 1024 // MAX-PARK SAFETY VALVE (~1s @ 1kHz, ~4s @ 250Hz)
-static u64 osc_env_energy;           // DECAYED disp^2 + v^2 RESERVOIR
-static u32 osc_env_skip;             // GRADED-BAND CADENCE DIVIDER
-static bool osc_env_parked;          // OSCILLATOR PARKED AT EQUILIBRIUM
-                                     // (bool, NOT u32: LLVM GlobalOpt SHRINKS A
-                                     // 0/1-ONLY INTERNAL GLOBAL TO 1 BYTE WHILE
-                                     // BTF KEEPS THE 4-BYTE TYPE -- THE KERNEL
-                                     // REJECTS THE .bss DATASEC SIZE MISMATCH)
-static u64 osc_env_park_ticks;       // TICKS SPENT PARKED (HEARTBEAT CAP)
-
-// F1a: the SINGLE un-park owner. Called from the CPU-0 tick (rescue edge) and
-// from pandemonium_runnable (wake edge). Re-primes the reservoir above RELEASE
-// (refractory dwell, so a bursty wake cannot immediately re-park) and resets the
-// graded-band divider + heartbeat. Does NOT touch oscillator_velocity_ns or
-// codel_target_ns -- the integrator stays single-writer on CPU 0; this only
-// flips the envelope state so the next CPU-0 tick runs the full recompute. The
-// osc_env_skip reset was previously only transitive (true via the graded-band
-// path); making it explicit here keeps the wake edge correct from any caller.
-static __always_inline void osc_env_unpark(void)
-{
-	u64 env_floor = (1ULL << (2 * oscillator_damping_shift)) +
-			(1ULL << (2 * oscillator_spring_shift));
-	u64 env_release = env_floor << (OSC_ENV_DECAY_SHIFT + 2);
-	osc_env_parked = false;
-	osc_env_park_ticks = 0;
-	osc_env_skip = 0;
-	osc_env_energy = env_release << 1;
-}
+// PER-CPU IDLE ACCUMULATION (STRATEGY 2: MEASURE-ONLY).
+// SET ON IDLE-ENTRY IN pandemonium_update_idle, READ + RESET ON
+// IDLE-EXIT TO ACCUMULATE TOTAL IDLE TIME. NO SCHEDULING DECISION
+// CONSUMES THESE YET -- THEY ARE A FREE SIGNAL FOR USERSPACE (procdb
+// PRESSURE, ADAPTIVE LOOP REGIME HINTS, FUTURE DNB / KIM-JO B_n).
+// MATCHES THE lavd / layered IDLE-TRACKING PATTERN.
+static u64 pcpu_idle_start_ns[MAX_CPUS];
+static u64 pcpu_idle_total_ns[MAX_CPUS];
 
 // LONGRUN DETECTION
 // TRACKS SUSTAINED BATCH DSQ PRESSURE. WHEN BATCH DSQ IS NON-EMPTY
@@ -271,11 +214,21 @@ static u64 last_tau_snapshot;
 // THE OSCILLATOR'S SPRING (RESTORING TERM) -- WITHOUT IT THE OSCILLATOR
 // HAS NO EQUILIBRIUM AND CAN ACCUMULATE OPEN-LOOP DRIFT.
 // FALLBACK 2MS UNTIL RUST WRITES; SAME ORDER AS codel_target_max_ns.
-static u64 codel_target_equilibrium_ns = 2000000ULL;
+static u64 codel_seed_ns = 2000000ULL;
 
-// PHI MIGRATION POTENTIAL: distance penalty b*R_eff is pre-folded into the
-// reff_value map (in ns) by Rust at topology detect, so dispatch STEP 1 reads it
-// directly. No BPF-side scale global, no per-tick mirror, no per-steal multiply.
+// IDLE QUIESCENCE ENVELOPE (v5.13.0): when the CoDel oscillator settles to its
+// equilibrium and stays there, PARK it -- pin the target at c_eq, freeze the
+// velocity integrator, stop the per-tick arithmetic until a rescue event or an
+// equilibrium retune disturbs it. A Schmitt trigger on the oscillator's energy
+// reservoir (decayed disp^2 + v^2): PARK below env_park, RELEASE above
+// env_release (2x hysteresis). Saves the per-tick recompute on a quiet system.
+#define OSC_ENV_DECAY_SHIFT     3    // RESERVOIR DECAY: env -= env >> 3 PER UPDATE
+#define OSC_ENV_GRADED_DIV      4    // GRADED BAND: RECOMPUTE EVERY 4TH TICK
+#define OSC_ENV_HEARTBEAT_TICKS 1024 // MAX-PARK SAFETY VALVE (~1s @ 1kHz, ~4s @ 250Hz)
+static u64 osc_env_energy;           // DECAYED disp^2 + v^2 RESERVOIR
+static u32 osc_env_skip;             // GRADED-BAND CADENCE DIVIDER
+static bool osc_env_parked;          // OSCILLATOR PARKED AT EQUILIBRIUM
+static u64 osc_env_park_ticks;       // TICKS SPENT PARKED (HEARTBEAT CAP)
 
 // USER EXIT
 
@@ -306,19 +259,6 @@ struct {
 	__type(value, u32);
 } cache_domain SEC(".maps");
 
-// EMERGENT OVERFLOW-DOMAIN MAP (T3b.2): cpu_domain[cpu] = emergent domain id from
-// the T2 min-conductance tree, partitioned to the L3 granularity. THE cpu_domain_of
-// REPLACEMENT: the overflow DSQs re-key from per-domain to per-emergent-domain, so
-// dispatch drains its domain's overflow then climbs the tree -- the boundary is
-// drawn by the conductance landscape, not a hardcoded multi-domain table. POPULATED BY
-// RUST AT TOPOLOGY DETECT; consumed by dispatch STEP 3/4 once re-keyed.
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__uint(max_entries, MAX_CPUS);
-	__type(key, u32);
-	__type(value, u32);
-} cpu_domain SEC(".maps");
-
 // PROCESS CLASSIFICATION DATABASE: BPF OBSERVES, RUST LEARNS, BPF APPLIES
 // OBSERVE: BPF WRITES MATURE TASK CLASSIFICATION, RUST DRAINS EVERY SECOND
 struct {
@@ -344,12 +284,7 @@ struct {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
-	// F12: sized MAX_CPUS * MAX_L2_SIBLINGS = one slot per (physical-core) L2
-	// group on any topology. The old 512 capped it at 64 L2 groups, so on a
-	// >64-physical-core part (EPYC 9654, Threadripper PRO, dual-socket) the
-	// Rust writer's group_id*MAX_L2_SIBLINGS+slot overflowed the map and init
-	// aborted -- the scheduler would not load. No-op at <=64 groups.
-	__uint(max_entries, MAX_CPUS * MAX_L2_SIBLINGS);
+	__uint(max_entries, 512);
 	__type(key, u32);
 	__type(value, u32);
 } l2_siblings SEC(".maps");
@@ -380,22 +315,6 @@ struct {
 	__type(key, u32);
 	__type(value, u32);
 } reff_value SEC(".maps");
-
-// EMERGENT-DOMAIN CROSSING PRICE: PER-CPU phi OF THE DOMAIN CUT TO EACH TARGET.
-// domain_phi[cpu * MAX_AFFINITY_CANDIDATES + slot] = (phi * 1e6) OF THE LOWEST
-// COMMON-ANCESTOR CUT SEPARATING cpu FROM affinity_rank[...][slot], FROM THE T2
-// MIN-CONDUCTANCE DOMAIN TREE. PAIRS 1:1 WITH affinity_rank. A LOW phi IS A LOOSE
-// SEAM (MAJOR BOUNDARY -- SOCKET / CROSS-L3, FAR); A HIGH phi IS A TIGHT SEAM
-// (NEAR). SENTINEL (u32)-1 = SAME LEAF (NO BOUNDARY, MAXIMALLY LOCAL) *AND* SLOTS
-// PAST THE TOPOLOGY END. THE BOUNDED-LOCAL STEAL (T3b.2) READS THIS TO CLIMB THE
-// DOMAIN TREE -- THE CONTINUOUS, EMERGENT REPLACEMENT FOR cpu_domain_of's SAME/DIFFERENT
-// -cache domain TEST. POPULATED BY RUST AT TOPOLOGY DETECT.
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__uint(max_entries, MAX_CPUS * MAX_AFFINITY_CANDIDATES);
-	__type(key, u32);
-	__type(value, u32);
-} domain_phi SEC(".maps");
 
 // STEP 1 SCAN RATE-LIMIT: per-CPU timestamp of the last R_eff steal scan.
 // PERCPU SO IT IS THIS-CPU-LOCAL -- NO CROSS-CPU COHERENCE TRAFFIC. THE PEER
@@ -434,6 +353,10 @@ struct task_ctx {
 	u64 last_run_at;
 	u64 wakeup_freq;
 	u64 last_woke_at;
+	u64 enqueue_at;      // SET AT EVERY scx_bpf_dsq_insert_vtime SITE;
+	                     // CONSUMED IN pandemonium_running TO COMPUTE
+	                     // PER-TASK SOJOURN (LITERAL CoDel METRIC).
+	                     // CLEARED AFTER CONSUME TO AVOID STALE READS.
 	u64 avg_runtime;
 	u64 runtime_dev;     // EWMA OF |RUNTIME - AVG_RUNTIME| (VARIANCE SIGNAL)
 	u64 cached_weight;
@@ -441,16 +364,15 @@ struct task_ctx {
 	u64 csw_rate;
 	u64 lat_cri;
 	u64 sleep_start_ns;  // SET IN quiescent(), USED IN running()
-	u64 waker_bitmap;    // BIT i = CPU i woke this task; popcount = partner cardinality
 	u32 tier;
 	u32 ewma_age;
 	s32 last_cpu;        // LAST CPU THIS TASK RAN ON (FOR CACHE AFFINITY)
-	s32 home_cpu;        // STABLE PLACEMENT HOME: PINNED TO THE FIRST CPU THE
-	                     // TASK RAN ON; NEVER CHASES last_cpu. WARM-STAY ANCHOR
-	                     // SO THE TASK RETURNS HOME INSTEAD OF DRIFTING.
 	u8  dispatch_path;   // 0=IDLE, 1=HARD_KICK, 2=SOFT_KICK
 	u8  ran_since_wake;  // is_wakeup = !ran_since_wake; SET 1 IN running(), 0 ON WAKE
-	u8  shape;           // FLOW SIGNATURE: SHAPE_* (FROZEN AT MATURITY)
+	u8  pinned_service;  // 1 = PER-CPU KERNEL-SERVICE TASK (PF_KTHREAD, nr_cpus_allowed==1,
+	                     // normal-prio) USERSPACE BLOCKS ON. THE ONE KTHREAD JUDGEMENT:
+	                     // SET ONCE IN runnable(); READ BY enqueue() FOR FORCED HOME-CPU
+	                     // PLACEMENT AND BY tick() FOR THE PINNED-WAITER PREEMPT BACKSTOP.
 	u8  _pad[1];
 };
 
@@ -462,66 +384,6 @@ struct {
 } task_ctx_stor SEC(".maps");
 
 // HELPERS
-
-// per-domain OVERFLOW DSQ IDs. LAYOUT:
-//   [0, nr_cpu_ids)                                   per-CPU DSQs
-//   [nr_cpu_ids + 2*MAX_NODES,             ...)       per-domain interactive overflow
-//   [nr_cpu_ids + 2*MAX_NODES + MAX_OVERFLOW_DOMAINS, ...) per-domain batch overflow
-// THE 2*MAX_NODES GAP RESERVES IDs THAT EARLIER PER-NODE TIERS USED; KEEPING
-// THE OFFSET CONSTANT MEANS HARDWARE-INDEPENDENT AT COMPILE TIME. DSQs ARE
-// CREATED ONCE AT INIT FROM A FIXED MAP; THE RUNTIME nr_overflow_domains GATES WHICH ARE
-// ADDRESSED.
-static __always_inline u64 domain_inter_dsq(u32 dom)
-{
-	dom &= (MAX_OVERFLOW_DOMAINS - 1);   // F12: never index past the created DSQ range
-	return nr_cpu_ids + 2ULL * MAX_NODES + (u64)dom;
-}
-
-static __always_inline u64 domain_batch_dsq(u32 dom)
-{
-	dom &= (MAX_OVERFLOW_DOMAINS - 1);   // F12: see domain_inter_dsq
-	return nr_cpu_ids + 2ULL * MAX_NODES + MAX_OVERFLOW_DOMAINS + (u64)dom;
-}
-
-// F12: the per-domain overflow DSQ id ranges -- inter [base, base+MAX_OVERFLOW_DOMAINS),
-// batch [base+MAX_OVERFLOW_DOMAINS, base+2*MAX_OVERFLOW_DOMAINS), base = nr_cpu_ids +
-// 2*MAX_NODES -- must fit the reserved id gap and not collide with the per-CPU
-// DSQs [0, nr_cpu_ids). The mask above + this assert guarantee it.
-_Static_assert(MAX_OVERFLOW_DOMAINS <= 2 * MAX_NODES,
-	       "per-domain overflow DSQ ranges must fit the reserved id gap");
-
-// Overflow domain of a CPU (T3b.2): now the EMERGENT domain from the T2
-// min-conductance tree (cpu_domain map), not the discrete llc_domain. The
-// partition targets the L3 granularity, so on a real part cpu_domain == the old
-// llc_domain value and this is behavior-preserving -- the boundary is just drawn
-// by the conductance landscape instead of a hardcoded multi-domain table. The name
-// stays cpu_domain_of until T7's vocabulary sweep; every overflow site re-keys here.
-static __always_inline u32 cpu_domain_of(s32 cpu)
-{
-	if (cpu < 0 || (u32)cpu >= nr_cpu_ids)
-		return 0;
-	u32 key = (u32)cpu;
-	u32 *cd = bpf_map_lookup_elem(&cpu_domain, &key);
-	u32 dom = cd ? *cd : 0;
-	// Never return a domain beyond the created overflow-DSQ range. Rust caps the
-	// partition at the L3 count (<= MAX_OVERFLOW_DOMAINS); this guards a stale map
-	// value or a post-detect hotplug from indexing an uncreated overflow DSQ.
-	return dom < MAX_OVERFLOW_DOMAINS ? dom : 0;
-}
-
-// CROSS-DOMAIN SCATTER BUMP. COUNTS A CROSS-DOMAIN LANDING ON PATH `idx` (XDOM_*)
-// WHEN THE TASK'S HOME CPU AND THE CHOSEN CPU SIT IN DIFFERENT cache domains.
-// last_home < 0 (NO PRIOR CPU) IS NOT A MIGRATION. FREE-COMPUTE: ONE cpu_domain_of
-// COMPARE ON AN ALREADY-TAKEN PLACEMENT BRANCH. CONSUMED BY THE ADAPTIVE MWU
-// SCATTER PATHWAY AND SURFACED PER-RUN BY THE BENCH SUITE.
-static __always_inline void cross_domain_bump(struct pandemonium_stats *s, u32 idx,
-				      s32 last_home, s32 dst)
-{
-	if (!s || idx >= 8 || last_home < 0)
-		return;
-	if (cpu_domain_of(last_home) != cpu_domain_of(dst))
-		s->nr_cross_domain[idx] += 1;
-}
 
 static __always_inline struct pandemonium_stats *get_stats(void)
 {
@@ -652,144 +514,12 @@ static __always_inline s32 find_idle_by_affinity(s32 src_cpu,
 	return -1;
 }
 
-// PHI PLACEMENT TARGET (SUBORDINATE SUB-MECHANISM). WARMTH'S ONLY ROLE ON THE
-// WAKEUP FAST PATH IS TO BIAS WHICH IDLE CPU IS CHOSEN -- IT NEVER PLACES A WAKEE ON
-// A BUSY CORE HERE. PLACING ON BUSY VIA THIS PATH ISSUED KICK_IDLE (A NO-OP ON A
-// BUSY CPU) AND BYPASSED THE dfl -> enqueue PATH, STRANDING THE WAKEE UNTIL THE
-// RUNNING TASK YIELDED: ~90% DEADLINE MISS UNDER SATURATION, IDENTICAL WHETHER THE
-// WARM-STAY WAS A DEEP OVERRIDE OR A 1-DEEP WHISPER -- THE BUG WAS THE BUSY
-// PLACEMENT ITSELF, NOT ITS DEPTH. SO WARMTH NEVER RETURNS A BUSY CPU:
-//   - ANCHOR IDLE -> TAKE IT (WARM AND IMMEDIATE).
-//   - ELSE NEAREST/WARMEST IDLE: find_idle_by_affinity WALKS R_eff ORDER, SO A
-//     same-domain IDLE IS PREFERRED OVER A CROSS-DOMAIN ONE AUTOMATICALLY -- THAT IS THE
-//     BIAS, EXPRESSED BY *WHICH* IDLE, NEVER BY REFUSING TO USE ONE.
-//   - NOTHING IDLE -> RETURN -1, AND select_cpu FALLS THROUGH TO dfl -> enqueue, THE
-//     PROVEN PATH THAT PLACES BUSY-CORE WAKEUPS WITH A REAL PREEMPT (KICK_PREEMPT).
-// find_idle_by_affinity ALREADY RETURNS THE ANCHOR ITSELF WHEN IT IS IDLE (RANK SLOT
-// 0 = SELF), SO A CORRECT SUBORDINATE PLACEMENT BIAS COLLAPSES TO EXACTLY THAT WALK.
-// A PLACE-ON-BUSY WARM-STAY, IF EVER PURSUED, BELONGS IN THE enqueue PATH THAT KICKS
-// PREEMPT -- NEVER THE IDLE FAST PATH.
-static __always_inline s32 phi_warm_target(s32 anchor,
-					   const struct cpumask *allowed,
-					   u32 tier)
-{
-	(void)tier;
-	return find_idle_by_affinity(anchor, allowed);
-}
-
-// WARM-STAY GATE. RETURNS THE ANCHOR (last_cpu) TO HOLD THE WAKEE ON WHEN THE
-// ANCHOR IS UNCONGESTED -- I.E. PREFER QUEUEING ON prev_cpu OVER FANNING THE
-// WAKEE OUT TO A COLD IDLE SIBLING. RETURNS -1 WHEN THE CALLER SHOULD IDLE-SEEK
-// AS USUAL (ANCHOR CONGESTED, OR WARM-STAY INAPPLICABLE).
-//
-// CONGESTION = THE ANCHOR'S SOJOURN (now - ITS EMPTY->NONEMPTY STAMP, THE SAME
-// SIGNAL THE DISPATCH STEP 1 STEAL READS) EXCEEDING codel_target_ns -- THE
-// OSCILLATOR'S ADAPTIVE "STANDARD OPERATIONS" PRESSURE MARK. BELOW IT, THE
-// ANCHOR IS DRAINING HEALTHILY AND THE WAKEE SHOULD STAY CACHE-WARM; ABOVE IT,
-// THE ANCHOR IS GENUINELY BACKED UP AND FANNING OUT IS JUSTIFIED. THIS IS THE
-// PLACEMENT-SIDE DUAL OF THE STEAL THRESHOLD: A WAKEE STAYS ON ITS WARM CORE
-// RIGHT UP TO THE SOJOURN AT WHICH THE STEAL MACHINERY WOULD RELOCATE IT.
-//
-// THE CALLER MUST ROUTE A HELD WAKEE THROUGH A PREEMPT-KICKED PLACEMENT (THE
-// ENQUEUE PATH), NEVER select_cpu's KICK_IDLE FAST PATH -- A KICK_IDLE ON A
-// BUSY ANCHOR IS A NO-OP AND STRANDS THE WAKEE (THE ~90% DEADLINE-MISS SCAR
-// DOCUMENTED ABOVE phi_warm_target). select_cpu THEREFORE ONLY DEFERS HERE.
-//
-// EXCLUDES: NON-WAKEUPS, LAT_CRITICAL (FLEES FOR IMMEDIACY), KTHREADS. THE
-// ANCHOR (home_cpu, ELSE last_cpu) MUST BE VALID AND IN THE WAKEE'S ALLOWED MASK.
-// DECOUPLED FROM affinity_mode: STICKINESS IS FUNDAMENTAL MIGRATION RESISTANCE,
-// NOT AN ADAPTIVE-ONLY L2 FEATURE -- SO IT ENGAGES IN BPF-ONLY MODE TOO, WHERE
-// THE MIGRATION STORM (2375 MOVES/THREAD VS EEVDF'S 45) WAS MEASURED.
-
-// IPC HANDOFF DISCRIMINATOR -- THE NARROW GATE BRANCH. The replacement for the
-// blunt is_wakeup preempt is NOT "any short task" (that was the rank object,
-// which preempted globally and torched 58% of deadlines). It is a SELF-CHECK for
-// a true tight synchronous handoff partner: a matured, non-BATCH task woken by
-// only a handful of distinct partners (popcount of the waker bitmap <=
-// SHAPE_TIGHT_MAX). That set is ~2 threads -- the pinger pair -- so fast-pathing
-// it on REQUEUE (where is_wakeup is false and the baseline makes it wait a tick)
-// cannot move the deadline numbers, while every other task falls through to the
-// exact baseline behavior. WAKES are unchanged (is_wakeup still fires); this only
-// ADDS the requeue case for genuine handoff partners. LAT_CRITICAL always
-// qualifies (the latency floor); BATCH and unclassified tasks never do.
-static __always_inline bool is_handoff_partner(const struct task_ctx *tctx)
-{
-	if (!tctx)
-		return false;
-	if (tctx->tier == TIER_LAT_CRITICAL)
-		return true;
-	if (tctx->tier == TIER_BATCH)
-		return false;
-	if (tctx->ewma_age < EWMA_AGE_MATURE)
-		return false;            // not yet classified -- stay on baseline
-	return __builtin_popcountll(tctx->waker_bitmap) <= SHAPE_TIGHT_MAX;
-}
-
-static __always_inline s32 warm_stay_anchor(struct task_struct *p,
-					    struct task_ctx *tctx,
-					    struct tuning_knobs *knobs,
-					    bool is_wakeup, u64 now)
-{
-	// ADMIT A WAKE, OR A REQUEUED TRUE HANDOFF PARTNER (the narrow IPC branch),
-	// to the warm per-CPU seat. Everything else stays on baseline.
-	if (!tctx || (!is_wakeup && !is_handoff_partner(tctx)))
-		return -1;
-	if (!knobs)
-		return -1;
-	if (tctx->tier == TIER_LAT_CRITICAL || (p->flags & PF_KTHREAD))
-		return -1;
-	// STABLE HOME ANCHOR: PREFER THE PINNED HOME OVER last_cpu, WHICH IS REWRITTEN
-	// EVERY stopping() AND SO CHASES THE TASK ACROSS CPUs -- THE MIGRATION-STORM
-	// ROOT. AN UNCONGESTED HOME PULLS THE TASK BACK INSTEAD OF DRIFTING. FALLS
-	// BACK TO last_cpu UNTIL HOME IS PINNED (FIRST RUN).
-	s32 lc = (tctx->home_cpu >= 0) ? tctx->home_cpu : tctx->last_cpu;
-	if (lc < 0 || (u32)lc >= nr_cpu_ids)
-		return -1;
-	if (!bpf_cpumask_test_cpu(lc, p->cpus_ptr))
-		return -1;
-	// OCCUPANCY GATE (fan-out 1:N): if the home per-CPU DSQ already holds a
-	// queued waiter, release the NEXT same-home wakee to idle-seek instead of
-	// stacking it. A 1:N parent wakes K children whose home_cpu collides onto a
-	// few cores; warm-stay seats with NO spill, so without this they pile on one
-	// per-CPU DSQ and the per-round straggler waits a CoDel-aged steal/tick (the
-	// fan-out ms p50). The FIRST wakee (nq==0) still takes the warm seat, so the
-	// 1:1 IPC handoff -- where the waker is on-CPU, not queued -- is unaffected.
-	if (scx_bpf_dsq_nr_queued((u64)lc) > 0)
-		return -1;
-	u64 stamp = pcpu_enqueue_ns[(u32)lc & (MAX_CPUS - 1)].ns;
-	u64 sojourn = (stamp && now > stamp) ? (now - stamp) : 0;
-	// PHI-PRICED STAY. THE STAY AND THE STEP-1 STEAL MUST RELEASE AT THE SAME
-	// THRESHOLD, OR THEY FIGHT: THE STEAL FIRES AT codel_target + dist_extra
-	// (THE R_eff DISTANCE PENALTY, PRE-FOLDED IN reff_value), BUT AN
-	// UNCONDITIONAL BAIL AT BARE codel_target GAVE UP THE HOME TOO EARLY (EAGER
-	// NON-STORM FAN-OUT) WHILE AN UNCONDITIONAL STORM EXEMPTION NEVER GAVE IT UP
-	// (DEEP PILE -> STEAL RE-SCATTERS IT -> THE MIGRATION RAMP). READING THE
-	// HOME'S OWN SLOT-0 PENALTY (DISTANCE TO ITS NEAREST PEER -- THE CHEAPEST
-	// RELIEF TARGET) MAKES WARM-STAY HOLD THE TASK HOME UP TO EXACTLY THE
-	// SOJOURN AT WHICH THAT NEAREST PEER'S STEAL WOULD RELIEVE IT. BELOW IT:
-	// STAY (RELIEF, IF ANY, WOULD BE A CHEAP NEAR MOVE). ABOVE IT: RELEASE TO
-	// IDLE-SEEK -- THE TASK WAS ABOUT TO BE STOLEN ANYWAY, SO PLACE IT WELL NOW.
-	// Φ THUS GOVERNS IPC/WAKE-STORM/FORK-THREAD PLACEMENT ON ONE THRESHOLD:
-	// A NEAR (LOW-R_eff) HOME RELEASES QUICKLY (CHEAP MOVES OK); A FAR HOME
-	// (HIGH-R_eff, CROSS-DOMAIN) HOLDS HARD (CROSSING IS EXPENSIVE). ALL SHAPES,
-	// NO BINARY STORM BRANCH. reff_value ALL-ZERO (MONOLITHIC / --phi-scale 0)
-	// COLLAPSES TO BARE codel_target -- EXACT PRIOR BEHAVIOR. LAT_CRITICAL
-	// RETURNED AT LINE 616, SO AUDIO KEEPS ITS UNCONDITIONAL ESCAPE (NO SCAR).
-	u32 base0 = (u32)lc * MAX_AFFINITY_CANDIDATES;
-	u32 *dxp = bpf_map_lookup_elem(&reff_value, &base0);
-	u32 dx = dxp ? *dxp : 0;
-	u64 home_dist_extra = (dx == (u32)-1) ? 0 : (u64)dx;
-	if (sojourn > codel_target_ns + home_dist_extra)
-		return -1;        // home aged past its Phi threshold: idle-seek
-	return lc;                // within Phi tolerance: stay warm
-}
-
 // SIBLING PER-CPU DSQ WITH ROOM: WALKS THE SAME R_EFF-RANKED LIST AS
 // find_idle_by_affinity BUT WITH "HAS ROOM" AS THE PREDICATE INSTEAD OF
 // "IS IDLE". USED BY THE WAKE_SYNC AND normal_path DEPTH-GATE SPILL SITES
 // IN select_cpu TO ROUTE OVERFLOW INTO A SIBLING PER-CPU DSQ -- WHICH IS
 // REACHED BY DISPATCH STEP 0 (OWN) OR STEP 1 (L2 STEAL) -- INSTEAD OF
-// FUNNELING INTO domain_inter_dsq, WHICH DISPATCH ONLY REACHES AT STEP 3.
+// FUNNELING INTO THE SHARED NODE DSQ THAT DISPATCH ONLY REACHES AT STEP 3.
 // BUDGET IS TAU-DERIVED (LIKE EVERY OTHER TOPOLOGY-SCALED VALUE):
 //   budget = K_SPILL_BUDGET / tau_ns
 // where K_SPILL_BUDGET = TAU_SCALE_NS / 2 = 80e6. THIS IS LAMBDA_2 / 2 --
@@ -798,64 +528,30 @@ static __always_inline s32 warm_stay_anchor(struct task_struct *p,
 // CLAMPED TO [6, MAX_AFFINITY_CANDIDATES]. SET IN apply_tau_scaling().
 static u32 pcpu_spill_search_budget = 6;
 
-// STATIC SCAN CEILING FOR THE SPILL HELPER ONLY. THE RUNTIME BUDGET ABOVE IS
-// SMALL (6 AT 12C, 16 AT 32C); MAX_AFFINITY_CANDIDATES (= 128) AS THE LOOP'S
-// COMPILE-TIME BOUND IS PURE VERIFIER-ANALYSIS DEPTH. THE LEAST-LOADED CROSS-DOMAIN
-// TIE-BREAK ADDS A THIRD PER-ITERATION MAP LOOKUP (cpu_domain_of -> llc_domain) ON
-// TOP OF affinity_rank + nr_queued; INLINED INTO select_cpu, 128 ITERATIONS x 3
-// LOOKUPS OVERRUNS THE INSTRUCTION BUDGET. 32 COVERS EVERY REALISTIC TOPOLOGY
-// (NO SPILL WANTS THE 33RD-NEAREST SEAT) AND LEAVES HEADROOM OVER THE PROVEN
-// 128 x 2-LOOKUP ORIGINAL. THE steal-side LOOPS KEEP THE FULL 128 -- THEY HAVE
-// NO THIRD LOOKUP.
-#define PCPU_SPILL_SCAN_MAX 32
-
 static __always_inline s32 find_pcpu_with_room(s32 src_cpu,
 					       const struct cpumask *allowed)
 {
 	if (src_cpu < 0 || (u32)src_cpu >= nr_cpu_ids)
 		return -1;
 
-	// R_EFF-RANKED SIBLING SPILL: affinity_rank IS THE FULL R_EFF-ASCENDING
-	// RANK (SLOT 0 = L2 SIBLING). A same-domain PEER WITH ROOM WINS IMMEDIATELY
-	// (LOCALITY, R_eff ORDER). WHEN ONLY CROSS-DOMAIN SEATS HAVE ROOM, TAKE THE
-	// LEAST-LOADED ONE RATHER THAN THE NEAREST: on an asymmetric online width
-	// (e.g. 8C = 5 cores on one cache domain, 3 on the other) the nearest cross-domain
-	// seat is the SAME for every over-full source, so "first with room"
-	// funnels all spill onto one core (measured: the 8C cpu4:999 hotspot, 4x
-	// the next, and the cross-domain wakes parked there were the IPC tick-floor
-	// tail). Least-loaded self-spreads as seats fill. Still no gate -- Phi
-	// orders the walk and prices cross-domain downstream; this only breaks the
-	// tie among cross-domain seats that already have room.
-	u32 src_dom = cpu_domain_of(src_cpu);
 	u32 base = (u32)src_cpu * MAX_AFFINITY_CANDIDATES;
 	u32 checked = 0;
-	s32 best_cross_domain = -1;
-	u32 best_cross_domain_q = pcpu_depth_base;
-	for (int i = 0; i < PCPU_SPILL_SCAN_MAX; i++) {
+	for (int i = 0; i < MAX_AFFINITY_CANDIDATES; i++) {
 		u32 key = base + (u32)i;
 		u32 *val = bpf_map_lookup_elem(&affinity_rank, &key);
 		if (!val || *val == (u32)-1)
 			break;
-		u32 peer = *val;
-		if (peer >= nr_cpu_ids)
+		if (*val >= nr_cpu_ids)
 			continue;
-		if (allowed && !bpf_cpumask_test_cpu((s32)peer, allowed))
+		if (allowed && !bpf_cpumask_test_cpu((s32)*val, allowed))
 			continue;
-		u32 q = scx_bpf_dsq_nr_queued((u64)peer);
-		if (q < pcpu_depth_base) {
-			if (cpu_domain_of((s32)peer) == src_dom)
-				return (s32)peer;
-			if (q < best_cross_domain_q) {
-				best_cross_domain_q = q;
-				best_cross_domain = (s32)peer;
-			}
-		}
+		if (scx_bpf_dsq_nr_queued((u64)*val) < pcpu_depth_base)
+			return (s32)*val;
 		if (++checked >= pcpu_spill_search_budget)
 			break;
 	}
 
-	// No same-domain room: least-loaded cross-domain seat within budget (or -1).
-	return best_cross_domain;
+	return -1;
 }
 
 // PICK A DSQ FOR WAKE-SYNC OR INITIAL ENQUEUE WITH SIBLING-SPILL FALLBACK.
@@ -863,19 +559,18 @@ static __always_inline s32 find_pcpu_with_room(s32 src_cpu,
 //   1. src_cpu's PER-CPU DSQ IF UNDER pcpu_depth_base AND IN allowed.
 //   2. R_EFF-RANKED SIBLING PER-CPU DSQ WITH ROOM AND IN allowed.
 //      DISPATCH REACHES THESE AT STEP 0 (OWN) OR STEP 1 (L2 STEAL).
-//   3. LAST RESORT: domain_inter_dsq FOR src_cpu's cache domain. HARD STARVATION RESCUE
-//      BOUNDS WAIT. ALSO THE ESCAPE VALVE WHEN allowed EXCLUDES src_cpu AND
-//      ALL R_EFF SIBLINGS -- TASK CAN ALWAYS BE DRAINED BY ANY same-domain CORE
-//      VIA STEP 3 OF THE DISPATCH WATERFALL, OR CROSS-DOMAIN VIA STEP 5 WORK
-//      CONSERVATION. PREVENTS THE PER-CPU DSQ AFFINITY-STRANDING CLASS
-//      BEHIND scx ISSUE #728 / RUNNABLE-TASK STALLS WHEN cpus_ptr CHANGES
-//      MID-FLIGHT (LIBVIRT CGROUP CPUSETS, kthread_bind, ETC.).
+//   3. LAST RESORT: SHARED NODE DSQ. HARD STARVATION RESCUE BOUNDS WAIT.
+//      ALSO THE ESCAPE VALVE WHEN allowed EXCLUDES src_cpu AND ALL R_EFF
+//      SIBLINGS -- TASK CAN ALWAYS BE DRAINED BY ANY ALLOWED CPU ON THE
+//      NODE VIA STEP 3 OF THE DISPATCH WATERFALL. PREVENTS THE PER-CPU
+//      DSQ AFFINITY-STRANDING CLASS BEHIND scx ISSUE #728 / RUNNABLE-TASK
+//      STALLS WHEN cpus_ptr CHANGES MID-FLIGHT (LIBVIRT CGROUP CPUSETS,
+//      kthread_bind, ETC.).
 // *out_cpu RECEIVES THE CPU SCX SHOULD WAKE (THE PER-CPU DSQ OWNER WE
-// LANDED IN; src_cpu IF WE FELL BACK TO domain_inter_dsq).
+// LANDED IN; src_cpu IF WE FELL BACK TO NODE DSQ).
 static __always_inline u64 pick_pcpu_dsq_with_spill(s32 src_cpu,
 						    const struct cpumask *allowed,
-						    u32 shape, bool keep_own,
-					    s32 *out_cpu)
+						    s32 *out_cpu)
 {
 	u64 now = bpf_ktime_get_ns();
 	bool src_ok = (u64)src_cpu < nr_cpu_ids &&
@@ -885,95 +580,95 @@ static __always_inline u64 pick_pcpu_dsq_with_spill(s32 src_cpu,
 	    scx_bpf_dsq_nr_queued((u64)src_cpu) < pcpu_depth_base) {
 		if ((u32)src_cpu < MAX_CPUS)
 			__sync_val_compare_and_swap(
-				&pcpu_enqueue_ns[(u32)src_cpu].ns,
+				&sojourn_stamp_pcpu[src_cpu & (MAX_CPUS - 1)],
 				0, now);
 		*out_cpu = src_cpu;
 		return (u64)src_cpu;
 	}
 
-	// FALSIFYING TEST (20-AGENT CONSENSUS): DISABLE THE SHAPE_STORM BRANCH.
-	// HYPOTHESIS: STORM WAKEES ROUTED TO domain_inter_dsq (A cache domain-WIDE SHARED DSQ)
-	// WHILE KICKING ONLY `src_cpu` DECOUPLES PLACEMENT FROM DRAIN -- THE KICKED
-	// CPU IS NOT NECESSARILY THE same-domain PEER THAT WINS STEP 3a's DRAIN RACE.
-	// P(KICKED CPU DRAINS) ≈ 1/6 ON A 6-CPU cache domain, SO ~5/6 OF STORM WAKEUPS
-	// PRODUCE A MIGRATION ON EVERY SINGLE WAKE -- ACCOUNTING FOR THE MEASURED
-	// 22× MIGRATION MULTIPLIER AND 2.1× WAKEUP AMPLIFIER. LETTING STORM FALL
-	// THROUGH TO find_pcpu_with_room + B-v2 OVER-DEPTH OWN PLACES THE WAKEE ON
-	// A SPECIFIC NAMED CPU'S PER-CPU DSQ, RESTORING KICK == DRAIN IDENTITY.
-	// (void)now IN THIS BRANCH SINCE WE NO LONGER ARM interactive_enqueue_ns.
-	// if (shape == SHAPE_STORM) {
-	// 	__sync_val_compare_and_swap(&interactive_enqueue_ns, 0, now);
-	// 	*out_cpu = src_cpu;
-	// 	return domain_inter_dsq(cpu_domain_of(src_cpu));
-	// }
-	(void)shape;
-
-	// HANDOFF PARTNER (keep_own): A is about to block and free src_cpu within
-	// ~us, so the post-block STEP 0 on src_cpu drains B next. Skip the sibling
-	// spill -- a spill strands B on a per-CPU DSQ that src_cpu's STEP 0 never
-	// looks at, reachable only by the rate-limited / nq>1-guarded STEP 1 steal
-	// or the tick (the ~1% / 1.3ms IPC tail). Fall through to the over-depth-own
-	// seat on src_cpu below (bounded by the CoDel sojourn steal). NO kick change
-	// -- pure placement, the zero-IPI half of the fix.
-	s32 spill = keep_own ? -1 : find_pcpu_with_room(src_cpu, allowed);
+	s32 spill = find_pcpu_with_room(src_cpu, allowed);
 	if (spill >= 0) {
 		if ((u32)spill < MAX_CPUS)
 			__sync_val_compare_and_swap(
-				&pcpu_enqueue_ns[(u32)spill].ns,
+				&sojourn_stamp_pcpu[spill & (MAX_CPUS - 1)],
 				0, now);
 		*out_cpu = spill;
 		return (u64)spill;
 	}
 
-	// B v2: NO ROOM ON A NEAR (same-domain) SIBLING. KEEP THE WAKEE ON ITS OWN
-	// WARM CORE OVER-DEPTH RATHER THAN SCATTERING TO domain_inter_dsq IMMEDIATELY.
-	// THE DEEP PER-CPU QUEUE IS BOUNDED BY THE CoDel SOJOURN STEAL (RELIEVED
-	// TO A NEAR same-domain CORE ONCE IT WAITS PAST codel_target), SO IT STAYS
-	// L1/L2-WARM WITHOUT SCATTERING. domain_inter_dsq IS THE ESCAPE VALVE BELOW
-	// ONLY WHEN src_cpu ISN'T IN THE allowed MASK (THE AFFINITY CASE).
-	if (src_ok) {
-		if ((u32)src_cpu < MAX_CPUS)
-			__sync_val_compare_and_swap(
-				&pcpu_enqueue_ns[(u32)src_cpu].ns,
-				0, now);
-		*out_cpu = src_cpu;
-		return (u64)src_cpu;
-	}
-
-	// AFFINITY-STRANDED ESCAPE: src_cpu isn't in allowed. Route to src_cpu's
-	// cache domain-local overflow DSQ; if allowed excludes the whole cache domain, the cross-domain
-	// drain at STEP 3b picks it up as work-conservation.
-	__sync_val_compare_and_swap(
-		&interactive_enqueue_ns[cpu_domain_of(src_cpu) & (MAX_OVERFLOW_DOMAINS - 1)],
-		0, now);
+	s32 node = __COMPAT_scx_bpf_cpu_node(src_cpu);
+	if (node < 0 || (u32)node >= nr_nodes) node = 0;
+	__sync_val_compare_and_swap(&sojourn_stamp_overflow.inter, 0, now);
 	*out_cpu = src_cpu;
-	return domain_inter_dsq(cpu_domain_of(src_cpu));
+	return nr_cpu_ids + (u64)node;
 }
 
-// NO ARM FUNCTION: THE PER-CPU WAITING SIGNAL IS pcpu_enqueue_ns[cpu], STAMPED
+// NO ARM FUNCTION: THE PER-CPU WAITING SIGNAL IS sojourn_stamp_pcpu[cpu], STAMPED
 // AT PLACEMENT; tick() READS IT DIRECTLY (SEE THE PER-CPU PREEMPT IN tick()).
+
+// CODEL DRAIN RATE: UPDATE MIN SOJOURN WHEN A TASK STARTS RUNNING.
+// CALLED FROM pandemonium_running WITH THE TASK'S MEASURED PER-TASK
+// SOJOURN (now - tctx->enqueue_at). REPLACES THE OLD DSQ-EMPTY-CYCLE
+// PROXY THAT READ sojourn_stamp_pcpu[cpu] -- THAT METRIC IS EXACT FOR
+// THE FIRST TASK IN AN EMPTY-TO-NONEMPTY TRANSITION BUT WEAKENS FOR
+// LATER TASKS AND FOR SOJOURN-ORDERED DSQs WHERE HEAD != FIRST-ARRIVAL.
+// THE PER-TASK MEASUREMENT IS THE LITERAL CoDel METRIC FROM RFC 8289.
+static __always_inline void update_pcpu_sojourn(u32 cpu, u64 sojourn)
+{
+	if (cpu >= MAX_CPUS) return;
+	if (sojourn < pcpu_min_sojourn_ns[cpu])
+		pcpu_min_sojourn_ns[cpu] = sojourn;
+}
+
+// CODEL STALL DETECTION: MIN SOJOURN ABOVE DYNAMIC TARGET FOR INTERVAL = STALLED.
+// THE TARGET (codel_target_ns) IS MODULATED BY DAMPED OSCILLATION IN tick().
+// RESCUES PULL THE TARGET DOWN (TIGHTEN). QUIET PUSHES IT UP (RELAX).
+// THE TARGET ADAPTS TO WHAT "NORMAL SOJOURN" IS ON THIS SYSTEM RIGHT NOW.
+static __always_inline bool pcpu_dsq_is_stalled(u32 cpu, u64 now)
+{
+	if (cpu >= MAX_CPUS) return false;
+	u64 min_s = pcpu_min_sojourn_ns[cpu];
+
+	if (min_s < codel_target_ns) {
+		pcpu_stall_start_ns[cpu] = 0;
+		pcpu_min_sojourn_ns[cpu] = ~0ULL;
+		return false;
+	}
+
+	if (pcpu_stall_start_ns[cpu] == 0) {
+		pcpu_stall_start_ns[cpu] = now + sojourn_interval_ns;
+		return false;
+	}
+
+	if (now >= pcpu_stall_start_ns[cpu]) {
+		pcpu_min_sojourn_ns[cpu] = ~0ULL;
+		pcpu_stall_start_ns[cpu] = 0;
+		return true;
+	}
+
+	return false;
+}
 
 // SOJOURN GATE: RETURNS TRUE IF BOTH OVERFLOW DSQs ARE WITHIN THE RESCUE
 // WINDOW (i.e. IT IS SAFE TO RETURN FROM dispatch() AFTER A SUCCESSFUL
 // STEP 0 / STEP 1 HIT WITHOUT STARVING A SHARED OVERFLOW DSQ). CALLERS
 // SHORT-CIRCUIT AS `if (sojourn_gate_pass(now)) return;` -- IF AN OVERFLOW
-// SIDE HAS AGED PAST overflow_sojourn_rescue_ns, FALL THROUGH SO STEP 2
+// SIDE HAS AGED PAST codel_target_ns, FALL THROUGH SO STEP 2
 // SERVES OVERFLOW ON THIS DISPATCH CYCLE TOO.
 //
 // THIS GATE IS LOAD-BEARING. WITHOUT IT, EVERY CPU WHOSE OWN PER-CPU DSQ
 // HAS WORK SUCCEEDS AT STEP 0 AND RETURNS, NEVER VISITING STEP 2.  UNDER
 // SUSTAINED LOAD WHERE ALL CPUs ARE BUSY, OVERFLOW DSQs AGE TO THE
-// starvation_rescue_ns SAFETY NET (~167MS) BEFORE ANYONE SERVICES THEM --
+// codel_starve_ns SAFETY NET (~167MS) BEFORE ANYONE SERVICES THEM --
 // LONG ENOUGH TO STARVE WORKQUEUE WORKERS (INCLUDING scx_watchdog_workfn)
 // AND CAUSE 30S WATCHDOG KILLS, AUDIO DROPOUTS, AND BURST-TAIL LATENCY.
 // COST: TWO STATIC READS, TWO COMPARES PER SUCCESSFUL DRAIN.
-static __always_inline bool sojourn_gate_pass(u64 now, u32 dom)
+static __always_inline bool sojourn_gate_pass(u64 now)
 {
-	u32 cx = dom & (MAX_OVERFLOW_DOMAINS - 1);
-	u64 ie = interactive_enqueue_ns[cx];
-	u64 be = batch_enqueue_ns[cx];
-	return (ie == 0 || (now - ie) <= overflow_sojourn_rescue_ns) &&
-	       (be == 0 || (now - be) <= overflow_sojourn_rescue_ns);
+	u64 ie = sojourn_stamp_overflow.inter;
+	u64 be = sojourn_stamp_overflow.batch;
+	return (ie == 0 || (now - ie) <= codel_target_ns) &&
+	       (be == 0 || (now - be) <= codel_target_ns);
 }
 
 // DRAIN ONE TASK FROM AN OVERFLOW DSQ; CLEAR ITS EMPTY->NONEMPTY STAMP WHEN
@@ -992,25 +687,10 @@ static __always_inline bool overflow_drain_clear(u64 dsq, u64 *stamp)
 	return true;
 }
 
-// cache domain-LOCAL OVERFLOW DRAIN: DRAIN MY cache domain'S OVERFLOW DSQ. CROSS-DOMAIN WORK
-// CONSERVATION IS A SINGLE EXPLICIT LOOP IN DISPATCH (BELOW THE LOCAL STEPS),
-// NOT FOLDED INTO THIS HELPER -- THE ORIGINAL "DRAIN LOCAL + SCAN OTHER cache domains"
-// SHAPE INLINED FOUR TIMES (STEP 3, STEP 4, BOTH RESCUE PATHS) BLEW THE
-// PROGRAM PAST THE VERIFIER'S INSTRUCTION CEILING (-E2BIG). SPLITTING THE
-// LOCAL FAST PATH FROM THE CROSS-DOMAIN SCAN KEEPS INLINED HELPERS TINY AND
-// PUTS THE LOOP WHERE IT RUNS ONCE PER DISPATCH.
-static __always_inline bool domain_overflow_drain_local(u32 my_dom,
-						     bool batch,
-						     u64 *stamp)
-{
-	u64 dsq = batch ? domain_batch_dsq(my_dom) : domain_inter_dsq(my_dom);
-	return overflow_drain_clear(dsq, stamp);
-}
-
 // SERVICE WHICHEVER OVERFLOW SIDE (INTERACTIVE OR BATCH) HAS THE OLDER
 // PENDING ENQUEUE AGED PAST `thresh`. RETURNS TRUE IF DISPATCHED.
-// USED AT TWO THRESHOLDS IN dispatch(): starvation_rescue_ns (THE SAFETY
-// NET, FIRES BEFORE STEP 2 AND IS NEVER GATED) AND overflow_sojourn_rescue_ns
+// USED AT TWO THRESHOLDS IN dispatch(): codel_starve_ns (THE SAFETY
+// NET, FIRES BEFORE STEP 2 AND IS NEVER GATED) AND codel_target_ns
 // (STEP 2, THE NORMAL OVERFLOW SERVICE PATH). ONE FUNCTION REPLACES SIX
 // REDUNDANT RESCUE BLOCKS THAT WERE ALL DOING THE SAME scx_bpf_dsq_move_to_local
 // AT DIFFERENT THRESHOLDS WITH DIFFERENT GATING.
@@ -1020,13 +700,13 @@ static __always_inline bool domain_overflow_drain_local(u32 my_dom,
 // PRESSURE SIGNAL); SAFETY NET SETS IT FALSE (BACKSTOP-ONLY, NOT THE NORMAL
 // SIGNAL THE OSCILLATOR SHOULD MODEL).
 static __always_inline bool try_service_older_overflow(u64 now,
-						        u32 my_dom,
+						        u64 node_dsq,
+						        u64 batch_dsq,
 						        u64 thresh,
 						        bool feed_oscillator)
 {
-	u32 cx = my_dom & (MAX_OVERFLOW_DOMAINS - 1);
-	u64 ie = interactive_enqueue_ns[cx];
-	u64 be = batch_enqueue_ns[cx];
+	u64 ie = sojourn_stamp_overflow.inter;
+	u64 be = sojourn_stamp_overflow.batch;
 	u64 i_age = (ie > 0 && now > ie) ? (now - ie) : 0;
 	u64 b_age = (be > 0 && now > be) ? (now - be) : 0;
 
@@ -1048,18 +728,14 @@ static __always_inline bool try_service_older_overflow(u64 now,
 	bool dispatched_any = false;
 
 	if (serve_interactive) {
-		if (domain_overflow_drain_local(my_dom, false,
-					     &interactive_enqueue_ns[cx]))
+		if (overflow_drain_clear(node_dsq, &sojourn_stamp_overflow.inter))
 			dispatched_any = true;
-		if (b_aged && domain_overflow_drain_local(my_dom, true,
-						       &batch_enqueue_ns[cx]))
+		if (b_aged && overflow_drain_clear(batch_dsq, &sojourn_stamp_overflow.batch))
 			dispatched_any = true;
 	} else {
-		if (domain_overflow_drain_local(my_dom, true,
-					     &batch_enqueue_ns[cx]))
+		if (overflow_drain_clear(batch_dsq, &sojourn_stamp_overflow.batch))
 			dispatched_any = true;
-		if (i_aged && domain_overflow_drain_local(my_dom, false,
-						       &interactive_enqueue_ns[cx]))
+		if (i_aged && overflow_drain_clear(node_dsq, &sojourn_stamp_overflow.inter))
 			dispatched_any = true;
 	}
 
@@ -1120,10 +796,15 @@ static __always_inline void apply_tau_scaling(u64 tau_ns, u64 codel_eq_ns)
 	// SAFETY RAIL (KILL SWITCH IF A k_i IS MISCALIBRATED).
 	u64 v;
 
+	v = scale_tau(tau_ns, K_SOJOURN_INTERVAL);
+	if (v < 2000000ULL) v = 2000000ULL;
+	if (v > 12000000ULL) v = 12000000ULL;
+	sojourn_interval_ns = v;
+
 	v = scale_tau(tau_ns, K_STARVATION_RESCUE);
 	if (v < 20000000ULL) v = 20000000ULL;
 	if (v > 500000000ULL) v = 500000000ULL;
-	starvation_rescue_ns = v;
+	codel_starve_ns = v;
 
 	v = scale_tau(tau_ns, K_CODEL_FLOOR);
 	if (v < 200000ULL) v = 200000ULL;
@@ -1136,12 +817,12 @@ static __always_inline void apply_tau_scaling(u64 tau_ns, u64 codel_eq_ns)
 	longrun_thresh_ns = v;
 
 	v = scale_tau(tau_ns, K_CODEL_MAX);
-	// NO FIXED FLOOR: THE OLD 1ms FLOOR PINNED codel_target_max AT 12C
-	// (0.05*13.3ms = 665us -> 1ms) AND 8C, OVERRIDING THE tau-DERIVED VALUE --
-	// THE ONE FLOOR THAT ACTUALLY BINDS ON THIS BOX. FLOOR INSTEAD AT THE
-	// OSCILLATOR'S OWN FLOOR SO THE WORKING WINDOW CAN NEVER INVERT (max >=
-	// floor) AT DENSE TOPOLOGIES WHERE 0.05*tau WOULD DIP BELOW codel_floor,
-	// WHILE LETTING THE TARGET TRACK tau ON REAL HARDWARE.
+	// NO FIXED FLOOR: the old 1ms floor pinned codel_target_max at 12C
+	// (0.05*13.3ms = 665us -> 1ms) and 8C, overriding the tau-derived value --
+	// the one floor that actually binds on this box. Floor instead at the
+	// oscillator's own floor so the working window can never invert (max >=
+	// floor) at dense topologies where 0.05*tau would dip below codel_floor,
+	// while letting the target track tau on real hardware.
 	if (v < codel_target_floor_ns) v = codel_target_floor_ns;
 	if (v > 8000000ULL) v = 8000000ULL;           // CEILING 8MS (stall-blind guard)
 	codel_target_max_ns = v;
@@ -1154,16 +835,13 @@ static __always_inline void apply_tau_scaling(u64 tau_ns, u64 codel_eq_ns)
 		u64 eq = codel_eq_ns;
 		if (eq < codel_target_floor_ns) eq = codel_target_floor_ns;
 		if (eq > codel_target_max_ns)   eq = codel_target_max_ns;
-		codel_target_equilibrium_ns = eq;
+		codel_seed_ns = eq;
 	}
 
-	// OVERFLOW-GATE DELTA, PRODUCED BY R_eff FOR FREE. THE GATE THAT OPENS
-	// OVERFLOW SERVICE (sojourn_gate_pass + STEP 2) NOW KEYS ON THE
-	// R_eff-DERIVED CODEL EQUILIBRIUM -- THE ALREADY-COMPUTED SPECTRAL SCALAR
-	// -- INSTEAD OF A HAND-TUNED k*tau TIME. SOJOURN (enqueue-age) IS
-	// UNCHANGED: STILL THE MEASURED PRESSURE AND THE OLDER-SIDE SELECTOR.
-	// R_eff SETS ONLY WHEN THE GATE OPENS; SOJOURN FILLS IT.
-	overflow_sojourn_rescue_ns = codel_target_equilibrium_ns;
+	// OVERFLOW GATE: sojourn_gate_pass + STEP 2 key on the LIVE codel_target_ns
+	// (the R_eff-seeded equilibrium the oscillator parks at, modulated by load) --
+	// no separate overflow threshold to seed. Sojourn (enqueue-age) is the measured
+	// pressure and the older-side selector; R_eff sets WHEN the gate opens.
 
 	// OSCILLATOR DYNAMICS: DERIVED FROM tau SO THE CONTROLLER RUNS ON THE
 	// SAME TIME CONSTANT AS ITS TARGET RANGE. DIRECT-DIVIDE (NOT Q16)
@@ -1236,8 +914,7 @@ static __always_inline void apply_tau_scaling(u64 tau_ns, u64 codel_eq_ns)
 		affinity_search_online = b;
 	}
 
-	// SLEEP-BOOST LAG CAP (NOT A VTIME CAP -- THE VTIME ENGINE WAS RETIRED
-	// IN v5.11.0; THIS BOUNDS THE SOJOURN-WARP CREDIT). SCALES WITH TOPOLOGY TIMING.
+	// VTIME LAG CAP. SLEEP-BOOST CEILING SCALES WITH TOPOLOGY TIMING.
 	// lag_cap_ns = K_LAG_CAP * tau (1.0 * tau AT 12C REFERENCE = 40MS).
 	// CLAMPED [8MS, 80MS].
 	v = scale_tau(tau_ns, K_LAG_CAP);
@@ -1256,32 +933,11 @@ static __always_inline void pcpu_drain_clear(u32 cpu)
 		return;
 	if (scx_bpf_dsq_nr_queued((u64)cpu) != 0)
 		return;
-	u64 old = pcpu_enqueue_ns[cpu].ns;
+	u64 old = sojourn_stamp_pcpu[cpu];
 	if (old > 0)
-		__sync_val_compare_and_swap(&pcpu_enqueue_ns[cpu].ns, old, 0);
-}
-
-// HEAL A STALE PER-CPU WAITER STAMP, THEN KICK ONLY IF A REAL WAITER REMAINS.
-// pcpu_enqueue_ns[cpu] IS ARMED ON PLACEMENT AND CLEARED BY pcpu_drain_clear
-// AFTER A SUCCESSFUL move_to_local. IF A QUEUED TASK IS INSTEAD REMOVED BY A
-// NON-DISPATCH PATH -- TASK EXIT, OR A SETAFFINITY DEQUEUE THAT BYPASSES
-// dispatch() -- THE DSQ EMPTIES BUT THE STAMP STAYS ARMED, AND NO move_to_local
-// WILL EVER SUCCEED ON THE NOW-EMPTY DSQ TO CLEAR IT. THE TICK SCAN WOULD THEN
-// KICK THAT IDLE CPU EVERY TICK FOREVER: A SPURIOUS-WAKEUP IDLE-POWER DRAIN, AND
-// A CORRUPTED (STALE-OLD) SOJOURN FOR THE NEXT TASK THAT LANDS THERE. CONFIRM
-// THE DSQ BEFORE KICKING: pcpu_drain_clear ZEROES THE STAMP WHEN nr_queued == 0,
-// SO A SURVIVED (STILL NON-ZERO) STAMP MEANS A GENUINE WAITER. RETURNS TRUE IFF
-// IT KICKED. THE nr_queued PROBE RUNS ONLY ON A STAMP ALREADY AGED PAST
-// THRESHOLD (THE RARE SUSPICIOUS CASE), SO THE COMMON PATH IS UNCHANGED.
-static bool pcpu_kick_if_waiter(u32 cpu)
-{
-	if (cpu >= MAX_CPUS)
-		return false;
-	pcpu_drain_clear(cpu);
-	if (pcpu_enqueue_ns[cpu].ns == 0)
-		return false;
-	scx_bpf_kick_cpu(cpu, SCX_KICK_PREEMPT);
-	return true;
+		__sync_val_compare_and_swap(&sojourn_stamp_pcpu[cpu], old, 0);
+	if (pcpu_pinned_strand_ns[cpu] > 0)
+		pcpu_pinned_strand_ns[cpu] = 0;
 }
 
 // HISTOGRAM BUCKETING: MATCHES HIST_EDGES_NS AND SLEEP_EDGES_NS IN RUST
@@ -1387,45 +1043,33 @@ static __always_inline u64 effective_weight(const struct task_struct *p,
 
 // SCHEDULING HELPERS
 
-// SOJOURN SELECTOR (NO VIRTUAL TIME): THE DSQ SORT KEY IS THE ENQUEUE
-// TIMESTAMP, SO THE QUEUE ORDERS OLDEST-FIRST -- AT ANY FIXED DISPATCH
-// INSTANT THE SMALLEST KEY IS THE EARLIEST INSERT, I.E. THE LARGEST
-// SOJOURN (now - enqueue time). THE TIER WARP BACK-DATES HIGHER TIERS SO
-// THEY SORT AHEAD; IT IS BOUNDED (<= lag_cap_ns), SO A STREAM OF
-// LAT_CRITICAL WAKEUPS CAN NEVER STARVE A BATCH TASK OLDER THAN THE WARP.
+// SOJOURN SELECTOR (NO VIRTUAL TIME): the DSQ sort key is the enqueue
+// timestamp, so the queue orders oldest-first -- at any fixed dispatch
+// instant the smallest key is the earliest insert, i.e. the largest
+// sojourn (now - enqueue_at). The tier warp back-dates higher tiers so
+// they sort ahead; it is BOUNDED (<= lag_cap_ns), so a stream of
+// LAT_CRITICAL wakeups can never starve a BATCH task older than the warp.
 // PER-TASK SOJOURN POTENTIAL (Q16, 0..65536). TIER SETS THE CEILING SHARE;
 // PER-TASK BEHAVIOR SETS THE MAGNITUDE. BOUNDED SUM OF MONOTONIC RAMPS --
 // CONTINUOUS, NO TIER CLIFF, NO UNBOUNDED ADVANTAGE.
 static __always_inline u32 task_potentiality_q16(const struct task_ctx *tctx,
 						 const struct tuning_knobs *knobs)
 {
-	if (tctx->ewma_age < EWMA_AGE_MATURE) {
-		// UNOBSERVED. A FRESH FORK ENTERS AS TIER_INTERACTIVE WITH A SHORT
-		// avg_runtime; WITHOUT A PRIME IT WARPS 0 -> SORTS AT now (DEAD-LAST,
-		// LIKE BATCH) -> LOSES THE 4C DISPATCH RACE TO A FULL STRESS SLICE
-		// (THE app-launch ms BLOWOUT). GIVE A GENUINELY-FRESH, SHORT-RUNTIME,
-		// INTERACTIVE TASK A SMALL BOUNDED BACK-DATE THAT DECAYS TO 0 BY
-		// MATURITY (WHERE THE EARNED WARP BELOW TAKES OVER). BOUNDED << THE
-		// MATURE CEILING SO MATURED/DEADLINE WORK ALWAYS SORTS AHEAD; SHORT-
-		// RUNTIME-GATED SO A FRESH HOG EARNS NOTHING; ORDERING ONLY (FEEDS THE
-		// DSQ KEY, NEVER A PREEMPT) AND lag_cap-BOUNDED, SO A FORK STORM STILL
-		// CANNOT LEAPFROG ESTABLISHED WORK.
-		if (tctx->tier == TIER_INTERACTIVE) {
-			u64 slice = knobs && knobs->slice_ns
-				  ? knobs->slice_ns : 1000000;
-			if (tctx->avg_runtime < slice) {
-				u32 ramp = (u32)(EWMA_AGE_MATURE -
-						 tctx->ewma_age);
-				return (PRIME_FRESH_Q16 * ramp) /
-				       EWMA_AGE_MATURE;
-			}
-		}
-		return 0;                  // BATCH / HOG / UNCLASSIFIED: NO PRIME
-	}
+	if (tctx->ewma_age < EWMA_AGE_MATURE)
+		return 0;                  // UNOBSERVED: NO POTENTIAL
 	if (tctx->tier == TIER_BATCH)
 		return 0;                  // BATCH NEVER WARPS
 	if (tctx->tier == TIER_LAT_CRITICAL)
 		return 1u << 16;           // RT FLOOR: ABSOLUTE, FULL CEILING
+
+	// PINNED KERNEL-SERVICE FLOOR: the welded per-CPU kworker userspace blocks
+	// on earns its back-date by ROLE, not interactive shape. Its bursty I/O work
+	// scores ~0 on both axes below, so the behavioral earner would strand it
+	// behind a LAT_CRITICAL holder until the ~167ms codel net instead of the
+	// ~20ms warp. A pure read of the ONE pinned_service judgement set in
+	// runnable() -- no PF_KTHREAD/cpumask re-test. BELOW the LAT_CRITICAL ceiling.
+	if (tctx->pinned_service)
+		return 1u << 15;           // == lag_cap_ns>>1, the v5.11.0 INTERACTIVE value
 
 	// INTERACTIVE: EARNED CONTINUOUSLY FROM PER-TASK BEHAVIOR.
 	u64 slice = knobs ? knobs->slice_ns : 1000000;
@@ -1450,29 +1094,6 @@ static __always_inline u32 task_potentiality_q16(const struct task_ctx *tctx,
 	return acc;                        // 0..65536
 }
 
-// FLOW SIGNATURE CLASSIFIER (CLASSIFY ONCE, FREEZE AT MATURITY). EACH WAKEUP
-// SETS THE WAKER CPU'S BIT; THE POPCOUNT IS THE TASK'S DISTINCT-PARTNER
-// CARDINALITY. AT MATURITY: <= SHAPE_TIGHT_MAX PARTNERS IS A TIGHT LOOP; A
-// PARTNER SET SPANNING AT LEAST HALF THE MACHINE IS A STORM MESH; EVERYTHING
-// BETWEEN DEFAULTS TO TIGHT (LATENCY-SAFE -- ITS STEAL STAYS FREELY RELIEVABLE).
-// THEN FREEZE -- DETERMINISTIC PER TASK, SO ROUTING CAN'T COIN-FLIP.
-static __always_inline void update_shape(struct task_ctx *tctx, u32 waker)
-{
-	if (tctx->shape != SHAPE_UNCLASSIFIED)
-		return;                                 // FROZEN
-	if (waker < 64)
-		tctx->waker_bitmap |= (1ULL << waker);
-
-	if (tctx->ewma_age < EWMA_AGE_MATURE)
-		return;                                 // STILL OBSERVING
-
-	u32 card = (u32)__builtin_popcountll(tctx->waker_bitmap);
-	if (card > SHAPE_TIGHT_MAX && card * 2 >= nr_cpu_ids)
-		tctx->shape = SHAPE_STORM;
-	else
-		tctx->shape = SHAPE_TIGHT;
-}
-
 static __always_inline u64 task_deadline(struct task_ctx *tctx,
 					 const struct tuning_knobs *knobs)
 {
@@ -1489,7 +1110,7 @@ static __always_inline u64 task_deadline(struct task_ctx *tctx,
 	// SOJOURN BACK-PRESSURE: ORDERING IS now - warp, OLDEST-FIRST -- A STARVING
 	// TASK RISES AS IT AGES, AND BOUNDED WARP MAKES IT STARVATION-FREE. DEEP-QUEUE
 	// DRAINAGE IS THE OVERFLOW RESCUE'S JOB (try_service_older_overflow AT
-	// overflow_sojourn_rescue_ns), FORCED BY WAIT NOT DEPTH.
+	// codel_target_ns), FORCED BY WAIT NOT DEPTH.
 	return now > warp ? now - warp : 0;
 }
 
@@ -1544,211 +1165,96 @@ static __always_inline u64 task_slice(const struct task_ctx *tctx,
 // SELECT_CPU: FAST-PATH IDLE CPU DISPATCH TO PER-CPU DSQ
 // DISPATCHES TO NAMED PER-CPU DSQ (u64)cpu -- VISIBLE TO WORK STEALING
 // AND SOJOURN RESCUE. DEPTH-GATED: IF PER-CPU DSQ ALREADY HAS TASKS,
-// SPILL TO domain_inter_dsq SO ANY same-domain CORE CAN GRAB IT.
+// SPILL TO SHARED NODE DSQ SO ANY CPU CAN GRAB IT.
 // THE CPU IS IDLE SO IT ENTERS dispatch() IMMEDIATELY AND DRAINS.
 s32 BPF_STRUCT_OPS(pandemonium_select_cpu, struct task_struct *p,
 		   s32 prev_cpu, u64 wake_flags)
 {
 	bool is_idle = false;
 
-	// WARM-STAY: IF THE WAKEE'S ANCHOR (last_cpu) IS UNCONGESTED, HOLD IT THERE
-	// RATHER THAN FAN OUT TO A COLD IDLE SIBLING. select_cpu ONLY DEFERS (RETURNS
-	// THE ANCHOR WITHOUT DISPATCHING) -- THE ACTUAL PLACEMENT HAPPENS IN enqueue,
-	// WHICH KICKS PREEMPT (select_cpu's IDLE PATHS KICK IDLE, A NO-OP ON A BUSY
-	// ANCHOR). COMPUTED ONCE; GATES THE IDLE-SEEK BELOW. THE TIGHT-PARTNER SYNC
-	// COLOCATION STILL RUNS FIRST (IT'S A DELIBERATE PIPE-BUFFER LOCALITY BET).
-	s32 stay_hold;
-	{
-		struct task_ctx *tc = lookup_task_ctx(p);
-		struct tuning_knobs *kn = get_knobs();
-		bool wake = tc && !tc->ran_since_wake;
-		stay_hold = warm_stay_anchor(p, tc, kn, wake, bpf_ktime_get_ns());
-	}
-
-	// SET WHEN THE SYNC BLOCK WALKS last_cpu's affinity_rank AND FINDS NO NEAR
-	// IDLE: normal_path BELOW WOULD RE-WALK THE IDENTICAL (INIT-FIXED) RANK FOR
-	// THE IDENTICAL RESULT, SO IT SKIPS. ONLY FIRES FOR SYNC WAKES WHOSE
-	// prev_cpu == last_cpu; NON-SYNC WAKES LEAVE IT FALSE (normal_path WALKS ONCE).
-	bool last_cpu_idle_miss = false;
-
-	// WAKE_SYNC LOCALITY: PREFER AN IDLE CPU NEAR THE WAKEE'S WARM CORE. THIS IS
-	// A LOCALITY-OPTIMIZED SPREAD -- IT PLACES ONLY WHEN AN IDLE CORE IS FOUND,
-	// SO IT STAYS WARM AND WORK-CONSERVING (LOWER R_eff THAN THE ANY-IDLE PICK
-	// scx_bpf_select_cpu_dfl MAKES BELOW). IF NO NEAR IDLE, FALL THROUGH TO THE
-	// dfl SEARCH (ANY IDLE ANYWHERE); UNDER TRUE SATURATION THE TASK GOES TO
-	// enqueue, LANDS ON A STEALABLE PER-CPU DSQ, AND THE dispatch FLOW STEAL
-	// ROUTES IT BY SHAPE -- STORM SPREADS, TIGHT STAYS LOCAL.
+	// RESISTANCE AFFINITY: WAKEE_FLIPS-GATED WAKE_SYNC
+	// GATE: wakee_flips (per-task wakeup partner diversity) separates
+	//   1:1 pipe pairs (low flips, affinity beneficial) from
+	//   1:N server patterns (high flips, affinity harmful).
+	// PLACEMENT: R_eff ranked search from waker's CPU finds cheapest
+	//   idle CPU in waker's L2 group. Falls back to waker's DSQ if
+	//   no idle found and DSQ depth allows.
+	// REFERENCE: kernel wake_wide() uses same wakee_flips signal.
+	//   Kyng et al. effective resistance for migration cost.
 	if (wake_flags & SCX_WAKE_SYNC) {
-		struct task_ctx *tctx = lookup_task_ctx(p);
-		s32 waker_cpu = bpf_get_smp_processor_id();
-		// TRACK THE WAKER EVEN ON THE SYNC-PLACED PATH (enqueue's update_shape
-		// DOESN'T RUN WHEN select_cpu DISPATCHES), SO PARTNER CARDINALITY STAYS
-		// LIVE AND A 1:N SERVER SELF-CORRECTS OUT OF THE TIGHT CLASS BELOW.
-		if (tctx && waker_cpu >= 0 && waker_cpu < 64 &&
-		    tctx->shape == SHAPE_UNCLASSIFIED)
-			tctx->waker_bitmap |= (1ULL << (u32)waker_cpu);
-		// PIPE-PARTNER CO-LOCATION (EEVDF WAKE-AFFINE): ON A SYNC WAKE THE WAKER
-		// IS ABOUT TO BLOCK, SO ITS CORE FREES IN MICROSECONDS AND THE DATA IT
-		// JUST PRODUCED (THE PIPE BUFFER) IS CACHE-HOT. FOR A 1:1-ISH PARTNER
-		// (FEW DISTINCT WAKERS: waker_bitmap POPCOUNT <= SHAPE_TIGHT_MAX, OR A
-		// FROZEN SHAPE_TIGHT) SEAT THE WAKEE DIRECTLY ON THE WAKER'S PER-CPU DSQ
-		// -- THE ONE CASE WE DELIBERATELY QUEUE ON A BUSY CORE INSTEAD OF FLEEING
-		// TO A COLD IDLE SIBLING -- SO BOTH PIPE ENDS STAY WARM ON ONE CACHE.
-		// 1:N SERVERS (MANY WAKERS) FALL THROUGH TO THE WARM-NEAR-IDLE SEARCH SO
-		// CLIENTS DON'T PILE ONTO THE SERVER'S CPU.
-		u32 partners = tctx
-			? (u32)__builtin_popcountll(tctx->waker_bitmap) : 0;
-		bool tight = (tctx && tctx->shape == SHAPE_TIGHT) ||
-			     partners <= SHAPE_TIGHT_MAX;
-		// MULTI-cache domain ONLY: SEATING THE WAKEE ON THE WAKER'S CORE IS A REAL
-		// MIGRATION. IT PAYS OFF ONLY WHEN THE PARTNERS WOULD OTHERWISE SIT IN
-		// DIFFERENT L3s (CROSS-DOMAIN COLD) -- ON A MONOLITHIC L3 (nr_overflow_domains <= 1)
-		// EVERY CORE SHARES THE CACHE, SO THERE IS ZERO LOCALITY UPSIDE AND IT
-		// IS PURE MIGRATION CHURN THAT OVERRIDES THE HOME-PIN. GATE IT OFF THERE
-		// AND LET warm_stay_anchor's STABLE HOME GOVERN INSTEAD.
-		if (nr_overflow_domains > 1 && tight && (u64)waker_cpu < nr_cpu_ids &&
-		    bpf_cpumask_test_cpu(waker_cpu, p->cpus_ptr)) {
-			struct tuning_knobs *knobs = get_knobs();
-			u64 sl = tctx ? task_slice(tctx, knobs) : 1000000;
-			u64 dl = tctx ? task_deadline(tctx, knobs)
-				      : bpf_ktime_get_ns();
-			s32 dst_cpu;
-			u64 dst_dsq = pick_pcpu_dsq_with_spill(waker_cpu, p->cpus_ptr,
-				tctx ? tctx->shape : SHAPE_UNCLASSIFIED,
-				is_handoff_partner(tctx), &dst_cpu);
-			scx_bpf_dsq_insert_vtime(p, dst_dsq, sl, dl, 0);
-			// F0: the seat is a BUSY core. SCX_KICK_IDLE no-ops on a busy CPU and
-			// strands the wakee until the next tick. But bare KICK_PREEMPT on
-			// EVERY sync co-location STORMS preemption on a fork/messaging mesh --
-			// the waker co-locates the wakee onto its OWN cpu and then gets
-			// preempted every hop, bouncing work across cores (measured: cache-
-			// miss rate 4%->17%, IPC 0.42->0.28, ~4.5x slower than EEVDF). So
-			// PREEMPT only when the seat is a SPILL SIBLING (dst_cpu != waker_cpu:
-			// a busy core that is NOT the about-to-block waker, so no imminent
-			// free yield -- the real strand). When the seat IS the waker (the 1:1
-			// / handoff case), KICK_IDLE: the waker blocks in microseconds and
-			// STEP 0 drains the wakee, no preempt churn. Kick-semantics only.
-			scx_bpf_kick_cpu(dst_cpu,
-				dst_cpu != waker_cpu ? SCX_KICK_PREEMPT : SCX_KICK_IDLE);
-			if (tctx) {
-				tctx->dispatch_path = 0;
-			}
-			struct pandemonium_stats *s = get_stats();
-			if (s) {
-				s->nr_idle_hits += 1;
-				s->nr_dispatches += 1;
-				cross_domain_bump(s, XDOM_SEL_TIGHT, tctx ? tctx->last_cpu : -1, dst_cpu);
-			}
-			return dst_cpu;
-		}
-		s32 anchor = (prev_cpu >= 0 && (u64)prev_cpu < nr_cpu_ids)
-			   ? prev_cpu : waker_cpu;
-		// stay_hold >= 0 MEANS WARM-STAY IS PREFERRED -- SKIP THE IDLE-SEEK
-		// AND LET normal_path DEFER THE WAKEE TO enqueue's PREEMPT PLACEMENT.
-		if (stay_hold < 0 && (u64)anchor < nr_cpu_ids) {
-			// PHI PLACEMENT: STAY ON THE WARM CORE (IDLE OR SHALLOW-BUSY)
-			// RATHER THAN FLEE TO A COLD IDLE SIBLING.
-			s32 target = phi_warm_target(anchor, p->cpus_ptr,
-						     tctx ? tctx->tier : TIER_INTERACTIVE);
-			if (target >= 0) {
-				struct tuning_knobs *knobs = get_knobs();
-				u64 sl = tctx ? task_slice(tctx, knobs)
-					      : 1000000;
-				s32 dst_cpu;
-				u64 dst_dsq = pick_pcpu_dsq_with_spill(target, p->cpus_ptr, tctx ? tctx->shape : SHAPE_UNCLASSIFIED, is_handoff_partner(tctx), &dst_cpu);
-				u64 dl = tctx ? task_deadline(tctx, knobs) : bpf_ktime_get_ns();
-				scx_bpf_dsq_insert_vtime(p,
-					dst_dsq, sl, dl, 0);
-				// IPC FIX -- LOAD-BEARING, DO NOT REMOVE (commit 5224a8d5e).
-				// THE PER-CPU DSQ INSERT NEEDS AN EXPLICIT KICK OR THE
-				// WAKEE WAITS FOR THE NEXT TICK. pick_pcpu_dsq_with_spill
-				// CAN REDIRECT THE SEAT (dst_cpu) OFF THE VERIFIED-IDLE
-				// `target` ONTO A BUSY SPILL SIBLING / OVER-DEPTH src_cpu --
-				// KICK_IDLE NO-OPS ON A BUSY CPU, STRANDING THE WAKEE UNTIL
-				// THE ~1ms TICK. PREEMPT WHEN SPILLED (seat != target),
-				// IDLE WHEN THE SEAT IS THE IDLE PICK (mirrors :1610).
-				scx_bpf_kick_cpu(dst_cpu,
-					dst_cpu != target ? SCX_KICK_PREEMPT : SCX_KICK_IDLE);
-				if (tctx) {
-					tctx->dispatch_path = 0;
-				}
-				struct pandemonium_stats *s = get_stats();
-				if (s) {
-					s->nr_idle_hits += 1;
-					s->nr_dispatches += 1;
-					cross_domain_bump(s, XDOM_SEL_SYNC, tctx ? tctx->last_cpu : -1, dst_cpu);
-					if (dst_cpu != target)
-						s->nr_spill_kick_preempt += 1;
-				}
-				return dst_cpu;
-			}
-			// MISS: ANCHOR'S affinity_rank HAD NO NEAR IDLE. IF ANCHOR IS THE
-			// WAKEE'S last_cpu, normal_path WALKS THE IDENTICAL FIXED RANK FOR THE
-			// IDENTICAL RESULT -- RECORD THE MISS SO IT SKIPS THE REDUNDANT WALK.
-			// (IF A SIBLING IDLES IN THE ~us GAP, THE dfl PICK BELOW STILL USES IT,
-			// SO NO WORK-CONSERVATION LOSS -- JUST ONE FEWER RANK WALK PER WAKE.)
-			if (tctx && anchor == tctx->last_cpu)
-				last_cpu_idle_miss = true;
-		}
-	}
+		struct task_struct *waker =
+			(struct task_struct *)bpf_get_current_task_btf();
+		if (waker) {
+			u32 wflips = BPF_CORE_READ(waker, wakee_flips);
+			u32 pflips = p->wakee_flips;
+			// CARVE-OUT (SEE topology.rs): wakee_flips IS A COUNT,
+			// NOT A DURATION. nr_cpu_ids IS THE NATURAL UNIT FOR
+			// "DIVERSE vs CONCENTRATED" WAKEUP PARTNERS AND MATCHES
+			// THE KERNEL'S wake_wide() CONVENTION.
+			u32 thresh = nr_cpu_ids;
 
-	// WARM-STAY DEFER: anchor uncongested -> return it without dispatching, so
-	// p flows to enqueue's PREEMPT-kicked warm-stay placement instead of any
-	// idle-seek below (the normal_path warm pick or the dfl any-idle pick).
-	if (stay_hold >= 0)
-		return stay_hold;
+			// WAKE_WIDE: SKIP IF EITHER SIDE WAKES DIVERSE TASKS
+			if (wflips <= thresh && pflips <= thresh) {
+				s32 waker_cpu = bpf_get_smp_processor_id();
+				if ((u64)waker_cpu >= nr_cpu_ids)
+					goto normal_path;
 
-	// SHAPE-ROUTED WARM PLACEMENT (B): BEFORE THE dfl ANY-IDLE PICK -- WHICH IS
-	// TOPOLOGY-BLIND AND CAN SEAT THE WAKEE ON A CROSS-DOMAIN IDLE CORE (COLD L3,
-	// THE STORM'S CACHE-MISS SOURCE) -- KEEP IT ON ITS WARM CACHE. ANCHOR ON THE
-	// WAKEE'S OWN LAST CORE AND SEARCH R_eff-NEAR (SAME L2/cache domain FIRST). TIGHT GRABS
-	// ITS EXACT WARM CORE WHEN IT'S FREE (TIGHTEST CONSOLIDATION); BOTH SHAPES
-	// THEN TAKE THE NEAREST IDLE. FALLS THROUGH TO dfl ONLY WHEN NOTHING WARM-NEAR
-	// IS IDLE (TRUE SATURATION -- enqueue TIER 2 THEN WARM-ANCHORS IT).
-	{
-		struct task_ctx *tctx = lookup_task_ctx(p);
-		// FORK SEED: a freshly forked thread has last_cpu = -1 (enable), so it
-		// would skip this warm path and fall to the node-wide dfl pick below. On
-		// a single-NUMA dual-cache domain part that scatters the fork wakee across the
-		// cache domain/L3 boundary (montauk bench-enduser, 7950X3D: 15-18% cross-cache domain vs
-		// EEVDF 3.6%). Anchor a never-ran task on prev_cpu -- the parent's CPU at
-		// fork -- so it takes the SAME per-domain Phi-priced warm route established
-		// tasks take. Phi still prices the distance; cross-cache domain spill stays
-		// possible when the home cache domain is full. No fork branch, no bail gate.
-		s32 anchor = (tctx && tctx->last_cpu >= 0) ? tctx->last_cpu : prev_cpu;
-		if (!last_cpu_idle_miss && tctx && anchor >= 0 &&
-		    (u64)anchor < nr_cpu_ids &&
-		    bpf_cpumask_test_cpu(anchor, p->cpus_ptr)) {
-			// PHI PLACEMENT (ALL SHAPES): WARM CORE IF IDLE, ELSE QUEUE ON IT
-			// WHEN SHALLOW-BUSY (STAY L2-WARM) INSTEAD OF FLEEING COLD; ONLY A
-			// FULL WARM CORE FALLS THROUGH TO THE NEAREST IDLE. LAT_CRITICAL IS
-			// EXEMPT FROM THE QUEUE-ON-BUSY (KEEPS FLEEING FOR IMMEDIACY).
-			s32 target = phi_warm_target(anchor, p->cpus_ptr, tctx->tier);
-			if (target >= 0) {
-				struct tuning_knobs *knobs = get_knobs();
-				u64 sl = task_slice(tctx, knobs);
-				u64 dl = task_deadline(tctx, knobs);
-				s32 seat_cpu;
-				u64 seat_dsq = pick_pcpu_dsq_with_spill(target, p->cpus_ptr, tctx->shape, is_handoff_partner(tctx), &seat_cpu);
-				scx_bpf_dsq_insert_vtime(p, seat_dsq, sl, dl, 0);
-				// Spill can seat off the verified-idle `target` onto a busy
-				// sibling -- KICK_IDLE no-ops there and strands to the tick.
-				scx_bpf_kick_cpu(seat_cpu,
-					seat_cpu != target ? SCX_KICK_PREEMPT : SCX_KICK_IDLE);
-				tctx->dispatch_path = 0;
-				struct pandemonium_stats *s = get_stats();
-				if (s) {
-					s->nr_idle_hits += 1;
-					s->nr_dispatches += 1;
-					count_l2_affinity(s, tctx, seat_cpu);
-					cross_domain_bump(s, XDOM_SEL_NORMAL, anchor, seat_cpu);
-					if (seat_cpu != target)
-						s->nr_spill_kick_preempt += 1;
+				// R_EFF RANKED IDLE SEARCH FROM WAKER
+				s32 target = find_idle_by_affinity(waker_cpu, p->cpus_ptr);
+				if (target >= 0) {
+					struct task_ctx *tctx = lookup_task_ctx(p);
+					struct tuning_knobs *knobs = get_knobs();
+					u64 sl = tctx ? task_slice(tctx, knobs)
+						      : 1000000;
+					s32 dst_cpu;
+					u64 dst_dsq = pick_pcpu_dsq_with_spill(target, p->cpus_ptr, &dst_cpu);
+					u64 dl = tctx ? task_deadline(tctx, knobs) : bpf_ktime_get_ns();
+					scx_bpf_dsq_insert_vtime(p,
+						dst_dsq, sl, dl, 0);
+					if (tctx) {
+						tctx->dispatch_path = 0;
+						tctx->enqueue_at = bpf_ktime_get_ns();
+					}
+					struct pandemonium_stats *s = get_stats();
+					if (s) {
+						s->nr_idle_hits += 1;
+						s->nr_dispatches += 1;
+					}
+					return dst_cpu;
 				}
-				return seat_cpu;
+
+				// NO IDLE NEAR WAKER: DSQ DISPATCH IF DSQ IS FLOWING
+				// CODEL: IF MIN SOJOURN < 500us OVER LAST 8ms, TASKS
+				// ARE CYCLING THROUGH FAST. DSQ DISPATCH IS SAFE.
+				// IF STALLED (PINNED WORKERS), FALL THROUGH TO
+				// NORMAL PATH WHERE scx_bpf_select_cpu_dfl HANDLES
+				// PREEMPTION AND LOAD BALANCING.
+				if (!pcpu_dsq_is_stalled(
+					(u32)waker_cpu, bpf_ktime_get_ns())) {
+					struct task_ctx *tctx = lookup_task_ctx(p);
+					struct tuning_knobs *knobs = get_knobs();
+					u64 sl = tctx ? task_slice(tctx, knobs)
+						      : 1000000;
+					s32 dst_cpu;
+					u64 dst_dsq = pick_pcpu_dsq_with_spill(waker_cpu, p->cpus_ptr, &dst_cpu);
+					u64 dl = tctx ? task_deadline(tctx, knobs) : bpf_ktime_get_ns();
+					scx_bpf_dsq_insert_vtime(p,
+						dst_dsq, sl, dl, 0);
+					if (tctx) {
+						tctx->dispatch_path = 0;
+						tctx->enqueue_at = bpf_ktime_get_ns();
+					}
+					struct pandemonium_stats *s = get_stats();
+					if (s) {
+						s->nr_idle_hits += 1;
+						s->nr_dispatches += 1;
+					}
+					return dst_cpu;
+				}
 			}
 		}
 	}
+normal_path:;
 
 	s32 cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
 	s32 dst_cpu = cpu;
@@ -1760,20 +1266,17 @@ s32 BPF_STRUCT_OPS(pandemonium_select_cpu, struct task_struct *p,
 
 		// PER-CPU DSQ PLACEMENT WITH L2/R_EFF SPILL. CACHE-HOT IF cpu
 		// HAS ROOM; SIBLING PER-CPU DSQ NEXT (REACHED BY DISPATCH STEP 0
-		// ON SIBLING OR STEP 1 L2 STEAL); LAST-RESORT domain_inter_dsq.
-		u64 dst_dsq = pick_pcpu_dsq_with_spill(cpu, p->cpus_ptr, tctx ? tctx->shape : SHAPE_UNCLASSIFIED, is_handoff_partner(tctx), &dst_cpu);
+		// ON SIBLING OR STEP 1 L2 STEAL); LAST-RESORT SHARED NODE DSQ.
+		u64 dst_dsq = pick_pcpu_dsq_with_spill(cpu, p->cpus_ptr, &dst_cpu);
 		u64 dl = tctx ? task_deadline(tctx, knobs)
 			      : bpf_ktime_get_ns();
 		scx_bpf_dsq_insert_vtime(p, dst_dsq, sl, dl, 0);
 
-		// `cpu` is the verified-idle dfl pick (gated by is_idle). Spill can
-		// redirect dst_cpu onto a busy sibling, where KICK_IDLE no-ops and
-		// strands the wakee to the ~1ms tick -- PREEMPT when spilled.
-		scx_bpf_kick_cpu(dst_cpu,
-			dst_cpu != cpu ? SCX_KICK_PREEMPT : SCX_KICK_IDLE);
+		scx_bpf_kick_cpu(dst_cpu, SCX_KICK_IDLE);
 
 		if (tctx) {
 			tctx->dispatch_path = 0;
+			tctx->enqueue_at = bpf_ktime_get_ns();
 		}
 
 		struct pandemonium_stats *s = get_stats();
@@ -1782,9 +1285,6 @@ s32 BPF_STRUCT_OPS(pandemonium_select_cpu, struct task_struct *p,
 			s->nr_dispatches += 1;
 			if (tctx)
 				count_l2_affinity(s, tctx, dst_cpu);
-			cross_domain_bump(s, XDOM_SEL_DFL, tctx ? tctx->last_cpu : -1, dst_cpu);
-			if (dst_cpu != cpu)
-				s->nr_spill_kick_preempt += 1;
 		}
 
 #if TRACE_SCHED
@@ -1805,6 +1305,7 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 {
 	s32 node = __COMPAT_scx_bpf_cpu_node(scx_bpf_task_cpu(p));
 	if (node < 0 || (u32)node >= nr_nodes) node = 0;
+	u64 node_dsq = nr_cpu_ids + (u64)node;
 
 	struct task_ctx *tctx = lookup_task_ctx(p);
 
@@ -1815,61 +1316,59 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 	// CLASSIFY: WAKEUP VS RE-ENQUEUE
 	bool is_wakeup = tctx && !tctx->ran_since_wake;
 
-	// FLOW SIGNATURE: RECORD THIS WAKEUP'S WAKER CPU IN THE PERSISTED SHAPE
-	// BITMAP (CLASSIFY ONCE BY PARTNER CARDINALITY, FREEZE AT MATURITY). THE
-	// WAKER IS THE ENQUEUEING CPU.
-	if (tctx && is_wakeup)
-		update_shape(tctx, bpf_get_smp_processor_id());
-
-	// TIER 0 -- WARM-STAY: AN UNCONGESTED ANCHOR (last_cpu) KEEPS THE WAKEE ON
-	// ITS WARM CORE INSTEAD OF FANNING OUT TO A COLD IDLE SIBLING -- THE DUAL OF
-	// THE DISPATCH STEAL THRESHOLD (SEE warm_stay_anchor). PLACED DIRECTLY ON
-	// last_cpu's PER-CPU DSQ WITH NO SPILL: A LOW-SOJOURN ANCHOR DRAINS FAST EVEN
-	// WHEN DEEP, SO A DEPTH-BASED SPILL WOULD MIGRATE AGAINST THE WARM-STAY. KICK
-	// PREEMPT BECAUSE last_cpu MAY BE BUSY (KICK_IDLE WOULD NO-OP AND STRAND THE
-	// WAKEE -- THE SCAR ABOVE phi_warm_target). THIS IS WHERE select_cpu's
-	// WARM-STAY DEFER LANDS. ABOVE-THRESHOLD SOJOURN RETURNS -1 HERE AND THE
-	// WAKEE FANS OUT THROUGH TIER 1 BELOW EXACTLY AS BEFORE.
-	{
-		s32 hold = warm_stay_anchor(p, tctx, knobs, is_wakeup,
-					    bpf_ktime_get_ns());
-		if (hold >= 0) {
-			u64 hdl = task_deadline(tctx, knobs);
-			u64 hnow = bpf_ktime_get_ns();
+	// PINNED KERNEL-SERVICE PLACEMENT: a per-CPU kthread (ksoftirqd/N, kworker/N)
+	// userspace blocks on can run ONLY on its home CPU -- there is no placement
+	// choice. Insert straight into the home CPU's per-CPU DSQ (drained FIRST by
+	// dispatch STEP 0, cache-hot) and PREEMPT-kick it, so it runs within one
+	// dispatch cycle instead of burying in node_dsq and falling to the ~167ms
+	// codel_starve net. A pure read of pinned_service (the ONE judgement set in
+	// runnable()): no PF_KTHREAD/cpumask re-test here. Covers BOTH the on-home and
+	// the cross-CPU wakeup -- the home per-CPU DSQ is correct either way (the old
+	// on-home-only fast path left the cross-CPU strand at the 167ms net).
+	if (tctx && tctx->pinned_service) {
+		s32 home = scx_bpf_task_cpu(p);
+		if (home >= 0 && (u64)home < nr_cpu_ids) {
+			dl = task_deadline(tctx, knobs);
+			scx_bpf_dsq_insert_vtime(p, (u64)home, sl, dl, enq_flags);
+			// Mark this CPU as carrying a welded waiter so tick() can rescue it
+			// at the tight preempt floor if this PREEMPT-kick does not take. Stamp
+			// BOTH the pinned-strand stamp AND the generic per-CPU waiter stamp:
+			// tick() returns early when sojourn_stamp_pcpu[cpu]==0, so without this
+			// second stamp the pinned rescue is unreachable when the welded kworker
+			// waits alone behind a LAT_CRITICAL hog -- the 122s kworker strand.
+			u64 pin_now = bpf_ktime_get_ns();
 			__sync_val_compare_and_swap(
-				&pcpu_enqueue_ns[(u32)hold & (MAX_CPUS - 1)].ns,
-				0, hnow);
-			scx_bpf_dsq_insert_vtime(p, (u64)hold, sl, hdl, enq_flags);
-			scx_bpf_kick_cpu(hold, SCX_KICK_PREEMPT);
+				&pcpu_pinned_strand_ns[home & (MAX_CPUS - 1)], 0, pin_now);
+			__sync_val_compare_and_swap(
+				&sojourn_stamp_pcpu[home & (MAX_CPUS - 1)], 0, pin_now);
+			scx_bpf_kick_cpu(home, SCX_KICK_PREEMPT);
 			tctx->dispatch_path = 1;
+			tctx->enqueue_at = bpf_ktime_get_ns();
+
 			struct pandemonium_stats *s = get_stats();
 			if (s) {
-				s->nr_shared += 1;
 				s->nr_dispatches += 1;
-				// COUNT THE KICK BY WHAT WAS ISSUED. A re-enqueue here
-				// took KICK_IDLE (A's gate), so it is a soft kick -- a
-				// truthful kick H is what makes a storm log distinguish a
-				// real IPI storm from IDLE re-enqueue churn.
-				if (is_wakeup)
-					s->nr_hard_kicks += 1;
-				else
-					s->nr_soft_kicks += 1;
+				s->nr_hard_kicks += 1;
 				if (is_wakeup)
 					s->nr_enq_wakeup += 1;
 				else
 					s->nr_enq_requeue += 1;
-				count_l2_affinity(s, tctx, hold);
 			}
 			return;
 		}
 	}
 
-	// TIER 1: IDLE CPU -> THAT CPU'S PER-CPU DSQ + KICK
-	// L2 PLACEMENT: TRY IDLE SIBLING IN SAME L2 DOMAIN FIRST, SO cpu IS
-	// BIASED TO THE WAKEE'S last_cpu L2 GROUP (CACHE-WARM). SEAT THE WAKEE
-	// ON cpu'S OWN PER-CPU DSQ ((u64)cpu). cpu WAS JUST FOUND IDLE, SO ITS
-	// PER-CPU DSQ IS SHALLOW; NO SPILL SEARCH NEEDED.
+	// TIER 1: IDLE CPU -> NODE DSQ + KICK
+	// L2 PLACEMENT: TRY IDLE SIBLING IN SAME L2 DOMAIN FIRST.
 	// LAT_CRITICAL AND KERNEL THREADS SKIP AFFINITY -- FASTEST CPU WINS.
+	// TASK GOES TO SHARED NODE DSQ SO ANY CPU ON THE NODE CAN DRAIN IT
+	// VIA STEP 3 (UNCONDITIONAL node_dsq DRAIN). pick_pcpu_dsq_with_spill
+	// IS RESERVED FOR THE PLACEMENT SITES THAT ARE TIED TO A SPECIFIC CPU
+	// (TIER 2 PREEMPTION, select_cpu); FOR IDLE-CPU PLACEMENT, THE EAGER
+	// R_eff SEARCH (UP TO 6 MAP LOOKUPS + nr_queued QUERIES PER ENQUEUE)
+	// IS A WIRE-SPEED REGRESSION ON FORK-STORM WORKLOADS WITHOUT
+	// MEASURABLE PLACEMENT BENEFIT -- STEP 3 PICKS UP node_dsq TASKS
+	// WITHIN ONE DISPATCH CYCLE.
 	s32 cpu = -1;
 	if (knobs && knobs->affinity_mode > 0 && tctx &&
 	    tctx->tier != TIER_LAT_CRITICAL &&
@@ -1879,29 +1378,11 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 	if (cpu < 0)
 		cpu = __COMPAT_scx_bpf_pick_idle_cpu_node(p->cpus_ptr, node, 0);
 	if (cpu >= 0 && (u64)cpu < nr_cpu_ids) {
-		// TIER 1: WE FOUND A SPECIFIC IDLE CPU. SEAT THE WAKEE ON THAT CPU'S
-		// OWN PER-CPU DSQ AND KICK IT -- KICK==DRAIN IDENTITY, THE KICKED CPU
-		// IS THE ONE THAT DISPATCHES THE WAKEE. THE PRIOR SHAPE_STORM ROUTE TO
-		// domain_inter_dsq (cache domain-WIDE SHARED) WHILE KICKING ONE CPU DECOUPLED
-		// PLACEMENT FROM DRAIN: P(KICKED CPU WINS THE SHARED-DSQ RACE) ~ 1/cache domain
-		// SIZE, SO ~5/6 OF STORM WAKEUPS MIGRATED ON EVERY WAKE (THE WAKE-STORM
-		// LEAK / 1037-PER-THREAD MIGRATION FLOOR). PER-CPU PLACEMENT PINS THE
-		// WAKEE WHERE IT WAS KICKED; THE EXISTING STEP-1 R_eff STEAL STILL
-		// RELIEVES IT cache domain-LOCALLY IF IT AGES PAST THE PHI THRESHOLD.
-		u64 tier1_dsq = (u64)cpu;
-		bool tier1_to_overflow = false;
 		dl = tctx ? task_deadline(tctx, knobs)
 			  : bpf_ktime_get_ns();
-		scx_bpf_dsq_insert_vtime(p, tier1_dsq, sl, dl, enq_flags);
-		// ARM THE cache domain-OVERFLOW SOJOURN STAMP ONLY WHEN THIS PLACEMENT
-		// ACTUALLY LANDS IN domain_inter_dsq. PER-CPU PLACEMENTS (THE COMMON
-		// NON-STORM TIER 1 CASE) DON'T TOUCH domain_inter_dsq -- ARMING THE
-		// STAMP HERE WOULD LEAVE IT SET WITH NOTHING TO CLEAR IT, CAUSING
-		// STEP 2 RESCUE TO READ A STALE "HEAD AGE" THAT TRACKS NOTHING.
-		if (tier1_to_overflow)
-			__sync_val_compare_and_swap(
-				&interactive_enqueue_ns[cpu_domain_of((s32)cpu) & (MAX_OVERFLOW_DOMAINS - 1)],
-				0, bpf_ktime_get_ns());
+		scx_bpf_dsq_insert_vtime(p, node_dsq, sl, dl, enq_flags);
+		__sync_val_compare_and_swap(&sojourn_stamp_overflow.inter, 0,
+					    bpf_ktime_get_ns());
 
 		u64 kick_flag = (tctx && tctx->tier != TIER_BATCH)
 			      ? SCX_KICK_PREEMPT : SCX_KICK_IDLE;
@@ -1909,19 +1390,13 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 
 		if (tctx) {
 			tctx->dispatch_path = 0;
+			tctx->enqueue_at = bpf_ktime_get_ns();
 		}
 
 		struct pandemonium_stats *s = get_stats();
 		if (s) {
 			s->nr_shared += 1;
 			s->nr_dispatches += 1;
-			// Tier 1 was not counting its kick -- a PREEMPT here was
-			// invisible in kick H. Count by the flag actually issued.
-			if (kick_flag == SCX_KICK_PREEMPT)
-				s->nr_hard_kicks += 1;
-			else
-				s->nr_soft_kicks += 1;
-			cross_domain_bump(s, XDOM_ENQ_T1, tctx ? tctx->last_cpu : -1, cpu);
 			if (is_wakeup)
 				s->nr_enq_wakeup += 1;
 			else
@@ -1936,48 +1411,45 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 		return;
 	}
 
-	// TIER 2: WARM-ANCHOR WAKEUP -- WAKEE'S OWN last_cpu PER-CPU DSQ + KICK
-	// A WAKING TASK (OR LAT_CRITICAL RE-ENQUEUE) IS SEATED TOWARD THE CORE IT
-	// LAST RAN ON, NOT AN ARBITRARY NODE-WIDE PICK. pick_pcpu_dsq_with_spill
-	// GIVES THE WARM PER-CPU DSQ IF IT HAS ROOM, ELSE A NEAR R_eff SIBLING,
-	// ELSE domain_inter_dsq AS THE LAST-RESORT ESCAPE VALVE. dispatch STEP 0
-	// DRAINS THE WARM PER-CPU DSQ WHEN last_cpu NEXT DISPATCHES; STEP 1
-	// (NEAREST-SURPLUS STEAL) COVERS A SIBLING LANDING.
+	// TIER 2: WAKEUP PREEMPTION -- NODE DSQ + SELECTIVE KICK
+	// ALL WAKEUPS GET NODE DSQ DISPATCH: A TASK WAKING FROM SLEEP
+	// HAS EXTERNAL INPUT TO DELIVER (TIMER, IO, USER) REGARDLESS OF
+	// BEHAVIORAL TIER. THE CLASSIFIER OPERATES ON HISTORICAL BEHAVIOR;
+	// THE WAKEUP IS THE REAL-TIME LATENCY SIGNAL.
+	// LAT_CRITICAL ALSO GETS PREEMPTION ON REQUEUE.
+	// ONLINE GUARD: pick_any_cpu_node() CAN RETURN OFFLINE CPUs DURING
+	// HOTPLUG. OFFLINE CPUs HAVE NO CURRENT TASK (cpu_curr == NULL).
 	if (tctx &&
-	    (tctx->tier == TIER_LAT_CRITICAL || is_wakeup ||
-	     is_handoff_partner(tctx))) {
-		// WARM-ANCHOR: PREFER THE WAKEE'S OWN LAST CORE. pick_pcpu_dsq_with_spill
-		// THEN SEATS IT ON THAT cpu'S PER-CPU DSQ (WARM), A NEAR R_eff SIBLING,
-		// OR domain_inter_dsq AS LAST RESORT.
-		cpu = (tctx->last_cpu >= 0 && (u64)tctx->last_cpu < nr_cpu_ids)
-		    ? tctx->last_cpu
-		    : __COMPAT_scx_bpf_pick_any_cpu_node(p->cpus_ptr, node, 0);
+	    (tctx->tier == TIER_LAT_CRITICAL || is_wakeup)) {
+		cpu = __COMPAT_scx_bpf_pick_any_cpu_node(
+			p->cpus_ptr, node, 0);
 		if (cpu >= 0 && (u64)cpu < nr_cpu_ids &&
 		    __COMPAT_scx_bpf_cpu_curr(cpu)) {
+			// PER-CPU PLACEMENT WITH L2/R_EFF SPILL. SAME REACHABILITY
+			// LOGIC AS select_cpu: cpu's PER-CPU IF ROOM, ELSE A SIBLING
+			// VIA find_pcpu_with_room, ELSE LAST-RESORT NODE DSQ.
 			s32 t2_cpu;
-			u64 tier2_dsq = pick_pcpu_dsq_with_spill(cpu, p->cpus_ptr, tctx->shape, is_handoff_partner(tctx), &t2_cpu);
+			u64 tier2_dsq = pick_pcpu_dsq_with_spill(cpu, p->cpus_ptr, &t2_cpu);
 
 			dl = task_deadline(tctx, knobs);
 			scx_bpf_dsq_insert_vtime(p, tier2_dsq, sl, dl,
 						  enq_flags);
 
-			u64 kick_flag = (is_wakeup || is_handoff_partner(tctx))
+			u64 kick_flag = (is_wakeup ||
+				 tctx->tier == TIER_LAT_CRITICAL)
 				? SCX_KICK_PREEMPT : SCX_KICK_IDLE;
 			scx_bpf_kick_cpu(t2_cpu, kick_flag);
+			// NODE_DSQ SPILL: SERVICED BY THE DISPATCH SOJOURN GATE AND
+			// tick()'s PER-CPU PREEMPT; NOTHING TO ARM (THE GLOBAL PREEMPT
+			// FLAG WAS REMOVED FOR THE PER-CPU TICK PREEMPT).
 			tctx->dispatch_path = 1;
+			tctx->enqueue_at = bpf_ktime_get_ns();
 
 			struct pandemonium_stats *s = get_stats();
 			if (s) {
 				s->nr_shared += 1;
 				s->nr_dispatches += 1;
-				// Counted hard unconditionally even when it issued
-				// KICK_IDLE on a LAT_CRITICAL re-enqueue -- the boot-storm
-				// miscount that made kick H track enq R on cold boot.
-				// Count by the flag actually issued.
-				if (kick_flag == SCX_KICK_PREEMPT)
-					s->nr_hard_kicks += 1;
-				else
-					s->nr_soft_kicks += 1;
+				s->nr_hard_kicks += 1;
 				if (is_wakeup)
 					s->nr_enq_wakeup += 1;
 				else
@@ -1998,37 +1470,33 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 	// ewma_age=0 WOULD FLOOD THE BATCH DSQ AND STARVE FOR 30-40S
 	// WAITING FOR SOJOURN RESCUE THAT NEVER REACHES THE TAIL.
 	// LAT_CRITICAL TASKS ARE NEVER REDIRECTED.
-	// TIER 3 ROUTES TO THE per-domain OVERFLOW DSQ FOR THE TASK'S HOME CPU'S cache domain.
-	// Dispatch STEP 3 drains it cache domain-locally (cache-coherent inside the L3);
-	// STEP 5 is the cross-domain work-conservation scan when local cache domain is empty.
-	s32 src_cpu_t3 = scx_bpf_task_cpu(p);
-	u32 src_dom_t3 = cpu_domain_of(src_cpu_t3);
-	bool is_batch_t3 = tctx && tctx->tier == TIER_BATCH;
-	u64 target_dsq = is_batch_t3 ? domain_batch_dsq(src_dom_t3)
-				     : domain_inter_dsq(src_dom_t3);
+	u64 target_dsq = (tctx && tctx->tier == TIER_BATCH)
+		? (nr_cpu_ids + nr_nodes + (u64)node)
+		: node_dsq;
 
 	// SOJOURN TRACKING: RECORD WHEN OVERFLOW DSQs TRANSITION FROM EMPTY.
 	// DISPATCH STEP 0 CHECKS THESE TO RESCUE TASKS AGING PAST THRESHOLD.
-	if (is_batch_t3)
-		__sync_val_compare_and_swap(&batch_enqueue_ns[src_dom_t3 & (MAX_OVERFLOW_DOMAINS - 1)], 0, bpf_ktime_get_ns());
-	else
-		__sync_val_compare_and_swap(&interactive_enqueue_ns[src_dom_t3 & (MAX_OVERFLOW_DOMAINS - 1)], 0, bpf_ktime_get_ns());
+	if (target_dsq != node_dsq)
+		__sync_val_compare_and_swap(&sojourn_stamp_overflow.batch, 0, bpf_ktime_get_ns());
+	if (target_dsq == node_dsq)
+		__sync_val_compare_and_swap(&sojourn_stamp_overflow.inter, 0, bpf_ktime_get_ns());
 
 	// WARP IS BOUNDED BY lag_cap_ns INSIDE task_deadline() (NO CEILING CLAMP).
 	dl = tctx ? task_deadline(tctx, knobs) : bpf_ktime_get_ns();
 
 	scx_bpf_dsq_insert_vtime(p, target_dsq, sl, dl, enq_flags);
 
+	if (tctx)
+		tctx->enqueue_at = bpf_ktime_get_ns();
+
 #if TRACE_SCHED
 	if (is_sched_task(p))
 		bpf_printk("PAND: enq tier3 pid=%d dsq=%llu tier=%d", p->pid, target_dsq, tctx ? tctx->tier : -1);
 #endif
 
-	// cache domain OVERFLOW (domain_inter_dsq OR domain_batch_dsq). WAKEUPS KICK
-	// scx_bpf_task_cpu(p); IF BUSY, tick()'s PER-CPU PREEMPT DISLODGES
-	// THE RESIDENT. NO FLAG.
-	u64 kick_flags = (is_wakeup || is_handoff_partner(tctx))
-		       ? SCX_KICK_PREEMPT : 0;
+	// SHARED OVERFLOW (node_dsq OR batch_dsq). WAKEUPS KICK scx_bpf_task_cpu(p);
+	// IF BUSY, tick()'s PER-CPU PREEMPT DISLODGES THE RESIDENT. NO FLAG.
+	u64 kick_flags = is_wakeup ? SCX_KICK_PREEMPT : 0;
 	scx_bpf_kick_cpu(scx_bpf_task_cpu(p), kick_flags);
 
 	if (tctx)
@@ -2049,76 +1517,74 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 }
 
 // DISPATCH: CPU IS IDLE AND NEEDS WORK
-// HYBRID PER-CPU + per-domain OVERFLOW DESIGN:
+// HYBRID PER-CPU + NODE DSQ DESIGN:
 //   SELECT_CPU -> PER-CPU DSQ (DEPTH-GATED, VISIBLE, STEALABLE)
-//   ENQUEUE TIER 1/2 -> PER-CPU DSQ (WARM); SHAPE_STORM -> domain_inter_dsq
-//   ENQUEUE TIER 3 -> domain_inter_dsq / domain_batch_dsq (L3-LOCAL, SOJOURN-ORDERED)
+//   ENQUEUE TIER 1/2 -> NODE DSQ (SHARED, ANY CPU DRAINS)
+//   ENQUEUE TIER 3 -> PER-NODE BATCH/INTERACTIVE DSQ
 //
 // 0. OWN PER-CPU DSQ (CACHE-HOT, ZERO CONTENTION)
 // 1. R_EFF STEAL (AFFINITY_RANK -- L2 SIBLING AT SLOT 0, R_EFF PEERS AT SLOTS 1+)
-// SAFETY NET. SERVICE OLDER OVERFLOW SIDE PAST starvation_rescue_ns
-// 2. SERVICE OLDER OVERFLOW SIDE PAST overflow_sojourn_rescue_ns
-// 3. cache domain-LOCAL INTERACTIVE OVERFLOW (domain_inter_dsq[my_dom])
-// 4. cache domain-LOCAL BATCH OVERFLOW (domain_batch_dsq[my_dom])
-// 5. CROSS-DOMAIN SCAN (WORK CONSERVATION ACROSS L3 INTERCONNECT)
+// SAFETY NET. SERVICE OLDER OVERFLOW SIDE PAST codel_starve_ns
+// 2. SERVICE OLDER OVERFLOW SIDE PAST codel_target_ns
+// 3. NODE INTERACTIVE OVERFLOW (LAT_CRIT + INTERACTIVE, SOJOURN-ORDERED)
+// 4. NODE BATCH OVERFLOW (NORMAL BATCH FALLBACK)
+// 5. CROSS-NODE STEAL (INTERACTIVE + BATCH PER REMOTE NODE)
 // 6. KEEP_RUNNING IF PREV STILL WANTS CPU AND NOTHING QUEUED
 void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 {
-	u32 my_dom = cpu_domain_of(cpu);
+	s32 node = __COMPAT_scx_bpf_cpu_node(cpu);
+	if (node < 0 || (u32)node >= nr_nodes) node = 0;
+	u64 node_dsq = nr_cpu_ids + (u64)node;
+	u64 batch_dsq = nr_cpu_ids + nr_nodes + (u64)node;
 	struct pandemonium_stats *s;
 	u64 now = bpf_ktime_get_ns();
-	// STEP 1 SCAN-WINDOW FLAG: ONE RATE-LIMIT STAMP PER codel_target WINDOW,
-	// SET AND CONSUMED IN STEP 1.
-	bool steal_scan = false;
 
 	// STEP 0: OWN PER-CPU DSQ -- HIGHEST PRIORITY, CACHE-HOT.
 	// SOJOURN GATE AT EXIT: IF EITHER OVERFLOW SIDE HAS AGED PAST
-	// overflow_sojourn_rescue_ns, FALL THROUGH SO STEP 2 SERVES OVERFLOW
+	// codel_target_ns, FALL THROUGH SO STEP 2 SERVES OVERFLOW
 	// ON THIS DISPATCH TOO. WITHOUT THIS GATE, EVERY CPU WITH HOT PER-CPU
 	// WORK NEVER VISITS OVERFLOW; SCX_WATCHDOG_WORKFN AND OTHER WORKQUEUE
-	// WORKERS GET STARVED IN domain_inter_dsq UNTIL THE 167MS SAFETY NET FIRES.
+	// WORKERS GET STARVED IN node_dsq UNTIL THE 167MS SAFETY NET FIRES.
 	if ((u64)cpu < nr_cpu_ids &&
 	    scx_bpf_dsq_move_to_local((u64)cpu, 0)) {
-		// Clear the DSQ-empty-cycle timestamp.
+		// pcpu_min_sojourn_ns IS UPDATED BY pandemonium_running WHEN
+		// THE TASK ACTUALLY STARTS RUNNING (SEE PER-TASK SOJOURN BLOCK).
+		// HERE WE JUST CLEAR THE DSQ-EMPTY-CYCLE TIMESTAMP.
 		pcpu_drain_clear((u32)cpu);
 		s = get_stats();
 		if (s)
 			s->nr_dispatches += 1;
-		if (sojourn_gate_pass(now, my_dom))
+		if (sojourn_gate_pass(now))
 			return;
 	}
 
-	// STEP 1: R_EFF STEAL. SINGLE LOOP OVER affinity_rank: SLOT 0 IS THE
-	// L2 SIBLING (LOWEST R_EFF), SLOTS 1+ ARE R_EFF-RANKED PEERS, CROSS-DOMAIN
-	// INCLUDED. NO TIER BOUNDARY: Φ (the reff_value penalty) ALONE PRICES
-	// DISTANCE -- A CROSS-DOMAIN PULL NEEDS ~tau OF SUSTAINED BACKLOG, AN SMT
-	// SIBLING (R_eff~0) RELIEVES FREELY. affinity_rank IS AUTHORITATIVE FOR
-	// PLACEMENT DISTANCE.
-	// BUDGET = pcpu_spill_search_budget (nr_cpu_ids/2 CLAMPED TO
-	// [6, MAX_AFFINITY_CANDIDATES]), MATCHING THE ENQUEUE-SIDE SPILL HELPER.
+	// STEP 1: SOJOURN-AGE R_EFF STEAL. SINGLE LOOP OVER affinity_rank: SLOT 0
+	// IS THE NEAREST PEER (LOWEST R_EFF), SLOTS 1+ ARE R_EFF-RANKED PEERS.
+	// affinity_rank IS AUTHORITATIVE FOR PLACEMENT DISTANCE -- interface-agnostic,
+	// no CCX label, dynamically R_eff-ordered for this topology. STEAL THE NEAREST
+	// PEER WHOSE PER-CPU DSQ BACKLOG HAS AGED PAST codel_target: distance plus
+	// staleness, NOT a raw load grab (the old most-loaded steal scattered pairs
+	// the instant any peer had q>0 -- montauk: 42% cross-domain, no distance decay).
+	// BUDGET = pcpu_spill_search_budget, MATCHING THE ENQUEUE-SIDE SPILL HELPER.
 	{
 		u32 my_cpu = (u32)cpu;
 		u32 base = my_cpu * MAX_AFFINITY_CANDIDATES;
 		u32 checked = 0;
 		s32 best_peer = -1;
-		// SCAN RATE-LIMIT: the peer walk (affinity_rank lookup + per-peer
-		// nr_queued) is the dominant per-dispatch cache cost under wake-heavy
-		// LOADS. A PEER CANNOT ACCUMULATE STEALABLE BACKLOG (AGED PAST
-		// codel_target + b*R_eff) FASTER THAN codel_target, SO SCANNING MORE
-		// OFTEN THAN THAT IS PURE WASTE. GATE ON A PER-CPU TIMER; BETWEEN SCANS
-		// WE FALL THROUGH TO OVERFLOW/IDLE AND tick()'s REMOTE SCAN STILL KICKS
-		// ANY AGED PER-CPU DSQ, SO NO WORK IS STRANDED.
+		// SCAN RATE-LIMIT: the peer walk is the dominant per-dispatch cost under
+		// wake-heavy loads, and backlog cannot age past the steal threshold faster
+		// than the threshold itself -- so scan once per codel_target window.
+		// Between scans we fall through; tick()'s remote sojourn scan still kicks
+		// any aged per-CPU DSQ, so nothing is stranded.
 		u32 zero = 0;
 		u64 *last_scan = bpf_map_lookup_elem(&last_spill_scan, &zero);
-		steal_scan = !last_scan || *last_scan == 0 ||
-			     (now - *last_scan) >= codel_target_ns;
+		bool steal_scan = !last_scan || *last_scan == 0 ||
+				  (now - *last_scan) >= codel_target_ns;
 		if (steal_scan && last_scan)
 			*last_scan = now;
-		// SOURCE: R_eff FLOW STEAL. affinity_rank IS DISTANCE-ORDERED (SLOT 0 =
-		// L2 SIBLING), SO THE FIRST QUALIFYING PEER IS THE CLOSEST -- MIN-COST
-		// FLOW. SURPLUS > 1 GUARD: a peer needs at least 2 queued before we pull
-		// one (a lone warm task is never yanked). BOUNDED LOOP, LOCK-FREE
-		// move_to_local.
+		// affinity_rank IS DISTANCE-ORDERED (SLOT 0 = NEAREST), SO THE FIRST
+		// QUALIFYING PEER IS THE CLOSEST STALE ONE -- MIN-COST FLOW. BOUNDED
+		// LOOP, LOCK-FREE move_to_local.
 		for (int i = 0; steal_scan && i < MAX_AFFINITY_CANDIDATES; i++) {
 			u32 key = base + (u32)i;
 			u32 *val = bpf_map_lookup_elem(&affinity_rank, &key);
@@ -2132,10 +1598,10 @@ void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 					break;
 				continue;
 			}
-			// SOJOURN = peer DSQ backlog age. 0 means the peer's per-CPU DSQ is
-			// empty (stamp cleared on drain), so skip the remote DSQ-object touch
-			// (scx_bpf_dsq_nr_queued) for idle peers -- the common wake-heavy case.
-			u64 enq = pcpu_enqueue_ns[peer & (MAX_CPUS - 1)].ns;
+			// SOJOURN = peer per-CPU DSQ backlog age. 0 = empty (stamp cleared on
+			// drain), so skip the remote DSQ-object touch for idle peers -- the
+			// common wake-heavy case.
+			u64 enq = sojourn_stamp_pcpu[peer & (MAX_CPUS - 1)];
 			if (enq == 0) {
 				if (++checked >= pcpu_spill_search_budget)
 					break;
@@ -2143,19 +1609,23 @@ void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 			}
 			u32 nq = scx_bpf_dsq_nr_queued((u64)peer);
 			if (nq >= 1) {
-				// PHI STEAL-RESIST (SHAPE-BLIND): sojourn >= codel_target +
-				// b*R_eff, built only from values we already produce. SOJOURN is
-				// `enq` above (no remote head peek, no remote task_ctx deref). THE
-				// DISTANCE PENALTY b*R_eff is pre-folded into reff_value at topology
-				// detect (already ns), so the steal does ONE indexed read and no
-				// multiply: an SMT sibling (R_eff~0) stays freely relievable while a
-				// cross-domain pull needs ~tau of sustained backlog. reff_value all-zero
-				// (monolithic / --phi-scale 0) => flat codel_target, prior behavior.
+				// PHI STEAL-RESIST: the distance penalty b*R_eff is pre-folded
+				// into reff_value at topology detect (already ns), so the steal
+				// does ONE indexed read and no multiply -- an SMT sibling (R_eff~0)
+				// stays freely relievable while a cross-domain pull needs ~tau of
+				// sustained backlog. reff_value all-zero (monolithic / --phi-scale
+				// 0) => flat codel_target, prior behavior. surplus>1: pull only
+				// when 2+ queued, so a lone warm task is never yanked. LONE-TASK
+				// RESCUE (nq==1): a lone task is pinned until it ages past the
+				// overflow window, then stolen here far below the ~167ms net.
 				u32 *dxp = bpf_map_lookup_elem(&reff_value, &key);
 				u32 dx = dxp ? *dxp : 0;
 				u64 dist_extra = (dx == (u32)-1) ? 0 : (u64)dx;
 				u64 phi_thresh = codel_target_ns + dist_extra;
-				if (now >= enq && (now - enq) >= (nq > 1 ? phi_thresh : phi_thresh + overflow_sojourn_rescue_ns) /* LONE-TASK STARVATION RESCUE (nq==1): the surplus>1 rule pins a lone WARM task for cache locality, but montauk's dispatch-stall shows a lone burst wakee stranded on a BUSY peer's per-CPU DSQ is served 0% by that peer's STEP 0 (MIRROR, PREEMPT-STARVED) and 100% by steal (SUB), tailing to 100ms-947ms (worst 26.7s at 2C) since the only other rescue -- tick()'s rotating sojourn scan -- is sparse and never fires on an idle/all-idle-at-low-width topology. A lone task aged past the overflow window is no longer warm-worth-pinning: steal it here, far below the ~167ms net. Phi still prices distance; fresh lone tasks (< the window) stay pinned. */) {
+				u64 thresh = (nq > 1)
+					? phi_thresh
+					: phi_thresh + codel_target_ns;
+				if (now >= enq && (now - enq) >= thresh) {
 					best_peer = (s32)peer;
 					break;
 				}
@@ -2165,79 +1635,67 @@ void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 		}
 		if (best_peer >= 0 &&
 		    scx_bpf_dsq_move_to_local((u64)best_peer, 0)) {
+			// pcpu_min_sojourn_ns IS UPDATED BY pandemonium_running
+			// ON THE STOLEN-TO CPU.
 			pcpu_drain_clear((u32)best_peer);
 			s = get_stats();
-			if (s) {
+			if (s)
 				s->nr_dispatches += 1;
-				// STEAL: task's home is best_peer, now consumed by `cpu`.
-				cross_domain_bump(s, XDOM_STEAL, best_peer, cpu);
-			}
-			if (sojourn_gate_pass(now, my_dom))
+			if (sojourn_gate_pass(now))
 				return;
 		}
 	}
 
 	// SAFETY NET: HARD STARVATION RESCUE. SERVICE WHICHEVER OVERFLOW SIDE
-	// IS OLDER PAST starvation_rescue_ns (TAU-SCALED, ~167MS AT 12C).
-	// cache domain-LOCAL DRAIN FIRST, CROSS-DOMAIN FALLBACK FOR WORK-CONSERVATION.
-	if (try_service_older_overflow(now, my_dom,
-				       starvation_rescue_ns, false))
+	// IS OLDER PAST codel_starve_ns (TAU-SCALED, ~167MS AT 12C).
+	// FIRES BEFORE STEP 2 SO IT CANNOT BE GATED. ENQUEUE-SIDE PER-CPU
+	// SPILL SHOULD KEEP THIS RARELY EXERCISED; IF IT DOES FIRE,
+	// PLACEMENT IS WRONG OR TIME-BASED SERVICE IS BLOCKED -- DETECTABLE
+	// VIA nr_dispatches DELTA WHEN STEP 2 COUNTERS DON'T MOVE.
+	if (try_service_older_overflow(now, node_dsq, batch_dsq,
+				       codel_starve_ns, false))
 		return;
 
-	// STEP 2: SERVICE OLDER OVERFLOW SIDE PAST overflow_sojourn_rescue_ns
-	// (TAU-SCALED, ~10MS AT 12C). FEEDS THE OSCILLATOR.
-	if (try_service_older_overflow(now, my_dom,
-				       overflow_sojourn_rescue_ns, true))
+	// STEP 2: SERVICE OLDER OVERFLOW SIDE PAST codel_target_ns
+	// (TAU-SCALED, ~10MS AT 12C). ONE COMPARISON, ONE DRAIN. FEEDS THE
+	// OSCILLATOR (true) -- THIS IS THE REPRESENTATIVE PRESSURE SIGNAL
+	// THAT TIGHTENS codel_target_ns ON SUSTAINED LOAD.
+	if (try_service_older_overflow(now, node_dsq, batch_dsq,
+				       codel_target_ns, true))
 		return;
 
-	// STEP 3: per-domain INTERACTIVE OVERFLOW (LOCAL). Cache-coherent drain
-	// of my cache domain's overflow DSQ.
-	if (domain_overflow_drain_local(my_dom, false, &interactive_enqueue_ns[my_dom & (MAX_OVERFLOW_DOMAINS - 1)])) {
+	// STEP 3: NODE INTERACTIVE OVERFLOW (LAT_CRIT + INTERACTIVE, SOJOURN-ORDERED)
+	// UNCONDITIONAL DRAIN OF THE INTERACTIVE OVERFLOW DSQ.
+	if (overflow_drain_clear(node_dsq, &sojourn_stamp_overflow.inter)) {
 		s = get_stats();
 		if (s)
 			s->nr_dispatches += 1;
 		return;
 	}
 
-	// STEP 4: per-domain BATCH OVERFLOW (LOCAL).
-	if (domain_overflow_drain_local(my_dom, true, &batch_enqueue_ns[my_dom & (MAX_OVERFLOW_DOMAINS - 1)])) {
+	// STEP 4: NODE BATCH OVERFLOW (NORMAL BATCH FALLBACK)
+	if (overflow_drain_clear(batch_dsq, &sojourn_stamp_overflow.batch)) {
 		s = get_stats();
 		if (s)
 			s->nr_dispatches += 1;
 		return;
 	}
 
-	// STEP 5: CROSS-DOMAIN WORK CONSERVATION. SCAN OTHER cache domains ONCE; DRAIN ANY
-	// NON-EMPTY OVERFLOW (INTERACTIVE FIRST PER cache domain, THEN BATCH). RUNS ONLY
-	// WHEN THE LOCAL cache domain IS EMPTY, SO CROSS-DOMAIN MIGRATION HERE IS PURE
-	// IDLE-TIME WORK CONSERVATION -- CACHE COST IS OFFSET BY AVOIDING IDLE
-	// CORES. LOOP BOUND MAX_OVERFLOW_DOMAINS; nr_overflow_domains CAPS EARLY-EXIT.
-	for (u32 c = 0; c < MAX_OVERFLOW_DOMAINS; c++) {
-		if (c >= nr_overflow_domains)
-			break;
-		if (c == my_dom)
-			continue;
-		if (overflow_drain_clear(domain_inter_dsq(c),
-					 &interactive_enqueue_ns[c & (MAX_OVERFLOW_DOMAINS - 1)])) {
-			s = get_stats();
-			if (s) {
-				s->nr_dispatches += 1;
-				// STEP 5 DRAINS cache domain `c`'s OVERFLOW ONTO THIS CPU'S cache domain:
-				// ALWAYS CROSS-DOMAIN BY CONSTRUCTION (c != my_dom).
-				if (s->nr_cross_domain[XDOM_STEP5] < ~0ULL)
-					s->nr_cross_domain[XDOM_STEP5] += 1;
+	// CROSS-NODE STEAL
+	for (u32 n = 0; n < nr_nodes && n < MAX_NODES; n++) {
+		if (n != (u32)node) {
+			if (scx_bpf_dsq_move_to_local(nr_cpu_ids + (u64)n, 0)) {
+				s = get_stats();
+				if (s)
+					s->nr_dispatches += 1;
+				return;
 			}
-			return;
-		}
-		if (overflow_drain_clear(domain_batch_dsq(c),
-					 &batch_enqueue_ns[c & (MAX_OVERFLOW_DOMAINS - 1)])) {
-			s = get_stats();
-			if (s) {
-				s->nr_dispatches += 1;
-				if (s->nr_cross_domain[XDOM_STEP5] < ~0ULL)
-					s->nr_cross_domain[XDOM_STEP5] += 1;
+			if (scx_bpf_dsq_move_to_local(nr_cpu_ids + nr_nodes + (u64)n, 0)) {
+				s = get_stats();
+				if (s)
+					s->nr_dispatches += 1;
+				return;
 			}
-			return;
 		}
 	}
 
@@ -2261,20 +1719,6 @@ void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 void BPF_STRUCT_OPS(pandemonium_runnable, struct task_struct *p,
 		    u64 enq_flags)
 {
-	// F1a: WAKE-EDGE DETECTOR (the §3 "open-loop blindness" amendment, honored
-	// in substance). A wakee arriving into a PARKED controller is the disturbance
-	// the detector must catch on the wake path -- not on a post-damage rescue
-	// (the old un-park trigger). Un-park here, before any dispatch prices against
-	// codel_target_ns, and kick CPU 0 so the full recompute runs this beat rather
-	// than waiting for CPU 0's next tick (which may never fire under tickless
-	// idle). Gated on osc_env_parked: a predicted-not-taken branch under load
-	// (the controller only parks in quiescence, where this path is the point).
-	if (osc_env_parked) {
-		osc_env_unpark();
-		if (bpf_get_smp_processor_id() != 0)
-			scx_bpf_kick_cpu(0, SCX_KICK_PREEMPT);
-	}
-
 	struct task_ctx *tctx = lookup_task_ctx(p);
 	if (!tctx)
 		return;
@@ -2334,13 +1778,27 @@ void BPF_STRUCT_OPS(pandemonium_runnable, struct task_struct *p,
 	    p->static_prio <= KTHREAD_HIPRI_STATIC_PRIO_MAX)
 		new_tier = TIER_BATCH;
 
-	// KWORKER FLOOR: WORKQUEUE WORKERS HANDLE I/O COMPLETIONS, TIMER
-	// CALLBACKS, AND DEFERRED INTERRUPT WORK. USERSPACE BLOCKS ON THESE.
-	// THEIR LOW EWMA SCORES (INFREQUENT WAKEUPS, LONG RUNTIMES) PUSH
-	// THEM TO BATCH, BUT THEY ARE LATENCY-CRITICAL KERNEL INFRASTRUCTURE.
-	// ALSO RE-PROMOTES ANY PF_WQ_WORKER DEMOTED BY THE KTHREAD OVERRIDE
-	// ABOVE -- WORKQUEUE WORKERS ARE PF_KTHREAD BUT THE FLOOR WINS.
-	if (new_tier == TIER_BATCH && (p->flags & PF_WQ_WORKER))
+	// KERNEL-INFRASTRUCTURE FLOOR: WORKQUEUE WORKERS HANDLE I/O COMPLETIONS,
+	// TIMER CALLBACKS, AND DEFERRED INTERRUPT WORK. USERSPACE BLOCKS ON THESE.
+	// THEIR LOW EWMA SCORES (INFREQUENT WAKEUPS, LONG RUNTIMES) PUSH THEM TO
+	// BATCH, BUT THEY ARE LATENCY-CRITICAL KERNEL INFRASTRUCTURE. EXTENDED TO THE
+	// PER-CPU SOFTIRQ DAEMONS (ksoftirqd/N -- PF_KTHREAD, ONE ALLOWED CPU, NOT A
+	// PF_WQ_WORKER): THEY RUN THE SAME DEFERRED WORK (softirqs) USERSPACE BLOCKS
+	// ON BUT MISSED THE PF_WQ_WORKER FLOOR AND BURIED IN BATCH node_dsq, FALLING
+	// TO THE ~167ms net (montauk 2C: 43 of 51 strands were ksoftirqd -> 1 after).
+	// NORMAL-PRIORITY ONLY -- the nice<=-10 override above keeps its BATCH demotion.
+	// PINNED KERNEL-SERVICE: the ONE kthread judgement, computed here and nowhere
+	// else. A per-CPU kthread (ksoftirqd/N, kworker/N) welded to its home CPU that
+	// userspace blocks on. enqueue() reads pinned_service for forced home-CPU
+	// placement; tick() reads it for the preempt backstop. WQ workers that are NOT
+	// pinned (unbound, nr_cpus_allowed>1) still get the INTERACTIVE floor below but
+	// not the home-CPU forcing -- they can run anywhere, so steal/spill applies.
+	bool pinned_kservice =
+		(p->flags & PF_KTHREAD) && p->nr_cpus_allowed == 1 &&
+		p->static_prio > KTHREAD_HIPRI_STATIC_PRIO_MAX;
+
+	if (new_tier == TIER_BATCH &&
+	    ((p->flags & PF_WQ_WORKER) || pinned_kservice))
 		new_tier = TIER_INTERACTIVE;
 
 	// RT-POLICY FLOOR: SCHED_FIFO/SCHED_RR (PipeWire/JACK RT THREADS, THREADED
@@ -2349,6 +1807,7 @@ void BPF_STRUCT_OPS(pandemonium_runnable, struct task_struct *p,
 	if (p->policy == SCHED_FIFO || p->policy == SCHED_RR)
 		new_tier = TIER_LAT_CRITICAL;
 
+	tctx->pinned_service = pinned_kservice ? 1 : 0;
 	tctx->tier = new_tier;
 }
 
@@ -2367,9 +1826,28 @@ void BPF_STRUCT_OPS(pandemonium_running, struct task_struct *p)
 		return;
 	}
 
+	// PINNED KERNEL-SERVICE: this CPU's welded waiter is now running -- clear the
+	// rescue stamp so tick() stops preempting the resident for it.
+	if (tctx->pinned_service) {
+		u32 rcpu = bpf_get_smp_processor_id();
+		if (rcpu < MAX_CPUS)
+			pcpu_pinned_strand_ns[rcpu] = 0;
+	}
+
 	u64 now = bpf_ktime_get_ns();
 	tctx->last_run_at = now;
 	tctx->ran_since_wake = true;   // is_wakeup = !ran_since_wake
+
+	// PER-TASK SOJOURN: TIME FROM scx_bpf_dsq_insert_vtime TO RUN START.
+	// LITERAL CoDel METRIC. FEEDS pcpu_min_sojourn_ns FOR THE STALL
+	// DETECTOR. CLEAR enqueue_at AFTER CONSUME SO NEXT RUN WITHOUT A
+	// PRECEDING ENQUEUE (KEEP_RUNNING PATH) DOESN'T DOUBLE-COUNT.
+	if (tctx->enqueue_at > 0 && now > tctx->enqueue_at) {
+		u64 sojourn = now - tctx->enqueue_at;
+		u32 cpu = bpf_get_smp_processor_id();
+		update_pcpu_sojourn(cpu, sojourn);
+		tctx->enqueue_at = 0;
+	}
 
 	// WAKEUP-TO-RUN LATENCY
 	// ONLY RECORD ONCE PER WAKEUP: CLEAR last_woke_at AFTER RECORDING.
@@ -2432,12 +1910,6 @@ void BPF_STRUCT_OPS(pandemonium_stopping, struct task_struct *p,
 
 	tctx->cached_weight = effective_weight(p, tctx);
 	tctx->last_cpu = bpf_get_smp_processor_id();
-	// STABLE HOME: PIN ONCE TO THE FIRST CPU WE RUN ON; NEVER CHASE last_cpu
-	// (REWRITTEN EVERY STOP -> THE MIGRATION-STORM ROOT). RE-HOME ONLY IF THE OLD
-	// HOME WENT INVALID (HOTPLUG / AFFINITY CHANGE) SO WE NEVER STRAND THE TASK.
-	if (tctx->home_cpu < 0 || (u32)tctx->home_cpu >= nr_cpu_ids ||
-	    !bpf_cpumask_test_cpu(tctx->home_cpu, p->cpus_ptr))
-		tctx->home_cpu = tctx->last_cpu;
 
 	u64 now = bpf_ktime_get_ns();
 	u64 slice = now > tctx->last_run_at ? now - tctx->last_run_at : 0;
@@ -2449,18 +1921,18 @@ void BPF_STRUCT_OPS(pandemonium_stopping, struct task_struct *p,
 					      tctx->ewma_age);
 	}
 
-	// CPU-BOUND DEMOTION. LONG-RUNNERS THAT NEVER SLEEP KEEP ewma_age
-	// PINNED AT 1 (INCREMENTED ONLY ON SLEEP->RUNNABLE IN runnable()),
-	// SO classify_tier NEVER RERUNS. THE CLASSIFIER-BASED PATH LEAVES
-	// SUCH TASKS AT TIER_INTERACTIVE INDEFINITELY, WHICH MAKES THEM
-	// UNPREEMPTIBLE BY tick() (ONLY TIER_BATCH RECEIVES THE TICK RESCUE
-	// AT LINE ~2031). THRESHOLD SCALES WITH slice_ns: AN INTERACTIVE
-	// LONG-RUNNER'S avg_runtime ASYMPTOTES TO THE SLICE CAP, SO A
-	// FIXED-NS THRESHOLD ABOVE slice_ns CAN NEVER FIRE FOR THE EXACT
-	// TASKS THE DEMOTION IS MEANT TO CATCH. 75% OF slice_cap CATCHES
-	// PURE CPU-BOUND WITHIN ~6 STOP CYCLES (~6ms WALL). THE ewma_age
-	// GUARD SPARES LEGIT INTERACTIVE TASKS THAT USE FULL SLICE BUT
-	// SLEEP FREQUENTLY -- THEIR ewma_age GROWS ON EVERY SLEEP->WAKE.
+	// CPU-BOUND DEMOTION. Long-runners that never sleep keep ewma_age
+	// pinned at 1 (incremented only on sleep->runnable in runnable()),
+	// so classify_tier never reruns. The classifier-based path leaves
+	// such tasks at TIER_INTERACTIVE indefinitely, which makes them
+	// unpreemptible by tick() (only TIER_BATCH receives the tick rescue
+	// at line ~2031). Threshold scales with slice_ns: an INTERACTIVE
+	// long-runner's avg_runtime asymptotes to the slice cap, so a
+	// fixed-ns threshold above slice_ns can never fire for the exact
+	// tasks the demotion is meant to catch. 75% of slice_cap catches
+	// pure CPU-bound within ~6 stop cycles (~6ms wall). The ewma_age
+	// guard spares legit interactive tasks that use full slice but
+	// sleep frequently -- their ewma_age grows on every sleep->wake.
 	{
 		struct tuning_knobs *kk = get_knobs();
 		u64 slice_cap = kk ? kk->slice_ns : 1000000;
@@ -2504,24 +1976,24 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 	struct pandemonium_stats *s = get_stats();
 	struct tuning_knobs *knobs = get_knobs();
 
-	// TAU-SCALING: RE-DERIVE THE TIMING STATICS IF RUST WROTE A NEW
-	// topology_tau_ns (INITIAL DETECT OR HOTPLUG). NOT GATED TO CPU 0
-	// BECAUSE THE ORIGINAL GATE LEFT A 1-50ms WINDOW BETWEEN RUST'S
-	// write_topology_fields() AND THE FIRST CPU-0 TICK DURING WHICH
-	// EVERY tau-DERIVED STATIC SAT AT ITS 12C-REFERENCE FALLBACK --
-	// MATERIAL ON NON-12C TOPOLOGIES. THE FUNCTION IS IDEMPOTENT UNDER
-	// NO-CHANGE (tau_ns == snap RETURNS IMMEDIATELY) AND THE
-	// last_tau_snapshot CAS MAKES CONCURRENT CALLS FROM MULTIPLE CPUs
-	// SAFE: FIRST NON-ZERO CALL WINS, SUBSEQUENT CALLS SHORT-CIRCUIT.
-	// OVERHEAD: ~5ns SINGLE COMPARE PER TICK PER CPU WHEN UNCHANGED.
+	// TAU-SCALING: re-derive the timing statics if Rust wrote a new
+	// topology_tau_ns (initial detect or hotplug). NOT gated to CPU 0
+	// because the original gate left a 1-50ms window between Rust's
+	// write_topology_fields() and the first CPU-0 tick during which
+	// every tau-derived static sat at its 12C-reference fallback --
+	// material on non-12C topologies. The function is idempotent under
+	// no-change (tau_ns == snap returns immediately) and the
+	// last_tau_snapshot CAS makes concurrent calls from multiple CPUs
+	// safe: first non-zero call wins, subsequent calls short-circuit.
+	// Overhead: ~5ns single compare per tick per CPU when unchanged.
 	apply_tau_scaling(knobs ? knobs->topology_tau_ns : 0,
 	                  knobs ? knobs->codel_eq_ns : 0);
 
 	// THE OSCILLATOR IS THE ONE DETECTOR. RESCUE DELTAS ARE THE ONLY SIGNAL
 	// IT CONSUMES; IT ADAPTS codel_target_ns WHICH DRIVES THE PER-CPU CoDel
 	// STALL DECISION AND HARD STARVATION RESCUE. NO BURST DETECTOR. NO FLAGS.
-	// OSCILLATOR UPDATE STAYS GATED TO CPU 0 -- SINGLE-WRITER TO VELOCITY
-	// AND POSITION FIELDS, NO NEED FOR CAS IN THE INTEGRATION LOOP.
+	// Oscillator update stays gated to CPU 0 -- single-writer to velocity
+	// and position fields, no need for CAS in the integration loop.
 	if (bpf_get_smp_processor_id() == 0) {
 		// DAMPED HARMONIC OSCILLATOR (FULL FORM):
 		//     ẍ + 2γẋ + ω₀²(x - c_eq) = F(t)
@@ -2529,10 +2001,10 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 		// 2γẋ: DAMPING (v >> damping_shift)
 		// ω₀²(x - c_eq): SPRING (RESTORING TOWARD R_eff EQUILIBRIUM)
 		// BUTTERWORTH-OPTIMAL DAMPING (ζ ≈ 0.707) VIA
-		// spring_shift = 2*damping_shift + 1. ~4.3% STEP-RESPONSE
-		// OVERSHOOT PER IMPULSE KEEPS THE CONTROLLER PROBING THE
-		// CONVEX-RESPONSE BOUNDARY INSTEAD OF PARKING INSIDE IT
-		// (SONTAG'S LOGARITHMIC-RATE CONVEXITY).
+		// spring_shift = 2*damping_shift + 1. ~4.3% step-response
+		// overshoot per impulse keeps the controller probing the
+		// convex-response boundary instead of parking inside it
+		// (Sontag's logarithmic-rate convexity).
 		// 2C (THIN): FAST RESTORE, LARGE SPRING SHIFT WINDOW.
 		// 12C (DENSE): GENTLE RESTORE, TARGET TRACKS STALL POINT.
 		{
@@ -2542,12 +2014,9 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 
 			// ENVELOPE THRESHOLDS: DERIVED FROM THE SPRING/DAMP
 			// DEAD-BAND QUANTA (THE ENERGY OF ONE NO-OP-RESOLUTION
-			// STEP ON EACH AXIS), PRE-SCALED BY THE RESERVOIR GAIN
-			// (<< DECAY_SHIFT: A STEADY INSTANTANEOUS ENERGY E
-			// CONVERGES THE RESERVOIR TO E << DECAY_SHIFT). RELEASE
-			// SITS 2x ABOVE PARK -- MULTIPLICATIVE HYSTERESIS, A
-			// SCHMITT TRIGGER ON ENERGY, NOT A CHANGE-POINT
-			// ACCUMULATOR. TWO SHIFTS AND AN ADD PER PASS: FREE.
+			// STEP ON EACH AXIS), PRE-SCALED BY THE RESERVOIR GAIN.
+			// RELEASE SITS 2x ABOVE PARK -- A SCHMITT TRIGGER ON
+			// ENERGY. TWO SHIFTS AND AN ADD PER PASS: FREE.
 			u64 env_floor =
 				(1ULL << (2 * oscillator_damping_shift)) +
 				(1ULL << (2 * oscillator_spring_shift));
@@ -2555,40 +2024,30 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 			u64 env_release = env_floor << (OSC_ENV_DECAY_SHIFT + 2);
 
 			if (osc_env_parked) {
-				// ARMED DETECTOR, EVERY TICK, THREE COMPARES: A
-				// RESCUE EVENT (DISCRETE COUNT -- ONE RESCUE IS A
-				// REAL EVENT, NOT ANALOG NOISE, SO NO EPSILON),
-				// THE EQUILIBRIUM MOVED UNDER THE PARKED VALUE
-				// (MWU/tau RETUNE), OR THE MAX-PARK HEARTBEAT.
+				// A RESCUE EVENT, THE EQUILIBRIUM MOVED UNDER THE
+				// PARKED VALUE (MWU/tau RETUNE), OR THE MAX-PARK
+				// HEARTBEAT FALLS THROUGH TO A FULL RECOMPUTE.
 				if (delta == 0 &&
-				    codel_target_ns == codel_target_equilibrium_ns &&
+				    codel_target_ns == codel_seed_ns &&
 				    ++osc_env_park_ticks < OSC_ENV_HEARTBEAT_TICKS)
 					goto osc_env_done;
-				// WAKE EDGE: FULL RECOMPUTE THIS SAME TICK, BEFORE
-				// ANY DISPATCH PRICES AGAINST THE TARGET AGAIN --
-				// NEVER "RESUME CADENCE AND WAIT ONE PERIOD".
-				// REFRACTORY DWELL: RE-PRIME THE RESERVOIR ABOVE
-				// RELEASE SO CONTRACTION RESTARTS FROM SCRATCH AND
-				// A BURSTY WAKE CANNOT IMMEDIATELY RE-PARK.
-				osc_env_unpark();   // F1a: single un-park owner
+				// WAKE EDGE: RE-PRIME THE RESERVOIR ABOVE RELEASE
+				// SO A BURSTY WAKE CANNOT IMMEDIATELY RE-PARK.
+				osc_env_parked = false;
+				osc_env_park_ticks = 0;
+				osc_env_energy = env_release << 1;
 			} else if (delta == 0 && osc_env_energy < env_release) {
 				// GRADED BAND: CONTRACTION IS GRADUAL (DIVIDED
 				// CADENCE), EXPANSION IS INSTANT (ANY RESCUE
 				// FALLS THROUGH TO THE FULL RECOMPUTE ABOVE).
-				// THE BAND IS DELIBERATELY SHORT -- RACE INTO
-				// PARK; THE COST CURVE IS FLAT FOR THE FIRST
-				// FEW CADENCE CUTS AND ALL THE RISK IS DEEPER.
 				if (++osc_env_skip < OSC_ENV_GRADED_DIV)
 					goto osc_env_done;
 				osc_env_skip = 0;
 				if (osc_env_energy < env_park) {
-					// PARK: PIN THE TARGET AT THE FIXED POINT
-					// THE DYNAMICS CONVERGE TO (ASYMPTOTICALLY
-					// EXACT, ONE STORE), FREEZE THE VELOCITY
-					// INTEGRATOR (ANTI-WINDUP: IT MUST NOT
-					// ACCUMULATE ACROSS THE BAND AND SLINGSHOT
-					// AT WAKE), STOP THE ARITHMETIC.
-					codel_target_ns = codel_target_equilibrium_ns;
+					// PARK: PIN THE TARGET AT THE FIXED POINT,
+					// FREEZE THE VELOCITY INTEGRATOR (ANTI-
+					// WINDUP), STOP THE ARITHMETIC.
+					codel_target_ns = codel_seed_ns;
 					oscillator_velocity_ns = 0;
 					osc_env_parked = true;
 					osc_env_park_ticks = 0;
@@ -2618,7 +2077,7 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 			// IF x < c_eq -> POSITIVE v IMPULSE (PULL UP). ARITHMETIC
 			// RIGHT-SHIFT ON SIGNED s64 PRESERVES THE SIGN.
 			s64 disp = (s64)codel_target_ns -
-				   (s64)codel_target_equilibrium_ns;
+				   (s64)codel_seed_ns;
 			oscillator_velocity_ns -= disp >> oscillator_spring_shift;
 
 			// DAMPING (-2γẋ): VELOCITY DECAY VIA bit-SHIFT.
@@ -2641,25 +2100,14 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 				nc = (s64)codel_target_max_ns;
 			codel_target_ns = (u64)nc;
 
-			// CLOSE THE LOOP: the rescue threshold the oscillator's signal
-			// (global_rescue_count) is meant to govern now tracks the live
-			// target the oscillator moves -- not the frozen equilibrium. So
-			// global_rescue_count -> codel_target_ns -> overflow_sojourn_rescue_ns
-			// -> rescue rate -> global_rescue_count actually closes. Single
-			// writer (CPU0 tick), no new state. apply_tau_scaling()'s seed at
-			// codel_target_equilibrium_ns still holds before the first tick.
-			overflow_sojourn_rescue_ns = codel_target_ns;
-
 			// RESERVOIR UPDATE: POST-INTEGRATE STATE, VALUES ALREADY
 			// IN HAND -- THE ENVELOPE READS WHAT THE RECOMPUTE JUST
-			// MAINTAINED, IT NEVER DERIVES ANYTHING OF ITS OWN
-			// (FREE-COMPUTE). DECAYED ACCUMULATION RATHER THAN
-			// INSTANTANEOUS ENERGY: INSTANTANEOUS RIPPLES AT 2w AND
-			// A CADENCE KEYED TO IT WOULD PUMP THE TRANSIENT IT IS
-			// DAMPING (PARAMETRIC RESONANCE).
+			// MAINTAINED (FREE-COMPUTE). DECAYED ACCUMULATION, NOT
+			// INSTANTANEOUS ENERGY: RIPPLES AT 2w WITH A CADENCE
+			// KEYED TO IT WOULD PUMP THE TRANSIENT IT DAMPS.
 			{
 				s64 ed = (s64)codel_target_ns -
-					 (s64)codel_target_equilibrium_ns;
+					 (s64)codel_seed_ns;
 				s64 ev = oscillator_velocity_ns;
 				osc_env_energy -=
 					osc_env_energy >> OSC_ENV_DECAY_SHIFT;
@@ -2674,10 +2122,7 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 		s->longrun_mode_active = longrun_mode ? 1 : 0;
 	}
 
-	// F3: this CPU's cache domain batch-overflow age. The per-CPU sojourn enforcement
-	// below is cache domain-local-correct; longrun_mode (CPU-0 only) thus tracks CPU-0's
-	// cache domain -- acceptable; a machine-wide OR-reduce across cache domain is a v5.15.0 refinement.
-	u64 bens = batch_enqueue_ns[cpu_domain_of(scx_bpf_task_cpu(p)) & (MAX_OVERFLOW_DOMAINS - 1)];
+	u64 bens = sojourn_stamp_overflow.batch;
 	if (bens > 0) {
 		u64 now = bpf_ktime_get_ns();
 		u64 sojourn = now - bens;
@@ -2693,30 +2138,30 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 		//   tick (BELOW): preempt_thresh_ns IS LEFT-SHIFTED BY
 		//     longrun_preempt_shift, GIVING BATCH RUNNERS MORE ROPE
 		//     BEFORE INTERACTIVE-WAITING PREEMPTS THEM.
-		// CPU 0 IS THE SOLE WRITER: ALIGNS WITH THE OSCILLATOR / TAU-
-		// SCALING STATICS THAT ARE ALSO CPU-0-WRITTEN.
+		// CPU 0 IS THE SOLE WRITER: ALIGNS WITH THE OSCILLATOR / TAU
+		// SCALING / VTIME-CEILING STATICS THAT ARE ALSO CPU-0-WRITTEN.
 		// PREVENTS MULTI-CPU TICK RACES THAT FLICKERED THE BOOL UNDER
-		// BURST WHILE batch_enqueue_ns WAS BEING SET/CLEARED VIA CAS.
+		// BURST WHILE sojourn_stamp_overflow.batch WAS BEING SET/CLEARED VIA CAS.
 		if (bpf_get_smp_processor_id() == 0)
 			longrun_mode = sojourn > longrun_thresh_ns;
 
 		// SOJOURN ENFORCEMENT: THRESHOLD SET BY RUST ADAPTIVE LAYER FROM
 		// OBSERVED DISPATCH RATE. IF OVERFLOW HAS STARVED PAST THE THRESHOLD,
 		// KICK THIS CPU TO FORCE A DISPATCH OF THE BURIED TASK.
-		// PREEMPT BATCH *OR* INTERACTIVE RUNNERS: THE OLD "INTERACTIVE SLICES
-		// ARE SHORT, THEY YIELD ON THEIR OWN" ASSUMPTION HOLDS IN ISOLATION BUT
-		// BREAKS UNDER A FORK-STORM -- THE CORES RUN A CONVEYOR BELT OF
-		// INTERACTIVE WORKERS, EACH YIELDING FAST ONLY FOR THE NEXT STORM
-		// WORKER, SO THE BURIED TASK NEVER GETS IN. PREEMPTING AN INTERACTIVE
-		// RUNNER UNDER SUSTAINED STARVATION IS THE JUST-ENOUGH BACK-PRESSURE
-		// THAT LETS IT THROUGH; LATCRIT IS LEFT ALONE (GENUINELY TOP PRIORITY).
+		// PREEMPT BATCH *OR* INTERACTIVE RUNNERS: the old "interactive slices
+		// are short, they yield on their own" assumption holds in isolation but
+		// breaks under a fork-storm -- the cores run a conveyor belt of
+		// interactive workers, each yielding fast only for the NEXT storm
+		// worker, so the buried task never gets in. Preempting an interactive
+		// runner under sustained starvation is the just-enough back-pressure
+		// that lets it through; LATCRIT is left alone (genuinely top priority).
 		// PER-CPU (NOT CPU-0-ONLY): EACH CPU SELF-PREEMPTS WHEN IT'S HOGGING.
-		// KEY THE KICK ON THE R_eff OVERFLOW-GATE DELTA, NOT THE TIGHTER ADAPTIVE
-		// sojourn_thresh: STEP 0/1 ONLY FALL THROUGH TO SERVE OVERFLOW ONCE THE
-		// SOJOURN PASSES overflow_sojourn_rescue_ns, SO A KICK FIRED EARLIER JUST
-		// LETS THE FREED CORE RE-GRAB ANOTHER STORM WORKER. ALIGNING THE TWO MEANS
-		// THE PREEMPTED CORE ACTUALLY LANDS ON THE BURIED TASK ON RE-DISPATCH.
-		if (sojourn > overflow_sojourn_rescue_ns) {
+		// Key the kick on the R_eff overflow-gate delta, NOT the tighter adaptive
+		// sojourn_thresh: STEP 0/1 only fall through to serve overflow once the
+		// sojourn passes codel_target_ns, so a kick fired earlier just
+		// lets the freed core re-grab another storm worker. Aligning the two means
+		// the preempted core actually lands on the buried task on re-dispatch.
+		if (sojourn > codel_target_ns) {
 			struct task_ctx *tctx = lookup_task_ctx(p);
 			if (tctx && (tctx->tier == TIER_BATCH ||
 				     tctx->tier == TIER_INTERACTIVE)) {
@@ -2738,16 +2183,35 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 	{
 		u32 this_cpu = bpf_get_smp_processor_id();
 		u64 now2 = bpf_ktime_get_ns();
-		u64 pcpu_sojourn_thresh = knobs
-			? knobs->sojourn_thresh_ns : 5000000;
+		u64 codel_thresh_ns = knobs
+			? knobs->codel_thresh_ns : 5000000;
+
+		// INTERACTIVE RESCUE: PREEMPT A BATCH HOG PAST preempt_thresh
+		if (sojourn_stamp_overflow.inter && this_cpu < MAX_CPUS) {
+			struct task_ctx *rtctx = lookup_task_ctx(p);
+			if (rtctx && rtctx->tier == TIER_BATCH) {
+				u64 pbase = knobs
+					? knobs->preempt_thresh_ns : 1000000;
+				u64 pthr = longrun_mode
+					? (pbase << longrun_preempt_shift) : pbase;
+				u64 on_cpu = rtctx->last_run_at > 0
+					? now2 - rtctx->last_run_at : 0;
+				if (on_cpu >= pthr) {
+					scx_bpf_kick_cpu(this_cpu,
+							 SCX_KICK_PREEMPT);
+					return;
+				}
+			}
+		}
 
 		// LOCAL: OWN PER-CPU DSQ
 		if (this_cpu < MAX_CPUS) {
-			u64 pcpu_oldest = pcpu_enqueue_ns[this_cpu].ns;
+			u64 pcpu_oldest = sojourn_stamp_pcpu[this_cpu];
 			if (pcpu_oldest > 0 &&
-			    (now2 - pcpu_oldest) > pcpu_sojourn_thresh) {
-				if (pcpu_kick_if_waiter(this_cpu))
-					return;
+			    (now2 - pcpu_oldest) > codel_thresh_ns) {
+				scx_bpf_kick_cpu(this_cpu,
+						 SCX_KICK_PREEMPT);
+				return;
 			}
 		}
 
@@ -2767,39 +2231,35 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 				for (u32 i = 0; i < 4; i++) {
 					if (i >= nr)
 						break;
-					// SAME VERIFIER-PORTABLE MASK AS THE nr > 4 BRANCH (Issue #8).
-					u32 scan_cpu = i & (MAX_CPUS - 1);
+					u32 scan_cpu = i;
 					if (scan_cpu == this_cpu)
 						continue;
-					u64 remote_stamp = pcpu_enqueue_ns[scan_cpu].ns;
+					u64 remote_stamp = sojourn_stamp_pcpu[
+						scan_cpu & (MAX_CPUS - 1)];
 					if (remote_stamp > 0 &&
-					    (now2 - remote_stamp) > pcpu_sojourn_thresh)
-						pcpu_kick_if_waiter(scan_cpu);
+					    (now2 - remote_stamp) > codel_thresh_ns)
+						scx_bpf_kick_cpu(scan_cpu,
+								 SCX_KICK_PREEMPT);
 				}
 			} else {
 				u32 scan_base = (u32)(now2 >> 20);
 				for (int i = 0; i < 4; i++) {
-					// MASK THE INDEX, DO NOT COMPARISON-SKIP IT. OLDER-KERNEL
-					// VERIFIERS CANNOT PROVE (scan_base + i) % nr IS BOUNDED, SO
-					// pcpu_enqueue_ns[scan_cpu] TRIPS "math between map_value
-					// pointer and register with unbounded min value" (Issue #8:
-					// Ubuntu 25.10 / 5950X; newer kernels accept the bare % nr).
-					// & (MAX_CPUS-1) IS A VERIFIER-PORTABLE BOUND, NOT A FOOTGUN
-					// -- DO NOT "CLEAN IT UP" BACK INTO A >= MAX_CPUS SKIP.
 					u32 scan_cpu =
-						((scan_base + (u32)i) % nr) & (MAX_CPUS - 1);
+						(scan_base + (u32)i) % nr;
 					if (scan_cpu == this_cpu)
 						continue;
-					u64 remote_stamp = pcpu_enqueue_ns[scan_cpu].ns;
+					u64 remote_stamp = sojourn_stamp_pcpu[
+						scan_cpu & (MAX_CPUS - 1)];
 					if (remote_stamp > 0 &&
-					    (now2 - remote_stamp) > pcpu_sojourn_thresh)
-						pcpu_kick_if_waiter(scan_cpu);
+					    (now2 - remote_stamp) > codel_thresh_ns)
+						scx_bpf_kick_cpu(scan_cpu,
+								 SCX_KICK_PREEMPT);
 				}
 			}
 		}
 	}
 
-	// PER-CPU PREEMPT: SIGNAL IS pcpu_enqueue_ns[this_cpu] (OLDEST WAITER AGE),
+	// PER-CPU PREEMPT: SIGNAL IS sojourn_stamp_pcpu[this_cpu] (OLDEST WAITER AGE),
 	// SO EACH CPU DECIDES FROM ITS OWN STATE -- NO GLOBAL TOKEN. THE COARSE
 	// sojourn_thresh NET ABOVE HANDLED THE LONG-WAIT CASE; THIS IS THE TIGHT
 	// BAND AT k*tau (preempt_thresh_ns): BATCH RESIDENT YIELDS AT THE BASE,
@@ -2807,16 +2267,54 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 	u32 wcpu = bpf_get_smp_processor_id();
 	if (wcpu >= MAX_CPUS)
 		return;
-	u64 waiter = pcpu_enqueue_ns[wcpu].ns;
+	u64 waiter = sojourn_stamp_pcpu[wcpu];
 	if (waiter == 0)
-		return;
-
-	struct task_ctx *tctx = lookup_task_ctx(p);
-	if (!tctx || tctx->tier == TIER_LAT_CRITICAL)
 		return;
 
 	u64 wnow = bpf_ktime_get_ns();
 	u64 wait_age = wnow > waiter ? wnow - waiter : 0;
+	struct task_ctx *tctx = lookup_task_ctx(p);
+
+	// PINNED KERNEL-SERVICE RESCUE: a welded ksoftirqd/kworker waiter whose enqueue
+	// PREEMPT-kick did not take (LAT_CRITICAL holder) must not age to the generic 2x
+	// codel_target backstop -- it is softirq/workqueue work userspace blocks on.
+	// Rescue at the tight preempt floor. Stamp set in enqueue(), cleared in running().
+	u64 pin_wait = pcpu_pinned_strand_ns[wcpu];
+	if (pin_wait > 0) {
+		u64 pin_age = wnow > pin_wait ? wnow - pin_wait : 0;
+		u64 pin_thresh = knobs ? knobs->preempt_thresh_ns : 1000000;
+		if (pin_age >= pin_thresh) {
+			scx_bpf_kick_cpu(wcpu, SCX_KICK_PREEMPT);
+			if (!s)
+				s = get_stats();
+			if (s)
+				s->nr_preempt += 1;
+			return;
+		}
+	}
+
+	// PINNED-WAITER BACKSTOP: a per-CPU DSQ waiter aged past 2x codel_target
+	// preempts the holder even when the resident is LAT_CRITICAL or ctxless.
+	// This is the pinned kernel-service rescue (the enqueue PREEMPT-kick is the
+	// primary; this catches the case where it did not take, e.g. the holder is
+	// LAT_CRITICAL and the tight-band exemption below would otherwise let it
+	// strand the welded ksoftirqd/kworker indefinitely -- steal cannot rescue a
+	// pinned task). Sits just above the steal beat and far below the ~167ms net,
+	// so it only fires for the no-rescue strand. A price on the exemption, not
+	// its removal -- a genuinely short task never ages this far.
+	if (wait_age >= (codel_target_ns << 1)) {
+		scx_bpf_kick_cpu(wcpu, SCX_KICK_PREEMPT);
+		if (!s)
+			s = get_stats();
+		if (s)
+			s->nr_preempt += 1;
+		return;
+	}
+
+	// TIGHT-BAND PREEMPT: BATCH yields at the base, INTERACTIVE at 2x,
+	// LAT_CRITICAL exempt (the backstop above is its only override).
+	if (!tctx || tctx->tier == TIER_LAT_CRITICAL)
+		return;
 
 	u64 base_thresh = knobs ? knobs->preempt_thresh_ns : 1000000;
 	u64 batch_thresh = longrun_mode ? (base_thresh << longrun_preempt_shift)
@@ -2825,12 +2323,11 @@ void BPF_STRUCT_OPS(pandemonium_tick, struct task_struct *p)
 		   : batch_thresh;
 
 	if (wait_age >= thresh) {
-		if (pcpu_kick_if_waiter(wcpu)) {
-			if (!s)
-				s = get_stats();
-			if (s)
-				s->nr_preempt += 1;
-		}
+		scx_bpf_kick_cpu(wcpu, SCX_KICK_PREEMPT);
+		if (!s)
+			s = get_stats();
+		if (s)
+			s->nr_preempt += 1;
 	}
 }
 
@@ -2853,11 +2350,7 @@ void BPF_STRUCT_OPS(pandemonium_enable, struct task_struct *p)
 		tctx->tier = TIER_INTERACTIVE;
 		tctx->ewma_age = 0;
 		tctx->dispatch_path = 0;
-		// -1 = NEVER RAN. select_cpu's warm path anchors a last_cpu<0 task on
-		// prev_cpu (the parent's CPU at fork) so it warm-routes per-domain instead
-		// of aliasing CPU 0 or scattering via the node-wide dfl pick.
-		tctx->last_cpu = -1;
-		tctx->home_cpu = -1;   // pinned on first run (stopping)
+		tctx->pinned_service = 0;
 
 		// PROCDB: APPLY LEARNED CLASSIFICATION FROM PRIOR RUNS
 		char key[16];
@@ -2888,8 +2381,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 
 	// PER-CPU DSQs.
 	// SELECT_CPU DISPATCHES TO PER-CPU DSQ (CACHE-HOT, VISIBLE, STEALABLE).
-	// ENQUEUE TIER 1/2 SEATS WAKEES ON A WARM PER-CPU DSQ; OVERFLOW
-	// (TIER 3 / B-v2 ESCAPE) FALLS TO domain_inter_dsq.
+	// ENQUEUE ALWAYS USES SHARED NODE DSQ (EVEN DISTRIBUTION).
 	// VISIBILITY LAYERS:
 	//   1. L2 WORK STEALING IN DISPATCH -- IDLE CPUs PULL FROM SIBLINGS
 	//   2. ROTATING TICK SCAN -- CATCHES STALE TASKS ON IDLE CPUs
@@ -2897,24 +2389,21 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 	for (u32 i = 0; i < nr_cpu_ids && i < MAX_CPUS; i++)
 		scx_bpf_create_dsq(i, -1);
 
-	// CREATE per-domain OVERFLOW DSQs (INTERACTIVE + BATCH). MAX_OVERFLOW_DOMAINS
-	// SLOTS PRE-ALLOCATED; nr_overflow_domains (SET BY Rust POST-LOAD) GATES WHICH ARE LIVE.
-	// PRE-ALLOCATING ALL MAX_OVERFLOW_DOMAINS COSTS A FEW UNUSED DSQ HEADERS, AVOIDS
-	// THE BOOTSTRAP ORDER PROBLEM (pandemonium_init RUNS BEFORE TOPOLOGY DETECT).
-	// THESE ARE L3-SCOPED, SO STEP 3/4 DRAIN STAYS cache domain-LOCAL; STEP 5 SCANS
-	// OTHER cache domains FOR WORK CONSERVATION WHEN THE LOCAL cache domain IS EMPTY.
-	for (u32 i = 0; i < MAX_OVERFLOW_DOMAINS; i++)
-		scx_bpf_create_dsq(nr_cpu_ids + 2ULL * MAX_NODES + i, -1);
-	for (u32 i = 0; i < MAX_OVERFLOW_DOMAINS; i++)
-		scx_bpf_create_dsq(nr_cpu_ids + 2ULL * MAX_NODES + MAX_OVERFLOW_DOMAINS + i, -1);
+	// CREATE PER-NODE INTERACTIVE OVERFLOW DSQs (DSQ ID = nr_cpu_ids + NODE)
+	for (u32 i = 0; i < nr_nodes && i < MAX_NODES; i++)
+		scx_bpf_create_dsq(nr_cpu_ids + i, (s32)i);
+
+	// CREATE PER-NODE BATCH OVERFLOW DSQs (DSQ ID = nr_cpu_ids + nr_nodes + NODE)
+	for (u32 i = 0; i < nr_nodes && i < MAX_NODES; i++)
+		scx_bpf_create_dsq(nr_cpu_ids + nr_nodes + i, (s32)i);
 
 	// ALL TIMING-CONSTANT AND OSCILLATOR-DYNAMICS STATICS BELOW ARE DERIVED
 	// FROM tau (Fiedler-based time constant) VIA apply_tau_scaling() AT THE
 	// FIRST CPU-0 TICK. MIDPOINT CONSTANTS HERE PROVIDE SANE BEHAVIOR DURING
 	// THE ~1MS WINDOW BETWEEN struct_ops ATTACH AND THAT FIRST TICK. THEY
 	// ARE OVERWRITTEN IMMEDIATELY -- DON'T READ SIGNIFICANCE INTO THEM.
-	starvation_rescue_ns       = 100000000ULL;  // 100ms midpoint of [20, 500]
-	overflow_sojourn_rescue_ns =   6000000ULL;  //   6ms midpoint of [4, 10]
+	codel_starve_ns       = 100000000ULL;  // 100ms midpoint of [20, 500]
+	sojourn_interval_ns        =   4000000ULL;  //   4ms midpoint of [2, 12]
 	codel_target_floor_ns      =    500000ULL;  // 500us midpoint of [200, 800]
 	pcpu_depth_base            = 2;             // 8C-12C MIDPOINT; apply_tau_scaling
 	                                            //   recomputes continuously as
@@ -2934,6 +2423,10 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 	oscillator_velocity_ns = 0;
 	prev_rescue_snapshot = 0;
 	global_rescue_count = 0;
+	for (u32 i = 0; i < nr_cpu_ids && i < MAX_CPUS; i++) {
+		pcpu_min_sojourn_ns[i] = ~0ULL;
+		pcpu_stall_start_ns[i] = 0;
+	}
 
 	longrun_mode = false;
 
@@ -2946,18 +2439,18 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 		knobs->lat_cri_thresh_high = LAT_CRI_THRESH_HIGH; // 32
 		knobs->lat_cri_thresh_low  = LAT_CRI_THRESH_LOW;  // 8
 		knobs->affinity_mode = 0;                // OFF BY DEFAULT (RUST SETS PER REGIME)
-		knobs->sojourn_thresh_ns = 5000000;      // 5MS DEFAULT (RUST OVERRIDES)
+		knobs->codel_thresh_ns = 5000000;      // 5MS DEFAULT (RUST OVERRIDES)
 		knobs->burst_slice_ns = 1000000;         // 1MS DEFAULT (BURST/LONGRUN CEILING)
 		knobs->topology_tau_ns = 0;              // RUST WRITES AT TOPOLOGY DETECT
 		knobs->codel_eq_ns = 0;                  // RUST WRITES AT TOPOLOGY DETECT
 	}
 
-	// BELT-AND-SUSPENDERS: DERIVE tau-SCALED STATICS IMMEDIATELY IF RUST
-	// SOMEHOW WROTE topology_tau_ns BEFORE THIS INIT RUNS (struct_ops
-	// RELOAD, HOT PATH RACE). NORMAL CASE IS knobs->topology_tau_ns == 0
-	// HERE, IN WHICH CASE apply_tau_scaling() SHORT-CIRCUITS ON THE
-	// tau_ns == 0 CHECK AND THE MIDPOINT FALLBACKS SET ABOVE STAND UNTIL
-	// THE FIRST TICK AFTER RUST WRITES tau.
+	// Belt-and-suspenders: derive tau-scaled statics immediately if Rust
+	// somehow wrote topology_tau_ns before this init runs (struct_ops
+	// reload, hot path race). Normal case is knobs->topology_tau_ns == 0
+	// here, in which case apply_tau_scaling() short-circuits on the
+	// tau_ns == 0 check and the midpoint fallbacks set above stand until
+	// the first tick after Rust writes tau.
 	apply_tau_scaling(knobs ? knobs->topology_tau_ns : 0,
 	                  knobs ? knobs->codel_eq_ns : 0);
 
@@ -2973,8 +2466,8 @@ void BPF_STRUCT_OPS(pandemonium_exit, struct scx_exit_info *ei)
 // EXIT_TASK: PER-TASK CLEANUP ON DEATH. BPF_F_NO_PREALLOC TASK
 // STORAGE AUTO-FREES task_ctx, SO THIS HOOK IS NOT REQUIRED FOR
 // MEMORY CORRECTNESS. WE STILL DEFINE IT TO:
-//   1. ZERO HOT-PATH TIMESTAMPS DEFENSIVELY (sleep_start_ns)
-//      -- ANY STALE READ IN THE NARROW WINDOW
+//   1. ZERO HOT-PATH TIMESTAMPS DEFENSIVELY (enqueue_at,
+//      sleep_start_ns) -- ANY STALE READ IN THE NARROW WINDOW
 //      BEFORE STORAGE GC SEES ZEROS, NOT GARBAGE.
 //   2. PROVIDE A SYMMETRIC HOOK FOR FUTURE PER-TASK CLEANUP --
 //      MATCHES THE lavd / rusty / layered / flow PATTERN ACROSS
@@ -2985,7 +2478,36 @@ void BPF_STRUCT_OPS(pandemonium_exit_task, struct task_struct *p,
 	struct task_ctx *tctx = lookup_task_ctx(p);
 	if (!tctx)
 		return;
+	tctx->enqueue_at = 0;
 	tctx->sleep_start_ns = 0;
+}
+
+// UPDATE_IDLE: STRATEGY 2 (MEASURE-ONLY, NO SCHEDULING DECISION).
+// FIRES ON EVERY IDLE-ENTER AND IDLE-EXIT TRANSITION FOR EACH CPU.
+// ON ENTRY: STAMP pcpu_idle_start_ns[cpu] WITH bpf_ktime_get_ns().
+// ON EXIT:  ACCUMULATE (now - start) INTO pcpu_idle_total_ns[cpu]
+//           AND ZERO THE START STAMP.
+// IDLE TASK CANNOT BE PREEMPTED, SO NO RACE WITH CONCURRENT WRITERS
+// FOR THE SAME CPU (THE HOOK IS CALLED FROM THE CPU IT REPORTS).
+// IF idle_start_ns IS ALREADY ZERO ON EXIT THE SCHEDULER MISSED THE
+// MATCHING ENTER (LOAD HAPPENED WHILE THE CPU WAS ALREADY IDLE) --
+// SKIP THE ACCUMULATION TO AVOID GARBAGE DELTAS.
+void BPF_STRUCT_OPS(pandemonium_update_idle, s32 cpu, bool idle)
+{
+	u64 now;
+
+	if ((u32)cpu >= MAX_CPUS)
+		return;
+
+	now = bpf_ktime_get_ns();
+	if (idle) {
+		pcpu_idle_start_ns[cpu] = now;
+	} else {
+		u64 start = pcpu_idle_start_ns[cpu];
+		if (start && now > start)
+			pcpu_idle_total_ns[cpu] += (now - start);
+		pcpu_idle_start_ns[cpu] = 0;
+	}
 }
 
 // QUIESCENT: TASK GOES TO SLEEP -- RECORD TIMESTAMP FOR SLEEP ANALYSIS
@@ -3005,12 +2527,14 @@ void BPF_STRUCT_OPS(pandemonium_quiescent, struct task_struct *p,
 void BPF_STRUCT_OPS(pandemonium_cpu_release, s32 cpu,
 		    struct scx_cpu_release_args *args)
 {
-	// PORTABLE CALL: scx_bpf_reenqueue_local() RETURNS void ON v2 (NEWER)
-	// KERNELS AND THROUGH scx's compat.bpf.h SHIM; CAPTURING ITS RETURN ONLY
-	// COMPILED ON v1 (OLDER) KERNELS. CALL AS void -- THE RE-ENQUEUE STILL
-	// HAPPENS; THE nr_reenqueue STAT IS NOT PORTABLY COUNTABLE HERE. (Issue #8
-	// class: a kfunc signature that diverges across kernels / the scx build.)
+	// scx for-6.19 made scx_bpf_reenqueue_local() return void (deferred async
+	// reenqueue); the old u32 task-count is gone. Call it without capturing so the
+	// shared source compiles against BOTH the vendored (u32) and monorepo (void)
+	// APIs; count the invocation for the diagnostic stat.
 	scx_bpf_reenqueue_local();
+	struct pandemonium_stats *s = get_stats();
+	if (s)
+		s->nr_reenqueue += 1;
 }
 
 // CPU HOTPLUG CALLBACKS
@@ -3024,12 +2548,15 @@ void BPF_STRUCT_OPS(pandemonium_cpu_release, s32 cpu,
 
 void BPF_STRUCT_OPS(pandemonium_cpu_online, s32 cpu)
 {
-	if ((u32)cpu < MAX_CPUS)
-		__sync_lock_test_and_set(&pcpu_enqueue_ns[cpu].ns, 0);
-	// FORCE THE NEXT CPU-0 TICK TO RE-DERIVE tau-SCALED STATICS. RUST WILL
-	// HAVE RECOMPUTED lambda_2 AGAINST THE NEW TOPOLOGY AND WRITTEN A FRESH
-	// topology_tau_ns; CLEARING THE SNAPSHOT MAKES apply_tau_scaling() PICK
-	// IT UP INSTEAD OF SHORT-CIRCUITING ON THE STALE VALUE. ATOMIC STORE
+	if ((u32)cpu < MAX_CPUS) {
+		__sync_lock_test_and_set(&sojourn_stamp_pcpu[cpu], 0);
+		pcpu_min_sojourn_ns[cpu] = ~0ULL;
+		pcpu_stall_start_ns[cpu] = 0;
+	}
+	// Force the next CPU-0 tick to re-derive tau-scaled statics. Rust will
+	// have recomputed lambda_2 against the new topology and written a fresh
+	// topology_tau_ns; clearing the snapshot makes apply_tau_scaling() pick
+	// it up instead of short-circuiting on the stale value. ATOMIC STORE
 	// PAIRS WITH apply_tau_scaling()'s CAS SO A CONCURRENT TICK CAN'T
 	// OVERWRITE THIS CLEAR.
 	__sync_lock_test_and_set(&last_tau_snapshot, 0);
@@ -3037,14 +2564,15 @@ void BPF_STRUCT_OPS(pandemonium_cpu_online, s32 cpu)
 
 void BPF_STRUCT_OPS(pandemonium_cpu_offline, s32 cpu)
 {
-	if ((u32)cpu < MAX_CPUS)
-		__sync_lock_test_and_set(&pcpu_enqueue_ns[cpu].ns, 0);
+	if ((u32)cpu < MAX_CPUS) {
+		__sync_lock_test_and_set(&sojourn_stamp_pcpu[cpu], 0);
+		pcpu_min_sojourn_ns[cpu] = ~0ULL;
+		pcpu_stall_start_ns[cpu] = 0;
+	}
 	__sync_lock_test_and_set(&last_tau_snapshot, 0);
 
-	for (u32 c = 0; c < MAX_OVERFLOW_DOMAINS; c++) {
-		__sync_lock_test_and_set(&interactive_enqueue_ns[c], 0);
-		__sync_lock_test_and_set(&batch_enqueue_ns[c], 0);
-	}
+	__sync_lock_test_and_set(&sojourn_stamp_overflow.inter, 0);
+	__sync_lock_test_and_set(&sojourn_stamp_overflow.batch, 0);
 
 	// RESET OSCILLATOR FEEDBACK TO AVOID STALE DELTA POST-SUSPEND
 	__sync_lock_test_and_set(&global_rescue_count, 0);
@@ -3062,6 +2590,7 @@ SCX_OPS_DEFINE(pandemonium_ops,
 	       .tick         = (void *)pandemonium_tick,
 	       .enable       = (void *)pandemonium_enable,
 	       .quiescent    = (void *)pandemonium_quiescent,
+	       .update_idle  = (void *)pandemonium_update_idle,
 	       .cpu_release  = (void *)pandemonium_cpu_release,
 	       .cpu_online   = (void *)pandemonium_cpu_online,
 	       .cpu_offline  = (void *)pandemonium_cpu_offline,

--- a/scheds/rust/scx_pandemonium/src/chaos.rs
+++ b/scheds/rust/scx_pandemonium/src/chaos.rs
@@ -189,14 +189,45 @@ pub fn mean<const N: usize>(w: &RawWindow<N>) -> f64 {
     s / w.filled as f64
 }
 
+#[allow(dead_code)]
+pub fn min<const N: usize>(w: &RawWindow<N>) -> f64 {
+    let mut it = w.iter();
+    let mut m = match it.next() {
+        Some(x) => x,
+        None => return 0.0,
+    };
+    for x in it {
+        if x < m {
+            m = x;
+        }
+    }
+    m
+}
+
+#[allow(dead_code)]
+pub fn max<const N: usize>(w: &RawWindow<N>) -> f64 {
+    let mut it = w.iter();
+    let mut m = match it.next() {
+        Some(x) => x,
+        None => return 0.0,
+    };
+    for x in it {
+        if x > m {
+            m = x;
+        }
+    }
+    m
+}
+
 // HORIZONTAL VISIBILITY GRAPH
 //
 // FOR A SEQUENCE x_1..x_N, NODES i AND j (i < j) ARE HVG-CONNECTED IFF
 // x_k < min(x_i, x_j) FOR ALL i < k < j. ADJACENT NODES (j = i+1) ARE
 // ALWAYS CONNECTED.
 //
-// hvg_degrees BUILDS THE DEGREE VECTOR ONCE; hvg_stats DERIVES BOTH
-// LAMBDA AND ENTROPY FROM IT IN A SINGLE O(N^2) PASS.
+// hvg_degrees BUILDS THE DEGREE VECTOR ONCE; hvg_mean_degree AND
+// hvg_entropy ARE THIN WRAPPERS OVER IT. WHEN BOTH ARE NEEDED IN THE
+// SAME TICK, USE hvg_stats TO AMORTIZE THE O(N^2) CONSTRUCTION.
 //
 // BRUTE-FORCE O(N^2). AT N <= 128 (>1-MINUTE WINDOW AT 1HZ) THIS IS
 // UNDER 16K COMPARISONS, DONE ONCE PER SECOND.
@@ -229,6 +260,50 @@ fn hvg_degrees<const N: usize>(w: &RawWindow<N>) -> Option<([u32; N], usize)> {
         }
     }
     Some((deg, n))
+}
+
+// HVG MEAN DEGREE (LAMBDA). PRIMARY DISCRIMINATOR FOR REGIME DETECTION.
+//   - PERIODIC: ~2
+//   - CHAOTIC / IID RANDOM: -> 4
+#[allow(dead_code)]
+pub fn hvg_mean_degree<const N: usize>(w: &RawWindow<N>) -> f64 {
+    let (deg, n) = match hvg_degrees(w) {
+        Some(v) => v,
+        None => return 0.0,
+    };
+    let mut sum: u64 = 0;
+    for d in deg.iter().take(n) {
+        sum += *d as u64;
+    }
+    sum as f64 / n as f64
+}
+
+// HVG SHANNON ENTROPY (S). CORROBORATING DISCRIMINATOR.
+// 0 = SHARP DEGREE DISTRIBUTION (PERIODIC). HVG_S_IID ~= 1.91 = IID
+// ASYMPTOTE. INTERMEDIATE VALUES = MIXED OR CHAOTIC DYNAMICS.
+#[allow(dead_code)]
+pub fn hvg_entropy<const N: usize>(w: &RawWindow<N>) -> f64 {
+    let (deg, n) = match hvg_degrees(w) {
+        Some(v) => v,
+        None => return 0.0,
+    };
+
+    let mut hist: [u32; N] = [0; N];
+    for d in deg.iter().take(n) {
+        let bucket = (*d as usize).min(n - 1);
+        hist[bucket] += 1;
+    }
+
+    let total = n as f64;
+    let mut s_hvg = 0.0;
+    for c in hist.iter().take(n) {
+        if *c == 0 {
+            continue;
+        }
+        let p = *c as f64 / total;
+        s_hvg -= p * p.ln();
+    }
+    s_hvg
 }
 
 // AMORTIZED LAMBDA + ENTROPY. ONE O(N^2) PASS BUILDS THE DEGREE VECTOR;

--- a/scheds/rust/scx_pandemonium/src/cli/probe.rs
+++ b/scheds/rust/scx_pandemonium/src/cli/probe.rs
@@ -10,6 +10,13 @@ const MAX_SAMPLES: usize = 16384;
 /// For EEVDF baseline, we measure in userspace.
 /// Either way: ZERO I/O during measurement, bulk output at end.
 pub fn run_probe() {
+    // DISTINCT COMM so montauk can target JUST the latency probe -- the stress
+    // workers all share the "pandemonium" comm, making the probe untraceable in
+    // isolation. Mirrors the IPC workload's IPC_COMM = "pand-ipc".
+    unsafe {
+        libc::prctl(libc::PR_SET_NAME, b"pand-probe\0".as_ptr() as libc::c_ulong);
+    }
+
     ctrlc::set_handler(move || {
         RUNNING.store(false, Ordering::Relaxed);
     })

--- a/scheds/rust/scx_pandemonium/src/event.rs
+++ b/scheds/rust/scx_pandemonium/src/event.rs
@@ -13,7 +13,6 @@ pub struct Snapshot {
     pub shared: u64,
     pub preempt: u64,
     pub keep_run: u64,
-    pub osc_parks: u64,
     pub wake_avg_us: u64,
     pub hard_kicks: u64,
     pub soft_kicks: u64,
@@ -38,7 +37,6 @@ impl EventLog {
                     shared: 0,
                     preempt: 0,
                     keep_run: 0,
-                    osc_parks: 0,
                     wake_avg_us: 0,
                     hard_kicks: 0,
                     soft_kicks: 0,
@@ -61,7 +59,6 @@ impl EventLog {
         shared: u64,
         preempt: u64,
         keep_run: u64,
-        osc_parks: u64,
         wake_avg_us: u64,
         hard_kicks: u64,
         soft_kicks: u64,
@@ -75,7 +72,6 @@ impl EventLog {
             shared,
             preempt,
             keep_run,
-            osc_parks,
             wake_avg_us,
             hard_kicks,
             soft_kicks,
@@ -189,7 +185,6 @@ impl EventLog {
         let total_shared: u64 = snapshots.iter().map(|s| s.shared).sum();
         let total_preempt: u64 = snapshots.iter().map(|s| s.preempt).sum();
         let total_keep: u64 = snapshots.iter().map(|s| s.keep_run).sum();
-        let total_parks: u64 = snapshots.iter().map(|s| s.osc_parks).sum();
 
         let peak_d = snapshots.iter().map(|s| s.dispatches).max().unwrap_or(0);
 
@@ -202,7 +197,6 @@ impl EventLog {
         println!("  TOTAL SHARED:      {}", total_shared);
         println!("  TOTAL PREEMPT:     {}", total_preempt);
         println!("  TOTAL KEEP_RUN:    {}", total_keep);
-        println!("  TOTAL OSC PARKS:   {}", total_parks);
         println!("  PEAK DISPATCH/S:   {}", peak_d);
         if elapsed_s > 0.0 {
             println!("  AVG DISPATCH/S:    {:.0}", total_d as f64 / elapsed_s);

--- a/scheds/rust/scx_pandemonium/src/main.rs
+++ b/scheds/rust/scx_pandemonium/src/main.rs
@@ -64,13 +64,6 @@ struct Cli {
     /// Run BPF scheduler only, disable Rust adaptive control loop
     #[arg(long)]
     no_adaptive: bool,
-
-    /// Override the topology-derived Phi distance scale (phi_dist_scale_q16).
-    /// 0 disables the Phi steal-resist (flat CoDel target); omit for the
-    /// topology value. Test/bench use -- the override holds across both the
-    /// adaptive and --no-adaptive paths.
-    #[arg(long)]
-    phi_scale: Option<u64>,
 }
 
 #[derive(Subcommand)]
@@ -98,7 +91,6 @@ fn main() -> Result<()> {
     let dump_log = cli.dump_log;
     let nr_cpus = cli.nr_cpus;
     let no_adaptive = cli.no_adaptive;
-    let phi_scale = cli.phi_scale;
 
     if cli.version {
         println!(
@@ -109,7 +101,7 @@ fn main() -> Result<()> {
     }
 
     match cli.command {
-        None => run_scheduler(verbose, dump_log, nr_cpus, no_adaptive, phi_scale),
+        None => run_scheduler(verbose, dump_log, nr_cpus, no_adaptive),
         Some(SubCmd::Probe) => {
             cli::probe::run_probe();
             Ok(())
@@ -126,7 +118,6 @@ fn run_scheduler(
     dump_log: bool,
     nr_cpus: Option<u64>,
     no_adaptive: bool,
-    phi_scale: Option<u64>,
 ) -> Result<()> {
     ctrlc::set_handler(move || {
         SHUTDOWN.store(true, Ordering::Relaxed);
@@ -180,7 +171,7 @@ fn run_scheduler(
         match topology::CpuTopology::detect(nr_cpus_display as usize) {
             Ok(topo) => {
                 topo.log_summary();
-                if let Err(e) = topo.populate_bpf_map(&mut sched) {
+                if let Err(e) = topo.populate_bpf_map(&sched) {
                     log_warn!("CACHE TOPOLOGY MAP WRITE FAILED: {}", e);
                 }
                 if let Err(e) = topo.populate_l2_siblings_map(&sched) {
@@ -189,46 +180,14 @@ fn run_scheduler(
                 // RESISTANCE AFFINITY: COMPUTE R_EFF VIA LAPLACIAN PSEUDOINVERSE
                 // AND POPULATE BPF AFFINITY RANK MAP. SPECTRUM CARRIES lambda_2
                 // AND tau_ns FOR UNIVERSAL TOPOLOGY-DERIVED SCALING.
-                let (reff, rank, mut spectrum) = topo.compute_resistance_affinity();
-                if let Some(pv) = phi_scale {
-                    log_info!(
-                        "PHI OVERRIDE: phi_dist_scale_q16 {} -> {} (--phi-scale)",
-                        spectrum.phi_dist_scale_q16,
-                        pv
-                    );
-                    spectrum.phi_dist_scale_q16 = pv;
-                }
+                let (reff, rank, spectrum) = topo.compute_resistance_affinity();
+                let phi_dist_scale_q16 = spectrum.phi_dist_scale_q16;
                 topo.log_resistance_affinity(&reff, &rank, spectrum);
-                // T2: derive the emergent de-facto-NUMA domain tree from the cache
-                // graph (min-conductance cuts) and log it. T3's bounded steal reads it.
-                let domains = topo.compute_domain_tree();
-                topo.log_domains(&domains);
-                // T3b.1: flatten the tree to the per-CPU-pair crossing-price matrix
-                // and write it 1:1 with the affinity rank (domain_phi map).
-                let domain_phi = topo.domain_cross_phi_matrix(&domains);
-                if let Err(e) = topo.populate_affinity_rank_map(
-                    &sched,
-                    &reff,
-                    &rank,
-                    spectrum.phi_dist_scale_q16,
-                    &domain_phi,
-                ) {
+                if let Err(e) =
+                    topo.populate_affinity_rank_map(&sched, &reff, &rank, phi_dist_scale_q16)
+                {
                     log_warn!("AFFINITY RANK MAP WRITE FAILED: {}", e);
                 }
-                // T3b.2: partition the tree into emergent overflow domains (L3
-                // granularity) and write cpu_domain -- the the discrete domain map replacement.
-                let ov_domains = topo.overflow_domain_count();
-                let cpu_dom = topo.domain_partition(&domains, ov_domains);
-                for (cpu, &d) in cpu_dom.iter().enumerate() {
-                    if let Err(e) = sched.write_cpu_domain(cpu as u32, d) {
-                        log_warn!("CPU DOMAIN MAP WRITE FAILED (cpu {}): {}", cpu, e);
-                        break;
-                    }
-                }
-                log_info!(
-                    "OVERFLOW DOMAINS: {} (emergent, cpu_domain populated)",
-                    ov_domains
-                );
                 // WRITE tau_ns + codel_eq_ns INTO tuning_knobs. BPF'S tick() ON
                 // CPU 0 PICKS THESE UP AND DERIVES THE TAU-SCALED TIMING STATICS
                 // AND THE R_eff-DERIVED CODEL EQUILIBRIUM TARGET.
@@ -272,7 +231,6 @@ fn run_scheduler(
                 let delta_shared = stats.nr_shared.wrapping_sub(prev.nr_shared);
                 let delta_preempt = stats.nr_preempt.wrapping_sub(prev.nr_preempt);
                 let delta_keep = stats.nr_keep_running.wrapping_sub(prev.nr_keep_running);
-                let delta_parks = stats.nr_osc_park.wrapping_sub(prev.nr_osc_park);
                 let delta_wake_sum = stats.wake_lat_sum.wrapping_sub(prev.wake_lat_sum);
                 let delta_wake_samples = stats.wake_lat_samples.wrapping_sub(prev.wake_lat_samples);
                 let delta_hard = stats.nr_hard_kicks.wrapping_sub(prev.nr_hard_kicks);
@@ -362,7 +320,6 @@ fn run_scheduler(
                     delta_shared,
                     delta_preempt,
                     delta_keep,
-                    delta_parks,
                     wake_avg_us,
                     delta_hard,
                     delta_soft,
@@ -394,23 +351,14 @@ fn run_scheduler(
             } else {
                 0
             };
-            // CROSS-DOMAIN SCATTER ATTRIBUTION (PER XDOM_* PATH), ON THE [KNOBS]
-            // LINE SO THE BENCH SUITE CAPTURES IT UNIFORMLY ACROSS BPF/ADAPTIVE
-            // (LETS THE SUITE COMPARE SCATTER BETWEEN MODES). scatter_pct IS THE
-            // PLACEMENT-SIDE FRACTION (idx 0..6).
-            let x = &final_stats.nr_cross_domain;
-            let x_scatter: u64 = x[0..6].iter().sum();
-            let x_scatter_pct = if final_stats.nr_dispatches > 0 {
-                x_scatter * 100 / final_stats.nr_dispatches
-            } else {
-                0
-            };
             println!(
-                "[KNOBS] regime=BPF slice_ns={} batch_ns={} preempt_ns={} l2_hit=B:{}%/I:{}%/L:{}% cross_domain_scatter_pct={} cross_domain_sel_tight={} cross_domain_sel_sync={} cross_domain_sel_normal={} cross_domain_sel_dfl={} cross_domain_enq_t1={} cross_domain_enq_t2={} cross_domain_steal={} cross_domain_step5={}",
-                knobs.slice_ns, knobs.batch_slice_ns,
+                "[KNOBS] regime=BPF slice_ns={} batch_ns={} preempt_ns={} l2_hit=B:{}%/I:{}%/L:{}%",
+                knobs.slice_ns,
+                knobs.batch_slice_ns,
                 knobs.preempt_thresh_ns,
-                l2_cum_b, l2_cum_i, l2_cum_l,
-                x_scatter_pct, x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7],
+                l2_cum_b,
+                l2_cum_i,
+                l2_cum_l,
             );
 
             sched.read_exit_info()

--- a/scheds/rust/scx_pandemonium/src/scheduler.rs
+++ b/scheds/rust/scx_pandemonium/src/scheduler.rs
@@ -49,19 +49,11 @@ pub struct PandemoniumStats {
     pub batch_sojourn_ns: u64,
     pub longrun_mode_active: u64,
     pub nr_overflow_rescue: u64,
-    // CROSS-DOMAIN SCATTER ATTRIBUTION (PER XDOM_* PATH) -- MATCHES nr_cross_domain[8] IN
-    // intf.h. PLACEMENT-SIDE PATHS FEED THE MWU SCATTER LOSS PATHWAY.
-    pub nr_cross_domain: [u64; 8],
-    // OSCILLATOR ENVELOPE PARK ENTRIES (CPU-0 TICK WRITER; intf.h nr_osc_park)
     pub nr_osc_park: u64,
-    // SPILL-KICK PREEMPTS (select_cpu seat redirected off the idle pick onto a
-    // busy spill CPU; intf.h nr_spill_kick_preempt). Confirms the tick-floor fix.
-    pub nr_spill_kick_preempt: u64,
 }
 
 // COMPILE-TIME ABI SAFETY: MUST MATCH STRUCT LAYOUTS IN intf.h
-// 200 (base) + 8*8 (nr_cross_domain) + 8 (nr_osc_park) + 8 (nr_spill_kick_preempt) = 280.
-const _: () = assert!(std::mem::size_of::<PandemoniumStats>() == 280);
+const _: () = assert!(std::mem::size_of::<PandemoniumStats>() == 208);
 const _: () = assert!(std::mem::size_of::<TuningKnobs>() == 80);
 
 // MAX_AFFINITY_CANDIDATES IS DEFINED IN intf.h. THE RUST MIRROR IN
@@ -219,11 +211,7 @@ impl<'a> Scheduler<'a> {
                     total.longrun_mode_active = stats.longrun_mode_active;
                 }
                 total.nr_overflow_rescue += stats.nr_overflow_rescue;
-                for i in 0..8 {
-                    total.nr_cross_domain[i] += stats.nr_cross_domain[i];
-                }
                 total.nr_osc_park += stats.nr_osc_park;
-                total.nr_spill_kick_preempt += stats.nr_spill_kick_preempt;
             }
         }
 
@@ -274,10 +262,6 @@ impl<'a> Scheduler<'a> {
             codel_target_ns: bss.codel_target_ns,
             codel_target_floor_ns: bss.codel_target_floor_ns,
             codel_target_max_ns: data.codel_target_max_ns,
-            // NEAREST-PEER PHI HOLD WARM-STAY PRICES IN (SLOT 0 = CHEAPEST
-            // PEER, THE VALUE warm_stay_anchor READS FOR THE HOME CPU). CPU 0
-            // IS REPRESENTATIVE ON A HOMOGENEOUS TOPOLOGY.
-            home_dist_extra_ns: self.read_reff_value(0, 0) as u64,
         }
     }
 
@@ -358,27 +342,6 @@ impl<'a> Scheduler<'a> {
         Ok(())
     }
 
-    // POPULATE EMERGENT OVERFLOW-DOMAIN MAP (T3b.2). cpu_domain[cpu] = the
-    // emergent domain id from the T2 tree (the discrete domain map replacement).
-    pub fn write_cpu_domain(&self, cpu: u32, domain: u32) -> Result<()> {
-        let key = cpu.to_ne_bytes();
-        let val = domain.to_ne_bytes();
-        self.skel
-            .maps
-            .cpu_domain
-            .update(&key, &val, libbpf_rs::MapFlags::ANY)?;
-        Ok(())
-    }
-
-    // SET nr_overflow_domains (post-load mutable global). Walked from topology at startup.
-    // Gates how many of the MAX_OVERFLOW_DOMAINS per-domain overflow DSQs are addressed
-    // by dispatch drain loops.
-    pub fn write_nr_overflow_domains(&mut self, nr_overflow_domains: u32) {
-        if let Some(data) = self.skel.maps.data_data.as_mut() {
-            data.nr_overflow_domains = nr_overflow_domains;
-        }
-    }
-
     // POPULATE L2 SIBLINGS MAP ENTRY
     pub fn write_l2_sibling(&self, group_id: u32, slot: u32, cpu: u32) -> Result<()> {
         let key = (group_id * 8 + slot).to_ne_bytes();
@@ -407,8 +370,8 @@ impl<'a> Scheduler<'a> {
         Ok(())
     }
 
-    // POPULATE R_eff COST ORACLE MAP (PAIRS 1:1 WITH affinity_rank).
-    // reff_value[cpu * MAX_AFFINITY_CANDIDATES + slot] = quantized R_eff TO THAT TARGET.
+    // WRITE ONE reff_value SLOT: THE PRE-FOLDED PHI DISTANCE PENALTY (ns) TO THE
+    // PEER AT affinity_rank[cpu][slot]. THE STEP-1 STEAL READS IT AS dist_extra.
     pub fn write_reff_value(&self, cpu: u32, slot: u32, value: u32) -> Result<()> {
         let stride = crate::bpf_intf::MAX_AFFINITY_CANDIDATES;
         let key = (cpu * stride + slot).to_ne_bytes();
@@ -418,44 +381,6 @@ impl<'a> Scheduler<'a> {
             .reff_value
             .update(&key, &val, libbpf_rs::MapFlags::ANY)?;
         Ok(())
-    }
-
-    // POPULATE EMERGENT-DOMAIN CROSSING-PRICE MAP (PAIRS 1:1 WITH affinity_rank).
-    // domain_phi[cpu * MAX_AFFINITY_CANDIDATES + slot] = (phi * 1e6) OF THE CUT
-    // SEPARATING cpu FROM THAT RANKED PEER. (u32)-1 = SAME LEAF / UNUSED SLOT.
-    pub fn write_domain_phi(&self, cpu: u32, slot: u32, value: u32) -> Result<()> {
-        let stride = crate::bpf_intf::MAX_AFFINITY_CANDIDATES;
-        let key = (cpu * stride + slot).to_ne_bytes();
-        let val = value.to_ne_bytes();
-        self.skel
-            .maps
-            .domain_phi
-            .update(&key, &val, libbpf_rs::MapFlags::ANY)?;
-        Ok(())
-    }
-
-    // READ ONE reff_value SLOT (ns PHI HOLD TO THAT RANKED PEER). RETURNS 0 ON
-    // MISS OR THE (u32)-1 UNUSED-SLOT SENTINEL. USED BY THE ADAPTIVE LOOP TO
-    // LEARN THE NEAREST-PEER HOLD WARM-STAY PRICES IN (SLOT 0 = CHEAPEST PEER).
-    pub fn read_reff_value(&self, cpu: u32, slot: u32) -> u32 {
-        let stride = crate::bpf_intf::MAX_AFFINITY_CANDIDATES;
-        let key = (cpu * stride + slot).to_ne_bytes();
-        match self
-            .skel
-            .maps
-            .reff_value
-            .lookup(&key, libbpf_rs::MapFlags::ANY)
-        {
-            Ok(Some(bytes)) if bytes.len() >= 4 => {
-                let v = u32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-                if v == u32::MAX {
-                    0
-                } else {
-                    v
-                }
-            }
-            _ => 0,
-        }
     }
 
     // READ UEI EXIT INFO. RETURNS (should_restart).

--- a/scheds/rust/scx_pandemonium/src/scheduler.rs
+++ b/scheds/rust/scx_pandemonium/src/scheduler.rs
@@ -54,7 +54,7 @@ pub struct PandemoniumStats {
 
 // COMPILE-TIME ABI SAFETY: MUST MATCH STRUCT LAYOUTS IN intf.h
 const _: () = assert!(std::mem::size_of::<PandemoniumStats>() == 208);
-const _: () = assert!(std::mem::size_of::<TuningKnobs>() == 80);
+const _: () = assert!(std::mem::size_of::<TuningKnobs>() == 72);
 
 // MAX_AFFINITY_CANDIDATES IS DEFINED IN intf.h. THE RUST MIRROR IN
 // bpf_intf.rs MUST KEEP THE SAME VALUE; IF THE TWO SIDES DRIFT, THE
@@ -379,6 +379,20 @@ impl<'a> Scheduler<'a> {
         self.skel
             .maps
             .reff_value
+            .update(&key, &val, libbpf_rs::MapFlags::ANY)?;
+        Ok(())
+    }
+
+    // WRITE ONE spill_depth SLOT: THE PRE-FOLDED PHI PLACEMENT THRESHOLD (DSQ
+    // DEPTH) FOR THE PEER AT affinity_rank[cpu][slot]. THE SPILL HELPER READS IT
+    // AS THE PER-PEER DEPTH CAP -- THE PLACEMENT MIRROR OF reff_value's STEAL DELAY.
+    pub fn write_spill_depth(&self, cpu: u32, slot: u32, value: u32) -> Result<()> {
+        let stride = crate::bpf_intf::MAX_AFFINITY_CANDIDATES;
+        let key = (cpu * stride + slot).to_ne_bytes();
+        let val = value.to_ne_bytes();
+        self.skel
+            .maps
+            .spill_depth
             .update(&key, &val, libbpf_rs::MapFlags::ANY)?;
         Ok(())
     }

--- a/scheds/rust/scx_pandemonium/src/topology.rs
+++ b/scheds/rust/scx_pandemonium/src/topology.rs
@@ -46,59 +46,10 @@ const C_EQ_CEIL_NS: u64 = 8_000_000; // 8ms
 
 #[derive(Clone, Copy, Debug)]
 pub struct TopologySpectrum {
-    pub fiedler: f64,     // lambda_2
-    pub tau_ns: u64,      // clamped TAU_SCALE_NS / lambda_2
-    pub codel_eq_ns: u64, // <R_eff> * 2m * tau, clamped
-    // Phi migration-potential distance->wait scale (Q16). The extra head-wait a
-    // steal must clear before crossing to a peer = (reff * this) >> 16 ns. Always
-    // computed now (T1): the continuous metric prices distance on every part, no
-    // binary topology gate -- on a monolithic part it calibrates to the L2 seam.
-    pub phi_dist_scale_q16: u64,
-}
-
-// T2: the emergent domain tree. Leaves are tightly-coupled CPU sets (an L2 group
-// / core -- nothing meaningful to partition below); internal nodes are a
-// min-conductance cut carrying its phi, the price to cross that seam. T3's
-// bounded-local steal climbs this tree: drain your leaf, then your subtree,
-// crossing a cut only when its phi says the imbalance pays. The discrete cache domain
-// enum is gone -- this structure emerges from the cache graph, per machine.
-#[derive(Debug, Clone)]
-pub enum DomainNode {
-    Leaf(Vec<usize>),
-    Cut {
-        phi: f64,
-        left: Box<DomainNode>,
-        right: Box<DomainNode>,
-    },
-}
-
-#[allow(dead_code)]
-impl DomainNode {
-    // Flatten to the leaf CPU sets -- each an emergent atomic domain.
-    pub fn leaves(&self) -> Vec<Vec<usize>> {
-        match self {
-            DomainNode::Leaf(cpus) => vec![cpus.clone()],
-            DomainNode::Cut { left, right, .. } => {
-                let mut v = left.leaves();
-                v.extend(right.leaves());
-                v
-            }
-        }
-    }
-
-    // Every cut's phi -- the crossing-price ladder (coarser seams cost less, so
-    // phi rises with depth as the steal climbs toward more tightly-coupled work).
-    pub fn cut_phis(&self) -> Vec<f64> {
-        match self {
-            DomainNode::Leaf(_) => Vec::new(),
-            DomainNode::Cut { phi, left, right } => {
-                let mut v = vec![*phi];
-                v.extend(left.cut_phis());
-                v.extend(right.cut_phis());
-                v
-            }
-        }
-    }
+    pub fiedler: f64,            // lambda_2
+    pub tau_ns: u64,             // clamped TAU_SCALE_NS / lambda_2
+    pub codel_eq_ns: u64,        // <R_eff> * 2m * tau, clamped
+    pub phi_dist_scale_q16: u64, // tau*65536/reff_norm; 0 on monolithic L3 (flat target)
 }
 
 fn extract_fiedler(eigenvalues: &[f64]) -> f64 {
@@ -166,7 +117,8 @@ pub struct CpuTopology {
     pub l2_domain: Vec<u32>,      // l2_domain[cpu] = group_id
     pub l2_groups: Vec<Vec<u32>>, // l2_groups[group_id] = [cpu, ...]
     pub socket_domain: Vec<u32>,  // socket_domain[cpu] = socket_id
-    pub llc_domain: Vec<u32>,     // llc_domain[cpu] = L3 GROUP (== socket WHEN MONOLITHIC)
+    pub llc_domain: Vec<u32>,     // llc_domain[cpu] = L3/CCX GROUP (== socket WHEN MONOLITHIC)
+    pub ccx_active: bool, // TRUE WHEN A SOCKET HOLDS >1 L3/CCX (AMD CHIPLET): ENABLES SAME-CCX RUNG
     pub nr_sockets: u32,
 }
 
@@ -226,12 +178,12 @@ impl CpuTopology {
 
         let nr_sockets = seen_sockets.len() as u32;
 
-        // DETECT L3 / cache domain / cache domain DOMAIN (index3). ON AMD multi-domain PARTS index3
-        // SUBDIVIDES THE SOCKET INTO cache domain GROUPS; ON MONOLITHIC-L3 PARTS IT
+        // DETECT L3 / CCX / CCD DOMAIN (index3). ON AMD CHIPLET PARTS index3
+        // SUBDIVIDES THE SOCKET INTO CCX/CCD GROUPS; ON MONOLITHIC-L3 PARTS IT
         // SPANS THE WHOLE SOCKET. USE THE TIER ONLY WHEN IT GENUINELY
         // SUBDIVIDES A SOCKET (MORE L3 GROUPS THAN SOCKETS) AND index3 WAS
         // PRESENT FOR EVERY CPU; OTHERWISE llc_domain == socket_domain SO THE
-        // CROSS-DOMAIN RUNG IN build_laplacian NEVER FIRES (EXACT NO-OP).
+        // CROSS-CCX RUNG IN build_laplacian NEVER FIRES (EXACT NO-OP).
         let mut llc_domain = vec![0u32; nr_cpus];
         let mut seen_llc: Vec<Vec<u32>> = Vec::new();
         let mut llc_ok = true;
@@ -258,14 +210,7 @@ impl CpuTopology {
             };
             llc_domain[cpu] = group_id;
         }
-        // MAX_OVERFLOW_DOMAINS mirrors src/bpf/intf.h: the BPF side creates exactly
-        // this many per-domain overflow DSQs. If a (multi-socket, high-cache domain) box has
-        // more L3 groups than that, degrade to the socket domain rather than let
-        // a cache domain id index an uncreated DSQ -> dispatch failure -> ejection.
-        const MAX_OVERFLOW_DOMAINS: usize = 32;
-        let llc_subdivides = llc_ok
-            && seen_llc.len() > nr_sockets as usize
-            && seen_llc.len() <= MAX_OVERFLOW_DOMAINS;
+        let llc_subdivides = llc_ok && seen_llc.len() > nr_sockets as usize;
         if !llc_subdivides {
             llc_domain = socket_domain.clone();
         }
@@ -276,23 +221,16 @@ impl CpuTopology {
             l2_groups: seen_groups,
             socket_domain,
             llc_domain,
+            ccx_active: llc_subdivides,
             nr_sockets,
         })
     }
 
     // WRITE L2 DOMAIN MAP TO BPF ARRAY VIA SCHEDULER
-    pub fn populate_bpf_map(&self, sched: &mut Scheduler) -> Result<()> {
+    pub fn populate_bpf_map(&self, sched: &Scheduler) -> Result<()> {
         for cpu in 0..self.nr_cpus {
             sched.write_cache_domain(cpu as u32, self.l2_domain[cpu])?;
         }
-        // nr_overflow_domains = number of distinct llc_domain values (the overflow-domain count)
-        let mut seen: Vec<u32> = Vec::new();
-        for &g in &self.llc_domain {
-            if !seen.contains(&g) {
-                seen.push(g);
-            }
-        }
-        sched.write_nr_overflow_domains(seen.len() as u32);
         Ok(())
     }
 
@@ -320,14 +258,13 @@ impl CpuTopology {
     //
     // EDGE CONDUCTANCES (INVERSE RESISTANCE):
     //   L2 SIBLINGS:      10.0  (SHARED L2, NEAR-ZERO MIGRATION COST)
-    //   SAME L3 / cache domain:     3.0  (SHARED LLC; ONLY WHEN A SOCKET HOLDS >1 cache domain)
-    //   CROSS-DOMAIN SOCKET:  1.0  (CROSS-DOMAIN INTERCONNECT HOP, ~8x CORE-TO-CORE LATENCY)
+    //   SAME L3 / CCX:     3.0  (SHARED LLC; ONLY WHEN A SOCKET HOLDS >1 CCX)
+    //   CROSS-CCX SOCKET:  1.0  (INFINITY-FABRIC HOP, ~8x CORE-TO-CORE LATENCY)
     //   CROSS-SOCKET:      0.3  (NUMA HOP, HIGH COST)
-    // RAISING THE same-domain RUNG (NOT LOWERING THE CROSS-DOMAIN CUT) RANKS
-    // SAME-L3 PEERS AHEAD OF CROSS-L3 ONES WITHOUT MOVING lambda_2: THE CROSS-L3
-    // CUT STAYS 1.0, SO tau AND codel_eq ARE UNCHANGED. THE L3 RUNG IS ALWAYS ON;
-    // on a monolithic part llc_domain == socket_domain, so it coincides with the
-    // socket rung and the continuous R_eff metric calibrates to the L2 boundary.
+    // RAISING THE SAME-CCX RUNG (NOT LOWERING THE CROSS-CCX CUT) RANKS
+    // SAME-CCX PEERS AHEAD OF CROSS-CCX ONES WITHOUT MOVING lambda_2: THE
+    // CROSS-CCX CUT STAYS 1.0, SO tau AND codel_eq ARE UNCHANGED. THE RUNG
+    // IS GATED ON ccx_active SO MONOLITHIC-L3 PARTS ARE AN EXACT NO-OP.
     //
     // THE LAPLACIAN L = D - W WHERE D IS DEGREE MATRIX, W IS WEIGHTED ADJACENCY.
     // L+ (MOORE-PENROSE PSEUDOINVERSE) COMPUTED VIA EIGENDECOMPOSITION:
@@ -338,40 +275,26 @@ impl CpuTopology {
     // REFERENCE: Christiano-Kelner-Madry-Spielman-Teng (STOC 2011),
     //            Chen-Kyng-Liu-Peng-Gutenberg-Sachdeva (FOCS 2022)
 
-    // Phi FIX A: SMT siblings SHARE L2, so a move between them costs ~0 cache.
-    // Make the edge very stiff -> R_eff(SMT-sib) ~ 0, which lands the Phi migration
-    // barrier exactly at the physical-core / L2 boundary (a real cold-L2 refill)
-    // instead of penalizing free intra-core moves. lambda_2 is the cross-domain Fiedler
-    // cut (independent of L2 stiffness) so tau is unchanged, and codel_eq is already
-    // clamped at its ceiling, so the oscillator timescales are invariant.
-    const CONDUCTANCE_L2: f64 = 1000.0; // L2 / SMT SIBLINGS
-    const CONDUCTANCE_LLC: f64 = 3.0; // SAME L3 (ABOVE SOCKET; always-on rung)
-    const CONDUCTANCE_SOCKET: f64 = 1.0; // SAME SOCKET, CROSS-DOMAIN (IF HOP) -- OR MONOLITHIC SAME-SOCKET
+    const CONDUCTANCE_L2: f64 = 10.0; // L2 / SMT SIBLINGS
+    const CONDUCTANCE_LLC: f64 = 3.0; // SAME L3 / CCX (ABOVE SOCKET; ONLY WHEN ccx_active)
+    const CONDUCTANCE_SOCKET: f64 = 1.0; // SAME SOCKET, CROSS-CCX (IF HOP) -- OR MONOLITHIC SAME-SOCKET
     const CONDUCTANCE_CROSS: f64 = 0.3; // CROSS-SOCKET NUMA HOP
 
     // BUILD WEIGHTED GRAPH LAPLACIAN FROM CPU TOPOLOGY
-    // Conductance edge weight between two CPUs, derived from the cache hierarchy.
-    // The single source of truth for BOTH the Laplacian (R_eff / tau) and the
-    // domain cut below, so the emergent locality boundary and the placement metric
-    // price the exact same graph -- the continuous metric drives everything.
-    fn conductance(&self, i: usize, j: usize) -> f64 {
-        if self.l2_domain[i] == self.l2_domain[j] {
-            Self::CONDUCTANCE_L2
-        } else if self.llc_domain[i] == self.llc_domain[j] {
-            Self::CONDUCTANCE_LLC
-        } else if self.socket_domain[i] == self.socket_domain[j] {
-            Self::CONDUCTANCE_SOCKET
-        } else {
-            Self::CONDUCTANCE_CROSS
-        }
-    }
-
     fn build_laplacian(&self) -> Vec<f64> {
         let n = self.nr_cpus;
         let mut l = vec![0.0f64; n * n];
         for i in 0..n {
             for j in (i + 1)..n {
-                let w = self.conductance(i, j);
+                let w = if self.l2_domain[i] == self.l2_domain[j] {
+                    Self::CONDUCTANCE_L2
+                } else if self.ccx_active && self.llc_domain[i] == self.llc_domain[j] {
+                    Self::CONDUCTANCE_LLC
+                } else if self.socket_domain[i] == self.socket_domain[j] {
+                    Self::CONDUCTANCE_SOCKET
+                } else {
+                    Self::CONDUCTANCE_CROSS
+                };
                 l[i * n + j] = -w;
                 l[j * n + i] = -w;
                 l[i * n + i] += w;
@@ -379,397 +302,6 @@ impl CpuTopology {
             }
         }
         l
-    }
-
-    // ---- T2: emergent domain cut (SOSA min-conductance) --------------------
-    // The discrete cache domain layer is replaced by domains that EMERGE from the
-    // cache graph. The boundary is the min-conductance cut: phi = cut_weight /
-    // min(vol_a, vol_b). Low phi = a loosely-coupled seam = a real domain edge;
-    // the phi of the cut IS the cross-domain crossing price (THE FLAG: the price
-    // draws the boundary, no gate). Balance-free -- the seam falls where the
-    // silicon divides (asymmetric X3D / P+E included), not where volume balances.
-
-    // Conductance phi of a bipartition of `members` (in_side[c] = c is on side A).
-    // O(|members|^2); boot-time only. The random-walk variant (next) avoids the
-    // full scan for large N -- this exact form is the ground-truth + the price.
-    #[allow(dead_code)]
-    fn cut_conductance(&self, members: &[usize], in_side: &[bool]) -> f64 {
-        let mut cut = 0.0f64;
-        let (mut vol_a, mut vol_b) = (0.0f64, 0.0f64);
-        for &a in members {
-            for &b in members {
-                if a == b {
-                    continue;
-                }
-                let w = self.conductance(a, b);
-                if in_side[a] {
-                    vol_a += w;
-                } else {
-                    vol_b += w;
-                }
-                if in_side[a] != in_side[b] {
-                    cut += w; // each crossing edge counted twice (a,b and b,a)
-                }
-            }
-        }
-        cut /= 2.0;
-        let denom = vol_a.min(vol_b);
-        if denom <= 0.0 {
-            f64::INFINITY
-        } else {
-            cut / denom
-        }
-    }
-
-    // Fiedler vector (eigenvector of lambda_2) of the full graph -- the ground
-    // truth the scalable random-walk cut is cross-checked against. eigenvectors
-    // are column-major: component i of eigenvector k is eigenvectors[i*n + k].
-    #[allow(dead_code)]
-    fn fiedler_vector(eigenvalues: &[f64], eigenvectors: &[f64], n: usize) -> Vec<f64> {
-        let mut idx: Vec<usize> = (0..n).collect();
-        idx.sort_by(|&a, &b| {
-            eigenvalues[a]
-                .partial_cmp(&eigenvalues[b])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        let k = if n >= 2 { idx[1] } else { idx[0] }; // 2nd smallest = lambda_2
-        (0..n).map(|i| eigenvectors[i * n + k]).collect()
-    }
-
-    // Single-level min-conductance cut of `members` via the Fiedler sweep: order
-    // the members by their Fiedler component, sweep every prefix as side A, keep
-    // the split with the lowest phi. Balance-free. Returns (side_a, side_b, phi),
-    // or None for a singleton. fvec is indexed by global CPU id.
-    #[allow(dead_code)]
-    fn fiedler_sweep_cut(
-        &self,
-        members: &[usize],
-        fvec: &[f64],
-    ) -> Option<(Vec<usize>, Vec<usize>, f64)> {
-        if members.len() < 2 {
-            return None;
-        }
-        let mut ordered = members.to_vec();
-        ordered.sort_by(|&a, &b| {
-            fvec[a]
-                .partial_cmp(&fvec[b])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        let mut in_side = vec![false; self.nr_cpus];
-        let (mut best_phi, mut best_k) = (f64::INFINITY, 1usize);
-        for k in 1..ordered.len() {
-            in_side[ordered[k - 1]] = true; // grow the prefix one vertex
-            let phi = self.cut_conductance(members, &in_side);
-            if phi < best_phi {
-                best_phi = phi;
-                best_k = k;
-            }
-        }
-        Some((
-            ordered[..best_k].to_vec(),
-            ordered[best_k..].to_vec(),
-            best_phi,
-        ))
-    }
-
-    // True when every member shares one L2 group -- the atomic leaf. L2 siblings
-    // are maximally coupled; there is no meaningful seam to find below them.
-    #[allow(dead_code)]
-    fn all_same_l2(&self, members: &[usize]) -> bool {
-        members
-            .windows(2)
-            .all(|w| self.l2_domain[w[0]] == self.l2_domain[w[1]])
-    }
-
-    // Min-conductance cut of an ARBITRARY CPU subset (recursion-safe). The global
-    // Fiedler degrades inside a subtree, so this builds the INDUCED Laplacian on
-    // `members`, eigendecomposes it, and sweeps by the SUBSET's own Fiedler. (2d
-    // replaces these internals with a local random walk -- no eigensolve, so it
-    // scales; the tree-builder is agnostic to which produces the cut.) Returns
-    // global CPU ids.
-    #[allow(dead_code)]
-    fn domain_cut(&self, members: &[usize]) -> Option<(Vec<usize>, Vec<usize>, f64)> {
-        let k = members.len();
-        if k < 2 {
-            return None;
-        }
-        let mut lap = vec![0.0f64; k * k]; // induced Laplacian, local-indexed 0..k
-        for ia in 0..k {
-            for ib in (ia + 1)..k {
-                let w = self.conductance(members[ia], members[ib]);
-                lap[ia * k + ib] = -w;
-                lap[ib * k + ia] = -w;
-                lap[ia * k + ia] += w;
-                lap[ib * k + ib] += w;
-            }
-        }
-        let (ev, evec) = Self::symmetric_eigen(&lap, k);
-        let fsub = Self::fiedler_vector(&ev, &evec, k); // local-indexed
-        let mut order: Vec<usize> = (0..k).collect();
-        order.sort_by(|&a, &b| {
-            fsub[a]
-                .partial_cmp(&fsub[b])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        let mut in_side = vec![false; self.nr_cpus]; // global-indexed for cut_conductance
-        let (mut best_phi, mut best_k) = (f64::INFINITY, 1usize);
-        for s in 1..k {
-            in_side[members[order[s - 1]]] = true; // grow the prefix (global id)
-            let phi = self.cut_conductance(members, &in_side);
-            if phi < best_phi {
-                best_phi = phi;
-                best_k = s;
-            }
-        }
-        let side_a: Vec<usize> = order[..best_k].iter().map(|&li| members[li]).collect();
-        let side_b: Vec<usize> = order[best_k..].iter().map(|&li| members[li]).collect();
-        Some((side_a, side_b, best_phi))
-    }
-
-    // Below this many CPUs the exact eigen cut is cheap, so use it; above it,
-    // the O(n^3) Jacobi is the wall and the random-walk cut takes over. This is an
-    // implementation dispatch on cost, not a placement gate (THE FLAG untouched).
-    const WALK_CUT_THRESHOLD: usize = 64;
-
-    // SCALABLE min-conductance cut: the SAME sweep as domain_cut, but the vertex
-    // ordering comes from a RANDOM WALK instead of an eigendecomposition -- no
-    // O(n^3) eigensolve, so it scales. Power iteration on the NORMALIZED operator
-    // M = 2I - L_sym, where L_sym = I - D^{-1/2} A D^{-1/2} is the symmetric
-    // normalized Laplacian (eigenvalues in [0,2] regardless of edge-weight scale,
-    // so stiff L2 edges don't dominate the shift the way a raw cI - L would). Its
-    // null eigenvector is D^{1/2}*1 (the walk's stationary distribution, deflated
-    // out each step); the next is the normalized Fiedler -- the iterate converges
-    // to it with a gap set by the CONDUCTANCE structure, not the weight magnitude.
-    // The sweep order is f[i] = y[i] / sqrt(deg[i]) (un-normalizing back to the
-    // walk eigenvector). Deterministic hash start (not a ramp -- ramps can align
-    // with a non-Fiedler mode) so a topology yields the same domains every boot.
-    // Cross-checked against domain_cut as ground truth (the T2 gate).
-    #[allow(dead_code)]
-    fn walk_cut(&self, members: &[usize]) -> Option<(Vec<usize>, Vec<usize>, f64)> {
-        let k = members.len();
-        if k < 2 {
-            return None;
-        }
-        let mut adj = vec![0.0f64; k * k];
-        let mut deg = vec![0.0f64; k];
-        for ia in 0..k {
-            for ib in 0..k {
-                if ia == ib {
-                    continue;
-                }
-                let w = self.conductance(members[ia], members[ib]);
-                adj[ia * k + ib] = w;
-                deg[ia] += w;
-            }
-        }
-        // D^{-1/2} and the stationary direction D^{1/2}*1 (L_sym's null vector).
-        let dis: Vec<f64> = deg
-            .iter()
-            .map(|&d| if d > 0.0 { 1.0 / d.sqrt() } else { 0.0 })
-            .collect();
-        let dsq: Vec<f64> = deg.iter().map(|&d| d.sqrt()).collect();
-        let dsq_sq: f64 = dsq.iter().map(|x| x * x).sum::<f64>().max(1e-30);
-        // Deflate out the stationary (null) component each step.
-        let deflate = |v: &mut [f64]| {
-            let dot: f64 = v.iter().zip(&dsq).map(|(a, b)| a * b).sum();
-            let coef = dot / dsq_sq;
-            for i in 0..k {
-                v[i] -= coef * dsq[i];
-            }
-        };
-        let mut y: Vec<f64> = (0..k)
-            .map(|i| {
-                let h = (i as u64).wrapping_mul(2654435761) & 0xffff;
-                h as f64 / 65535.0 - 0.5
-            })
-            .collect();
-        deflate(&mut y);
-        // A weak cut has a tiny normalized eigenvalue gap, so the per-iteration
-        // rate is near 1 and convergence can take thousands of steps -- iterate to
-        // CONVERGENCE (the direction stops moving), not a fixed count, capped high.
-        // Each step is O(k^2); a one-time boot cost, well under a millisecond.
-        const MAX_ITERS: usize = 20_000;
-        const TOL: f64 = 1e-10;
-        let mut w = vec![0.0f64; k];
-        for _ in 0..MAX_ITERS {
-            // (M y)[i] = y[i] + D^{-1/2}_i * sum_j A_ij * D^{-1/2}_j * y[j]
-            for i in 0..k {
-                let row = &adj[i * k..i * k + k];
-                let mut s = 0.0;
-                for j in 0..k {
-                    s += row[j] * dis[j] * y[j];
-                }
-                w[i] = y[i] + dis[i] * s;
-            }
-            deflate(&mut w);
-            let norm = w.iter().map(|x| x * x).sum::<f64>().sqrt();
-            if norm < 1e-12 {
-                break;
-            }
-            // cos angle between the new direction and the old unit vector y.
-            let dot: f64 = w.iter().zip(&y).map(|(a, b)| a * b).sum::<f64>() / norm;
-            for i in 0..k {
-                y[i] = w[i] / norm;
-            }
-            if 1.0 - dot.abs() < TOL {
-                break;
-            }
-        }
-        // Sweep order by the un-normalized walk eigenvector f[i] = y[i]/sqrt(deg).
-        let f: Vec<f64> = (0..k).map(|i| y[i] * dis[i]).collect();
-        let mut order: Vec<usize> = (0..k).collect();
-        order.sort_by(|&a, &b| f[a].partial_cmp(&f[b]).unwrap_or(std::cmp::Ordering::Equal));
-        let mut in_side = vec![false; self.nr_cpus];
-        let (mut best_phi, mut best_k) = (f64::INFINITY, 1usize);
-        for s in 1..k {
-            in_side[members[order[s - 1]]] = true;
-            let phi = self.cut_conductance(members, &in_side);
-            if phi < best_phi {
-                best_phi = phi;
-                best_k = s;
-            }
-        }
-        Some((
-            order[..best_k].iter().map(|&li| members[li]).collect(),
-            order[best_k..].iter().map(|&li| members[li]).collect(),
-            best_phi,
-        ))
-    }
-
-    // Dispatch: exact eigen cut below the threshold, scalable random-walk cut
-    // above. Both produce the same boundary on real cache graphs (gate-tested).
-    #[allow(dead_code)]
-    fn best_cut(&self, members: &[usize]) -> Option<(Vec<usize>, Vec<usize>, f64)> {
-        if members.len() <= Self::WALK_CUT_THRESHOLD {
-            self.domain_cut(members)
-        } else {
-            self.walk_cut(members)
-        }
-    }
-
-    // Recurse the cut into the emergent domain tree. Leaf when the members are a
-    // single L2 group (or one CPU) -- maximally coupled, no seam. Each Cut carries
-    // its phi (the crossing price). This IS de-facto NUMA: the boundary is drawn
-    // by the conductance landscape, not a hardcoded topology table.
-    #[allow(dead_code)]
-    pub fn build_domain_tree(&self, members: &[usize]) -> DomainNode {
-        if members.len() <= 1 || self.all_same_l2(members) {
-            return DomainNode::Leaf(members.to_vec());
-        }
-        match self.best_cut(members) {
-            Some((a, b, phi)) if !a.is_empty() && !b.is_empty() => DomainNode::Cut {
-                phi,
-                left: Box::new(self.build_domain_tree(&a)),
-                right: Box::new(self.build_domain_tree(&b)),
-            },
-            _ => DomainNode::Leaf(members.to_vec()),
-        }
-    }
-
-    // Compute the emergent domain tree over all online CPUs -- the de-facto-NUMA
-    // hierarchy from which T3's bounded-local steal reads its locality clusters
-    // and per-cut crossing prices. Public: the T2 -> T3 hand-off point.
-    pub fn compute_domain_tree(&self) -> DomainNode {
-        self.build_domain_tree(&(0..self.nr_cpus).collect::<Vec<_>>())
-    }
-
-    // Log the emergent domains at boot -- observability that the tree the steal
-    // will climb matches the silicon: atomic-domain count, cut depth, the
-    // crossing-price (phi) range, and the first leaves.
-    pub fn log_domains(&self, tree: &DomainNode) {
-        let leaves = tree.leaves();
-        let phis = tree.cut_phis();
-        let (pmin, pmax) = phis.iter().fold((f64::INFINITY, 0.0f64), |(lo, hi), &p| {
-            (lo.min(p), hi.max(p))
-        });
-        log_info!(
-            "EMERGENT DOMAINS: {} atomic, {} cuts, crossing phi {:.4}..{:.4}",
-            leaves.len(),
-            phis.len(),
-            if phis.is_empty() { 0.0 } else { pmin },
-            pmax
-        );
-        let preview: Vec<String> = leaves.iter().take(8).map(|l| format!("{:?}", l)).collect();
-        log_info!("EMERGENT DOMAINS: leaves {}", preview.join(" "));
-    }
-
-    // T3b.1: the per-CPU-pair crossing-price matrix the bounded steal reads.
-    // m[i*n + j] = (phi * 1e6) of the LCA cut separating CPU i and CPU j -- the
-    // price to steal across that emergent domain boundary. A LOW phi is a loose
-    // seam (a major boundary -- socket / cross-L3 -- far, needs more imbalance to
-    // cross); a HIGH phi is a tight seam (near). Same-leaf pairs share NO cut:
-    // sentinel u32::MAX = maximally local, the steal never has to "cross" for them.
-    // Replaces the discrete domain map's discrete same/different-cache domain test with a continuous,
-    // emergent boundary price (THE FLAG: priced, not gated).
-    pub fn domain_cross_phi_matrix(&self, tree: &DomainNode) -> Vec<u32> {
-        let n = self.nr_cpus;
-        let mut m = vec![u32::MAX; n * n]; // default: no boundary (same leaf)
-        Self::fill_cross_phi(tree, n, &mut m);
-        m
-    }
-
-    fn fill_cross_phi(node: &DomainNode, n: usize, m: &mut [u32]) {
-        if let DomainNode::Cut { phi, left, right } = node {
-            let lc: Vec<usize> = left.leaves().concat();
-            let rc: Vec<usize> = right.leaves().concat();
-            let p = (phi * 1_000_000.0).round().clamp(0.0, u32::MAX as f64) as u32;
-            for &a in &lc {
-                for &b in &rc {
-                    m[a * n + b] = p; // pairs whose lowest common ancestor IS this cut
-                    m[b * n + a] = p;
-                }
-            }
-            Self::fill_cross_phi(left, n, m);
-            Self::fill_cross_phi(right, n, m);
-        }
-    }
-
-    // Number of emergent OVERFLOW DOMAINS to target = distinct L3 groups (the old
-    // per-domain count), so re-keying the overflow DSQs preserves granularity.
-    pub fn overflow_domain_count(&self) -> usize {
-        let mut v = self.llc_domain.clone();
-        v.sort_unstable();
-        v.dedup();
-        v.len().max(1)
-    }
-
-    // T3b.2: partition CPUs into emergent OVERFLOW DOMAINS -- the the discrete domain map
-    // replacement. Descend the tree from the root, repeatedly splitting the
-    // frontier subtree whose cut has the LOWEST phi (the coarsest, most-separable
-    // seam) until `target` domains exist or no cut remains. Each resulting subtree
-    // is one overflow domain; dom[cpu] is its id. The granularity is the old L3
-    // count, but the boundary is now drawn by the emergent tree, not the discrete domain map.
-    pub fn domain_partition(&self, tree: &DomainNode, target: usize) -> Vec<u32> {
-        let mut frontier: Vec<&DomainNode> = vec![tree];
-        while frontier.len() < target.max(1) {
-            let mut best: Option<(usize, f64)> = None;
-            for (i, node) in frontier.iter().enumerate() {
-                if let DomainNode::Cut { phi, .. } = node {
-                    if best.map_or(true, |(_, bp)| *phi < bp) {
-                        best = Some((i, *phi));
-                    }
-                }
-            }
-            let Some((idx, _)) = best else { break }; // no cuts left to split
-            let node = frontier[idx];
-            if let DomainNode::Cut { left, right, .. } = node {
-                frontier.swap_remove(idx);
-                frontier.push(left.as_ref());
-                frontier.push(right.as_ref());
-            }
-        }
-        let n = self.nr_cpus;
-        let mut dom = vec![0u32; n];
-        for (id, node) in frontier.iter().enumerate() {
-            for leaf in node.leaves() {
-                for c in leaf {
-                    if c < n {
-                        dom[c] = id as u32;
-                    }
-                }
-            }
-        }
-        dom
     }
 
     // SYMMETRIC EIGENDECOMPOSITION VIA JACOBI ROTATIONS
@@ -918,17 +450,18 @@ impl CpuTopology {
         let reff = Self::extract_reff(&l_pinv, n);
         let rank = Self::build_affinity_rank(&reff, n);
         let codel_eq_ns = compute_codel_eq_ns(&eigenvalues, n, tau_ns);
-        // Phi FIX B: distance scale calibrated so the most distant pair (max R_eff)
-        // maps to ~tau of required steal-wait, an SMT sibling (R_eff ~ 0) to ~0. Only
-        // sustained backlog (~tau) justifies a far move; a single queued slice does
-        // not. reff_norm uses the same 1e6 scale the BPF reff_value map stores.
-        // ALWAYS computed: on a single-L3 part the most distant pair is the cross-L2
-        // (cross-core) max, so reff_norm auto-calibrates the brake to the L2 boundary
-        // instead of vanishing -- the continuous metric drives placement on EVERY
-        // processor, with no binary topology gate in front of it (THE FLAG).
+        // PHI DISTANCE SCALE: calibrated so the most distant pair (max R_eff) maps to
+        // ~tau of required steal-wait, an SMT sibling (R_eff~0) to ~0 -- only sustained
+        // backlog (~tau) justifies a cross-domain move. 0 on monolithic L3 (no distance
+        // structure to price) -> flat codel_target, exact prior behavior. reff_norm uses
+        // the same 1e6 scale the BPF reff_value map stores.
         let max_reff = reff.iter().cloned().fold(0.0f64, f64::max);
         let reff_norm = ((max_reff * 1_000_000.0).round() as u64).max(1);
-        let phi_dist_scale_q16 = tau_ns.saturating_mul(65536) / reff_norm;
+        let phi_dist_scale_q16 = if self.ccx_active {
+            tau_ns.saturating_mul(65536) / reff_norm
+        } else {
+            0
+        };
         (
             reff,
             rank,
@@ -955,7 +488,6 @@ impl CpuTopology {
         reff: &[f64],
         rank: &[u32],
         phi_dist_scale_q16: u64,
-        domain_phi: &[u32],
     ) -> Result<()> {
         let stride = crate::bpf_intf::MAX_AFFINITY_CANDIDATES as usize;
         let valid = self.nr_cpus.saturating_sub(1).min(stride);
@@ -963,19 +495,11 @@ impl CpuTopology {
             for slot in 0..valid {
                 let val = rank[cpu * self.nr_cpus + slot];
                 sched.write_affinity_rank(cpu as u32, slot as u32, val)?;
-                // T3b.1: the emergent-domain crossing price to this ranked peer,
-                // 1:1 with the rank slot (sentinel for an out-of-range peer id).
-                let dphi = domain_phi
-                    .get(cpu * self.nr_cpus + val as usize)
-                    .copied()
-                    .unwrap_or(u32::MAX);
-                sched.write_domain_phi(cpu as u32, slot as u32, dphi)?;
-                // FOLD THE PHI DISTANCE PENALTY AT INIT: reff_value stores the
-                // final steal extra-wait in ns, (R_eff * phi_dist_scale_q16) >> 16,
-                // so the BPF steal does one indexed read and no multiply. The 1e6
-                // scale matches build_affinity_rank's sort key. phi_dist_scale_q16
-                // is 0 on monolithic / --phi-scale 0 -> every penalty 0 -> flat
-                // codel_target (exact prior behavior).
+                // FOLD THE PHI DISTANCE PENALTY AT INIT: reff_value stores the final
+                // steal extra-wait in ns, (R_eff * phi_dist_scale_q16) >> 16, so the
+                // BPF steal does one indexed read and no multiply. The 1e6 scale
+                // matches build_affinity_rank's sort key. phi_dist_scale_q16 is 0 on
+                // monolithic -> every penalty 0 -> flat codel_target.
                 let r_scaled = (reff[cpu * self.nr_cpus + val as usize] * 1_000_000.0)
                     .round()
                     .clamp(0.0, u32::MAX as f64) as u64;
@@ -986,7 +510,6 @@ impl CpuTopology {
             for slot in valid..stride {
                 sched.write_affinity_rank(cpu as u32, slot as u32, u32::MAX)?;
                 sched.write_reff_value(cpu as u32, slot as u32, u32::MAX)?;
-                sched.write_domain_phi(cpu as u32, slot as u32, u32::MAX)?;
             }
         }
         Ok(())
@@ -1044,8 +567,13 @@ impl CpuTopology {
         llc.sort_unstable();
         llc.dedup();
         log_info!(
-            "LLC DOMAINS: {} (L3 rung always-on, continuous Phi)",
-            llc.len()
+            "LLC DOMAINS: {} (SAME-CCX RUNG {})",
+            llc.len(),
+            if self.ccx_active {
+                "ACTIVE"
+            } else {
+                "INACTIVE -- MONOLITHIC L3"
+            }
         );
     }
 }
@@ -1071,250 +599,4 @@ fn parse_cpu_list(s: &str) -> Vec<u32> {
     result.sort();
     result.dedup();
     result
-}
-
-#[cfg(test)]
-mod t2_cut_tests {
-    use super::*;
-
-    // 8 CPUs, no SMT (each its own L2), one socket, two L3 groups: {0..3},{4..7}.
-    // Intra-L3 edges weigh CONDUCTANCE_LLC (3.0), inter-L3 same-socket weigh
-    // CONDUCTANCE_SOCKET (1.0) -- two clusters joined by weak edges.
-    fn synth_2domain() -> CpuTopology {
-        CpuTopology {
-            nr_cpus: 8,
-            l2_domain: (0..8u32).collect(),
-            l2_groups: Vec::new(),
-            socket_domain: vec![0u32; 8],
-            llc_domain: vec![0, 0, 0, 0, 1, 1, 1, 1],
-            nr_sockets: 1,
-        }
-    }
-
-    #[test]
-    fn min_conductance_cut_splits_on_llc() {
-        let t = synth_2domain();
-        let lap = t.build_laplacian();
-        let (ev, evec) = CpuTopology::symmetric_eigen(&lap, 8);
-        let fvec = CpuTopology::fiedler_vector(&ev, &evec, 8);
-        let members: Vec<usize> = (0..8).collect();
-        let (a, b, phi) = t.fiedler_sweep_cut(&members, &fvec).expect("cut");
-        let (mut sa, mut sb) = (a.clone(), b.clone());
-        sa.sort();
-        sb.sort();
-        let (llc0, llc1) = (vec![0usize, 1, 2, 3], vec![4usize, 5, 6, 7]);
-        assert!(
-            (sa == llc0 && sb == llc1) || (sa == llc1 && sb == llc0),
-            "expected the L3 boundary, got {:?} | {:?}",
-            sa,
-            sb
-        );
-        assert!(phi.is_finite() && phi > 0.0 && phi < 1.0, "phi = {}", phi);
-    }
-
-    #[test]
-    fn cut_conductance_zero_weight_guard() {
-        // A singleton member set has no valid bipartition -> None, not a panic.
-        let t = synth_2domain();
-        assert!(t.fiedler_sweep_cut(&[3usize], &vec![0.0; 8]).is_none());
-    }
-
-    // 8 CPUs WITH SMT: 4 L2 pairs {0,1}{2,3}{4,5}{6,7}, two L3 groups {0..3},
-    // {4..7}, one socket. L2-sib 1000, same-L3 cross-L2 3.0, cross-L3 same-socket
-    // 1.0 -- a clean two-level hierarchy whose tree should be L3 over L2 pairs.
-    fn synth_smt_2domain() -> CpuTopology {
-        CpuTopology {
-            nr_cpus: 8,
-            l2_domain: vec![0, 0, 1, 1, 2, 2, 3, 3],
-            l2_groups: Vec::new(),
-            socket_domain: vec![0u32; 8],
-            llc_domain: vec![0, 0, 0, 0, 1, 1, 1, 1],
-            nr_sockets: 1,
-        }
-    }
-
-    #[test]
-    fn top_cut_is_the_l3_seam() {
-        let t = synth_smt_2domain();
-        let (a, b, phi) = t.domain_cut(&(0..8).collect::<Vec<_>>()).expect("cut");
-        let (mut sa, mut sb) = (a.clone(), b.clone());
-        sa.sort();
-        sb.sort();
-        let (l3a, l3b) = (vec![0usize, 1, 2, 3], vec![4usize, 5, 6, 7]);
-        assert!(
-            (sa == l3a && sb == l3b) || (sa == l3b && sb == l3a),
-            "top cut should be the L3 seam, got {:?} | {:?}",
-            sa,
-            sb
-        );
-        assert!(phi.is_finite() && phi > 0.0 && phi < 1.0, "phi = {}", phi);
-    }
-
-    #[test]
-    fn domain_tree_leaves_are_l2_groups() {
-        let t = synth_smt_2domain();
-        let tree = t.build_domain_tree(&(0..8).collect::<Vec<_>>());
-        let mut leaves: Vec<Vec<usize>> = tree
-            .leaves()
-            .into_iter()
-            .map(|mut l| {
-                l.sort();
-                l
-            })
-            .collect();
-        leaves.sort();
-        assert_eq!(
-            leaves,
-            vec![vec![0, 1], vec![2, 3], vec![4, 5], vec![6, 7]],
-            "leaves should be the 4 L2 groups"
-        );
-        // The root cut (L3 seam) is the cheapest crossing: coarser seam, lower phi.
-        let phis = tree.cut_phis();
-        assert!(!phis.is_empty(), "tree should have cuts");
-        let root_phi = phis[0];
-        assert!(
-            phis.iter().all(|&p| root_phi <= p + 1e-9),
-            "root cut should be the lowest phi, got {:?}",
-            phis
-        );
-    }
-
-    // Two cuts induce the same bipartition (ignoring which side is A vs B)?
-    fn same_bipartition(
-        a: &(Vec<usize>, Vec<usize>, f64),
-        b: &(Vec<usize>, Vec<usize>, f64),
-    ) -> bool {
-        let norm = |c: &(Vec<usize>, Vec<usize>, f64)| {
-            let (mut x, mut y) = (c.0.clone(), c.1.clone());
-            x.sort();
-            y.sort();
-            if x < y {
-                (x, y)
-            } else {
-                (y, x)
-            }
-        };
-        norm(a) == norm(b)
-    }
-
-    #[test]
-    fn walk_cut_matches_eigen_cut_smt() {
-        let t = synth_smt_2domain();
-        let m: Vec<usize> = (0..8).collect();
-        let eigen = t.domain_cut(&m).expect("eigen");
-        let walk = t.walk_cut(&m).expect("walk");
-        assert!(
-            same_bipartition(&eigen, &walk),
-            "walk {:?}|{:?} != eigen {:?}|{:?}",
-            walk.0,
-            walk.1,
-            eigen.0,
-            eigen.1
-        );
-    }
-
-    // 16 CPUs, 2 sockets {0..7}{8..15}, 4 L3 groups, 8 L2 pairs. The weakest seam
-    // is cross-socket (CONDUCTANCE_CROSS 0.3) -- both cuts must land there,
-    // exercising the random walk on a deeper graph than the 8-CPU case.
-    fn synth_2socket() -> CpuTopology {
-        CpuTopology {
-            nr_cpus: 16,
-            l2_domain: (0..16).map(|c| (c / 2) as u32).collect(),
-            l2_groups: Vec::new(),
-            socket_domain: (0..16).map(|c| (c / 8) as u32).collect(),
-            llc_domain: (0..16).map(|c| (c / 4) as u32).collect(),
-            nr_sockets: 2,
-        }
-    }
-
-    #[test]
-    fn walk_cut_matches_eigen_cut_2socket() {
-        let t = synth_2socket();
-        let m: Vec<usize> = (0..16).collect();
-        let eigen = t.domain_cut(&m).expect("eigen");
-        let walk = t.walk_cut(&m).expect("walk");
-        let (mut wa, mut wb) = (walk.0.clone(), walk.1.clone());
-        wa.sort();
-        wb.sort();
-        let (s0, s1): (Vec<usize>, Vec<usize>) = ((0..8).collect(), (8..16).collect());
-        assert!(
-            (wa == s0 && wb == s1) || (wa == s1 && wb == s0),
-            "walk top cut should be the socket seam, got {:?}|{:?}",
-            wa,
-            wb
-        );
-        assert!(same_bipartition(&eigen, &walk), "walk != eigen on 2-socket");
-    }
-
-    #[test]
-    fn compute_domain_tree_public_wrapper() {
-        let t = synth_smt_2domain();
-        let tree = t.compute_domain_tree();
-        assert_eq!(tree.leaves().len(), 4, "smt 2-domain -> 4 L2-group leaves");
-    }
-
-    #[test]
-    fn single_cpu_is_one_leaf() {
-        let t = CpuTopology {
-            nr_cpus: 1,
-            l2_domain: vec![0],
-            l2_groups: Vec::new(),
-            socket_domain: vec![0],
-            llc_domain: vec![0],
-            nr_sockets: 1,
-        };
-        let tree = t.compute_domain_tree();
-        assert_eq!(tree.leaves(), vec![vec![0usize]]);
-        assert!(tree.cut_phis().is_empty(), "a single CPU has no cuts");
-    }
-
-    #[test]
-    fn cross_phi_matrix_prices_the_boundaries() {
-        let t = synth_smt_2domain();
-        let tree = t.compute_domain_tree();
-        let m = t.domain_cross_phi_matrix(&tree);
-        let n = 8;
-        // Same leaf {0,1}: no boundary -> sentinel.
-        assert_eq!(m[0 * n + 1], u32::MAX, "same-leaf pair must be sentinel");
-        // Cross-L2 same-L3 (0,2) and cross-L3 (0,4): real, priced boundaries.
-        assert_ne!(m[0 * n + 2], u32::MAX);
-        assert_ne!(m[0 * n + 4], u32::MAX);
-        // Cross-L2 is the TIGHTER (nearer) seam -> higher phi than cross-L3.
-        assert!(
-            m[0 * n + 2] > m[0 * n + 4],
-            "cross-L2 phi {} should exceed cross-L3 phi {}",
-            m[0 * n + 2],
-            m[0 * n + 4]
-        );
-        // CPUs 2 and 3 are the same sibling L2 pair: identical crossing price from 0.
-        assert_eq!(m[0 * n + 2], m[0 * n + 3]);
-        // Symmetric.
-        assert_eq!(m[0 * n + 4], m[4 * n + 0]);
-    }
-
-    #[test]
-    fn overflow_partition_matches_l3_groups() {
-        let t = synth_smt_2domain();
-        assert_eq!(t.overflow_domain_count(), 2, "two L3 groups");
-        let tree = t.compute_domain_tree();
-        let dom = t.domain_partition(&tree, 2);
-        assert!(
-            dom[0] == dom[1] && dom[1] == dom[2] && dom[2] == dom[3],
-            "L3 group 0 is one overflow domain: {:?}",
-            dom
-        );
-        assert!(
-            dom[4] == dom[5] && dom[5] == dom[6] && dom[6] == dom[7],
-            "L3 group 1 is one overflow domain: {:?}",
-            dom
-        );
-        assert_ne!(dom[0], dom[4], "the two L3 groups are distinct domains");
-        // target 1 -> a single overflow domain (monolithic re-key).
-        let mono = t.domain_partition(&tree, 1);
-        assert!(
-            mono.iter().all(|&d| d == 0),
-            "target 1 = one domain: {:?}",
-            mono
-        );
-    }
 }

--- a/scheds/rust/scx_pandemonium/src/topology.rs
+++ b/scheds/rust/scx_pandemonium/src/topology.rs
@@ -44,6 +44,14 @@ const TAU_CEIL_NS: u64 = 40_000_000; // 40MS
 const C_EQ_FLOOR_NS: u64 = 200_000; // 200us
 const C_EQ_CEIL_NS: u64 = 8_000_000; // 8ms
 
+// SPILL-Phi PLACEMENT DEPTH THRESHOLDS. Rust folds R_eff into a per-peer DSQ-depth
+// cap the BPF spill helper applies: near peers (R_eff~0) accept spills up to
+// SPILL_NEAR_DEPTH, the most distant only when near-empty (SPILL_FAR_DEPTH).
+// Monolithic (no distance structure to price) -> flat SPILL_MONO_DEPTH.
+const SPILL_NEAR_DEPTH: u32 = 4;
+const SPILL_FAR_DEPTH: u32 = 1;
+const SPILL_MONO_DEPTH: u32 = 2;
+
 #[derive(Clone, Copy, Debug)]
 pub struct TopologySpectrum {
     pub fiedler: f64,            // lambda_2
@@ -411,6 +419,109 @@ impl CpuTopology {
         r
     }
 
+    // INTEGER-EXACT R_eff (v5.16.0 SPILL-Phi #67). The f64 conductance rung
+    // (10/3/1/0.3) scaled x10 clears the 0.3 cross-socket cut, so the Laplacian is
+    // integer and R_eff is an EXACT rational -- the spanning-2-forest over
+    // spanning-tree determinant ratio (Barrett et al., Spanning 2-Forests and
+    // Resistance Distance) -- with no float rounding. Bareiss fraction-free
+    // elimination keeps every step integer; i128 holds it through
+    // REFF_EXACT_MAX_CPUS, above which the float pseudoinverse path takes over.
+    // Hand-verified: the 2-CPU (0.1) and 3-CPU path (0.2) cases reproduce the f64
+    // R_eff exactly.
+    const ICOND_L2: i128 = 100;
+    const ICOND_LLC: i128 = 30;
+    const ICOND_SOCKET: i128 = 10;
+    const ICOND_CROSS: i128 = 3;
+    const ICOND_RECOVER: f64 = 10.0; // undo the x10 conductance scale
+    const REFF_EXACT_MAX_CPUS: usize = 24;
+
+    fn build_laplacian_int(&self) -> Vec<i128> {
+        let n = self.nr_cpus;
+        let mut l = vec![0i128; n * n];
+        for i in 0..n {
+            for j in (i + 1)..n {
+                let w = if self.l2_domain[i] == self.l2_domain[j] {
+                    Self::ICOND_L2
+                } else if self.ccx_active && self.llc_domain[i] == self.llc_domain[j] {
+                    Self::ICOND_LLC
+                } else if self.socket_domain[i] == self.socket_domain[j] {
+                    Self::ICOND_SOCKET
+                } else {
+                    Self::ICOND_CROSS
+                };
+                l[i * n + j] = -w;
+                l[j * n + i] = -w;
+                l[i * n + i] += w;
+                l[j * n + j] += w;
+            }
+        }
+        l
+    }
+
+    // BAREISS FRACTION-FREE DETERMINANT of an integer matrix (row-major, m x m).
+    // Every division is exact by the Bareiss invariant. None on i128 overflow or a
+    // zero pivot -- a connected reduced Laplacian is positive-definite, so a zero
+    // pivot only ever means fall-back-to-float here, never a real singular case.
+    pub fn bareiss_det(mut a: Vec<i128>, m: usize) -> Option<i128> {
+        let mut prev: i128 = 1;
+        for k in 0..m.saturating_sub(1) {
+            let pivot = a[k * m + k];
+            if pivot == 0 {
+                return None;
+            }
+            for i in (k + 1)..m {
+                for j in (k + 1)..m {
+                    let t1 = a[i * m + j].checked_mul(pivot)?;
+                    let t2 = a[i * m + k].checked_mul(a[k * m + j])?;
+                    a[i * m + j] = t1.checked_sub(t2)? / prev;
+                }
+            }
+            prev = pivot;
+        }
+        if m == 0 {
+            Some(1)
+        } else {
+            Some(a[(m - 1) * m + (m - 1)])
+        }
+    }
+
+    // det of the integer Laplacian with the given index set's rows AND columns gone.
+    fn minor_det(l_int: &[i128], n: usize, remove: &[usize]) -> Option<i128> {
+        let keep: Vec<usize> = (0..n).filter(|x| !remove.contains(x)).collect();
+        let m = keep.len();
+        let mut sub = vec![0i128; m * m];
+        for (a, &ri) in keep.iter().enumerate() {
+            for (b, &cj) in keep.iter().enumerate() {
+                sub[a * m + b] = l_int[ri * n + cj];
+            }
+        }
+        Self::bareiss_det(sub, m)
+    }
+
+    // EXACT R_eff(i,j) = det(L minus rows/cols i,j) / det(L minus row/col 0), the
+    // spanning-2-forest / spanning-tree ratio, in the integer Laplacian's units.
+    // None on overflow so the caller falls back to the float path.
+    pub fn reff_from_int_laplacian(l_int: &[i128], n: usize) -> Option<Vec<f64>> {
+        if n < 2 {
+            return Some(vec![0.0; n * n]);
+        }
+        let tau = Self::minor_det(l_int, n, &[0])?;
+        if tau == 0 {
+            return None;
+        }
+        let tau_f = tau as f64;
+        let mut r = vec![0.0f64; n * n];
+        for i in 0..n {
+            for j in (i + 1)..n {
+                let f = Self::minor_det(l_int, n, &[i, j])?;
+                let v = ((f as f64) / tau_f).max(0.0);
+                r[i * n + j] = v;
+                r[j * n + i] = v;
+            }
+        }
+        Some(r)
+    }
+
     // BUILD PER-CPU AFFINITY RANK: FOR EACH CPU, ALL OTHERS SORTED BY R_EFF
     // Returns flat array: affinity_rank[cpu * nr_cpus + slot] = target_cpu
     fn build_affinity_rank(reff: &[f64], n: usize) -> Vec<u32> {
@@ -446,8 +557,19 @@ impl CpuTopology {
         let (eigenvalues, eigenvectors) = Self::symmetric_eigen(&laplacian, n);
         let fiedler = extract_fiedler(&eigenvalues);
         let tau_ns = compute_tau_ns(fiedler, n);
-        let l_pinv = Self::compute_pseudoinverse(&eigenvalues, &eigenvectors, n);
-        let reff = Self::extract_reff(&l_pinv, n);
+        // EXACT INTEGER R_eff (Bareiss spanning-2-forest / spanning-tree determinant
+        // ratio) where i128 holds it; else the float pseudoinverse. Both agree to
+        // fixed-point precision (hand-verified 2-/3-CPU), so downstream is unchanged.
+        let reff: Vec<f64> = match (n <= Self::REFF_EXACT_MAX_CPUS)
+            .then(|| Self::reff_from_int_laplacian(&self.build_laplacian_int(), n))
+            .flatten()
+        {
+            Some(r) => r.into_iter().map(|x| x * Self::ICOND_RECOVER).collect(),
+            None => {
+                let l_pinv = Self::compute_pseudoinverse(&eigenvalues, &eigenvectors, n);
+                Self::extract_reff(&l_pinv, n)
+            }
+        };
         let rank = Self::build_affinity_rank(&reff, n);
         let codel_eq_ns = compute_codel_eq_ns(&eigenvalues, n, tau_ns);
         // PHI DISTANCE SCALE: calibrated so the most distant pair (max R_eff) maps to
@@ -491,6 +613,11 @@ impl CpuTopology {
     ) -> Result<()> {
         let stride = crate::bpf_intf::MAX_AFFINITY_CANDIDATES as usize;
         let valid = self.nr_cpus.saturating_sub(1).min(stride);
+        // SPILL-Phi: fold the SAME R_eff into a per-peer DSQ-depth cap the BPF
+        // spill helper applies (near peers accept at higher depth, far peers
+        // near-empty only). max_reff normalizes distance to [0,1]; monolithic
+        // (phi_dist_scale 0) -> flat SPILL_MONO_DEPTH, no distance to price.
+        let max_reff = reff.iter().cloned().fold(0.0f64, f64::max).max(1e-9);
         for cpu in 0..self.nr_cpus {
             for slot in 0..valid {
                 let val = rank[cpu * self.nr_cpus + slot];
@@ -506,10 +633,22 @@ impl CpuTopology {
                 let dist_extra =
                     (r_scaled.saturating_mul(phi_dist_scale_q16) >> 16).min(u32::MAX as u64) as u32;
                 sched.write_reff_value(cpu as u32, slot as u32, dist_extra)?;
+                // PLACEMENT THRESHOLD: same R_eff, applied as a depth cap not a delay.
+                let spill_d = if phi_dist_scale_q16 == 0 {
+                    SPILL_MONO_DEPTH
+                } else {
+                    let frac = (reff[cpu * self.nr_cpus + val as usize] / max_reff).clamp(0.0, 1.0);
+                    (SPILL_NEAR_DEPTH as f64 - (SPILL_NEAR_DEPTH - SPILL_FAR_DEPTH) as f64 * frac)
+                        .round()
+                        .clamp(SPILL_FAR_DEPTH as f64, SPILL_NEAR_DEPTH as f64)
+                        as u32
+                };
+                sched.write_spill_depth(cpu as u32, slot as u32, spill_d)?;
             }
             for slot in valid..stride {
                 sched.write_affinity_rank(cpu as u32, slot as u32, u32::MAX)?;
                 sched.write_reff_value(cpu as u32, slot as u32, u32::MAX)?;
+                sched.write_spill_depth(cpu as u32, slot as u32, SPILL_MONO_DEPTH)?;
             }
         }
         Ok(())

--- a/scheds/rust/scx_pandemonium/src/tuning.rs
+++ b/scheds/rust/scx_pandemonium/src/tuning.rs
@@ -35,12 +35,17 @@ const LIGHT_P99_CEIL_NS: u64 = 3_000_000; // 3MS
 const MIXED_P99_CEIL_NS: u64 = 5_000_000; // 5MS: BELOW 16MS FRAME BUDGET
 const HEAVY_P99_CEIL_NS: u64 = 10_000_000; // 10MS: HEAVY LOAD, REALISTIC
 
-// CLASSIFIER THRESHOLDS
-// LAT_CRI SCORE BOUNDARIES FOR TIER CLASSIFICATION
-// EXPOSED AS TUNING KNOBS FOR RUNTIME ADJUSTMENT
+// SPILL TEMPERATURE (v5.16.0 SPILL-Phi #69). T = T_base*(1 + kappa*H), H the
+// Bandt-Pompe permutation entropy in [0,1]; Q16 fixed-point (65536 = T_base = 1.0).
+// Computed each tick from the chaos layer, shipped as a non-MWU knob overlaid like
+// topology_tau_ns. Inert until the SPILL price (#70) consumes it.
+pub const SPILL_TEMP_BASE_Q16: u64 = 65536;
+pub const SPILL_TEMP_KAPPA: f64 = 1.0;
 
-pub const DEFAULT_LAT_CRI_THRESH_HIGH: u64 = 32; // >= THIS: LAT_CRITICAL
-pub const DEFAULT_LAT_CRI_THRESH_LOW: u64 = 8; // >= THIS: INTERACTIVE, BELOW: BATCH
+pub fn spill_temp_q16(h: f64) -> u64 {
+    let h = h.clamp(0.0, 1.0);
+    ((SPILL_TEMP_BASE_Q16 as f64) * (1.0 + SPILL_TEMP_KAPPA * h)) as u64
+}
 
 // TUNING KNOBS
 // MATCHES struct tuning_knobs IN BPF (intf.h)
@@ -56,8 +61,6 @@ pub struct TuningKnobs {
     pub slice_ns: u64,
     pub preempt_thresh_ns: u64,
     pub batch_slice_ns: u64,
-    pub lat_cri_thresh_high: u64,
-    pub lat_cri_thresh_low: u64,
     pub affinity_mode: u64,
     pub codel_thresh_ns: u64,
     pub burst_slice_ns: u64,
@@ -69,6 +72,7 @@ pub struct TuningKnobs {
     // R_eff-DERIVED CODEL EQUILIBRIUM TARGET (<R_eff> * 2m * tau).
     // CO-LOCATED WITH topology_tau_ns; SAME ZERO/WRITE/CLAMP SEMANTICS.
     pub codel_eq_ns: u64,
+    pub spill_temp_q16: u64,
 }
 
 impl Default for TuningKnobs {
@@ -77,13 +81,12 @@ impl Default for TuningKnobs {
             slice_ns: 1_000_000,
             preempt_thresh_ns: 1_000_000,
             batch_slice_ns: 20_000_000,
-            lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
-            lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
             affinity_mode: AFFINITY_OFF,
             codel_thresh_ns: 5_000_000,
             burst_slice_ns: 1_000_000,
             topology_tau_ns: 0,
             codel_eq_ns: 0,
+            spill_temp_q16: SPILL_TEMP_BASE_Q16,
         }
     }
 }
@@ -124,37 +127,34 @@ pub fn regime_knobs(r: Regime) -> TuningKnobs {
             slice_ns: LIGHT_SLICE_NS,
             preempt_thresh_ns: LIGHT_PREEMPT_NS,
             batch_slice_ns: LIGHT_BATCH_NS,
-            lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
-            lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
             affinity_mode: AFFINITY_WEAK,
             codel_thresh_ns: 5_000_000,
             burst_slice_ns: 1_000_000,
             topology_tau_ns: 0,
             codel_eq_ns: 0,
+            spill_temp_q16: SPILL_TEMP_BASE_Q16,
         },
         Regime::Mixed => TuningKnobs {
             slice_ns: MIXED_SLICE_NS,
             preempt_thresh_ns: MIXED_PREEMPT_NS,
             batch_slice_ns: MIXED_BATCH_NS,
-            lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
-            lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
             affinity_mode: AFFINITY_STRONG,
             codel_thresh_ns: 5_000_000,
             burst_slice_ns: 1_000_000,
             topology_tau_ns: 0,
             codel_eq_ns: 0,
+            spill_temp_q16: SPILL_TEMP_BASE_Q16,
         },
         Regime::Heavy => TuningKnobs {
             slice_ns: HEAVY_SLICE_NS,
             preempt_thresh_ns: HEAVY_PREEMPT_NS,
             batch_slice_ns: HEAVY_BATCH_NS,
-            lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
-            lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
             affinity_mode: AFFINITY_WEAK,
             codel_thresh_ns: 5_000_000,
             burst_slice_ns: 1_000_000,
             topology_tau_ns: 0,
             codel_eq_ns: 0,
+            spill_temp_q16: SPILL_TEMP_BASE_Q16,
         },
     }
 }
@@ -418,8 +418,6 @@ const EX_SATURATED: usize = 5;
 const SC_SLICE: [f64; 6] = [0.74, 1.00, 1.23, 0.98, 0.49, 1.47];
 const SC_PREEMPT: [f64; 6] = [0.74, 1.00, 1.23, 0.98, 0.49, 1.47];
 const SC_BATCH: [f64; 6] = [0.78, 1.00, 1.30, 1.30, 0.52, 1.04];
-const SC_LCRI_HI: [f64; 6] = [0.74, 1.00, 1.23, 0.98, 0.98, 0.98];
-const SC_LCRI_LO: [f64; 6] = [0.70, 1.00, 1.40, 0.93, 0.93, 0.93];
 const SC_SOJOURN: [f64; 6] = [0.80, 1.00, 1.60, 0.93, 0.53, 1.07];
 const SC_BURST: [f64; 6] = [0.74, 1.00, 1.47, 0.98, 0.49, 1.23];
 
@@ -906,8 +904,6 @@ impl MwuController {
             preempt_thresh_ns: blend_continuous(b.preempt_thresh_ns, &SC_PREEMPT, &w)
                 .max(b.preempt_thresh_ns),
             batch_slice_ns: blend_continuous(b.batch_slice_ns, &SC_BATCH, &w),
-            lat_cri_thresh_high: blend_continuous(b.lat_cri_thresh_high, &SC_LCRI_HI, &w),
-            lat_cri_thresh_low: blend_continuous(b.lat_cri_thresh_low, &SC_LCRI_LO, &w),
             affinity_mode: majority_discrete(&DV_AFFINITY, &w),
             codel_thresh_ns: blended_sojourn,
             burst_slice_ns: blended_burst,
@@ -916,6 +912,7 @@ impl MwuController {
             // VALUES BACK ONTO MWU'S OUTPUT BEFORE WRITING -- PASSTHROUGH.
             topology_tau_ns: 0,
             codel_eq_ns: 0,
+            spill_temp_q16: SPILL_TEMP_BASE_Q16,
         };
         self.last_knobs = k;
         k
@@ -1023,8 +1020,6 @@ pub fn knobs_differ(a: &TuningKnobs, b: &TuningKnobs) -> bool {
     a.slice_ns != b.slice_ns
         || a.preempt_thresh_ns != b.preempt_thresh_ns
         || a.batch_slice_ns != b.batch_slice_ns
-        || a.lat_cri_thresh_high != b.lat_cri_thresh_high
-        || a.lat_cri_thresh_low != b.lat_cri_thresh_low
         || a.affinity_mode != b.affinity_mode
         || a.codel_thresh_ns != b.codel_thresh_ns
         || a.burst_slice_ns != b.burst_slice_ns

--- a/scheds/rust/scx_pandemonium/src/tuning.rs
+++ b/scheds/rust/scx_pandemonium/src/tuning.rs
@@ -59,7 +59,7 @@ pub struct TuningKnobs {
     pub lat_cri_thresh_high: u64,
     pub lat_cri_thresh_low: u64,
     pub affinity_mode: u64,
-    pub sojourn_thresh_ns: u64,
+    pub codel_thresh_ns: u64,
     pub burst_slice_ns: u64,
     // FIEDLER-DERIVED TOPOLOGY TIME CONSTANT (TAU_SCALE_NS / lambda_2).
     // ZERO MEANS RUST HAS NOT YET WRITTEN tau; BPF USES THE PRE-FIRST-TICK
@@ -80,7 +80,7 @@ impl Default for TuningKnobs {
             lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
             lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
             affinity_mode: AFFINITY_OFF,
-            sojourn_thresh_ns: 5_000_000,
+            codel_thresh_ns: 5_000_000,
             burst_slice_ns: 1_000_000,
             topology_tau_ns: 0,
             codel_eq_ns: 0,
@@ -127,7 +127,7 @@ pub fn regime_knobs(r: Regime) -> TuningKnobs {
             lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
             lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
             affinity_mode: AFFINITY_WEAK,
-            sojourn_thresh_ns: 5_000_000,
+            codel_thresh_ns: 5_000_000,
             burst_slice_ns: 1_000_000,
             topology_tau_ns: 0,
             codel_eq_ns: 0,
@@ -139,7 +139,7 @@ pub fn regime_knobs(r: Regime) -> TuningKnobs {
             lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
             lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
             affinity_mode: AFFINITY_STRONG,
-            sojourn_thresh_ns: 5_000_000,
+            codel_thresh_ns: 5_000_000,
             burst_slice_ns: 1_000_000,
             topology_tau_ns: 0,
             codel_eq_ns: 0,
@@ -151,7 +151,7 @@ pub fn regime_knobs(r: Regime) -> TuningKnobs {
             lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
             lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
             affinity_mode: AFFINITY_WEAK,
-            sojourn_thresh_ns: 5_000_000,
+            codel_thresh_ns: 5_000_000,
             burst_slice_ns: 1_000_000,
             topology_tau_ns: 0,
             codel_eq_ns: 0,
@@ -185,7 +185,7 @@ fn scale_tau_u64(tau_ns: u64, k_q16: u64) -> u64 {
     (tau_ns as u128 * k_q16 as u128 >> 16) as u64
 }
 
-pub fn scaled_regime_knobs(r: Regime, nr_cpus: u64, tau_ns: u64) -> TuningKnobs {
+pub fn scaled_regime_knobs(r: Regime, _nr_cpus: u64, tau_ns: u64) -> TuningKnobs {
     let mut knobs = regime_knobs(r);
 
     let slice_cap_tau = scale_tau_u64(tau_ns, K_SLICE_CAP_Q16).clamp(500_000, 8_000_000);
@@ -194,27 +194,11 @@ pub fn scaled_regime_knobs(r: Regime, nr_cpus: u64, tau_ns: u64) -> TuningKnobs 
 
     knobs.slice_ns = knobs.slice_ns.min(slice_cap_tau);
     knobs.preempt_thresh_ns = knobs.preempt_thresh_ns.min(preempt_cap_tau);
-
-    // LOW-CORE SLICE CAP. tau IS LARGEST AT LOW CORE COUNT (lambda_2 SHRINKS
-    // AS CORES DROP), SO THE tau SLICE CAP ABOVE IS LOOSEST EXACTLY WHERE A
-    // WIDE BATCH SLICE DOES THE MOST DAMAGE: ON 2-4 CORES THE HEAVY PROFILE'S
-    // 4ms SLICE DENIES A LATENCY-SENSITIVE PROBE ACROSS MANY CONSECUTIVE
-    // SLICES, PRODUCING THE 50-200ms LONG-RUN/MIXED P99 TAIL AT LOW CORE.
-    // idle_pct READS LOW AT LOW CORE COUNT -- BECAUSE THE
-    // BPF WARM-STAY/PER-CPU LANDING DELIBERATELY BYPASSES THE IDLE FAST PATH
-    // -- SO THE REGIME FALSELY LATCHES HEAVY AND INHERITS ITS 4ms SLICE. THE
-    // BPF BASELINE RUNS 1ms HERE WITH NO SUCH TAIL, AND THE LONG-RUN WORK
-    // NUMBERS SHOW THE WIDE SLICE BUYS NO THROUGHPUT ON SO FEW CORES. CAP THE
-    // SLICE TO THE MIXED VALUE AT <=4 CORES; 8C/12C (WHERE ADAPTIVE WINS AND
-    // THE WIDER SLICE EARNS THROUGHPUT) ARE UNTOUCHED.
-    if nr_cpus <= 4 {
-        knobs.slice_ns = knobs.slice_ns.min(MIXED_SLICE_NS);
-    }
     if matches!(r, Regime::Mixed) {
         let batch_cap_tau = scale_tau_u64(tau_ns, K_BATCH_CAP_Q16).clamp(10_000_000, 80_000_000);
         knobs.batch_slice_ns = knobs.batch_slice_ns.min(batch_cap_tau);
     }
-    knobs.sojourn_thresh_ns = sojourn_tau;
+    knobs.codel_thresh_ns = sojourn_tau;
 
     knobs
 }
@@ -355,12 +339,6 @@ const EQUILIBRIUM: [f64; N_EXPERTS] = [0.04, 0.80, 0.04, 0.04, 0.04, 0.04];
 
 const WEIGHT_FLOOR: f64 = 1e-6;
 
-// CROSS-DOMAIN SCATTER THRESHOLD (PATHWAY 6). PLACEMENT-SIDE CROSS-DOMAIN MIGRATION
-// FRACTION ABOVE THIS (PERCENT OF DISPATCHES) IS TREATED AS STORM PRESSURE.
-// EEVDF'S MEASURED BASELINE IS ~14%; 20 LEAVES HEADROOM SO NORMAL CROSS-DOMAIN
-// WORK-CONSERVATION DOES NOT TRIP THE PATHWAY, ONLY A GENUINE SCATTER CLIMB.
-const SCATTER_THRESH_PCT: u64 = 20;
-
 // WARM-UP GATE: FOR THE FIRST WARMUP_TICKS CALLS PER REGIME, SCORE THE
 // LOSS PATHWAYS (KEEP prev_* EDGE STATE CURRENT) BUT SKIP THE WEIGHT
 // UPDATE AND RETURN BASELINE KNOBS. PREVENTS THE FIRST NOISY TICKS
@@ -446,18 +424,12 @@ const SC_SOJOURN: [f64; 6] = [0.80, 1.00, 1.60, 0.93, 0.53, 1.07];
 const SC_BURST: [f64; 6] = [0.74, 1.00, 1.47, 0.98, 0.49, 1.23];
 
 // DISCRETE KNOB VALUES (ABSOLUTE, NOT SCALE FACTORS)
-// FORK_STORM (INDEX 4) IS WEAK, NOT OFF: THE BPF READS affinity_mode ONLY AS
-// A BINARY GATE (main.bpf.c:1619, > 0) ON find_idle_l2_sibling. OFF DISABLES
-// THE L2 SIBLING PRE-FILTER, SO DURING A STORM WAKEES SEAT TOPOLOGY-BLIND AND
-// SCATTER CROSS-DOMAIN -- FIGHTING THE PHI/WARM-STAY PLACEMENT INSTEAD OF HELPING.
-// WEAK KEEPS THE L2 PRE-FILTER ON. (STRONG VS WEAK IS A NO-OP TO THE BPF; ONLY
-// OFF DIFFERS.)
 const DV_AFFINITY: [u64; 6] = [
     AFFINITY_STRONG,
     AFFINITY_STRONG,
     AFFINITY_WEAK,
     AFFINITY_WEAK,
-    AFFINITY_WEAK,
+    AFFINITY_OFF,
     AFFINITY_WEAK,
 ];
 fn blend_continuous(base: u64, scales: &[f64; 6], w: &[f64; N_EXPERTS]) -> u64 {
@@ -505,12 +477,6 @@ pub struct MwuSignals {
     pub io_pct: u64,
     pub rescue_count: u64,
     pub wakeup_rate: u64,
-    // CROSS-DOMAIN SCATTER FRACTION THIS TICK: PLACEMENT-SIDE CROSS-DOMAIN LANDINGS
-    // (XDOM_SEL_* + XDOM_ENQ_T1, EXCLUDING THE PHI-CORRECT STEAL/STEP5 WORK-
-    // CONSERVATION PATHS) AS A PERCENTAGE OF DISPATCHES. EEVDF BASELINE ~14%;
-    // PANDEMONIUM'S STORM REGRESSION RAN ~48%. PATHWAY 6 KEYS ON THIS SO MWU
-    // CAN SEE THE MIGRATION STORM IT MIGHT BE INDUCING AND STEER AWAY FROM IT.
-    pub scatter_pct: u64,
     // CHAOS PRIMITIVES (RAW-WINDOW DERIVED, NO EWMA, NO SCHMITT).
     // hvg_lambda     := HVG MEAN DEGREE OF THE idle_pct WINDOW
     // bp_h_delta     := bp_h(THIS TICK) - bp_h(PREVIOUS TICK), WHERE
@@ -540,13 +506,6 @@ pub struct OscillatorState {
     pub codel_target_ns: u64,
     pub codel_target_floor_ns: u64,
     pub codel_target_max_ns: u64,
-    // HOME NEAREST-PEER PHI HOLD (reff_value SLOT 0, ns). THE BPF WARM-STAY
-    // AND STEP-1 R_eff STEAL RELEASE AT codel_target_ns + THIS, NOT AT THE
-    // BARE CODEL WINDOW. position() MEASURES THE BARE WINDOW; THE ABSOLUTE
-    // CHECKS BELOW ADD THIS TERM SO THE DEFER DECISION IS TAKEN AGAINST THE
-    // EFFECTIVE PHI RELEASE POINT THE BPF ACTUALLY USES. 0 = READBACK
-    // UNAVAILABLE -> TREATED AS NO EXTRA HOLD (NEUTRAL).
-    pub home_dist_extra_ns: u64,
 }
 
 impl OscillatorState {
@@ -561,14 +520,6 @@ impl OscillatorState {
             .codel_target_ns
             .saturating_sub(self.codel_target_floor_ns) as f64;
         (pos / range).clamp(0.0, 1.0)
-    }
-
-    // EFFECTIVE PHI RELEASE POINT: WHERE WARM-STAY / STEP-1 STEAL ACTUALLY LET
-    // A TASK LEAVE HOME (codel_target + NEAREST-PEER HOLD). THE DEFER GATE
-    // COMPARES THIS AGAINST codel_eq TO DECIDE WHETHER THE BPF HAS GENUINELY
-    // RESPONDED, RATHER THAN TRUSTING THE BARE-WINDOW position() ALONE.
-    pub fn effective_release_ns(&self) -> u64 {
-        self.codel_target_ns.saturating_add(self.home_dist_extra_ns)
     }
 }
 
@@ -594,10 +545,6 @@ pub struct MwuController {
     prev_io_bucket: IoBucket,
     prev_rescuing: bool,
     prev_lambda_chaotic: bool,
-    // LAST TICK'S CROSS-DOMAIN SCATTER %. PATHWAY 6 IS RISING-EDGE GATED ON THIS
-    // SO A STABLE HIGH-SCATTER REGIME (E.G. 8C+ THROUGHPUT WHERE IT WINS) IS
-    // NOT PENALIZED -- ONLY A CLIMBING STORM IS.
-    prev_scatter_pct: u64,
     losses_applied: bool,
     // TRUE WHEN THE ACTIVE WEIGHT VECTOR MOVED THIS TICK.
     weights_changed: bool,
@@ -618,7 +565,6 @@ impl MwuController {
             prev_io_bucket: IoBucket::Mid,
             prev_rescuing: false,
             prev_lambda_chaotic: false,
-            prev_scatter_pct: 0,
             losses_applied: false,
             weights_changed: false,
         }
@@ -640,7 +586,6 @@ impl MwuController {
         self.prev_io_bucket = IoBucket::Mid;
         self.prev_rescuing = false;
         self.prev_lambda_chaotic = false;
-        self.prev_scatter_pct = 0;
         self.losses_applied = false;
         self.weights_changed = false;
         self.last_knobs = self.baseline;
@@ -707,23 +652,9 @@ impl MwuController {
         // POSITION 0.0 = TIGHTENED (FLOOR), 1.0 = RELAXED (MAX).
         // < 0.40 -> BPF HAS RESPONDED HEAVILY; SKIP RESCUE-DRIVEN LOSSES.
         // > 0.90 -> BPF SAYS QUIET; RESCUE BURSTS ARE STALE NOISE; SKIP.
-        //
-        // position() MEASURES THE BARE codel WINDOW, BUT THE BPF ACTUALLY
-        // RELEASES WARM-STAY / STEP-1 STEAL AT codel_target + home_dist_extra
-        // (THE NEAREST-PEER PHI HOLD). WITH A LARGE HOLD THE BARE POSITION CAN
-        // READ "LOOSE" WHILE THE EFFECTIVE RELEASE IS STILL HARD, AND MWU WOULD
-        // WRONGLY STAY OUT OF GENUINE RESCUE PRESSURE. CONFIRM EACH SIDE WITH
-        // THE EFFECTIVE RELEASE VS THE PHI EQUILIBRIUM (codel_eq, FROM THE
-        // BASELINE): ONLY TREAT THE OSCILLATOR AS TIGHT WHEN THE EFFECTIVE
-        // RELEASE IS BELOW EQUILIBRIUM, AND AS LOOSE WHEN IT IS ABOVE. WITH
-        // home_dist_extra_ns = 0 (READBACK UNAVAILABLE) THIS REDUCES TO THE
-        // BARE-POSITION BEHAVIOR. codel_eq = 0 (UNSEEDED) DISABLES THE ABSOLUTE
-        // QUALIFIER (THE BARE POSITION GOVERNS), NEVER GATING SPURIOUSLY.
         let osc_pos = osc.position();
-        let eff_release = osc.effective_release_ns();
-        let codel_eq = self.baseline.codel_eq_ns;
-        let osc_already_tight = osc_pos < 0.40 && (codel_eq == 0 || eff_release < codel_eq);
-        let osc_already_loose = osc_pos > 0.90 && (codel_eq == 0 || eff_release > codel_eq);
+        let osc_already_tight = osc_pos < 0.40;
+        let osc_already_loose = osc_pos > 0.90;
         let defer_to_oscillator = osc_already_tight || osc_already_loose;
 
         let mut losses = [0.0f64; N_EXPERTS];
@@ -792,7 +723,7 @@ impl MwuController {
         //
         // FORK_STORM EXPERT (SC_SLICE=0.49, SC_PREEMPT=0.49, SC_BATCH=0.52,
         // SC_SOJOURN=0.53, SC_BURST=0.49) DOMINATES THE BLEND DURING A REAL
-        // STORM, DRIVING burst_slice_ns / preempt_thresh_ns / sojourn_thresh_ns
+        // STORM, DRIVING burst_slice_ns / preempt_thresh_ns / codel_thresh_ns
         // / batch_slice_ns DOWN END-TO-END.
         let fork_thresh = scale_tau_u64(tau_ns, K_FORK_STORM_RATE_Q16).max(FORK_STORM_RATE_FLOOR);
         let fork_storm = sig.wakeup_rate > fork_thresh && sig.rescue_count > 0;
@@ -851,35 +782,6 @@ impl MwuController {
             }
         }
         self.prev_lambda_chaotic = sig.hvg_lambda >= crate::chaos::HVG_LAMBDA_CHAOTIC_MIN;
-
-        // PATHWAY 6: CROSS-DOMAIN SCATTER (PHI-AWARE, RISING-EDGE GATED).
-        // sig.scatter_pct IS THE PLACEMENT-SIDE CROSS-DOMAIN MIGRATION FRACTION
-        // (XDOM_SEL_* + XDOM_ENQ_T1, EXCLUDING THE PHI-CORRECT STEAL/STEP5
-        // WORK-CONSERVATION PATHS -- COMPUTED IN THE ADAPTIVE LOOP). WHEN IT
-        // CLIMBS PAST THE EEVDF-BASELINE HEADROOM THE BLEND HAS DRIFTED TOWARD
-        // EXPERTS THAT SCATTER WAKEES THE BPF WARM-STAY/PER-CPU LANDING TRIED
-        // TO KEEP HOME. PENALIZE THE EXPERTS THAT FAVOR WIDE SLICES + WEAK/OFF
-        // AFFINITY (THROUGHPUT, SATURATED, FORK_STORM) SO THE BLEND RE-WEIGHTS
-        // TOWARD LATENCY/BALANCED AND AFFINITY STRONG, ALIGNING THE ADAPTIVE
-        // LAYER WITH PHI PLACEMENT INSTEAD OF FIGHTING IT.
-        //
-        // RISING-EDGE: ONLY FIRES WHILE SCATTER IS HIGH AND INCREASING. A
-        // STABLE HIGH-SCATTER REGIME (8C+ THROUGHPUT, WHERE WIDE-SLICE SCATTER
-        // IS A WINNING TRADE) PLATEAUS AND IS NOT PENALIZED -- ONLY A CLIMBING
-        // STORM IS. EX_BALANCED/EX_LATENCY ARE NEVER PENALIZED (THEY ARE THE
-        // DIRECTION WE WANT THE BLEND TO MOVE TOWARD).
-        let scatter_high = sig.scatter_pct > SCATTER_THRESH_PCT;
-        let scatter_rising = scatter_high && sig.scatter_pct > self.prev_scatter_pct;
-        if scatter_rising {
-            let v = ((sig.scatter_pct as f64 - SCATTER_THRESH_PCT as f64)
-                / SCATTER_THRESH_PCT as f64)
-                .clamp(0.0, 3.0);
-            losses[EX_THROUGHPUT] += v * 1.00;
-            losses[EX_SATURATED] += v * 0.80;
-            losses[EX_FORK_STORM] += v * 0.60;
-            has_loss = true;
-        }
-        self.prev_scatter_pct = sig.scatter_pct;
 
         // WARM-UP GATE. THE PATHWAYS ABOVE HAVE SCORED `losses` AND
         // UPDATED THE prev_* EDGE STATE. FOR THE FIRST WARMUP_TICKS
@@ -981,27 +883,17 @@ impl MwuController {
         let b = &self.baseline;
         let blended_slice = blend_continuous(b.slice_ns, &SC_SLICE, &w);
         let blended_burst = blend_continuous(b.burst_slice_ns, &SC_BURST, &w);
-        let mut blended_sojourn = blend_continuous(b.sojourn_thresh_ns, &SC_SOJOURN, &w);
+        let mut blended_sojourn = blend_continuous(b.codel_thresh_ns, &SC_SOJOURN, &w);
 
-        // SOJOURN FLOOR: tick() KICKS PER-CPU DSQs WHOSE OLDEST TASK HAS AGED
-        // PAST sojourn_thresh_ns (BPF, main.bpf.c:2374). THAT EVICTION DEADLINE
-        // MUST NOT SIT ABOVE THE THRESHOLD WARM-STAY / STEP-1 R_eff STEAL
-        // ACTUALLY RELEASE AT, OR THE ADAPTIVE LAYER HOLDS TASKS LONG PAST THE
-        // POINT THE PHI GATES ASSUMED RELIEF HAD ARRIVED (THE 2C/4C LONG-RUN /
-        // LAT P99 TAIL). THE BPF OVERFLOW RESCUE IS NO LONGER "[4ms,10ms]" --
-        // IT WAS REWIRED TO THE PHI EQUILIBRIUM (overflow_sojourn_rescue_ns =
-        // codel_target_equilibrium_ns, main.bpf.c:995), SUB-MS AT LOW CORE.
-        // ANCHOR THE FLOOR TO THAT SAME PHI-DERIVED EQUILIBRIUM SO USERSPACE
-        // EVICTION AND THE BPF PHI RELEASE AGREE. THE +blended_slice TERM IS
-        // THE GENUINE DISPATCH-SERVICE-WINDOW GUARD (KEPT). codel_eq_ns CAN BE
-        // SEEDED 0 BY MwuController::new BEFORE THE TOPOLOGY OVERLAY LANDS --
-        // GUARD AGAINST COLLAPSING THE FLOOR AND REINTRODUCING THE KICK STORM.
-        let floor_base = if b.codel_eq_ns >= 200_000 {
-            b.codel_eq_ns
-        } else {
-            4_000_000
-        };
-        let sojourn_floor = floor_base.saturating_add(blended_slice);
+        // SOJOURN FLOOR: dispatch waterfall services aged overflow at
+        // the live codel_target_ns (BPF-side, the oscillator-modulated target).
+        // tick() also kicks per-CPU DSQs whose oldest task has aged past
+        // codel_thresh_ns. If MWU drives codel_thresh_ns below the
+        // dispatch service window + one slice, every tick generates kicks
+        // on per-CPU DSQs that the dispatcher will service on the next
+        // dispatch anyway -- a kick storm. Floor against the worst-case
+        // dispatch service window to prevent it.
+        let sojourn_floor = 4_000_000u64.saturating_add(blended_slice);
         if blended_sojourn < sojourn_floor {
             blended_sojourn = sojourn_floor;
         }
@@ -1017,7 +909,7 @@ impl MwuController {
             lat_cri_thresh_high: blend_continuous(b.lat_cri_thresh_high, &SC_LCRI_HI, &w),
             lat_cri_thresh_low: blend_continuous(b.lat_cri_thresh_low, &SC_LCRI_LO, &w),
             affinity_mode: majority_discrete(&DV_AFFINITY, &w),
-            sojourn_thresh_ns: blended_sojourn,
+            codel_thresh_ns: blended_sojourn,
             burst_slice_ns: blended_burst,
             // topology_tau_ns AND codel_eq_ns ARE OWNED BY THE TOPOLOGY LAYER;
             // MWU DOESN'T TOUCH THEM. THE MONITOR LOOP OVERLAYS THE LIVE BPF
@@ -1134,6 +1026,6 @@ pub fn knobs_differ(a: &TuningKnobs, b: &TuningKnobs) -> bool {
         || a.lat_cri_thresh_high != b.lat_cri_thresh_high
         || a.lat_cri_thresh_low != b.lat_cri_thresh_low
         || a.affinity_mode != b.affinity_mode
-        || a.sojourn_thresh_ns != b.sojourn_thresh_ns
+        || a.codel_thresh_ns != b.codel_thresh_ns
         || a.burst_slice_ns != b.burst_slice_ns
 }


### PR DESCRIPTION
v5.16.0 attempts to resolve a latent hard freeze on XFS + NO_HZ_FULL machines and
subtracts the machinery that masked it down to a single invariant. A per-CPU kthread
(XFS I/O completion, reclaim, a ksoftirqd) was walled off behind a non-yielding
resident: never preempted because LAT_CRITICAL was exempt, its only forward-progress
rescue tick-gated and so suppressed under NO_HZ_FULL, the scx watchdog blind because
dispatch kept flowing for every other task. montauk kstrand and dispatch-stall named
it from captured data. The fix is one bound, enforced from dispatch and off the tick;
the EWMA earner, the tier-tiered preempt ladder and the per-class rescue stamps are
subtracted to that single invariant. v5.16.0 also lands SPILL-Phi, the enqueue-side
R_eff placement price. UNIFIED SOJOURN BOUND below carries the freeze fix; this records
what has landed and validated.

UNIFIED SOJOURN BOUND -- src/bpf/main.bpf.c
- A latent hard freeze on XFS + NO_HZ_FULL machines: a per-CPU kthread (XFS I/O
  completion, reclaim, a ksoftirqd) walled off behind a non-yielding resident --
  never preempted because LAT_CRITICAL was exempt, the only forward-progress rescue
  tick-gated and so suppressed under NO_HZ_FULL, the scx watchdog blind because
  dispatch kept flowing for every other task. montauk kstrand + dispatch-stall named
  it from captured data: 1069 HELD strands, 0 DARK, PREEMPT-STARVED, no eject.
- sweep_bound_preempt() at dispatch entry enforces the bound the sort key already
  promised -- warp is capped at lag_cap_ns, so a task whose sojourn passes it
  out-sorts every warped task. Every dispatch on every CPU scans a rotating budget
  window of per-CPU DSQ stamps and PREEMPT-kicks any CPU whose head has waited past
  lag_cap_ns, any tier, no exemption. Because it fires from OTHER CPUs' dispatch a
  walled-off CPU is rescued off its own tick, so NO_HZ_FULL cannot suppress it.
  Budgeted, O(1) per dispatch, flat as N grows. Validated on a loaded box: worst
  kstrand strand 167.6ms -> 50ms, strand count 731 -> 3, scx CI PASS 2C-16C, storm
  0.0%, the pcpu-burst and sojourn-pressure wins held.

FLAT TIER WARP -- src/bpf/main.bpf.c
- task_potentiality_q16 earned the sojourn back-date from an EWMA behavioral model (a
  service-deficit axis and a runtime-variance axis) gated on a maturity counter. The
  maturity gate ran BEFORE the role floor, so a cold or rarely-woken pinned kworker --
  exactly the XFS / reclaim class -- scored zero warp and sorted dead last, the
  ordering half of the freeze. With the unified bound guaranteeing starvation-freedom
  the warp is pure ordering preference, never a rescue lever, so it collapses to a
  flat tier constant: LAT_CRITICAL full ceiling, BATCH none, everything else the
  v5.11.0 half-ceiling. ewma_age, avg_runtime, runtime_dev and pinned_service no
  longer feed the sort key.

ROLE-BASED TIER CLASSIFIER -- src/bpf/main.bpf.c
- runnable()'s EWMA behavioral model -- a wakeup-frequency and a context-switch-rate
  EWMA feeding compute_lat_cri / classify_tier -- is replaced by a role read:
  SCHED_FIFO/RR -> LAT_CRITICAL, all other userspace -> INTERACTIVE, the existing
  kthread floors kept (PF_WQ_WORKER -> INTERACTIVE, hi-pri PF_KTHREAD -> BATCH). No
  maturity gate, no per-task measurement. task_slice() likewise drops avg_runtime
  sizing for LAT_CRITICAL/INTERACTIVE -- a flat base_slice cap, since those tiers
  yield early on sleep so the slice is a ceiling not a target. The EWMA hog demotion
  in stopping() is removed: the tick rescue it fed is gone and the sweep preempts any
  tier at the bound.

EWMA STATE AND HELPERS DELETED -- src/bpf/main.bpf.c
- Nothing reads the EWMA state any more, so it is gone: avg_runtime, runtime_dev,
  ewma_age, wakeup_freq, csw_rate, lat_cri and prev_nvcsw out of task_ctx; the
  runnable/stopping update path, the calc_avg / update_freq / compute_lat_cri /
  classify_tier helpers and the procdb behavioral publish all deleted. last_woke_at
  stays for the wake-latency histogram, re-stamped in runnable(). The pinned-service
  rescue stamp pcpu_pinned_strand_ns goes too -- pinned kthreads still route to their
  home per-CPU DSQ and stamp the sweep's sojourn signal, they just no longer feed a
  tick rescue that no longer exists.

TICK ENFORCEMENT TOWER DEMOLISHED -- src/bpf/main.bpf.c
- pandemonium_tick() carried all the starvation enforcement: a per-CPU preempt tower
  (pinned rescue, 2x-codel backstop, tier-tiered tight-band with its LAT_CRITICAL
  exemption), an overflow batch/interactive preempt and a rotating per-CPU sojourn
  scan. All removed -- the tick now runs only the CoDel oscillator and longrun
  detection and touches preemption nowhere. Every rescue it held is subsumed by
  sweep_bound_preempt() at dispatch entry, which fires off the held CPU's tick (it is
  another CPU's dispatch), so NO_HZ_FULL can no longer suppress the rescue.

UNIVERSAL BOUND -- src/bpf/main.bpf.c
- The sweep now bounds the overflow node/batch DSQ heads as well as the per-CPU DSQs:
  a head aged past lag_cap_ns forces a rotating CPU off its resident so it re-enters
  dispatch and drains the aged head, closing the all-CPUs-held tickless overflow gap.
  One invariant, every DSQ, off-tick. Validated with the tower gone: worst held strand
  167ms -> 13-42ms across runs, all MED, scx CI PASS 2C-16C, storm 0.0%; fork-thread
  went 1.1x-worse -> 2.5x better (the maturity gate had been a fork tax) and pcpu-burst
  recovered, both on a load-24 box where IPC's standing weakness tracks the load
  (15.9x at load 18.6 -> 43x at load 24), not the rework.

SPILL-Phi PLACEMENT PRICE -- src/bpf/main.bpf.c, src/topology.rs,
src/scheduler.rs, src/tuning.rs
- The enqueue-side counterpart to the steal-side Phi already shipped: placement
  spill is priced by effective resistance, not a flat depth gate. The
  computation lives in Rust, the application in the kernel -- the rail the STEAL
  reff_value read already proved. Rust folds R_eff into a per-peer spill_depth
  threshold at topology detect (near peers accept spills at higher DSQ depth,
  distant peers only when near-empty); the BPF does one indexed spill_depth read
  and compares nr_queued against it, no runtime multiply. A monolithic L3 has no
  distance to price, so the threshold is flat and the spill price is a deliberate
  no-op there -- exact prior behavior.
- Integer-exact R_eff, the price input: the topology R_eff table is built from a
  Bareiss fraction-free determinant ratio (spanning-2-forest over spanning-tree)
  on an integer Laplacian, exact to ~24 CPUs with a float pseudoinverse fallback
  above. The steal delay and the spill threshold share this one table.
- Chaos-to-temperature bridge: a Bandt-Pompe permutation-entropy H drives a
  spill temperature T = T_base*(1+kappa*H), shipped in the tuning knobs as the
  placement price's regime input.
- Validated: loads and verifies under the BPF state budget, scx CI PASS 2C-16C,
  no ejection across the dev-scale gauntlet, the v5.16.0 baseline wins held
  (fork-thread 2x, cold-wake-starve strand 418ms -> 26ms, pcpu-burst 1.3x).