### PR TITLE
Migrate to scx_bpf_task_set_slice/dsq_vtime() for setting slice/dsq_vtime

### DIFF
--- a/rust/scx_rustland_core/assets/bpf/main.bpf.c
+++ b/rust/scx_rustland_core/assets/bpf/main.bpf.c
@@ -913,7 +913,7 @@ void BPF_STRUCT_OPS(rustland_dispatch, s32 cpu, struct task_struct *prev)
 	 */
 	if (prev && is_queued(prev) &&
 	    (!is_usersched_task(prev) || usersched_has_pending_tasks()))
-		prev->scx.slice = slice_ns;
+		scx_bpf_task_set_slice(prev, slice_ns);
 }
 
 void BPF_STRUCT_OPS(rustland_runnable, struct task_struct *p, u64 enq_flags)
@@ -989,8 +989,8 @@ void BPF_STRUCT_OPS(rustland_stopping, struct task_struct *p, bool runnable)
  */
 void BPF_STRUCT_OPS(rustland_enable, struct task_struct *p)
 {
-	p->scx.dsq_vtime = 0;
-	p->scx.slice = slice_ns;
+	scx_bpf_task_set_dsq_vtime(p, 0);
+	scx_bpf_task_set_slice(p, slice_ns);
 }
 
 /*

--- a/scheds/experimental/scx_flow/src/bpf/dispatch.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/dispatch.bpf.c
@@ -59,6 +59,6 @@ void BPF_STRUCT_OPS(flow_dispatch, s32 cpu, struct task_struct *prev)
 	if (!prev || !(prev->scx.flags & SCX_TASK_QUEUED))
 		return;
 
-	prev->scx.slice = task_slice_ns(lookup_task_ctx(prev));
+	scx_bpf_task_set_slice(prev, task_slice_ns(lookup_task_ctx(prev)));
 	return;
 }

--- a/scheds/experimental/scx_flow/src/bpf/task.bpf.c
+++ b/scheds/experimental/scx_flow/src/bpf/task.bpf.c
@@ -33,7 +33,7 @@ void BPF_STRUCT_OPS(flow_enable, struct task_struct *p)
 
 bool BPF_STRUCT_OPS(flow_yield, struct task_struct *from, struct task_struct *to)
 {
-	from->scx.slice = FLOW_SLICE_MIN_NS;
+	scx_bpf_task_set_slice(from, FLOW_SLICE_MIN_NS);
 	return false;
 }
 

--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -731,7 +731,7 @@ static u64 task_dl(struct task_struct *p, s32 cpu, struct task_ctx *tctx)
 	 */
 	vtime_min = vtime_now - scale_by_task_weight(p, slice_lag * lag_scale);
 	if (time_before(p->scx.dsq_vtime, vtime_min))
-		p->scx.dsq_vtime = vtime_min;
+		scx_bpf_task_set_dsq_vtime(p, vtime_min);
 
 	/*
 	 * Cap the partial accumulated vruntime since last sleep to
@@ -1039,7 +1039,7 @@ void BPF_STRUCT_OPS(bpfland_dispatch, s32 cpu, struct task_struct *prev)
 	 * round on the same CPU.
 	 */
 	if (prev && keep_running(prev, cpu))
-		prev->scx.slice = task_slice(prev, cpu);
+		scx_bpf_task_set_slice(prev, task_slice(prev, cpu));
 }
 
 /*
@@ -1167,7 +1167,7 @@ void BPF_STRUCT_OPS(bpfland_stopping, struct task_struct *p, bool runnable)
 	 * sleep.
 	 */
 	delta_vtime = scale_by_task_weight_inverse(p, slice);
-	p->scx.dsq_vtime += delta_vtime;
+	scx_bpf_task_set_dsq_vtime(p, p->scx.dsq_vtime + (delta_vtime));
 	tctx->awake_vtime += delta_vtime;
 
 	/*
@@ -1206,7 +1206,7 @@ void BPF_STRUCT_OPS(bpfland_enable, struct task_struct *p)
 	/*
 	 * Initialize the task vruntime to the current global vruntime.
 	 */
-	p->scx.dsq_vtime = vtime_now;
+	scx_bpf_task_set_dsq_vtime(p, vtime_now);
 }
 
 s32 BPF_STRUCT_OPS(bpfland_init_task, struct task_struct *p,

--- a/scheds/rust/scx_cake/src/bpf/cake.bpf.c
+++ b/scheds/rust/scx_cake/src/bpf/cake.bpf.c
@@ -1787,8 +1787,8 @@ static __noinline void enqueue_nostaged(struct task_struct *p, u64 enq_flags)
 		enq_llc = cpu_llc_id[task_cpu < nr_cpus ? task_cpu : enq_cpu];
 	}
 	/* Cold path: scx_bpf_now() always — cache miss irrelevant here. */
-	p->scx.dsq_vtime = scx_bpf_now();
-	p->scx.slice = quantum_ns;
+	scx_bpf_task_set_dsq_vtime(p, scx_bpf_now());
+	scx_bpf_task_set_slice(p, quantum_ns);
 	enqueue_dsq_dispatch(p, enq_flags,
 			    ((u64)enq_cpu << 32) | enq_llc);
 }
@@ -1815,13 +1815,13 @@ static __noinline void enqueue_requeue_path(
 	u64 staged = hot->staged_vtime_bits;
 	u64 requeue_slice = p->scx.slice ?: quantum_ns;
 	u32 dsq_weight = (u32)(staged & 0xFFFFFFFF);
-	p->scx.dsq_vtime = now_cached + dsq_weight;
+	scx_bpf_task_set_dsq_vtime(p, now_cached + dsq_weight);
 	/* Cut 5: flat 50% requeue slice for all classes.
 	 * GAME 75%/non-GAME 50% differentiation removed — vtime ordering
 	 * already provides GAME priority. Saves yl_flag + variable multiply. */
 	requeue_slice >>= 1;
 	requeue_slice += (200000 - requeue_slice) & -(requeue_slice < 200000);
-	p->scx.slice = requeue_slice;
+	scx_bpf_task_set_slice(p, requeue_slice);
 	enqueue_dsq_dispatch(p, enq_flags,
 			    ((u64)enq_cpu << 32) | enq_llc);
 }
@@ -1856,13 +1856,13 @@ static __noinline void enqueue_wakeup_path(
 	u8 is_game = (hot->task_class == CAKE_CLASS_GAME);
 	/* Write vtime to entity — kernel enqueue_entity pattern.
 	 * vtime, staged, dsq_weight, new_flow all DIE here. */
-	p->scx.dsq_vtime = vtime;
+	scx_bpf_task_set_dsq_vtime(p, vtime);
 	/* GAME DOUBLE-SLICE: frame-time headroom during GAMING.
 	 * Only GAME+GAMING gets an explicit 2× quantum for frame pacing. */
 	/* Per-CPU sched_state_local: use enq_cpu (already have it from caller).
 	 * Avoids bpf_get_smp_processor_id() kfunc which causes 3 spills (Rule 73). */
 	if (is_game && cpu_bss[enq_cpu].sched_state_local == CAKE_STATE_GAMING)
-		p->scx.slice = quantum_ns << 1;
+		scx_bpf_task_set_slice(p, quantum_ns << 1);
 	/* hot is now DEAD — all 6 derivatives consumed or stored.
 	 * FunSearch: bpf_get_smp_processor_id() kfunc removed.
 	 * enq_cpu hoisted to enqueue_body (caller) — eliminates
@@ -1997,7 +1997,7 @@ void BPF_STRUCT_OPS(cake_dispatch, s32 raw_cpu, struct task_struct *prev)
 	 * Cosmos/bpfland both implement this. Especially important for gaming
 	 * where single-task-per-core is the common steady state. */
 	if (prev && (prev->scx.flags & SCX_TASK_QUEUED))
-		prev->scx.slice = quantum_ns;
+		scx_bpf_task_set_slice(prev, quantum_ns);
 
 	/* Check-before-write: if CPU is already marked idle from a previous
 	 * dispatch miss, skip the store (Rule 11: MESI optimization). */

--- a/scheds/rust/scx_chaos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_chaos/src/bpf/main.bpf.c
@@ -524,7 +524,7 @@ void BPF_STRUCT_OPS(chaos_dispatch, s32 cpu, struct task_struct *prev)
 		}
 
 		// restore vtime to p2dq's timeline
-		p->scx.dsq_vtime = taskc->p2dq_vtime;
+		scx_bpf_task_set_dsq_vtime(p, taskc->p2dq_vtime);
 
 		async_p2dq_enqueue_weak(&promise, p, taskc->enq_flags);
 		complete_p2dq_enqueue_move(&promise, BPF_FOR_EACH_ITER, p);
@@ -656,7 +656,7 @@ void BPF_STRUCT_OPS(chaos_tick, struct task_struct *p)
 		return;
 
 	if (taskc->pending_trait == CHAOS_TRAIT_KPROBE_RANDOM_DELAYS)
-		p->scx.slice = 0;
+		scx_bpf_task_set_slice(p, 0);
 }
 
 s32 BPF_STRUCT_OPS_SLEEPABLE(chaos_init_task, struct task_struct *p,

--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -945,7 +945,7 @@ static u64 task_dl(struct task_struct *p, struct task_ctx *tctx)
 	u64 vtime_min = vtime_now - vsleep_max;
 
 	if (time_before(p->scx.dsq_vtime, vtime_min))
-		p->scx.dsq_vtime = vtime_min;
+		scx_bpf_task_set_dsq_vtime(p, vtime_min);
 
 	return p->scx.dsq_vtime + scale_by_task_weight_inverse(p, tctx->exec_runtime);
 }
@@ -1133,7 +1133,7 @@ void BPF_STRUCT_OPS(cosmos_tick, struct task_struct *p)
 				scx_bpf_dsq_nr_queued(shared_dsq(cpu));
 
 		if (is_smt_contended(cpu) || (is_cpu_busy(cpu) && cpu_busy))
-			p->scx.slice = 0;
+			scx_bpf_task_set_slice(p, 0);
 	}
 }
 
@@ -1290,7 +1290,7 @@ void BPF_STRUCT_OPS(cosmos_dispatch, s32 cpu, struct task_struct *prev)
 	 * is on the primary domain.
 	 */
 	if (prev && keep_running(prev, cpu))
-		prev->scx.slice = task_slice(prev);
+		scx_bpf_task_set_slice(prev, task_slice(prev));
 }
 
 void BPF_STRUCT_OPS(cosmos_runnable, struct task_struct *p, u64 enq_flags)
@@ -1396,7 +1396,7 @@ void BPF_STRUCT_OPS(cosmos_stopping, struct task_struct *p, bool runnable)
 	 * Cap the maximum accumulated time since last sleep to @slice_lag,
 	 * to prevent starving CPU-intensive tasks.
 	 */
-	p->scx.dsq_vtime += scale_by_task_weight_inverse(p, slice);
+	scx_bpf_task_set_dsq_vtime(p, p->scx.dsq_vtime + (scale_by_task_weight_inverse(p, slice)));
 	tctx->exec_runtime = MIN(tctx->exec_runtime + slice, slice_lag);
 
 	/*
@@ -1407,7 +1407,7 @@ void BPF_STRUCT_OPS(cosmos_stopping, struct task_struct *p, bool runnable)
 
 void BPF_STRUCT_OPS(cosmos_enable, struct task_struct *p)
 {
-	p->scx.dsq_vtime = vtime_now;
+	scx_bpf_task_set_dsq_vtime(p, vtime_now);
 }
 
 s32 BPF_STRUCT_OPS(cosmos_init_task, struct task_struct *p,

--- a/scheds/rust/scx_flash/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_flash/src/bpf/main.bpf.c
@@ -729,7 +729,7 @@ void BPF_STRUCT_OPS(flash_dispatch, s32 cpu, struct task_struct *prev)
 					 scale_by_weight_inverse(prev, slice);
 
 			if (prev_vtime < q_vtime) {
-				prev->scx.slice = task_slice(prev);
+				scx_bpf_task_set_slice(prev, task_slice(prev));
 				return;
 			}
 		}
@@ -744,7 +744,7 @@ void BPF_STRUCT_OPS(flash_dispatch, s32 cpu, struct task_struct *prev)
 	 * round on the same CPU.
 	 */
 	if (need_running)
-		prev->scx.slice = task_slice(prev);
+		scx_bpf_task_set_slice(prev, task_slice(prev));
 }
 
 /*
@@ -891,7 +891,7 @@ void BPF_STRUCT_OPS(flash_stopping, struct task_struct *p, bool runnable)
 		/*
 		 * Update task's vruntime and accumulated runtime.
 		 */
-		p->scx.dsq_vtime += scale_by_weight_inverse(p, slice);
+		scx_bpf_task_set_dsq_vtime(p, p->scx.dsq_vtime + (scale_by_weight_inverse(p, slice)));
 	}
 
 	/*
@@ -934,7 +934,7 @@ void BPF_STRUCT_OPS(flash_enable, struct task_struct *p)
 	if (rr_sched)
 		return;
 
-	p->scx.dsq_vtime = vtime_now;
+	scx_bpf_task_set_dsq_vtime(p, vtime_now);
 }
 
 s32 BPF_STRUCT_OPS(flash_cgroup_init, struct cgroup *cgrp,
@@ -1164,7 +1164,7 @@ static int tickless_timerfn(void *map, int *key, struct bpf_timer *timer)
 			u64 slice = bpf_ktime_get_ns() - tctx->last_run_at;
 
 			if (slice > slice_max)
-				p->scx.slice = 0;
+				scx_bpf_task_set_slice(p, 0);
 		}
 		bpf_task_release(p);
 	}

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -868,8 +868,8 @@ s32 BPF_STRUCT_OPS(lavd_select_cpu, struct task_struct *p, s32 prev_cpu,
 			if (enable_cpu_bw &&
 			    (cgroup_throttled(p, ictx.taskc, false) == -EAGAIN))
 				goto out;
-			p->scx.dsq_vtime = calc_when_to_run(p, ictx.taskc);
-			p->scx.slice = LAVD_SLICE_MAX_NS_DFL;
+			scx_bpf_task_set_dsq_vtime(p, calc_when_to_run(p, ictx.taskc));
+			scx_bpf_task_set_slice(p, LAVD_SLICE_MAX_NS_DFL);
 			account_queued_load(ictx.taskc, cpuc->cpdom_id);
 			account_queued_load_pcpu(ictx.taskc,
 						 get_primary_cpu(cpuc->cpu_id));
@@ -911,9 +911,9 @@ void BPF_STRUCT_OPS(lavd_enqueue, struct task_struct *p, u64 enq_flags)
 		else
 			reset_task_flag(taskc, LAVD_FLAG_IS_WAKEUP);
 
-		p->scx.dsq_vtime = calc_when_to_run(p, taskc);
+		scx_bpf_task_set_dsq_vtime(p, calc_when_to_run(p, taskc));
 	}
-	p->scx.slice = LAVD_SLICE_MIN_NS_DFL;
+	scx_bpf_task_set_slice(p, LAVD_SLICE_MIN_NS_DFL);
 
 	/*
 	 * Find a proper DSQ for the task, which is either the task's
@@ -1184,7 +1184,7 @@ void consume_prev(struct task_struct *prev, task_ctx *taskc_prev, struct cpu_ctx
 	/*
 	 * Refill the time slice.
 	 */
-	prev->scx.slice = calc_time_slice(taskc_prev, cpuc);
+	scx_bpf_task_set_slice(prev, calc_time_slice(taskc_prev, cpuc));
 
 	/*
 	 * Reset prev task's lock and futex boost count
@@ -1582,13 +1582,13 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 	 * is not turned on.
 	 */
 	if (p->scx.slice == SCX_SLICE_DFL)
-		p->scx.dsq_vtime = READ_ONCE(cur_logical_clk);
+		scx_bpf_task_set_dsq_vtime(p, READ_ONCE(cur_logical_clk));
 
 	/*
 	 * Calculate the task's time slice here,
 	 * as it depends on the system load.
 	 */
-	p->scx.slice = calc_time_slice(taskc, cpuc);
+	scx_bpf_task_set_slice(p, calc_time_slice(taskc, cpuc));
 
 	/*
 	 * Update the current logical clock.

--- a/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/preempt.bpf.c
@@ -322,7 +322,7 @@ void shrink_slice_at_tick(struct task_struct *p, struct cpu_ctx *cpuc, u64 now)
 		new_slice_wall = time_delta(ub_wall, duration_wall);
 	}
 
-	p->scx.slice = new_slice_wall;
+	scx_bpf_task_set_slice(p, new_slice_wall);
 	reset_cpu_flag(cpuc, LAVD_FLAG_SLICE_BOOST);
 	cpuc->nr_preempt++;
 }
@@ -331,7 +331,7 @@ __hidden
 void preempt_at_tick(struct task_struct *p, struct cpu_ctx *cpuc)
 {
 	reset_cpu_flag(cpuc, LAVD_FLAG_SLICE_BOOST);
-	p->scx.slice = 0;
+	scx_bpf_task_set_slice(p, 0);
 
 	cpuc->nr_preempt++;
 }

--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -1660,7 +1660,7 @@ bool maybe_update_task_llc(struct task_struct *p, struct task_ctx *taskc, s32 ne
 		return false;
 
 	vtime_delta = p->scx.dsq_vtime - prev_llcc->vtime_now[layer_id];
-	p->scx.dsq_vtime = new_llcc->vtime_now[layer_id] + vtime_delta;
+	scx_bpf_task_set_dsq_vtime(p, new_llcc->vtime_now[layer_id] + vtime_delta);
 
 	taskc->llc_id = new_llc_id;
 	return true;
@@ -2319,7 +2319,7 @@ static bool keep_running(struct cpu_ctx *cpuc, struct task_struct *p,
 		 */
 		u64 dsq_id = layer_dsq_id(layer->id, cpuc->llc_id);
 		if (!scx_bpf_dsq_nr_queued(dsq_id)) {
-			p->scx.slice = layer->slice_ns;
+			scx_bpf_task_set_slice(p, layer->slice_ns);
 			lstat_inc(LSTAT_KEEP, layer, cpuc);
 			return true;
 		}
@@ -2343,7 +2343,7 @@ static bool keep_running(struct cpu_ctx *cpuc, struct task_struct *p,
 		}
 
 		if (has_idle) {
-			p->scx.slice = layer->slice_ns;
+			scx_bpf_task_set_slice(p, layer->slice_ns);
 			lstat_inc(LSTAT_KEEP, layer, cpuc);
 			return true;
 		}
@@ -2724,7 +2724,7 @@ void BPF_STRUCT_OPS(layered_dispatch, s32 cpu, struct task_struct *prev)
 		 */
 		if (is_task_layer_hint_stale(prev, prev_taskc))
 			return;
-		prev->scx.slice = prev_layer->slice_ns;
+		scx_bpf_task_set_slice(prev, prev_layer->slice_ns);
 		return;
 	}
 
@@ -2873,7 +2873,7 @@ replenish:
          * for layer membership change and subsequent CPU selection.
          */
         if (prev_taskc && prev_layer && !is_task_layer_hint_stale(prev, prev_taskc))
-		prev->scx.slice = prev_layer->slice_ns;
+		scx_bpf_task_set_slice(prev, prev_layer->slice_ns);
 }
 
 /*
@@ -3292,7 +3292,7 @@ static void switch_to_layer(struct task_struct *p, struct task_ctx *taskc, u64 l
 	 * Revisit if high frequency dynamic layer switching
 	 * needs to be supported.
 	 */
-	p->scx.dsq_vtime = llcc->vtime_now[layer_id];
+	scx_bpf_task_set_dsq_vtime(p, llcc->vtime_now[layer_id]);
 }
 
 static void maybe_refresh_layer(struct task_struct *p __arg_trusted, struct task_ctx *taskc, u64 now)
@@ -3706,7 +3706,7 @@ void BPF_STRUCT_OPS(layered_stopping, struct task_struct *p, bool runnable)
 	if (cpuc->yielding && runtime < task_layer->slice_ns)
 		runtime = task_layer->slice_ns;
 
-	p->scx.dsq_vtime += runtime * 100 / p->scx.weight;
+	scx_bpf_task_set_dsq_vtime(p, p->scx.dsq_vtime + (runtime * 100 / p->scx.weight));
 }
 
 bool BPF_STRUCT_OPS(layered_yield, struct task_struct *from, struct task_struct *to)
@@ -3729,10 +3729,10 @@ bool BPF_STRUCT_OPS(layered_yield, struct task_struct *from, struct task_struct 
 	}
 
 	if (from->scx.slice > layer->yield_step_ns) {
-		from->scx.slice -= layer->yield_step_ns;
+		scx_bpf_task_set_slice(from, from->scx.slice - (layer->yield_step_ns));
 		lstat_inc(LSTAT_YIELD_IGNORE, layer, cpuc);
 	} else {
-		from->scx.slice = 0;
+		scx_bpf_task_set_slice(from, 0);
 		cpuc->yielding = true;
 	}
 

--- a/scheds/rust/scx_mitosis/src/bpf/llc_aware.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/llc_aware.bpf.h
@@ -474,10 +474,11 @@ static inline int set_task_llc(struct task_struct *p, struct task_ctx *tctx, u32
 		return -EINVAL;
 
 	if (reset_vtime || !llc_is_valid(old_llc) || old_llc >= nr_llc || old_llc >= MAX_LLCS) {
-		p->scx.dsq_vtime = READ_ONCE(cell->llcs[new_llc].vtime_now);
+		scx_bpf_task_set_dsq_vtime(p, READ_ONCE(cell->llcs[new_llc].vtime_now));
 	} else if (old_llc != new_llc) {
 		s64 vtime_delta = p->scx.dsq_vtime - READ_ONCE(cell->llcs[old_llc].vtime_now);
-		p->scx.dsq_vtime = READ_ONCE(cell->llcs[new_llc].vtime_now) + vtime_delta;
+		scx_bpf_task_set_dsq_vtime(p,
+					   READ_ONCE(cell->llcs[new_llc].vtime_now) + vtime_delta);
 	}
 
 	tctx->llc = new_llc;

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -353,7 +353,7 @@ static inline int update_task_cpumask(struct task_struct *p, struct task_ctx *tc
 		if (dsq_is_invalid(tctx->dsq))
 			return -EINVAL;
 
-		p->scx.dsq_vtime = READ_ONCE(cpu_ctx->vtime_now);
+		scx_bpf_task_set_dsq_vtime(p, READ_ONCE(cpu_ctx->vtime_now));
 		tctx->all_cell_cpus_allowed = false;
 		return 0;
 	}
@@ -375,7 +375,7 @@ static inline int update_task_cpumask(struct task_struct *p, struct task_ctx *tc
 	if (!(cell = lookup_cell(tctx->cell)))
 		return -ENOENT;
 
-	p->scx.dsq_vtime = READ_ONCE(cell->llcs[FAKE_FLAT_CELL_LLC].vtime_now);
+	scx_bpf_task_set_dsq_vtime(p, READ_ONCE(cell->llcs[FAKE_FLAT_CELL_LLC].vtime_now));
 	tctx->all_cell_cpus_allowed = true;
 
 	return 0;
@@ -618,7 +618,7 @@ static __always_inline s32 update_pinned_dsq(struct task_struct *p, struct task_
 		return -1;
 
 	tctx->dsq = get_cpu_dsq_id(new_cpu);
-	p->scx.dsq_vtime = READ_ONCE(new_cctx->vtime_now);
+	scx_bpf_task_set_dsq_vtime(p, READ_ONCE(new_cctx->vtime_now));
 	return new_cpu;
 }
 
@@ -1059,7 +1059,7 @@ void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 		scx_bpf_error("Task %d has zero weight", p->pid);
 		return;
 	}
-	p->scx.dsq_vtime += used * 100 / p->scx.weight;
+	scx_bpf_task_set_dsq_vtime(p, p->scx.dsq_vtime + (used * 100 / p->scx.weight));
 
 	/*
 	 * Only advance this CPU's local vtime when the slice ends on a CPU

--- a/scheds/rust/scx_mitosis/src/bpf/slice_shrinking.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/slice_shrinking.bpf.h
@@ -112,7 +112,7 @@ static inline void slice_shrink_apply(struct task_struct *p, u64 limit,
 				      struct cpu_ctx *cctx)
 {
 	if (p->scx.slice > limit) {
-		p->scx.slice = limit;
+		scx_bpf_task_set_slice(p, limit);
 		if (result == SHRINK_MAX)
 			cstat_inc(CSTAT_SLICE_SHRINK_MAX, cell, cctx);
 		else if (result == SHRINK_PROPORTIONAL)

--- a/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_p2dq/src/bpf/main.bpf.c
@@ -1021,12 +1021,12 @@ static void update_vtime(struct task_struct *p, struct cpu_ctx *cpuc,
 				  llcx->vtime - scaled_min : 0;
 
 		if (p->scx.dsq_vtime < vtime_floor)
-			p->scx.dsq_vtime = vtime_floor;
+			scx_bpf_task_set_dsq_vtime(p, vtime_floor);
 
 		return;
 	}
 
-	p->scx.dsq_vtime = llcx->vtime;
+	scx_bpf_task_set_dsq_vtime(p, llcx->vtime);
 
 	return;
 }
@@ -1057,7 +1057,7 @@ static bool keep_running(struct cpu_ctx *cpuc, struct llc_ctx *llcx,
 
 	u64 slice_ns = task_slice_ns(p, cpuc->slice_ns);
 	cpuc->ran_for += slice_ns;
-	p->scx.slice = slice_ns;
+	scx_bpf_task_set_slice(p, slice_ns);
 	stat_inc(P2DQ_STAT_KEEP);
 	return true;
 }
@@ -2430,7 +2430,7 @@ void BPF_STRUCT_OPS(p2dq_stopping, struct task_struct *p, bool runnable)
 	used = now - taskc->last_run_at;
 	scaled_used = scale_by_task_weight_inverse(p, used);
 
-	p->scx.dsq_vtime += scaled_used;
+	scx_bpf_task_set_dsq_vtime(p, p->scx.dsq_vtime + scaled_used);
 	__sync_fetch_and_add(&llcx->vtime, used);
 
 	/* Update PELT metrics if enabled */
@@ -3193,7 +3193,7 @@ static s32 p2dq_init_task_impl(struct task_struct *p, struct scx_init_task_args 
 	else
 		task_ctx_clear_flag(taskc, TASK_CTX_F_INTERACTIVE);
 
-	p->scx.dsq_vtime = llcx->vtime;
+	scx_bpf_task_set_dsq_vtime(p, llcx->vtime);
 	task_refresh_llc_runs(taskc);
 
 	// When a task is initialized set the DSQ id to invalid. This causes

--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -779,7 +779,7 @@ static void clamp_task_vtime(struct task_struct *p, struct task_ctx *taskc, u64 
 	 * an entire day until it's caught up to the other tasks' vtimes.
 	 */
 	if (time_before(p->scx.dsq_vtime, min_vruntime)) {
-		p->scx.dsq_vtime = min_vruntime;
+		scx_bpf_task_set_dsq_vtime(p, min_vruntime);
 		taskc->deadline = p->scx.dsq_vtime + task_compute_dl(p, taskc, enq_flags);
 		stat_add(RUSTY_STAT_DL_CLAMP, 1);
 	} else {
@@ -844,7 +844,7 @@ static bool task_set_domain(struct task_struct *p __arg_trusted,
 		taskc->domc = new_domc;
 
 		cast_kern(new_domc);
-		p->scx.dsq_vtime = dom_min_vruntime(new_domc);
+		scx_bpf_task_set_dsq_vtime(p, dom_min_vruntime(new_domc));
 		taskc->deadline = p->scx.dsq_vtime +
 				  scale_inverse_fair(taskc->avg_runtime, taskc->weight);
 		bpf_cpumask_and(t_cpumask, cast_mask(d_cpumask), p->cpus_ptr);
@@ -1519,7 +1519,7 @@ static void stopping_update_vtime(struct task_struct *p,
 	taskc->sum_runtime += delta;
 	taskc->avg_runtime = calc_avg(taskc->avg_runtime, taskc->sum_runtime);
 
-	p->scx.dsq_vtime += scale_inverse_fair(delta, p->scx.weight);
+	scx_bpf_task_set_dsq_vtime(p, p->scx.dsq_vtime + (scale_inverse_fair(delta, p->scx.weight)));
 	taskc->deadline = p->scx.dsq_vtime + task_compute_dl(p, taskc, 0);
 }
 

--- a/scheds/rust/scx_tickless/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_tickless/src/bpf/main.bpf.c
@@ -435,7 +435,7 @@ static int sched_timerfn(void *map, int *key, struct bpf_timer *timer)
 		 * can be preempted.
 		 */
 		if (p->scx.slice == SCX_SLICE_INF) {
-			p->scx.slice = slice_ns;
+			scx_bpf_task_set_slice(p, slice_ns);
 			__sync_fetch_and_add(&nr_preemptions, 1);
 		}
 	}
@@ -524,7 +524,7 @@ void BPF_STRUCT_OPS(tickless_dispatch, s32 cpu, struct task_struct *prev)
 	 * Keep running the previous task if it still wants to run.
 	 */
 	if (prev && prev->scx.flags & SCX_TASK_QUEUED)
-		prev->scx.slice = SCX_SLICE_INF;
+		scx_bpf_task_set_slice(prev, SCX_SLICE_INF);
 }
 
 /*


### PR DESCRIPTION
Use scx_bpf_task_set_slice/dsq_vtime() setters
Writing directly to p->scx.slice and p->scx.dsq_vtime is deprecated and
emits a warning on newer kernels:
```
  sched_ext: Writing directly to p->scx.slice/dsq_vtime is deprecated,
  use scx_bpf_task_set_slice/dsq_vtime()
```
Switch the direct writes to the scx_bpf_task_set_slice() and
scx_bpf_task_set_dsq_vtime() compat wrappers, which use the new kfuncs
when available and fall back to the direct write on older kernels.