### PR TITLE
lib: cmask distribute helpers and caller-chosen allocator element alignment

### DIFF
--- a/lib/arena.bpf.c
+++ b/lib/arena.bpf.c
@@ -45,7 +45,7 @@ int arena_init(struct arena_init_args *args)
 		return ret;
 	}
 
-	ret = scx_task_init(args->task_ctx_size);
+	ret = scx_task_init(args->task_ctx_size, args->task_ctx_align);
 	if (ret) {
 		bpf_printk("scx_task_init failed with %d", ret);
 		return ret;

--- a/lib/atq.bpf.c
+++ b/lib/atq.bpf.c
@@ -12,7 +12,8 @@ static struct scx_allocator scx_atq_allocator;
 __weak
 int scx_atq_init(void)
 {
-	return scx_alloc_init(&scx_atq_allocator, sizeof(scx_atq_t));
+	return scx_alloc_init(&scx_atq_allocator, sizeof(scx_atq_t),
+			      SCX_CACHELINE_SIZE);
 }
 
 __weak

--- a/lib/atq.bpf.c
+++ b/lib/atq.bpf.c
@@ -25,11 +25,9 @@ u64 scx_atq_create_internal(bool fifo, size_t capacity)
 	if (unlikely(!atq))
 		return (u64)NULL;
 
-	atq->tid = sdt_tailer(&scx_atq_allocator, atq)->tid;
-
 	atq->tree = rb_create(RB_NOALLOC, RB_DUPLICATE);
 	if (!atq->tree) {
-		scx_alloc_free_idx(&scx_atq_allocator, atq->tid.idx);
+		scx_free(&scx_atq_allocator, atq);
 		return (u64)NULL;
 	}
 
@@ -49,7 +47,7 @@ int scx_atq_destroy(scx_atq_t __arg_arena *atq)
 	}
 	rb_destroy(atq->tree);
 
-	scx_alloc_free_idx(&scx_atq_allocator, atq->tid.idx);
+	scx_free(&scx_atq_allocator, atq);
 	return 0;
 }
 

--- a/lib/atq.bpf.c
+++ b/lib/atq.bpf.c
@@ -18,16 +18,14 @@ int scx_atq_init(void)
 __weak
 u64 scx_atq_create_internal(bool fifo, size_t capacity)
 {
-	struct sdt_data __arena *data = NULL;
 	scx_atq_t *atq;
 
 	/* Note that scx_alloc() returns a zero-initialized memory. */
-	data = scx_alloc(&scx_atq_allocator);
-	if (unlikely(!data))
+	atq = scx_alloc(&scx_atq_allocator);
+	if (unlikely(!atq))
 		return (u64)NULL;
 
-	atq = (scx_atq_t *)data->payload;
-	atq->tid = data->tid;
+	atq->tid = sdt_tailer(&scx_atq_allocator, atq)->tid;
 
 	atq->tree = rb_create(RB_NOALLOC, RB_DUPLICATE);
 	if (!atq->tree) {

--- a/lib/bitmap.bpf.c
+++ b/lib/bitmap.bpf.c
@@ -13,7 +13,7 @@ int scx_bitmap_init(__u64 total_mask_size)
 {
 	mask_size = div_round_up(total_mask_size, 8);
 
-	return scx_alloc_init(&scx_bitmap_allocator, mask_size * 8);
+	return scx_alloc_init(&scx_bitmap_allocator, mask_size * 8, 8);
 }
 
 __weak

--- a/lib/bitmap.bpf.c
+++ b/lib/bitmap.bpf.c
@@ -13,7 +13,7 @@ int scx_bitmap_init(__u64 total_mask_size)
 {
 	mask_size = div_round_up(total_mask_size, 8);
 
-	return scx_alloc_init(&scx_bitmap_allocator, mask_size * 8 + sizeof(union sdt_id));
+	return scx_alloc_init(&scx_bitmap_allocator, mask_size * 8);
 }
 
 __weak
@@ -26,7 +26,6 @@ u64 scx_bitmap_alloc_internal(void)
 	if (unlikely(!mask))
 		return (u64)(NULL);
 
-	mask->tid = sdt_tailer(&scx_bitmap_allocator, mask)->tid;
 	bpf_for(i, 0, mask_size) {
 		mask->bits[i] = 0ULL;
 	}
@@ -44,7 +43,7 @@ int scx_bitmap_free(scx_bitmap_t __arg_arena mask)
 {
 	scx_arena_subprog_init();
 
-	scx_alloc_free_idx(&scx_bitmap_allocator, mask->tid.idx);
+	scx_free(&scx_bitmap_allocator, mask);
 	return 0;
 }
 

--- a/lib/bitmap.bpf.c
+++ b/lib/bitmap.bpf.c
@@ -19,16 +19,14 @@ int scx_bitmap_init(__u64 total_mask_size)
 __weak
 u64 scx_bitmap_alloc_internal(void)
 {
-	struct sdt_data __arena *data = NULL;
 	scx_bitmap_t mask;
 	int i;
 
-	data = scx_alloc(&scx_bitmap_allocator);
-	if (unlikely(!data))
+	mask = scx_alloc(&scx_bitmap_allocator);
+	if (unlikely(!mask))
 		return (u64)(NULL);
 
-	mask = (scx_bitmap_t)data->payload;
-	mask->tid = data->tid;
+	mask->tid = sdt_tailer(&scx_bitmap_allocator, mask)->tid;
 	bpf_for(i, 0, mask_size) {
 		mask->bits[i] = 0ULL;
 	}

--- a/lib/cgroup_bw.bpf.c
+++ b/lib/cgroup_bw.bpf.c
@@ -17,8 +17,6 @@
 extern int scx_cgroup_bw_enqueue_cb(u64 taskc);
 
 enum scx_cgroup_consts {
-	/* cache line size of an architecture */
-	SCX_CACHELINE_SIZE		= 64,
 	/* clock boottime constant */
 	CBW_CLOCK_BOOTTIME		= 7,
 	/* replenish period in nsec: 100 msec */

--- a/lib/rbtree.bpf.c
+++ b/lib/rbtree.bpf.c
@@ -41,16 +41,14 @@ int scx_rb_init(void)
 
 u64 rb_create_internal(enum rbtree_alloc alloc, enum rbtree_insert_mode insert)
 {
-	struct sdt_data __arena *data;
 	rbtree_t *rbtree;
 
 	/* Note that scx_alloc() returns a zero-initialized memory. */
-	data = scx_alloc(&scx_rbtree_allocator);
-	if (unlikely(!data))
+	rbtree = scx_alloc(&scx_rbtree_allocator);
+	if (unlikely(!rbtree))
 		return (u64)(NULL);
 
-	rbtree = (rbtree_t *)data->payload;
-	rbtree->tid = data->tid;
+	rbtree->tid = sdt_tailer(&scx_rbtree_allocator, rbtree)->tid;
 
 	rbtree->alloc = alloc;
 	rbtree->insert = insert;
@@ -198,7 +196,6 @@ int rb_find(rbtree_t __arg_arena *rbtree, u64 key, u64 *value)
 
 static inline rbnode_t *rb_node_alloc_common(rbtree_t __arg_arena *rbtree, u64 key, u64 value)
 {
-	struct sdt_data __arena *data;
 	rbnode_t *rbnode;
 	volatile rbnode_t *node;
 
@@ -212,12 +209,11 @@ static inline rbnode_t *rb_node_alloc_common(rbtree_t __arg_arena *rbtree, u64 k
 	} while (cmpxchg(&rbtree->freelist, rbnode, rbnode->parent) != rbnode && can_loop);
 
 	if (!rbnode) {
-		data = scx_alloc(&scx_rbnode_allocator);
-		if (unlikely(!data))
+		rbnode = scx_alloc(&scx_rbnode_allocator);
+		if (unlikely(!rbnode))
 			return NULL;
 
-		rbnode = (rbnode_t *)data->payload;
-		rbnode->tid = data->tid;
+		rbnode->tid = sdt_tailer(&scx_rbnode_allocator, rbnode)->tid;
 	}
 	
 	if (!rbnode)

--- a/lib/rbtree.bpf.c
+++ b/lib/rbtree.bpf.c
@@ -31,12 +31,12 @@ int scx_rb_init(void)
 	int ret;
 
 	/* Initialize slab allocators for rbtree_t and rbnode_t. */
-	ret = scx_alloc_init(&scx_rbtree_allocator, sizeof(rbtree_t));
+	ret = scx_alloc_init(&scx_rbtree_allocator, sizeof(rbtree_t), 8);
 	if (ret)
 		return ret;
 
 	/* Note that there is no destructor for the slab allocator. */
-	return scx_alloc_init(&scx_rbnode_allocator, sizeof(rbnode_t));
+	return scx_alloc_init(&scx_rbnode_allocator, sizeof(rbnode_t), 8);
 }
 
 u64 rb_create_internal(enum rbtree_alloc alloc, enum rbtree_insert_mode insert)

--- a/lib/rbtree.bpf.c
+++ b/lib/rbtree.bpf.c
@@ -48,8 +48,6 @@ u64 rb_create_internal(enum rbtree_alloc alloc, enum rbtree_insert_mode insert)
 	if (unlikely(!rbtree))
 		return (u64)(NULL);
 
-	rbtree->tid = sdt_tailer(&scx_rbtree_allocator, rbtree)->tid;
-
 	rbtree->alloc = alloc;
 	rbtree->insert = insert;
 
@@ -73,11 +71,11 @@ int rb_destroy(rbtree_t __arg_arena *rbtree)
 	node = rbtree->freelist;
 	while (node && can_loop) {
 		next = node->parent;
-		scx_alloc_free_idx(&scx_rbnode_allocator, node->tid.idx);
+		scx_free(&scx_rbnode_allocator, node);
 		node = next;
 	}
 
-	scx_alloc_free_idx(&scx_rbtree_allocator, rbtree->tid.idx);
+	scx_free(&scx_rbtree_allocator, rbtree);
 	return 0;
 }
 
@@ -212,8 +210,6 @@ static inline rbnode_t *rb_node_alloc_common(rbtree_t __arg_arena *rbtree, u64 k
 		rbnode = scx_alloc(&scx_rbnode_allocator);
 		if (unlikely(!rbnode))
 			return NULL;
-
-		rbnode->tid = sdt_tailer(&scx_rbnode_allocator, rbnode)->tid;
 	}
 	
 	if (!rbnode)

--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -291,7 +291,7 @@ static int pool_set_size(struct sdt_pool *pool, __u64 data_size, __u64 nr_pages)
 
 /* initialize the whole thing, maybe misnomer */
 __hidden int
-scx_alloc_init(struct scx_allocator *alloc, __u64 data_size)
+scx_alloc_init(struct scx_allocator *alloc, __u64 data_size, __u64 align)
 {
 	size_t min_chunk_size;
 	int ret;
@@ -321,9 +321,15 @@ scx_alloc_init(struct scx_allocator *alloc, __u64 data_size)
 			return -ENOMEM;
 	}
 
-	/* Wrap data into a descriptor and word align. */
+	if (!align)
+		align = 8;
+	if (unlikely(align < 8 || (align & (align - 1)))) {
+		scx_err_loc("invalid alignment %llu", align);
+		return -EINVAL;
+	}
+
 	data_size += sizeof(struct sdt_data);
-	data_size = round_up(data_size, 8);
+	data_size = round_up(data_size, align);
 
 	/*
 	 * Ensure we allocate large enough chunks from the arena to avoid excessive

--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -399,7 +399,7 @@ int scx_alloc_free_idx(struct scx_allocator *alloc, __u64 idx)
 	sdt_desc_t * __arena *desc_children;
 	struct sdt_chunk __arena *chunk;
 	sdt_desc_t *desc;
-	struct sdt_data __arena *data;
+	void __arena *data;
 	__u64 level, shift, pos;
 	__u64 lv_pos[SDT_TASK_LEVELS];
 	int ret;
@@ -453,13 +453,16 @@ int scx_alloc_free_idx(struct scx_allocator *alloc, __u64 idx)
 	pos = idx & mask;
 	data = chunk->data[pos];
 	if (likely(data)) {
-		*data = (struct sdt_data) {
-			.tid.genn = data->tid.genn + 1,
+		struct sdt_data __arena *tailer = sdt_tailer(alloc, data);
+		__u64 __arena *words = data;
+
+		*tailer = (struct sdt_data) {
+			.tid.genn = tailer->tid.genn + 1,
 		};
 
 		/* Zero out one word at a time. */
 		for (i = zero; i < (alloc->pool.elem_size - sizeof(struct sdt_data)) / 8 && can_loop; i++) {
-			data->payload[i] = 0;
+			words[i] = 0;
 		}
 	}
 
@@ -543,7 +546,8 @@ static sdt_desc_t * desc_find_empty(sdt_desc_t *desc,
 	return desc;
 }
 
-static void scx_alloc_finish(struct sdt_data __arena *data, __u64 idx)
+static void scx_alloc_finish(struct scx_allocator *alloc, void __arena *data,
+			     __u64 idx)
 {
 	bpf_spin_lock(&alloc_lock);
 
@@ -554,7 +558,7 @@ static void scx_alloc_finish(struct sdt_data __arena *data, __u64 idx)
 
 	bpf_spin_unlock(&alloc_lock);
 
-	data->tid.idx = idx;
+	sdt_tailer(alloc, data)->tid.idx = idx;
 }
 
 /* global so loop callers don't explode the verifier insn budget */
@@ -562,7 +566,7 @@ __noinline
 u64 scx_alloc_internal(struct scx_allocator *alloc)
 {
 	struct scx_alloc_stack __arena *stack = prealloc_stack;
-	struct sdt_data __arena *data = NULL;
+	void __arena *data = NULL;
 	struct sdt_chunk __arena *chunk;
 	sdt_desc_t *desc;
 	__u64 idx, pos;
@@ -615,7 +619,7 @@ u64 scx_alloc_internal(struct scx_allocator *alloc)
 
 	chunk->data[pos] = data;
 
-	scx_alloc_finish(data, idx);
+	scx_alloc_finish(alloc, data, idx);
 
 	return (u64)data;
 }
@@ -1487,8 +1491,9 @@ int scx_urcu_pending(struct scx_urcu *urcu)
 }
 
 __hidden
-void scx_urcu_free(struct scx_urcu *urcu, struct sdt_data __arena *data)
+void scx_urcu_free(struct scx_urcu *urcu, struct scx_allocator *alloc, void __arena *payload)
 {
+	struct sdt_data __arena *data = sdt_tailer(alloc, payload);
 	u32 side, i;
 
 	scx_arena_subprog_init();

--- a/lib/sdt_cgroup.bpf.c
+++ b/lib/sdt_cgroup.bpf.c
@@ -43,9 +43,9 @@ struct {
 struct scx_allocator scx_cgrp_allocator;
 
 __hidden
-int scx_cgrp_init(__u64 data_size)
+int scx_cgrp_init(__u64 data_size, __u64 align)
 {
-	return scx_alloc_init(&scx_cgrp_allocator, data_size);
+	return scx_alloc_init(&scx_cgrp_allocator, data_size, align);
 }
 
 __hidden

--- a/lib/sdt_cgroup.bpf.c
+++ b/lib/sdt_cgroup.bpf.c
@@ -25,12 +25,12 @@
 
 /*
  * Cgroup BPF map entry pointing to the data area allocated in arena. The
- * allocation's identity lives in data->tid: the pointer is the single word that
- * alloc and free race on.
+ * allocation's identity lives in its tailer: the pointer is the single word
+ * that alloc and free race on.
  */
 struct scx_cgrp_map_val {
 	__u64			cptr;
-	struct sdt_data __arena	*data;
+	void __arena		*data;
 };
 
 struct {
@@ -51,8 +51,8 @@ int scx_cgrp_init(__u64 data_size)
 __hidden
 void __arena *scx_cgrp_alloc(struct cgroup *cgrp)
 {
-	struct sdt_data __arena *data;
 	struct scx_cgrp_map_val *mval;
+	void __arena *data;
 	__u64 old;
 
 	mval = bpf_cgrp_storage_get(&scx_cgrp_map, cgrp, 0, BPF_LOCAL_STORAGE_GET_F_CREATE);
@@ -61,9 +61,9 @@ void __arena *scx_cgrp_alloc(struct cgroup *cgrp)
 		return NULL;
 	}
 
-	data = (struct sdt_data __arena *)READ_ONCE(*(__u64 *)&mval->data);
+	data = (void __arena *)READ_ONCE(*(__u64 *)&mval->data);
 	if (unlikely(data))
-		return (void __arena *)data->payload;
+		return data;
 
 	data = scx_alloc(&scx_cgrp_allocator);
 	if (unlikely(!data)) {
@@ -74,13 +74,14 @@ void __arena *scx_cgrp_alloc(struct cgroup *cgrp)
 	/* racing allocs publish with cmpxchg, the loser uses the winner's */
 	old = __sync_val_compare_and_swap((__u64 *)&mval->data, 0, (__u64)data);
 	if (unlikely(old)) {
-		scx_alloc_free_idx(&scx_cgrp_allocator, data->tid.idx);
-		data = (struct sdt_data __arena *)old;
+		scx_alloc_free_idx(&scx_cgrp_allocator,
+				   sdt_tailer(&scx_cgrp_allocator, data)->tid.idx);
+		data = (void __arena *)old;
 	} else {
 		mval->cptr = (__u64)cgrp;
 	}
 
-	return (void __arena *)data->payload;
+	return data;
 }
 
 /*
@@ -91,7 +92,6 @@ void __arena *scx_cgrp_alloc(struct cgroup *cgrp)
 __hidden
 void __arena *scx_cgrp_data(struct cgroup *cgrp)
 {
-	struct sdt_data __arena *data;
 	struct scx_cgrp_map_val *mval;
 
 	scx_arena_subprog_init();
@@ -100,11 +100,7 @@ void __arena *scx_cgrp_data(struct cgroup *cgrp)
 	if (unlikely(!mval))
 		return NULL;
 
-	data = (struct sdt_data __arena *)READ_ONCE(*(__u64 *)&mval->data);
-	if (unlikely(!data))
-		return NULL;
-
-	return (void __arena *)data->payload;
+	return (void __arena *)READ_ONCE(*(__u64 *)&mval->data);
 }
 
 /*
@@ -115,8 +111,8 @@ void __arena *scx_cgrp_data(struct cgroup *cgrp)
 __hidden
 void scx_cgrp_free(struct cgroup *cgrp)
 {
-	struct sdt_data __arena *data;
 	struct scx_cgrp_map_val *mval;
+	void __arena *data;
 
 	scx_arena_subprog_init();
 
@@ -124,11 +120,12 @@ void scx_cgrp_free(struct cgroup *cgrp)
 	if (unlikely(!mval))
 		return;
 
-	data = (struct sdt_data __arena *)__sync_lock_test_and_set((__u64 *)&mval->data, 0);
+	data = (void __arena *)__sync_lock_test_and_set((__u64 *)&mval->data, 0);
 	if (unlikely(!data))
 		return;
 
-	scx_alloc_free_idx(&scx_cgrp_allocator, data->tid.idx);
+	scx_alloc_free_idx(&scx_cgrp_allocator,
+			   sdt_tailer(&scx_cgrp_allocator, data)->tid.idx);
 }
 
 static struct scx_urcu scx_cgrp_urcu;
@@ -141,8 +138,8 @@ static struct scx_urcu scx_cgrp_urcu;
 __hidden
 void scx_cgrp_free_rcu(struct cgroup *cgrp)
 {
-	struct sdt_data __arena *data;
 	struct scx_cgrp_map_val *mval;
+	void __arena *data;
 
 	scx_arena_subprog_init();
 
@@ -150,11 +147,11 @@ void scx_cgrp_free_rcu(struct cgroup *cgrp)
 	if (unlikely(!mval))
 		return;
 
-	data = (struct sdt_data __arena *)__sync_lock_test_and_set((__u64 *)&mval->data, 0);
+	data = (void __arena *)__sync_lock_test_and_set((__u64 *)&mval->data, 0);
 	if (unlikely(!data))
 		return;
 
-	scx_urcu_free(&scx_cgrp_urcu, data);
+	scx_urcu_free(&scx_cgrp_urcu, &scx_cgrp_allocator, data);
 }
 
 /* scx_urcu driver programs, discovered by name and run by the userspace side */

--- a/lib/sdt_cgroup.bpf.c
+++ b/lib/sdt_cgroup.bpf.c
@@ -74,8 +74,7 @@ void __arena *scx_cgrp_alloc(struct cgroup *cgrp)
 	/* racing allocs publish with cmpxchg, the loser uses the winner's */
 	old = __sync_val_compare_and_swap((__u64 *)&mval->data, 0, (__u64)data);
 	if (unlikely(old)) {
-		scx_alloc_free_idx(&scx_cgrp_allocator,
-				   sdt_tailer(&scx_cgrp_allocator, data)->tid.idx);
+		scx_free(&scx_cgrp_allocator, data);
 		data = (void __arena *)old;
 	} else {
 		mval->cptr = (__u64)cgrp;
@@ -124,8 +123,7 @@ void scx_cgrp_free(struct cgroup *cgrp)
 	if (unlikely(!data))
 		return;
 
-	scx_alloc_free_idx(&scx_cgrp_allocator,
-			   sdt_tailer(&scx_cgrp_allocator, data)->tid.idx);
+	scx_free(&scx_cgrp_allocator, data);
 }
 
 static struct scx_urcu scx_cgrp_urcu;

--- a/lib/sdt_task.bpf.c
+++ b/lib/sdt_task.bpf.c
@@ -55,9 +55,9 @@ void __arena *scx_task_alloc(struct task_struct *p)
 }
 
 __hidden
-int scx_task_init(__u64 data_size)
+int scx_task_init(__u64 data_size, __u64 align)
 {
-	return scx_alloc_init(&scx_task_allocator, data_size);
+	return scx_alloc_init(&scx_task_allocator, data_size, align);
 }
 
 __hidden

--- a/lib/sdt_task.bpf.c
+++ b/lib/sdt_task.bpf.c
@@ -16,7 +16,7 @@
 struct scx_task_map_val {
 	union sdt_id		tid;
 	__u64			tptr;
-	struct sdt_data __arena	*data;
+	void __arena		*data;
 };
 
 struct {
@@ -31,8 +31,8 @@ struct scx_allocator scx_task_allocator;
 __hidden
 void __arena *scx_task_alloc(struct task_struct *p)
 {
-	struct sdt_data __arena *data = NULL;
 	struct scx_task_map_val *mval;
+	void __arena *data;
 
 	mval = bpf_task_storage_get(&scx_task_map, p, 0,
 				    BPF_LOCAL_STORAGE_GET_F_CREATE);
@@ -47,11 +47,11 @@ void __arena *scx_task_alloc(struct task_struct *p)
 		return NULL;
 	}
 
-	mval->tid = data->tid;
+	mval->tid = sdt_tailer(&scx_task_allocator, data)->tid;
 	mval->tptr = (__u64) p;
 	mval->data = data;
 
-	return (void __arena *)data->payload;
+	return data;
 }
 
 __hidden
@@ -71,7 +71,7 @@ void __arena *__scx_task_data(struct task_struct *p)
 	if (unlikely(!mval || !mval->data))
 		return NULL;
 
-	return (void __arena *)mval->data->payload;
+	return mval->data;
 }
 
 __hidden
@@ -114,7 +114,7 @@ __hidden
 void scx_task_free_rcu(struct task_struct *p)
 {
 	struct scx_task_map_val *mval;
-	struct sdt_data __arena *data;
+	void __arena *data;
 
 	scx_arena_subprog_init();
 
@@ -122,11 +122,11 @@ void scx_task_free_rcu(struct task_struct *p)
 	if (unlikely(!mval))
 		return;
 
-	data = (struct sdt_data __arena *)__sync_lock_test_and_set((__u64 *)&mval->data, 0);
+	data = (void __arena *)__sync_lock_test_and_set((__u64 *)&mval->data, 0);
 	if (unlikely(!data))
 		return;
 
-	scx_urcu_free(&scx_task_urcu, data);
+	scx_urcu_free(&scx_task_urcu, &scx_task_allocator, data);
 }
 
 /* scx_urcu driver programs, discovered by name and run by the userspace side */

--- a/lib/selftests/selftest.c
+++ b/lib/selftests/selftest.c
@@ -28,12 +28,15 @@
 
 #include "selftest.skel.h"
 
+/* libbpf >= 1.7 declares these itself */
+#if LIBBPF_MAJOR_VERSION == 1 && LIBBPF_MINOR_VERSION < 7
 struct bpf_prog_stream_read_opts {
 	size_t sz;
 	size_t :0;
 };
 
 extern int bpf_prog_stream_read(int prog_fd, __u32 stream_id, void *buf, __u32 buf_len, struct bpf_prog_stream_read_opts *opts) __attribute__((weak));
+#endif
 
 char *topo_command = "lscpu --all --parse \
 		      | cut -f 1,2,4,9 -d ',' \
@@ -267,10 +270,13 @@ selftest(struct selftest *skel)
 	if (opts.retval)
 		fprintf(stderr, "error %d in %s\n", opts.retval, __func__);
 
+#if LIBBPF_MAJOR_VERSION == 1 && LIBBPF_MINOR_VERSION < 7
+	/* the fallback decl is weak, the symbol may be missing at runtime */
 	if (!bpf_prog_stream_read) {
 		fprintf(stderr, "[BPF Streams Unavailable]\n");
 		return 0;
 	}
+#endif
 	printf("BPF stdout:\n");
 	while ((ret = bpf_prog_stream_read(prog_fd, 1, buf, 1024, NULL)) > 0)
 		printf("%.*s", ret, buf);

--- a/rust/scx_arena/scx_arena/src/arenalib.rs
+++ b/rust/scx_arena/scx_arena/src/arenalib.rs
@@ -34,6 +34,7 @@ const MAX_CPU_SUPPORTED: usize = 640;
 #[derive(Debug)]
 pub struct ArenaLib<'a> {
     task_size: usize,
+    task_align: usize,
     obj: &'a mut Object,
 }
 
@@ -75,6 +76,7 @@ impl<'a> ArenaLib<'a> {
         let mut args = types::arena_init_args {
             static_pages: Self::STATIC_ALLOC_PAGES_GRANULARITY as c_ulong,
             task_ctx_size: self.task_size as c_ulong,
+            task_ctx_align: self.task_align as c_ulong,
         };
 
         let input = ProgramInput {
@@ -251,12 +253,22 @@ impl<'a> ArenaLib<'a> {
     }
 
     /// Create an Arenalib object This call only initializes the Rust side of Arenalib.
-    pub fn init(obj: &'a mut Object, task_size: usize, nr_cpus: usize) -> Result<Self> {
+    /// @task_align: task ctx element alignment, 0 for word alignment.
+    pub fn init(
+        obj: &'a mut Object,
+        task_size: usize,
+        task_align: usize,
+        nr_cpus: usize,
+    ) -> Result<Self> {
         if nr_cpus >= MAX_CPU_SUPPORTED {
             bail!("Scheduler specifies too many CPUs");
         }
 
-        Ok(Self { task_size, obj })
+        Ok(Self {
+            task_size,
+            task_align,
+            obj,
+        })
     }
 
     /// Set up the BPF arena library state and, when the object carries the

--- a/rust/scx_arena/scx_arena/src/lib.rs
+++ b/rust/scx_arena/scx_arena/src/lib.rs
@@ -24,6 +24,15 @@ use anyhow::Result;
 use libbpf_rs::libbpf_sys;
 use libbpf_rs::MapCore as _;
 
+/// Cacheline size assumed by the arena allocator's alignment parameter.
+/// Mirrors scheds/include/lib/const-defs.h, keep in sync.
+#[cfg(target_arch = "s390x")]
+pub const CACHELINE_SIZE: usize = 256;
+#[cfg(target_arch = "powerpc64")]
+pub const CACHELINE_SIZE: usize = 128;
+#[cfg(not(any(target_arch = "s390x", target_arch = "powerpc64")))]
+pub const CACHELINE_SIZE: usize = 64;
+
 const MEMBARRIER_CMD_GLOBAL: libc::c_long = 1;
 const URCU_DOORBELL: &str = "scx_urcu_doorbell";
 const URCU_MIN_INTERVAL: Duration = Duration::from_millis(1);

--- a/rust/scx_arena/selftests/src/main.rs
+++ b/rust/scx_arena/selftests/src/main.rs
@@ -108,6 +108,7 @@ fn setup_arenas(skel: &mut BpfSkel<'_>) -> Result<()> {
     let mut args = types::arena_init_args {
         static_pages: STATIC_ALLOC_PAGES_GRANULARITY,
         task_ctx_size: TASK_SIZE,
+        task_ctx_align: 0,
     };
 
     let input = ProgramInput {

--- a/scheds/include/bpf_arena_spin_lock.h
+++ b/scheds/include/bpf_arena_spin_lock.h
@@ -114,9 +114,9 @@ struct arena_qnode {
 #define unlikely(x) __builtin_expect(!!(x), 0)
 #endif
 
-extern struct arena_qnode __arena __hidden qnodes[_Q_MAX_CPUS][_Q_MAX_NODES];
-
 #ifdef __BPF__
+
+extern struct arena_qnode __arena __hidden qnodes[_Q_MAX_CPUS][_Q_MAX_NODES];
 
 static inline u32 encode_tail(int cpu, int idx)
 {

--- a/scheds/include/lib/arena.h
+++ b/scheds/include/lib/arena.h
@@ -12,6 +12,8 @@
 struct arena_init_args {
 	u64 static_pages;
 	u64 task_ctx_size;
+	/* task ctx element alignment, 0 for word alignment */
+	u64 task_ctx_align;
 };
 
 int arena_init(struct arena_init_args *args);

--- a/scheds/include/lib/atq.h
+++ b/scheds/include/lib/atq.h
@@ -23,7 +23,6 @@ enum scx_task_throttle {
 };
 
 struct scx_atq {
-	union sdt_id tid;
 	rbtree_t *tree;
 	arena_spinlock_t lock;
 	u64 capacity;

--- a/scheds/include/lib/const-defs.h
+++ b/scheds/include/lib/const-defs.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (c) 2026 Tejun Heo <tj@kernel.org> */
+#pragma once
+
+/*
+ * Constants shared across the lib and the schedulers. Freestanding so that
+ * scheduler interface headers consumed by bindgen can include it. Rust code
+ * cannot; rust/scx_arena/scx_arena/src/lib.rs mirrors the values, keep in sync.
+ */
+enum scx_const_defs {
+	/* mirrors the kernel's per-arch L1_CACHE_SHIFT */
+#if defined(__TARGET_ARCH_s390) || defined(__s390x__)
+	SCX_CACHELINE_SIZE	= 256,
+#elif defined(__TARGET_ARCH_powerpc) || defined(__powerpc64__)
+	SCX_CACHELINE_SIZE	= 128,
+#else
+	SCX_CACHELINE_SIZE	= 64,
+#endif
+};

--- a/scheds/include/lib/cpumask.h
+++ b/scheds/include/lib/cpumask.h
@@ -6,7 +6,6 @@
 #define SCXMASK_NLONG (512 / 8)
 
 struct scx_bitmap {
-	union sdt_id tid;
 	u64 bits[SCXMASK_NLONG];
 };
 

--- a/scheds/include/lib/rbtree.h
+++ b/scheds/include/lib/rbtree.h
@@ -15,7 +15,6 @@ struct rbnode;
 typedef struct rbnode __arena rbnode_t;
 
 struct rbnode {
-	union sdt_id tid;
 	rbnode_t *parent;
 	union {
 		struct {
@@ -65,7 +64,6 @@ enum rbtree_insert_mode {
 };
 
 struct rbtree {
-	union sdt_id tid;
 	rbnode_t *root;
 	rbnode_t *freelist;
 	enum rbtree_alloc alloc;

--- a/scheds/include/lib/sdt_alloc.h
+++ b/scheds/include/lib/sdt_alloc.h
@@ -13,6 +13,8 @@
 #include "sdt_task_defs.h"
 #endif
 
+#include "const-defs.h"
+
 struct scx_stk_seg;
 typedef struct scx_stk_seg __arena scx_stk_seg_t;
 

--- a/scheds/include/lib/sdt_alloc.h
+++ b/scheds/include/lib/sdt_alloc.h
@@ -78,10 +78,22 @@ int scx_alloc_init(struct scx_allocator *alloc, __u64 data_size);
 u64 scx_alloc_internal(struct scx_allocator *alloc);
 int scx_alloc_free_idx(struct scx_allocator *alloc, __u64 idx);
 
-#define scx_alloc(alloc) ((struct sdt_data __arena *)scx_alloc_internal((alloc)))
+#define scx_alloc(alloc) ((void __arena *)scx_alloc_internal((alloc)))
+
+/*
+ * The metadata of the allocation holding @payload. It trails the payload inside
+ * the element so that the payload starts at the element's alignment boundary.
+ */
+static inline struct sdt_data __arena *sdt_tailer(struct scx_allocator *alloc,
+						  void __arena *payload)
+{
+	return (struct sdt_data __arena *)
+		((__u64)payload + alloc->pool.elem_size - sizeof(struct sdt_data));
+}
 
 int scx_urcu_pending(struct scx_urcu *urcu);
-void scx_urcu_free(struct scx_urcu *urcu, struct sdt_data __arena *data);
+void scx_urcu_free(struct scx_urcu *urcu, struct scx_allocator *alloc,
+		   void __arena *payload);
 int scx_urcu_reclaim(struct scx_urcu *urcu, struct scx_allocator *alloc);
 
 u64 scx_static_alloc_internal(size_t bytes, size_t alignment);

--- a/scheds/include/lib/sdt_alloc.h
+++ b/scheds/include/lib/sdt_alloc.h
@@ -91,6 +91,12 @@ static inline struct sdt_data __arena *sdt_tailer(struct scx_allocator *alloc,
 		((__u64)payload + alloc->pool.elem_size - sizeof(struct sdt_data));
 }
 
+/* free by payload pointer, the tailer carries the index */
+static inline int scx_free(struct scx_allocator *alloc, void __arena *payload)
+{
+	return scx_alloc_free_idx(alloc, sdt_tailer(alloc, payload)->tid.idx);
+}
+
 int scx_urcu_pending(struct scx_urcu *urcu);
 void scx_urcu_free(struct scx_urcu *urcu, struct scx_allocator *alloc,
 		   void __arena *payload);

--- a/scheds/include/lib/sdt_alloc.h
+++ b/scheds/include/lib/sdt_alloc.h
@@ -74,7 +74,7 @@ struct scx_urcu {
 
 void scx_arena_subprog_init(void);
 
-int scx_alloc_init(struct scx_allocator *alloc, __u64 data_size);
+int scx_alloc_init(struct scx_allocator *alloc, __u64 data_size, __u64 align);
 u64 scx_alloc_internal(struct scx_allocator *alloc);
 int scx_alloc_free_idx(struct scx_allocator *alloc, __u64 idx);
 

--- a/scheds/include/lib/sdt_alloc.h
+++ b/scheds/include/lib/sdt_alloc.h
@@ -10,9 +10,21 @@
 
 #include <bpf_arena_common.bpf.h>
 #include <bpf_arena_spin_lock.h>
-#include "sdt_task_defs.h"
+
+#else /* __BPF__ */
+
+/* For userspace programs, __arena is a no-op. */
+#ifndef __arena
+#define __arena
 #endif
 
+/* Userspace only carries pointers to arena spinlocks. */
+struct __qspinlock;
+#define arena_spinlock_t struct __qspinlock
+
+#endif /* __BPF__ */
+
+#include "sdt_task_defs.h"
 #include "const-defs.h"
 
 struct scx_stk_seg;

--- a/scheds/include/lib/sdt_cgroup.h
+++ b/scheds/include/lib/sdt_cgroup.h
@@ -9,7 +9,7 @@
 struct cgroup;
 
 void __arena *scx_cgrp_data(struct cgroup *cgrp);
-int scx_cgrp_init(__u64 data_size);
+int scx_cgrp_init(__u64 data_size, __u64 align);
 void __arena *scx_cgrp_alloc(struct cgroup *cgrp);
 void scx_cgrp_free(struct cgroup *cgrp);
 void scx_cgrp_free_rcu(struct cgroup *cgrp);

--- a/scheds/include/lib/sdt_task.h
+++ b/scheds/include/lib/sdt_task.h
@@ -12,7 +12,7 @@
 
 void __arena *__scx_task_data(struct task_struct *p);
 void __arena *scx_task_data(struct task_struct *p);
-int scx_task_init(__u64 data_size);
+int scx_task_init(__u64 data_size, __u64 align);
 void __arena *scx_task_alloc(struct task_struct *p);
 void scx_task_free(struct task_struct *p);
 void scx_task_free_rcu(struct task_struct *p);

--- a/scheds/include/lib/sdt_task_defs.h
+++ b/scheds/include/lib/sdt_task_defs.h
@@ -49,13 +49,13 @@ struct sdt_desc {
 };
 
 /*
- * Leaf node containing per-task data. urcu_link chains deferred frees so that
- * the payload stays intact for readers until reclaim.
+ * Allocation metadata, trailing the caller's payload so that the payload starts
+ * at the element's alignment boundary, see sdt_tailer(). urcu_link chains
+ * deferred frees so that the payload stays intact for readers until reclaim.
  */
 struct sdt_data {
 	union sdt_id			tid;
 	__u64				urcu_link;
-	__u64				payload[];
 };
 
 /*
@@ -64,7 +64,7 @@ struct sdt_data {
 struct sdt_chunk {
 	union {
 		sdt_desc_t * descs[SDT_TASK_ENTS_PER_CHUNK];
-		struct sdt_data __arena *data[SDT_TASK_ENTS_PER_CHUNK];
+		void __arena *data[SDT_TASK_ENTS_PER_CHUNK];
 	};
 };
 

--- a/scheds/include/lib/topology.h
+++ b/scheds/include/lib/topology.h
@@ -1,10 +1,5 @@
 #pragma once
 
-#include <lib/cpumask.h>
-
-struct topology;
-typedef struct topology __arena * topo_ptr;
-
 enum topo_level {
 	TOPO_TOP	= 0,
 	TOPO_NODE	= 1,
@@ -13,6 +8,14 @@ enum topo_level {
 	TOPO_CPU	= 4,
 	TOPO_MAX_LEVEL	= 5,
 };
+
+/* Everything below is BPF-only; userspace only consumes the levels above. */
+#ifdef __BPF__
+
+#include <lib/cpumask.h>
+
+struct topology;
+typedef struct topology __arena * topo_ptr;
 
 struct topology {
 	topo_ptr parent;
@@ -99,3 +102,5 @@ extern u64 topo_nodes[TOPO_MAX_LEVEL][NR_CPUS];
 extern int nr_topo_nodes[TOPO_MAX_LEVEL];
 
 #define TOPO_NR(type) nr_topo_nodes[TOPO_##type - 1]
+
+#endif /* __BPF__ */

--- a/scheds/include/scx/cid.bpf.h
+++ b/scheds/include/scx/cid.bpf.h
@@ -733,6 +733,74 @@ static __always_inline u32 cmask_next_and_set_wrap(const struct scx_cmask __aren
 	return found < start ? found : a_end;
 }
 
+/* per-cpu rotor for cmask_any_distribute() */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, u32);
+	__type(value, u32);
+} cmask_distribute_rotor __weak SEC(".maps");
+
+/**
+ * cmask_any_distribute - Pick a set cid, spreading successive picks
+ * @m: cmask to pick from
+ *
+ * Counterpart of bpf_cpumask_any_distribute(): a per-cpu rotor makes successive
+ * picks rotate through the set cids instead of repeating the first one. Returns
+ * cmask_end(@m) if @m is empty.
+ */
+static __always_inline u32 cmask_any_distribute(const struct scx_cmask __arena *m)
+{
+	u32 zero = 0, pick;
+	u32 *rotor;
+
+	if (unlikely(!(rotor = bpf_map_lookup_elem(&cmask_distribute_rotor, &zero))))
+		return cmask_first_set(m);
+
+	pick = cmask_next_set_wrap(m, *rotor + 1);
+	if (pick < cmask_end(m))
+		*rotor = pick;
+	return pick;
+}
+
+/**
+ * cmask_any_and_distribute - Pick a cid set in both masks, spreading picks
+ * @a: first cmask, the scan is bounded by its range
+ * @b: second cmask
+ *
+ * Counterpart of bpf_cpumask_any_and_distribute(). Shares the rotor with
+ * cmask_any_distribute() the same way the kernel counterparts share theirs.
+ * Returns cmask_end(@a) if the intersection is empty.
+ */
+static __always_inline u32 cmask_any_and_distribute(const struct scx_cmask __arena *a,
+						    const struct scx_cmask __arena *b)
+{
+	u32 zero = 0, pick;
+	u32 *rotor;
+
+	if (unlikely(!(rotor = bpf_map_lookup_elem(&cmask_distribute_rotor, &zero))))
+		return cmask_next_and_set(a, b, a->base);
+
+	pick = cmask_next_and_set_wrap(a, b, *rotor + 1);
+	if (pick < cmask_end(a))
+		*rotor = pick;
+	return pick;
+}
+
+/**
+ * cmask_distribute_rotor_pos - Last cid picked by the distribute helpers
+ *
+ * For callers that anchor scans of their own on the shared rotor. Returns 0
+ * when nothing has been picked on this cpu yet.
+ */
+static __always_inline u32 cmask_distribute_rotor_pos(void)
+{
+	u32 zero = 0;
+	u32 *rotor = bpf_map_lookup_elem(&cmask_distribute_rotor, &zero);
+
+	return likely(rotor) ? *rotor : 0;
+}
+
 /*
  * Like cmask_next_and_set() but over the intersection of THREE masks. Return
  * a->base + a->nr_cids if no cid is set in all three at or after @start.

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -27,6 +27,7 @@
 #include "user_exit_info.bpf.h"
 #include "enum_defs.autogen.h"
 #include "bpf_arena_common.bpf.h"
+#include <lib/const-defs.h>
 
 #define PF_IDLE				0x00000002	/* I am an IDLE thread */
 #define PF_IO_WORKER			0x00000010	/* Task is an IO worker */

--- a/scheds/rust/scx_chaos/src/lib.rs
+++ b/scheds/rust/scx_chaos/src/lib.rs
@@ -448,7 +448,7 @@ impl Builder<'_> {
         scx_p2dq::init_skel!(&mut skel, topo);
 
         let task_size = std::mem::size_of::<types::task_p2dq>();
-        let arenalib = ArenaLib::init(skel.object_mut(), task_size, *NR_CPU_IDS)?;
+        let arenalib = ArenaLib::init(skel.object_mut(), task_size, 0, *NR_CPU_IDS)?;
         arenalib.setup()?;
 
         let out = unsafe {

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -519,7 +519,7 @@ impl<'a> Scheduler<'a> {
         // Initialize arena
         let mut skel = scx_ops_load!(skel, lavd_ops, uei)?;
         let task_size = std::mem::size_of::<types::task_ctx>();
-        let arenalib = ArenaLib::init(skel.object_mut(), task_size, *NR_CPU_IDS)?;
+        let arenalib = ArenaLib::init(skel.object_mut(), task_size, 0, *NR_CPU_IDS)?;
         arenalib.setup()?;
 
         // Attach.

--- a/scheds/rust/scx_mitosis/src/bpf/intf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/intf.h
@@ -6,6 +6,7 @@
 #define __INTF_H
 
 #include <stdbool.h>
+#include <lib/const-defs.h>
 
 #ifndef __VMLINUX_H__
 typedef unsigned long long u64;
@@ -13,7 +14,6 @@ typedef unsigned int u32;
 #endif
 
 enum consts {
-	CACHELINE_SIZE = 64,
 	MAX_CPUS_SHIFT = 9,
 	MAX_CPUS = 1 << MAX_CPUS_SHIFT,
 	MAX_CPUS_U8 = MAX_CPUS / 8,
@@ -77,10 +77,10 @@ struct cgrp_ctx {
 struct subcell_llc {
 	u64 vtime_now;
 	u32 nr_queued;
-} __attribute__((aligned(CACHELINE_SIZE)));
+} __attribute__((aligned(SCX_CACHELINE_SIZE)));
 
 // Ensure we don't have multiple of these on the same cacheline.
-_Static_assert(sizeof(struct subcell_llc) >= CACHELINE_SIZE,
+_Static_assert(sizeof(struct subcell_llc) >= SCX_CACHELINE_SIZE,
 	       "subcell_llc must be at least one cache line");
 
 /* Cell cpumask data for a single cell or subcell */
@@ -121,7 +121,7 @@ struct cell {
 
 // Verify these are the same size in both BPF and Rust.
 _Static_assert(sizeof(struct cell) ==
-		       (CACHELINE_SIZE + (sizeof(struct subcell) * MAX_SUBCELLS_PER_CELL)),
+	       (SCX_CACHELINE_SIZE + (sizeof(struct subcell) * MAX_SUBCELLS_PER_CELL)),
 	       "struct cell size must be stable for Rust bindings");
 
 /* Cell assignment entry: maps a cgroup to a cell */

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -536,7 +536,7 @@ fn main(opts: CliOpts) -> Result<()> {
         let mut sched =
             Scheduler::init(&opts.sched, &opts.libbpf, &mut open_object, &opts.log_level)?;
         let task_size = std::mem::size_of::<types::task_p2dq>();
-        let arenalib = ArenaLib::init(sched.skel.object_mut(), task_size, *NR_CPU_IDS)?;
+        let arenalib = ArenaLib::init(sched.skel.object_mut(), task_size, 0, *NR_CPU_IDS)?;
         arenalib.setup()?;
 
         sched.start()?;


### PR DESCRIPTION
Prep patches for an upcoming cid conversion, useful on their own. Updated
per review: the allocator alignment work now sits on top of a set of lib
preps addressing both review comments.

- cid.bpf.h gains cmask_any_distribute() and cmask_any_and_distribute(),
  cmask counterparts of the kernel's cpumask distribute helpers sharing a
  per-CPU rotor, so pick sites can spread the picks instead of always
  taking the first set bit.

- New lib/const-defs.h carries SCX_CACHELINE_SIZE with per-arch values
  mirroring the kernel's L1_CACHE_SHIFT (64 default, 128 on powerpc64, 256
  on s390), replacing the ad hoc always-64 definitions (@arighi's
  arch-dependent cacheline comment).

- The userspace half of lib/selftests builds again (the lib headers'
  userspace mode had rotted unnoticed; CI only builds
  lib/selftests/compat). Used below for validation.

- The allocation metadata (sdt_data) moves behind the payload: elements
  are payload-first, so scx_alloc() returns pointers that genuinely carry
  the requested alignment (@arighi's returned-object alignment comment).
  New scx_free() frees by pointer with the index fetched from the trailing
  metadata, letting ATQs, rbtrees, rbnodes and bitmaps drop their embedded
  allocation ids.

- scx_alloc_init(), scx_task_init(), scx_cgrp_init() and ArenaLib::init()
  gain the element alignment parameter (0 = word). ATQs are allocated
  cacheline-aligned; existing schedulers keep word alignment and identical
  layouts.

Testing: cargo build and fmt clean (scx_mitosis, scx_lavd, scx_p2dq,
scx_chaos); lib selftests (atq, btree, lvqueue, minheap, rbtree) pass in a
VM on sched_ext/for-7.3; traced stress runs verified the allocator
alloc/free/RCU-free lifecycle invariants (no premature frees, exact
payload zeroing, no reclaim stalls) and payload alignment (task ctx
pointers cacheline-aligned); exercised further under a WIP scheduler with
fork-storm and cell-reconfig churn.
