### PR TITLE
[mitosis] Enrich trace output for cells

### DIFF
--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -1160,8 +1160,20 @@ impl<'a> Scheduler<'a> {
         self.collect_demand_metrics(&cpu_ctxs)
             .context("collecting demand metrics")?;
 
-        for (cell_id, cell) in &self.cells {
-            trace!("CELL[{}]: {}", cell_id, cell.cpus);
+        let mut sorted_cells: Vec<_> = self.cells.iter().collect();
+        sorted_cells.sort_by_key(|(cell_id, _)| *cell_id);
+        for (cell_id, cell) in sorted_cells {
+            let cell_metrics = self.metrics.cells.get(cell_id);
+            let util_pct = cell_metrics.map_or(0.0, |metrics| metrics.util_pct);
+            let smoothed_util_pct = cell_metrics.map_or(0.0, |metrics| metrics.smoothed_util_pct);
+            trace!(
+                "CELL[{}]: {} ({} CPUs, util={:.1}%, smoothed={:.1}%)",
+                cell_id,
+                cell.cpus,
+                cell.cpus.weight(),
+                util_pct,
+                smoothed_util_pct
+            );
         }
 
         for (cell_id, cell) in self.cells.iter() {


### PR DESCRIPTION
Improve cell TRACE output. 

Cells used to print in unstable order, this sorts them by cell number.

Adds CPU count plus current/smoothed utilization, making rebalance/debug runs easier to inspect.

Before:
`CELL[0]: fffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff`

After:
`... CELL[0]: fffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff (316 CPUs, util=2.7%, smoothed=1.8%)`