### PR TITLE
scx_mitosis: Mark init_task callback sleepable

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -323,13 +323,21 @@ static inline int update_task_cell(struct task_struct *p, struct task_ctx *tctx,
 		 * and the task is exiting.
 		 */
 		if (exiting_task_workaround_enabled && (p->flags & PF_EXITING)) {
-			struct cgroup *rootcg = READ_ONCE(root_cgrp);
-			if (!rootcg) {
-				scx_bpf_error("Unexpected uninitialized rootcg");
-				return -ENOENT;
+			/*
+			 * We may be invoked from sleepable context (init_task),
+			 * thus require RCU protection to ensure that kptr
+			 * loaded for the root cgroup remains valid while
+			 * performing cgroup context lookup.
+			 */
+			scoped_guard(rcu)
+			{
+				struct cgroup *rootcg = READ_ONCE(root_cgrp);
+				if (!rootcg) {
+					scx_bpf_error("Unexpected uninitialized rootcg");
+					return -ENOENT;
+				}
+				cgc = lookup_cgrp_ctx(rootcg);
 			}
-
-			cgc = lookup_cgrp_ctx(rootcg);
 		}
 
 		if (!cgc) {
@@ -351,6 +359,11 @@ static inline int update_task_cell(struct task_struct *p, struct task_ctx *tctx,
 	tctx->cell = cgc->cell;
 	tctx->cgid = cg->kn->id;
 
+	/*
+	 * We may be called from sleepable context (init_task), provide RCU
+	 * protection for cpumask update to ensure kptrs are well formed.
+	 */
+	guard(rcu)();
 	return update_task_cpumask(p, tctx);
 }
 
@@ -1270,8 +1283,10 @@ static int init_task_impl(struct task_struct *p, struct cgroup *cgrp)
 	return update_task_cell(p, tctx, cgrp);
 }
 
-s32 BPF_STRUCT_OPS(mitosis_init_task, struct task_struct *p, struct scx_init_task_args *args)
+s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init_task, struct task_struct *p,
+			     struct scx_init_task_args *args)
 {
+	struct cgroup *cgrp __free(cgroup) = NULL;
 	/*
 	 * When CPU controller is disabled, args->cgroup is root, so we need
 	 * to get the task's actual cgroup for both logging and cell assignment.
@@ -1279,7 +1294,7 @@ s32 BPF_STRUCT_OPS(mitosis_init_task, struct task_struct *p, struct scx_init_tas
 	 * SCX cgroup callbacks won't fire.
 	 */
 	if (cpu_controller_disabled) {
-		struct cgroup *cgrp __free(cgroup) = task_cgroup(p);
+		cgrp = task_cgroup(p);
 		if (!cgrp)
 			return -ENOENT;
 
@@ -1290,8 +1305,15 @@ s32 BPF_STRUCT_OPS(mitosis_init_task, struct task_struct *p, struct scx_init_tas
 
 		return init_task_impl(p, cgrp);
 	}
-
-	return init_task_impl(p, args->cgroup);
+	/*
+	 * Extra refcount bump below can be dropped and args->cgroup can be used
+	 * directly when minimum kernel version advances to >= v7.4, per the patch
+	 * https://lore.kernel.org/bpf/95d7ccc17681aa3a4a2eeb1b073f00f7@kernel.org.
+	 */
+	cgrp = bpf_cgroup_from_id(args->cgroup->kn->id);
+	if (!cgrp)
+		return -ENOENT;
+	return init_task_impl(p, cgrp);
 }
 
 __hidden void dump_cpumask_word(s32 word, const struct cpumask *cpumask)

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -1287,6 +1287,8 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init_task, struct task_struct *p,
 			     struct scx_init_task_args *args)
 {
 	struct cgroup *cgrp __free(cgroup) = NULL;
+	int ret;
+
 	/*
 	 * When CPU controller is disabled, args->cgroup is root, so we need
 	 * to get the task's actual cgroup for both logging and cell assignment.
@@ -1295,15 +1297,24 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init_task, struct task_struct *p,
 	 */
 	if (cpu_controller_disabled) {
 		cgrp = task_cgroup(p);
-		if (!cgrp)
+		if (!cgrp) {
+			scx_bpf_error("task_cgroup() failed");
 			return -ENOENT;
+		}
 
 		/* Ensure cgroup hierarchy is initialized (handles ancestors + this cgroup) */
-		int ret = init_cgrp_ctx_with_ancestors(cgrp);
-		if (ret)
+		ret = init_cgrp_ctx_with_ancestors(cgrp);
+		if (ret) {
+			scx_bpf_error("init_cgrp_ctx_with_ancestors() failed");
 			return ret;
+		}
 
-		return init_task_impl(p, cgrp);
+		ret = init_task_impl(p, cgrp);
+		if (ret) {
+			scx_bpf_error("init_task_impl failed");
+			return ret;
+		}
+		return 0;
 	}
 	/*
 	 * Extra refcount bump below can be dropped and args->cgroup can be used
@@ -1311,9 +1322,16 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init_task, struct task_struct *p,
 	 * https://lore.kernel.org/bpf/95d7ccc17681aa3a4a2eeb1b073f00f7@kernel.org.
 	 */
 	cgrp = bpf_cgroup_from_id(args->cgroup->kn->id);
-	if (!cgrp)
+	if (!cgrp) {
+		scx_bpf_error("bpf_cgroup_from_id() failed");
 		return -ENOENT;
-	return init_task_impl(p, cgrp);
+	}
+	ret = init_task_impl(p, cgrp);
+	if (ret) {
+		scx_bpf_error("init_task_impl() failed");
+		return ret;
+	}
+	return 0;
 }
 
 __hidden void dump_cpumask_word(s32 word, const struct cpumask *cpumask)


### PR DESCRIPTION
Make a fix similar to commit 3eb68fe2d010 ("scx_layered: Make init_task sleepable") such that the BPF verifier can make allocations in the function fallback to non-GFP_ATOMIC case. Passing args->cgroup directly is problematic since it is not annotated as a trusted pointer. When this happens, non-sleepable callbacks mark it as plain PTR_TO_BTF_ID, which is not accepted by most kfuncs taking trusted args but taken by bpf_cgrp_storage_get() for backward compatibility reasons. When the callback is marked sleepable, this pointer becomes untrusted is not even accepted by bpf_cgrp_storage_get(). Thus obtain a new referenced pointer through bpf_cgroup_from_id(). We cannot use bpf_cgroup_acquire() in either sleepable or non-sleepable case since it needs a trusted pointer. This extra refcount bump can be dropped once the minimum kernel version is bumped to v7.4, per the patch in [0].

  [0]: https://lore.kernel.org/bpf/95d7ccc17681aa3a4a2eeb1b073f00f7@kernel.org