### PR TITLE
scx_p2dq: Fix addr_space_cast verifier failure on newer kernels

### DIFF
--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -304,10 +304,10 @@ static s32 pref_idle_cpu(struct llc_ctx *llcx)
 	struct scx_minheap_elem helem;
 	int ret;
 
-	if ((ret = arena_spin_lock((void __arena *)&llcx->idle_lock)))
+	if ((ret = arena_spin_lock(&((struct llc_ctx __arena *)llcx)->idle_lock)))
 		return ret;
 	ret = scx_minheap_pop(llcx->idle_cpu_heap, &helem);
-	arena_spin_unlock((void __arena *)&llcx->idle_lock);
+	arena_spin_unlock(&((struct llc_ctx __arena *)llcx)->idle_lock);
 	if (ret)
 		return -EINVAL;
 
@@ -3114,11 +3114,11 @@ void BPF_STRUCT_OPS(p2dq_update_idle, s32 cpu, bool idle)
 	// Since we use a minheap convert the highest prio to lowest score.
 	idle_score = scx_bpf_now() - ((1<<7) * (u64)priority);
 
-	if ((ret = arena_spin_lock((void __arena *)&llcx->idle_lock)))
+	if ((ret = arena_spin_lock(&((struct llc_ctx __arena *)llcx)->idle_lock)))
 		return;
 
 	scx_minheap_insert(llcx->idle_cpu_heap, (u64)cpu, idle_score);
-	arena_spin_unlock((void __arena *)&llcx->idle_lock);
+	arena_spin_unlock(&((struct llc_ctx __arena *)llcx)->idle_lock);
 
 	return;
 }


### PR DESCRIPTION
p2dq_enqueue failed to load on 6.16+ kernels with:
```
  addr_space_cast insn can only convert between address space 1 and 0
```
The idle_lock spinlock lives in a struct llc_ctx that is stored in a regular BPF_MAP_TYPE_ARRAY (address space 0). Taking the member address first and then casting it to __arena, as in
```
  arena_spin_lock((void __arena *)&llcx->idle_lock)
```
causes clang-19 to lower the addr_space_cast with imm=0 (a no-op AS0->AS0 cast). Older kernels tolerated this, but 6.16+ reject any addr_space_cast that does not convert between address space 1 and 0. (Newer clang lowers the same code to a valid cast, which is why it only reproduced with the CI toolchain.)

Cast the base pointer to __arena before taking the member address so the cast applies to the map-value pointer itself, producing a valid AS0->AS1 conversion under both clang-19 and clang-22. Verified that main.bpf.o no longer contains any imm=0 addr_space_cast instructions with either compiler.