### PR TITLE
scx_mitosis: Close the lost-wakeup window when disabling llc draining

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/llc_aware.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/llc_aware.bpf.h
@@ -389,6 +389,17 @@ static inline s32 try_draining_work(u32 cell_id, u32 subcell_id, s32 local_llc,
 		pending = READ_ONCE(candidate_llc_state->nr_queued);
 		if (!pending) {
 			subcell_llc_drain_disable(subcell, candidate_llc);
+			/*
+			 * Either a racing enqueue's drain enable lands after
+			 * the disable above and draining stays enabled, or this
+			 * recheck sees the work queued before the enable. The
+			 * racing kick can be consumed while draining was
+			 * disabled, so kick again.
+			 */
+			if (READ_ONCE(candidate_llc_state->nr_queued)) {
+				subcell_llc_drain_enable(subcell, candidate_llc);
+				kick_subcell_idle_cpu(cell_id, subcell_id);
+			}
 			continue;
 		}
 
@@ -482,8 +493,11 @@ static inline s32 try_draining_work(u32 cell_id, u32 subcell_id, s32 local_llc,
 			pending = READ_ONCE(candidate_llc_state->nr_queued);
 		}
 
-		if (disabled && pending > 0)
+		if (disabled && pending > 0) {
 			subcell_llc_drain_enable(subcell, candidate_llc);
+			/* Same consumed-kick window as the recheck above. */
+			kick_subcell_idle_cpu(cell_id, subcell_id);
+		}
 
 		if (consumed)
 			return continue_dispatch ? CONTINUE_DISPATCH : 0;


### PR DESCRIPTION
try_draining_work() clears an LLC's drain bit after reading a zero
nr_queued. A racing enqueue can increment nr_queued and OR the still-set
drain bit, a no-op, right before the clear lands, leaving queued work behind
a cleared drain bit. The task is then stranded until the next enqueue to the
same LLC or a configuration refresh re-enables draining.

Recheck nr_queued after clearing and re-enable like the consume path below
already does, and kick an idle subcell CPU on both re-enable paths since the
enqueue-side kick may have been consumed against the cleared bit. The enable
and disable are atomics on the same word and thus totally ordered against
each other, so whichever way the race resolves the bit ends up set whenever
queued work remains.

Testing: the same fix is carried in a fork of scx_mitosis where the drain
paths were exercised with cell reconfiguration and fork churn on a
multi-LLC vng guest. This port to the subcell rework is build-tested.
