### PR TITLE
add tests against distro kernels

### DIFF
--- a/.github/workflows/ci-new.yml
+++ b/.github/workflows/ci-new.yml
@@ -1,0 +1,77 @@
+name: ci-new
+
+on:
+  workflow_dispatch:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+env:
+  RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold"
+  KTSTR_VERSION: "0.48.0"
+  # tj's sched_ext for-next on kernel.org: the reference kernel each scheduler
+  # is verified against alongside its distro kernel.
+  KERNEL_SCHED_EXT_FOR_NEXT: "git+https://git.kernel.org/pub/scm/linux/kernel/git/tj/sched_ext.git#branch=for-next"
+
+jobs:
+  # One verifier leg per (scheduler, distro kernel, arch). `cargo ktstr verifier`
+  # boots the scheduler across topologies and checks it verifies, attaches, and
+  # dispatches on each --kernel: tj's sched_ext for-next (reference) and the
+  # distro kernel. Non-blocking (continue-on-error): a distro kernel can fail to
+  # load current scx BPF, and that reports without gating CI.
+  verifier:
+    name: 'verifier ${{ matrix.leg.package }} ${{ matrix.leg.runner }}'
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        leg:
+          # kernels: space-separated distro kernels verified in one run,
+          # alongside for-next. ktstr's GKE (COS) kernels are x86_64-only,
+          # so only the scx-x64 leg carries gke.
+          - { runner: scx-x64,   scheduler: layered, package: scx_layered, kernels: fedora gke }
+          - { runner: scx-arm64, scheduler: layered, package: scx_layered, kernels: fedora }
+    runs-on: ${{ matrix.leg.runner }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      # The ktstr binaries are cached repo-wide keyed on version + arch, so
+      # one build serves every leg and run. Save happens right after install
+      # (not via the cache action's post step) so legs that fail the verifier
+      # still upload it.
+      - name: Restore cargo-ktstr
+        id: cache-ktstr
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cargo/bin/*ktstr*
+          key: cargo-ktstr-${{ env.KTSTR_VERSION }}-${{ runner.arch }}
+      - name: Install cargo-ktstr
+        if: steps.cache-ktstr.outputs.cache-hit != 'true'
+        run: cargo install --locked "ktstr@${KTSTR_VERSION}"
+      - name: Save cargo-ktstr cache
+        if: steps.cache-ktstr.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cargo/bin/*ktstr*
+          key: cargo-ktstr-${{ env.KTSTR_VERSION }}-${{ runner.arch }}
+      - name: Build ${{ matrix.leg.package }}
+        run: cargo build --release --locked -p ${{ matrix.leg.package }}
+      - name: 'Verify ${{ matrix.leg.scheduler }}: for-next + ${{ matrix.leg.kernels }}'
+        run: |
+          kernels=()
+          for k in ${{ matrix.leg.kernels }}; do kernels+=(--kernel "$k"); done
+          cargo ktstr verifier \
+            --scheduler ${{ matrix.leg.scheduler }} \
+            --kernel "$KERNEL_SCHED_EXT_FOR_NEXT" \
+            "${kernels[@]}" \
+            -p ${{ matrix.leg.package }} --features ktstr-tests

--- a/.github/workflows/ci-new.yml
+++ b/.github/workflows/ci-new.yml
@@ -41,6 +41,8 @@ jobs:
           # the arm64 leg verifies for-next alone.
           - { runner: scx-x64,   scheduler: lavd,    package: scx_lavd,    kernels: steamos }
           - { runner: scx-arm64, scheduler: lavd,    package: scx_lavd,    kernels: '' }
+          - { runner: scx-x64,   scheduler: cosmos,  package: scx_cosmos,  kernels: ubuntu }
+          - { runner: scx-arm64, scheduler: cosmos,  package: scx_cosmos,  kernels: ubuntu }
     runs-on: ${{ matrix.leg.runner }}
     timeout-minutes: 120
     steps:

--- a/.github/workflows/ci-new.yml
+++ b/.github/workflows/ci-new.yml
@@ -37,6 +37,10 @@ jobs:
           # so only the scx-x64 leg carries gke.
           - { runner: scx-x64,   scheduler: layered, package: scx_layered, kernels: fedora gke }
           - { runner: scx-arm64, scheduler: layered, package: scx_layered, kernels: fedora }
+          # SteamOS ships x86_64 only, so steamos rides the scx-x64 leg and
+          # the arm64 leg verifies for-next alone.
+          - { runner: scx-x64,   scheduler: lavd,    package: scx_lavd,    kernels: steamos }
+          - { runner: scx-arm64, scheduler: lavd,    package: scx_lavd,    kernels: '' }
     runs-on: ${{ matrix.leg.runner }}
     timeout-minutes: 120
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,10 @@ jobs:
           - name: scx__stable__6_13
             url: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
             tag: linux-6.13.y
-            veristat-disable: scx_lavd scx_arena_selftests
+            veristat-disable: scx_arena_selftests
           - name: scx__stable__6_16
             url: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
             tag: linux-6.16.y
-            veristat-disable: scx_lavd
           - name: scx__stable__6_18
             url: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
             tag: linux-6.18.y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           - name: scx__stable__6_13
             url: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
             tag: linux-6.13.y
-            veristat-disable: scx_layered scx_lavd scx_arena_selftests
+            veristat-disable: scx_lavd scx_arena_selftests
           - name: scx__stable__6_16
             url: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
             tag: linux-6.16.y

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6572,6 +6572,7 @@ dependencies = [
  "gpoint",
  "hex",
  "itertools 0.14.0",
+ "ktstr 0.48.0",
  "libbpf-rs",
  "libc",
  "nix 0.31.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6472,6 +6472,7 @@ dependencies = [
  "clap",
  "crossbeam",
  "ctrlc",
+ "ktstr 0.48.0",
  "libbpf-rs",
  "log",
  "nvml-wrapper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +662,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-config2"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ada53f7339c78084fb37d7e17f34e76537541c4fbb02fa3a2baa14b8faad37"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,12 +747,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1355,6 +1381,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a45ee8994e5307cb4c60cfc1c20bf7263ffb771ddc135c9f768a14bcbc15b09"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "schannel",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.90+curl-8.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97799a0d220bfb3361e0fe4936966ff8c4b24d65c3f06dfc70d7b680b44e7897"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+ "rustls-ffi",
+ "vcpkg",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "cursive"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +1763,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-primitive-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
+dependencies = [
+ "num-traits",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +2020,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.9",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1997,6 +2063,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2252,6 +2328,7 @@ dependencies = [
  "gix-worktree-state",
  "gix-worktree-stream",
  "nonempty",
+ "prodash",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -2499,11 +2576,13 @@ checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
 dependencies = [
  "bytes",
  "crc32fast",
+ "crossbeam-channel",
  "gix-path",
  "gix-trace",
  "gix-utils",
  "libc",
  "once_cell",
+ "parking_lot",
  "prodash",
  "thiserror 2.0.18",
  "walkdir",
@@ -2993,6 +3072,7 @@ checksum = "186874f7ad1fb2f9a2f2aa9c2dabc7f9dd087bef74c1a0eee2b4a9cf0248fcb3"
 dependencies = [
  "base64",
  "bstr",
+ "curl",
  "gix-command",
  "gix-credentials",
  "gix-features",
@@ -3745,6 +3825,22 @@ dependencies = [
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -3752,7 +3848,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -3771,6 +3867,15 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -3826,6 +3931,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "kstring"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3862,7 +3976,7 @@ dependencies = [
  "humantime",
  "indicatif",
  "itoa",
- "ktstr-macros",
+ "ktstr-macros 0.18.0",
  "kvm-bindings",
  "kvm-ioctls",
  "libbpf-cargo",
@@ -3918,10 +4032,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "ktstr"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "735190a3f2bde6f9d4480adb847e80c0af268501809be01aa2f7c0c4aae70775"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64",
+ "blazesym",
+ "btf-rs",
+ "cargo-config2",
+ "cargo-platform 0.1.9",
+ "cargo_metadata 0.19.2",
+ "cc",
+ "clap",
+ "clap_complete",
+ "comfy-table",
+ "cpio",
+ "crc32fast",
+ "ctor",
+ "flate2",
+ "fs2",
+ "gimli 0.33.0",
+ "gix",
+ "glob",
+ "goblin",
+ "hex",
+ "humantime",
+ "indicatif",
+ "itoa",
+ "jobserver",
+ "ktstr-macros 0.48.0",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libbpf-cargo",
+ "libbpf-rs",
+ "libbpf-sys",
+ "libc",
+ "linkme",
+ "linux-loader",
+ "lz4_flex",
+ "md-5",
+ "memchr",
+ "memmap2",
+ "netlink-packet-core",
+ "netlink-packet-generic",
+ "netlink-sys",
+ "nix 0.31.3",
+ "object 0.39.1",
+ "perf-event-open-sys",
+ "postcard",
+ "quick-xml",
+ "rand 0.10.1",
+ "rayon",
+ "regex",
+ "reqwest 0.13.4",
+ "rmesg",
+ "rpm",
+ "rustix 1.1.4",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.11.0",
+ "siphasher",
+ "smallvec",
+ "statrs",
+ "strsim",
+ "strum 0.28.0",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+ "tree-sitter",
+ "tree-sitter-c",
+ "virtio-bindings",
+ "virtio-queue",
+ "vm-fdt",
+ "vm-memory",
+ "vm-superio",
+ "vmm-sys-util",
+ "walkdir",
+ "xz2",
+ "zerocopy",
+ "zstd",
+]
+
+[[package]]
 name = "ktstr-macros"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804ac7f070403560b0246484e03b897d369447b60bf194dc4e3081b199126900"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ktstr-macros"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8cac9e40f6dd6fdffd8f78f52b49341d14b1a85a68346e5673a651faf331382"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4028,6 +4244,18 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4229,6 +4457,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4409,6 +4647,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5354,6 +5601,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5732,7 +5988,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.7.0",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -5788,6 +6044,41 @@ dependencies = [
  "strum 0.27.2",
  "strum_macros 0.27.2",
 ]
+
+[[package]]
+name = "rpm"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a5c5d43b95d73d6f0a1b8fbeab72a7ebebf618cdc99f2b9a28f269ee343766e"
+dependencies = [
+ "base64",
+ "bitflags 2.11.1",
+ "digest 0.10.7",
+ "enum-display-derive",
+ "enum-primitive-derive",
+ "flate2",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "memchr",
+ "nom 8.0.0",
+ "num",
+ "num-derive",
+ "num-traits",
+ "rpm-version",
+ "sha1",
+ "sha2 0.10.9",
+ "sha3",
+ "thiserror 2.0.18",
+ "zeroize",
+ "zstd",
+]
+
+[[package]]
+name = "rpm-version"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56568fb1bf1d2c0a640aac216b3d84d65e210ca1997df922bf124f2bfaf9efd9"
 
 [[package]]
 name = "rustc-demangle"
@@ -5857,6 +6148,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-ffi"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4128514cb6472050cba340cdac098a235c53e6aad276737ce1d7b24a19260392"
+dependencies = [
+ "libc",
+ "log",
+ "rustls",
+ "rustls-platform-verifier 0.5.3",
+ "rustls-webpki",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5880,13 +6184,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.7.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -5895,7 +6199,28 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 1.0.8",
  "windows-sys 0.61.2",
 ]
 
@@ -6278,6 +6603,7 @@ dependencies = [
  "fastrand",
  "fb_procfs",
  "inotify",
+ "ktstr 0.48.0",
  "lazy_static",
  "libbpf-rs",
  "libc",
@@ -6313,7 +6639,7 @@ dependencies = [
  "ctrlc",
  "inotify",
  "itertools 0.14.0",
- "ktstr",
+ "ktstr 0.18.0",
  "lazy_static",
  "libbpf-rs",
  "libc",
@@ -6778,6 +7104,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7005,6 +7341,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7221,7 +7567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -8125,6 +8471,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.8",
+]
+
+[[package]]
+name = "webpki-root-certs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
@@ -8375,6 +8730,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -8416,6 +8780,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8477,6 +8856,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -8495,6 +8880,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -8510,6 +8901,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8543,6 +8940,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -8558,6 +8961,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8579,6 +8988,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -8594,6 +9009,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/scheds/rust/scx_cosmos/Cargo.toml
+++ b/scheds/rust/scx_cosmos/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2021"
 description = "Lightweight scheduler optimized for preserving task-to-CPU locality. https://github.com/sched-ext/scx/tree/main"
 license = "GPL-2.0-only"
 
+# BPF verification is covered by the ktstr verifier CI
+# (.github/workflows/ci-new.yml) on for-next + a distro kernel, not veristat.
+[package.metadata.veristat]
+disable = true
+
 [dependencies]
 anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
@@ -21,9 +26,18 @@ scx_utils = { path = "../../../rust/scx_utils", version = "1.1.2", features = ["
 serde = { version = "1", features = ["derive"] }
 simplelog = "0.12"
 
+# Test-only scheduler harness, pulled in only by the `ktstr-tests` feature for
+# the gated verifier declaration under tests/. Not built for normal scheduler
+# builds. Optional (not a dev-dependency) so the feature can gate it.
+ktstr = { version = "=0.48.0", optional = true }
+
 [build-dependencies]
 scx_cargo = { path = "../../../rust/scx_cargo", version = "1.1.2" }
 
 [features]
 enable_backtrace = []
 gpu-topology = []
+# Gates the ktstr verifier declaration under tests/ and pulls in the optional
+# ktstr harness. Off by default; enable with `--features ktstr-tests` under
+# `cargo ktstr verifier`.
+ktstr-tests = ["dep:ktstr"]

--- a/scheds/rust/scx_cosmos/tests/ktstr_tests.rs
+++ b/scheds/rust/scx_cosmos/tests/ktstr_tests.rs
@@ -1,0 +1,13 @@
+#![cfg(feature = "ktstr-tests")]
+//! ktstr verifier declaration for scx_cosmos.
+//!
+//! `cargo ktstr verifier` boots scx_cosmos in a KVM VM and checks it verifies,
+//! attaches, and dispatches. scx_cosmos attaches with defaults, so no
+//! `sched_args` are required. Declaration only.
+
+use ktstr::prelude::*;
+
+declare_scheduler!(COSMOS, {
+    name = "cosmos",
+    binary = "scx_cosmos",
+});

--- a/scheds/rust/scx_lavd/Cargo.toml
+++ b/scheds/rust/scx_lavd/Cargo.toml
@@ -11,6 +11,11 @@ blocklist = [
   "stable/6_12" # https://github.com/sched-ext/scx/issues/3046
 ]
 
+# BPF verification is covered by the ktstr verifier CI
+# (.github/workflows/ci-new.yml) on for-next + a distro kernel, not veristat.
+[package.metadata.veristat]
+disable = true
+
 [dependencies]
 scx_arena = { path = "../../../rust/scx_arena/scx_arena", version = "1.1.2" }
 anyhow = "1"
@@ -38,8 +43,17 @@ combinations = "0.1"
 rlimit = "0.11"
 nix = "0.31"
 
+# Test-only scheduler harness, pulled in only by the `ktstr-tests` feature for
+# the gated verifier declaration under tests/. Not built for normal scheduler
+# builds. Optional (not a dev-dependency) so the feature can gate it.
+ktstr = { version = "=0.48.0", optional = true }
+
 [build-dependencies]
 scx_cargo = { path = "../../../rust/scx_cargo", version = "1.1.2" }
 
 [features]
 enable_backtrace = []
+# Gates the ktstr verifier declaration under tests/ and pulls in the optional
+# ktstr harness. Off by default; enable with `--features ktstr-tests` under
+# `cargo ktstr verifier`.
+ktstr-tests = ["dep:ktstr"]

--- a/scheds/rust/scx_lavd/tests/ktstr_tests.rs
+++ b/scheds/rust/scx_lavd/tests/ktstr_tests.rs
@@ -1,0 +1,13 @@
+#![cfg(feature = "ktstr-tests")]
+//! ktstr verifier declaration for scx_lavd.
+//!
+//! `cargo ktstr verifier` boots scx_lavd in a KVM VM and checks it verifies,
+//! attaches, and dispatches. scx_lavd attaches with defaults, so no
+//! `sched_args` are required. Declaration only.
+
+use ktstr::prelude::*;
+
+declare_scheduler!(LAVD, {
+    name = "lavd",
+    binary = "scx_lavd",
+});

--- a/scheds/rust/scx_layered/Cargo.toml
+++ b/scheds/rust/scx_layered/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2021"
 description = "A highly configurable multi-layer BPF / user space hybrid scheduler used within sched_ext, which is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. https://github.com/sched-ext/scx/tree/main"
 license = "GPL-2.0-only"
 
+# BPF verification is covered by the ktstr verifier CI
+# (.github/workflows/ci-new.yml) on for-next + a distro kernel, not veristat.
+[package.metadata.veristat]
+disable = true
+
 [dependencies]
 anyhow = "1"
 bitvec = "1"
@@ -37,6 +42,11 @@ nvml-wrapper = "0.12"
 nix = { version = "0.31", features = ["sched"] }
 sysinfo = "0.38"
 
+# Test-only scheduler harness, pulled in only by the `ktstr-tests` feature for
+# the gated verifier declaration under tests/. Not built for normal scheduler
+# builds. Optional (not a dev-dependency) so the feature can gate it.
+ktstr = { version = "=0.48.0", optional = true }
+
 [dev-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.1.2", features = ["testutils"] }
 
@@ -45,6 +55,10 @@ scx_cargo = { path = "../../../rust/scx_cargo", version = "1.1.2" }
 
 [features]
 enable_backtrace = []
+# Gates the ktstr verifier declaration under tests/ and pulls in the optional
+# ktstr harness. Off by default; enable with `--features ktstr-tests` under
+# `cargo ktstr verifier`.
+ktstr-tests = ["dep:ktstr"]
 
 [package.metadata.appimage]
 auto_link = true

--- a/scheds/rust/scx_layered/tests/ktstr_tests.rs
+++ b/scheds/rust/scx_layered/tests/ktstr_tests.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "ktstr-tests")]
+//! ktstr verifier declaration for scx_layered.
+//!
+//! `cargo ktstr verifier` boots scx_layered in a KVM VM and checks it verifies,
+//! attaches, and dispatches. scx_layered always needs a layer config, so
+//! `--run-example` supplies the built-in example layers. Declaration only.
+
+use ktstr::prelude::*;
+
+declare_scheduler!(LAYERED, {
+    name = "layered",
+    binary = "scx_layered",
+    sched_args = ["--run-example"],
+});


### PR DESCRIPTION
I've been working on this for a while now and I think I'm starting to be happy with how it works so tagging folks to provide awareness of where schedulers do/do not verify.

This PR adds a non-blocking CI job which runs schedulers against a battery of topologies in VMs rapidly, against both for-next and misc distro kernels I think we care about.

It runs layered against fedora/gke/for-next, cosmos against ubuntu/for-next, and lavd against steamos/for-next.

<img width="1426" height="1412" alt="CleanShot 2026-07-29 at 23 40 22@2x" src="https://github.com/user-attachments/assets/f2089cb1-bbec-46ab-a778-24ef55e1ccb1" />

I'll keep iterating on this slowly but I think this is how we want CI/scheduler guardrails to work. I've had luck reproducing production issues with this framework, and the churn on this PR was me getting (massive) oversubscription to work right (i.e. retaining the ability to break schedulers in the way they break in prod without requiring 1 host per scenario and multiple hours of runtime).

LMK thoughts or if I can help clear anything up about this!

To run the new tests on this PR locally, install the tool which runs these tests `cargo install ktstr --locked`, fill in kernels you wish to test [in the command ci uses here](https://github.com/sched-ext/scx/pull/3700/changes#diff-d42ef5081ce4862a0091770b7f229811e50a95711edac08b2f603b8d9a6ebf21R79), and the same thing on ci will be ran locally.