### PR TITLE
lib: Add scx_task/cgrp_free_rcu(), poor man's RCU deferred freeing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5724,6 +5724,7 @@ dependencies = [
  "anyhow",
  "libbpf-rs",
  "libbpf-sys",
+ "libc",
  "scx_cargo",
  "scx_utils",
  "simplelog",

--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -1449,3 +1449,116 @@ int scx_userspace_arena_free_pages(struct scx_userspace_arena_free_pages_args *c
 	bpf_arena_free_pages(&arena, ctx->addr, pages);
 	return 0;
 }
+
+/*
+ * Poor man's userspace-driven RCU, standing in until BPF grows bpf_call_rcu().
+ * scx_urcu_free() pushes freed nodes onto the active side of a two-sided list.
+ * Userspace waits using membarrier(MEMBARRIER_CMD_GLOBAL), which is
+ * synchronize_rcu(), and then runs a BPF program which calls scx_urcu_reclaim()
+ * to return the draining side to the allocator and flip the sides.
+ *
+ * A side may only be reclaimed after a grace period which started after the
+ * side stopped being active. Readers still holding pointers into the nodes and
+ * frees which read the active index before the flip are all inside RCU read
+ * sections which such a grace period waits out.
+ */
+
+/* sized so that exhaustion means seconds of spinning */
+#define SCX_URCU_CAS_TRIES	(1U << 23)
+
+/* per-call reclaim cap to bound the verifier walk */
+#define SCX_URCU_RECLAIM_BATCH	4096
+
+/*
+ * Doorbell waking userspace when a free makes the lists go empty to non-empty,
+ * shared by every scx_urcu instance: a wakeup should drain all of them.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 4096);
+} scx_urcu_doorbell SEC(".maps");
+
+/* Whether any node is awaiting reclaim. */
+__hidden
+int scx_urcu_pending(struct scx_urcu *urcu)
+{
+	return READ_ONCE(urcu->head[0]) || READ_ONCE(urcu->head[1]);
+}
+
+__hidden
+void scx_urcu_free(struct scx_urcu *urcu, struct sdt_data __arena *data)
+{
+	u32 side, i;
+
+	scx_arena_subprog_init();
+
+	side = READ_ONCE(urcu->active) & 1;
+	bpf_for(i, 0, SCX_URCU_CAS_TRIES) {
+		u64 head = READ_ONCE(urcu->head[side]);
+
+		data->urcu_link = head;
+		if (__sync_val_compare_and_swap(&urcu->head[side], head, (u64)data) != head)
+			continue;
+
+		/*
+		 * Ring on this side's empty to non-empty transition.
+		 *
+		 * No wakeup is lost: userspace sleeps only after seeing both
+		 * sides empty, so the first free afterwards lands on an empty
+		 * side and rings, and later frees pile behind it.
+		 *
+		 * Testing the other side too would lose wakeups: a free which
+		 * read the side before a flip lands opposite one which read it
+		 * after, and each can see the other's node and stay quiet.
+		 */
+		if (!head) {
+			u32 *e = bpf_ringbuf_reserve(&scx_urcu_doorbell, sizeof(*e), 0);
+
+			/* a full doorbell already has wakeups pending */
+			if (e) {
+				*e = 0;
+				bpf_ringbuf_submit(e, 0);
+			}
+		}
+		return;
+	}
+	scx_bpf_error("urcu free CAS exhausted");
+}
+
+/*
+ * Call only after a grace period which started after the previous call. Returns
+ * nonzero when the batch cap cut the walk short: call again, the leftovers need
+ * no new grace period.
+ */
+__hidden
+int scx_urcu_reclaim(struct scx_urcu *urcu, struct scx_allocator *alloc)
+{
+	u32 side = (READ_ONCE(urcu->active) ^ 1) & 1;
+	u32 i;
+
+	scx_arena_subprog_init();
+
+	/*
+	 * The grace period has flushed every free which could still see this
+	 * side as active, so plain accesses suffice from here on.
+	 */
+	bpf_for(i, 0, SCX_URCU_RECLAIM_BATCH) {
+		struct sdt_data __arena *data = (struct sdt_data __arena *)urcu->head[side];
+
+		if (!data)
+			break;
+		urcu->head[side] = data->urcu_link;
+		scx_alloc_free_idx(alloc, data->tid.idx);
+	}
+
+	if (urcu->head[side])
+		return 1;
+
+	/*
+	 * The xchg keeps the flip from becoming visible before the walk's head
+	 * updates: a free that saw the flip early could push onto a stale head
+	 * value which the walk's store then overwrites.
+	 */
+	__sync_lock_test_and_set(&urcu->active, side);
+	return 0;
+}

--- a/lib/sdt_cgroup.bpf.c
+++ b/lib/sdt_cgroup.bpf.c
@@ -130,3 +130,42 @@ void scx_cgrp_free(struct cgroup *cgrp)
 
 	scx_alloc_free_idx(&scx_cgrp_allocator, data->tid.idx);
 }
+
+static struct scx_urcu scx_cgrp_urcu;
+
+/*
+ * The deferred counterpart of scx_cgrp_free(): queue @cgrp's allocation, if
+ * any, for freeing after a grace period, currently provided by the scx_urcu
+ * machinery in lib/sdt_alloc.bpf.c. Same repetition rules as scx_cgrp_free().
+ */
+__hidden
+void scx_cgrp_free_rcu(struct cgroup *cgrp)
+{
+	struct sdt_data __arena *data;
+	struct scx_cgrp_map_val *mval;
+
+	scx_arena_subprog_init();
+
+	mval = bpf_cgrp_storage_get(&scx_cgrp_map, cgrp, 0, 0);
+	if (unlikely(!mval))
+		return;
+
+	data = (struct sdt_data __arena *)__sync_lock_test_and_set((__u64 *)&mval->data, 0);
+	if (unlikely(!data))
+		return;
+
+	scx_urcu_free(&scx_cgrp_urcu, data);
+}
+
+/* scx_urcu driver programs, discovered by name and run by the userspace side */
+SEC("syscall")
+int scx_urcu_cgrp_pending(void *ctx)
+{
+	return scx_urcu_pending(&scx_cgrp_urcu);
+}
+
+SEC("syscall")
+int scx_urcu_cgrp_reclaim(void *ctx)
+{
+	return scx_urcu_reclaim(&scx_cgrp_urcu, &scx_cgrp_allocator);
+}

--- a/lib/sdt_task.bpf.c
+++ b/lib/sdt_task.bpf.c
@@ -61,22 +61,28 @@ int scx_task_init(__u64 data_size)
 }
 
 __hidden
-void __arena *scx_task_data(struct task_struct *p)
+void __arena *__scx_task_data(struct task_struct *p)
 {
-	struct sdt_data __arena *data;
 	struct scx_task_map_val *mval;
 
 	scx_arena_subprog_init();
 
 	mval = bpf_task_storage_get(&scx_task_map, p, 0, 0);
-	if (!mval) {
-		scx_err_loc("bpf_task_storage_get failed");
+	if (unlikely(!mval || !mval->data))
 		return NULL;
-	}
 
-	data = mval->data;
+	return (void __arena *)mval->data->payload;
+}
 
-	return (void __arena *)data->payload;
+__hidden
+void __arena *scx_task_data(struct task_struct *p)
+{
+	void __arena *data = __scx_task_data(p);
+
+	if (unlikely(!data))
+		scx_err_loc("no task data");
+
+	return data;
 }
 
 __hidden

--- a/lib/sdt_task.bpf.c
+++ b/lib/sdt_task.bpf.c
@@ -101,3 +101,43 @@ void scx_task_free(struct task_struct *p)
 	scx_alloc_free_idx(&scx_task_allocator, mval->tid.idx);
 	bpf_task_storage_delete(&scx_task_map, p);
 }
+
+static struct scx_urcu scx_task_urcu;
+
+/*
+ * The deferred counterpart of scx_task_free(): queue @p's allocation, if any,
+ * for freeing after a grace period, currently provided by the scx_urcu
+ * machinery in lib/sdt_alloc.bpf.c. For free path hooks: absence is not an
+ * error and repeated calls are no-ops, the first caller claims the allocation.
+ */
+__hidden
+void scx_task_free_rcu(struct task_struct *p)
+{
+	struct scx_task_map_val *mval;
+	struct sdt_data __arena *data;
+
+	scx_arena_subprog_init();
+
+	mval = bpf_task_storage_get(&scx_task_map, p, 0, 0);
+	if (unlikely(!mval))
+		return;
+
+	data = (struct sdt_data __arena *)__sync_lock_test_and_set((__u64 *)&mval->data, 0);
+	if (unlikely(!data))
+		return;
+
+	scx_urcu_free(&scx_task_urcu, data);
+}
+
+/* scx_urcu driver programs, discovered by name and run by the userspace side */
+SEC("syscall")
+int scx_urcu_task_pending(void *ctx)
+{
+	return scx_urcu_pending(&scx_task_urcu);
+}
+
+SEC("syscall")
+int scx_urcu_task_reclaim(void *ctx)
+{
+	return scx_urcu_reclaim(&scx_task_urcu, &scx_task_allocator);
+}

--- a/rust/scx_arena/scx_arena/Cargo.toml
+++ b/rust/scx_arena/scx_arena/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-2.0-only"
 
 [dependencies]
 anyhow = "1"
+libc = "0.2"
 libbpf-rs = "=0.26.2"
 libbpf-sys = "=1.7.0"
 simplelog = "0.12"

--- a/rust/scx_arena/scx_arena/src/arenalib.rs
+++ b/rust/scx_arena/scx_arena/src/arenalib.rs
@@ -259,11 +259,12 @@ impl<'a> ArenaLib<'a> {
         Ok(Self { task_size, obj })
     }
 
-    /// Set up the BPF arena library state.
+    /// Set up the BPF arena library state and, when the object carries the
+    /// scx_urcu doorbell, spawn the detached reclaim daemon.
     pub fn setup(&self) -> Result<()> {
         self.setup_arena()?;
         self.setup_topology()?;
 
-        Ok(())
+        crate::urcu_spawn(self.obj)
     }
 }

--- a/rust/scx_arena/scx_arena/src/lib.rs
+++ b/rust/scx_arena/scx_arena/src/lib.rs
@@ -11,3 +11,158 @@ mod bpf_skel;
 
 mod arenalib;
 pub use arenalib::ArenaLib;
+
+use std::os::fd::AsFd;
+use std::os::fd::AsRawFd;
+use std::os::fd::OwnedFd;
+use std::time::Duration;
+use std::time::Instant;
+
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Result;
+use libbpf_rs::libbpf_sys;
+use libbpf_rs::MapCore as _;
+
+const MEMBARRIER_CMD_GLOBAL: libc::c_long = 1;
+const URCU_DOORBELL: &str = "scx_urcu_doorbell";
+const URCU_MIN_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Userspace half of the scx_urcu machinery, see the BPF side in
+/// lib/sdt_alloc.bpf.c. ArenaLib::setup() spawns the daemon when the object
+/// carries the scx_urcu doorbell and it runs detached for the rest of the
+/// process, so nothing is visible to the scheduler: its whole surface is
+/// calling the scx_*_free_rcu() variants from its free path hooks.
+///
+/// The daemon sleeps on the doorbell and, when woken, waits an RCU grace
+/// period, membarrier(MEMBARRIER_CMD_GLOBAL) is synchronize_rcu(), and runs
+/// the lib-provided scx_urcu_<storage>_pending/reclaim driver programs until
+/// nothing is awaiting reclaim, one grace period per cycle shared across the
+/// storages and at least URCU_MIN_INTERVAL between the side flips.
+fn urcu_run_prog(fd: &OwnedFd) -> Result<u32> {
+    let mut opts: libbpf_sys::bpf_test_run_opts = unsafe { std::mem::zeroed() };
+
+    opts.sz = std::mem::size_of::<libbpf_sys::bpf_test_run_opts>() as _;
+    let ret = unsafe { libbpf_sys::bpf_prog_test_run_opts(fd.as_raw_fd(), &mut opts) };
+    if ret != 0 {
+        bail!("urcu driver program run failed: {}", ret);
+    }
+    Ok(opts.retval)
+}
+
+fn urcu_daemon(doorbell: libbpf_rs::MapHandle, pairs: Vec<(OwnedFd, OwnedFd)>) -> Result<()> {
+    let mut builder = libbpf_rs::RingBufferBuilder::new();
+    builder
+        .add(&doorbell, |_| 0)
+        .context("adding urcu doorbell to ring buffer")?;
+    let rb = builder
+        .build()
+        .context("building urcu doorbell ring buffer")?;
+
+    let mut last: Option<Instant> = None;
+    loop {
+        let mut fds = [libc::pollfd {
+            fd: doorbell.as_fd().as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        }];
+
+        let ret = unsafe { libc::poll(fds.as_mut_ptr(), 1, -1) };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            bail!("urcu doorbell poll failed: {}", err);
+        }
+
+        /* drain until nothing is awaiting reclaim */
+        loop {
+            if let Some(last) = last {
+                let elapsed = last.elapsed();
+                if elapsed < URCU_MIN_INTERVAL {
+                    std::thread::sleep(URCU_MIN_INTERVAL - elapsed);
+                }
+            }
+
+            /*
+             * Consume before the pending checks. A free landing afterwards is
+             * either seen by the checks or leaves its ring behind and the poll
+             * returns immediately. The reverse order can consume the ring of a
+             * free the checks missed and sleep on it.
+             */
+            rb.consume().context("consuming urcu doorbell")?;
+
+            let mut reclaims = Vec::new();
+            for (pending, reclaim) in &pairs {
+                if urcu_run_prog(pending)? != 0 {
+                    reclaims.push(reclaim);
+                }
+            }
+            if reclaims.is_empty() {
+                break;
+            }
+            last = Some(Instant::now());
+
+            let ret = unsafe { libc::syscall(libc::SYS_membarrier, MEMBARRIER_CMD_GLOBAL, 0, 0) };
+            if ret != 0 {
+                bail!(
+                    "membarrier(GLOBAL) failed: {}",
+                    std::io::Error::last_os_error()
+                );
+            }
+
+            for reclaim in reclaims {
+                while urcu_run_prog(reclaim)? != 0 {}
+            }
+        }
+    }
+}
+
+/// Spawn the detached urcu reclaim daemon if @obj carries the scx_urcu
+/// doorbell and driver programs. Called from ArenaLib::setup().
+pub(crate) fn urcu_spawn(obj: &libbpf_rs::Object) -> Result<()> {
+    let Some(doorbell) = obj.maps().find(|m| m.name() == URCU_DOORBELL) else {
+        return Ok(());
+    };
+    let doorbell =
+        libbpf_rs::MapHandle::try_from(&doorbell).context("cloning urcu doorbell handle")?;
+
+    let mut pairs = Vec::new();
+    for prog in obj.progs() {
+        let Some(name) = prog.name().to_str() else {
+            continue;
+        };
+        let Some(base) = name.strip_suffix("_pending") else {
+            continue;
+        };
+        if !name.starts_with("scx_urcu_") {
+            continue;
+        }
+
+        let reclaim_name = format!("{}_reclaim", base);
+        let reclaim = obj
+            .progs()
+            .find(|p| p.name() == reclaim_name.as_str())
+            .with_context(|| format!("urcu driver program {} not found", reclaim_name))?;
+
+        pairs.push((
+            prog.as_fd().try_clone_to_owned()?,
+            reclaim.as_fd().try_clone_to_owned()?,
+        ));
+    }
+    if pairs.is_empty() {
+        return Ok(());
+    }
+
+    std::thread::Builder::new()
+        .name("scx-urcu".into())
+        .spawn(move || {
+            if let Err(e) = urcu_daemon(doorbell, pairs) {
+                eprintln!("scx-urcu daemon exiting on error: {:#}", e);
+            }
+        })
+        .context("spawning urcu daemon thread")?;
+
+    Ok(())
+}

--- a/scheds/include/lib/sdt_alloc.h
+++ b/scheds/include/lib/sdt_alloc.h
@@ -44,6 +44,18 @@ struct scx_stk {
 	scx_stk_seg_t *reserve;
 };
 
+/*
+ * Poor man's userspace-driven RCU for sdt allocations. Freed nodes accumulate
+ * on the active side while the draining side sits out a grace period which
+ * userspace provides, membarrier(MEMBARRIER_CMD_GLOBAL) being
+ * synchronize_rcu(), before its nodes return to the allocator. Stands in until
+ * BPF grows bpf_call_rcu().
+ */
+struct scx_urcu {
+	__u64		head[2];	/* struct sdt_data ptrs linked via urcu_link */
+	__u32		active;
+};
+
 #ifdef __BPF__
 
 void scx_arena_subprog_init(void);
@@ -53,6 +65,10 @@ u64 scx_alloc_internal(struct scx_allocator *alloc);
 int scx_alloc_free_idx(struct scx_allocator *alloc, __u64 idx);
 
 #define scx_alloc(alloc) ((struct sdt_data __arena *)scx_alloc_internal((alloc)))
+
+int scx_urcu_pending(struct scx_urcu *urcu);
+void scx_urcu_free(struct scx_urcu *urcu, struct sdt_data __arena *data);
+int scx_urcu_reclaim(struct scx_urcu *urcu, struct scx_allocator *alloc);
 
 u64 scx_static_alloc_internal(size_t bytes, size_t alignment);
 #define scx_static_alloc(bytes, alignment) ((void __arena *)scx_static_alloc_internal((bytes), (alignment)))

--- a/scheds/include/lib/sdt_cgroup.h
+++ b/scheds/include/lib/sdt_cgroup.h
@@ -12,5 +12,6 @@ void __arena *scx_cgrp_data(struct cgroup *cgrp);
 int scx_cgrp_init(__u64 data_size);
 void __arena *scx_cgrp_alloc(struct cgroup *cgrp);
 void scx_cgrp_free(struct cgroup *cgrp);
+void scx_cgrp_free_rcu(struct cgroup *cgrp);
 
 #endif	/* __BPF__ */

--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -15,5 +15,6 @@ void __arena *scx_task_data(struct task_struct *p);
 int scx_task_init(__u64 data_size);
 void __arena *scx_task_alloc(struct task_struct *p);
 void scx_task_free(struct task_struct *p);
+void scx_task_free_rcu(struct task_struct *p);
 
 #endif /* __BPF__ */

--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -10,6 +10,7 @@
 
 #ifdef __BPF__
 
+void __arena *__scx_task_data(struct task_struct *p);
 void __arena *scx_task_data(struct task_struct *p);
 int scx_task_init(__u64 data_size);
 void __arena *scx_task_alloc(struct task_struct *p);

--- a/scheds/include/lib/sdt_task_defs.h
+++ b/scheds/include/lib/sdt_task_defs.h
@@ -49,10 +49,12 @@ struct sdt_desc {
 };
 
 /*
- * Leaf node containing per-task data.
+ * Leaf node containing per-task data. urcu_link chains deferred frees so that
+ * the payload stays intact for readers until reclaim.
  */
 struct sdt_data {
 	union sdt_id			tid;
+	__u64				urcu_link;
 	__u64				payload[];
 };
 


### PR DESCRIPTION
Consumers reaching sdt task and cgroup data through side channels need RCU
semantics: lookups that fail once the owner is gone and pointers that stay
valid until the end of the RCU section. BPF is yet to grow bpf_call_rcu(),
so add scx_task_free_rcu() and scx_cgrp_free_rcu() backed by scx_urcu, a
poor man's substitute with the grace period driven from userspace,
membarrier(MEMBARRIER_CMD_GLOBAL) being synchronize_rcu(). The names
promise only the semantics: once BPF can defer frees natively, the
implementation swaps out under the same callers.

Freed nodes accumulate on the active side of a two-sided list and a
doorbell ringbuf wakes the reclaim daemon, which waits a grace period and
returns the draining side to the allocator. The driver programs ride in
the lib objects and ArenaLib::setup() discovers them and spawns the daemon
automatically, so the whole scheduler-side surface is calling the free_rcu
variants from free path hooks. The first patch is a small prep splitting
out __scx_task_data() for quiet lookups.

The membarrier() trick was suggested by Kumar Kartikeya Dwivedi.

Based on #3761; retargets to main once it merges.

Testing: fork storms plus burst/quiescence patterns with every urcu event
traced alongside membarrier syscalls in a single ftrace timeline, verifying
per-node lifecycle alternation, that every reclaimed node was pushed before
the grace period opening its drain cycle, flip -> grace period -> walk
ordering on every cycle, no stalls or stranded frees, and that reclaim is
fully demand-gated with no grace periods while idle.
