### PR TITLE
scx_lavd: Size cgroup LLC map from topology

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -486,6 +486,16 @@ impl<'a> Scheduler<'a> {
 
         // Initialize CPU topology with CLI arguments
         let order = CpuOrder::new(opts.topology.as_ref(), opts.no_use_em).unwrap();
+        if opts.enable_cpu_bw {
+            let nr_llcs = u32::try_from(order.nr_llcs).context("Too many LLC domains")?;
+            let max_entries = skel
+                .maps
+                .cbw_cgrp_map
+                .max_entries()
+                .checked_mul(nr_llcs)
+                .context("LLC context map is too large")?;
+            skel.maps.cbw_cgrp_llc_map.set_max_entries(max_entries)?;
+        }
         Self::init_cpus(&mut skel, &order);
         Self::init_cpdoms(&mut skel, &order);
 


### PR DESCRIPTION
Fixes #3694.

`cbw_cgrp_llc_map` has a fixed 65,536-entry capacity, which supports 2,048 cgroups only on systems with at most 32 LLC domains. On an Ampere Altra Max M128-30, scx detects 128 LLC domains and the effective capacity drops to 512 cgroups.

Set `max_entries` before BPF load using the existing cgroup map capacity multiplied by the detected LLC count.
