### PR TITLE
scx: deduplicate arena spinlock qnodes across linked objects

### DIFF
--- a/lib/common.bpf.c
+++ b/lib/common.bpf.c
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+ */
+#include <scx/common.bpf.h>
+#include <lib/sdt_task.h>
+
+/*
+ * Storage for the queue nodes declared by bpf_arena_spin_lock.h. Each program
+ * linking the arena spinlock provides exactly one definition, so that the array
+ * is emitted once rather than once per translation unit.
+ */
+struct arena_qnode __arena __hidden qnodes[_Q_MAX_CPUS][_Q_MAX_NODES];

--- a/rust/scx_arena/scx_arena/build.rs
+++ b/rust/scx_arena/scx_arena/build.rs
@@ -8,6 +8,7 @@ fn main() {
         .unwrap()
         .enable_skel("src/bpf/main.bpf.c", "bpf")
         .add_source("src/bpf/lib/arena.bpf.c")
+        .add_source("src/bpf/lib/common.bpf.c")
         .add_source("src/bpf/lib/atq.bpf.c")
         .add_source("src/bpf/lib/bitmap.bpf.c")
         .add_source("src/bpf/lib/cpumask.bpf.c")

--- a/rust/scx_arena/selftests/build.rs
+++ b/rust/scx_arena/selftests/build.rs
@@ -8,6 +8,7 @@ fn main() {
         .unwrap()
         .enable_skel("src/bpf/main.bpf.c", "main")
         .add_source("src/bpf/lib/arena.bpf.c")
+        .add_source("src/bpf/lib/common.bpf.c")
         .add_source("src/bpf/lib/atq.bpf.c")
         .add_source("src/bpf/lib/dhq.bpf.c")
         .add_source("src/bpf/lib/bitmap.bpf.c")

--- a/scheds/include/bpf_arena_spin_lock.h
+++ b/scheds/include/bpf_arena_spin_lock.h
@@ -114,7 +114,7 @@ struct arena_qnode {
 #define unlikely(x) __builtin_expect(!!(x), 0)
 #endif
 
-static struct arena_qnode __arena qnodes[_Q_MAX_CPUS][_Q_MAX_NODES];
+extern struct arena_qnode __arena __hidden qnodes[_Q_MAX_CPUS][_Q_MAX_NODES];
 
 #ifdef __BPF__
 

--- a/scheds/rust/scx_cake/build.rs
+++ b/scheds/rust/scx_cake/build.rs
@@ -18,6 +18,7 @@ fn main() {
         .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
         .enable_skel("src/bpf/cake.bpf.c", "bpf")
         .add_source("src/bpf/lib/arena.bpf.c")
+        .add_source("src/bpf/lib/common.bpf.c")
         .add_source("src/bpf/lib/rbtree.bpf.c")
         .add_source("src/bpf/lib/atq.bpf.c")
         .add_source("src/bpf/lib/sdt_alloc.bpf.c")

--- a/scheds/rust/scx_chaos/build.rs
+++ b/scheds/rust/scx_chaos/build.rs
@@ -8,6 +8,7 @@ fn main() {
         .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
         .enable_skel("src/bpf/main.bpf.c", "bpf")
         .add_source("src/bpf/lib/arena.bpf.c")
+        .add_source("src/bpf/lib/common.bpf.c")
         .add_source("src/bpf/lib/atq.bpf.c")
         .add_source("src/bpf/lib/bitmap.bpf.c")
         .add_source("src/bpf/lib/dhq.bpf.c")

--- a/scheds/rust/scx_lavd/build.rs
+++ b/scheds/rust/scx_lavd/build.rs
@@ -18,6 +18,7 @@ fn main() {
         .add_source("src/bpf/sys_stat.bpf.c")
         .add_source("src/bpf/util.bpf.c")
         .add_source("src/bpf/lib/arena.bpf.c")
+        .add_source("src/bpf/lib/common.bpf.c")
         .add_source("src/bpf/lib/atq.bpf.c")
         .add_source("src/bpf/lib/bitmap.bpf.c")
         .add_source("src/bpf/lib/cgroup_bw.bpf.c")

--- a/scheds/rust/scx_p2dq/build.rs
+++ b/scheds/rust/scx_p2dq/build.rs
@@ -9,6 +9,7 @@ fn main() {
         .enable_intf("src/bpf/intf.h", "bpf_intf.rs")
         .enable_skel("src/bpf/main.bpf.c", "bpf")
         .add_source("src/bpf/lib/arena.bpf.c")
+        .add_source("src/bpf/lib/common.bpf.c")
         .add_source("src/bpf/lib/atq.bpf.c")
         .add_source("src/bpf/lib/dhq.bpf.c")
         .add_source("src/bpf/lib/bitmap.bpf.c")


### PR DESCRIPTION
bpf_arena_spin_lock.h defined its qnodes array as `static` in the header, so every translation unit including it emitted a private 1 MB copy. bpftool gen object then concatenated each object's .addr_space.1 bytes, leaving the surplus copies as dead weight in every linked scheduler.

Declare qnodes `extern __hidden` in the header and define it once in a new lib/common.bpf.c, mirroring the kernel selftests' libarena/src/common.bpf.c so the layout stays in sync for future updates. Link common.bpf.c into every scheduler that uses the arena spinlock.

Effect on .addr_space.1 in the linked bpf.bpf.o (bytes):

| scheduler           | copies  |   before |    after |
| ------------------- | ------- | -------: | -------: |
| scx_lavd            | 21 -> 1 | 22020096 |  1048576 |
| scx_p2dq            | 11 -> 1 | 11534336 |  1048576 |
| scx_cake            |  9 -> 1 |  9437184 |  1048576 |
| scx_chaos           | 10 -> 1 | 10485760 |  1048576 |
| scx_arena selftests | 21 -> 1 | 22020096 |  1048576 |

This mirrors the same fix made first in the kernel tree:
  https://lore.kernel.org/sched-ext/20260803001807.646357-1-changwoo@igalia.com/