### PR TITLE
lib/cgroup_bw: size the per-(cgroup, LLC) map to the system's LLC count

### DIFF
--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -45,8 +45,6 @@ enum scx_cgroup_consts {
 	CBW_CONSUMPTION_RATE_DECAY	= 3,
 	/* maximum number of cgroups */
 	CBW_NR_CGRP_MAX			= 2048,
-	/* maximum number of scx_cgroup_llc_ctx: 2048 cgroups * 32 LLCs */
-	CBW_NR_CGRP_LLC_MAX		= (CBW_NR_CGRP_MAX * 32),
 	/* The maximum height of a cgroup tree.
 	 * cgroupv2 default maximum depth is 32 (kernel CGROUPS_DEPTH_MAX). */
 	CBW_CGRP_TREE_HEIGHT_MAX	= 32,
@@ -300,7 +298,8 @@ struct {
 	__type(key, struct cgroup_llc_id);
 	__type(value, struct cbw_llc_entry);
 	__uint(map_flags, BPF_F_NO_PREALLOC);
-	__uint(max_entries, CBW_NR_CGRP_LLC_MAX);
+	/* single-LLC default; userspace grows it to CBW_NR_CGRP_MAX * nr_llcs */
+	__uint(max_entries, CBW_NR_CGRP_MAX);
 } cbw_cgrp_llc_map SEC(".maps");
 
 /*

--- a/rust/scx_utils/src/cgroup.rs
+++ b/rust/scx_utils/src/cgroup.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+// Author: Changwoo Min <changwoo@igalia.com>
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+//! Userspace helpers for the cgroup-related BPF libraries. Currently this
+//! covers `lib/cgroup_bw` (cpu.max); a scheduler that links it calls the
+//! helper below once between opening and loading its skeleton.
+
+use anyhow::anyhow;
+use anyhow::Result;
+use libbpf_rs::OpenObject;
+
+/// Per-cgroup context map defined in `lib/cgroup_bw.bpf.c`.
+const CBW_CGRP_MAP: &str = "cbw_cgrp_map";
+/// Per-(cgroup, LLC) context map defined in `lib/cgroup_bw.bpf.c`.
+const CBW_CGRP_LLC_MAP: &str = "cbw_cgrp_llc_map";
+
+/// Size the cpu.max per-(cgroup, LLC) context map to the running system.
+///
+/// `cbw_cgrp_llc_map` holds one entry per LLC for each tracked cgroup. Its
+/// BPF definition ships with a single-LLC default (`CBW_NR_CGRP_MAX`
+/// entries) because a BPF map's `max_entries` is fixed at load time while
+/// the LLC count is only known at runtime. Call this once after opening and
+/// before loading the skeleton to grow it to `<cgroup cap> * nr_llcs`.
+///
+/// The cgroup cap is read from the sibling `cbw_cgrp_map`, so the
+/// `CBW_NR_CGRP_MAX` constant stays defined only in the BPF source.
+pub fn resize_cgroup_bw_llc_map(open_obj: &mut OpenObject, nr_llcs: usize) -> Result<()> {
+    let cgrp_max = open_obj
+        .maps_mut()
+        .find(|m| m.name().to_str() == Some(CBW_CGRP_MAP))
+        .map(|m| m.max_entries())
+        .ok_or_else(|| anyhow!("cgroup_bw: map `{CBW_CGRP_MAP}` not found"))?;
+
+    let max_entries = cgrp_max
+        .checked_mul(nr_llcs as u32)
+        .ok_or_else(|| anyhow!("cgroup_bw: `{CBW_CGRP_LLC_MAP}` size overflow"))?;
+
+    open_obj
+        .maps_mut()
+        .find(|m| m.name().to_str() == Some(CBW_CGRP_LLC_MAP))
+        .ok_or_else(|| anyhow!("cgroup_bw: map `{CBW_CGRP_LLC_MAP}` not found"))?
+        .set_max_entries(max_entries)?;
+
+    Ok(())
+}

--- a/rust/scx_utils/src/lib.rs
+++ b/rust/scx_utils/src/lib.rs
@@ -107,6 +107,9 @@ pub use netdev::NetDev;
 
 pub mod pm;
 
+pub mod cgroup;
+pub use cgroup::resize_cgroup_bw_llc_map;
+
 pub mod enums;
 pub use enums::scx_enums;
 

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -37,6 +37,7 @@ use crossbeam::channel::Receiver;
 use crossbeam::channel::RecvTimeoutError;
 use crossbeam::channel::Sender;
 use crossbeam::channel::TrySendError;
+use libbpf_rs::skel::OpenSkel;
 use libbpf_rs::skel::Skel;
 use libbpf_rs::OpenObject;
 use libbpf_rs::PrintLevel;
@@ -497,6 +498,10 @@ impl<'a> Scheduler<'a> {
 
         // Initialize skel according to @opts.
         Self::init_globals(&mut skel, &opts, &order, debug_level);
+
+        // Size the cpu.max per-(cgroup, LLC) map to this system's LLC count
+        // before loading (a map's max_entries is fixed at load time).
+        scx_utils::resize_cgroup_bw_llc_map(skel.open_object_mut(), order.nr_llcs)?;
 
         // Initialize arena
         let mut skel = scx_ops_load!(skel, lavd_ops, uei)?;


### PR DESCRIPTION
cbw_cgrp_llc_map was capped at CBW_NR_CGRP_MAX * 32, a hardcoded assumption of at most 32 LLCs: oversized on typical machines and too small to index every (cgroup, LLC) pair on systems with more than 32 LLCs.

A BPF map's max_entries is fixed at load time, and the LLC count is only known at runtime, so the map cannot size itself. Add a library-owned userspace helper, scx_utils::resize_cgroup_bw_llc_map(), which reads the cgroup cap from the sibling cbw_cgrp_map and grows cbw_cgrp_llc_map to cap * nr_llcs between open and load. The BPF map now ships a single-LLC default (CBW_NR_CGRP_MAX), and CBW_NR_CGRP_MAX stays defined only in the BPF source.

A scheduler that links lib/cgroup_bw calls the helper once before loading, mirroring the existing ArenaLib init pattern; wire it up in scx_lavd. The new helper lives in a general scx_utils::cgroup module so future cgroup-related helpers can join it.

Closes: https://github.com/sched-ext/scx/issues/3694