### PR TITLE
scx_rusty: release retained task cpumask before reuse

### DIFF
--- a/scheds/rust/scx_rusty/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rusty/src/bpf/main.bpf.c
@@ -123,6 +123,21 @@ static s32 create_save_cpumask(struct bpf_cpumask **kptr)
 	return 0;
 }
 
+/*
+ * Hash map value recycling may retain referenced kptrs instead of eagerly
+ * releasing them. Explicitly detach and release any retained cpumask before
+ * initializing a recycled map value. On older kernels the exchange normally
+ * returns NULL, making this a no-op.
+ */
+static void release_retained_cpumask(struct bpf_cpumask **kptr)
+{
+	struct bpf_cpumask *cpumask;
+
+	cpumask = bpf_kptr_xchg(kptr, NULL);
+	if (cpumask)
+		bpf_cpumask_release(cpumask);
+}
+
 static int scx_rusty_percpu_storage_init(void)
 {
 	void *map = &scx_percpu_bpfmask_map;
@@ -1688,6 +1703,7 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rusty_init_task, struct task_struct *p,
 		return -EINVAL;
 	}
 
+	release_retained_cpumask(&mask_map_value->instance);
 	ret = create_save_cpumask(&mask_map_value->instance);
 	if (ret) {
 		bpf_map_delete_elem(&task_masks, &p_map);
@@ -1705,7 +1721,14 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rusty_init_task, struct task_struct *p,
 void BPF_STRUCT_OPS(rusty_exit_task, struct task_struct *p,
 		    struct scx_exit_task_args *args)
 {
+	struct bpfmask_wrapper *mask_map_value;
+	struct task_struct *p_map;
 	long ret;
+
+	p_map = p;
+	mask_map_value = bpf_map_lookup_elem(&task_masks, &p_map);
+	if (mask_map_value)
+		release_retained_cpumask(&mask_map_value->instance);
 
 	sdt_task_free(p);
 


### PR DESCRIPTION
Linux 7.2 changed BPF map update and delete semantics in commit a3a81d247651 (bpf: Cancel special fields on map value recycle). Referenced kptrs are no longer eagerly destroyed when a map value is recycled because their destructors are not safe in every BPF execution context.

task_masks is a preallocated hash map whose value owns a referenced bpf_cpumask kptr. A recycled entry can therefore retain the old mask. Rusty then exchanges in a new mask, sees the retained pointer, and reports kptr already had cpumask, causing scheduler startup to fail.

Detach and release any retained cpumask before initializing the entry. Older kernels already leave the slot empty, so the exchange returns NULL and this is a no-op there.

Validated on Linux 7.2.0-rc4+ and Linux 6.18.40.