### PR TITLE
scx_mitosis: only skip cgroup callbacks when cpu controller is disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,9 @@ jobs:
               --affinity 1 --affinity-delay 1 --affinity-pin &
             stress_pid=$!
             if [ "$sched" = "mitosis" ]; then
+              echo +cpu | sudo tee /sys/fs/cgroup/cgroup.subtree_control >/dev/null || true
               sudo mkdir -p /sys/fs/cgroup/ci.slice
+              echo +cpu | sudo tee /sys/fs/cgroup/ci.slice/cgroup.subtree_control >/dev/null
             fi
             sudo timeout --foreground --preserve-status 45 \
               target/ci/scx_${sched} ${flags[$sched]:-"-v"}

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -43,6 +43,7 @@ const volatile unsigned char all_cpus[MAX_CPUS_U8];
 const volatile u64 slice_ns;
 const volatile u64 root_cgid = 1;
 const volatile bool exiting_task_workaround_enabled = true;
+// When true, we didn't detect the cpu controller on scheduler startup.
 const volatile bool cpu_controller_disabled = false;
 const volatile bool reject_multicpu_pinning = false;
 const volatile bool enable_borrowing = false;

--- a/scheds/rust/scx_mitosis/src/cell_manager.rs
+++ b/scheds/rust/scx_mitosis/src/cell_manager.rs
@@ -21,10 +21,12 @@ use inotify::{Inotify, WatchMask};
 use scx_utils::Cpumask;
 use tracing::{debug, info};
 
+pub(crate) const CGROUP_ROOT: &str = "/sys/fs/cgroup";
+
 /// Strip the cgroup mount prefix from a stored cell path, yielding the
 /// root-relative cgroup path (e.g. `/sys/fs/cgroup/a/b` -> `/a/b`).
 fn cgroup_root_relative(path: &Path) -> String {
-    path.strip_prefix("/sys/fs/cgroup")
+    path.strip_prefix(CGROUP_ROOT)
         .map(|rel| format!("/{}", rel.to_string_lossy()))
         .unwrap_or_else(|_| path.to_string_lossy().into_owned())
 }
@@ -802,7 +804,7 @@ impl CellManager {
         cell0_min_cpus: usize,
         cpu_to_llc: HashMap<usize, usize>,
     ) -> Result<Self> {
-        let path = PathBuf::from(format!("/sys/fs/cgroup{}", cell_parent_path));
+        let path = PathBuf::from(format!("{}{}", CGROUP_ROOT, cell_parent_path));
         if !path.exists() {
             bail!("Cell parent cgroup path does not exist: {}", path.display());
         }

--- a/scheds/rust/scx_mitosis/src/main.rs
+++ b/scheds/rust/scx_mitosis/src/main.rs
@@ -12,7 +12,7 @@ mod stats;
 mod topology;
 mod undefok_flags;
 
-use cell_manager::{CellManager, CpuAssignment, CpuRecipient};
+use cell_manager::{CellManager, CpuAssignment, CpuRecipient, CGROUP_ROOT};
 
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
@@ -20,6 +20,7 @@ use std::fmt;
 use std::fmt::Display;
 use std::mem::MaybeUninit;
 use std::os::fd::AsFd;
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
@@ -31,6 +32,7 @@ use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
+use cgroupfs::CgroupReader;
 use clap::Parser;
 use libbpf_rs::MapCore as _;
 use libbpf_rs::OpenObject;
@@ -137,8 +139,8 @@ struct Opts {
     #[clap(long, default_value = "true", action = clap::ArgAction::Set)]
     exiting_task_workaround: bool,
 
-    /// Disable SCX cgroup callbacks (for when CPU cgroup controller is disabled).
-    /// Uses tracepoints and cgroup iteration instead.
+    /// Enable fallback cgroup tracking when CPU controller is disabled.
+    /// Uses tracepoints and cgroup iteration if cpu controller is not enabled.
     #[clap(long, action = clap::ArgAction::SetTrue)]
     cpu_controller_disabled: bool,
 
@@ -362,6 +364,15 @@ impl Display for DistributionStats {
     }
 }
 
+fn cgroup_cpu_controller_enabled(parent_cgroup: &str) -> Result<bool> {
+    let cgroup = CgroupReader::new_with_relative_path(
+        PathBuf::from(CGROUP_ROOT),
+        PathBuf::from(parent_cgroup),
+    )?;
+    let enabled_controllers = cgroup.read_cgroup_subtree_control()?;
+    Ok(enabled_controllers.contains("cpu"))
+}
+
 impl<'a> Scheduler<'a> {
     fn managed_cell_parent<'b>(opts: &'b Opts) -> Result<&'b str> {
         opts.cell_parent_cgroup
@@ -379,6 +390,7 @@ impl<'a> Scheduler<'a> {
         let topology = Topology::with_args(&opts.topology).context("detecting system topology")?;
 
         let nr_llc = topology.all_llcs.len().max(1);
+        let parent_cgroup = Self::managed_cell_parent(opts)?;
 
         let mut skel_builder = BpfSkelBuilder::default();
         skel_builder
@@ -404,8 +416,22 @@ impl<'a> Scheduler<'a> {
 
         rodata.slice_ns = scx_enums.SCX_SLICE_DFL;
         rodata.exiting_task_workaround_enabled = opts.exiting_task_workaround;
-        rodata.cpu_controller_disabled = opts.cpu_controller_disabled;
         rodata.dynamic_affinity_cpu_selection = opts.dynamic_affinity_cpu_selection;
+
+        let cgroup_cpu_controller_enabled = cgroup_cpu_controller_enabled(parent_cgroup)
+            .context("cgroup_cpu_controller_enabled")?;
+        if !cgroup_cpu_controller_enabled && !opts.cpu_controller_disabled {
+            bail!(
+                "cpu controller is not enabled for {}. use --cpu-controller-disabled to enable fallback.",
+                parent_cgroup,
+            );
+        }
+        let cpu_controller_disabled =
+            opts.cpu_controller_disabled && !cgroup_cpu_controller_enabled;
+        if cpu_controller_disabled {
+            info!("cpu_controller_disabled=true");
+        }
+        rodata.cpu_controller_disabled = cpu_controller_disabled;
 
         // Slice shrinking configuration
         if opts.slice_shrink_min_us >= opts.slice_shrink_max_us {
@@ -451,7 +477,6 @@ impl<'a> Scheduler<'a> {
             .launch()
             .context("launching stats server")?;
 
-        let parent_cgroup = Self::managed_cell_parent(opts)?;
         let exclude: HashSet<String> = opts.cell_exclude.iter().cloned().collect();
         let cell_manager = CellManager::new(
             parent_cgroup,

--- a/scheds/rust/scx_mitosis/test/test_cpu_controller_disabled.sh
+++ b/scheds/rust/scx_mitosis/test/test_cpu_controller_disabled.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+#
+# Smoke test for scx_mitosis --cpu-controller-disabled rollout gating.
+#
+# The scheduler should:
+# - fail when the managed parent cgroup lacks +cpu and the rollout flag is absent
+# - use disabled-controller fallback when the parent lacks +cpu and the flag is set
+# - stay on the normal cgroup path when the parent has +cpu, even if the flag is set
+
+set -euo pipefail
+
+SCHEDULER_BIN="${SCHEDULER_BIN:-./target/release/scx_mitosis}"
+CGROUP_BASE="/sys/fs/cgroup/scx_mitosis_cpu_controller_disabled.$$"
+DISABLED_PARENT="$CGROUP_BASE/disabled_parent"
+ENABLED_PARENT="$CGROUP_BASE/enabled_parent"
+LOG_DIR="/tmp/scx_mitosis_cpu_controller_disabled.$$"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+SCHED_PID=""
+
+log_info() {
+	echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_error() {
+	echo -e "${RED}[ERROR]${NC} $1" >&2
+}
+
+stop_scheduler() {
+	if [[ -n "$SCHED_PID" ]]; then
+		kill -INT "$SCHED_PID" 2>/dev/null || true
+		wait "$SCHED_PID" 2>/dev/null || true
+		SCHED_PID=""
+	fi
+}
+
+cleanup() {
+	echo -e "\n${YELLOW}Cleanup...${NC}"
+	stop_scheduler
+	rmdir "$DISABLED_PARENT" 2>/dev/null || true
+	rmdir "$ENABLED_PARENT" 2>/dev/null || true
+	rmdir "$CGROUP_BASE" 2>/dev/null || true
+	rm -rf "$LOG_DIR"
+}
+
+trap cleanup EXIT INT TERM
+
+cgroup_arg() {
+	local cgroup="$1"
+
+	echo "${cgroup#/sys/fs/cgroup}"
+}
+
+check_scheduler() {
+	local log_file="$1"
+
+	if [[ -z "$SCHED_PID" ]] || ! kill -0 "$SCHED_PID" 2>/dev/null; then
+		log_error "scx_mitosis exited unexpectedly"
+		cat "$log_file" >&2
+		exit 1
+	fi
+}
+
+check_sched_ext_enabled() {
+	local log_file="$1"
+
+	if [[ "$(cat /sys/kernel/sched_ext/state 2>/dev/null)" != "enabled" ]]; then
+		log_error "sched_ext did not enable"
+		cat "$log_file" >&2
+		exit 1
+	fi
+}
+
+start_scheduler() {
+	local parent="$1"
+	local log_file="$2"
+	shift 2
+
+	log_info "Starting scx_mitosis for $(cgroup_arg "$parent") $*"
+	"$SCHEDULER_BIN" \
+		--cell-parent-cgroup "$(cgroup_arg "$parent")" \
+		"$@" \
+		> "$log_file" 2>&1 &
+	SCHED_PID=$!
+	sleep 3
+	check_scheduler "$log_file"
+	check_sched_ext_enabled "$log_file"
+}
+
+expect_startup_failure_without_flag() {
+	local log_file="$LOG_DIR/missing_cpu_without_flag.log"
+	local status
+
+	log_info "Checking startup fails when parent lacks +cpu and flag is absent"
+	set +e
+	timeout --signal=INT --kill-after=5s 5s \
+		"$SCHEDULER_BIN" \
+		--cell-parent-cgroup "$(cgroup_arg "$DISABLED_PARENT")" \
+		> "$log_file" 2>&1
+	status=$?
+	set -e
+
+	if [[ "$status" -eq 0 || "$status" -eq 124 ]]; then
+		log_error "scx_mitosis did not fail fast when parent lacked +cpu and flag was absent"
+		cat "$log_file" >&2
+		exit 1
+	fi
+
+	if ! grep -q "cpu controller is not enabled" "$log_file"; then
+		log_error "startup failure did not report missing cpu controller"
+		cat "$log_file" >&2
+		exit 1
+	fi
+}
+
+expect_fallback_with_flag() {
+	local log_file="$LOG_DIR/missing_cpu_with_flag.log"
+
+	log_info "Checking fallback enables when parent lacks +cpu and flag is set"
+	start_scheduler "$DISABLED_PARENT" "$log_file" --cpu-controller-disabled
+
+	if ! grep -q "cpu_controller_disabled=true" "$log_file"; then
+		log_error "disabled-controller fallback was not enabled"
+		cat "$log_file" >&2
+		exit 1
+	fi
+
+	stop_scheduler
+}
+
+expect_normal_path_with_cpu_and_flag() {
+	local log_file="$LOG_DIR/cpu_enabled_with_flag.log"
+
+	log_info "Checking fallback stays disabled when parent has +cpu and flag is set"
+	start_scheduler "$ENABLED_PARENT" "$log_file" --cpu-controller-disabled
+
+	if grep -q "cpu_controller_disabled=true" "$log_file"; then
+		log_error "disabled-controller fallback was enabled while parent had +cpu"
+		cat "$log_file" >&2
+		exit 1
+	fi
+
+	stop_scheduler
+}
+
+if [[ "$EUID" -ne 0 ]]; then
+	log_error "Must run as root"
+	exit 1
+fi
+
+if [[ ! -x "$SCHEDULER_BIN" ]]; then
+	log_error "Scheduler binary not found: $SCHEDULER_BIN"
+	log_error "Please build with: cargo build --release -p scx_mitosis"
+	exit 1
+fi
+
+if [[ ! -f "/sys/kernel/sched_ext/state" ]]; then
+	log_error "sched_ext not available (missing /sys/kernel/sched_ext/state)"
+	exit 1
+fi
+
+if [[ ! -f "/sys/fs/cgroup/cgroup.controllers" ]]; then
+	log_error "/sys/fs/cgroup is not a cgroupv2 mount"
+	exit 1
+fi
+
+if ! grep -qw "cpu" /sys/fs/cgroup/cgroup.controllers; then
+	log_error "cpu controller is not available in /sys/fs/cgroup/cgroup.controllers"
+	exit 1
+fi
+
+mkdir -p "$LOG_DIR"
+mkdir -p "$CGROUP_BASE"
+
+echo "+cpu" > /sys/fs/cgroup/cgroup.subtree_control 2>/dev/null || true
+if ! grep -qw "cpu" "$CGROUP_BASE/cgroup.controllers"; then
+	log_error "cpu controller is not available to temporary test cgroup"
+	exit 1
+fi
+
+echo "+cpu" > "$CGROUP_BASE/cgroup.subtree_control"
+mkdir -p "$DISABLED_PARENT" "$ENABLED_PARENT"
+echo "+cpu" > "$ENABLED_PARENT/cgroup.subtree_control"
+
+expect_startup_failure_without_flag
+expect_fallback_with_flag
+expect_normal_path_with_cpu_and_flag
+
+echo -e "${GREEN}PASS${NC}: scx_mitosis cpu-controller-disabled gating smoke test passed"


### PR DESCRIPTION
We only want the `--cpu-controller-disabled` flag to disable scx cgroup ops when the cpu controller is not enabled.

This change adds a start up check for the cpu controller in the parent cgroup, and only sets `cpu_controller_disabled=true` when we run with `--cpu-controller-disabled` *and* the cpu controller is not enabled. If the controller is not enabled and we don't run with the flag, mitosis will exit.

Added script tests.