### PR TITLE
sdt_alloc: Eagerly eject scheduler on task allocation failure

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -565,7 +565,7 @@ u64 scx_alloc_internal(struct scx_allocator *alloc)
 	/* On success, call returns with the lock taken. */
 	ret = scx_alloc_attempt(stack);
 	if (ret != 0) {
-		scx_err_loc("scx_alloc_attempt failed with %d\n", ret);
+		scx_bpf_error("scx_alloc_attempt failed with %d\n", ret);
 		return (u64)NULL;
 	}
 
@@ -575,7 +575,7 @@ u64 scx_alloc_internal(struct scx_allocator *alloc)
 	bpf_spin_unlock(&alloc_lock);
 
 	if (unlikely(desc == NULL)) {
-		scx_err_loc("failed to find empty tree key");
+		scx_bpf_error("failed to find empty tree key");
 		return (u64)NULL;
 	}
 
@@ -588,7 +588,7 @@ u64 scx_alloc_internal(struct scx_allocator *alloc)
 		data = scx_alloc_from_pool_sleepable(&alloc->pool);
 		if (!data) {
 			scx_alloc_free_idx(alloc, idx);
-			scx_err_loc("failed to allocate data from pool");
+			scx_bpf_error("failed to allocate data from pool");
 			return (u64)NULL;
 		}
 	}

--- a/lib/sdt_task.bpf.c
+++ b/lib/sdt_task.bpf.c
@@ -37,13 +37,13 @@ void __arena *scx_task_alloc(struct task_struct *p)
 	mval = bpf_task_storage_get(&scx_task_map, p, 0,
 				    BPF_LOCAL_STORAGE_GET_F_CREATE);
 	if (!mval) {
-		scx_err_loc("bpf_task_storage_get failed");
+		scx_bpf_error("bpf_task_storage_get failed");
 		return NULL;
 	}
 
 	data = scx_alloc(&scx_task_allocator);
 	if (unlikely(!data)) {
-		scx_err_loc("scx_alloc failed");
+		scx_bpf_error("scx_alloc failed");
 		return NULL;
 	}
 


### PR DESCRIPTION
Eagerly remove the scheduler with scx_bpf_error() when an allocation failure happens in the task allocator. Up until now the allocator has avoided running scx-specific code, but since the currently used allocator is being deprecated soon, and diagnostics get truncated in some environments, directly call scx_bpf_error to preserve the most diagnostics related to the failure.