### PR TITLE
[RFC] Prevent CONFIG_FUNCTION_TRACER dependency in is_migration_disabled()

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -530,65 +530,18 @@ static __always_inline const struct cpumask *cast_mask(struct bpf_cpumask *mask)
 }
 
 /*
- * True if the non-sleepable BPF trampoline prolog (__bpf_prog_enter) calls
- * migrate_disable() for the current task. Recorded once by
- * scx_lib_init_probe, an fentry program on bpf_scx_reg() that fires during
- * the natural scheduler-attach call chain (auto-attached by scx_ops_attach!).
- *
- * Defaults to true (conservative). Over-reporting in is_migration_disabled()
- * causes local-only dispatch, which is safe. Under-reporting can crash the
- * scheduler, so we err high if the probe somehow fails to run.
- */
-bool __scx_prolog_disables_migration __weak = true;
-
-/*
- * scx_lib_init_probe - non-sleepable prolog probe.
- *
- * Attached to bpf_scx_reg(), the .reg callback in bpf_sched_ext_ops
- * (kernel/sched/ext.c). The kernel's struct_ops machinery invokes
- * bpf_scx_reg when userspace creates the scheduler link, before
- * ops.init() fires. Its address is taken in the vtable, so the symbol
- * is non-inlinable and has been stable since introduction.
- *
- * Entering via fentry runs us through __bpf_prog_enter -- the
- * non-sleepable prolog that consumers of is_migration_disabled() live
- * under.
- *
- * Loud warning: the prolog adds at most 1 to migration_disabled.
- * Reading > 1 means something upstream in the
- * bpf_struct_ops_link_create -> bpf_scx_reg path disabled migration
- * before the prolog ran, invalidating the probe; audit and adjust.
- */
-SEC("fentry/bpf_scx_reg") __weak
-int scx_lib_init_probe(void *ctx)
-{
-	if (bpf_core_field_exists(((struct task_struct *)0)->migration_disabled)) {
-		const struct task_struct *p = bpf_get_current_task_btf();
-		unsigned int md = p->migration_disabled;
-
-		if (md > 1)
-			bpf_printk("scx_lib_init_probe: unexpected migration_disabled=%u "
-				   "upstream of BPF prolog; probe result unreliable",
-				   md);
-
-		__scx_prolog_disables_migration = md > 0;
-	}
-	return 0;
-}
-
-/*
  * Return true if task @p cannot migrate to a different CPU, false
  * otherwise.
  *
- * IMPORTANT: designed for NON-SLEEPABLE BPF contexts only. Sleepable
- * contexts (BPF_STRUCT_OPS_SLEEPABLE, SEC("syscall"),
- * SEC("fentry.s/...")) enter via __bpf_prog_enter_sleepable() or
- * __bpf_prog_enter_sleepable_recur(), both of which unconditionally
- * call migrate_disable(); this helper can yield a false negative for
- * p == current there, which can crash the scheduler.
+ * This is exact for non-sleepable BPF programs on v6.18 and newer.
+ * Sleepable BPF programs unconditionally call migrate_disable() in their
+ * prolog, so on !CONFIG_PREEMPT_RCU they may conservatively report current
+ * as migration-disabled.
  */
 static inline bool is_migration_disabled(const struct task_struct *p)
 {
+	unsigned int migration_disabled;
+
 	/*
 	 * Testing p->migration_disabled in BPF is tricky because the BPF prolog
 	 * (__bpf_prog_enter) may call migrate_disable() for the current task,
@@ -597,37 +550,24 @@ static inline bool is_migration_disabled(const struct task_struct *p)
 	 *
 	 * Since commit 8e4f0b1ebcf2 ("bpf: use rcu_read_lock_dont_migrate() for
 	 * trampoline.c"), the BPF prolog calls migrate_disable() only when
-	 * CONFIG_PREEMPT_RCU is enabled. Two fast paths cover the common cases:
+	 * CONFIG_PREEMPT_RCU is enabled. In that configuration,
+	 * migration_disabled == 1 for @p == current is from the BPF prolog and
+	 * doesn't indicate that the task itself is migration-disabled.
 	 *
-	 *   1) CONFIG_PREEMPT_RCU: prolog always calls migrate_disable(), so
-	 *      migration_disabled == 1 for the current task is ambiguous.
-	 *      Disambiguate by checking p == current.
-	 *
-	 *   2) v6.18+ without CONFIG_PREEMPT_RCU: prolog never calls
-	 *      migrate_disable(), so migration_disabled == 1 is unambiguously
-	 *      a real migrate_disable() call.
-	 *
-	 * A slow path handles pre-v6.18 kernels without CONFIG_PREEMPT_RCU,
-	 * where the prolog historically called migrate_disable() unconditionally
-	 * but a cherry-picked downstream kernel may not. The runtime-probed flag
-	 * __scx_prolog_disables_migration (set by scx_lib_init_probe) distinguishes
-	 * the two cases without relying on the kernel version alone.
+	 * On older kernels without CONFIG_PREEMPT_RCU, the BPF prolog also calls
+	 * migrate_disable(). Returning the field directly can therefore
+	 * conservatively classify current as migration-disabled. This may force
+	 * local dispatch but avoids a false negative, which could dispatch a truly
+	 * migration-disabled task to a remote CPU.
 	 */
-	if (bpf_core_field_exists(p->migration_disabled)) {
-		if (p->migration_disabled == 1) {
-			/* Fast path: prolog always disables migration */
-			if (CONFIG_PREEMPT_RCU)
-				return bpf_get_current_task_btf() != p;
-			/* Fast path: prolog never disables migration */
-			if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(6, 18, 0))
-				return true;
-			/* Slow path: pre-v6.18, !PREEMPT_RCU - use runtime flag */
-			return __scx_prolog_disables_migration ?
-			       bpf_get_current_task_btf() != p : true;
-		}
-		return p->migration_disabled;
-	}
-	return false;
+	if (!bpf_core_field_exists(p->migration_disabled))
+		return false;
+
+	migration_disabled = p->migration_disabled;
+	/* sched_ext tasks have unique non-zero pids, so this tests p != current. */
+	if (migration_disabled == 1 && CONFIG_PREEMPT_RCU)
+		return (u32)bpf_get_current_pid_tgid() != p->pid;
+	return migration_disabled;
 }
 
 /* rcu */

--- a/scheds/include/scx/user_exit_info.bpf.h
+++ b/scheds/include/scx/user_exit_info.bpf.h
@@ -18,18 +18,22 @@
 
 #include "user_exit_info_common.h"
 
+extern bool CONFIG_BPF_EVENTS __kconfig __weak;
+
 #define UEI_DEFINE(__name)							\
 	char RESIZABLE_ARRAY(data, __name##_dump);				\
 	const volatile u32 __name##_dump_len;					\
 	struct user_exit_info __name SEC(".data")
 
 #define UEI_RECORD(__uei_name, __ei) ({						\
-	bpf_probe_read_kernel_str(__uei_name.reason,				\
-				  sizeof(__uei_name.reason), (__ei)->reason);	\
-	bpf_probe_read_kernel_str(__uei_name.msg,				\
-				  sizeof(__uei_name.msg), (__ei)->msg);		\
-	bpf_probe_read_kernel_str(__uei_name##_dump,				\
-				  __uei_name##_dump_len, (__ei)->dump);		\
+	if (CONFIG_BPF_EVENTS) {							\
+		bpf_probe_read_kernel_str(__uei_name.reason,			\
+					  sizeof(__uei_name.reason), (__ei)->reason); \
+		bpf_probe_read_kernel_str(__uei_name.msg,			\
+					  sizeof(__uei_name.msg), (__ei)->msg);	\
+		bpf_probe_read_kernel_str(__uei_name##_dump,			\
+					  __uei_name##_dump_len, (__ei)->dump);	\
+	}									\
 	if (bpf_core_field_exists((__ei)->exit_code))				\
 		__uei_name.exit_code = (__ei)->exit_code;			\
 	__uei_name.exit_cpu = -1;						\


### PR DESCRIPTION
This series allows schedulers using the common scx infrastructure to load on kernels built without ftrace support.

The immediate problem is that common.bpf.h uses an `fentry/bpf_scx_reg` program to determine whether the BPF trampoline calls `migrate_disable()`. Attaching this program requires ftrace, so kernels built with `CONFIG_FUNCTION_TRACER=n` reject the attachment with `-EBUSY`. As a result, every scheduler including common.bpf.h fails to load.

Similarly, `UEI_RECORD()` currently uses tracing-only helpers even when `CONFIG_BPF_EVENTS=n`. The first patch avoids those helpers in that configuration, retaining the numeric exit information while omitting the unavailable strings.

The second patch removes the fentry-based migration-disabled probe. Since kernel commit `8e4f0b1ebcf2 ("bpf: use rcu_read_lock_dont_migrate() for trampoline.c")`, included in v6.18, the non-sleepable trampoline calls `migrate_disable()` only when `CONFIG_PREEMPT_RCU` is enabled. We can therefore use `CONFIG_PREEMPT_RCU` directly on v6.18 and newer kernels:
```
   Kernel configuration     Behavior
   PREEMPT_RCU              Discount the prolog increment for current
   !PREEMPT_RCU             Read migration_disabled directly
```
This preserves the existing classification on v6.18 and newer kernels, without introducing false positives or additional runtime/load-time overhead.

There is a deliberate compatibility tradeoff for kernels older than v6.18 with `CONFIG_PREEMPT_RCU=n`. On those kernels, the older trampoline may still increment `current->migration_disabled`. Without the runtime fentry probe, a normal task passed as current may therefore be conservatively classified as migration-disabled, potentially re-introducing a false-positive migration-disabled detection.

However, this possible regression is limited to the current task on pre-v6.18 kernels with `CONFIG_PREEMPT_RCU=n`. The field remains accurate for non-current tasks and genuinely migration-disabled tasks. The conservative result may keep current local unnecessarily, but it avoids the unsafe opposite result of migrating a genuinely migration-disabled task.

I also considered alternative runtime detection mechanisms, such as using `bpf_dummy_ops` with `BPF_PROG_TEST_RUN`. However, `bpf_dummy_ops` requires `CONFIG_NET=y`, so that approach would introduce another configuration dependency. The proposed compromise appears to be the simplest way to support v6.18 and newer kernels reliably across all valid sched_ext kernel configurations, while removing the dependency on ftrace. Feedback on alternative approaches is welcome.

This fixes issue #3745.