### PR TITLE
scx_lavd: Scale the deadline compete window by the oversubscription ratio

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lat_cri.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/lat_cri.bpf.c
@@ -346,18 +346,33 @@ static u64 calc_virtual_deadline_delta(struct task_struct *p,
 	return deadline >> LAVD_SHIFT;
 }
 
+static u64 calc_compete_window(void)
+{
+	u64 nr_q = sys_stat.nr_queued_task;
+	u64 nr_a = max(sys_stat.nr_active, 1);
+
+	/*
+	 * The compete window is meant to boost bursty tasks that wake and
+	 * block frequently, as they'll benefit from the enqueue-time boost
+	 * more frequently than longer-running tasks. However, if the window is
+	 * too large, then the global clock will be incremented very
+	 * infrequently, which can cause fairness issues.
+	 *
+	 * We therefore shrink the window proportionally to the
+	 * oversubscription ratio so that the window scales inversely with the
+	 * number of enqueued tasks.
+	 */
+	if (nr_q > nr_a)
+		return (LAVD_DL_COMPETE_WINDOW * nr_a) / nr_q;
+	return LAVD_DL_COMPETE_WINDOW;
+}
+
 __hidden
 u64 calc_when_to_run(struct task_struct *p, task_ctx *taskc)
 {
 	u64 dl_delta, clc;
 
-	/*
-	 * Before enqueueing a task to a run queue, we should decide when a
-	 * task should be scheduled. We start from -LAVD_DL_COMPETE_WINDOW
-	 * so that the current task can compete against the already enqueued
-	 * tasks within [-LAVD_DL_COMPETE_WINDOW, 0].
-	 */
 	dl_delta = calc_virtual_deadline_delta(p, taskc);
-	clc = READ_ONCE(cur_logical_clk) - LAVD_DL_COMPETE_WINDOW;
+	clc = READ_ONCE(cur_logical_clk) - calc_compete_window();
 	return clc + dl_delta;
 }


### PR DESCRIPTION
In calc_when_to_run(), lavd computes a task's vtime as (logical_clock - LAVD_DL_COMPETE_WINDOW + delta). The idea here is to give a boost to tasks that have bursty workloads by giving them a boost when they're first enqueued (thus, tasks that run for short windows enqueue more frequently, and get more frequent boosts).

In a8a25fcb ("Increase greedy factor in deadline calculation"), this window was extended as part of an effort to prevent fork bombs from starving latency-critical tasks. Unfortunately, this also introduced a regression in lavd:

When a task's deadline delta is smaller than the aforementioned window, then its vtime lands behind cur_logical_clk. cur_logical_clk is monotonically increasing, and advance_cur_logical_clk() therefore correctly checks that the vtime of a task is not behind the current clock value. However, with a much larger window, it will become much less likely that a given task will actually be able to increment the logical clock due to its vtime being a function of subtracting the window. For workloads such as hackbench which have a ton of bursty tasks, this can cause problems because the only fairness mechanism is now dl_delta.

To fix this, we can scale the window by how oversubscribed the system is. We can grant the full window while the runnable backlog fits the active CPUs, and shrink it by nr_active/nr_queued beyond that so aging resumes as the backlog grows. This uses the same normalization calc_sys_time_slice() and advance_cur_logical_clk() already apply, and the same nr_queued <= nr_active boundary as can_boost_slice().

On my AMD 7950X, this resulted in the following improvements on hackbench -g8 -l10000:

Before:
25.54 +/- 0.37x

After:
17.43 +/- 0.04s

Fixes: #3303

Note: This fix was found + initial draft created by the Crucible project: https://github.com/Byte-Lab/crucible