### PR TITLE
scxtop: Add memory bandwidth support 

### DIFF
--- a/tools/scxtop/src/app.rs
+++ b/tools/scxtop/src/app.rs
@@ -20,7 +20,8 @@ use crate::get_default_events;
 use crate::render::bpf_programs::{ProgramDetailParams, ProgramsListParams};
 use crate::render::scheduler::{DsqSummaryParams, ProcessLatencyParams, SchedulerViewParams};
 use crate::render::{
-    BpfProgramRenderer, MemoryRenderer, NetworkRenderer, ProcessRenderer, SchedulerRenderer,
+    BandwidthRenderer, BpfProgramRenderer, MemoryRenderer, NetworkRenderer, ProcessRenderer,
+    SchedulerRenderer,
 };
 use crate::search;
 use crate::symbol_data::SymbolData;
@@ -113,6 +114,7 @@ pub struct App<'a> {
     mem_info: MemStatSnapshot,
     memory_view_state: ComponentViewState,
     network_view_state: ComponentViewState,
+    bandwidth_stats: crate::bandwidth_stats::BandwidthStats,
 
     scheduler: String,
     max_cpu_events: usize,
@@ -280,11 +282,13 @@ impl<'a> App<'a> {
         for llc in topo.all_llcs.values() {
             let mut data = LlcData::new(llc.id, llc.node_id, llc.all_cpus.len(), max_cpu_events);
             data.initialize_events(&default_events_str);
+            data.initialize_events(crate::bandwidth_stats::ALL_EVENTS);
             llc_data.insert(llc.id, data);
         }
         for node in topo.nodes.values() {
             let mut data = NodeData::new(node.id, node.all_cpus.len(), max_cpu_events);
             data.initialize_events(&default_events_str);
+            data.initialize_events(crate::bandwidth_stats::ALL_EVENTS);
             node_data.insert(node.id, data);
         }
 
@@ -379,6 +383,7 @@ impl<'a> App<'a> {
             mem_info,
             memory_view_state: ComponentViewState::Default,
             network_view_state: ComponentViewState::Default,
+            bandwidth_stats: crate::bandwidth_stats::BandwidthStats::new(),
             scheduler,
             max_cpu_events,
             max_sched_events: max_cpu_events,
@@ -541,11 +546,13 @@ impl<'a> App<'a> {
         for llc in topo.all_llcs.values() {
             let mut data = LlcData::new(llc.id, llc.node_id, llc.all_cpus.len(), max_cpu_events);
             data.initialize_events(&default_events_str);
+            data.initialize_events(crate::bandwidth_stats::ALL_EVENTS);
             llc_data.insert(llc.id, data);
         }
         for node in topo.nodes.values() {
             let mut data = NodeData::new(node.id, node.all_cpus.len(), max_cpu_events);
             data.initialize_events(&default_events_str);
+            data.initialize_events(crate::bandwidth_stats::ALL_EVENTS);
             node_data.insert(node.id, data);
         }
 
@@ -643,6 +650,7 @@ impl<'a> App<'a> {
             mem_info,
             memory_view_state: ComponentViewState::Default,
             network_view_state: ComponentViewState::Default,
+            bandwidth_stats: crate::bandwidth_stats::BandwidthStats::new(),
             scheduler,
             max_cpu_events,
             max_sched_events: max_cpu_events,
@@ -1115,6 +1123,7 @@ impl<'a> App<'a> {
     /// Uses view-specific data collection to optimize performance.
     fn on_tick(&mut self) -> Result<()> {
         match self.state {
+            AppState::Bandwidth => self.on_tick_bandwidth(),
             AppState::BpfProgramDetail => self.on_tick_bpf_program_detail(),
             AppState::BpfPrograms => self.on_tick_bpf_programs(),
             AppState::Default => self.on_tick_default(),
@@ -2544,6 +2553,7 @@ impl<'a> App<'a> {
         // Update terminal width for overhead history sizing
         self.terminal_width = area.width;
         match self.state {
+            AppState::Bandwidth => self.render_bandwidth(frame),
             AppState::BpfPrograms => self.render_bpf_programs(frame),
             AppState::BpfProgramDetail => self.render_bpf_program_detail(frame),
             AppState::Help => self.render_help(frame),
@@ -2891,6 +2901,15 @@ impl<'a> App<'a> {
                         .active_keymap
                         .action_keys_string(Action::SetState(AppState::Memory)),
                     self.memory_view_state
+                ),
+                Style::default(),
+            )),
+            Line::from(Span::styled(
+                format!(
+                    "{}: display memory bandwidth view",
+                    self.config
+                        .active_keymap
+                        .action_keys_string(Action::SetState(AppState::Bandwidth)),
                 ),
                 Style::default(),
             )),
@@ -3787,6 +3806,27 @@ impl<'a> App<'a> {
 
         frame.render_widget(paragraph, area);
         Ok(())
+    }
+
+    /// Renders the bandwidth application state.
+    fn render_bandwidth(&mut self, frame: &mut Frame) -> Result<()> {
+        // Each metric row is split left/right into LLC and Node panels of
+        // equal width, so a sparkline in either panel wants that many
+        // samples to fill horizontally.
+        let panel_width = (frame.area().width / 2) as usize;
+        if self.max_cpu_events != panel_width && panel_width > 0 {
+            self.resize_events(panel_width);
+        }
+        let theme = self.theme();
+        BandwidthRenderer::render_bandwidth_view(
+            frame,
+            &self.bandwidth_stats,
+            &self.llc_data,
+            &self.node_data,
+            &self.view_state,
+            self.config.tick_rate_ms(),
+            theme,
+        )
     }
 
     /// Renders the memory application state.
@@ -7284,6 +7324,65 @@ impl<'a> App<'a> {
     /// Memory view: focus on memory stats
     fn on_tick_memory(&mut self) -> Result<()> {
         self.mem_info.update()?;
+        Ok(())
+    }
+
+    /// Bandwidth view: sample resctrl MBM/CMT counters, roll up per-LLC
+    /// readings into node-level and system-level aggregates, and append them
+    /// to the per-topology EventData ring buffers used by the renderer.
+    fn on_tick_bandwidth(&mut self) -> Result<()> {
+        // Push a zero for every LLC/Node first — the renderer needs a fresh
+        // sample slot even when nothing is collected this tick.
+        for event in crate::bandwidth_stats::ALL_EVENTS {
+            for llc_data in self.llc_data.values_mut() {
+                llc_data.add_event_data(event, 0);
+            }
+            for node_data in self.node_data.values_mut() {
+                node_data.add_event_data(event, 0);
+            }
+        }
+
+        let snapshot = match self.bandwidth_stats.sample()? {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+
+        // Map resctrl domain id (== Llc::kernel_id) to the monotonic id used
+        // as the key for LlcData / NodeData.
+        for llc in self.topo.all_llcs.values() {
+            let Some(reading) = snapshot.per_domain.get(&llc.kernel_id) else {
+                continue;
+            };
+            if let Some(llc_data) = self.llc_data.get_mut(&llc.id) {
+                llc_data.add_cpu_event_data(
+                    crate::bandwidth_stats::EVENT_MBM_LOCAL_BPS,
+                    reading.mbm_local_bps,
+                );
+                llc_data.add_cpu_event_data(
+                    crate::bandwidth_stats::EVENT_MBM_TOTAL_BPS,
+                    reading.mbm_total_bps,
+                );
+                llc_data.add_cpu_event_data(
+                    crate::bandwidth_stats::EVENT_LLC_OCCUPANCY,
+                    reading.llc_occupancy_bytes,
+                );
+            }
+            if let Some(node_data) = self.node_data.get_mut(&llc.node_id) {
+                node_data.add_cpu_event_data(
+                    crate::bandwidth_stats::EVENT_MBM_LOCAL_BPS,
+                    reading.mbm_local_bps,
+                );
+                node_data.add_cpu_event_data(
+                    crate::bandwidth_stats::EVENT_MBM_TOTAL_BPS,
+                    reading.mbm_total_bps,
+                );
+                node_data.add_cpu_event_data(
+                    crate::bandwidth_stats::EVENT_LLC_OCCUPANCY,
+                    reading.llc_occupancy_bytes,
+                );
+            }
+        }
+
         Ok(())
     }
 

--- a/tools/scxtop/src/bandwidth_stats.rs
+++ b/tools/scxtop/src/bandwidth_stats.rs
@@ -1,0 +1,326 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+//! Memory-bandwidth and L3 occupancy collection via Intel RDT / AMD PQoS
+//! monitoring exported through the kernel's resctrl filesystem.
+//!
+//! Reads counters from `/sys/fs/resctrl/mon_data/mon_L3_<id>/` and derives
+//! bytes-per-second rates from tick-to-tick deltas.
+
+use anyhow::{bail, Result};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+pub const RESCTRL_ROOT: &str = "/sys/fs/resctrl";
+
+/// Event-name keys used to store bandwidth samples in the shared
+/// per-topology EventData maps.
+pub const EVENT_MBM_LOCAL_BPS: &str = "mbm_local_bps";
+pub const EVENT_MBM_TOTAL_BPS: &str = "mbm_total_bps";
+pub const EVENT_LLC_OCCUPANCY: &str = "llc_occupancy_bytes";
+
+pub const ALL_EVENTS: &[&str] = &[
+    EVENT_MBM_LOCAL_BPS,
+    EVENT_MBM_TOTAL_BPS,
+    EVENT_LLC_OCCUPANCY,
+];
+
+/// Per-L3-domain reading derived from a single sample.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct LlcBandwidth {
+    /// Local (same-NUMA) memory bandwidth in bytes/sec.
+    pub mbm_local_bps: u64,
+    /// Total memory bandwidth in bytes/sec.
+    pub mbm_total_bps: u64,
+    /// Instantaneous L3 occupancy in bytes.
+    pub llc_occupancy_bytes: u64,
+}
+
+/// Result of a sample() call: one reading per L3 domain, keyed by
+/// resctrl domain id (matches [`scx_utils::Topology`]'s LLC `kernel_id`).
+#[derive(Clone, Debug, Default)]
+pub struct BandwidthSnapshot {
+    pub per_domain: BTreeMap<usize, LlcBandwidth>,
+}
+
+#[derive(Clone, Debug)]
+enum State {
+    /// Detection has not been attempted yet.
+    Uninit,
+    /// Ready to sample. Holds the last raw counter values and their timestamp.
+    Ready {
+        domains: Vec<Domain>,
+        has_local: bool,
+        has_total: bool,
+        has_occupancy: bool,
+    },
+    /// Detection failed; reason is displayed in the view.
+    Unavailable(String),
+}
+
+#[derive(Clone, Debug)]
+struct Domain {
+    id: usize,
+    path: PathBuf,
+    last_local: Option<u64>,
+    last_total: Option<u64>,
+    last_read: Option<Instant>,
+}
+
+pub struct BandwidthStats {
+    state: State,
+}
+
+impl Default for BandwidthStats {
+    fn default() -> Self {
+        Self {
+            state: State::Uninit,
+        }
+    }
+}
+
+impl BandwidthStats {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Human-readable description of the current source (or the reason
+    /// no source is available). Suitable for a view header.
+    pub fn source_label(&self) -> String {
+        match &self.state {
+            State::Uninit => "resctrl (not probed)".to_string(),
+            State::Ready {
+                has_local,
+                has_total,
+                has_occupancy,
+                ..
+            } => {
+                let mut feats: Vec<&str> = Vec::new();
+                if *has_local {
+                    feats.push("local_bw");
+                }
+                if *has_total {
+                    feats.push("total_bw");
+                }
+                if *has_occupancy {
+                    feats.push("occupancy");
+                }
+                format!("resctrl [{}]", feats.join(","))
+            }
+            State::Unavailable(reason) => format!("unavailable: {reason}"),
+        }
+    }
+
+    pub fn is_available(&self) -> bool {
+        matches!(self.state, State::Ready { .. })
+    }
+
+    /// Returns which of the three metrics the current source actually
+    /// exposes. Used by the renderer to hide/label empty panels.
+    pub fn feature_flags(&self) -> (bool, bool, bool) {
+        match &self.state {
+            State::Ready {
+                has_local,
+                has_total,
+                has_occupancy,
+                ..
+            } => (*has_local, *has_total, *has_occupancy),
+            _ => (false, false, false),
+        }
+    }
+
+    /// Reads all monitor domains and returns per-LLC bandwidth. Returns
+    /// `Ok(None)` if the source is unavailable.
+    ///
+    /// The first successful call primes the deltas and returns `Ok(Some(..))`
+    /// with zero-valued bandwidths (occupancy is a gauge, so it's populated
+    /// immediately).
+    pub fn sample(&mut self) -> Result<Option<BandwidthSnapshot>> {
+        if matches!(self.state, State::Uninit) {
+            self.state = detect();
+        }
+        let State::Ready {
+            domains,
+            has_local,
+            has_total,
+            has_occupancy,
+            ..
+        } = &mut self.state
+        else {
+            return Ok(None);
+        };
+
+        let now = Instant::now();
+        let mut out = BandwidthSnapshot::default();
+
+        for dom in domains.iter_mut() {
+            let mut reading = LlcBandwidth::default();
+
+            // Bandwidth (rate metrics: need a delta).
+            let cur_local = if *has_local {
+                read_counter(&dom.path.join("mbm_local_bytes"))
+                    .ok()
+                    .flatten()
+            } else {
+                None
+            };
+            let cur_total = if *has_total {
+                read_counter(&dom.path.join("mbm_total_bytes"))
+                    .ok()
+                    .flatten()
+            } else {
+                None
+            };
+
+            if let (Some(prev), Some(cur), Some(prev_t)) =
+                (dom.last_local, cur_local, dom.last_read)
+            {
+                reading.mbm_local_bps = to_bps(prev, cur, now.duration_since(prev_t).as_secs_f64());
+            }
+            if let (Some(prev), Some(cur), Some(prev_t)) =
+                (dom.last_total, cur_total, dom.last_read)
+            {
+                reading.mbm_total_bps = to_bps(prev, cur, now.duration_since(prev_t).as_secs_f64());
+            }
+
+            if *has_occupancy {
+                if let Ok(Some(occ)) = read_counter(&dom.path.join("llc_occupancy")) {
+                    reading.llc_occupancy_bytes = occ;
+                }
+            }
+
+            dom.last_local = cur_local.or(dom.last_local);
+            dom.last_total = cur_total.or(dom.last_total);
+            dom.last_read = Some(now);
+
+            out.per_domain.insert(dom.id, reading);
+        }
+
+        Ok(Some(out))
+    }
+}
+
+fn detect() -> State {
+    let root = Path::new(RESCTRL_ROOT);
+    if !root.is_dir() {
+        return State::Unavailable(format!("{RESCTRL_ROOT} not present"));
+    }
+    let mon_data = root.join("mon_data");
+    if !mon_data.is_dir() {
+        return State::Unavailable(
+            "resctrl not mounted (try: mount -t resctrl resctrl /sys/fs/resctrl)".to_string(),
+        );
+    }
+
+    let features = fs::read_to_string(root.join("info/L3_MON/mon_features")).unwrap_or_default();
+    let has_local = features
+        .split_ascii_whitespace()
+        .any(|f| f == "mbm_local_bytes");
+    let has_total = features
+        .split_ascii_whitespace()
+        .any(|f| f == "mbm_total_bytes");
+    let has_occupancy = features
+        .split_ascii_whitespace()
+        .any(|f| f == "llc_occupancy");
+    if !has_local && !has_total && !has_occupancy {
+        return State::Unavailable("L3_MON exposes no supported features".to_string());
+    }
+
+    let domains = match enumerate_domains(&mon_data) {
+        Ok(d) if !d.is_empty() => d,
+        Ok(_) => return State::Unavailable("no mon_L3_* domains found".to_string()),
+        Err(e) => return State::Unavailable(format!("enumerate mon_data: {e}")),
+    };
+
+    State::Ready {
+        domains,
+        has_local,
+        has_total,
+        has_occupancy,
+    }
+}
+
+fn enumerate_domains(mon_data: &Path) -> Result<Vec<Domain>> {
+    let mut out = Vec::new();
+    for entry in fs::read_dir(mon_data)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(rest) = name.strip_prefix("mon_L3_") else {
+            continue;
+        };
+        let id = match rest.parse::<usize>() {
+            Ok(id) => id,
+            Err(_) => continue,
+        };
+        out.push(Domain {
+            id,
+            path: entry.path(),
+            last_local: None,
+            last_total: None,
+            last_read: None,
+        });
+    }
+    out.sort_by_key(|d| d.id);
+    Ok(out)
+}
+
+/// Reads a resctrl counter file. Returns `Ok(None)` when the counter
+/// reports "Unavailable" (kernel signals that the RMID lost its slot).
+fn read_counter(path: &Path) -> Result<Option<u64>> {
+    let raw = fs::read_to_string(path)?;
+    let trimmed = raw.trim();
+    if trimmed.eq_ignore_ascii_case("Unavailable") {
+        return Ok(None);
+    }
+    match trimmed.parse::<u64>() {
+        Ok(v) => Ok(Some(v)),
+        Err(e) => bail!("parse {}: {}", path.display(), e),
+    }
+}
+
+fn to_bps(prev: u64, cur: u64, seconds: f64) -> u64 {
+    if seconds <= 0.0 {
+        return 0;
+    }
+    // The kernel unwraps hardware counters into a 64-bit software counter,
+    // so a simple wrapping delta is enough for the pathological reset case.
+    let delta = cur.wrapping_sub(prev);
+    (delta as f64 / seconds) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bps_zero_when_no_elapsed() {
+        assert_eq!(to_bps(100, 200, 0.0), 0);
+    }
+
+    #[test]
+    fn bps_computes_rate() {
+        assert_eq!(to_bps(1_000, 2_000, 1.0), 1_000);
+        assert_eq!(to_bps(0, 1_000_000_000, 2.0), 500_000_000);
+    }
+
+    #[test]
+    fn bps_handles_wrap() {
+        assert_eq!(to_bps(u64::MAX - 99, u64::MAX, 1.0), 99);
+        assert_eq!(to_bps(u64::MAX, 0, 1.0), 1);
+    }
+
+    #[test]
+    fn detect_reports_unavailable_gracefully() {
+        // We just want to prove the collector doesn't panic when nothing is
+        // present. On CI the resctrl root may or may not exist.
+        let mut s = BandwidthStats::new();
+        let _ = s.sample();
+        let label = s.source_label();
+        assert!(!label.is_empty());
+    }
+}

--- a/tools/scxtop/src/keymap.rs
+++ b/tools/scxtop/src/keymap.rs
@@ -54,6 +54,7 @@ impl Default for KeyMap {
         bindings.insert(Key::Char('M'), Action::SetState(AppState::Memory));
         bindings.insert(Key::Char('?'), Action::SetState(AppState::Help));
         bindings.insert(Key::Char('l'), Action::SetState(AppState::Llc));
+        bindings.insert(Key::Char('B'), Action::SetState(AppState::Bandwidth));
         bindings.insert(Key::Char('n'), Action::SetState(AppState::Node));
         bindings.insert(Key::Char('N'), Action::SetState(AppState::Network));
         bindings.insert(Key::Char('w'), Action::SetState(AppState::Power));
@@ -379,6 +380,7 @@ pub fn parse_action(action_str: &str) -> Result<Action> {
         "ToggleLocalization" => Ok(Action::ToggleLocalization),
         "ToggleHwPressure" => Ok(Action::ToggleHwPressure),
         "AppStateHelp" | "SetState(Help)" => Ok(Action::SetState(AppState::Help)),
+        "AppStateBandwidth" | "SetState(Bandwidth)" => Ok(Action::SetState(AppState::Bandwidth)),
         "AppStateLlc" | "SetState(Llc)" => Ok(Action::SetState(AppState::Llc)),
         "AppStateMangoApp" | "SetState(MangoApp)" => Ok(Action::SetState(AppState::MangoApp)),
         "AppStateMemory" | "SetState(Memory)" => Ok(Action::SetState(AppState::Memory)),

--- a/tools/scxtop/src/lib.rs
+++ b/tools/scxtop/src/lib.rs
@@ -4,6 +4,7 @@
 // GNU General Public License version 2.
 
 mod app;
+pub mod bandwidth_stats;
 pub mod bpf_intf;
 mod bpf_prog_data;
 pub mod bpf_skel;
@@ -40,6 +41,7 @@ pub mod util;
 
 pub use crate::bpf_skel::types::bpf_event;
 pub use app::App;
+pub use bandwidth_stats::{BandwidthSnapshot, BandwidthStats, LlcBandwidth};
 pub use bpf_prog_data::{BpfProgData, BpfProgStats};
 pub use bpf_skel::*;
 pub use columns::{Column, Columns};
@@ -88,6 +90,8 @@ pub const SCHED_NAME_PATH: &str = "/sys/kernel/sched_ext/root/ops";
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum AppState {
+    /// Application is in the memory-bandwidth state.
+    Bandwidth,
     /// Application is in the BPF programs state.
     BpfPrograms,
     /// Application is in the BPF program detail state.
@@ -807,6 +811,7 @@ impl std::fmt::Display for Action {
             Action::ToggleLocalization => write!(f, "ToggleLocalization"),
             Action::ToggleHwPressure => write!(f, "ToggleHwPressure"),
             Action::SetState(AppState::Help) => write!(f, "AppStateHelp"),
+            Action::SetState(AppState::Bandwidth) => write!(f, "AppStateBandwidth"),
             Action::SetState(AppState::Llc) => write!(f, "AppStateLlc"),
             Action::SetState(AppState::Network) => write!(f, "AppStateNetwork"),
             Action::SetState(AppState::Node) => write!(f, "AppStateNode"),

--- a/tools/scxtop/src/render/bandwidth.rs
+++ b/tools/scxtop/src/render/bandwidth.rs
@@ -28,22 +28,16 @@ pub struct BandwidthRenderer;
 #[derive(Copy, Clone)]
 enum Metric {
     MbmLocal,
+    MbmRemote,
     MbmTotal,
     Occupancy,
 }
 
 impl Metric {
-    fn event(self) -> &'static str {
-        match self {
-            Metric::MbmLocal => EVENT_MBM_LOCAL_BPS,
-            Metric::MbmTotal => EVENT_MBM_TOTAL_BPS,
-            Metric::Occupancy => EVENT_LLC_OCCUPANCY,
-        }
-    }
-
     fn title(self) -> &'static str {
         match self {
             Metric::MbmLocal => "Local Memory Bandwidth",
+            Metric::MbmRemote => "Remote Memory Bandwidth",
             Metric::MbmTotal => "Total Memory Bandwidth",
             Metric::Occupancy => "L3 Cache Occupancy",
         }
@@ -51,7 +45,7 @@ impl Metric {
 
     fn format(self, v: u64) -> String {
         match self {
-            Metric::MbmLocal | Metric::MbmTotal => format_bytes_per_sec(v),
+            Metric::MbmLocal | Metric::MbmRemote | Metric::MbmTotal => format_bytes_per_sec(v),
             Metric::Occupancy => format_bytes(v),
         }
     }
@@ -78,6 +72,7 @@ impl BandwidthRenderer {
         let (has_local, has_total, has_occupancy) = stats.feature_flags();
         let metrics: Vec<Metric> = [
             (Metric::MbmLocal, has_local),
+            (Metric::MbmRemote, has_local && has_total),
             (Metric::MbmTotal, has_total),
             (Metric::Occupancy, has_occupancy),
         ]
@@ -155,11 +150,34 @@ fn render_unavailable(frame: &mut Frame, area: Rect, stats: &BandwidthStats, the
     frame.render_widget(para, area);
 }
 
+fn series_for_metric<F>(metric: Metric, read: F) -> Vec<u64>
+where
+    F: Fn(&str) -> Vec<u64>,
+{
+    match metric {
+        Metric::MbmLocal => read(EVENT_MBM_LOCAL_BPS),
+        Metric::MbmTotal => read(EVENT_MBM_TOTAL_BPS),
+        Metric::Occupancy => read(EVENT_LLC_OCCUPANCY),
+        Metric::MbmRemote => {
+            // Derived: total − local per sample, saturating at zero to
+            // absorb the case where local reads race ahead of total on
+            // the first prime tick.
+            let total = read(EVENT_MBM_TOTAL_BPS);
+            let local = read(EVENT_MBM_LOCAL_BPS);
+            total
+                .iter()
+                .zip(local.iter().chain(std::iter::repeat(&0)))
+                .map(|(t, l)| t.saturating_sub(*l))
+                .collect()
+        }
+    }
+}
+
 fn llc_values(metric: Metric, llc_data: &BTreeMap<usize, LlcData>) -> Vec<(usize, Vec<u64>, u64)> {
     llc_data
         .iter()
         .map(|(id, d)| {
-            let series = d.event_data_immut(metric.event());
+            let series = series_for_metric(metric, |e| d.event_data_immut(e));
             let current = series.last().copied().unwrap_or(0);
             (*id, series, current)
         })
@@ -173,26 +191,48 @@ fn node_values(
     node_data
         .iter()
         .map(|(id, d)| {
-            let series = d.event_data_immut(metric.event());
+            let series = series_for_metric(metric, |e| d.event_data_immut(e));
             let current = series.last().copied().unwrap_or(0);
             (*id, series, current)
         })
         .collect()
 }
 
+/// Nearest-rank percentile over a pre-sorted slice.
+fn percentile_sorted(sorted: &[u64], p: u32) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let n = sorted.len();
+    // ceil(p/100 * n) - 1, saturating to 0.
+    let idx = (n as u64 * p as u64).div_ceil(100).saturating_sub(1) as usize;
+    sorted[idx.min(n - 1)]
+}
+
 fn stats_line(
     theme: &AppTheme,
     title: &str,
     metric: Metric,
-    values: &[u64],
+    entries: &[(usize, Vec<u64>, u64)],
     system_total: u64,
 ) -> Line<'static> {
-    let max = *values.iter().max().unwrap_or(&0);
-    let avg: u64 = if values.is_empty() {
+    // Flatten every history sample from every entry — that's the pool the
+    // window-wide max/avg/p95 are computed over. Percentiles across only
+    // the current per-entry values are meaningless at 2-8 entries.
+    let mut flat: Vec<u64> = entries
+        .iter()
+        .flat_map(|(_, s, _)| s.iter().copied())
+        .collect();
+    flat.sort_unstable();
+
+    let max = flat.last().copied().unwrap_or(0);
+    let avg: u64 = if flat.is_empty() {
         0
     } else {
-        (values.iter().map(|v| *v as u128).sum::<u128>() / values.len() as u128) as u64
+        (flat.iter().map(|v| *v as u128).sum::<u128>() / flat.len() as u128) as u64
     };
+    let p95 = percentile_sorted(&flat, 95);
+
     Line::from(vec![
         Span::styled(format!("{title} — "), theme.title_style()),
         Span::styled(metric.title(), theme.title_style()),
@@ -200,6 +240,8 @@ fn stats_line(
         Span::styled(metric.format(system_total), theme.text_important_color()),
         Span::styled("  max=", theme.text_color()),
         Span::styled(metric.format(max), theme.text_important_color()),
+        Span::styled("  p95=", theme.text_color()),
+        Span::styled(metric.format(p95), theme.text_important_color()),
         Span::styled("  avg=", theme.text_color()),
         Span::styled(metric.format(avg), theme.text_important_color()),
     ])
@@ -222,9 +264,8 @@ fn render_llc_panel(
     theme: &AppTheme,
 ) {
     let entries = llc_values(metric, llc_data);
-    let currents: Vec<u64> = entries.iter().map(|(_, _, c)| *c).collect();
-    let system_total: u64 = currents.iter().sum();
-    let title = stats_line(theme, "LLCs", metric, &currents, system_total);
+    let system_total: u64 = entries.iter().map(|(_, _, c)| *c).sum();
+    let title = stats_line(theme, "LLCs", metric, &entries, system_total);
     render_topology_panel(
         frame, area, view_state, theme, title, "LLC", metric, &entries,
     );
@@ -239,9 +280,8 @@ fn render_node_panel(
     theme: &AppTheme,
 ) {
     let entries = node_values(metric, node_data);
-    let currents: Vec<u64> = entries.iter().map(|(_, _, c)| *c).collect();
-    let system_total: u64 = currents.iter().sum();
-    let title = stats_line(theme, "Nodes", metric, &currents, system_total);
+    let system_total: u64 = entries.iter().map(|(_, _, c)| *c).sum();
+    let title = stats_line(theme, "Nodes", metric, &entries, system_total);
     render_topology_panel(
         frame, area, view_state, theme, title, "Node", metric, &entries,
     );

--- a/tools/scxtop/src/render/bandwidth.rs
+++ b/tools/scxtop/src/render/bandwidth.rs
@@ -1,0 +1,394 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use crate::bandwidth_stats::{
+    BandwidthStats, EVENT_LLC_OCCUPANCY, EVENT_MBM_LOCAL_BPS, EVENT_MBM_TOTAL_BPS,
+};
+use crate::util::{format_bytes, format_bytes_per_sec};
+use crate::{AppTheme, LlcData, NodeData, ViewState};
+
+use anyhow::Result;
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Style};
+use ratatui::symbols::bar::NINE_LEVELS;
+use ratatui::symbols::line::THICK;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{
+    Bar, BarChart, BarGroup, Block, BorderType, Borders, LineGauge, Paragraph, RenderDirection,
+    Sparkline, Wrap,
+};
+use ratatui::Frame;
+
+use std::collections::BTreeMap;
+
+pub struct BandwidthRenderer;
+
+#[derive(Copy, Clone)]
+enum Metric {
+    MbmLocal,
+    MbmTotal,
+    Occupancy,
+}
+
+impl Metric {
+    fn event(self) -> &'static str {
+        match self {
+            Metric::MbmLocal => EVENT_MBM_LOCAL_BPS,
+            Metric::MbmTotal => EVENT_MBM_TOTAL_BPS,
+            Metric::Occupancy => EVENT_LLC_OCCUPANCY,
+        }
+    }
+
+    fn title(self) -> &'static str {
+        match self {
+            Metric::MbmLocal => "Local Memory Bandwidth",
+            Metric::MbmTotal => "Total Memory Bandwidth",
+            Metric::Occupancy => "L3 Cache Occupancy",
+        }
+    }
+
+    fn format(self, v: u64) -> String {
+        match self {
+            Metric::MbmLocal | Metric::MbmTotal => format_bytes_per_sec(v),
+            Metric::Occupancy => format_bytes(v),
+        }
+    }
+}
+
+impl BandwidthRenderer {
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_bandwidth_view(
+        frame: &mut Frame,
+        stats: &BandwidthStats,
+        llc_data: &BTreeMap<usize, LlcData>,
+        node_data: &BTreeMap<usize, NodeData>,
+        view_state: &ViewState,
+        tick_rate_ms: usize,
+        theme: &AppTheme,
+    ) -> Result<()> {
+        let area = frame.area();
+
+        if !stats.is_available() {
+            render_unavailable(frame, area, stats, theme);
+            return Ok(());
+        }
+
+        let (has_local, has_total, has_occupancy) = stats.feature_flags();
+        let metrics: Vec<Metric> = [
+            (Metric::MbmLocal, has_local),
+            (Metric::MbmTotal, has_total),
+            (Metric::Occupancy, has_occupancy),
+        ]
+        .into_iter()
+        .filter_map(|(m, on)| if on { Some(m) } else { None })
+        .collect();
+
+        if metrics.is_empty() {
+            render_unavailable(frame, area, stats, theme);
+            return Ok(());
+        }
+
+        let header_line = Line::from(vec![
+            Span::styled("source: ", theme.text_color()),
+            Span::styled(stats.source_label(), theme.text_important_color()),
+            Span::styled("   tick: ", theme.text_color()),
+            Span::styled(format!("{tick_rate_ms}ms"), theme.text_important_color()),
+            Span::styled("   view: ", theme.text_color()),
+            Span::styled(view_state.to_string(), theme.text_important_color()),
+        ]);
+        let [header_area, body_area] =
+            Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]).areas(area);
+        frame.render_widget(
+            Paragraph::new(header_line).alignment(Alignment::Center),
+            header_area,
+        );
+
+        let row_constraints: Vec<Constraint> =
+            vec![Constraint::Ratio(1, metrics.len() as u32); metrics.len()];
+        let rows = Layout::vertical(row_constraints).split(body_area);
+
+        for (i, metric) in metrics.iter().enumerate() {
+            let [left, right] = Layout::horizontal([Constraint::Fill(1); 2]).areas(rows[i]);
+            render_llc_panel(frame, left, *metric, llc_data, view_state, theme);
+            render_node_panel(frame, right, *metric, node_data, view_state, theme);
+        }
+
+        Ok(())
+    }
+}
+
+fn render_unavailable(frame: &mut Frame, area: Rect, stats: &BandwidthStats, theme: &AppTheme) {
+    let text = vec![
+        Line::from(Span::styled(
+            "Memory-bandwidth monitoring unavailable",
+            theme.title_style(),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            stats.source_label(),
+            theme.text_important_color(),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Requires Intel RDT / AMD PQoS with the resctrl filesystem mounted.",
+            theme.text_color(),
+        )),
+        Line::from(Span::styled(
+            "Try:  sudo mount -t resctrl resctrl /sys/fs/resctrl",
+            theme.text_color(),
+        )),
+    ];
+    let block = Block::bordered()
+        .title(
+            Line::from("Bandwidth")
+                .style(theme.title_style())
+                .centered(),
+        )
+        .border_type(BorderType::Rounded)
+        .style(theme.border_style());
+    let para = Paragraph::new(text)
+        .block(block)
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(para, area);
+}
+
+fn llc_values(metric: Metric, llc_data: &BTreeMap<usize, LlcData>) -> Vec<(usize, Vec<u64>, u64)> {
+    llc_data
+        .iter()
+        .map(|(id, d)| {
+            let series = d.event_data_immut(metric.event());
+            let current = series.last().copied().unwrap_or(0);
+            (*id, series, current)
+        })
+        .collect()
+}
+
+fn node_values(
+    metric: Metric,
+    node_data: &BTreeMap<usize, NodeData>,
+) -> Vec<(usize, Vec<u64>, u64)> {
+    node_data
+        .iter()
+        .map(|(id, d)| {
+            let series = d.event_data_immut(metric.event());
+            let current = series.last().copied().unwrap_or(0);
+            (*id, series, current)
+        })
+        .collect()
+}
+
+fn stats_line(
+    theme: &AppTheme,
+    title: &str,
+    metric: Metric,
+    values: &[u64],
+    system_total: u64,
+) -> Line<'static> {
+    let max = *values.iter().max().unwrap_or(&0);
+    let avg: u64 = if values.is_empty() {
+        0
+    } else {
+        (values.iter().map(|v| *v as u128).sum::<u128>() / values.len() as u128) as u64
+    };
+    Line::from(vec![
+        Span::styled(format!("{title} — "), theme.title_style()),
+        Span::styled(metric.title(), theme.title_style()),
+        Span::styled("  ∑=", theme.text_color()),
+        Span::styled(metric.format(system_total), theme.text_important_color()),
+        Span::styled("  max=", theme.text_color()),
+        Span::styled(metric.format(max), theme.text_important_color()),
+        Span::styled("  avg=", theme.text_color()),
+        Span::styled(metric.format(avg), theme.text_important_color()),
+    ])
+    .centered()
+}
+
+fn panel_block(theme: &AppTheme, title: Line<'static>) -> Block<'static> {
+    Block::bordered()
+        .title_top(title)
+        .border_type(BorderType::Rounded)
+        .style(theme.border_style())
+}
+
+fn render_llc_panel(
+    frame: &mut Frame,
+    area: Rect,
+    metric: Metric,
+    llc_data: &BTreeMap<usize, LlcData>,
+    view_state: &ViewState,
+    theme: &AppTheme,
+) {
+    let entries = llc_values(metric, llc_data);
+    let currents: Vec<u64> = entries.iter().map(|(_, _, c)| *c).collect();
+    let system_total: u64 = currents.iter().sum();
+    let title = stats_line(theme, "LLCs", metric, &currents, system_total);
+    render_topology_panel(
+        frame, area, view_state, theme, title, "LLC", metric, &entries,
+    );
+}
+
+fn render_node_panel(
+    frame: &mut Frame,
+    area: Rect,
+    metric: Metric,
+    node_data: &BTreeMap<usize, NodeData>,
+    view_state: &ViewState,
+    theme: &AppTheme,
+) {
+    let entries = node_values(metric, node_data);
+    let currents: Vec<u64> = entries.iter().map(|(_, _, c)| *c).collect();
+    let system_total: u64 = currents.iter().sum();
+    let title = stats_line(theme, "Nodes", metric, &currents, system_total);
+    render_topology_panel(
+        frame, area, view_state, theme, title, "Node", metric, &entries,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_topology_panel(
+    frame: &mut Frame,
+    area: Rect,
+    view_state: &ViewState,
+    theme: &AppTheme,
+    title: Line<'static>,
+    label_prefix: &str,
+    metric: Metric,
+    entries: &[(usize, Vec<u64>, u64)],
+) {
+    let max_current = entries.iter().map(|(_, _, c)| *c).max().unwrap_or(0);
+    let max_ever = entries
+        .iter()
+        .flat_map(|(_, s, _)| s.iter().copied())
+        .max()
+        .unwrap_or(0)
+        .max(max_current);
+
+    let block = panel_block(theme, title);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if entries.is_empty() || inner.height == 0 {
+        return;
+    }
+
+    match view_state {
+        ViewState::Sparkline => {
+            render_sparklines(frame, inner, theme, label_prefix, metric, entries, max_ever);
+        }
+        ViewState::BarChart => {
+            render_barchart(frame, inner, theme, label_prefix, metric, entries, max_ever);
+        }
+        ViewState::LineGauge => {
+            render_line_gauges(frame, inner, theme, label_prefix, metric, entries, max_ever);
+        }
+    }
+}
+
+fn render_sparklines(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &AppTheme,
+    label_prefix: &str,
+    metric: Metric,
+    entries: &[(usize, Vec<u64>, u64)],
+    global_max: u64,
+) {
+    let visible = (area.height as usize).min(entries.len());
+    if visible == 0 {
+        return;
+    }
+    let constraints = vec![Constraint::Ratio(1, visible as u32); visible];
+    let rows = Layout::vertical(constraints).split(area);
+    for (i, (id, series, current)) in entries.iter().take(visible).enumerate() {
+        let label = format!("{label_prefix}{id} {}", metric.format(*current));
+        let sparkline = Sparkline::default()
+            .direction(RenderDirection::RightToLeft)
+            .data(series.as_slice())
+            .max(global_max.max(1))
+            .bar_set(NINE_LEVELS)
+            .style(Style::default().fg(theme.text_important_color()))
+            .block(Block::default().title(Line::from(label).style(theme.text_color())));
+        frame.render_widget(sparkline, rows[i]);
+    }
+}
+
+fn render_barchart(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &AppTheme,
+    label_prefix: &str,
+    metric: Metric,
+    entries: &[(usize, Vec<u64>, u64)],
+    max_current: u64,
+) {
+    if entries.is_empty() || area.height == 0 {
+        return;
+    }
+    let bars: Vec<Bar> = entries
+        .iter()
+        .map(|(id, _, current)| {
+            Bar::default()
+                .value(*current)
+                .label(Line::from(format!("{label_prefix}{id}")).style(theme.text_color()))
+                .text_value(metric.format(*current))
+                .style(Style::default().fg(theme.text_important_color()))
+        })
+        .collect();
+
+    // Horizontal bars stack vertically; bar_width is the row-thickness of
+    // each bar. Scale it so the group fills the panel height instead of
+    // leaving dead space below.
+    let bar_width = (area.height as usize / entries.len()).max(1) as u16;
+
+    let chart = BarChart::default()
+        .data(BarGroup::default().bars(&bars))
+        .max(max_current.max(1))
+        .direction(Direction::Horizontal)
+        .bar_gap(0)
+        .bar_width(bar_width)
+        .block(Block::default().borders(Borders::NONE));
+    frame.render_widget(chart, area);
+}
+
+fn render_line_gauges(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &AppTheme,
+    label_prefix: &str,
+    metric: Metric,
+    entries: &[(usize, Vec<u64>, u64)],
+    max_current: u64,
+) {
+    let visible = (area.height as usize).min(entries.len());
+    if visible == 0 {
+        return;
+    }
+    // Split the panel evenly so each gauge (which draws on a single line
+    // anyway) sits in its own vertically-centered slice, filling the panel.
+    let constraints = vec![Constraint::Ratio(1, visible as u32); visible];
+    let rows = Layout::vertical(constraints).split(area);
+    let denom = max_current.max(1) as f64;
+    for (i, (id, _, current)) in entries.iter().take(visible).enumerate() {
+        let ratio = ((*current as f64) / denom).clamp(0.0, 1.0);
+        let label = format!("{label_prefix}{id} {}", metric.format(*current));
+        let gauge = LineGauge::default()
+            .ratio(ratio)
+            .filled_symbol(THICK.horizontal)
+            .unfilled_symbol(THICK.horizontal)
+            .label(Line::from(label).style(theme.text_color()))
+            .filled_style(
+                Style::default()
+                    .fg(theme.text_important_color())
+                    .bg(Color::Reset),
+            )
+            .unfilled_style(
+                Style::default()
+                    .fg(theme.border_style().fg.unwrap_or(Color::Gray))
+                    .bg(Color::Reset),
+            );
+        frame.render_widget(gauge, rows[i]);
+    }
+}

--- a/tools/scxtop/src/render/mod.rs
+++ b/tools/scxtop/src/render/mod.rs
@@ -7,6 +7,8 @@
 pub mod process;
 // Memory rendering
 pub mod memory;
+// Memory-bandwidth rendering
+pub mod bandwidth;
 
 // Network rendering
 pub mod network;
@@ -15,6 +17,7 @@ pub mod scheduler;
 // BPF program rendering
 pub mod bpf_programs;
 
+pub use bandwidth::BandwidthRenderer;
 pub use bpf_programs::BpfProgramRenderer;
 pub use memory::MemoryRenderer;
 pub use network::NetworkRenderer;


### PR DESCRIPTION
Adds a new AppState::Bandwidth TUI view (bound to 'B') that samples
Intel RDT / AMD PQoS monitoring counters through the resctrl filesystem
and reports L3-local memory bandwidth, total memory bandwidth, and L3
cache occupancy. Per-LLC readings are rolled up to per-node and system
totals using the existing topology data holders.

<img width="5908" height="3188" alt="2026-07-29-15:43:55" src="https://github.com/user-attachments/assets/653b9062-47ac-4d0b-b57d-61641f488447" />
