### PR TITLE
scx: add scx_bpf_reenqueue_local_from_anywhere() compat helper

### DIFF
--- a/scheds/include/scx/compat.bpf.h
+++ b/scheds/include/scx/compat.bpf.h
@@ -6,6 +6,7 @@
  */
 #ifndef __SCX_COMPAT_BPF_H
 #define __SCX_COMPAT_BPF_H
+#include <errno.h>
 
 #define __COMPAT_ENUM_OR_ZERO(__type, __ent)					\
 ({										\
@@ -391,6 +392,15 @@ static inline void scx_bpf_reenqueue_local(void)
 		scx_bpf_reenqueue_local___v2___compat();
 	else
 		scx_bpf_reenqueue_local___v1();
+}
+
+static inline int scx_bpf_reenqueue_local_from_anywhere(void)
+{
+	if (__COMPAT_scx_bpf_reenqueue_local_from_anywhere()) {
+		scx_bpf_reenqueue_local___v2___compat();
+		return 0;
+	}
+	return -ENOTSUP;
 }
 
 /*

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -2071,16 +2071,8 @@ int BPF_PROG(lavd_sched_switch, bool preempt,
 	 */
 	if (unlikely(next->prio < MAX_RT_PRIO &&
 		     prev->prio >= MAX_RT_PRIO)) {
-		/*
-		 * Reenqueue any SCX tasks stranded on the local DSQ.
-		 * Use the v2 (call-from-anywhere) kfunc directly rather
-		 * than the generic compat wrapper: the wrapper inlines a
-		 * v1 fallback that is not callable from a tracepoint
-		 * context, and veristat (which doesn't honor autoload)
-		 * would reject it on kernels without v2.
-		 */
-		if (bpf_ksym_exists(scx_bpf_reenqueue_local___v2___compat))
-			scx_bpf_reenqueue_local___v2___compat();
+		/* Reenqueue any SCX tasks stranded on the local DSQ. */
+		scx_bpf_reenqueue_local_from_anywhere();
 	}
 	return 0;
 }


### PR DESCRIPTION
scx_bpf_reenqueue_local()'s generic compat wrapper inlines a v1 fallback that is only callable from ops.cpu_release, and veristat rejects it on kernels without v2. Callers draining a local DSQ from an arbitrary context (e.g. a tracepoint) must gate on the v2 kfunc directly.

Add scx_bpf_reenqueue_local_from_anywhere() to compat.bpf.h to encapsulate that: call the v2 kfunc when present and return 0, else return -ENOTSUP so the caller knows the drain did not run.

Update lavd_sched_switch() to use the helper in place of its open-coded ksym check.

No functional change intended.