### PR TITLE
scx_cosmos: key GPU hints by TGID

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -268,31 +268,31 @@ struct {
 } gpu_node_map SEC(".maps");
 
 /*
- * PID -> NUMA node mapping for GPU tasks (updated from userspace via NVML).
- * Key is the task's pid (thread id). Entries are removed when the task
- * is no longer using a GPU.
+ * Process TGID -> NUMA node mapping for GPU tasks (updated from userspace via
+ * NVML). Entries are removed when the process is no longer using a GPU.
  */
 #define MAX_GPU_PIDS	8192
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, MAX_GPU_PIDS);
-	__type(key, u32);	/* pid (task/thread id) */
+	__type(key, u32);	/* process tgid */
 	__type(value, u32);	/* node_id */
 } gpu_pid_map SEC(".maps");
 
 /*
- * Look up preferred NUMA node for a PID from userspace-provided GPU process
- * list (NVML). Returns node id or negative error.
+ * Look up the preferred NUMA node for a process TGID from the
+ * userspace-provided NVML GPU process list. Returns a node id or a negative
+ * error.
  */
-static int gpu_node_by_pid(u32 pid)
+static int gpu_node_by_tgid(u32 tgid)
 {
 	u32 *node;
 
 	if (!gpu_enabled || !numa_enabled)
 		return -ENOENT;
 
-	node = bpf_map_lookup_elem(&gpu_pid_map, &pid);
+	node = bpf_map_lookup_elem(&gpu_pid_map, &tgid);
 	if (!node)
 		return -ENOENT;
 
@@ -490,10 +490,10 @@ static bool can_use_node(const struct task_struct *p, int node)
 }
 
 /*
- * If the task is in gpu_pid_map and should run on a different node, pick a CPU
- * on the preferred GPU node. Returns the CPU id (>= 0) on success, or a
- * negative value if the task is not GPU-bound, is already on the right node,
- * or no suitable CPU was found.
+ * If the task's thread group is in gpu_pid_map and should run on a different
+ * node, pick a CPU on the preferred GPU node. Returns the CPU id (>= 0) on
+ * success, or a negative value if the task is not GPU-bound, is already on
+ * the right node, or no suitable CPU was found.
  */
 static s32 pick_cpu_on_gpu_node(const struct task_struct *p, int node,
 				struct task_ctx *tctx)
@@ -502,7 +502,7 @@ static s32 pick_cpu_on_gpu_node(const struct task_struct *p, int node,
 	struct bpf_cpumask *mask;
 	int target_node;
 
-	target_node = gpu_node_by_pid(p->pid);
+	target_node = gpu_node_by_tgid(p->tgid);
 	if (target_node < 0 || target_node == node || !can_use_node(p, target_node))
 		return -ENOENT;
 
@@ -1079,7 +1079,7 @@ s32 BPF_STRUCT_OPS(cosmos_select_cpu, struct task_struct *p, s32 prev_cpu, u64 w
 	}
 
 	/*
-	 * If GPU affinity is enabled and the task's pid is in gpu_pid_map
+	 * If GPU affinity is enabled and the task's TGID is in gpu_pid_map
 	 * but not on the GPU's node, try to pick a CPU on the GPU node.
 	 */
 	if (gpu_enabled && numa_enabled) {
@@ -1152,7 +1152,7 @@ void BPF_STRUCT_OPS(cosmos_enqueue, struct task_struct *p, u64 enq_flags)
 		return;
 
 	/*
-	 * If the task's pid is in gpu_pid_map (NVML GPU task), prefer the
+	 * If the task's TGID is in gpu_pid_map (NVML GPU process), prefer the
 	 * GPU NUMA node. If we're on a different node, migrate to the GPU
 	 * node.
 	 */

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -13,11 +13,9 @@ pub use bpf_intf::*;
 mod stats;
 use std::collections::{HashMap, HashSet};
 use std::ffi::{c_int, c_ulong};
-use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::mem::MaybeUninit;
-use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -825,9 +823,9 @@ impl<'a> Scheduler<'a> {
         })
     }
 
-    /// Sync PID -> GPU (node) map from NVML. When gpu_util_threshold > 0, only PIDs with
-    /// GPU utilization (SM or memory) >= threshold are added. Map is keyed by task pid.
-    /// Only processes using a single GPU are added; multi-GPU processes are excluded.
+    /// Sync process TGID -> GPU (node) map from NVML. When gpu_util_threshold > 0, only
+    /// processes with GPU utilization (SM or memory) >= threshold are added. Only processes
+    /// whose GPUs resolve to a single NUMA node are included.
     fn sync_gpu_pids(&mut self) -> Result<()> {
         let gpu_index_to_node = match &self.gpu_index_to_node {
             Some(m) => m,
@@ -871,15 +869,12 @@ impl<'a> Scheduler<'a> {
             }
         }
 
-        // Only add PIDs that use exactly one GPU to the map.
+        // Only add process TGIDs whose GPUs resolve to exactly one NUMA node.
         let mut current: HashMap<u32, u32> = HashMap::new();
         for (tgid, nodes) in pid_to_nodes {
             if nodes.len() == 1 {
                 let node = nodes.into_iter().next().unwrap();
                 current.insert(tgid, node);
-                for tid in Self::task_tids(tgid) {
-                    current.insert(tid, node);
-                }
             }
         }
 
@@ -897,7 +892,7 @@ impl<'a> Scheduler<'a> {
         Ok(())
     }
 
-    /// Record running compute/graphics process PIDs and the GPU node in pid_to_nodes.
+    /// Record running compute/graphics process TGIDs and the GPU node in pid_to_nodes.
     fn add_running_gpu_processes_to_set(
         device: &nvml_wrapper::Device<'_>,
         node: u32,
@@ -911,18 +906,6 @@ impl<'a> Scheduler<'a> {
         {
             pid_to_nodes.entry(proc.pid).or_default().insert(node);
         }
-    }
-
-    /// Return all thread IDs (tids) of the process with the given pid (tgid).
-    fn task_tids(pid: u32) -> Vec<u32> {
-        let task_dir = format!("/proc/{}/task", pid);
-        let Ok(entries) = fs::read_dir(Path::new(&task_dir)) else {
-            return Vec::new();
-        };
-        entries
-            .filter_map(|e| e.ok())
-            .filter_map(|e| e.file_name().to_str().and_then(|s| s.parse::<u32>().ok()))
-            .collect()
     }
 
     fn enable_primary_cpu(skel: &mut BpfSkel<'_>, cpu: i32) -> Result<(), u32> {


### PR DESCRIPTION
## Summary

NVML reports GPU users as process IDs, but `scx_cosmos` currently expands each process into every TID and stores every thread in `gpu_pid_map`

The commit basically do the following things
* Stores one TGID-to-NUMA-node entry per GPU process.
* Looks up GPU locality using `task_struct::tgid`
* Removes `/proc/<tgid>/task` enumeration.
* Automatically covers threads created after synchronization.
* Preserves the existing process-scoped GPU policy.

## Performance comparison
I compared the before/after performance with a CUDA process with controlled parked threads.

| Process tasks | Map Entries before | Map Entries after | Updates per sync before | Updates per sync after | Reduction |
| -------- | -------- | -------- | -------- | -------- | -------- |
| 4 | 4 | 1 | 4 | 1 | 75% |
| 64 | 64 | 1 | 64 | 1 | 98.44% |
| 256 | 256 | 1 | 256 | 1 | 99.61% |
| 512 | 512 | 1 | 512 | 1 | 99.80% |
| 1024 | 1024 | 1 | 1024 | 1 | 99.90% |


For a 492-thread CUDA process, 8 balanced paired trials produced:
- scx_cosmos CPU time: 1.493 → 0.619 ms/s
- Mean absolute saving: 0.874 ms/s
- Mean relative reduction: 58.3%
- Candidate improved all 8/8 pairs

An independent `perf task-clock` measurement showed a similar 59.0% reduction.

Note that these numbers measure the `scx_cosmos` userspace control-plane overhead, not application runtime.