### PR TITLE
scx_mitosis: Remove debug events

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -23,8 +23,6 @@ enum consts {
 	MAX_CG_DEPTH = 256,
 	MAX_LLCS = 16,
 
-	DEBUG_EVENTS_BUF_SIZE = 4096,
-
 	/* Size of cpumask in unsigned longs (supports up to 8192 CPUs) */
 	CPUMASK_LONG_ENTRIES = 128,
 };
@@ -36,31 +34,6 @@ enum consts {
  */
 struct llc_cpumask {
 	unsigned long bits[CPUMASK_LONG_ENTRIES];
-};
-
-/* Debug event types */
-enum debug_event_type {
-	DEBUG_EVENT_CGROUP_INIT,
-	DEBUG_EVENT_INIT_TASK,
-	DEBUG_EVENT_CGROUP_EXIT,
-};
-
-/* Debug event record - discriminated union */
-struct debug_event {
-	u64 timestamp;
-	u32 event_type;
-	union {
-		struct {
-			u64 cgid;
-		} cgroup_init;
-		struct {
-			u64 cgid;
-			u32 pid;
-		} init_task;
-		struct {
-			u64 cgid;
-		} cgroup_exit;
-	};
 };
 
 /* Statistics */

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -42,7 +42,6 @@ const volatile unsigned char all_cpus[MAX_CPUS_U8];
 
 const volatile u64 slice_ns;
 const volatile u64 root_cgid = 1;
-const volatile bool debug_events_enabled = false;
 const volatile bool exiting_task_workaround_enabled = true;
 const volatile bool cpu_controller_disabled = false;
 const volatile bool reject_multicpu_pinning = false;
@@ -61,18 +60,6 @@ struct llc_cpumask llc_to_cpus[MAX_LLCS];
 u32 applied_configuration_seq;
 u32 cpuset_seq;
 u32 applied_cpuset_seq;
-
-/*
- * Debug events circular buffer
- */
-u32 debug_event_pos;
-
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__uint(max_entries, DEBUG_EVENTS_BUF_SIZE);
-	__type(key, u32);
-	__type(value, struct debug_event);
-} debug_events SEC(".maps");
 
 /* Configuration struct for apply_cell_config, populated by userspace */
 struct cell_config cell_config;
@@ -201,70 +188,6 @@ static inline struct cpu_ctx *lookup_cpu_ctx(int cpu)
 	}
 
 	return cctx;
-}
-
-/*
- * Record debug events to the circular buffer
- */
-static inline void record_cgroup_init(u64 cgid)
-{
-	struct debug_event *event;
-	u32 pos, idx;
-
-	if (likely(!debug_events_enabled))
-		return;
-
-	pos = __sync_fetch_and_add(&debug_event_pos, 1);
-	idx = pos % DEBUG_EVENTS_BUF_SIZE;
-
-	event = bpf_map_lookup_elem(&debug_events, &idx);
-	if (unlikely(!event))
-		return;
-
-	event->timestamp = scx_bpf_now();
-	event->event_type = DEBUG_EVENT_CGROUP_INIT;
-	event->cgroup_init.cgid = cgid;
-}
-
-static inline void record_init_task(u64 cgid, u32 pid)
-{
-	struct debug_event *event;
-	u32 pos, idx;
-
-	if (likely(!debug_events_enabled))
-		return;
-
-	pos = __sync_fetch_and_add(&debug_event_pos, 1);
-	idx = pos % DEBUG_EVENTS_BUF_SIZE;
-
-	event = bpf_map_lookup_elem(&debug_events, &idx);
-	if (unlikely(!event))
-		return;
-
-	event->timestamp = scx_bpf_now();
-	event->event_type = DEBUG_EVENT_INIT_TASK;
-	event->init_task.cgid = cgid;
-	event->init_task.pid = pid;
-}
-
-static inline void record_cgroup_exit(u64 cgid)
-{
-	struct debug_event *event;
-	u32 pos, idx;
-
-	if (likely(!debug_events_enabled))
-		return;
-
-	pos = __sync_fetch_and_add(&debug_event_pos, 1);
-	idx = pos % DEBUG_EVENTS_BUF_SIZE;
-
-	event = bpf_map_lookup_elem(&debug_events, &idx);
-	if (unlikely(!event))
-		return;
-
-	event->timestamp = scx_bpf_now();
-	event->event_type = DEBUG_EVENT_CGROUP_EXIT;
-	event->cgroup_exit.cgid = cgid;
 }
 
 struct cell_cpumask_map cell_cpumasks SEC(".maps");
@@ -1139,8 +1062,6 @@ static int init_cgrp_ctx(struct cgroup *cgrp)
 {
 	struct cgrp_ctx *cgc;
 
-	record_cgroup_init(cgrp->kn->id);
-
 	if (!(cgc = bpf_cgrp_storage_get(&cgrp_ctxs, cgrp, 0, BPF_LOCAL_STORAGE_GET_F_CREATE))) {
 		scx_bpf_error("cgrp_ctx creation failed for cgid %llu", cgrp->kn->id);
 		return -ENOENT;
@@ -1216,7 +1137,6 @@ s32 BPF_STRUCT_OPS(mitosis_cgroup_exit, struct cgroup *cgrp)
 	if (cpu_controller_disabled)
 		return 0;
 
-	record_cgroup_exit(cgrp->kn->id);
 	return 0;
 }
 
@@ -1260,7 +1180,6 @@ int BPF_PROG(tp_cgroup_rmdir, struct cgroup *cgrp, const char *cgrp_path)
 	if (!cpu_controller_disabled)
 		return 0;
 
-	record_cgroup_exit(cgrp->kn->id);
 	return 0;
 }
 
@@ -1306,8 +1225,6 @@ static int init_task_impl(struct task_struct *p, struct cgroup *cgrp)
 	struct task_ctx *tctx;
 	struct bpf_cpumask *cpumask;
 	struct bpf_cpumask *llc_cpumask;
-
-	record_init_task(cgrp->kn->id, p->pid);
 
 	tctx = bpf_task_storage_get(&task_ctxs, p, 0, BPF_LOCAL_STORAGE_GET_F_CREATE);
 	if (!tctx) {
@@ -1494,48 +1411,6 @@ void BPF_STRUCT_OPS(mitosis_dump, struct scx_dump_ctx *dctx)
 			scx_bpf_dump("CPU[%d] cell=%d vtime=%llu nr_queued=%d\n", i, cpu_ctx->cell,
 				     READ_ONCE(cpu_ctx->vtime_now),
 				     scx_bpf_dsq_nr_queued(dsq_id.raw));
-		}
-	}
-
-	if (!debug_events_enabled)
-		return;
-
-	/* Dump debug events */
-	scx_bpf_dump("\n");
-	scx_bpf_dump("DEBUG EVENTS (last %d):\n", DEBUG_EVENTS_BUF_SIZE);
-
-	u32 total_events = READ_ONCE(debug_event_pos);
-	u32 start_idx =
-		total_events > DEBUG_EVENTS_BUF_SIZE ? total_events - DEBUG_EVENTS_BUF_SIZE : 0;
-
-	bpf_for(i, 0, DEBUG_EVENTS_BUF_SIZE)
-	{
-		u32 event_num = start_idx + i;
-		if (event_num >= total_events)
-			break;
-
-		u32 idx = event_num % DEBUG_EVENTS_BUF_SIZE;
-		struct debug_event *event = bpf_map_lookup_elem(&debug_events, &idx);
-		if (!event)
-			continue;
-
-		switch (event->event_type) {
-		case DEBUG_EVENT_CGROUP_INIT:
-			scx_bpf_dump("[%3d] CGROUP_INIT cgid=%llu ts=%llu\n", event_num,
-				     event->cgroup_init.cgid, event->timestamp);
-			break;
-		case DEBUG_EVENT_INIT_TASK:
-			scx_bpf_dump("[%3d] INIT_TASK   cgid=%llu pid=%u ts=%llu\n", event_num,
-				     event->init_task.cgid, event->init_task.pid, event->timestamp);
-			break;
-		case DEBUG_EVENT_CGROUP_EXIT:
-			scx_bpf_dump("[%3d] CGROUP_EXIT cgid=%llu ts=%llu\n", event_num,
-				     event->cgroup_exit.cgid, event->timestamp);
-			break;
-		default:
-			scx_bpf_dump("[%3d] UNKNOWN     type=%u ts=%llu\n", event_num,
-				     event->event_type, event->timestamp);
-			break;
 		}
 	}
 }

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -119,11 +119,6 @@ struct Opts {
     #[clap(long, value_delimiter = ',')]
     undefok: Vec<String>,
 
-    /// Enable debug event tracking for cgroup_init, init_task, and cgroup_exit.
-    /// Events are recorded in a ring buffer and output in dump().
-    #[clap(long, action = clap::ArgAction::SetTrue)]
-    debug_events: bool,
-
     /// Enable workaround for exiting tasks with offline cgroups during scheduler load.
     /// This works around a kernel bug where tasks can be initialized with cgroups that
     /// were never initialized. Disable this once the kernel bug is fixed.
@@ -366,7 +361,6 @@ impl<'a> Scheduler<'a> {
             .expect("BUG: rodata_data missing after skel open");
 
         rodata.slice_ns = scx_enums.SCX_SLICE_DFL;
-        rodata.debug_events_enabled = opts.debug_events;
         rodata.exiting_task_workaround_enabled = opts.exiting_task_workaround;
         rodata.cpu_controller_disabled = opts.cpu_controller_disabled;
         rodata.dynamic_affinity_cpu_selection = opts.dynamic_affinity_cpu_selection;


### PR DESCRIPTION
Cleaning these up since we're not getting use out of them (and they were added to help with a specific problem). Let's take a stab at better debug features later if we need something like this.