### PR TITLE
scx_mitosis: split out debug events

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/debug_events.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/debug_events.bpf.h
@@ -1,0 +1,150 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. */
+/*
+ * This software may be used and distributed according to the terms of the
+ * GNU General Public License version 2.
+ */
+#pragma once
+
+#define DEBUG_EVENTS_BUF_SIZE 4096
+
+enum debug_event_type {
+	DEBUG_EVENT_CGROUP_INIT,
+	DEBUG_EVENT_INIT_TASK,
+	DEBUG_EVENT_CGROUP_EXIT,
+};
+
+struct debug_event {
+	u64 timestamp;
+	u32 event_type;
+	union {
+		struct {
+			u64 cgid;
+		} cgroup_init;
+		struct {
+			u64 cgid;
+			u32 pid;
+		} init_task;
+		struct {
+			u64 cgid;
+		} cgroup_exit;
+	};
+};
+
+const volatile bool debug_events_enabled = false;
+
+u32 debug_event_pos;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, DEBUG_EVENTS_BUF_SIZE);
+	__type(key, u32);
+	__type(value, struct debug_event);
+} debug_events SEC(".maps");
+
+static inline void record_cgroup_init(u64 cgid)
+{
+	struct debug_event *event;
+	u32 pos, idx;
+
+	if (likely(!debug_events_enabled))
+		return;
+
+	pos = __sync_fetch_and_add(&debug_event_pos, 1);
+	idx = pos % DEBUG_EVENTS_BUF_SIZE;
+
+	event = bpf_map_lookup_elem(&debug_events, &idx);
+	if (unlikely(!event))
+		return;
+
+	event->timestamp = scx_bpf_now();
+	event->event_type = DEBUG_EVENT_CGROUP_INIT;
+	event->cgroup_init.cgid = cgid;
+}
+
+static inline void record_init_task(u64 cgid, u32 pid)
+{
+	struct debug_event *event;
+	u32 pos, idx;
+
+	if (likely(!debug_events_enabled))
+		return;
+
+	pos = __sync_fetch_and_add(&debug_event_pos, 1);
+	idx = pos % DEBUG_EVENTS_BUF_SIZE;
+
+	event = bpf_map_lookup_elem(&debug_events, &idx);
+	if (unlikely(!event))
+		return;
+
+	event->timestamp = scx_bpf_now();
+	event->event_type = DEBUG_EVENT_INIT_TASK;
+	event->init_task.cgid = cgid;
+	event->init_task.pid = pid;
+}
+
+static inline void record_cgroup_exit(u64 cgid)
+{
+	struct debug_event *event;
+	u32 pos, idx;
+
+	if (likely(!debug_events_enabled))
+		return;
+
+	pos = __sync_fetch_and_add(&debug_event_pos, 1);
+	idx = pos % DEBUG_EVENTS_BUF_SIZE;
+
+	event = bpf_map_lookup_elem(&debug_events, &idx);
+	if (unlikely(!event))
+		return;
+
+	event->timestamp = scx_bpf_now();
+	event->event_type = DEBUG_EVENT_CGROUP_EXIT;
+	event->cgroup_exit.cgid = cgid;
+}
+
+static void dump_debug_events(void)
+{
+	struct debug_event *event;
+	u32 total_events, start_idx, i;
+	u32 event_num, idx;
+
+	if (!debug_events_enabled)
+		return;
+
+	scx_bpf_dump("\n");
+	scx_bpf_dump("DEBUG EVENTS (last %d):\n", DEBUG_EVENTS_BUF_SIZE);
+
+	total_events = READ_ONCE(debug_event_pos);
+	start_idx = total_events > DEBUG_EVENTS_BUF_SIZE ? total_events - DEBUG_EVENTS_BUF_SIZE : 0;
+
+	bpf_for(i, 0, DEBUG_EVENTS_BUF_SIZE)
+	{
+		event_num = start_idx + i;
+		if (event_num >= total_events)
+			break;
+
+		idx = event_num % DEBUG_EVENTS_BUF_SIZE;
+		event = bpf_map_lookup_elem(&debug_events, &idx);
+		if (!event)
+			continue;
+
+		switch (event->event_type) {
+		case DEBUG_EVENT_CGROUP_INIT:
+			scx_bpf_dump("[%3d] CGROUP_INIT cgid=%llu ts=%llu\n", event_num,
+				     event->cgroup_init.cgid, event->timestamp);
+			break;
+		case DEBUG_EVENT_INIT_TASK:
+			scx_bpf_dump("[%3d] INIT_TASK   cgid=%llu pid=%u ts=%llu\n", event_num,
+				     event->init_task.cgid, event->init_task.pid, event->timestamp);
+			break;
+		case DEBUG_EVENT_CGROUP_EXIT:
+			scx_bpf_dump("[%3d] CGROUP_EXIT cgid=%llu ts=%llu\n", event_num,
+				     event->cgroup_exit.cgid, event->timestamp);
+			break;
+		default:
+			scx_bpf_dump("[%3d] UNKNOWN     type=%u ts=%llu\n", event_num,
+				     event->event_type, event->timestamp);
+			break;
+		}
+	}
+}

--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -23,8 +23,6 @@ enum consts {
 	MAX_CG_DEPTH = 256,
 	MAX_LLCS = 16,
 
-	DEBUG_EVENTS_BUF_SIZE = 4096,
-
 	/* Size of cpumask in unsigned longs (supports up to 8192 CPUs) */
 	CPUMASK_LONG_ENTRIES = 128,
 };
@@ -36,31 +34,6 @@ enum consts {
  */
 struct llc_cpumask {
 	unsigned long bits[CPUMASK_LONG_ENTRIES];
-};
-
-/* Debug event types */
-enum debug_event_type {
-	DEBUG_EVENT_CGROUP_INIT,
-	DEBUG_EVENT_INIT_TASK,
-	DEBUG_EVENT_CGROUP_EXIT,
-};
-
-/* Debug event record - discriminated union */
-struct debug_event {
-	u64 timestamp;
-	u32 event_type;
-	union {
-		struct {
-			u64 cgid;
-		} cgroup_init;
-		struct {
-			u64 cgid;
-			u32 pid;
-		} init_task;
-		struct {
-			u64 cgid;
-		} cgroup_exit;
-	};
 };
 
 /* Statistics */

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -27,6 +27,7 @@
 #define FAKE_FLAT_CELL_LLC 0
 
 #include "mitosis.bpf.h"
+#include "debug_events.bpf.h"
 #include "dsq.bpf.h"
 #include "slice_shrinking.bpf.h"
 #include "llc_aware.bpf.h"
@@ -42,7 +43,6 @@ const volatile unsigned char all_cpus[MAX_CPUS_U8];
 
 const volatile u64 slice_ns;
 const volatile u64 root_cgid = 1;
-const volatile bool debug_events_enabled = false;
 const volatile bool exiting_task_workaround_enabled = true;
 const volatile bool cpu_controller_disabled = false;
 const volatile bool reject_multicpu_pinning = false;
@@ -61,18 +61,6 @@ struct llc_cpumask llc_to_cpus[MAX_LLCS];
 u32 applied_configuration_seq;
 u32 cpuset_seq;
 u32 applied_cpuset_seq;
-
-/*
- * Debug events circular buffer
- */
-u32 debug_event_pos;
-
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__uint(max_entries, DEBUG_EVENTS_BUF_SIZE);
-	__type(key, u32);
-	__type(value, struct debug_event);
-} debug_events SEC(".maps");
 
 /* Configuration struct for apply_cell_config, populated by userspace */
 struct cell_config cell_config;
@@ -201,70 +189,6 @@ static inline struct cpu_ctx *lookup_cpu_ctx(int cpu)
 	}
 
 	return cctx;
-}
-
-/*
- * Record debug events to the circular buffer
- */
-static inline void record_cgroup_init(u64 cgid)
-{
-	struct debug_event *event;
-	u32 pos, idx;
-
-	if (likely(!debug_events_enabled))
-		return;
-
-	pos = __sync_fetch_and_add(&debug_event_pos, 1);
-	idx = pos % DEBUG_EVENTS_BUF_SIZE;
-
-	event = bpf_map_lookup_elem(&debug_events, &idx);
-	if (unlikely(!event))
-		return;
-
-	event->timestamp = scx_bpf_now();
-	event->event_type = DEBUG_EVENT_CGROUP_INIT;
-	event->cgroup_init.cgid = cgid;
-}
-
-static inline void record_init_task(u64 cgid, u32 pid)
-{
-	struct debug_event *event;
-	u32 pos, idx;
-
-	if (likely(!debug_events_enabled))
-		return;
-
-	pos = __sync_fetch_and_add(&debug_event_pos, 1);
-	idx = pos % DEBUG_EVENTS_BUF_SIZE;
-
-	event = bpf_map_lookup_elem(&debug_events, &idx);
-	if (unlikely(!event))
-		return;
-
-	event->timestamp = scx_bpf_now();
-	event->event_type = DEBUG_EVENT_INIT_TASK;
-	event->init_task.cgid = cgid;
-	event->init_task.pid = pid;
-}
-
-static inline void record_cgroup_exit(u64 cgid)
-{
-	struct debug_event *event;
-	u32 pos, idx;
-
-	if (likely(!debug_events_enabled))
-		return;
-
-	pos = __sync_fetch_and_add(&debug_event_pos, 1);
-	idx = pos % DEBUG_EVENTS_BUF_SIZE;
-
-	event = bpf_map_lookup_elem(&debug_events, &idx);
-	if (unlikely(!event))
-		return;
-
-	event->timestamp = scx_bpf_now();
-	event->event_type = DEBUG_EVENT_CGROUP_EXIT;
-	event->cgroup_exit.cgid = cgid;
 }
 
 struct cell_cpumask_map cell_cpumasks SEC(".maps");
@@ -1497,47 +1421,7 @@ void BPF_STRUCT_OPS(mitosis_dump, struct scx_dump_ctx *dctx)
 		}
 	}
 
-	if (!debug_events_enabled)
-		return;
-
-	/* Dump debug events */
-	scx_bpf_dump("\n");
-	scx_bpf_dump("DEBUG EVENTS (last %d):\n", DEBUG_EVENTS_BUF_SIZE);
-
-	u32 total_events = READ_ONCE(debug_event_pos);
-	u32 start_idx =
-		total_events > DEBUG_EVENTS_BUF_SIZE ? total_events - DEBUG_EVENTS_BUF_SIZE : 0;
-
-	bpf_for(i, 0, DEBUG_EVENTS_BUF_SIZE)
-	{
-		u32 event_num = start_idx + i;
-		if (event_num >= total_events)
-			break;
-
-		u32 idx = event_num % DEBUG_EVENTS_BUF_SIZE;
-		struct debug_event *event = bpf_map_lookup_elem(&debug_events, &idx);
-		if (!event)
-			continue;
-
-		switch (event->event_type) {
-		case DEBUG_EVENT_CGROUP_INIT:
-			scx_bpf_dump("[%3d] CGROUP_INIT cgid=%llu ts=%llu\n", event_num,
-				     event->cgroup_init.cgid, event->timestamp);
-			break;
-		case DEBUG_EVENT_INIT_TASK:
-			scx_bpf_dump("[%3d] INIT_TASK   cgid=%llu pid=%u ts=%llu\n", event_num,
-				     event->init_task.cgid, event->init_task.pid, event->timestamp);
-			break;
-		case DEBUG_EVENT_CGROUP_EXIT:
-			scx_bpf_dump("[%3d] CGROUP_EXIT cgid=%llu ts=%llu\n", event_num,
-				     event->cgroup_exit.cgid, event->timestamp);
-			break;
-		default:
-			scx_bpf_dump("[%3d] UNKNOWN     type=%u ts=%llu\n", event_num,
-				     event->event_type, event->timestamp);
-			break;
-		}
-	}
+	dump_debug_events();
 }
 
 void BPF_STRUCT_OPS(mitosis_dump_task, struct scx_dump_ctx *dctx, struct task_struct *p)

--- a/scheds/rust/scx_mitosis/test/test_debug_events.sh
+++ b/scheds/rust/scx_mitosis/test/test_debug_events.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Validate scx_mitosis debug-event recording through a live sched_ext dump.
+
+set -euo pipefail
+
+SCHEDULER_BIN="${SCHEDULER_BIN:-./target/release/scx_mitosis}"
+TRACE_ROOT="/sys/kernel/tracing"
+TEST_NAME="scx_mitosis_debug_events_$$"
+CGROUP_BASE="/sys/fs/cgroup/$TEST_NAME"
+CELL_CGROUP="$CGROUP_BASE/cell"
+TRACE_INSTANCE="$TRACE_ROOT/instances/$TEST_NAME"
+TRACE_OUTPUT="/tmp/$TEST_NAME.trace"
+SCHED_LOG="/tmp/$TEST_NAME.log"
+
+SCHED_PID=""
+WORKER_PID=""
+TRACE_READER_PID=""
+CELL_CGID=""
+
+cleanup() {
+	set +e
+
+	if [[ -n "$TRACE_READER_PID" ]]; then
+		kill "$TRACE_READER_PID" 2>/dev/null
+		wait "$TRACE_READER_PID" 2>/dev/null
+	fi
+
+	if [[ -d "$CELL_CGROUP" ]]; then
+		echo 1 > "$CELL_CGROUP/cgroup.kill" 2>/dev/null
+	fi
+	if [[ -n "$WORKER_PID" ]]; then
+		wait "$WORKER_PID" 2>/dev/null
+	fi
+
+	if [[ -n "$SCHED_PID" ]]; then
+		kill -TERM "$SCHED_PID" 2>/dev/null
+		for _ in $(seq 1 20); do
+			kill -0 "$SCHED_PID" 2>/dev/null || break
+			sleep 0.1
+		done
+		if kill -0 "$SCHED_PID" 2>/dev/null; then
+			kill -KILL "$SCHED_PID" 2>/dev/null
+		fi
+		wait "$SCHED_PID" 2>/dev/null
+	fi
+
+	rmdir "$CELL_CGROUP" 2>/dev/null
+	rmdir "$CGROUP_BASE" 2>/dev/null
+	rmdir "$TRACE_INSTANCE" 2>/dev/null
+}
+
+trap cleanup EXIT INT TERM
+
+if [[ "$EUID" -ne 0 ]]; then
+	echo "Must run as root" >&2
+	exit 1
+fi
+
+if [[ ! -x "$SCHEDULER_BIN" ]]; then
+	echo "Scheduler binary not found: $SCHEDULER_BIN" >&2
+	exit 1
+fi
+
+if [[ ! -e /sys/kernel/sched_ext/state ]]; then
+	echo "sched_ext is not available" >&2
+	exit 1
+fi
+
+mkdir "$CGROUP_BASE"
+if ! grep -q cpu "$CGROUP_BASE/cgroup.subtree_control" 2>/dev/null; then
+	echo +cpu > "$CGROUP_BASE/cgroup.subtree_control"
+fi
+
+"$SCHEDULER_BIN" \
+	--cell-parent-cgroup "/$TEST_NAME" \
+	--debug-events \
+	> "$SCHED_LOG" 2>&1 &
+SCHED_PID=$!
+sleep 3
+
+if ! ps -p "$SCHED_PID" > /dev/null 2>&1; then
+	echo "scx_mitosis failed to start" >&2
+	cat "$SCHED_LOG" >&2
+	exit 1
+fi
+
+if [[ "$(</sys/kernel/sched_ext/state)" != "enabled" ]]; then
+	echo "sched_ext did not enable" >&2
+	cat "$SCHED_LOG" >&2
+	exit 1
+fi
+
+mkdir "$CELL_CGROUP"
+CELL_CGID="$(stat -c %i "$CELL_CGROUP")"
+
+bash -c "echo \$\$ > '$CELL_CGROUP/cgroup.procs'; sleep 60 & wait" &
+WORKER_PID=$!
+sleep 0.5
+
+echo 1 > "$CELL_CGROUP/cgroup.kill"
+wait "$WORKER_PID" 2>/dev/null || true
+WORKER_PID=""
+rmdir "$CELL_CGROUP"
+sleep 0.5
+
+mkdir "$TRACE_INSTANCE"
+echo 1 > "$TRACE_INSTANCE/events/sched_ext/sched_ext_dump/enable"
+cat "$TRACE_INSTANCE/trace_pipe" > "$TRACE_OUTPUT" &
+TRACE_READER_PID=$!
+sleep 0.1
+
+echo D > /proc/sysrq-trigger
+sleep 1
+
+kill "$TRACE_READER_PID" 2>/dev/null || true
+wait "$TRACE_READER_PID" 2>/dev/null || true
+TRACE_READER_PID=""
+
+for event in CGROUP_INIT INIT_TASK CGROUP_EXIT; do
+	if ! grep -Eq "$event[[:space:]]+cgid=$CELL_CGID" "$TRACE_OUTPUT"; then
+		echo "Missing debug event for cgroup $CELL_CGID: $event" >&2
+		grep "cgid=$CELL_CGID" "$TRACE_OUTPUT" >&2 || true
+		exit 1
+	fi
+done
+
+echo "PASS: captured CGROUP_INIT, INIT_TASK, and CGROUP_EXIT"
+echo "Trace: $TRACE_OUTPUT"


### PR DESCRIPTION
This change just moves debug events out into their own file. We could also just get rid of them entirely if we aren't getting any use out of them at this point.


```
$ cargo build --release -p scx_mitosis
warning: /home/dforsyth/dev/scx/rust/scx_rustland_core/Cargo.toml: unused manifest key: lib.include
    Finished `release` profile [optimized] target(s) in 0.79s
$ sudo scheds/rust/scx_mitosis/test/test_debug_events.sh
PASS: captured CGROUP_INIT, INIT_TASK, and CGROUP_EXIT
Trace: /tmp/scx_mitosis_debug_events_472310.trace
$ grep -E 'CGROUP_INIT|INIT_TASK|CGROUP_EXIT' /tmp/scx_mitosis_debug_events_472310.trace | head -n 5
           <...>-506492  [001] d..11 2159547.146739: sched_ext_dump: [  0] CGROUP_INIT cgid=1 ts=2159543049414751
           <...>-506492  [001] d..11 2159547.146741: sched_ext_dump: [  1] CGROUP_INIT cgid=32 ts=2159543049416331
           <...>-506492  [001] d..11 2159547.146743: sched_ext_dump: [  2] CGROUP_INIT cgid=77 ts=2159543049421361
           <...>-506492  [001] d..11 2159547.146744: sched_ext_dump: [  3] CGROUP_INIT cgid=907 ts=2159543049423701
           <...>-506492  [001] d..11 2159547.146746: sched_ext_dump: [  4] CGROUP_INIT cgid=1402 ts=2159543049425771
```