### PR TITLE
lib/sdt_alloc: carve pool elements under alloc_lock to prevent double…

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -193,27 +193,58 @@ void __arena *scx_alloc_from_pool(struct sdt_pool *pool,
 	return ptr;
 }
 
-/* Allocate element from the pool. Must be called with a then pool lock held. */
+/*
+ * Allocate an element from the pool. Takes alloc_lock internally; must be
+ * called WITHOUT it held. Carve under the lock; drop it only for the sleepable
+ * page refill, then re-check before installing, mirroring scx_alloc_stack().
+ */
 static
 void __arena *scx_alloc_from_pool_sleepable(struct sdt_pool *pool)
 {
-	__u64 elem_size, max_elems;
-	void __arena *slab;
+	__u64 elem_size = pool->elem_size;
+	__u64 max_elems = pool->max_elems;
+	__u64 nr_pages;
+	void __arena *slab = NULL;
 	void __arena *ptr;
 
-	elem_size = pool->elem_size;
-	max_elems = pool->max_elems;
+	bpf_spin_lock(&alloc_lock);
 
-	/* If the chunk is spent, get a new one. */
-	if (pool->idx >= max_elems) {
-		slab = bpf_arena_alloc_pages(&arena, NULL,
-			div_round_up(max_elems * elem_size, PAGE_SIZE), NUMA_NO_NODE, 0);
-		pool->slab = slab;
-		pool->idx = 0;
+	/* Fast path: carve the next element from the current slab. */
+	if (pool->idx < max_elems) {
+		ptr = (void __arena *)((__u64)pool->slab + elem_size * pool->idx);
+		pool->idx += 1;
+		bpf_spin_unlock(&alloc_lock);
+		return ptr;
 	}
 
-	ptr = (void __arena *)((__u64) pool->slab + elem_size * pool->idx);
+	/* Slab spent: drop the lock for the sleepable page allocation. */
+	bpf_spin_unlock(&alloc_lock);
+
+	nr_pages = div_round_up(max_elems * elem_size, PAGE_SIZE);
+	slab = bpf_arena_alloc_pages(&arena, NULL, nr_pages, NUMA_NO_NODE, 0);
+	if (!slab)
+		return NULL;
+
+	bpf_spin_lock(&alloc_lock);
+
+	/*
+	 * Re-check: another thread may have installed a fresh slab while we
+	 * slept. If still spent, install ours; otherwise keep the winner's and
+	 * free ours after unlocking.
+	 */
+	if (pool->idx >= max_elems) {
+		pool->slab = slab;
+		pool->idx = 0;
+		slab = NULL;
+	}
+
+	ptr = (void __arena *)((__u64)pool->slab + elem_size * pool->idx);
 	pool->idx += 1;
+
+	bpf_spin_unlock(&alloc_lock);
+
+	if (slab)	/* lost the refill race; release the unused slab */
+		bpf_arena_free_pages(&arena, slab, nr_pages);
 
 	return ptr;
 }


### PR DESCRIPTION
… allocation

scx_alloc_internal() reserves a distinct radix-tree index under alloc_lock, then drops the lock before binding that index to a data element from the pool. The element carve in scx_alloc_from_pool_sleepable() advances a shared cursor with no lock held:

	ptr = pool->slab + elem_size * pool->idx;
	pool->idx += 1;

ops.init_task is sleepable and runs concurrently on many CPUs, so under a fork storm two allocations race on that cursor.

Timeline -- TA on CPU0 and TB on CPU1, each having already reserved a distinct index (idxA != idxB) under the lock and dropped it. The slab cursor starts at pool->idx == N:

  1. CPU0: read pool->idx           -> N
  2. CPU1: read pool->idx           -> N    (before CPU0 increments)
  3. CPU0: ptr = slab + elem_size*N
  4. CPU1: ptr = slab + elem_size*N         (identical pointer)
  5. CPU0: pool->idx = N + 1
  6. CPU1: pool->idx = N + 1                (lost update; slot N+1 leaked)
  7. CPU0: chunk->data[posA] = ptr          (idxA's leaf slot)
  8. CPU1: chunk->data[posB] = ptr          (idxB's leaf slot, same ptr)
  9. CPU0: data->tid.idx = idxA
 10. CPU1: data->tid.idx = idxB             (clobbers the shared slot)

The index reservation kept idxA and idxB distinct, but steps 3-4 compute the same element pointer and steps 7-8 install it into both indices' leaf slots -- the element is allocated twice, and TA and TB share one task context. ops.init_task then writes each task's pid/cgrp_id into that one slot, last writer wins.

The shared context then leads to memory corruption and orphaned tasks that trip the runnable-task-stall watchdog.

Carve the element under alloc_lock, dropping the lock only for the sleepable bpf_arena_alloc_pages() refill and re-checking the cursor before installing the new slab -- the same lock-drop-allocate-recheck pattern scx_alloc_stack() already uses for the page stack. The index reservation was always serialized; this extends the same guarantee to the element carve, so each element is handed to exactly one allocation.