### PR TITLE
lib: Make scx_alloc_internal() a global function

### DIFF
--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -557,7 +557,8 @@ static void scx_alloc_finish(struct sdt_data __arena *data, __u64 idx)
 	data->tid.idx = idx;
 }
 
-__hidden
+/* global so loop callers don't explode the verifier insn budget */
+__noinline
 u64 scx_alloc_internal(struct scx_allocator *alloc)
 {
 	struct scx_alloc_stack __arena *stack = prealloc_stack;


### PR DESCRIPTION
scx_alloc_internal() was __hidden, which per the bpf_helpers.h rationale
makes a non-static function verify as if static: the verifier re-checks the
allocator body at every call site state. Since every call advances the pool
state (pool->idx, the chunk bitmaps), a caller allocating in a loop never
prunes and the verifier re-walks the whole allocator per iteration - a
256-iteration loop blows the 1M insn limit outright.

Make it a global function, non-static noinline with default visibility, so
the body is checked once on its own budget and calls stay opaque to
callers. The u64 return already matches the global calling convention,
scx_alloc() casts it for the caller.

Measured on a scheduler initializing per-entity buffers from loops: the two
affected programs dropped from 1M+ (load failure) to ~30k verified insns.
The kernel-side copy in tools/sched_ext/scx_sdt.bpf.c has the same latent
issue and should get the same change.
