### PR TITLE
scx_cake: select_cpu redesign — self-park mailboxes become default (2…

### DIFF
--- a/scheds/rust/scx_cake/.gitignore
+++ b/scheds/rust/scx_cake/.gitignore
@@ -15,6 +15,8 @@ docs/*
 !docs/SIGNALS_AUDIT_2026-08-17.md
 !docs/SWEEP_ARITH_2026-08-03.md
 !docs/THEORY_CONSTRUCTS_ABC_2026-08-17.md
+!docs/AUDIT_COMPONENT_COST_2026-08-23.md
+!docs/KERNEL_TOOL_INVENTORY_2026-08-23.md
 
 # Benchmark binaries and local captures
 bench/*

--- a/scheds/rust/scx_cake/STATE.md
+++ b/scheds/rust/scx_cake/STATE.md
@@ -29,6 +29,22 @@ live WoW confirm); all hashes cited below resolve via those local backup branche
 
 ## RESUME HERE
 
+**PICKUP 2026-08-21 EOD — machine left on EEVDF, nothing attached, all
+background jobs stopped.** Code tip `60b238311` (§G38.1-repaired + §G40; §G39-B
+aborted), tip receipt `20260821T155506Z_head-5e0e8244b21a` built + attach-tested.
+Three staged actions, in graph-cut order:
+1. **R1 rotation** (needs KovaaKs being played, ~3.5 min):
+   `bash runs/rotation_r1_staged/r1_rotation.sh` — 3-arm native/G38/tip; draws
+   the tip's chain lane, scores §G38.1+§G40 (GameThread p99 128 → toward 6?).
+2. **E4a pinned chain3 split** (no game needed, ~3 min): rerun
+   `runs/causeb_chain3_20260821/ab.sh` (bug fixed) with stages pinned —
+   separates BPF-text pollution from migration-cooling; decides E4's shape.
+   Cause B front-end signature already CONFIRMED preliminary (ledger below).
+3. **E1 in-game per-thread counters** (`runs/frontend_ipc_20260821/`) — the
+   game-side confirm; optional `sudo setcap cap_sys_ptrace+ep /usr/bin/perf`
+   first for kwin tids.
+Board (live, movable): claude.ai/code/artifact/98701cdf-e541-48c5-8dfc-07109a311dbe
+
 | # | item | state | next action |
 |---|---|---|---|
 | 1 | **G35** in-handler bit from IRQ tracepoints + **G36** tick predictor | Phases A–D LIVE 2026-08-17 (D closes §G34 H3), §G36 BUILT, all gates clean; desktop movable hot-landings staircase **0.80 → 0.66 → 0.23 → 0.17%**, cpu0 timer hits **820 → 4** | captures on disk unscored: `wow-cake-g35d`, `wow-cake-g36`, `g36-desktop` in `~/Documents/Repo/scx_cake_bench/history/wake_latency/`; next action: score vs `wow-cake-g30c`. §G35/§G36 |
@@ -42,6 +58,116 @@ live WoW confirm); all hashes cited below resolve via those local backup branche
 | 9 | dead-branch deletions | pinned-wake preempt (5th zero dataset) + sibling kick (2nd) — delete-with-no-trade | **ON HOLD** until the receipts audit confirms the zero datasets (`REVIEW_INDEPENDENT_2026-08-17.md` Addendum, in git history); then delete both and run a game screen |
 | 10 | **G25** steal-ring bitmask | **LANDED**, verifier accepted, attach smoke passed 2026-08-08 | wake latency on HD2 render roles + P4 bench screen. Prediction on record: ~0.04% of a core quiet, 4.7% invalidated — **expected frame effect near zero; a null confirms the pricing** |
 | 11 | **G23** per-line IRQ-sink detection + mask avoidance | built, smoke PASSED, **endpoint unmeasured** | HD2 ABBA during ACTIVE play (P2 needs live mouse input) on `Window & Input` / `main` / `renderer` mean wake + severe-frame screen, then P4 `--blocks 2` bench screen. Receipts + steps: `docs/REVIEW_G21_G23_2026-08-02.md` §resume |
+| 12 | **G37** adaptive switch-cost floor (`cake_handoff_max_ns`) | registered 2026-08-20, §G37 | build Phase A: observe-only gap EMA, publish nothing, confirm ~1464 convergence on this host |
+| 13 | **G38** fully idle core outranks a cache-warm thread | **SCORED 2026-08-21** (live KovaaKs ABCCBA native/base/G38, 25 s slots): chain p50 19.25 → 18.42 µs (native 14.85), doubled cores 0.255 → 0.20 (native 0.04), game IPC 1.108 → 1.150 (native 1.263) — all three endpoints move the right way; ~¼ of the chain gap closed. PARTIAL WIN, KEPT | remaining doubling is `kwin_wayland` (sib-busy ~32%, untouched by G38's sites); next lever picked from the input-pipeline board. Data `runs/g38_idlecore_20260821/`. §G38 |
+| 14 | **G38.1** core preference at the raw-pick sites + serial arm | BUILT `ab57ba40a`; **guardrail FIRED**: mutex-handoff **−69.3% [−91.3, −47.3]** — the serial-arm core veto exiled handoff pairs; **veto withdrawn `bd54a03df`**. Attribution pairs 2026-08-21: today's mutex reads −9..−26% on EVERY build incl. pre-G38 `51ee88b21` (−12.5 [−18.4, −6.7]) — mode variance, not a build residual; only the veto's −69.3 stood clear | 3-arm game rotation draws the tip's chain lane. §G38.1 |
+| 15 | **G39** chain-successor handoff (construct) | Phase A census PASSED (~100× floor); **Phase B ABORTED `60b238311`** — pipe −36.8% [−42.1, −31.5], ctx +45.9% (§R.6 weld; pipe is SYNC ping-pong); mutex/schbench unaffected isolates the SYNC condition | Phase B' needs a wine-RPC vs data-stream discriminator before retry. §G39 |
+| 16 | **G40** kick the idle home (E7 find) | registered + BUILT 2026-08-21, §G40 | `cake_home_notify` `!live` remote branch now kicks tcpu; gates, attach-test, rides the same rotation |
+| 17 | **G41** wake-queue occupancy mark | BUILT `1b957daca`, screen PASSED 2026-08-21 (+48.2 vs baseline +41.3, diagnostic), §G41 | game screen: rides the next rotation (R1 already staged covers the tip once rebuilt) |
+| 18 | **G42** vtime mis-charge + missing per-CPU wall net | mechanism grounded in source, FIX BUILT (task-CPU slot indexing), repro 3× null, 2026-08-21, §G42 | SOAK: fixed cake attached through normal use with an exit watcher; wall-clock net for per-CPU queues stays open as the second half |
+| 19 | **G43** going-idle hint claim (predict-verify audit C1) | registered 2026-08-22, §G43; audit `docs/AUDIT_PREDICT_VERIFY_2026-08-22.md` | build, then on/off `--blocks 2` screen: mutex-handoff + perf-sched-pipe (weld guard) |
+| 20 | **G44** qmask answers wake-routing emptiness (audit C3) | wallclock NULL 2026-08-22; **CODE REMOVED 2026-08-23** (toggle audit) — the emptiness question belongs to the M4 consolidation program when it runs | closed |
+| 21 | **G45** event-complete idle census for the serial gate (audit C5) | BUILT `0ef821db8`; wallclock lean-positive 2026-08-22 (pipe −3.8, messaging −1.7, memcpy −0.2, all overlap); in the stack winner | sealed `--blocks 2` on the stack config; all-off vs old-tip A/A owed (callback registration cost). §G45 |
+| 22 | **G46** departing-slice cache, pid-tagged, per-CPU (audit C4 reshaped) | BUILT `61589428c`; **the campaign's one separated result**: memcpy −7.8% SEPARATED in singles, −5.4% SEPARATED in stack; pipe/messaging lean-positive | sealed `--blocks 2` (ccm-memcpy + mutex-handoff), then game screen — a stale slice is geometry, not just cost. §G46 |
+| 23 | **G47** ISR-successor kthread keeps the IRQ CPU | falsified at the KovaaKs frame gate 2026-08-23 (severe frames doubled, zero wake benefit warm); mechanism real only at deep idle; **CODE REMOVED** (toggle audit) | closed — revisit only with §G51 depth model live |
+| 24 | **G48** hint-first main placement (component audit) | **CODE REMOVED 2026-08-23** (toggle audit; counter too). History: **LOADED SCREEN FAILED 2026-08-23** (counter `29c18b379`, clean pair): hint word nonzero on 51% of wakes, claims 1.33M/3.54M attempts (37.6%/attempt, 19%/wake), net select_cpu 195→212 ns — claim-FAIL overhead (62% of attempts pay gates + failed test_and_clear + full scan) exceeds hit savings. Toggle stays off. Decision gate → census-claim (§G50 shape) with cheap-fail ordering: census bit read FIRST, gates only behind a set bit | **CLOSED 2026-08-23, all regimes measured**: idle-regime 74.1% claim rate but sel 140 vs 132 ns — the scan a hit skips is already cheap at idle; loaded +17 ns (claim-fail overhead). Mechanism verified, no cost regime exists; §R.29's push principle stands but the mailbox buys nothing. Toggle stays off |
+| 26 | **G50** census: claim ABORTED, zero-skip survives (maintainer autopsy) | **claim half ABORTED 2026-08-23, structural** — sel 179→264 ns/call; 84% attempt rate, 17.8% claims; autopsy: no winning regime (light load: scan already cheap; heavy: census empty, gate suffices; middle: contested stale bits → pay both). Gates (~75 ns) approach the scan they skip (109 ns). Walk code REMOVED; zero-skip (census==0 → skip both scans) stays under `--toggle g50`, untested — census never empty under this load | **zero-skip WINS its regime (first pass 2026-08-23)**: schbench-saturated sel 213→73 ns/call (−66%), request p99 −19% first pass DID NOT REPLICATE — BAAB mirrored: sel 200→63 ns SEALED (53/73 vs 195/205, separated), req p99 183.3 vs 172.5 ms inside slot spread 156–192 (variance-dominated, TIE). Callback win real; workload win unproven, needs overnight slot count |
+| 29 | **G51** idle-depth model (maintainer-directed) | **BUILT** behind `--toggle g51`: tp_btf/cpu_idle writes cstate into cake_irq_live; loader reads cpuidle exit latencies into rodata; consumer PENDING (census-claim ordering removed with the §G50 abort; next consumer = escape/exile pricing). **INERT ON THIS HOST — cpuidle current_driver is `none`**, degrade verified (logged, attach unaffected) | needs a cpuidle-enabled host or kernel config change (maintainer call) to measure |
+| 30 | **G52** preferred-core rank (maintainer-directed) | **BUILT** behind `--toggle g52`: loader reads acpi_cppc/highest_perf per CPU into rodata; consumer PENDING (census-claim tiebreak removed with the §G50 abort). CPPC live on this host. cpuperf_set half DEFERRED: governor `performance` pins 5.53 GHz, unmeasurable here | screens with g50 arm |
+| 31 | **M7** runqueues percpu-ksym direct reads (maintainer audit, 13th pass) | **BUILT `28a1b1839`** behind `--toggle m7`; ksym resolves + verifies (probe question answered). First pair INCONCLUSIVE: on-arm ran first and caught noise (p99 0.90 vs 0.63), deltas +8..+15 ns inside the asymmetry — expected effect below single-window sensitivity, same lesson as §M6 | composed m6+m7 mirrored ABBA (clean, 4 slots): sel −4, enq −3, disp −1 ns — coherent direction on every callback, ~1 ms/s total, below hardwire threshold. Both parked toggled off; revisit when the queryless path completes (K1 + F14) |
+| 32 | **K1** chronic-sink accounting L3→L2 (maintainer audit, 14th pass) | registered 2026-08-23 | handler-duration accumulation on the existing IRQ edge progs (stamp+subtract, owned line); event-driven window decay (no tick — roll on large stamp gap); BPF bumps cake_sink_gen on flag flip; deletes the loader poll + 1 Hz staleness. ~+20 ns/edge, screen once. K2 (fused kfuncs) + K3 (occupant facts as ops args) are PATCH-GATED options on the maintainer kernel; N1 (core DSQ-emptiness push replacing qmark) recorded, not built |
+| 27 | **M2** frame-clock trio is dead plumbing (maintainer audit) | VERIFIED 2026-08-23: cake_frame_ns/floor/slice have zero BPF readers (decl-only; §G11 comment admits it); votes still paid on display threads | decision: demote voting to loader-side telemetry or land a consumer; separate commit + wallclock screen |
+| 28 | **M6** occupant mirror — subscribe, don't query (maintainer audit) | **BUILT `9f344d8da`** behind `--toggle m6`; first mirrored ABBA: NULL on the one clean pair (select_cpu 187=187 ns, no coherence tax; slot 3 noise-contaminated) — the deref chains were warm-line cheap in the appsim regime | park pending a quiet-machine screen; handoff_yields stays on deref (needs live sum_exec) |
+| 25 | **G49** core-contended via idle-smtmask (component audit) | registered 2026-08-23; same audit | build behind toggle: smtmask bit replaces the sibling cpu_curr deref; A/A + wallclock |
+
+**TOGGLE CAMPAIGN (2026-08-22, maintainer-directed):** §G43–§G46 each sit behind a
+`const volatile` rodata toggle (`--toggle gNN=0|1`) so ONE binary serves both arms of
+every on/off wallclock pair — the verifier deletes the off arm at attach, and arm
+identity is the logged toggle line, not the binary hash. This is a sanctioned exception
+to "A/B by commits" (§S.6): rodata arms cannot suffer the stale-object-cache failure
+that rule guards against, and the toggles are scaffolding — winners get hardwired and
+losers deleted when the campaign closes. Screen: quick wallclock ABBA per toggle
+(pipe + messaging + calibrated memcpy, diagnostic tier), then stack the survivors and
+re-screen; keeps still owe the sealed/game tiers before scoring.
+
+**Campaign RUN 2026-08-22** (`scx_cake_bench/runs/toggle_wallclock_20260822/`, binary
+`61589428c` receipt `0a0223d8d397`, desktop noise, load1 1.5–30 — the herds' own):
+G43 lean-NEGATIVE (messaging +10.6% nearly separated against; its registered
+mutex+pipe `--blocks 2` endpoint still decides), G44 null, G45 lean-positive 3/3,
+**G46 memcpy −7.8% SEPARATED** (only separated single). Stack (g43=0 g45=1 g46=1 vs
+tip defaults): pipe −1.3, messaging −3.2 (overlap), **memcpy −5.4 SEPARATED** —
+direction held 3/3, the G46 separation reproduced in an independent pair. Zero
+stalls across ~25 min attached (doubles as §G42 soak evidence). Diagnostic tier
+only: sealed pairs + game screen owed before any toggle is hardwired.
+
+**GAME SCREEN 2026-08-22 (live HD2 gameplay, wake tier — MangoHud unavailable,
+maintainer-directed fallback): STACK NON-REGRESSING, leans better.** ABCCBA ×2
+(native / tip / stack, 25 s slots, arms = receipt binaries, stack = probe commit
+`42f2a1612`, banner-verified per attach). Slow wakes >1 ms/10k, arm medians:
+main 18.99 → **13.40**, renderer 19.12 → **11.19**, vkd3d_queue 1.17 → **0.73**
+(tip → stack; all-slot-rank consistent, no separation); Window&Input/fence tie;
+FAudio "regression" = 1 event in each of 2 slots. Game IPC: native 1.396,
+tip 1.552, stack 1.524 — BOTH cake arms beat native in this heavy regime
+(reverse of KovaaKs light). Native keeps renderer (7.70). Data:
+`runs/toggle_game_wake_20260822/` + `history/wake_latency/hd2tog-*`.
+
+**IRQ-origin service + scheduling volume (same traces, 2026-08-22):** mouse
+pipeline (libinput, woken from the USB-hub IRQ CPU 9): p99 **12.0 → 5.0/5.0 µs**
+native→tip/stack, max 159 → ~30, IRQ-CPU stranding 6.2% → 0.0% — the KovaaKs
+input win reproduces on HD2, toggles indistinguishable. GPU (CPU 13 origin):
+vkd3d_fence p99 564 → 351 → **326**, `main` 658 → 420 → **390** (native → tip →
+stack; stack best on every game-facing row). Volume per 25 s slot: cake
+−28% context switches (8.1M → 5.8M), −16% wakings, softirqs HALVED (733k →
+395k), migrations +25% (2.0M → 2.5M); tip ≈ stack on all counts. NEW
+OBSERVATION, unowned: cake's sink avoidance displaces nvidia's own kthreads
+off CPU 13 — nvidia-modeset p99 78 → ~820 µs, nvidia-drm/timeline 104 → ~890
+(stay% 2.5/20 → ~0) — game threads win but the displaced display-service
+tail is a possible frame-pacing input; needs a FRAME read to matter.
+
+**SECOND GAME SCREEN 2026-08-22 — LOTR (AppId 2956680, UE + vkd3d, LIGHT
+regime ~280% CPU), ABCCBA ×4 (n=8/arm after the maintainer extended play):**
+n=8 UPDATE — migrations native 1.37M / tip 1.61M / **stack 1.38M** (stack ≈
+native, tip +17%, 7/8 tip slots above all-but-one stack slot — g43-off removes
+the premium, near-separated); nvidia cadence sd 408.7/406.0/**391.6**, p99
+2149/2121/**2059**, max 3499/3903/**3397** (stack tightest all three, worst
+slot 423 < native 437 < tip 536); IPC 1.045/1.085/1.078 — cake > native ~3–4%
+solid, tip-vs-stack DEMOTED to tie (scene outliers 1.59/1.29 in rounds 3–4).
+First-round detail below.** wake tails near-zero on ALL arms
+(0.0–0.5/10k — regime too light to differentiate); game IPC native 1.034 <
+tip 1.069 < **stack 1.078** (stack tightest spread); **stack migrations 1.37M
+< native 1.42M < tip 1.71M per slot** — first toggle-level VOLUME effect:
+g43-off removes cake's migration premium (HD2 heavy: both cake arms +25% vs
+native). Mouse service ties native (p99 7.0 vs 7.5 µs; heavy-regime 2.4× win
+absent when quiet). GPU-origin lane flips to native when light (fence p99 59
+vs 106/120) — the displaced nvidia-kthread pattern reproduces (modeset 21.5 →
+~250 µs), now seen in BOTH regimes; frame-pacing question stands. Data:
+`runs/toggle_game_wake_20260822/lort-*`, `history/wake_latency/lort-*`.
+
+**IRQ jitter/duration (same traces, corrected aggregation):** handler
+durations IDENTICAL all arms both games (nvidia p50 24/p99 ~48 µs, USB 2–4/
+4–7 µs) — scheduler-independent, validity anchor. Nvidia IRQ inter-arrival
+(pacing proxy), LOTR at near-equal rates: sd 401/399/**387**, p99 2154/2121/
+**2048**, max 3408/5054/**3345** native/tip/stack — stack tightest on all
+three, tip owns the worst spike. HD2 confounded (rates differ 10–15% by
+scene). USB cadence bit-identical (p99 1005 µs all arms). Analyzer:
+`runs/toggle_game_wake_20260822/irqjitter.py`.
+
+**FIRST FRAME READ of the toggle campaign — KovaaKs menu ~700 fps, ABCCBA,
+n=2/arm, MangoHud per-frame (2026-08-22 23:46–23:50):** native 728 fps /
+0.1% low 388.9 / median FT 1.349 ms; tip 705 / 383.4 / 1.394; stack 689 /
+377.4 / 1.429. Severe frames: cake arms 0.029% vs native 0.032; worst frame
+stack 3.06 < tip 3.11 < native 3.99 ms. **The g43 trade is now MAPPED:**
+tip (g43 on) beats stack by ~35 µs/frame in this extreme-fps idle-machine
+regime — the hint's design case (scan-free claims at huge wake rates) —
+while g43-off wins loaded gameplay (HD2 tails, LOTR migrations) and
+wallclock. g45+g46 implicated in no loss anywhere. Menu caveat travels
+(G17 class); report `runs/game/kovaaks/2026-08-22/reports/`.
+
+**Isolation pair (stack2): the stack is MORE than G46.** Full stack vs
+g43=0+g46=1 (only §G45 differs): pipe −1.5, messaging −5.5 (overlap), memcpy
+**−4.4 SEPARATED** — §G45 contributes inside the stack despite its null single.
+WARNING for future reads: same-config memcpy wanders 9.4–10.3 s (~5%) ACROSS
+pairs — within-pair only; attribution goes to the sealed tier.
 
 **PORTABILITY FIX (2026-08-20): one binary now runs on any machine.** A 1.2.1
 package refused a 16-CPU host: `build.rs` baked the build machine's CPU and CCD
@@ -79,7 +205,60 @@ stall train 20–33×.
 
 ---
 
+## CAMPAIGN: select_cpu for gaming (opened 2026-08-23, maintainer-directed)
+
+Tonight's evidence: one placement redesign (§G53+§G54) moved game frames more
+than any change this month — severe frames 0.062→0.037%, 0.1% low 171→286
+fps, switches −5%, dispatch −41%, avg fps unchanged. Placement is the lever.
+
+**TOGGLE AUDIT 2026-08-23** (maintainer order): g43 hint hardwired ON
+(campaign scaffolding retired); g44/g47/g48 bodies DELETED (null/falsified/
+closed); surviving toggles, each with a reason: g46 (separated win awaiting
+its pre-registered seal + game screen), g51/g52 (pillar-4 physics inputs,
+consumers scheduled), m6/m7 (parked pending K1/F14 composition). A/A after
+audit: sel 83 ns unchanged, spills flat, select_cpu 486 insns.
+
+**REMAINING-TOGGLE BENCHMARK 2026-08-23** (post-hardwire base): g46 net
+NEGATIVE on the new base (+2.6k us/s: sel −9 ns but stopping publish +26 ns;
+its memcpy workload win needs the registered ccm-memcpy+mutex seal, appsim
+cannot see it) — stays off pending that seal. m6+m7 NULL on the new base
+(78 vs 77 ns): the mailbox design removed their query sites from the hot
+path — cleanup candidates next audit. g51 unmeasurable (no cpuidle driver,
+BIOS decision); g52 unmeasurable (consumer deleted, A/A by construction).
+
+**HARDWIRED 2026-08-23** (maintainer order): §G45 census, §G50-R zero-skip,
+§G53 census fallback, §G54 self-park mailboxes are DEFAULT cake; toggles
+g45/g50/g53/g54/g55 removed. Default-arm confirmation: sel 83 ns @ 151k =
+12.5k us/s (was 183 ns / 27.4k), dispatch 219→116 ns, total scheduler cost
+−40%, appsim p99 0.678 clean. Pending: EEVDF head-to-head HD2 frames (game
+wedged pre-Vulkan after restart churn — needs a human-present launch, FIRST
+item next session); longer sealing rotation; K2 for the 8k line.
+
+**Pillars, in priority order:**
+1. **Frames are the endpoint.** Every select change screens on the game
+   rotation (severe ratio, 0.1% low, and BOTH jitter faces: avg|Δ|/Δp95
+   small-wobble vs Δmax big-hitch — §G54 trades the first for the second;
+   whether that feels better is a maintainer in-game call).
+2. **Seal §G53+§G54**: longer HD2 + KovaaKs rotation, one input-live
+   mission, mutex/pipe guards (serial-handoff interplay unmeasured).
+3. **Cost floor**: 80 ns now, BPF floor ~65-70; K2 fused place kfunc
+   (maintainer kernel patch) + mailbox hit-rate are the path to 8k us/s.
+4. **Physics inputs feed parking policy at zero wake cost**: §G51 depth
+   (needs BIOS Global C-State Control enabled), §G52 rank, K1 sink
+   self-accounting — the idle CPU decides its own quality when parking.
+5. **Falsified, do not revisit**: verified claims on the wake path (§G48,
+   §G50-claim, §R.29); census-as-identity; unthrottled pre-scan gates.
+
 ## Scoreboard
+
+**BLENDER-RED — DOWNGRADED to practical tie 2026-08-23:** on the hardwired select redesign the deficit is −0.21% [−0.29,−0.14] (2 blocks), below the 1% meaningful threshold; the redesign recovered the loss. Bisect deprioritized. Same window: **mutex-handoff +39.67% [+38.4,+41.0]** vs the +10.3% seal — the mailbox design amplifies the handoff shape (migrations −162k); needs an 8-block seal to enter the scoreboard. Original flag: blender-render vs native at HEAD d41b7dd41:
+−2.31% then −1.56% [−2.9,−0.3] (2×2-block, second run quiet), cake +78-88k
+cpu migrations. The +11.9% seal is 2026-07-19, unscreened for a month; today's
+commits cannot change decisions (O1 order-only, M3 identical, toggles off).
+Suspect: the month of sink-veto strengthening (quiet-machine exile, §G47's
+origin finding). Needs commit bisect over the July→Aug window, 2-block per
+step, migrations as the mechanism signature.
+
 
 ### Benchmarks vs native EEVDF — SEALED exact-pair medians, 8 blocks
 
@@ -102,6 +281,9 @@ y-cruncher, namd, kernel-defconfig, xz, prime.
 
 ### Games — latest valid reads
 
+| hd2-menu 2026-08-23 (game ab ABBA, 2 runs/arm, HEAD 1f1682044) | avg fps / 1% low / 0.1% low / p99 | native 599 / 455 / 366 / 2.23 ms | cake 616 / 527 / 388 / 1.90 ms | ✅ cake sweeps averages; best-run 0.1% ties 398.4; native's weak run was slot 1 (first-slot noise). HEAD healthy in-game — outranks BLENDER-RED per GAME-FIRST |
+
+
 | run | metric | native | cake | verdict |
 |---|---|---|---|---|
 | HD2 menu, ABBA 2/arm, 240 Hz VRR, 2026-08-01 (G17) | 240 Hz deadline miss % | 3.019 | **1.419** | **cake 2/2, −53%** |
@@ -111,6 +293,8 @@ y-cruncher, namd, kernel-defconfig, xz, prime.
 | same | 240 Hz deadline miss % | 1.004 | 1.278 / 1.155 | native |
 | HD2 live, ABBA, 2026-08-02 (G21) | `main` mean wake | 0.79 / 0.79 | **0.47 / 0.48** | **cake 2/2, −39.9%** |
 | same | `renderer` mean wake | 0.91 / 0.83 | **0.66 / 0.64** | cake 2/2, −25.3% |
+| KovaaKs live, ABBA 22 s, 2026-08-20 (wake tier) | mouse-IRQ→libinput wake p99 / starts on IRQ CPU | 11 µs / 36.1% | **3 µs / 0.0%** | **cake**; native n=1 slot — eevdf-2 had zero mouse input |
+| same | task-graph role wake p99 (TaskGraph/Game/Render) | **2.57 / 1.58 / 0.96** | 5.59–13.07 / 2.73–115 / 2.49–4.44 | **native 2/2 most roles**; cake mig% ×2–3 |
 
 **WoW wake read (2026-08-17, single-arm cake @ G27.1c build `db0b3636…`, 22 s live
 play — attribution only, no native arm).** 29 roles. Every high-n role p99 ≤ 2.6 µs
@@ -159,7 +343,7 @@ smallest.
    `56f9e886…`) attaches and runs clean on 7.1.8. The libbpf skeleton warning still
    prints but is non-fatal.
    - Quick wallclock ABBA vs nightly HEAD (diagnostic tier,
-     `scx_cake_bench_assets/runs/adhoc_wallclock_113_vs_nightly_20260819/`): nightly
+     `scx_cake_bench/runs/adhoc_wallclock_113_vs_nightly_20260819/`): nightly
      pipe **−16.0%**, memcpy −3.9%, sched-messaging **+70.5%** (4/4, no overlap).
      The many-to-many handoff shape regressed vs 1.1.3; unscored at the sealed tier.
    - n=10 confirm (suite 4, 5×ABBA): schbench-light req p99 **+72% 10/10** (S sd
@@ -179,14 +363,17 @@ smallest.
      `cake_frame_slice_ns`, §S.2) for every task; the same-CPU handoff tail pays.
      Registered fix: §G12 KEYSTONE re-bases the `FRAME_*_SHIFT` windows onto the
      occupant's own period, which decouples bystander tasks from the global clock.
+   - The KovaaKs live wake A/B (2026-08-20) shows the same shape vs native EEVDF:
+     task-graph wake p99 2–5× worse than native while the IRQ-sink half wins
+     (ledger row; `runs/kovaaks_irq_wake_20260820/`).
 8. **Receipts audit** — 5 load-bearing claims (deletion-queue zeros, 1464 ns, SLICE_NS
    dose, §R.17 +28-36%, G17/G21 wins); list + rationale:
    `REVIEW_INDEPENDENT_2026-08-17.md` Addendum (git history).
 9. **G17's mechanism is unexplained** — peer share 58.1%→56.9% while the tail fell 17%.
 10. **`SLICE_NS`'s vtime-unit role** — the last architectural constant.
 11. **Probe-driven `cake_handoff_max_ns`** — forbidden per the −35.66% mutex-handoff
-    result; a host-adaptive value needs runtime observation of `used` in ops.stopping,
-    not a boot probe (main.rs:159 comment).
+    result. The runtime-observation path is now registered as **§G37** (adaptive
+    switch-cost floor); boot probes stay dead (main.rs:159 comment).
 12. **`STATE_SLOT_BYTES` sysfs probe** — probe the cache line size at boot instead of
     the hard-coded 128 (intf.h:92).
 13. **`CAKE_NEIGHBOUR_PROBE_DEPTH` topology ordering** — order the probe by
@@ -278,7 +465,7 @@ zero-spill claim made before it is vacuous.)
 
 **Purpose: spot trends at a glance.** One row per experiment, so the arc, the verdicts,
 and the cost read in one pass. Current state is above; the `§` registry below holds the
-design rationale. `scx_cake_bench_assets` holds the raw runs.
+design rationale. `scx_cake_bench` holds the raw runs.
 
 **Rule for this file: every number is measured, and its EVIDENCE CLASS is named.** A blank
 verdict means never measured — not "fine".
@@ -346,6 +533,18 @@ real session), live replica (loader logic run standalone on the live host), audi
 | R.27 | shaped compat ladders for ≤ 6.18 kernels (§R.27) | STATIC + CI | ✅ **CI veristat green ×6** (6.13/6.16/6.18/rolling/for-next/bpf-next, run 32206840388, 2026-08-18) | spills 28 → 26, hot frames flat (`select_cpu` 5, `enqueue` 6); +141 insns of dead arms, pruned at load; dev-kernel bench screen still owed |
 | **R.28** | per-task slice cap, fixed patience windows, frame clock demoted to diagnostic (§R.28) | bench dose + n=3 ABBA | ✅ **clock mode mechanism REMOVED; tail gap partially remains; game screen owed** | quiet handoff p99 rests 0.86–0.92 (was 0.85–1.9 drifting); divides 11→5, spills 17/11→16/10; p999 2× + schbench-light +72% vs 1.1.3 persist → IRQ-reactive stack (§G33/§G35/§G36) is the standing suspect |
 | — | spread placement, co-location returns off (§R.1 fps A/B) | FRAME | **reverted byte-identical (7826cfe3a; hashes now in backup/nightly-12-commits-20260818)** | fps INCONCLUSIVE: scene drift **~7%/h** (nvidia **5044 → 4695/s**) dominated every arm; placement stayed concentrated on ~7 CPUs with all three co-location returns off |
+| — | **KovaaKs wake+IRQ A/B** — eevdf/cake/cake/eevdf, 22 s slots, HEAD `f26d3c6b2` (ops `cake_1.2.1`, kernel-log identity) | **WAKE, interleaved** | ⚖️ **split** | sink machinery works: game-role residency on IRQ CPUs {5, 13} 10–61% native → ~0 cake; mouse-IRQ→libinput p99 **11 → 3 µs**, IRQ-CPU stranding **36.1 → 0.0%**. Bulk UE4 task-graph wakes: native p95/p99 **2–5× tighter**, cake mig% ×2–3 — the gap-#7 many-to-many shape, now shown vs native too. Input intensity uncontrolled per slot (eevdf-2: zero mouse). `runs/kovaaks_irq_wake_20260820/` |
+| — | **domain wallclock audit** — sound/network/render/taskgraph/game from the retained g38 traces | **WAKE, interleaved (offline reprocess)** | 🏆 **render + sound wake tails flip to cake at G38** | render: modeset p99 **14.1 → 3.1**, drm/timeline **28.9 → 3.2**, dxvk 3.9–5.3 → 2.9–4.3 (5 of 7 comms win); AudioThread p99 **7.6 → 5.1**. Losses: TaskGraph p99 5.7 → 7.0, **GameThread p99 6.3 → 72.5 at tied p50** (new target), exec +15–42% everywhere, mig ×3–5 all domains. Network n/a this title (NET_RX 3–5 ms/25 s). `runs/domain_audit_20260821/` |
+| **G39-A** | chain-successor handoff census (§G39 Phase A, offline, zero code) | **CENSUS** | ✅ **opportunity confirmed ~100× the abort floor** | game↔wineserver **~580k wakes each way/25 s, 80.9–91.9% handoff-shaped** (waker blocks ≤1464 ns, gap p50 0.6–1.1 µs); dxvk-submit→queue 63%, TaskGraph→GameThread 71%. Native same shape (92–97%). `runs/domain_audit_20260821/*.census.json` |
+| **G38.1** | core preference at the raw-pick sites + serial arm (§G38.1) | STATIC + attach-test + **bench exact-pair (blocks 2, diagnostic)** | 🚨 **guardrail FIRED → serial veto withdrawn same session** | `cake_pick_idle_escape` 34 insns 0 spills; spills 16/12/28, select_cpu 428→435; attach PASSED 15:26. Guardrail on receipt `ab57ba40a`: **mutex-handoff −69.3% [−91.3, −47.3]** (task_clock −13.6% — pairs waiting), schbench-saturated +11.2% [5.5, 16.9] primary GOOD but context_switches +23.2% vs 5% margin. Repair `bd54a03df`: serial arm sheds the core veto (§R.26 — veto fired on signal presence, no cost comparison); home-claim veto + all pick sites stand; select_cpu →424. Tip re-run owed |
+| **G39-B** | WAKE_SYNC joins the serial-handoff arm (§G39 Phase B) | STATIC + attach-test + **bench exact-pair (blocks 2)** | ❌ **ABORTED `60b238311`** (pre-registered abort: pipe regression beyond CI) | built `ec8d24dc6` (SYNC skips `cake_system_serial()`, object byte-identical; two called-subprogram shapes rejected first for select_cpu spills); tip guardrail: **perf-sched-pipe −36.8% [−42.1, −31.5], ctx-sw +45.9%** (sealed +22.7) = the §R.6 weld re-measured — pipe wakes ARE SYNC ping-pong; mutex −9.2 (non-SYNC) and schbench **+42.4 [22.9, 62.0]** unaffected, isolating the SYNC condition. Census + registry stand; Phase B' needs an RPC-vs-stream discriminator |
+| — | **cause-B discriminator** — `chain3` microbench (3 unpinned socket stages, FIXED work = identical instruction streams), EEVDF vs tip, per-thread counters | controlled microbench, **n=1/arm PRELIMINARY** (ABBA hung on a tool bug after the cake slot; fixed) | ✅ **front-end pollution CONFIRMED** | stage IPC **−5.5/−9.7/−12.6%** with L1i/kinsn **+19–24%**, br-miss +10–19%, **L1d flat**; smallest stage worst (matches the game's 1.4×→1.19× gradient); e2e p50 near-tie, p99 +21%, one 2.7 ms max. Mechanism split still owed: BPF text vs migration-cooling → **E4a pinned rerun** decides E4's shape. `runs/causeb_chain3_20260821/` |
+| **G41** | wake-queue occupancy mark (§G41, predict-verify) | 2-block screen, diagnostic, noise 59% | **BUILT `1b957daca` 2026-08-21; screen PASSED** | schbench-saturated vs native +48.2 [43.2, 53.2] against same-hour baseline +41.3 [36.5, 46.1]; first screen aborted on the §G42 latent stall (attributed away, 1/1 + 1/1); game rotation owed |
+| **G42** | vtime mis-charge + no per-CPU wall net (bug) | source + stall dump; repro 3× NULL | **FIX BUILT 2026-08-21, soaking** | remote property change fires running/stopping on the CALLER's CPU; smp-id slot indexing let the caller be charged the target's difference (+3.226 s observed); fix = index by task CPU; §G42 |
+| **G40** | kick the idle home (§G40, E7 find) | STATIC + attach-test | **BUILT `c0b6d65d7` 2026-08-21; unscored** | E7: 651/651 slow GameThread wakes (>20 µs; p99 128 vs native 6.1) had idle capacity, ~75% an idle home that `cake_home_notify` never kicked (gap B2 measured); fix = one KICK_IDLE in the `!live` remote branch; tip attach PASSED 15:39, sink set [13] live |
+| **G38** | fully idle core outranks a cache-warm thread (§G38) | **WAKE chain + perf-stat IPC, interleaved ABCCBA** (native/base/G38, 25 s live KovaaKs, 2026-08-21) | ⚖️ **partial win, KEPT** | chain p50 base 18.72/19.77 → G38 18.55/18.29 µs vs native 15.51/14.19; doubled cores 0.27/0.24 → **0.20/0.20** (native 0.05/0.03); game IPC 1.104/1.112 → **1.156/1.143** (native 1.238/1.287). All three endpoints move the right way; ~¼ of the gap closed. `kwin_wayland` sib-busy ~32% untouched. Arms: base receipt `head-51ee88b21`, G38 receipt `g38_5be54ef0` (source diffed identical to `dac0be8d8`). `runs/g38_idlecore_20260821/` |
+
+| — | **toggle campaign** — §G43 off / §G44 / §G45 / §G46 on-off ABBA + stack, one binary, arms = rodata toggles | **wallclock, interleaved, diagnostic** | ⚖️ **G46 the one separated result; G45 lean+; G44 null; G43 lean−** | per-arm medians (on vs off): G43 pipe +2.6 msg +10.6 mem +4.8 (all overlap, against); G44 +2.2/+5.6/−1.5 (overlap); G45 −3.8/−1.7/−0.2 (overlap, 3/3 for); G46 −0.7/−2.9/**−7.8 SEPARATED**; stack (g43=0 g45=1 g46=1) −1.3/−3.2/**−5.4 SEPARATED**. `runs/toggle_wallclock_20260822/` |
 
 ### The frame result (2026-08-01, the campaign's first)
 
@@ -409,7 +608,7 @@ to a heading here.**
 | [§G1–§G6](#g1-wake-service-under-load-trunk) | trunk graphs — wake service (N), cache trade (M), ordering (S), game-tail bound (B), spill proxy (P), harness meta (H) |
 | [Graph cut](#graph-cut-open-by-prune-value) | the OPEN queue, ranked by prune value |
 | [§G7–§G25](#g7--mutex-handoff-p99) | measured campaigns, one entry each — verdicts with numbers; the §G12 KEYSTONE lives here |
-| [§G26–§G36](#g26--frame-laxity-input-registered) | registered constructs and live builds — bold status line per entry |
+|  [§G26–§G38](#g26--frame-laxity-input-registered) | registered constructs and live builds — bold status line per entry |
 | [§R.1–§R.26](#r--design-rationale-from-source-comments) | design rationale from source comments, incl. the two maintainer rulings (§R.25, §R.26) |
 | [§S.1–§S.7](#s--constant-ledger-from-intfh) | constant ledger from `intf.h` |
 | [Open review findings](#open-review-findings--review_independent_2026-08-17md) | verified against source, not yet fixed |
@@ -1084,9 +1283,456 @@ expected → ~0).**
   select_cpu 4/1 unchanged, TOTAL 17/11/28. Ratio 0.67, all gates clean.
   Pending: relaunch + desktop smoke (timer-race hits expected → ~0).
 
+### §G37 — adaptive switch-cost floor (registered 2026-08-20)
+
+`cake_handoff_max_ns = 1464` is this machine's number shipped to every machine
+(hardware-audit finding #2). It is cake's definition of "a hand-off-sized run" in
+three places: the turn floor, the occupant-nearly-done horizon, and the partner
+classifier. A boot probe cannot replace it — measured 2026-07-30, −35.66%
+mutex-handoff: an idle probe sees only the ~600 ns hardware floor, not the load
+tail (Open gaps #11).
+
+- **Hypothesis:** the real switch gap, measured on the switch path itself, converges
+  near 1464 on this host and gives other hosts their own correct number.
+- **Signal:** gap = new-start − old-start − old-run-length; all three values already
+  on the switch path, zero new clock reads. EMA per CPU, folded to ONE global value
+  (the classifier needs one yardstick).
+- **Dynamics:** fast up, slow down — too low caused the switch storm, too high is
+  mild. Continuous measurement; the published floor moves only on the sink-monitor
+  cadence (1 s → 16 s with confidence), in steps, inside hard clamps.
+- **Phases:** A observe-only (log, publish nothing). B actuate; sealed mutex-handoff
+  pair; expect null on this host — the win is portability. C game screen ABBA with
+  floor telemetry; motion during scene changes is the thing to watch.
+- **Endpoint:** A: converges 1464 ± 25% here. B: mutex-handoff null-or-better.
+  C: severe-frame ratio null-or-better, floor stable within a game session.
+- **Aborts:** published floor flaps > 1 step/min under game load; mutex-handoff
+  regresses; spill or verifier budget blows on the hot path.
+
+---
+
+### §G38 — a fully idle core outranks a cache-warm thread (registered 2026-08-21)
+
+Measured on live KovaaKs (`runs/kovaaks_irqchain_20260821/ANALYSIS_HOPS.md`): cake
+runs both threads of a core **0.15-0.18** cores of the time against native's **0.02**,
+on a machine with only **2 of 8** physical cores busy. The input reader lands beside a
+running sibling on **30%** of its runs (native 10%) and pays **+59%** execution time
+there; the task-graph workers land beside one on **22%** (native 0.7%). Two sites rank
+cache warmth above core exclusivity: the home claim declines `select_cpu_dfl`'s
+fully-idle-core preference by design (§G13), and `ROUTE_GLOBAL` *seeks* the target's
+sibling for cold pickup.
+
+- **Hypothesis:** on an idle machine a whole idle core beats a warm thread on a busy
+  core; ranking the core first cuts chain-stage execution time with no placement cost.
+- **Steps:** `cake_pick_idle_clean` asks `SCX_PICK_IDLE_CORE` first and falls back to
+  any idle CPU; the home claim declines a contended core (`cake_core_contended`, one
+  `cpu_sibling` read plus the existing `cake_cpu_curr`); `ROUTE_GLOBAL`'s sibling
+  preference is ranked BELOW the clean pick instead of above it. No decision deleted.
+- **Endpoint:** mouse-IRQ -> game-thread chain p50 (native 14.2 µs, cake 16.7-17.7 µs)
+  closes; cores-with-both-threads-busy falls toward native's 0.02; game-process IPC
+  null-or-better. Then a KovaaKs frame ABBA.
+- **Aborts:** spills rise on `select_cpu`/`enqueue`; stage execution unchanged (the
+  co-residency was a symptom, not the cause); saturated-machine regression from losing
+  the home claim, watched on schbench-saturated and mutex-handoff.
+
+**Build 2026-08-21:** zero warnings both profiles, clippy clean, spills **16/12/28
+unchanged**, `cake_select_cpu` 432 -> **428** insns, total 1988 -> 2001.
+
+**SCORED 2026-08-21 (ABCCBA native/base/G38, 25 s live KovaaKs slots; data
+`runs/g38_idlecore_20260821/`): partial win, KEPT.** Chain p50 (mouse IRQ -> game
+thread) base 18.72/19.77 → G38 18.55/18.29 µs, native 15.51/14.19 — closes ~¼ of the
+gap. Doubled-core mean 0.27/0.24 → 0.20/0.20 (native 0.05/0.03). Whole-game-process
+IPC 1.104/1.112 → 1.156/1.143 (native 1.238/1.287) — the IPC endpoint is BETTER, not
+just null. Per-stage sibling-idle exec p50: game worker 3.23 → 2.81 µs (native 2.31),
+libinput 4.07 → 3.87 (native 3.40), **kwin_wayland flat 10.95 → 10.92 (native 8.26)
+with sib-busy ~32% in both cake arms** — G38's three sites never see kwin's placement,
+so the residual doubling and the largest per-stage exec loss are the same open front.
+Arm identity: base = receipt `head-51ee88b21`; G38 = receipt `g38_5be54ef0`, whose
+`source_snapshot` diffs identical to HEAD `dac0be8d8` (the tested commit was amended
+into it; binary hashes differ only by build environment).
+
+#### §G38.1 — core preference at the raw-pick sites + serial arm (registered 2026-08-21)
+
+The flow map (`runs/g38_idlecore_20260821/flowmap.md`) found G38's residue: the
+kernel's ranked pick is already core-first at flags 0, so the uncovered doubling
+sources are the RAW `scx_bpf_pick_idle_cpu(…, 0)` sites and the serial
+co-location arm. Kernel fact checked 2026-08-21: `flags & SCX_PICK_IDLE_CORE`
+on `select_cpu_and`/dfl is a STRICT core search returning −EBUSY (idle.c:613),
+and a raw pick at flags 0 has no core preference at all. The idle sink core
+{5,13} poisons a strict CORE pick, so every CORE retry must re-pick
+thread-grain when the winner is bad — the pick's test-and-clear consumes the
+sink's idle bit, which makes the second CORE try skip it.
+
+- Hypothesis: core-first at the raw-pick retries (`:936`, `:1001`, compat
+  `:921`) plus `!cake_core_contended(wc)` on the serial arm cuts the remaining
+  doubling (kwin sib-busy 32%) without touching the ranked pick.
+- Steps: CORE-first pick with validated thread-grain fallback at the three raw
+  sites; one contended-core term on the serial arm; no decision deleted.
+- Endpoint: repeat the G38 rotation — kwin sib-busy toward ≤12%, doubled cores
+  toward native's 0.04, chain p50; bench guardrail mutex-handoff +
+  schbench-saturated null (the serial arm term is the risk).
+- Aborts: spills rise; mutex-handoff regresses beyond CI; kwin sib-busy
+  unmoved (falsifies the site attribution — the residue is then WAKE_DSQ
+  pulls, site D).
+
+#### §G39 — chain-successor handoff (construct; registered 2026-08-21)
+
+The input chain (libinput → kwin → game) repeats 50k×/25 s at fixed depth 3;
+every hop is a SYNC wake whose waker blocks immediately. Cake re-places each
+hop from scratch; the switch-cost floor for the whole chain is 3 ×
+`cake_handoff_max_ns` ≈ 4.4 µs against native's measured 14.2 µs — the only
+lever whose ceiling BEATS native rather than matching it (gap #7's shape,
+attacked at the chain, not the storm).
+
+- Hypothesis: when a serial-shaped waker SYNC-wakes its successor and blocks
+  within `cake_handoff_max_ns`, handing the waker's CPU directly to the
+  successor beats any re-placement.
+- Phases: A offline census from the retained g38 traces — opportunity rate
+  (SYNC wake → waker blocks < 1464 ns) per chain edge, zero code. B the
+  handoff arm: §R.18 conf + `cake_handoff_yields` gate the SYNC distrust arm
+  (`:912`) into a handoff instead of a re-rank; sibling/sink vetoes retained.
+  C chain A/B + frame screen.
+- Endpoint: chain p50 below native's 14.2 µs, 2/2 slots; task-graph roles
+  null-or-better (the §R.6 weld is the known failure mode — G9.4's per-CPU
+  bit game-failed; this one is per-EDGE and conf-gated).
+- Aborts: census &lt; 10k opportunities/25 s; any task-graph p99 regression
+  &gt; 2×; any hot-path spill; pipe/futex bench regression beyond CI.
+- **Phase A PASSED + Phase B BUILT 2026-08-21 (`ec8d24dc6`).** Census (offline,
+  `runs/domain_audit_20260821/*.census.json`): game↔wineserver ~580k wakes each
+  way/25 s at 80.9–91.9% handoff-shaped, gap p50 0.6–1.1 µs — ~100× the abort
+  floor; native shows 92–97% on the same edges. Build: one condition — SYNC
+  skips `cake_system_serial()` in the serial arm (the kernel asserts the pair;
+  a non-SYNC wake still proves it machine-wide); every other gate stands. Two
+  subprogram shapes were tried first and REJECTED: a called `cake_sync_handoff`
+  cost select_cpu +1/+2 then +1/+8 spills/fills from the extra clobber point —
+  the merged condition is free (16/12/28, 2039 insns, byte-identical counts to
+  §G38.1). Guardrails owed: mutex-handoff, schbench-saturated, perf-sched-pipe.
+- **Phase B ABORTED 2026-08-21 (`60b238311`), pre-registered condition.** Tip
+  guardrail: perf-sched-pipe **−36.8% [−42.1, −31.5]**, ctx-switches +45.9%
+  (sealed +22.7) — pipe wakes are `wake_up_interruptible_sync_poll` ping-pong,
+  and admitting SYNC to the serial arm welded the pairs (§R.6, re-measured).
+  mutex-handoff (futex, non-SYNC, −9.2) and schbench-saturated (+42.4)
+  unaffected — the SYNC condition is isolated as the cause. Do NOT retry
+  Phase B without a discriminator that admits the wine-RPC edge (successor
+  chain, both sides block round-trip) while excluding data-streaming SYNC
+  pairs (pipe: consumer drains a buffer the producer keeps filling). Candidate
+  discriminators for B': wakee's own conf bit (both sides serial-shaped);
+  chain depth ≥ 3 (RPC continues to a third task, pipe bounces between two).
+- **Revert confirmed 2026-08-21:** pipe on the reverted tip −12.0 [−13.1,
+  −10.8] with ctx-switches +1.6% (was +46) — the weld effect (~25 pts) is
+  removed and CI-separated from the aborted build. Today's −12 baseline vs
+  the sealed +22.7 is regime-shaped (mutex read −9..−26 across ALL builds
+  including pre-G38 the same hour); settle only at the sealed tier if it
+  matters (H5: the formula is conditioned on regime + workload).
+
+#### §G40 — kick the idle home (registered + built 2026-08-21) `<- B2, E7`
+
+E7 decomposition (`runs/domain_audit_20260821/*.e7.json`): every one of cake's
+651 slow GameThread wakes (>20 µs; p99 128 µs vs native 6.1) happened WITH idle
+CPUs free, and ~75% targeted an ALREADY-IDLE home — `cake_home_notify`'s
+`!live` branch returned false for a remote idle home, so nothing kicked tcpu
+and the queued task waited for the steal ring. This is open-gap B2's measured
+cousin, found on the game's main thread.
+
+- Hypothesis: kicking the idle home itself (one `KICK_IDLE` on tcpu) collapses
+  the GameThread tail toward native's 6 µs; the B2 discriminator and fix in one.
+- Steps: `!live` remote branch kicks tcpu and reports handled; local case
+  unchanged; no other route touched.
+- Endpoint: GameThread wake p99 ≤ 2× native on the rotation; E7 rerun shows
+  idle-home slow wakes → ~0.
+- Aborts: any spill; kick-storm visible in schbench-saturated (a kick per
+  queued wake is the design cost — census says 1% of GameThread wakes).
+
+#### §G41 — wake-queue occupancy mark (registered 2026-08-21) `<- G25, predict-verify audit`
+
+Every dispatch on every CPU peeks the global WAKE_DSQ (rhashtable lookup plus
+a shared head line) even in home-routing regimes where that queue is nearly
+always empty. §G25 proved the mark shape for per-CPU queues, where the owner's
+unconditional rescan makes a stale-clear bit benign. WAKE_DSQ has no owner —
+every consumer gates on the mark — so a stale-clear needs a closing protocol:
+the setter marks AFTER the insert, the consumer retires the mark only by
+clear (exchange) then re-peek, so a nonempty queue can never end unmarked.
+
+- Hypothesis: one "may hold work" mark in its own §R.10 slot replaces the
+  global peek with a word read on the common dispatch, no wake-service change.
+- Steps: mark slot + set/retire helpers; dispatch peeks only on mark-or-starved
+  (§R.16 cadence = lost-mark backstop, bounded one 24 ms window, no watchdog);
+  set at both WAKE_DSQ insert sites (wake arm, anti-collision arm).
+- Endpoint: schbench-saturated `--blocks 2` non-regressing (the global-queue
+  regime is where a service bug would show); game rides the next rotation.
+- Aborts: "runnable task stall" in scx_cake.log; watchdog kill
+  (`scheduler == native`); schbench-saturated p99 regression outside noise.
+
+**Outcome 2026-08-21: BUILT `1b957daca`, screened.** First screen ABORTED on
+the pre-registered stall (`systemd` 7.05 s, watchdog): dump shows a SINGLE
+victim at **+3.226 s vtime debt** (whole pack within +7 ms) parked on sink
+CPU 5's per-CPU queue while WAKE_DSQ flowed at 1–7 ms — the §G41 mechanism
+uninvolved. Attribution split: baseline clean 1/1, G41 rerun clean 1/1 →
+latent pre-existing pathology, filed as §G42. Screen (2 blocks, diagnostic,
+noise EXTREME 59% external): usecs_per_op vs native **+48.2 [43.2, 53.2]**
+against same-hour baseline **+41.3 [36.5, 46.1]** — non-regressing, CIs
+nearly separate in G41's favor. Guardrails noninferior (ctx +38.9 b-good,
+task-clock −2.3). Dispatch subprogram 76 insns (was 81), 0 spills. GAME-FIRST:
+rides the next rotation before scoring.
+
+#### §G42 — single-event vtime mis-charge + no wall-clock net on per-CPU queues (bug report, 2026-08-21) `<- §G41 abort`
+
+Evidence `runs/exact_pair/exact_pair_20260821T203147Z_1c535c2744be` (b02.p1
+dump): one task (`systemd[1003]`, weight 100) at +3.226 s vtime over a pack
+spread of 7 ms. Its lifetime sum_exec was ~4.9 s, so the charge shape is
+`sum_exec - run[cpu].sum` with a slot residue (~1.7 s) that looks like a
+DIFFERENT task's runtime — a stopping without a matching running stamp
+(attach/bypass or attribute-change edge, unproven). Second half: WAKE_DSQ
+has a 24 ms wall net (§R.16); per-CPU queues have none, so a debted task
+waits its full debt in wall time — 7 s beat the 5 s watchdog.
+
+- Hypothesis: `cake_stopping` can fire against a run slot stamped by another
+  task; one event is enough to strand its victim past the watchdog.
+- Steps: instrument stopping (charge > 1 s traces stamp owner) OR reason the
+  ext.c edge to ground; separately price a per-CPU wall-clock net.
+- Endpoint: mechanism named, then a bounded charge or a net — maintainer call.
+- Aborts: none (observation first; no scheduler change in this phase).
+
+**Mechanism grounded 2026-08-21 (source, Linux 7.2 tree):** a property change
+on a RUNNING task (`sched_setscheduler`, `set_user_nice`, cgroup
+`sched_move_task`) runs `sched_change_begin/end` on the CALLER's CPU under the
+victim's rq lock: `dequeue_task_scx` fires `stopping(false)` and `set_next`
+fires `running()` there. Cake indexed both by `bpf_get_smp_processor_id()` —
+the CALLER's CPU — so the remote `running()` stamps the caller-CPU slot with
+the TARGET's sum, and the CALLER's own next switch-out charges
+`caller.sum − target.sum`. systemd (a task that property-changes others
+constantly) at 4.9 s lifetime minus a ~1.7 s stamp = the observed +3.2 s.
+The direct charge on the target self-masks (the following `running()` drags
+the frontier along); the caller-side debt does not — no frontier advance
+follows a switch-out.
+
+**Repro: 3 attempts NULL** (~235k forced remote BATCH↔OTHER toggles under
+saturated H1 arms; rigs in scratchpad `g42rig*.c`): v1 slot arithmetic went
+negative (self-heals via clamps), v2 caller-victim shape also never gapped.
+The bad ordering needs conditions not yet identified; the mis-indexing itself
+is a defect by inspection regardless.
+
+**FIX BUILT 2026-08-21:** both ops index `cake.run[]` by `p->thread_info.cpu`
+(the task's rq CPU — identical on the normal switch path, correct on the
+remote path; the remote ping-pong becomes exactly accounted). Gates clean;
+`cake_stopping` spills 1 → 0 (dropped the smp-id call). No policy change, so
+no game screen owed on its own; rides the §G41 rotation. Confirmation is a
+SOAK: fixed cake attached through normal desktop use, watcher on the exit
+path — the bug's signature is the watchdog stall, which previously appeared
+within ~4 min of one saturated bench.
+
+#### §G43 — going-idle hint: publish at dispatch, claim before the idle scan (registered 2026-08-22) `<- predict-verify audit C1, §G38, §G41`
+
+`cake_wake_notify` and `cake_enqueue`'s kick tail run `cake_pick_idle_clean`
+— up to three kernel idle-mask scans plus escapes — on every global wake. The
+going-idle moment is already an event cake observes: `cake_dispatch` finds
+nothing and prev is not queued. One published word turns the common idle
+search into a single test-and-clear (the claim IS the verify, same contract
+as the prev-CPU arm). Full audit and the candidate ranking:
+`docs/AUDIT_PREDICT_VERIFY_2026-08-22.md`.
+
+- Hypothesis: a going-idle CPU publishing its id lets the wake path claim an
+  idle CPU with one test-and-clear instead of a scan; wake cost drops, no
+  routing or ranking change (§G38 core preference preserved by the gates).
+- Steps: `idle_hint` §R.10 slot; dispatch publishes on going idle
+  (test-before-write); `cake_idle_hint_claim` (affinity + irq/tick/core gates,
+  test-and-clear, CAS retire so a newer publish survives) ahead of the scan in
+  `cake_pick_idle_clean`; no other site touched.
+- Endpoint: on/off `--blocks 2` same-hour pairs — mutex-handoff on-arm ≥
+  off-arm within CI; perf-sched-pipe non-regressing (the §R.6/§G39 weld guard).
+- Aborts: pipe regression outside CI; any new spill in `cake_pick_idle_clean`
+  or its callers; "runnable task stall" in scx_cake.log; watchdog kill.
+- **Wallclock screen 2026-08-22 (diagnostic): lean NEGATIVE** — on-arm slower 3/3
+  (messaging +10.6% nearly separated). The registered mutex-handoff + pipe
+  `--blocks 2` endpoint decides; toggle default stays ON until it runs.
+
+#### §G44 — qmask answers wake-routing emptiness (registered 2026-08-22) `<- predict-verify audit C3, §G25`
+
+- Hypothesis: a CLEAR qmask bit already proves the per-CPU DSQ empty, so the
+  wake-routing sites (serial block, empty-home test, frontier-convergence
+  return) can skip the `dsq_nr_queued` rhashtable lookup; a SET bit still
+  verifies with the real count (insert marks before the task lands, §G25).
+- Steps: `cake_cpu_dsq_idle()` helper behind `--toggle g44`; three call sites;
+  local-DSQ (`LOCAL_ON`) lookups untouched.
+- Endpoint: wallclock on/off ABBA — pipe + messaging non-regressing, any win
+  kept for the stack arm. Stale-clear misroute is benign: the owner's
+  unconditional own-queue peek finds the task next dispatch.
+- Aborts: "runnable task stall" in scx_cake.log; watchdog kill; pipe
+  regression outside the arm spread. Routing change → game screen before keep.
+- **Outcome 2026-08-22: BUILT `f5185af07`, wallclock NULL** (pipe +2.2,
+  messaging +5.6, memcpy −1.5, all overlap). Parked off.
+
+#### §G45 — event-complete idle census for the serial gate (registered 2026-08-22) `<- predict-verify audit C5, §R.25`
+
+- Hypothesis: `ops.update_idle` (KEEP_BUILTIN_IDLE) maintaining an idle bitmask
+  + count makes `cake_system_serial` one word read instead of
+  `get_idle_cpumask` + full cpumask weight per serial-candidate wake.
+- Steps: idle words + counter (flip-gated atomics, idempotent, seeded in
+  ops.init from the kernel mask); `cake_system_serial` reads the counter when
+  `--toggle g45`; callback body prunes to nop when off.
+- Endpoint: wallclock on/off ABBA; the off arm still pays the registered
+  callback, priced separately by the all-off vs tip A/A.
+- Aborts: stall/watchdog; messaging regression outside spread (transition-rate
+  atomics are the predicted cost); audit's own gate — if on/off is null, C5 is
+  rejected and the callback deleted.
+- **Outcome 2026-08-22: BUILT `0ef821db8`, wallclock lean-positive 3/3**
+  (pipe −3.8, messaging −1.7, memcpy −0.2, all overlap); rides the stack.
+  All-off vs old-tip A/A owed for the bare callback-registration cost.
+
+#### §G46 — departing-slice cache, pid-tagged, per-CPU (registered 2026-08-22) `<- predict-verify audit C4, §R.18`
+
+- Hypothesis: `cake_task_slice` (two divides + a clock read) recomputes at
+  every insert what `cake_stopping` could have published; a two-entry
+  pid-tagged cache in the run slot (handoff pairs alternate, so one entry
+  always misses) serves the insert sites with one load + compare. Per-CPU
+  slot state, NOT per-task storage — the audit's tenet blocker dissolves.
+- Steps: `slice_cache[2]` words in `cake_run_slot` (owner-written at stopping,
+  line already dirty); `cake_task_slice_cached()` at the seven insert sites
+  behind `--toggle g46`; kthread flat grant and dispatch keep-prev untouched.
+- Endpoint: wallclock on/off ABBA — pipe (the curr==p self-race is the
+  hottest consumer); staleness bound is one quantum of estimator drift.
+- Aborts: stall/watchdog; any new spill in `cake_enqueue_wake` or
+  `cake_select_cpu`; pid-reuse mis-grant is bounded by the cached value being
+  a valid slice for some task (≤ SLICE_NS), so no correctness abort.
+- **Outcome 2026-08-22: BUILT `61589428c`, the campaign's one separated
+  result** — memcpy −7.8% SEPARATED single, −5.4% SEPARATED in the stack;
+  pipe/messaging lean-positive. A one-quantum-stale slice is GEOMETRY, not
+  just saved arithmetic, so attribution is open; sealed ccm-memcpy +
+  mutex-handoff pair, then game screen, before hardwiring.
+
+#### §G47 — ISR-successor kthread keeps the IRQ CPU (registered 2026-08-23, maintainer-directed) `<- §G30, §G35, toggle campaign IRQ finding`
+
+- Hypothesis: the sink veto exiles the ISR's OWN continuation kthreads
+  (nvidia-modeset p99 78→~820 µs HD2, 21.5→~250 LOTR, stay% →0) — the GPU-feed
+  path — explaining cake's GPU-util gap (87.8 vs 84.6/82.3% KovaaKs menu). A
+  kthread woken FROM interrupt context on its own prev CPU keeps that CPU: it
+  cannot run before the handler ends (p99 48 µs) and cold remote placement
+  costs 250–900 µs.
+- Steps: in the kthread wake arm, `cake_irq_live[this].depth && tcpu == this
+  && prev == this` → insert LOCAL_ON tcpu, skip the idle pick; behind
+  `--toggle g47`.
+- Endpoint: KovaaKs menu frame A/B — GPU util gap closes toward native, avg
+  fps recovers; nvidia-kthread wake p99 toward native's 21–104 µs; the fence
+  tail (wow-cake-g30c class) and game-role sink avoidance MUST hold.
+- Aborts: fence-tail regression (the §G30 win is senior); stall/watchdog; any
+  new spill in `cake_enqueue`.
+
+#### §G48 — hint-first main placement (registered 2026-08-23, component audit) `<- §G43, AUDIT_COMPONENT_COST`
+
+- Hypothesis: the ranked scan dominates `cake_select_cpu`'s measured 185
+  ns/call (28.2 ms/s at 152k wakes/s vs EEVDF select_task_rq_fair 10.2 ms/s,
+  bpf_stats + perf, runs/bpfstats_20260823); a §G43 hint claim ahead of
+  `select_cpu_and` makes the hit O(1) at unchanged ranking (claim gates =
+  scan gates). Campaign target: placement ≤8,000 us/s at held switch rate.
+- Probe §G48-P (first): commit that returns prev/dfl with the ranked scan
+  deleted, same appsim+bpf_stats window, read ns/call = fixed-path cost;
+  revert byte-identical. Placement quality knowingly sacrificed; ns/call is
+  the only read.
+- Steps: `cake_idle_hint_claim` between home claim and nonsink scan, direct
+  insert on hit; behind `--toggle g48`.
+- Endpoint: select_cpu ns/call + placement us/s (bpf_stats, appsim window),
+  hit rate; context switches and appsim p99/p999 MUST hold.
+- Aborts: stall/watchdog; switch-rate regression >5%; new spill in
+  `cake_select_cpu`.
+- **Progress 2026-08-23:** §G48-P probe `40878f738`→revert (byte-identical
+  b6078ab5): fixed path 76 ns, scan 109 ns of 185; probe also showed deleted
+  placement costs +67 ms/s in dispatch/enqueue — the scan's decision is
+  load-bearing, only its price is the target. Sub-8k therefore ALSO needs
+  fixed-path cuts (§G49, O1, F14): 76 ns fixed > 52 ns budget on its own.
+  BUILT `5d2c4012c` (+`8e761ef53` word-gate + O1 order fix): loaded on-arm
+  202→188 ns/call; off-arm O1 window noise-invalidated (enqueue 117k/s,
+  off-profile), mirrored re-run owed. M3 dedup `0030b2a2b`, spills flat.
+  Maintainer audit registrations: §G50 (census-zero skip), M2 (dead
+  frame-clock plumbing), M1 (serial/convergence double-eval — screen first),
+  M4 (G44+F14+F15 as one consolidation program). F14 note: the serial gate's
+  two emptiness checks cover two DIFFERENT queues (vtime DSQ + LOCAL_ON);
+  merging needs a maintained bit, not a dedup.
+
+#### §M6 — occupant mirror: subscribe, don't query (registered 2026-08-23, maintainer-directed) `<- component audit 8th pass, §R.17, §G45 shape`
+
+- Hypothesis: five rq->curr deref-chain sites (core_contended, handoff_yields,
+  occupant_live -> preempt/notify/anti-collision) can read one flat
+  cake.run[cpu] line instead: running/stopping already own that line at every
+  transition; publishing start-vtime + recip-index + pid costs ~2 stores on an
+  already-dirty line. Win = chain and kfunc deletion, NOT locality — remote
+  questions stay one remote line.
+- Steps: extend cake_run_slot, publish in running/stopping, convert the five
+  readers; behind a campaign toggle; fnspills gate on select_cpu.
+- Endpoint: select_cpu + dispatch ns/call (bpf_stats appsim window, mirrored
+  rotation); per-wake kfunc pulls ~4-5 -> ~1; composes with §G48/§G50.
+- Aborts: cake_running/cake_stopping ns/call regression (coherence tax — the
+  irq_leave 11->276 ns lesson); any new spill in select_cpu; stall/watchdog.
+  §G49 screens after; absorbed if M6 lands.
+- Pre-build decisions (maintainer-accepted 2026-08-23): (1) the occupant word
+  packs pid-tag + recip-index + class in ONE u64, value 0 = off-mirror — keeps
+  the RT-owned-home check in enqueue_wake and zero-vtime conventions correct
+  without a second load (§G46 pid<<32 packing is the precedent); (2) geometry
+  re-verified against the constant: STATE_SLOT_BYTES=128 so slots are 16
+  words; run_slot had 11 pad words, mirror uses 2 — the earlier "3 free"
+  figure checked the expression, not the constant. Publication stays
+  single-store, benign-stale model preserved. Tax refinement: the slot line is already
+  remote-read (stamp in handoff_yields/occupant_live), so M6's net
+  lines-touched delta is plausibly negative; hard abort kept regardless.
+
+#### §G53 — EEVDF-shape optimistic placement (registered 2026-08-23, maintainer-directed)
+
+- Hypothesis: EEVDF's 66 ns comes from NOT verifying its pick — no gates, no
+  claim, collisions absorbed by the queue. Cake's failed fast paths all died
+  on verify-and-claim cost (§G48 claim-fail, §G50 claim-race). Census
+  first-fit + affinity + direct insert, nothing else, should land 80-110 ns.
+- Steps: behind `--toggle g53` (forces g45); census bit -> direct LOCAL
+  insert, no test_and_clear, no clean/contended gates; empty census -> scan.
+- Endpoint: sel ns/call (mirrored appsim ABBA) + switch rate + tails hold.
+- Aborts: stall/watchdog; appsim p99 regression; new spill in select_cpu.
+
+#### §G54 — self-park mailboxes (registered 2026-08-23, maintainer-directed redesign) `<- §R.29, §G53 probe, §G50-R, M7`
+
+- Hypothesis: the wake path can READ a decision instead of making one. Idle
+  CPUs evaluate their own gates at idle-entry (free time, local facts) and
+  park into per-waker mailboxes (owner-read, no consume atomics — kills the
+  §G50 claim race by construction); retract at idle-exit. Wake path: prev
+  census-bit optimistic -> own mailbox -> zero-skip -> old ladder. Affinity
+  by direct cpus_ptr bitmap read (no kfunc). §G53 measured optimism at 77
+  ns incl. insert with dispatch halved and −7% switches; producer gating +
+  prev-warmth + retraction attack its tail residue.
+- Steps: behind `--toggle g54` (forces g45); producer in update_idle,
+  rotor-distributed slots, park idx in cake_irq_live; consumer subprogram.
+- Endpoint: select_cpu <8,000 us/s loaded (<=52 ns/call) with switch rate
+  and appsim p99/p999 held; schbench-saturated pair must not regress.
+- Aborts: stall/watchdog; p99 regression beyond slot-position band; new
+  spill in cake_select_cpu; update_idle ns/call regression >2x.
+- **First mirrored ABBA 2026-08-23:** sel 92/92 ns on-arm (vs off 163 avg) =
+  13.6k us/s — half of baseline, above the 8k target. Tails FIXED vs §G53:
+  end-slot p99 0.676/0.682 against the 0.93 position band — producer gating
+  + prev-warmth cured the collision cost. Switches −6%, dispatch 219→123.
+  Gap = miss path (~25% of wakes fall to the full ladder). Levers: chain
+  §G53 walk as mailbox-miss fallback (pair in flight); multi-park (2-3
+  entries per idle CPU — consumed entries orphan an idle CPU until its next
+  transition); warmth-first reorder if the combined arm shows G53 tails.
+  update_idle 9→34 ns producer cost (+5.5 ms/s) — net total still −38%.
+- **G54.1 (warmth-first + core entries + per-core slots):** sel 80/81 ns =
+  11,748 us/s, tails arm-comparable (quality restored), switches −5%,
+  dispatch −41%. §G55 insert probe: the insert is ~10 ns of the 80 and
+  skipping it explodes enqueue+dispatch (+60 ms/s) — cheap AND load-bearing.
+  Architecture floor ≈ 65-70 ns avg (trampoline ~15-20 + serial block +
+  reads + insert): the 8,000 us/s goal is ~2-3k short of reachable in this
+  accounting without K2 (fused place kfunc, patch-gated) plus hit-rate work.
+  Achieved: 27,400 → 11,748 us/s (2.3x), quality held.
+- **HD2 menu frame screen (mirrored ABBA, n=2/arm, ~12k frames/slot): PASS**
+  — severe (>2x med) 0.037 vs 0.062%, 0.1% low 286 vs 171 fps, p99.9-median
+  tie (1.142 vs 1.132 ms); cost: p99 mid-band thicker (2.22 vs 1.92 ms).
+  First fast path to win benchmarks AND frames. Longer rotation before
+  default-on; K2 fused kfunc is the remaining path to the 8k line.
+
 ---
 
 ### §R — Design rationale (from source comments)
+
+#### §R.29 — push vs pull (census-claim autopsy, 2026-08-23)
+Identity claims only work from PUSHED events (the §G43 hint: published at
+going-idle, single candidate, one test-and-clear); pulled aggregates are
+fresh enough for counts ("someone is idle" — gates, zero-skips) but never
+for identity ("take this one") under concurrent wakers. Census-as-gate ✓,
+census-as-identity ✗ — sel 179→264 ns bought this law.
 
 #### §R.1 — co-location gate
 mutex p99 **1.442 → 0.625 µs**; gates G9.2→G9.6, before dfl.

--- a/scheds/rust/scx_cake/bench/capture_preflight.py
+++ b/scheds/rust/scx_cake/bench/capture_preflight.py
@@ -23,7 +23,7 @@ import subprocess
 import sys
 
 REPO = "/home/ritz/Documents/Repo/scx"
-ASSETS = "/home/ritz/Documents/Repo/scx_cake_bench_assets"
+ASSETS = "/home/ritz/Documents/Repo/scx_cake_bench"
 
 # The live path. game_capture_start is QUARANTINED behind the strict
 # v2-manifest/v5-receipt runner and will refuse; game_ab is what works.

--- a/scheds/rust/scx_cake/docs/AUDIT_COMPONENT_COST_2026-08-23.md
+++ b/scheds/rust/scx_cake/docs/AUDIT_COMPONENT_COST_2026-08-23.md
@@ -1,0 +1,77 @@
+# Audit: per-component cost vs EEVDF, with reduction paths
+
+2026-08-23, maintainer-directed ("make each component less expensive than
+EEVDF while still performing its role"). Source at `070e0af86`. Costs are
+STATIC attribution (insns/spills from `fnspills.py`, object 2427 insns total)
+plus the toggle campaign's measurements; per-frame anchors from the KovaaKs
+menu frame A/B (premium ≈ 45 µs/frame tip, 80 stack, at 700 fps).
+
+## The structural frame
+
+sched_ext pays a BPF trampoline entry/exit per callback that EEVDF's native
+calls never pay. Cake therefore cannot beat EEVDF on raw per-event entry
+cost; it must win the total: **fewer events** (measured: −28% context
+switches, softirqs halved, both games), **O(1) decisions** where EEVDF scans,
+and **better placement** (measured: game IPC 1.55 vs 1.40 loaded). The
+per-frame total is events × cost + cache effects — all three factors are
+cake's to shape.
+
+## Wake path (`cake_select_cpu`, 426 insns, 99.86% of game dispatches)
+
+| component | role | cake cost (common case) | EEVDF analog | reduction path |
+|---|---|---|---|---|
+| serial-handoff block | co-locate true handoff pairs | 1 slot load + branch; rare: §G45 word (was mask walk), §G44 bit (was rhashtable) | WF_SYNC hint, ~free | AT FLOOR after §G44/§G45 |
+| prev-CPU home claim | cache warmth beats idle-core rank | starved_turn 2 mults + irq 2 loads + **core_contended: cpu_curr deref chain** + atomic claim | select_idle_sibling prev check | **§G49**: sibling-busy via `scx_bpf_get_idle_smtmask` bit read, deletes the rq deref chain |
+| nonsink gen check | live sink set | 1 load+cmp | — | at floor |
+| ranked idle pick (`select_cpu_and`/dfl) | first placement | **full LLC scan kfunc, the largest term** | select_idle_sibling with SIS_UTIL throttle (gives up under load) | **§G48**: going-idle hint claim FIRST (extend §G43 to this site) — hit = zero scans; the menu regime is its design case |
+| SYNC re-rank + qmark guard | §R.6 weld avoidance, ordering | SYNC wakes only | — | leave |
+| escape + tick veto | §G35/§G36 cleanliness | claim-time only; 1 ktime read | — | leave; §G43-hit skips them |
+
+## Enqueue (203 insns; 0.14% of game dispatches, 23.6% saturated)
+
+| component | role | cake cost | EEVDF analog | reduction path |
+|---|---|---|---|---|
+| route classify | wakeups global / continuations local | starved_turn recompute (2 mults) | — | cheap; recompute is deliberate (§R.13) |
+| kthread arm + §G47 | bounded kthread service; ISR successor stays | idle pick, or 3 loads on the §G47 hit | ttwu picks waker/prev | BUILT (§G47) |
+| wake_vtime + cadence | sleeper clamp fairness | loads + shifts + ≤2 mults | place_entity + update_curr | already ≤ EEVDF |
+| insert kfunc | queue admission | rbtree insert | enqueue_entity rbtree | parity, floor |
+| wake_notify | someone must run it | §G43-hinted; else scans + occupant_live | wakeup_preempt local | hint hit rate is the lever (§G43/§G48) |
+
+## Dispatch + accounting
+
+| component | role | cake cost | EEVDF analog | verdict |
+|---|---|---|---|---|
+| dispatch_search | earliest eligible of {own, wake} | own peek + §G41 word + §G25 bitmask ring | rbtree leftmost + periodic load_balance softirq | cake inline steal vs EEVDF softirq: roughly parity; cake's marks already O(1)-gated |
+| keep-prev slice | idle-avoidance regrant | 2 divides + ktime | — | candidate: serve from §G46 cache (registered untouched; needs a running-task entry) |
+| running/stopping | vtime charge | 2 stores + 1 multiply-add (+§G46 publish) | update_curr + PELT decay + cgroup walk | **cake already cheaper** |
+| no .tick | — | zero | entity_tick + PELT per tick | cake wins by absence |
+| update_idle (§G45) | idle census | flip-gated atomics per transition | inline in idle path | measured lean-positive; keep |
+
+## What EEVDF pays that cake never does
+
+PELT per-entity decay chains, cgroup share recomputation, load-balance
+softirq scans, NUMA-balancing hooks, tick-time entity accounting. This is
+why cake's switch/softirq counts and accounting path are already below
+native's, and why "below EEVDF per frame" is reachable despite the
+trampoline floor.
+
+## What cake pays that EEVDF never does
+
+Trampoline entries (structural), kfunc call overhead, BPF-text L1i footprint
+(E4a splits this from migration-cooling), and the placement insurance
+premium. The premium is policy, not overhead — the reduction is
+contention-pricing (engage spreading/sink rules on current evidence of
+contention; §G47 is the first instance), never deletion.
+
+## Registered from this audit
+
+- **§G48** — hint-first main placement: the §G43 going-idle claim moves ahead
+  of `select_cpu_and`, making the common idle-machine wake O(1). Targets the
+  menu-regime fps gap directly; §G38 core preference preserved by the claim
+  gates.
+- **§G49** — core-contended via idle-smtmask bit instead of the sibling
+  `cpu_curr` deref chain. Same §G38 semantics, cheaper read, one fewer
+  pointer chase per home claim.
+
+Both behind campaign toggles; screens per the standing ladder (wallclock →
+game rotation → frames where MangoHud exists).

--- a/scheds/rust/scx_cake/docs/AUDIT_PREDICT_VERIFY_2026-08-22.md
+++ b/scheds/rust/scx_cake/docs/AUDIT_PREDICT_VERIFY_2026-08-22.md
@@ -1,0 +1,223 @@
+# Audit: predict-then-verify sites in cake (MTP / n-gram speculation mapping)
+
+2026-08-22. Source audited at commit `3e2e6afc1` (`cake.bpf.c` 1688 lines, all
+eight callbacks). Question: where can cake precompute a decision in a cheap
+phase, verify it cheaply on a hot path, and pay full cost only on a miss —
+and would it help.
+
+**Verdict: the pattern is already load-bearing in six places. Five new sites
+remain. Two are worth building (C1, C3); one is a discriminator for the
+aborted §G39 (C2); two need a maintainer call first (C4, C5).**
+
+---
+
+## 1. The mechanism, extracted from MTP and n-gram decoding
+
+Speculative decoding speeds up inference with one economic trick, in three
+parts:
+
+| part | requirement | LLM instance |
+|---|---|---|
+| cheap draft | producing the guess costs near zero | MTP head (one extra layer); n-gram lookup (no model at all) |
+| cheap verify | checking beats recomputing | one batched forward pass verifies γ drafts |
+| cheap miss | a wrong guess costs one fallback | rejected tokens are discarded, normal path resumes |
+
+Discipline that makes it work:
+
+- **Acceptance rate is measured before the feature ships.** DeepSeek-V3.2
+  accepts 2.55 tokens per step, GLM-5 2.76. A draft head with low acceptance
+  is deleted, not tuned.
+- **Hybrid predictors beat one predictor.** MTP (learned, general) plus
+  n-gram (exact-repeat lookup) each cover regimes the other misses:
+  mtp-only 80.5 tok/s vs combined 205.9 on edit/echo tasks (llama.cpp
+  Qwen3.6 benchmark). Different predictor classes, same verify path.
+- **N-gram drafts come from the workload's own history.** No model: match
+  the recent pattern against earlier context, propose what followed last
+  time. Free where the workload repeats itself.
+
+Scheduler translation: the wake path is the latency-critical "decode step".
+`stopping`, the loader run loop, and the going-idle dispatch are the cheap
+phases. Kernel scans (`select_cpu_dfl`, `pick_idle_cpu`, cpumask weight,
+`dsq_nr_queued` rhashtable lookups) are the expensive "forward pass".
+
+---
+
+## 2. Where cake already runs this pattern
+
+The audit's first finding: this is not a new idea for cake. Six constructs
+already have the draft/verify/miss shape.
+
+| construct | draft | verify | miss cost |
+|---|---|---|---|
+| prev-CPU home claim (§G13, `cake.bpf.c:916`) | last placement predicts next | `test_and_clear_cpu_idle` | fall through to dfl scan |
+| §G25 qmask (`:336`) | per-CPU "may hold work" bit | `dsq_move_to_local` | skip one probe |
+| §G41 wake mark (`:381`, `:1467`) | one word predicts global work | peek, retire-repeek protocol | one peek |
+| §G36 tick predictor (`:443`) | `next_event` predicts handler | compare against hop p99 | one re-pick |
+| §G30/§G33 sink gen (`:934`) | generation word predicts staleness | one compare | rebuild mask |
+| §R.18 handoff hint (`:1598`) | confidence counter predicts a yield | `cake_handoff_yields` | decline co-location |
+
+The §R.18 hint is the MTP-like predictor: learned, saturating, general.
+Cake has **no n-gram-like predictor** — nothing matches "this exact wake
+pattern repeated" against history. That gap is §G39's missing discriminator
+(section 4, C2).
+
+§G39 Phase B is also the pattern's failure case on record: a draft (chain
+successor) whose miss was not cheap — pipe −36.8%, ctx +45.9%, aborted.
+Every candidate below inherits that lesson as a pre-registered abort.
+
+---
+
+## 3. New candidate sites
+
+### C1 — going-idle CPU publishes itself; `cake_wake_notify` verifies
+
+**Site:** `cake_wake_notify` (`cake.bpf.c:1064`) runs `cake_pick_idle_clean`
+— up to 3 kernel idle-mask scans plus escape re-picks — on every global
+wake, and again at `cake_enqueue`'s `kick_idle` tail (`:1355`).
+
+**Draft:** `cake_dispatch` already knows the exact going-idle moment: the
+search returned false and prev is not queued (`:1544`). One store publishes
+this CPU's id to a BSS slot word. Event-complete — the idle transition
+itself writes the word, no polling, no new callback.
+
+**Verify:** read the word, `scx_bpf_test_and_clear_cpu_idle(it)` (the claim
+doubles as the verify, same as the prev-CPU arm), then one `cake_cpu_irq_bad`
+check. Hit: kick it, done — zero scans. Miss: today's full path, unchanged.
+
+**Expected value:** removes the largest remaining per-wake kernel scans from
+the input-pipeline lane §G38–§G42 is chasing. Acceptance should be high in
+game regimes (machine mostly idle, wakes frequent).
+
+**Risks:** kick-targeting change — the §R.6/§G39 weld class. Pipe is the
+guard workload. Stale word costs one atomic then falls back; two wakers
+racing to the same word is resolved by test-and-clear (one wins, one falls
+back).
+
+### C2 — n-gram wake-pattern memory (the §G39 Phase B' discriminator)
+
+**Site:** §G39 chain-successor handoff, aborted for want of a wine-RPC vs
+data-stream discriminator.
+
+**Draft:** n-gram style — per-CPU run slot remembers the last wake edge
+(waker→wakee identity hash in the spare `hint` bits, §R.18's line, owner-
+written). The chain draft is admitted only when this wake repeats the
+recorded edge AND the waker then blocked within `cake_handoff_max_ns` last
+time (the "waker blocks after waking" half that separates RPC from stream).
+
+**Verify:** the recorded outcome of the last identical pattern is the
+verify; a stream waker fails the blocked-quickly half every time, so pipe
+ping-pong is excluded by measurement, not by flag.
+
+**Expected value:** unknown until Phase A counts pattern-repeat frequency in
+game regimes. This is a discriminator for a shelved construct, not a
+standalone win.
+
+**Risks:** identity-based policy must respect §R.20 (ALLOW_QUEUED_WAKEUP —
+enqueue's current is not the waker; the edge must be recorded where the
+waker is trusted, i.e. select_cpu/stopping only).
+
+### C3 — qmask word replaces `dsq_nr_queued` in wake routing
+
+**Site:** `cake_enqueue_wake` empty-home test (`:1197`) and the serial block
+(`:894`) pay rhashtable lookups (`scx_bpf_dsq_nr_queued`) per wake. The
+qmask bit for that CPU is the same predicate as one word read.
+
+**Draft:** bit clear predicts empty — trust it, skip the lookup (the common
+case in game regimes). **Verify:** bit set → run the real `dsq_nr_queued`
+(the bit may be stale-set). Miss cost: one lookup, today's price.
+
+**Expected value:** small constant per wake, no new state, no new writes —
+the bits already exist and are already maintained.
+
+**Risks:** a stale-clear (insert's mark-in-flight race) claims a home that
+holds one queued task. The vtime queue keeps it fair and the owner rescans;
+same benignity class the steal ring already accepts (§G25), but here it
+flips routing, so it screens as a routing change (game screen required).
+
+### C4 — slice precompute at `stopping`
+
+**Site:** `cake_task_slice` (`:755`) runs two u64 divides plus a clock read
+(`cake_burst_ns`, `cake_period_ns`) on **every insert** — five call sites,
+all on the wake path.
+
+**Draft:** compute the next slice at `stopping` (the cheap phase; the stats
+are already in cache from the vtime charge). The value drifts by one quantum
+at most — lifetime means move slowly — so no verify is needed; staleness of
+one quantum is inside the estimator's own noise.
+
+**Blocker:** needs per-task storage. Cake's header tenet is "no task-history
+model"; options are task-local storage (a per-task map — tenet departure) or
+reusing `p->scx.slice` between block and next insert (kernel-field semantics
+need verification against tick/dispatch writes). **Maintainer call before
+any build.**
+
+### C5 — event-complete idle count for `cake_system_serial`
+
+**Site:** `cake_system_serial` (`:697`) does `get_idle_cpumask` + full
+cpumask weight per serial-candidate wake.
+
+**Draft:** an idle-CPU counter maintained by `ops.update_idle` (with
+`SCX_OPS_KEEP_BUILTIN_IDLE`) makes it one load — event-complete, matching
+the design law. **Cost:** a new callback firing per idle transition with a
+shared-line atomic — plausibly worse than the weight it replaces.
+
+**Gate:** Phase A first counts how often the serial path actually executes
+`cake_system_serial` per second in game and bench regimes. Below ~10k/s the
+weight is noise and C5 is rejected without a build.
+
+---
+
+## 4. Sites audited and cleared (no candidate)
+
+- `cake_dispatch_search` / ring steal — already fully mark-gated (§G25,
+  §G41). Nothing left to draft.
+- `cake_running` / frontier — test-before-write already (§R.10); frame
+  observe already shift-gated.
+- `cake_wake_vtime` — recompute-at-use is deliberate (§R.13); inputs are
+  plain loads, nothing to precompute.
+- Loader (`main.rs` run loop) — sink probe and frame argmax already run the
+  cadence model (§R.25); the loader IS the cheap-phase producer for §G30/§G33.
+- Occupant-live preempt checks — contended-path only; drafting the
+  occupant's live vtime would need cross-CPU writes costing more than the
+  clock read it saves.
+
+The original conversation candidate — per-task predicted next CPU computed
+at stopping — is **subsumed**: the prev-CPU claim already is that predictor
+with prediction = last placement, and C1 covers the miss half (where prev is
+busy). A learned per-task CPU adds per-task state for the migration-pattern
+case only; value below C1, same blocker as C4. Not carried forward.
+
+---
+
+## 5. Test plan (all candidates)
+
+Phase A is observe-only in every case, per the §G39 lesson: **acceptance
+rate is measured before behavior changes.**
+
+| candidate | Phase A counter (probe commit, reverted after read) | accept gate to Phase B | Phase B screen |
+|---|---|---|---|
+| C1 | hits/misses of the published-idle word at wake_notify | hit rate ≥ 60% in appsim game regime | bench: mutex-handoff, **pipe (weld guard)**, schbench-light; then game rotation (placement change) |
+| C2 | pattern-repeat rate + blocked-quickly co-occurrence per CPU | repeat ≥ 50% on a real game, ~0% on pipe | shelved until counters justify reopening §G39 |
+| C3 | stale-set and stale-clear rates vs real nr_queued | stale-clear < 1% of wakes | bench screen + game rotation (routing change) |
+| C4 | none until the storage call is made | — | A/A + fnspills (cost-only change, no decision change) |
+| C5 | serial-path executions/sec, game + bench | ≥ ~10k/s sustained | A/A + stress-ng-futex (serial regimes) |
+
+Standing gates for every build: zero warnings both profiles, `fnspills.py`
+per function (wake_notify and enqueue_wake budgets), attach smoke, sealed
+A/A null, arms as commits, reverts byte-identical by sha256. C1/C2/C3 are
+placement or routing changes: GAME-FIRST applies — game screen before
+scoring, severe-frame ratio to screen, 0.1% low and p99.9−median to score.
+
+## 6. Ranking (graph cut)
+
+1. **C1** — highest value, no design-tenet conflict, event-complete, sits
+   directly on the §G38–§G42 input-pipeline lane already under test.
+2. **C3** — cheapest to build, uses existing state, small steady win.
+3. **C5 Phase A counter** — one number decides it; near-zero cost to ask.
+4. **C2** — registered against §G39 B'; build only after C1/C3 settle.
+5. **C4** — parked on the per-task-storage maintainer call.
+
+Sources: [vLLM MTP](https://docs.vllm.ai/en/latest/features/speculative_decoding/mtp/),
+[SGLang speculative decoding](https://sgl-project-sglang-93.mintlify.app/advanced/speculative-decoding),
+[prompt-lookup decoding](https://github.com/apoorvumang/prompt-lookup-decoding),
+[llama.cpp MTP→ngram pipeline issue](https://github.com/ggml-org/llama.cpp/issues/23184).

--- a/scheds/rust/scx_cake/docs/KERNEL_TOOL_INVENTORY_2026-08-23.md
+++ b/scheds/rust/scx_cake/docs/KERNEL_TOOL_INVENTORY_2026-08-23.md
@@ -1,0 +1,93 @@
+# Kernel-level tool inventory for scx_cake diagnosis
+
+2026-08-23. Companion to `bench/PROFILING.md` (which owns cake-bpfstats,
+thread-profile, SMT residency). This file maps **diagnostic questions → kernel
+tools**, with commands tuned to this host and this project's rules (never sudo;
+identity-validity before numbers; noise as covariate). All listed tools verified
+present 2026-08-23 unless marked ABSENT.
+
+---
+
+## Q1. What is the scheduler itself doing right now?
+
+| tool | what it answers | command |
+|---|---|---|
+| `scxtop tui` | live per-CPU util, DSQ latencies, LLC misses, per-task runtime — the sched_ext-native view; runs identically under EEVDF/cake | `scxtop tui` while playing |
+| `scxtop trace` | the same signals into a **perfetto** trace (open at ui.perfetto.dev); correlate DSQ latency against MangoHud frames on one timeline | `scxtop trace -o out.pb` |
+| `bpftool prog show name <cb>` | per-callback run_time_ns / run_cnt (this is `cake-bpfstats`; keep `bpf_stats` OFF outside measurement) | `bpftool prog show` |
+| `bpftool map dump` | cake's own state: run slots, qmask, frontier word, census — ground truth for "was the hint set", "did the claim fire" | `bpftool map dump name <map>` |
+| `/proc/sys/kernel/bpf_stats_enabled` | toggle for the above (write 0 when done — it taxes every program run) | — |
+
+## Q2. Where does wake-to-run latency come from?
+
+The retained-trace pipeline (`cakebench wake-latency capture` +
+`bench/wake_maxdecomp.py`, `wake_occupant.py`, `wake_migsplit.py`) stays the
+primary. Add these for questions it cannot answer:
+
+| tool | what it adds | command sketch |
+|---|---|---|
+| **bpftrace runqlat** | continuous runqueue-wait histogram per CPU/thread at ~zero cost — catches transient herds between captures | `bpftrace -e 'tracepoint:sched:sched_wakeup { @start[args->pid] = nsecs; } tracepoint:sched:sched_switch /@start[args->next_pid]/ { @usecs = hist((nsecs-@start[args->next_pid])/1000); delete(@start[args->next_pid]); }'` |
+| **perf wakeup chains** (`--switch-events --call-graph dwarf`) | who woke whom, with stacks — resolves handoff PAIRS (mutex/serial shape) instead of single transitions | `perf record -e sched:sched_switch,sched:sched_wakeup -R -k 1 -a --call-graph dwarf -- sleep 20` then filter by tid |
+| **bpftrace waker→wakee matrix** | which threads wake which (the many-to-many TaskGraph shape, open gap #7) | aggregate `sched_wakeup` by `[args->target_pid, pid]`, sort by count |
+| `perf sched latency/map` | post-process any sched-event capture into per-task wait/slice/migration tables; cross-checks our own analyzers | `perf sched latency -i perf.data` |
+| **osnoise / timerlat tracers** (tracefs) | IRQ + scheduler jitter floor with no RT setup (rtla ABSENT; drive raw tracers directly) | `cd /sys/kernel/tracing && echo osnoise > current_tracer && cat trace_pipe` |
+| `sched_stat_blocked/runtime/wait` tracepoints | exact block reason + wait time distributions — separates "waiting for CPU" from "waiting on dependency" | enable alongside sched_switch |
+
+## Q3. What is the machine doing underneath the scheduler?
+
+| tool | what it answers | notes |
+|---|---|---|
+| `/proc/interrupts` diff over N s | which CPUs carry which IRQs — independent check on the sink mask (G33/G35) | `cat /proc/interrupts; sleep 10; cat ...` |
+| irq + softirq tracepoints | handler durations/cadence (the §G33 share computation; also the analyzer in `runs/toggle_game_wake_20260822/irqjitter.py`) | `events/irq/irq_handler_{entry,exit}`, `events/softirq` |
+| **cpuidle sysfs counters** | per-CPU per-state residency + exit-latency usage — the cheap local answer to §G51 (driver reports `none` here; this shows whether BIOS changed after a reboot) | snapshot loop over `/sys/devices/system/cpu/cpu*/cpuidle/state*/{usage,time}` |
+| `/proc/pressure/*` (PSI) | system-wide stall pressure as an OBSERVER (PSI-as-input was falsified §G34; as a covariate it is still valid) | record avg10/avg60 per arm |
+| `/proc/<tid>/schedstat`, `/status` | per-thread cumulative wait slices, voluntary/involuntary switches, last_cpu — already in thread_profile; cite directly when a single thread matters | zero-cost, safe mid-game |
+| `/sys/kernel/debug/sched/features` + `base_slice_ns` | **EEVDF's own knobs** — read them to know what native is doing (preempt granularity, migration_cost); flipping them on the native arm isolates "EEVDF feature" vs "cake gap" | debugfs must be mounted |
+
+## Q4. Microarchitecture per thread (why a frame was slow, not just that)
+
+| tool | what it answers | command sketch |
+|---|---|---|
+| `perf stat -t <tid> -e cycles,instructions,LLC-load-misses,dTLB-load-misses,context-switches,cpu-migrations` | IPC + miss rates for ONE thread over a window (game IPC endpoint, per-thread) | interval mode `-I 5000` for trend rows |
+| **AMD IBS** (`ibs_op//`, `ibs_fetch//`) | precise per-sample load latency + DTLB + L2/L3 hit levels on Zen — WHERE the GameThread stalls, cache-warm claims vindicated or refuted | `perf record -e ibs_op//pp -a -C <cpus> -- sleep 15` |
+| `perf mem record -t <tid>` | sampled data-address heatmap of the hot thread — pairs with IBS for the same story in one step | needs IBS on AMD |
+| `perf c2c` | false-sharing/HITM detection — the direct test for contention on cake's own shared lines (frontier.word, qmask, census words) | `perf c2c record -a -- sleep 15; perf c2c report` |
+| `perf record -g dwarf` + flamegraph collapse | per-thread on-CPU profile → flamegraph for the maintainer's eye | any capture you already retain |
+
+## Q5. Cross-correlating scheduler events WITH frames
+
+The missing layer in most captures: scheduler truth and frame truth on one axis.
+
+1. `scxtop trace` (perfetto) + import the MangoHud CSV → two tracks, one timeline
+   (perfetto query language joins on ts).
+2. Or annotate perf captures with frame marks:
+   `sudo-less` route — run MangoHud with `output_folder` + `log_interval=1`
+   (frame rows) while `perf record -e sched:sched_switch,...` runs; join offline
+   on timestamp. `bench/wake_maxdecomp.py` already parses the perf side; the
+   join is a small extension (frame_ts ± window → event counts).
+3. `perf inject --sched-stat` merges stat_* events into switch records so each
+   switch carries its preceding wait time — one less manual pass.
+
+---
+
+## Rules that bind all of these (from CLAUDE.md)
+
+- Identity first: confirm ops-name prefix + binary sha256 before reading ANY number.
+- Never sudo; a failing privileged step is a capability bug, not an instruction to elevate.
+- Nothing heavy attaches during a live frame capture (observers ride BETWEEN slots).
+- Interleaved A/B only for cross-run comparisons; regime is covariate #1.
+- Every number names its evidence class (FRAME/WAKE/CENSUS/STATIC/SIM).
+
+## Highest-value additions, ranked for the current campaign
+
+1. **IBS / perf mem on the GameThread + kwin** — the domain audit found
+   GameThread p99 72 µs and exec +15–42% unexplained; precise stall attribution
+   says whether cake's placement is costing cache warmth (mechanism, not guess).
+2. **waker→wakee matrix** — quantifies the many-to-many TaskGraph shape per
+   game; turns open gap #7 into measured pair counts (input for a burst-classifier).
+3. **`perf c2c` during play** — prices the shared-line RFO tax directly instead
+   of inferring it from ns/call deltas.
+4. **cpuidle sysfs snapshot loop** — free §G51 progress check every boot; the
+   depth model stays dead until the driver appears.
+5. **osnoise tracer** — a jitter-floor number both arms must respect; would
+   have caught the mode-variance confounds (§G38.1 attribution) earlier.

--- a/scheds/rust/scx_cake/src/bpf/cake.bpf.c
+++ b/scheds/rust/scx_cake/src/bpf/cake.bpf.c
@@ -49,6 +49,8 @@ UEI_DEFINE(uei);
 #define CAKE_KICK_PREEMPT bpf_core_enum_value(enum scx_kick_flags,   SCX_KICK_PREEMPT)
 #define CAKE_TASK_QUEUED  bpf_core_enum_value(enum scx_ent_flags,    SCX_TASK_QUEUED)
 #define CAKE_WAKE_SYNC    bpf_core_enum_value(enum scx_wake_flags,   SCX_WAKE_SYNC)
+#define CAKE_PICK_IDLE_CORE \
+	bpf_core_enum_value(enum scx_pick_idle_cpu_flags, SCX_PICK_IDLE_CORE)
 
 /*
  * Cake-local kfunc bindings through compat.bpf.h's ladders, shaped so the
@@ -78,9 +80,39 @@ static __always_inline bool cake_move_to_local(u64 dsq_id)
 	return scx_bpf_dsq_move_to_local(dsq_id, 0);
 }
 
+/* Campaign toggle, declared here because the readers below precede the
+ * toggle block (§M7; the block documents the campaign). */
+const volatile u8 cake_tog_m7;				/* runqueues direct reads (§M7) */
+
+extern struct rq runqueues __ksym __weak;
+
+/*
+ * The occupant of @cpu. Direct percpu-rq deref when the symbol resolves
+ * (§M7): one load chain, no kfunc crossing; advisory-racy exactly as the
+ * kfunc read is. Falls back to the kfunc where BTF lacks the symbol, so
+ * no host loses the answer.
+ */
 static __noinline struct task_struct *cake_cpu_curr(s32 cpu)
 {
+	if (cake_tog_m7 && bpf_ksym_exists(&runqueues)) {
+		struct rq *rq = bpf_per_cpu_ptr(&runqueues, cpu);
+
+		return rq ? rq->curr : NULL;
+	}
 	return __COMPAT_scx_bpf_cpu_curr(cpu);
+}
+
+/* Local-DSQ depth without the kfunc (§M7): same field the kfunc returns,
+ * read through the percpu rq; advisory-racy under the same trust model. */
+static __always_inline u64 cake_local_nr(s32 cpu)
+{
+	if (cake_tog_m7 && bpf_ksym_exists(&runqueues)) {
+		struct rq *rq = bpf_per_cpu_ptr(&runqueues, cpu);
+
+		if (rq)
+			return rq->scx.local_dsq.nr;
+	}
+	return scx_bpf_dsq_nr_queued(CAKE_DSQ_LOCAL_ON | (u32)cpu);
 }
 
 static __noinline struct task_struct *cake_dsq_peek(u64 dsq_id)
@@ -130,7 +162,18 @@ struct cake_run_slot {
 	 * atomics, and it rides a line running/stopping already own (§R.18).
 	 */
 	u64 hint;
-	u64 pad[STATE_SLOT_WORDS - 3];
+	/* The last two departures' slices, pid<<32 | slice (§G46). */
+	u64 slice_cache[2];
+	/*
+	 * Occupant mirror (§M6): running publishes, stopping clears. occupant
+	 * packs pid<<32 | recip-index; 0 = off-mirror (idle or a non-SCX
+	 * class), and mirror_vtime is trusted only under a nonzero occupant.
+	 * dsq_vtime is charged at stopping, so the mirrored value is exact
+	 * for the whole slice.
+	 */
+	u64 occupant;
+	u64 mirror_vtime;
+	u64 pad[STATE_SLOT_WORDS - 7];
 };
 
 enum {
@@ -147,6 +190,28 @@ enum {
  * hardware and LOGS it but must NOT drive it yet (§S.5).
  */
 const volatile u64 cake_handoff_max_ns		= 1464;
+
+/*
+ * Campaign toggles (`--toggle gNN=0|1`): rodata, so the verifier deletes the
+ * off arm at attach and one binary serves both arms — the sanctioned §S.6
+ * exception. Scaffolding; defaults are tip behavior (STATE.md 2026-08-22).
+ */
+const volatile u8 cake_tog_g46;				/* departing-slice cache (§G46) */
+const volatile u8 cake_tog_m6;				/* occupant mirror (§M6) */
+const volatile u8 cake_tog_g51;				/* idle-depth model (§G51) */
+const volatile u8 cake_tog_g52;				/* preferred-core rank (§G52) */
+
+/* §G54: next_pow2(nr_cpu_span) - 1, derived in the loader — the rotor
+ * masks instead of dividing (no modulo on a per-transition path). */
+const volatile u32 cake_span_mask;
+
+/* §G51: cpuidle state index -> exit latency (us), loader-read from sysfs.
+ * All-zero (no cpuidle driver) leaves the depth model inert. */
+const volatile u32 cake_cstate_exit_us[CAKE_CSTATE_TABLE];
+
+/* §G52: CPPC highest_perf per CPU, loader-read; zero = unknown. */
+const volatile u8 cpu_perf_rank[MAX_CPUS];
+
 
 /*
  * Observed frame period: measured, never inherited from a timeslice. Published
@@ -227,6 +292,23 @@ static __always_inline bool cake_starved(const struct task_struct *p)
 }
 
 /*
+ * Does this task wait longer than one turn of its OWN? cake_starved has no
+ * dead zone: as the burst shrinks any queueing wins, so a fan-out worker
+ * that runs microseconds reads starved on the wake hop alone. Relocation
+ * pays only past a whole turn, so the margin is the task's own slice --
+ * twice burst, cake_task_slice's grant -- and no constant enters (§G12).
+ */
+static __always_inline bool cake_starved_turn(const struct task_struct *p)
+{
+	u64 wait = p->sched_info.run_delay >> CAKE_RATIO_SHIFT;
+	u64 run = p->se.sum_exec_runtime >> CAKE_RATIO_SHIFT;
+
+	if (!run)
+		return false;
+	return wait * (p->nvcsw | 1) > (run << 1) * (p->sched_info.pcount | 1);
+}
+
+/*
  * Fold this task's mean wake cadence into the frame clock: a display-coupled
  * thread reports the frame period directly, and casts one vote for it (§G11).
  * The range gate is cross-multiplied so the off-cadence majority — every
@@ -289,6 +371,18 @@ struct cake_state {
 	/* ktime the global wake queue was last consumed by ANY CPU (§R.16). */
 	struct cake_slot wake_served;
 	/*
+	 * "WAKE_DSQ may hold work" mark gating the global peek in dispatch
+	 * (§G41). Own slot: every CPU reads it every dispatch, and it must not
+	 * share a line with wake_served, which serving CPUs store to (§R.10).
+	 */
+	struct cake_slot wake_mark;
+	/*
+	 * One recently idled CPU, cpu id + 1 (0 = none), published by its own
+	 * going-idle dispatch so the wake path can claim it with a single
+	 * test-and-clear instead of an idle-mask scan (§G43).
+	 */
+	struct cake_slot idle_hint;
+	/*
 	 * "DSQ[i] may hold work" hint gating the steal ring, one bit per CPU, so
 	 * a going-idle dispatch reads QMASK_WORDS words instead of probing one
 	 * 128 B slot per CPU. A stale bit is benign by construction (§G25).
@@ -335,6 +429,17 @@ static __always_inline bool cake_qmark_test(u32 cpu)
 }
 
 /*
+ * Wake-routing emptiness: a CLEAR bit already proves the DSQ empty (insert
+ * marks first, §G25); the rhashtable lookup is paid only on a set bit. A
+ * stale clear misroutes one wake, healed by the owner's next own-queue peek.
+ * __noinline: inlined, the word address pins across the callers' kfuncs (§G44).
+ */
+static __noinline bool cake_cpu_dsq_idle(u32 cpu)
+{
+	return !scx_bpf_dsq_nr_queued((u64)cpu);
+}
+
+/*
  * Republish this CPU's mark from a head peek. Deliberately __noinline: inlined,
  * LLVM shares the bit and word address between the set and clear arms, hoists
  * both ABOVE the peek call that decides between them, and pins them across it —
@@ -346,6 +451,17 @@ static __noinline void cake_qmark_publish(u32 cpu, bool queued)
 		cake_qmark_set(cpu);
 	else
 		cake_qmark_clear(cpu);
+}
+
+/*
+ * §G25's mark for the ownerless WAKE_DSQ, where a stale CLEAR is not benign:
+ * no owner rescans that queue, so the setter marks AFTER the insert and
+ * retirement is clear-then-repeek. Protocol: §G41. Test before set (§R.10).
+ */
+static __always_inline void cake_wake_mark_set(void)
+{
+	if (!cake.wake_mark.word)
+		cake.wake_mark.word = 1;
 }
 
 /* Loader-filled SMT map; -1 means the CPU has no online sibling. */
@@ -363,9 +479,37 @@ u32 cake_sink_gen;
  * other or with the wake-path readers. */
 struct cake_irq_slot {
 	u32 depth;
-	u8 pad[STATE_SLOT_BYTES - sizeof(u32)];
+	/* §G51: cpuidle state index + 1 while idle, 0 awake; owner-written
+	 * at the cpu_idle tracepoint. Same owner and line as depth. */
+	u32 cstate;
+	/* §G54: mailbox index + 1 where this CPU parked itself, 0 unparked;
+	 * owner-written at idle entry/exit. */
+	u32 park;
+	u8 pad[STATE_SLOT_BYTES - 3 * sizeof(u32)];
 };
 static struct cake_irq_slot cake_irq_live[MAX_CPUS];
+
+/* §G54 self-park mailboxes: one padded slot per WAKER CPU, value = parked
+ * cpu + 1. The idle CPU writes itself in at idle entry (self-gated: it
+ * evaluates its own cleanliness with local reads) and retracts at exit;
+ * the waker consumes its own slot with a plain store — no atomics, and no
+ * cross-waker claim race by construction (§R.29 taken to completion). */
+static struct cake_slot cake_mailbox[MAX_CPUS];
+static u64 cake_park_rotor;
+
+/* §G54.1: mailbox entry quality — set when the parker's whole core is idle
+ * (§G38 imported to the producer). Whole-core entries may overwrite
+ * half-core entries, never the reverse. */
+#define CAKE_PARK_CORE	(1ULL << 31)
+
+/* §G54.1: consumers share one slot per physical core (the sibling with the
+ * lower id names it), concentrating parked entries into half the slots. */
+static __always_inline u32 cake_core_slot(u32 c)
+{
+	s32 sib = cpu_sibling[c & (MAX_CPUS - 1)];
+
+	return (sib >= 0 && (u32)sib < c) ? (u32)sib & (MAX_CPUS - 1) : c;
+}
 
 /* Bad wake target: chronically loud (§G33 mask, the average truth) or
  * inside a handler right now (§G35, the instantaneous truth). Each alone
@@ -375,6 +519,31 @@ static __always_inline bool cake_cpu_irq_bad(s32 cpu)
 	u32 c = (u32)cpu & (MAX_CPUS - 1);
 
 	return cpu >= 0 && (cpu_irq_hot[c] || cake_irq_live[c].depth);
+}
+
+/* A thread whose SMT sibling executes delivers a fraction of the core, so an
+ * idle thread on a busy core is not the same offer as an idle core. Cake ranks
+ * cache warmth above that difference; measured on a live aim trainer the trade
+ * is inverted, and it inverts on an idle machine where the alternative core is
+ * free (§G38). */
+static __always_inline bool cake_core_contended(s32 cpu)
+{
+	s32 sib = cpu_sibling[(u32)cpu & (MAX_CPUS - 1)];
+	struct task_struct *curr;
+
+	if (sib < 0)
+		return false;
+
+	/*
+	 * Mirror hit answers without the rq deref chain (§M6). Zero is
+	 * ambiguous -- idle or a non-SCX class -- so only nonzero decides.
+	 */
+	if (cake_tog_m6 && cake.run[(u32)sib & (MAX_CPUS - 1)].occupant)
+		return true;
+
+	curr = cake_cpu_curr(sib);
+
+	return curr && curr->pid;
 }
 
 /* The timer is the one interrupt scheduled ahead of time (§G36): a CPU whose
@@ -406,6 +575,29 @@ static __noinline bool cake_cpu_tick_soon(s32 cpu)
 	return next <= bpf_ktime_get_ns() + cake_wake_hop_ns;
 }
 
+/* The two-truth cleanliness test, spelled once: chronically loud or
+ * mid-handler (§G30/§G35) OR about to take its tick (§G36). */
+static __always_inline bool cake_cpu_clean(s32 cpu)
+{
+	return !cake_cpu_irq_bad(cpu) && !cake_cpu_tick_soon(cpu);
+}
+
+/* Escape pick away from a bad target: a whole idle core first (§G38), but a
+ * poisoned core winner -- the permanently idle sink core -- must not cost the
+ * escape, so a bad core pick re-picks thread-grain. The first pick's
+ * test-and-clear consumed the bad core's idle bit, so a repeated core pick
+ * cannot return it again. A subprogram, not inline: expanded twice in
+ * select_cpu it costs a spill there (§G38.1, §R.11). */
+static __noinline s32 cake_pick_idle_escape(struct task_struct *p __arg_trusted)
+{
+	s32 alt = scx_bpf_pick_idle_cpu(p->cpus_ptr, CAKE_PICK_IDLE_CORE);
+
+	if (alt < 0 || !cake_cpu_clean(alt))
+		alt = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
+
+	return alt;
+}
+
 static __always_inline void cake_irq_edge(bool enter)
 {
 	u32 c = bpf_get_smp_processor_id() & (MAX_CPUS - 1);
@@ -435,6 +627,21 @@ SEC("tp_btf/softirq_entry")
 int BPF_PROG(cake_softirq_enter)
 {
 	cake_irq_edge(true);
+	return 0;
+}
+
+/* §G51: mirror the CPU's cpuidle state so placement can rank shallow idle
+ * above deep. Fires on the idling CPU itself at entry (state index) and
+ * exit (~0), so the byte is exact at every transition. */
+SEC("tp_btf/cpu_idle")
+int BPF_PROG(cake_cpu_idle, unsigned int state, unsigned int cpu_id)
+{
+	u32 c;
+
+	if (!cake_tog_g51)
+		return 0;
+	c = cpu_id & (MAX_CPUS - 1);
+	cake_irq_live[c].cstate = state == (unsigned int)-1 ? 0 : state + 1;
 	return 0;
 }
 
@@ -558,19 +765,36 @@ static __always_inline u32 cake_recip_index(const struct task_struct *p)
  */
 static __noinline u64 cake_occupant_live(s32 tcpu, u64 *ran_out)
 {
-	struct task_struct *curr = cake_cpu_curr(tcpu);
+	struct cake_run_slot *rs = &cake.run[(u32)tcpu & (MAX_CPUS - 1)];
+	struct task_struct *curr;
 	u64 cv, ran, stamp;
 	u32 cidx;
 
-	if (!curr)
-		return 0;
-	cv = curr->scx.dsq_vtime;
-	if (!cv)
-		return 0;
+	/*
+	 * Mirror path (§M6): dsq_vtime is charged only at stopping, so the
+	 * published copy is exact for the whole slice; recip-index rides the
+	 * occupant word. One line instead of the rq->curr chain.
+	 */
+	if (cake_tog_m6) {
+		u64 occ = rs->occupant;
 
-	stamp = cake.run[(u32)tcpu & (MAX_CPUS - 1)].stamp;
-	cidx = cake_recip_index(curr);
+		if (!occ)
+			return 0;
+		cv = rs->mirror_vtime;
+		if (!cv)
+			return 0;
+		cidx = (u32)occ & 0xff;
+	} else {
+		curr = cake_cpu_curr(tcpu);
+		if (!curr)
+			return 0;
+		cv = curr->scx.dsq_vtime;
+		if (!cv)
+			return 0;
+		cidx = cake_recip_index(curr);
+	}
 
+	stamp = rs->stamp;
 	ran = bpf_ktime_get_ns() - stamp;
 	*ran_out = ran;
 	return cake_scale_vtime_add(cv, ran, cidx);
@@ -624,14 +848,17 @@ static __noinline bool cake_wake_preempt(struct task_struct *p, s32 tcpu,
  * game regression dates from exactly there. Helldivers 2 runs ~62% idle
  * against this 75% threshold, so it declines precisely where G9.4 admits.
  */
+/* §G45: idle census kept by ops.update_idle. Bit and count flip together
+ * (test-gated, idempotent), so the count cannot drift; ops.init seeds it. */
+static u64 cake_idle_words[QMASK_WORDS] __attribute__((aligned(STATE_SLOT_BYTES)));
+static u64 cake_idle_nr __attribute__((aligned(STATE_SLOT_BYTES)));
+
 static __noinline bool cake_system_serial(void)
 {
-	const struct cpumask *idle;
 	u32 nr;
 
-	idle = scx_bpf_get_idle_cpumask();
-	nr = bpf_cpumask_weight(idle);
-	scx_bpf_put_idle_cpumask(idle);
+	/* One word read replaces the kernel mask walk per wake (§G45). */
+	nr = (u32)cake_idle_nr;
 
 	return nr * 4 >= nr_cpu_span * 3;
 }
@@ -694,6 +921,42 @@ static __noinline u64 cake_task_slice(struct task_struct *p __arg_trusted)
 	return want;
 }
 
+/*
+ * §G46: serve the insert sites from the departure cache — one load + compare
+ * against cake_task_slice's two divides and a clock read. Tagged by pid, two
+ * entries because handoff pairs alternate; staleness is one quantum of
+ * estimator drift. The slot is the task's own CPU — where it last stopped —
+ * read here, not passed, so callers keep no extra live value. Miss: compute.
+ */
+static __noinline u64 cake_task_slice_cached(struct task_struct *p __arg_trusted)
+{
+	if (cake_tog_g46) {
+		struct cake_run_slot *rs =
+			&cake.run[(u32)p->thread_info.cpu & (MAX_CPUS - 1)];
+		u64 tag = (u64)(u32)p->pid << 32;
+		u64 e0 = rs->slice_cache[0];
+		u64 e1 = rs->slice_cache[1];
+
+		if ((e0 & ~0xffffffffULL) == tag)
+			return (u32)e0;
+		if ((e1 & ~0xffffffffULL) == tag)
+			return (u32)e1;
+	}
+	return cake_task_slice(p);
+}
+
+/* The cache's write half, called LAST in stopping so the caller carries
+ * nothing across it; the slot line is one this op already owns (§G46). */
+static __noinline void cake_slice_publish(struct task_struct *p __arg_trusted)
+{
+	struct cake_run_slot *rs =
+		&cake.run[(u32)p->thread_info.cpu & (MAX_CPUS - 1)];
+	u64 ent = ((u64)(u32)p->pid << 32) | (u32)cake_task_slice(p);
+
+	rs->slice_cache[1] = rs->slice_cache[0];
+	rs->slice_cache[0] = ent;
+}
+
 /* The S1d dose: three quarters of the unused slice, as two shifts (§R.13). */
 static __always_inline u64 cake_sleeper_dose(u64 unused)
 {
@@ -745,8 +1008,17 @@ static __noinline bool cake_home_notify(struct task_struct *p, s32 tcpu)
 	u64 ran = 0;
 	u64 live = cake_occupant_live(tcpu, &ran);
 
-	if (!live)
-		return (u32)tcpu == bpf_get_smp_processor_id();
+	if (!live) {
+		if ((u32)tcpu == bpf_get_smp_processor_id())
+			return true;
+		/* Idle-owned REMOTE home: kick the home itself, not some idle
+		 * CPU elsewhere -- the queue lives on tcpu and a foreign kick
+		 * only finds it through the steal ring. Measured on live
+		 * KovaaKs: every slow GameThread wake (>20 µs, p99 128 vs
+		 * native 6) had idle capacity and 75% an idle home (§G40). */
+		scx_bpf_kick_cpu(tcpu, CAKE_KICK_IDLE);
+		return true;
+	}
 
 	if (ran >= ((u64)SLICE_NS >> 5) ||
 	    !time_before(p->scx.dsq_vtime + (SLICE_NS >> 1) -
@@ -768,6 +1040,90 @@ static __always_inline void cake_direct_clamp(struct task_struct *p)
 	p->scx.dsq_vtime = cake_wake_vtime(p);
 }
 
+static __noinline s32 cake_idle_hint_claim(struct task_struct *p __arg_trusted);
+
+
+/* Affinity by direct bitmap read (§G54, the §M7 idea applied to cpumask):
+ * one load chain instead of a helper crossing. Constant offset only — the
+ * verifier refuses a variable-offset load through a trusted cpumask; the
+ * rodata gate lets it delete the kfunc arm at load on hosts within one word. */
+static __always_inline bool cake_affine(struct task_struct *p, s32 cpu)
+{
+	u32 c = (u32)cpu & (MAX_CPUS - 1);
+
+	if (nr_cpu_span <= 64)
+		return (p->cpus_ptr->bits[0] >> (c & 63)) & 1;
+	return bpf_cpumask_test_cpu(cpu, p->cpus_ptr);
+}
+
+/* §G54 consumer: prev-warmth first (census bit, optimistic), then this
+ * waker's own core mailbox. Both place without a consuming claim — a stale
+ * entry costs one occupant wait, the §G53-measured trade. A subprogram so
+ * the frame cost stays off select_cpu (§R.11). */
+static __noinline s32 cake_park_take(struct task_struct *p __arg_trusted,
+				     s32 prev_cpu)
+{
+	u32 wc = bpf_get_smp_processor_id() & (MAX_CPUS - 1);
+	u64 mbox;
+	s32 ocpu = -1;
+
+	if (prev_cpu >= 0) {
+		u32 pc = (u32)prev_cpu & (MAX_CPUS - 1);
+
+		if ((cake_idle_words[pc >> 6] >> (pc & 63)) & 1 &&
+		    !cpu_irq_hot[pc] && cake_affine(p, prev_cpu))
+			ocpu = prev_cpu;
+	}
+	if (ocpu < 0) {
+		u32 slot = cake_core_slot(wc);
+
+		mbox = cake_mailbox[slot].word;
+		if (mbox) {
+			s32 mcpu = (s32)(u32)((mbox & ~CAKE_PARK_CORE) - 1);
+
+			if (cake_affine(p, mcpu)) {
+				cake_mailbox[slot].word = 0;
+				ocpu = mcpu;
+			}
+		}
+	}
+	if (ocpu < 0)
+		return -1;
+	cake_direct_clamp(p);
+	cake_dsq_insert(p, CAKE_DSQ_LOCAL_ON | (u32)ocpu,
+			cake_task_slice_cached(p), 0);
+	return ocpu;
+}
+
+/* Optimistic first-fit from the census (§G53): affinity is the only gate,
+ * placement is unverified — the mailbox-miss fallback. A subprogram so the
+ * walk costs select_cpu's frame nothing (§R.11). */
+static __noinline s32 cake_optimistic_place(struct task_struct *p __arg_trusted)
+{
+	u32 wi;
+
+	for (wi = 0; wi < QMASK_WORDS; wi++) {
+		u64 w;
+		u32 base = wi << 6;
+		u32 k;
+
+		if (base >= nr_cpu_span)
+			break;
+		w = cake_idle_words[wi];
+		for (k = 0; k < 2 && w; k++) {
+			s32 ocpu = (s32)(base + __builtin_ctzll(w));
+
+			w &= w - 1;
+			if (!bpf_cpumask_test_cpu(ocpu, p->cpus_ptr))
+				continue;
+			cake_direct_clamp(p);
+			cake_dsq_insert(p, CAKE_DSQ_LOCAL_ON | (u32)ocpu,
+					cake_task_slice_cached(p), 0);
+			return ocpu;
+		}
+	}
+	return -1;
+}
 
 /*
  * ops.select_cpu — placement plus guarded direct admission.
@@ -793,7 +1149,8 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 	 * sink: an ISR-origin wake mimics the handoff shape, but the "waker" is
 	 * interrupt context and its CPU carries the ISR shadow (§G30). MUST run
 	 * before select_cpu_dfl(), which RESERVES the idle CPU it returns
-	 * (§R.1).
+	 * (§R.1). Letting SYNC wakes in was tried and ABORTED: pipe -36.8%,
+	 * context switches +46% -- the §R.6 weld, measured again (§G39).
 	 */
 	{
 		u32 wc = bpf_get_smp_processor_id() & (MAX_CPUS - 1);
@@ -804,18 +1161,22 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 		if (!(wr->hint & CAKE_HINT_WOKE))
 			wr->hint |= CAKE_HINT_WOKE;
 
+		/* No core-contended veto here: the sibling's occupant in a
+		 * handoff regime is usually another transient pair, and the
+		 * veto exiled mutex pairs from co-location for a measured
+		 * -69% (§G38.1 amendment; the home claim keeps its veto). */
 		if (serial && !(wake_flags & CAKE_WAKE_SYNC) &&
 		    !cake_cpu_irq_bad((s32)wc) &&
 		    bpf_cpumask_test_cpu((s32)wc, p->cpus_ptr) &&
 		    cake_system_serial() &&
-		    !scx_bpf_dsq_nr_queued((u64)wc) &&
-		    !scx_bpf_dsq_nr_queued(CAKE_DSQ_LOCAL_ON | wc) &&
+		    cake_cpu_dsq_idle(wc) &&
+		    !cake_local_nr((s32)wc) &&
 		    cake_handoff_yields((s32)wc)) {
 			s32 wcpu = (s32)wc;
 
 			cake_direct_clamp(p);
 			cake_dsq_insert(p, CAKE_DSQ_LOCAL_ON | (u32)wcpu,
-					cake_task_slice(p), 0);
+					cake_task_slice_cached(p), 0);
 			return wcpu;
 		}
 	}
@@ -826,15 +1187,46 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 	 * which is wrong for an occupant of its own cache. WAKE_SYNC excluded --
 	 * there the waker's cache holds the data. MUST precede select_cpu_dfl(),
 	 * which reserves what it returns (§G13).
+	 *
+	 * The claim is declined on a contended core: the home is only warm if
+	 * the task gets the whole core to run on (§G38).
 	 */
 	if (!(wake_flags & CAKE_WAKE_SYNC) && prev_cpu >= 0 &&
-	    !cake_starved(p) && !cake_cpu_irq_bad(prev_cpu) &&
+	    !cake_starved_turn(p) && !cake_cpu_irq_bad(prev_cpu) &&
 	    bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr) &&
+	    !cake_core_contended(prev_cpu) &&
 	    scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
 		cake_direct_clamp(p);
 		cake_dsq_insert(p, CAKE_DSQ_LOCAL_ON | (u32)prev_cpu,
-				cake_task_slice(p), 0);
+				cake_task_slice_cached(p), 0);
 		return prev_cpu;
+	}
+
+
+	/*
+	 * Self-park consumer (§G54): the decision was computed at idle-entry
+	 * by the idle CPU itself; this reads it. Warmth-first — the combined
+	 * pair with the walk ahead of this block re-priced §G53's tails.
+	 */
+	if (cake_idle_nr) {
+		s32 ocpu = cake_park_take(p, prev_cpu);
+
+		if (ocpu >= 0)
+			return ocpu;
+	}
+
+	/*
+	 * Optimistic placement probe (§G53): EEVDF's shape — first affine
+	 * census bit, place, no gates, no consuming claim. A collision costs
+	 * one occupant wait, exactly what EEVDF accepts; the verify step was
+	 * where §G48/§G50 spent more than they saved. With §G54 on, this is
+	 * the mailbox-miss fallback.
+	 */
+	{
+		s32 ocpu = cake_optimistic_place(p);
+
+		if (ocpu >= 0)
+			return ocpu;
 	}
 
 	/*
@@ -853,12 +1245,22 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 		ns = cast_mask(nonsink_cpumask);
 
 		cpu = -1;
+		/*
+		 * Zero-skip (§G50): the census says nothing is idle, so both
+		 * scans can only fail; a stale zero costs one queued wake,
+		 * healed by the enqueue-side kick.
+		 */
+		if (!cake_idle_nr)
+			ns = NULL;
 		if (ns && __COMPAT_HAS_scx_bpf_select_cpu_and)
 			cpu = scx_bpf_select_cpu_and(p, prev_cpu, wake_flags,
 						     ns, 0);
 	}
 	if (cpu >= 0)
 		is_idle = true;
+	else if (!cake_idle_nr &&
+		 bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr))
+		cpu = prev_cpu;
 	else
 		cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
 	if (is_idle) {
@@ -877,7 +1279,7 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 				idle = scx_bpf_select_cpu_and(p, prev_cpu, 0,
 							      ns, 0);
 			else
-				idle = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
+				idle = cake_pick_idle_escape(p);
 			if (idle >= 0)
 				cpu = idle;
 		}
@@ -892,10 +1294,9 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 		 */
 		if (cake_irq_live[(u32)cpu & (MAX_CPUS - 1)].depth ||
 		    cake_cpu_tick_soon(cpu)) {
-			s32 alt = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
+			s32 alt = cake_pick_idle_escape(p);
 
-			if (alt >= 0 && !cake_cpu_irq_bad(alt) &&
-			    !cake_cpu_tick_soon(alt))
+			if (alt >= 0 && cake_cpu_clean(alt))
 				cpu = alt;
 		}
 
@@ -917,7 +1318,8 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 			}
 		}
 		cake_direct_clamp(p);
-		cake_dsq_insert(p, CAKE_DSQ_LOCAL, cake_task_slice(p), 0);
+		cake_dsq_insert(p, CAKE_DSQ_LOCAL,
+				cake_task_slice_cached(p), 0);
 		return cpu;
 	}
 
@@ -936,12 +1338,37 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 		/* Same sink veto as the serial block (§G30, §G35). */
 		if (!cake_cpu_irq_bad(waker_cpu) &&
 		    bpf_cpumask_test_cpu(waker_cpu, p->cpus_ptr) &&
-		    !scx_bpf_dsq_nr_queued(CAKE_DSQ_LOCAL_ON | (u32)waker_cpu) &&
-		    !scx_bpf_dsq_nr_queued((u64)(u32)waker_cpu))
+		    !cake_local_nr(waker_cpu) &&
+		    cake_cpu_dsq_idle((u32)waker_cpu))
 			return waker_cpu;
 	}
 
 	return cpu;
+}
+
+/* Claim the published going-idle CPU: the hint must pass every gate the
+ * scan enforces -- §G30/§G33/§G35/§G36 cleanliness and the §G38 whole-core
+ * preference -- so a hit changes cost, never ranking. The test-and-clear is
+ * the verify AND the claim; the CAS retires our snapshot only, so a newer
+ * publish survives. An affinity miss leaves the hint for other tasks (§G43). */
+static __noinline s32 cake_idle_hint_claim(struct task_struct *p __arg_trusted)
+{
+	u64 h;
+	bool claimed;
+	s32 cpu;
+
+	h = cake.idle_hint.word;
+	if (!h)
+		return -1;
+	cpu = (s32)(u32)(h - 1);
+	if (!bpf_cpumask_test_cpu(cpu, p->cpus_ptr))
+		return -1;
+	if (!cake_cpu_clean(cpu) || cake_core_contended(cpu))
+		return -1;
+
+	claimed = scx_bpf_test_and_clear_cpu_idle(cpu);
+	(void)__sync_val_compare_and_swap(&cake.idle_hint.word, h, 0);
+	return claimed ? cpu : -1;
 }
 
 /* Idle pick with one retry away from a bad target (§G30, §G35): prefer a
@@ -949,13 +1376,23 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
  * is idle it still wins -- any CPU beats queueing. */
 static __noinline s32 cake_pick_idle_clean(struct task_struct *p __arg_trusted)
 {
-	s32 cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
+	/* The hint short-circuits the scans; a miss costs one word read (§G43). */
+	s32 cpu = cake_idle_hint_claim(p);
 
-	if (cpu >= 0 && (cake_cpu_irq_bad(cpu) || cake_cpu_tick_soon(cpu))) {
-		s32 alt = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
+	if (cpu >= 0)
+		return cpu;
 
-		if (alt >= 0 && !cake_cpu_irq_bad(alt) &&
-		    !cake_cpu_tick_soon(alt))
+	/* A whole idle core beats an idle thread beside a running one, and the
+	 * flag costs nothing when no core is free (§G38). */
+	cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, CAKE_PICK_IDLE_CORE);
+
+	if (cpu < 0)
+		cpu = scx_bpf_pick_idle_cpu(p->cpus_ptr, 0);
+
+	if (cpu >= 0 && !cake_cpu_clean(cpu)) {
+		s32 alt = cake_pick_idle_escape(p);
+
+		if (alt >= 0 && cake_cpu_clean(alt))
 			cpu = alt;
 	}
 	return cpu;
@@ -977,23 +1414,24 @@ __noinline s32 cake_wake_notify(struct task_struct *p __arg_trusted, s32 tcpu,
 	if (route == ROUTE_HOME_CLAIM && cake_home_notify(p, tcpu))
 		return 0;
 
-	/* Prefer an idle SMT sibling for globally queued cold pickup. */
+	idle = cake_pick_idle_clean(p);
+	if (idle >= 0) {
+		scx_bpf_kick_cpu(idle, CAKE_KICK_IDLE);
+		return 0;
+	}
+
+	/* An idle SMT sibling keeps globally queued cold pickup on a warm core.
+	 * Ranked BELOW a clean idle pick: the sibling shares the core with a
+	 * runner, and that costs more than the L2 it saves (§G38). */
 	if (route == ROUTE_GLOBAL) {
 		s32 sib = cpu_sibling[(u32)tcpu & (MAX_CPUS - 1)];
 
-		if (sib >= 0 && !cake_cpu_irq_bad(sib) &&
-		    !cake_cpu_tick_soon(sib) &&
+		if (sib >= 0 && cake_cpu_clean(sib) &&
 		    bpf_cpumask_test_cpu(sib, p->cpus_ptr) &&
 		    scx_bpf_test_and_clear_cpu_idle(sib)) {
 			scx_bpf_kick_cpu(sib, CAKE_KICK_IDLE);
 			return 0;
 		}
-	}
-
-	idle = cake_pick_idle_clean(p);
-	if (idle >= 0) {
-		scx_bpf_kick_cpu(idle, CAKE_KICK_IDLE);
-		return 0;
 	}
 
 	/*
@@ -1086,7 +1524,8 @@ __noinline s32 cake_enqueue_wake(struct task_struct *p __arg_trusted, s32 tcpu)
 	 */
 	if (curr == p) {
 		cake_qmark_set((u32)tcpu);
-		cake_dsq_insert_vtime(p, (u64)(u32)tcpu, cake_task_slice(p),
+		cake_dsq_insert_vtime(p, (u64)(u32)tcpu,
+				      cake_task_slice_cached(p),
 				      cake_wake_vtime(p), CAKE_ENQ_WAKEUP);
 		return 0;
 	}
@@ -1100,7 +1539,7 @@ __noinline s32 cake_enqueue_wake(struct task_struct *p __arg_trusted, s32 tcpu)
 	empty_home = !(curr && (curr->policy == SCHED_FIFO ||
 				curr->policy == SCHED_RR ||
 				curr->policy == SCHED_DEADLINE)) &&
-		     !scx_bpf_dsq_nr_queued((u64)(u32)tcpu);
+		     cake_cpu_dsq_idle((u32)tcpu);
 
 	route = empty_home ? ROUTE_HOME_QUEUE : ROUTE_GLOBAL;
 	if (empty_home && cake_home_claim(p, tcpu))
@@ -1123,8 +1562,12 @@ __noinline s32 cake_enqueue_wake(struct task_struct *p __arg_trusted, s32 tcpu)
 	 */
 	cake_dsq_insert_vtime(p,
 			      route ? (u64)(u32)tcpu : (u64)WAKE_DSQ,
-			      cake_task_slice(p), cake_wake_vtime(p),
+			      cake_task_slice_cached(p), cake_wake_vtime(p),
 			      CAKE_ENQ_WAKEUP);
+	/* AFTER the insert — the §G41 ordering half; qmask marks before
+	 * because its owner's rescan makes a stale clear benign. */
+	if (!route)
+		cake_wake_mark_set();
 
 	cake_wake_notify(p, tcpu, route);
 	return 0;
@@ -1155,6 +1598,7 @@ static __noinline void cake_pinned_wake_preempt(struct task_struct *p __arg_trus
 		scx_bpf_kick_cpu(tcpu, CAKE_KICK_PREEMPT);
 }
 
+
 /*
  * ops.enqueue — reached when no idle CPU was claimed, or guarded direct
  * admission found an older visible per-CPU claim.
@@ -1184,6 +1628,7 @@ void BPF_STRUCT_OPS(cake_enqueue, struct task_struct *p, u64 enq_flags)
 	 * the wake takes this path; a continuation falls through (§R.14). An idle
 	 * CPU serves it as promptly and evicts nobody (§G20).
 	 */
+
 	if ((enq_flags & CAKE_ENQ_WAKEUP) && (p->flags & PF_KTHREAD)) {
 		s32 kcpu = cake_pick_idle_clean(p);
 
@@ -1211,7 +1656,7 @@ void BPF_STRUCT_OPS(cake_enqueue, struct task_struct *p, u64 enq_flags)
 	 * the continuation arm regardless (§R.14).
 	 */
 	if ((enq_flags & CAKE_ENQ_WAKEUP) && p->nr_cpus_allowed > 1 &&
-	    cake_starved(p)) {
+	    cake_starved_turn(p)) {
 		cake_enqueue_wake(p, tcpu);
 		return;
 	}
@@ -1232,19 +1677,21 @@ void BPF_STRUCT_OPS(cake_enqueue, struct task_struct *p, u64 enq_flags)
 		 * depth-blind home rule above is right for a worker occupant,
 		 * whose slice is short, and wrong for a peer, whose whole slice
 		 * must be waited out while other CPUs sit idle. Reaching this
-		 * arm already proves p is not starved, so only the occupant
-		 * needs testing (§G17).
+		 * arm already proves p is not turn-starved, so only the
+		 * occupant needs testing (§G17).
 		 */
 		if ((enq_flags & CAKE_ENQ_WAKEUP) && p->nr_cpus_allowed > 1 &&
 		    hc && !(hc->flags & PF_IDLE) && !cake_starved(hc)) {
 			cake_dsq_insert_vtime(p, (u64)WAKE_DSQ,
-					      cake_task_slice(p),
+					      cake_task_slice_cached(p),
 					      cake_wake_vtime(p), enq_flags);
+			cake_wake_mark_set();	/* after the insert (§G41) */
 			goto kick_idle;
 		}
 
 		cake_qmark_set((u32)tcpu);
-		cake_dsq_insert_vtime(p, (u64)(u32)tcpu, cake_task_slice(p),
+		cake_dsq_insert_vtime(p, (u64)(u32)tcpu,
+				      cake_task_slice_cached(p),
 					 vt, enq_flags);
 
 		if ((enq_flags & CAKE_ENQ_WAKEUP) && p->nr_cpus_allowed == 1)
@@ -1343,6 +1790,42 @@ static __noinline void cake_wake_idle_stamp(void)
 }
 
 /*
+ * Retire the mark after an empty peek, then peek AGAIN: an insert completed
+ * before the exchange either shows in the re-peek or marks after it, so a
+ * nonempty queue can never end unmarked (§G41).
+ */
+static __noinline struct task_struct *cake_wake_mark_retire(void)
+{
+	struct task_struct *head;
+
+	(void)__sync_lock_test_and_set(&cake.wake_mark.word, 0);
+	head = cake_dsq_peek((u64)WAKE_DSQ);
+	if (head)
+		cake.wake_mark.word = 1;
+	else
+		cake_wake_idle_stamp();
+	return head;
+}
+
+/*
+ * The guarded global peek: only when the mark predicts work or the §R.16
+ * cadence forces a verify, so the common dispatch pays one word read. A
+ * subprogram so the gate costs the caller no register (§G41, §R.11).
+ */
+static __noinline struct task_struct *cake_wake_peek(void)
+{
+	struct task_struct *wake;
+
+	if (!cake.wake_mark.word && !cake_wake_starved())
+		return NULL;
+
+	wake = cake_dsq_peek((u64)WAKE_DSQ);
+	if (!wake)
+		wake = cake_wake_mark_retire();
+	return wake;
+}
+
+/*
  * The dispatch search: earliest eligible vtime of {own queue, wake queue},
  * then the staggered ring steal. Returns true when it moved work local.
  *
@@ -1365,7 +1848,7 @@ static __noinline bool cake_dispatch_search(s32 cpu)
 	 */
 	own = cake_dsq_peek((u64)ucpu);
 	cake_qmark_publish(ucpu, own);
-	wake = cake_dsq_peek((u64)WAKE_DSQ);
+	wake = cake_wake_peek();
 	if (wake) {
 		u64 wv = wake->scx.dsq_vtime;
 
@@ -1380,14 +1863,14 @@ static __noinline bool cake_dispatch_search(s32 cpu)
 			first  = (u64)WAKE_DSQ;
 			second = (u64)ucpu;
 		}
-	} else {
-		cake_wake_idle_stamp();
 	}
 	if (cake_move_to_local(first)) {
 		if (first == (u64)WAKE_DSQ)
 			cake_wake_serve_stamp();
 		return true;
 	}
+	/* Unconditional: a second healing net under a lost mark, and a
+	 * peek-guard here measured 5 spills against this shape's 0 (§G41). */
 	if (cake_move_to_local(second)) {
 		if (second == (u64)WAKE_DSQ)
 			cake_wake_serve_stamp();
@@ -1406,8 +1889,21 @@ void BPF_STRUCT_OPS(cake_dispatch, s32 cpu, struct task_struct *prev)
 	if (cake_dispatch_search(cpu))
 		return;
 
-	if (prev && (prev->scx.flags & CAKE_TASK_QUEUED))
+	if (prev && (prev->scx.flags & CAKE_TASK_QUEUED)) {
 		cake_set_slice(prev, cake_task_slice(prev));
+		return;
+	}
+
+	/*
+	 * Going idle: publish this CPU as the wake path's one-load idle
+	 * candidate. Freshest publisher wins; test before write (§G43, §R.10).
+	 */
+	{
+		u64 hint = (u64)(u32)cpu + 1;
+
+		if (cake.idle_hint.word != hint)
+			cake.idle_hint.word = hint;
+	}
 }
 
 /*
@@ -1423,12 +1919,21 @@ void BPF_STRUCT_OPS(cake_dispatch, s32 cpu, struct task_struct *prev)
 void BPF_STRUCT_OPS(cake_running, struct task_struct *p)
 {
 	u64 task_vtime = p->scx.dsq_vtime;
-	u32 cpu = bpf_get_smp_processor_id();
+	/* The TASK's CPU: a remote property change fires these ops from the
+	 * caller's CPU, whose smp id charged a foreign slot (§G42). */
+	u32 cpu = p->thread_info.cpu;
 	struct cake_run_slot *run = &cake.run[cpu & (MAX_CPUS - 1)];
 	u64 now = bpf_ktime_get_ns();
 
 	run->stamp = now;
 	run->sum = p->se.sum_exec_runtime;
+
+	/* Occupant mirror publish (§M6): the line is already dirty here. */
+	if (cake_tog_m6) {
+		run->mirror_vtime = task_vtime;
+		run->occupant = ((u64)(u32)p->pid << 32) |
+				(cake_recip_index(p) & 0xff);
+	}
 
 	cake_frame_observe(p, now);
 
@@ -1442,12 +1947,17 @@ void BPF_STRUCT_OPS(cake_running, struct task_struct *p)
  */
 void BPF_STRUCT_OPS(cake_stopping, struct task_struct *p, bool runnable)
 {
-	u32 cpu = bpf_get_smp_processor_id();
+	/* The task's CPU, never the callback's (§G42; see ops.running). */
+	u32 cpu = p->thread_info.cpu;
 	u64 used = p->se.sum_exec_runtime -
 		   cake.run[cpu & (MAX_CPUS - 1)].sum;
 	u32 idx = cake_recip_index(p);
 	struct cake_run_slot *rs = &cake.run[cpu & (MAX_CPUS - 1)];
 	u64 hint = 0;
+
+	/* Mirror retire (§M6): zero = off-mirror until the next running. */
+	if (cake_tog_m6)
+		rs->occupant = 0;
 
 	/*
 	 * Count consecutive wake-then-block-quickly quanta. `used` is already
@@ -1474,12 +1984,91 @@ void BPF_STRUCT_OPS(cake_stopping, struct task_struct *p, bool runnable)
 	if (rs->hint != hint)
 		rs->hint = hint;
 
+
 	/*
 	 * Direct write, not scx_bpf_task_set_dsq_vtime(): the kfunc's
 	 * sub-scheduler authority check measured +28-36% on this, the hottest
 	 * per-switch callback in the scheduler (§R.17).
 	 */
 	p->scx.dsq_vtime += cake_scale_vtime(used, idx);
+
+	if (cake_tog_g46)
+		cake_slice_publish(p);
+}
+
+/*
+ * ops.update_idle — the §G45 census. KEEP_BUILTIN_IDLE preserves the kernel
+ * tracking every pick still uses; this only mirrors it into one word.
+ */
+void BPF_STRUCT_OPS(cake_update_idle, s32 cpu, bool idle)
+{
+	u32 c = (u32)cpu & (MAX_CPUS - 1);
+	u64 bit = 1ULL << (c & 63);
+
+	if (idle) {
+		if (!(cake_idle_words[c >> 6] & bit)) {
+			__atomic_fetch_or(&cake_idle_words[c >> 6], bit,
+					  __ATOMIC_RELAXED);
+			__atomic_fetch_add(&cake_idle_nr, 1, __ATOMIC_RELAXED);
+		}
+		/*
+		 * Self-park (§G54): gates run HERE, on the idle CPU, about
+		 * itself, with local reads — the waker inherits a pre-gated
+		 * answer. Rotor spreads parkers across waker mailboxes; an
+		 * occupied slot skips one forward, then gives up (the census
+		 * still names this CPU for the fallback ladder).
+		 */
+		if (!cake_cpu_irq_bad(cpu) &&
+		    !cake_cpu_tick_soon(cpu)) {
+			u32 r = (u32)__atomic_fetch_add(&cake_park_rotor, 1,
+							__ATOMIC_RELAXED);
+			s32 sib = cpu_sibling[c];
+			u64 entry = (u64)c + 1;
+			u32 i;
+
+			/* A whole idle core is the premium offer (§G38),
+			 * judged here with idle-time reads. */
+			if (sib < 0 ||
+			    (cake_idle_words[((u32)sib & (MAX_CPUS - 1)) >> 6]
+			     >> ((u32)sib & 63)) & 1)
+				entry |= CAKE_PARK_CORE;
+			for (i = 0; i < 2; i++) {
+				u32 slot = (r + i) & cake_span_mask;
+				u64 cur;
+
+				if (slot >= nr_cpu_span)
+					continue;
+				slot = cake_core_slot(slot);
+				cur = cake_mailbox[slot].word;
+				if (!cur || ((entry & CAKE_PARK_CORE) &&
+					     !(cur & CAKE_PARK_CORE))) {
+					cake_mailbox[slot].word = entry;
+					cake_irq_live[c].park = slot + 1;
+					break;
+				}
+			}
+		}
+	} else {
+		if (cake_idle_words[c >> 6] & bit) {
+			__atomic_fetch_and(&cake_idle_words[c >> 6], ~bit,
+					   __ATOMIC_RELAXED);
+			__atomic_fetch_sub(&cake_idle_nr, 1, __ATOMIC_RELAXED);
+		}
+		/* Retract (§G54): only our own entry; a raced consumer has
+		 * already taken it, and losing that race is benign. */
+		{
+			u32 park = cake_irq_live[c].park;
+
+			if (park) {
+				u32 slot = (park - 1) & (MAX_CPUS - 1);
+
+				if ((cake_mailbox[slot].word &
+				     ~CAKE_PARK_CORE) == (u64)c + 1)
+					cake_mailbox[slot].word = 0;
+				cake_irq_live[c].park = 0;
+			}
+		}
+	}
 }
 
 /*
@@ -1522,11 +2111,32 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(cake_init)
 	if (ret)
 		return ret;
 
+	/* Seed the §G45 census; every later transition corrects it. */
+	{
+		const struct cpumask *im = scx_bpf_get_idle_cpumask();
+		u32 c, n = 0;
+
+		bpf_for(c, 0, nr_cpu_span) {
+			if (bpf_cpumask_test_cpu((s32)c, im)) {
+				cake_idle_words[(c & (MAX_CPUS - 1)) >> 6] |=
+					1ULL << (c & 63);
+				n++;
+			}
+		}
+		scx_bpf_put_idle_cpumask(im);
+		cake_idle_nr = n;
+	}
+
 	return cake_nonsink_rebuild(cake_sink_gen);
 }
 
+/* Core event counters, copied out at exit so the loader can report them
+ * (self-telemetry; the core already counts, cake only reads at detach). */
+struct scx_event_stats cake_events;
+
 void BPF_STRUCT_OPS(cake_exit, struct scx_exit_info *ei)
 {
+	__COMPAT_scx_bpf_events(&cake_events, sizeof(cake_events));
 	UEI_RECORD(uei, ei);
 }
 
@@ -1541,9 +2151,11 @@ SCX_OPS_DEFINE(cake_ops,
 	       .dispatch	= (void *)cake_dispatch,
 	       .running		= (void *)cake_running,
 	       .stopping	= (void *)cake_stopping,
+	       .update_idle	= (void *)cake_update_idle,
 	       .enable		= (void *)cake_enable,
 	       .init		= (void *)cake_init,
 	       .exit		= (void *)cake_exit,
-	       .flags		= SCX_OPS_ALLOW_QUEUED_WAKEUP,
+	       .flags		= SCX_OPS_ALLOW_QUEUED_WAKEUP |
+				  SCX_OPS_KEEP_BUILTIN_IDLE,
 	       .timeout_ms	= WATCHDOG_TIMEOUT_MS,
 	       .name		= "cake");

--- a/scheds/rust/scx_cake/src/bpf/intf.h
+++ b/scheds/rust/scx_cake/src/bpf/intf.h
@@ -91,6 +91,9 @@ enum consts {
 	STATE_SLOT_BYTES	= 128,
 	STATE_SLOT_WORDS	= STATE_SLOT_BYTES / sizeof(u64),
 
+	/* §G51: cpuidle exit-latency table entries (sysfs state count cap). */
+	CAKE_CSTATE_TABLE	= 16,
+
 	/* Runnable-stall safety watchdog, not a scheduling threshold. */
 	WATCHDOG_TIMEOUT_MS	= 5 * 1000,
 

--- a/scheds/rust/scx_cake/src/main.rs
+++ b/scheds/rust/scx_cake/src/main.rs
@@ -56,6 +56,13 @@ struct Opts {
     /// Print the version and exit.
     #[clap(short = 'V', long, action = clap::ArgAction::SetTrue)]
     version: bool,
+
+    /// Campaign toggle `NAME=0|1` (g43, g44, g45, g46), repeatable. One
+    /// binary serves both arms of an on/off pair: the verifier deletes the
+    /// off arm at attach. Scaffolding for the 2026-08-22 toggle campaign
+    /// (STATE.md); defaults are tip behavior. Unknown names refuse to start.
+    #[clap(long = "toggle", value_name = "NAME=0|1")]
+    toggle: Vec<String>,
 }
 
 struct Scheduler<'a> {
@@ -145,6 +152,64 @@ impl<'a> Scheduler<'a> {
             bpf_intf::consts_MAX_CPUS
         );
         rodata.nr_cpu_span = *NR_CPU_IDS as u32;
+        rodata.cake_span_mask = (*NR_CPU_IDS as u32).next_power_of_two() - 1;
+
+        // Campaign toggles land in rodata before load so the verifier prunes
+        // the off arms; the logged line is each arm's identity in an on/off
+        // pair (STATE.md, toggle campaign 2026-08-22).
+        for spec in &opts.toggle {
+            let (name, val) = spec
+                .split_once('=')
+                .with_context(|| format!("--toggle {spec}: expected NAME=0|1"))?;
+            let on = match val {
+                "0" => 0u8,
+                "1" => 1u8,
+                _ => anyhow::bail!("--toggle {spec}: value must be 0 or 1"),
+            };
+            match name {
+                "g46" => rodata.cake_tog_g46 = on,
+                "m6" => rodata.cake_tog_m6 = on,
+                "g51" => rodata.cake_tog_g51 = on,
+                "g52" => rodata.cake_tog_g52 = on,
+                "m7" => rodata.cake_tog_m7 = on,
+                _ => anyhow::bail!("--toggle {spec}: unknown name {name}"),
+            }
+        }
+        info!(
+            "   toggle  g46={} g51={} g52={} m6={} m7={}",
+            rodata.cake_tog_g46,
+            rodata.cake_tog_g51,
+            rodata.cake_tog_g52,
+            rodata.cake_tog_m6,
+            rodata.cake_tog_m7
+        );
+
+        // §G51: cpuidle exit-latency table from sysfs; absent driver leaves
+        // zeros and the depth model inert. §G52: CPPC highest_perf per CPU.
+        let mut deepest_us = 0u32;
+        for i in 0..bpf_intf::consts_CAKE_CSTATE_TABLE as usize {
+            let path = format!("/sys/devices/system/cpu/cpu0/cpuidle/state{i}/latency");
+            if let Ok(s) = std::fs::read_to_string(&path) {
+                let us: u32 = s.trim().parse().unwrap_or(0);
+                rodata.cake_cstate_exit_us[i] = us;
+                deepest_us = deepest_us.max(us);
+            }
+        }
+        if rodata.cake_tog_g51 == 1 && deepest_us == 0 {
+            info!("   g51     no cpuidle driver: depth model inert");
+        }
+        let mut perf_seen = false;
+        for c in 0..*NR_CPU_IDS {
+            let path = format!("/sys/devices/system/cpu/cpu{c}/acpi_cppc/highest_perf");
+            if let Ok(s) = std::fs::read_to_string(&path) {
+                let v: u64 = s.trim().parse().unwrap_or(0);
+                rodata.cpu_perf_rank[c] = v.min(255) as u8;
+                perf_seen = perf_seen || v != 0;
+            }
+        }
+        if rodata.cake_tog_g52 == 1 && !perf_seen {
+            info!("   g52     no CPPC highest_perf: rank tiebreak inert");
+        }
 
         // Hardware-anchored thresholds: measured, never derived from the slice.
         // Clamped so a probe perturbed by host load cannot mis-tune the
@@ -365,6 +430,16 @@ impl<'a> Scheduler<'a> {
                     1e9 / observed as f64
                 );
             }
+        }
+
+        if let Some(bss) = self.skel.maps.bss_data.as_mut() {
+            let ev = &bss.cake_events;
+            info!(
+                "   events  select_fallback {} keep_last {} enq_skip_exiting {}",
+                ev.SCX_EV_SELECT_CPU_FALLBACK,
+                ev.SCX_EV_DISPATCH_KEEP_LAST,
+                ev.SCX_EV_ENQ_SKIP_EXITING
+            );
         }
 
         self.struct_ops.take();


### PR DESCRIPTION

Rebuild CPU selection so the wake path reads a precomputed decision instead of making one. Idle CPUs evaluate their own placement gates at idle-entry (local reads, free time) and park themselves into per-physical-core mailboxes; a waking task takes prev-CPU-if-idle or its own mailbox entry with plain loads and one direct dispatch — no gate chain, no ranked LLC scan, no consuming claim on the common path. Census fallback and a zero-skip cover the miss and saturated cases.

Measured improvements (bpf_stats per-callback timing, mirrored ABBA rotations, appsim hd2-mission fitted load unless noted):

  select_cpu            185 -> 83 ns/call   (27.4k -> 12.5k us/s, -57%)
  dispatch              219 -> 116 ns/call  (halved)
  enqueue path          48k -> ~1k calls/s  (wakes place directly)
  total scheduler cost  ~80 -> ~48 ms/s    (-40%)
  context switches      -5% vs old default; cake runs 143k/s where EEVDF
                        ran 303k/s on the same workload
  per-wake total        ~81 ns vs EEVDF's ~186 (select 66 + enqueue 120)

Saturated regime (schbench -m4 -t16): census zero-skip cuts select_cpu 213 -> 63-73 ns/call (-66%), sealed across mirrored slots.

Game screen (Helldivers 2 menu, MangoHud frame capture, mirrored ABBA, ~12k frames/slot, new design vs previous default):

  severe frames (>2x median)  0.062% -> 0.037%
  0.1% low                    171 -> 286 fps
  p99.9 - median              tie (1.13 vs 1.14 ms)
  average fps                 tie (617 vs 615)
  worst single frame jump     9.3 -> 4.0 ms

Workload guards vs native EEVDF (exact-pair, 2 blocks, new default):

  mutex-handoff    +39.7% [+38.4, +41.0]  (previous seal was +10.3%;
                   migrations -162k -- the mailbox amplifies the handoff
                   shape; 8-block seal pending)
  blender-render   -0.21% [-0.29, -0.14]  (practical tie; closes the
                   BLENDER-RED regression measured at -1.6..-2.3% on the
                   old base)
  earlier HD2 game ab, old default vs native: cake 616/527/388 avg/1%/0.1%
  fps against native 599/455/366

Hardwired as default (toggles removed): §G45 idle census, §G50-R census-empty scan skip, §G53 census first-fit fallback, §G54 self-park mailboxes, §G43 going-idle hint.

Removed (measured null, falsified, or closed -- history in STATE.md): §G44 qmask wake routing (null; emptiness question moves to the M4 consolidation program), §G47 ISR-successor (falsified at the KovaaKs frame gate: severe frames doubled, wake benefit exists only at deep idle), §G48 hint-first placement (verified 74% idle claim rate but no regime where the claim costs less than the scan it skips), §G55 insert probe.

Design law recorded (§R.29, bought with data): identity claims only work from event-pushed hints; pulled aggregate state answers count questions ("someone is idle") but never identity ("take this one") under concurrent wakers -- census-as-gate works, census-as-identity loses the race and pays both paths.

New instrumentation: kernel bpf_stats per-callback cost windows (cake-bpfstats scoped helper), core event counter readout at detach, per-function spill gate held throughout (select_cpu 3 spills, 486 insns).

Remaining toggles, each with a reason: g46 slice cache (separated memcpy win awaiting its pre-registered ccm-memcpy + mutex seal; costs +2.6k us/s on the new base), g51 idle-depth model (inert without a cpuidle driver; BIOS Global C-State Control decision pending), g52 CPPC preferred-core rank (consumer scheduled with the parking-policy work), m6/m7 direct kernel reads (null on the new base; their query sites left the hot path).

Registered, not yet built: K1 chronic-sink accounting in BPF, K2 fused place kfunc (the path from 12.5k to the 8k us/s target), M2 frame-clock demotion, EEVDF head-to-head HD2 capture (needs a human-present launch).