### PR TITLE
[mitosis] Drop binary, thread, file, ln number info from trace output

### DIFF
--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -1494,10 +1494,7 @@ fn main(opts: Opts) -> Result<()> {
 
     match tracing_subscriber::fmt()
         .with_env_filter(env_filter)
-        .with_target(true)
-        .with_thread_ids(true)
-        .with_file(true)
-        .with_line_number(true)
+        .with_target(false)
         .try_init()
     {
         Ok(()) => {}


### PR DESCRIPTION
Mitosis TRACE output used to prefix every line with thread id, target, file, and line number. That made the high-volume trace logs harder to scan without adding much debugging value.

This disables the tracing target/file prefix while preserving the timestamp and level, which are the useful context for these periodic scheduler stats.

Before:

`2026-07-02T20:40:37.739576Z TRACE ThreadId(01) scx_mitosis: scheds/rust/scx_mitosis/src/main.rs:996: Total Decisions: ...`

After:

`2026-07-02T20:38:57.612605Z TRACE Total Decisions: ...`
