### PR TITLE
scx_layered: skip absent CPUs when initializing per-cpu ctxs

### DIFF
--- a/scheds/rust/scx_layered/src/main.rs
+++ b/scheds/rust/scx_layered/src/main.rs
@@ -2418,14 +2418,21 @@ impl<'a> Scheduler<'a> {
             .map(|(idx, _)| idx as u32)
             .collect();
 
-        // FIXME - this incorrectly assumes all possible CPUs are consecutive.
+        // The percpu map has one slot per possible CPU, but topo only tracks
+        // CPUs that are actually present. In VMs where CONFIG_NR_CPUS exceeds
+        // the number of vCPUs the guest boots with (e.g. NR_CPUS=512 with 384
+        // online), the possible range is sparse. Skip the topo-dependent init
+        // for absent slots; their ctx stays zero-initialized from the map
+        // lookup, which is fine because BPF never runs on those CPUs.
         for cpu in 0..*NR_CPUS_POSSIBLE {
             cpu_ctxs.push(
                 *plain::from_bytes(cpu_ctxs_vec[cpu].as_slice())
                     .expect("cpu_ctx: short or misaligned buffer"),
             );
 
-            let topo_cpu = topo.all_cpus.get(&cpu).unwrap();
+            let Some(topo_cpu) = topo.all_cpus.get(&cpu) else {
+                continue;
+            };
             let is_big = topo_cpu.core_type == CoreType::Big { turbo: true };
             cpu_ctxs[cpu].cpu = cpu as i32;
             cpu_ctxs[cpu].layer_id = MAX_LAYERS as u32;


### PR DESCRIPTION
init_cpus() iterated 0..NR_CPUS_POSSIBLE and unwrapped topo.all_cpus.get(&cpu), which panics for possible-but-not-present CPUs. On bare metal possible == online so this never triggers, but a VM booted on a kernel with CONFIG_NR_CPUS > vCPU count (e.g. an fbk kernel with NR_CPUS=512 booted with 384 vCPUs) has a sparse possible range and hits the panic at the first missing slot.

Guard the topo lookup and skip absent slots. The percpu map still gets one entry per possible CPU (the ctx stays zero-initialized for absent slots, which is fine because BPF never runs on them), so downstream code that indexes cpu_ctxs[cpu_id] keeps working.

Validated with virtme-run using --cpus 384 --qemu-opts -smp cpus=384,maxcpus=512 (KVM capped online at 256, so the actual guest saw possible=0-511 online=0-255):

Before (panic):

  VM_UP
  POSSIBLE=0-511
  ONLINE=0-255
  INFO scx_layered: CPUs: online/possible=256/512 nr_cores=256
  INFO scx_layered: Running scx_layered (build ID: 1.1.2 x86_64-unknown-linux-gnu/debug)
  thread 'main' (3014) panicked at scheds/rust/scx_layered/src/main.rs:2428:52:
  called `Option::unwrap()` on a `None` value
  EXITCODE=101

After (clean startup and shutdown):

  VM_UP
  POSSIBLE=0-511
  ONLINE=0-255
  INFO scx_layered: CPUs: online/possible=256/512 nr_cores=256
  INFO scx_layered: Running scx_layered (build ID: 1.1.2 x86_64-unknown-linux-gnu/debug)
  INFO scx_layered: Layered Scheduler Attached. Run `scx_layered --monitor` for metrics.
  EXIT: unregistered from user space
  INFO scx_layered: Unregister scx_layered scheduler
  EXITCODE=0
  