### PR TITLE
scx_lavd: reduce resident memory by 23MB

### DIFF
--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -33,7 +33,6 @@ use clap_num::number_range;
 use cpu_order::CpuOrder;
 use cpu_order::PerfCpuOrder;
 use crossbeam::channel;
-use crossbeam::channel::Receiver;
 use crossbeam::channel::RecvTimeoutError;
 use crossbeam::channel::Sender;
 use crossbeam::channel::TrySendError;
@@ -448,9 +447,7 @@ impl introspec {
 struct Scheduler<'a> {
     skel: BpfSkel<'a>,
     struct_ops: Option<libbpf_rs::Link>,
-    rb_mgr: libbpf_rs::RingBuffer<'static>,
     intrspc: introspec,
-    intrspc_rx: Receiver<SchedSample>,
     monitor_tid: Option<ThreadId>,
     stats_server: StatsServer<StatsReq, StatsRes>,
     mseq_id: u64,
@@ -521,23 +518,10 @@ impl<'a> Scheduler<'a> {
         let struct_ops = Some(scx_ops_attach!(skel, lavd_ops)?);
         let stats_server = StatsServer::new(stats::server_data(*NR_CPU_IDS as u64)).launch()?;
 
-        // Build a ring buffer for instrumentation
-        let (intrspc_tx, intrspc_rx) = channel::bounded(65536);
-        let rb_map = &mut skel.maps.introspec_msg;
-        let mut builder = libbpf_rs::RingBufferBuilder::new();
-        builder
-            .add(rb_map, move |data| {
-                Scheduler::relay_introspec(data, &intrspc_tx)
-            })
-            .unwrap();
-        let rb_mgr = builder.build().unwrap();
-
         Ok(Self {
             skel,
             struct_ops,
-            rb_mgr,
             intrspc: introspec::new(),
-            intrspc_rx,
             monitor_tid: None,
             stats_server,
             mseq_id: 0,
@@ -831,10 +815,36 @@ impl<'a> Scheduler<'a> {
         }
     }
 
+    /// Collect the scheduling samples the BPF side has queued, waiting up to
+    /// @timeout for them, or draining without waiting when it is None.
+    ///
+    /// Built per request rather than kept: crossbeam initializes every slot up
+    /// front, so a standing bounded(65536) channel cost 17.5MB resident. Unbounded
+    /// because the count depends on load, not on the request; intrspc.arg caps it.
+    fn drain_sched_samples(&mut self, timeout: Option<Duration>) -> Result<Vec<SchedSample>> {
+        let (intrspc_tx, intrspc_rx) = channel::unbounded();
+
+        {
+            let mut builder = libbpf_rs::RingBufferBuilder::new();
+            builder.add(&mut self.skel.maps.introspec_msg, move |data| {
+                Scheduler::relay_introspec(data, &intrspc_tx)
+            })?;
+            let rb_mgr = builder.build()?;
+
+            match timeout {
+                Some(timeout) => rb_mgr.poll(timeout)?,
+                None => rb_mgr.consume()?,
+            }
+        }
+
+        Ok(intrspc_rx.try_iter().collect())
+    }
+
     fn stats_req_to_res(&mut self, req: &StatsReq) -> Result<StatsRes> {
         Ok(match req {
             StatsReq::NewSampler(tid) => {
-                self.rb_mgr.consume().unwrap();
+                /* Discard whatever the BPF side queued before this client. */
+                self.drain_sched_samples(None)?;
                 self.monitor_tid = Some(*tid);
                 StatsRes::Ack
             }
@@ -900,12 +910,8 @@ impl<'a> Scheduler<'a> {
                 self.intrspc.arg = *nr_samples;
                 self.prep_introspec();
                 std::thread::sleep(Duration::from_millis(*interval_ms));
-                self.rb_mgr.poll(Duration::from_millis(100)).unwrap();
 
-                let mut samples = vec![];
-                while let Ok(ts) = self.intrspc_rx.try_recv() {
-                    samples.push(ts);
-                }
+                let samples = self.drain_sched_samples(Some(Duration::from_millis(100)))?;
 
                 self.cleanup_introspec();
 
@@ -1001,7 +1007,6 @@ impl<'a> Scheduler<'a> {
             }
             self.cleanup_introspec();
         }
-        self.rb_mgr.consume().unwrap();
 
         bpf_streams::dump_bpf_streams(&mut self.skel);
         let _ = self.struct_ops.take();

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -1024,6 +1024,21 @@ impl Drop for Scheduler<'_> {
     }
 }
 
+/// Return heap freed during initialization to the OS.
+///
+/// libbpf drops its copy of the BPF object's sections and its BTF once loading
+/// finishes, and the CPU topology and energy model are dropped once the BPF side
+/// has been initialized from them. glibc holds those pages until asked.
+///
+/// glibc only: musl has no malloc_trim(), and needs none, since it returns freed
+/// memory to the kernel rather than parking it in per-arena free lists.
+fn trim_heap_after_init() {
+    #[cfg(target_env = "gnu")]
+    unsafe {
+        libc::malloc_trim(0);
+    }
+}
+
 fn init_log(opts: &Opts) {
     let env_filter = EnvFilter::try_from_default_env()
         .or_else(|_| match EnvFilter::try_new(&opts.log_level) {
@@ -1122,6 +1137,7 @@ fn main(mut opts: Opts) -> Result<()> {
             build_id::full_version(env!("CARGO_PKG_VERSION"))
         );
         info!("scx_lavd scheduler starts running.");
+        trim_heap_after_init();
         if !sched.run(&opts, shutdown.clone())?.should_restart() {
             break;
         }


### PR DESCRIPTION
Two independent reductions to scx_lavd's memory footprint, measured on a 16-CPU
machine with no monitoring client attached — the default way it runs.

| | RssAnon |
|---|---|
| before | 27,308 kB |
| avoid the 17.5MB sample channel unless monitoring | 9,284 kB |
| return init-time heap to the OS before running | **3,856 kB** |

VmRSS: 78,196 kB -> ~54,700 kB.

**avoid the 17.5MB sample channel unless monitoring** — `init()` unconditionally
built a `bounded(65536)` channel for scheduling samples. Each slot is a 272 byte
`SchedSample` plus crossbeam's 8 byte stamp, written up front, so all 17.5MB was
resident even though nothing reads it unless a stats client asks for samples. The
channel and ring buffer are now built per request and dropped afterwards, and the
channel is unbounded since how many samples arrive depends on load, not on the
request.

**return init-time heap to the OS before running** — libbpf's copy of the BPF
object and its BTF, the CPU topology and the energy model are all dead once the
scheduler starts, but glibc keeps the pages in its arenas. `malloc_trim(0)` after
startup releases 5.3MB. glibc only; musl has no `malloc_trim()` and needs none.
