### PR TITLE
lib/cgroup_bw: Pack cgroup LLC map key

### DIFF
--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -289,7 +289,7 @@ struct {
 struct cgroup_llc_id {
 	u64		cgrp_id;
 	int		llc_id;
-};
+} __attribute__((packed));
 
 struct cbw_llc_entry {
 	u64	llcx;


### PR DESCRIPTION
Fixes #3693.

`struct cgroup_llc_id` has four bytes of implicit tail padding. BPF hash maps compare every byte of the key, so separately allocated update and lookup keys can differ even when `cgrp_id` and `llc_id` match.

The failed lookups prevent cgroup-exit cleanup from deleting per-LLC contexts. The map eventually fills and a later cgroup initialization fails.

Pack the key so only its declared fields participate in map operations.
