### PR TITLE
scx_lavd: do not inherit cpu.max state when forking a task

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -2141,7 +2141,11 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(lavd_init_task, struct task_struct *p,
 	 */
 	parent = bpf_task_from_pid(p->real_parent->pid);
 	if (parent && (taskc_parent = get_task_ctx(parent))) {
-		for (i = 0; i < sizeof(*taskc) && can_loop; i++)
+		/* Do not inherit cgroup status. */
+		for (i = 0; i < sizeof(taskc->atq) && can_loop; i++)
+			((char __arena *)taskc)[i] = 0;
+
+		for (i = sizeof(taskc->atq); i < sizeof(*taskc) && can_loop; i++)
 			((char __arena *)taskc)[i] = ((char __arena *)taskc_parent)[i];
 	} else {
 		for (i = 0; i < sizeof(*taskc) && can_loop; i++)


### PR DESCRIPTION
lavd_init_task() seeds a new task's context from its parent's to keep the same latency and performance-criticality. struct scx_task_cgroup_bw sits at offset 0 of task_ctx, so the byte copy also carries the cpu.max library's per-task state: the BTQ rbtree node, the throttle ownership and the cached cgroup context pointers. That state records where the parent sits in the scheduler, not a property of the task.

Zero that struct and inherit only the fields after it.