### PR TITLE
scx_layered: keep_running must account for local-DSQ-dispatched tasks

### DIFF
--- a/scheds/rust/scx_layered/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_layered/src/bpf/main.bpf.c
@@ -2293,6 +2293,14 @@ static bool keep_running(struct cpu_ctx *cpuc, struct task_struct *p,
 	if (scx_bpf_dsq_nr_queued(cpuc->hi_fb_dsq_id))
 		goto no;
 
+	/*
+	 * Anything already dispatched to this CPU's local DSQ should run.
+	 * Consider for example pcpu kthreads that are dispatched to the local
+	 * DSQ and which won't be detected by antistall.
+	 */
+	if (scx_bpf_dsq_nr_queued(SCX_DSQ_LOCAL_ON | cpuc->cpu))
+		goto no;
+
 	/* @p has fully consumed its slice and still wants to run */
 	cpuc->ran_current_for += layer->slice_ns;
 


### PR DESCRIPTION
keep_running() is invoked on the dispatch path when deciding whether a CPU should continue running the task whose slice has expired, or should instead pick a different task.

It currently has a fairly serious bug in that it does not check whether there is a task queued on the CPU's local DSQ. Pinned tasks such as per-CPU kthreads are direct-inserted there and can run nowhere else. antistall can't rescue them either, since it only scans layer and fallback DSQs. Such a task can therefore starve until the runnable-stall watchdog trips and ejects the scheduler.

Let's therefore add a check in keep_running() for whether there is another task on the local DSQ. This fixes stalls that were observed in production in GKE and EKS scenarios experiencing sustained CPU pressure.