### PR TITLE
common.bpf.h: default __scx_prolog_disables_migration to false

### DIFF
--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -535,11 +535,11 @@ static __always_inline const struct cpumask *cast_mask(struct bpf_cpumask *mask)
  * scx_lib_init_probe, an fentry program on bpf_scx_reg() that fires during
  * the natural scheduler-attach call chain (auto-attached by scx_ops_attach!).
  *
- * Defaults to true (conservative). Over-reporting in is_migration_disabled()
+ * Defaults to false (conservative). Over-reporting in is_migration_disabled()
  * causes local-only dispatch, which is safe. Under-reporting can crash the
  * scheduler, so we err high if the probe somehow fails to run.
  */
-bool __scx_prolog_disables_migration __weak = true;
+bool __scx_prolog_disables_migration __weak = false;
 
 /*
  * scx_lib_init_probe - non-sleepable prolog probe.


### PR DESCRIPTION
__scx_prolog_disables_migration is a flag that is_migration_disabled() uses on its slow path (pre-v6.18, !CONFIG_PREEMPT_RCU, migration_disabled == 1). It defaulted to true, which under-reports: for the current task the slow path then returns

	bpf_get_current_task_btf() != p

i.e. false, reporting migration as not disabled. Under-reporting can crash the scheduler while over-reporting only forces local-only dispatch, so the fallback is meant to err high -- and erring high means defaulting to false. So, default to false and fix the comment to match.

Fixes: c98c5ad22f7e ("common.bpf.h: probe BPF prolog migrate_disable() from non-sleepable context")
Reported-by: Sashiko <sashiko-bot@kernel.org>
Link: https://lore.kernel.org/sched-ext/20260818210732.AB27B1F000E9@smtp.kernel.org/
Suggested-by: Tejun Heo <tj@kernel.org>