### PR TITLE
lib: Guard the arena NULL pages and watch BPF streams

### DIFF
--- a/lib/alloc/asan.bpf.c
+++ b/lib/alloc/asan.bpf.c
@@ -463,7 +463,7 @@ __hidden __noasan int asan_init(struct asan_init_args *args)
 		&arena, (void __arena *)__asan_shadow_memory_dynamic_address,
 		shadow_pages, NUMA_NO_NODE, 0);
 	if (!shadowmap) {
-		arena_stderr("Could not allocate shadow map\n");
+		arena_stderr("Could not allocate shadow map");
 		return -ENOMEM;
 	}
 

--- a/lib/alloc/buddy.bpf.c
+++ b/lib/alloc/buddy.bpf.c
@@ -90,7 +90,7 @@ __weak
 int idx_set_allocated(buddy_chunk_t __arg_arena *chunk, u64 idx, bool allocated)
 {
 	if (unlikely(idx >= BUDDY_CHUNK_ITEMS)) {
-		arena_stderr("setting order of invalid idx (%d, max %d)\n", idx,
+		arena_stderr("setting order of invalid idx (%d, max %d)", idx,
 			     BUDDY_CHUNK_ITEMS);
 		return -EINVAL;
 	}
@@ -106,7 +106,7 @@ int idx_set_allocated(buddy_chunk_t __arg_arena *chunk, u64 idx, bool allocated)
 static int idx_is_allocated(buddy_chunk_t *chunk, u64 idx, bool *allocated)
 {
 	if (unlikely(idx >= BUDDY_CHUNK_ITEMS)) {
-		arena_stderr("setting order of invalid idx (%d, max %d)\n", idx,
+		arena_stderr("setting order of invalid idx (%d, max %d)", idx,
 			     BUDDY_CHUNK_ITEMS);
 		return -EINVAL;
 	}
@@ -121,12 +121,12 @@ int idx_set_order(buddy_chunk_t __arg_arena *chunk, u64 idx, u8 order)
 	u8 prev_order;
 
 	if (unlikely(order >= BUDDY_CHUNK_NUM_ORDERS)) {
-		arena_stderr("setting invalid order %u\n", order);
+		arena_stderr("setting invalid order %u", order);
 		return -EINVAL;
 	}
 
 	if (unlikely(idx >= BUDDY_CHUNK_ITEMS)) {
-		arena_stderr("setting order of invalid idx (%d, max %d)\n", idx,
+		arena_stderr("setting order of invalid idx (%d, max %d)", idx,
 			     BUDDY_CHUNK_ITEMS);
 		return -EINVAL;
 	}
@@ -157,7 +157,7 @@ static u8 idx_get_order(buddy_chunk_t *chunk, u64 idx)
 		       "order must fit in 4 bits");
 
 	if (unlikely(idx >= BUDDY_CHUNK_ITEMS)) {
-		arena_stderr("setting order of invalid idx\n");
+		arena_stderr("setting order of invalid idx");
 		return BUDDY_CHUNK_NUM_ORDERS;
 	}
 
@@ -171,7 +171,7 @@ static void __arena *idx_to_addr(buddy_chunk_t *chunk, size_t idx)
 	u64 address;
 
 	if (unlikely(idx >= BUDDY_CHUNK_ITEMS)) {
-		arena_stderr("setting order of invalid idx\n");
+		arena_stderr("setting order of invalid idx");
 		return NULL;
 	}
 
@@ -198,12 +198,12 @@ static buddy_header_t *idx_to_header(buddy_chunk_t *chunk, size_t idx)
 	u64 address;
 
 	if (unlikely(idx_is_allocated(chunk, idx, &allocated))) {
-		arena_stderr("accessing invalid idx 0x%lx\n", idx);
+		arena_stderr("accessing invalid idx 0x%lx", idx);
 		return NULL;
 	}
 
 	if (unlikely(allocated)) {
-		arena_stderr("accessing allocated idx 0x%lx as header\n", idx);
+		arena_stderr("accessing allocated idx 0x%lx as header", idx);
 		return NULL;
 	}
 
@@ -276,7 +276,7 @@ static u64 size_to_order(size_t size)
 	u64 order;
 
 	if (unlikely(!size)) {
-		arena_stderr("size 0 has no order\n");
+		arena_stderr("size 0 has no order");
 		return 64;
 	}
 
@@ -438,10 +438,10 @@ static buddy_chunk_t *buddy_chunk_get(struct buddy *buddy)
 		power2 = arena_fls(left);
 		if (unlikely(power2 >= BUDDY_CHUNK_NUM_ORDERS)) {
 			arena_stderr(
-				"buddy chunk metadata require allocation of order %d\n",
+				"buddy chunk metadata require allocation of order %d",
 				power2);
 			arena_stderr(
-				"chunk has size of 0x%lx bytes (left %lx bytes)\n",
+				"chunk has size of 0x%lx bytes (left %lx bytes)",
 				sizeof(*chunk), left);
 
 			buddy_unlock(buddy);
@@ -636,7 +636,7 @@ __weak u64 buddy_alloc_internal(struct buddy *buddy, size_t size)
 
 	order = size_to_order(size);
 	if (order >= BUDDY_CHUNK_NUM_ORDERS || order < 0) {
-		arena_stderr("invalid order %d (sz %lu)\n", order, size);
+		arena_stderr("invalid order %d (sz %lu)", order, size);
 		return (u64)NULL;
 	}
 
@@ -697,7 +697,7 @@ static __always_inline int buddy_free_unlocked(struct buddy *buddy, u64 addr)
 		return -EINVAL;
 
 	if (addr & (BUDDY_MIN_ALLOC_BYTES - 1)) {
-		arena_stderr("Freeing unaligned address %llx\n", addr);
+		arena_stderr("Freeing unaligned address %llx", addr);
 		return 0;
 	}
 

--- a/lib/arena.bpf.c
+++ b/lib/arena.bpf.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
  */
 #include <scx/common.bpf.h>
+#include <lib/arena_map.h>
 #include <lib/sdt_task.h>
 
 #include <lib/arena.h>
@@ -18,10 +19,40 @@
 
 struct task_ctx;
 
+/*
+ * A NULL arena pointer aliases the arena's first page at access time and a
+ * stray NULL dereference would silently read or corrupt live data. Keep the
+ * front of the arena unallocated so such accesses fault and get reported on the
+ * program's BPF stderr stream instead. The guard must exceed the largest single
+ * arena object so that indexing into one from NULL stays inside it. Negative
+ * offsets off NULL wrap to the top of the window, which cannot be guarded the
+ * same way as libbpf places the __arena globals there.
+ */
+enum {
+	NULL_GUARD_PAGES	= 8192,	/* 32MB with 4k pages */
+};
+
 SEC("syscall")
 int arena_init(struct arena_init_args *args)
 {
 	int ret;
+
+	/*
+	 * On kernels without full-range LDIMM64 offset support, libbpf places
+	 * the __arena globals at the bottom of the arena instead of the top and
+	 * the guard region is occupied from the get-go. The guard cannot work
+	 * there, skip it. qnodes is in the __arena globals, test its placement.
+	 */
+	if (bpf_ksym_exists(bpf_arena_reserve_pages) &&
+	    (u32)(u64)qnodes >= NULL_GUARD_PAGES * PAGE_SIZE) {
+		ret = bpf_arena_reserve_pages(&arena, NULL, NULL_GUARD_PAGES);
+		if (ret) {
+			bpf_printk("NULL guard: reserving pages [0, %u) failed with %d, "
+				   "the arena front was allocated before arena_init()",
+				   NULL_GUARD_PAGES, ret);
+			return ret;
+		}
+	}
 
 	ret = scx_static_init(args->static_pages);
 	if (ret)

--- a/lib/sdt_alloc.bpf.c
+++ b/lib/sdt_alloc.bpf.c
@@ -41,7 +41,7 @@ __hidden void scx_arena_subprog_init(void)
 	if (scx_arena_verify_once)
 		return;
 
-	scx_err_loc("arena pointer %p", &arena);
+	scx_err("IGN: arena pointer %p", &arena);
 	scx_arena_verify_once = true;
 }
 
@@ -579,7 +579,7 @@ u64 scx_alloc_internal(struct scx_allocator *alloc)
 	int ret;
 
 	if (!alloc) {
-		scx_err_loc("No allocator found\n");
+		scx_err_loc("No allocator found");
 		return (u64)NULL;
 	}
 
@@ -660,7 +660,7 @@ u64 scx_static_alloc_internal(size_t bytes, size_t alignment)
 
 	if (alloc_bytes > scx_static.max_alloc_bytes) {
 		bpf_spin_unlock(&alloc_lock);
-		scx_err_loc("invalid request %ld, max is %ld\n", alloc_bytes,
+		scx_err_loc("invalid request %ld, max is %ld", alloc_bytes,
 			      scx_static.max_alloc_bytes);
 		return (u64)NULL;
 	}

--- a/rust/scx_arena/scx_arena/src/arenalib.rs
+++ b/rust/scx_arena/scx_arena/src/arenalib.rs
@@ -30,26 +30,27 @@ use libbpf_rs::ProgramMut;
 /// Maximum length of CPU mask supported by the library in bits.
 const MAX_CPU_SUPPORTED: usize = 640;
 
-/// Holds state related to BPF arenas in the program.
+/// Live BPF arena library state. Returned by setup() and must be kept alive
+/// for as long as the scheduler instance uses the arena: dropping it stops
+/// and joins the library's background threads.
+#[must_use]
 #[derive(Debug)]
-pub struct ArenaLib<'a> {
-    task_size: usize,
-    task_align: usize,
-    obj: &'a mut Object,
+pub struct ArenaLib {
+    _urcu: Option<crate::Daemon>,
 }
 
-impl<'a> ArenaLib<'a> {
+impl ArenaLib {
     /// Maximum CPU mask size, derived from MAX_CPU_SUPPORTED.
     const MAX_CPU_ARRSZ: usize = (MAX_CPU_SUPPORTED + 63) / 64;
 
     /// Amount of pages allocated at once form the BPF map. by the static stack allocator.
     const STATIC_ALLOC_PAGES_GRANULARITY: c_ulong = 8;
 
-    fn run_prog_by_name(&self, name: &str, input: ProgramInput) -> Result<i32> {
+    fn run_prog_by_name(obj: &Object, name: &str, input: ProgramInput) -> Result<i32> {
         let c_name = CString::new(name)?;
         let ptr = unsafe {
             libbpf_sys::bpf_object__find_program_by_name(
-                self.obj.as_libbpf_object().as_ptr(),
+                obj.as_libbpf_object().as_ptr(),
                 c_name.as_ptr(),
             )
         };
@@ -69,14 +70,14 @@ impl<'a> ArenaLib<'a> {
     }
 
     /// Set up basic library state.
-    fn setup_arena(&self) -> Result<()> {
+    fn setup_arena(obj: &Object, task_size: usize, task_align: usize) -> Result<()> {
         // Allocate the arena memory from the BPF side so userspace initializes it before starting
         // the scheduler. Despite the function call's name this is neither a test nor a test run,
         // it's the recommended way of executing SEC("syscall") probes.
         let mut args = types::arena_init_args {
             static_pages: Self::STATIC_ALLOC_PAGES_GRANULARITY as c_ulong,
-            task_ctx_size: self.task_size as c_ulong,
-            task_ctx_align: self.task_align as c_ulong,
+            task_ctx_size: task_size as c_ulong,
+            task_ctx_align: task_align as c_ulong,
         };
 
         let input = ProgramInput {
@@ -89,7 +90,7 @@ impl<'a> ArenaLib<'a> {
             ..Default::default()
         };
 
-        let ret = self.run_prog_by_name("arena_init", input)?;
+        let ret = Self::run_prog_by_name(obj, "arena_init", input)?;
         if ret != 0 {
             bail!("Could not initialize arenas, setup_arenas returned {}", ret);
         }
@@ -97,7 +98,7 @@ impl<'a> ArenaLib<'a> {
         Ok(())
     }
 
-    fn setup_topology_node(&self, mask: &[u64], id: usize) -> Result<()> {
+    fn setup_topology_node(obj: &Object, mask: &[u64], id: usize) -> Result<()> {
         let mut args = types::arena_alloc_mask_args {
             bitmap: 0 as c_ulong,
         };
@@ -117,7 +118,7 @@ impl<'a> ArenaLib<'a> {
             ..Default::default()
         };
 
-        let ret = self.run_prog_by_name("arena_alloc_mask", input)?;
+        let ret = Self::run_prog_by_name(obj, "arena_alloc_mask", input)?;
 
         if ret != 0 {
             bail!(
@@ -151,7 +152,7 @@ impl<'a> ArenaLib<'a> {
             ..Default::default()
         };
 
-        let ret = self.run_prog_by_name("arena_topology_node_init", input)?;
+        let ret = Self::run_prog_by_name(obj, "arena_topology_node_init", input)?;
         if ret != 0 {
             bail!("arena_topology_node_init returned {}", ret);
         }
@@ -168,7 +169,7 @@ impl<'a> ArenaLib<'a> {
     ///
     /// NOTE: rust/scx_arena/selftests/src/main.rs::setup_topology() contains
     /// equivalent logic and must be kept in sync with this function.
-    fn setup_topology_max_children(&self, topo: &Topology) -> Result<()> {
+    fn setup_topology_max_children(obj: &Object, topo: &Topology) -> Result<()> {
         // Compute the maximum number of children at each topology level.
         // TOPO_TOP  (0): children are NUMA nodes
         // TOPO_NODE (1): children are LLCs
@@ -203,7 +204,7 @@ impl<'a> ArenaLib<'a> {
             ..Default::default()
         };
 
-        let ret = self.run_prog_by_name("arena_topology_init", input)?;
+        let ret = Self::run_prog_by_name(obj, "arena_topology_init", input)?;
         if ret != 0 {
             bail!("arena_topology_init returned {}", ret);
         }
@@ -211,21 +212,22 @@ impl<'a> ArenaLib<'a> {
         Ok(())
     }
 
-    fn setup_topology(&self) -> Result<()> {
+    fn setup_topology(obj: &Object) -> Result<()> {
         let topo = Topology::new().expect("Failed to build host topology");
 
-        self.setup_topology_max_children(&topo)?;
+        Self::setup_topology_max_children(obj, &topo)?;
 
         // Top level - ID 0 is fine as there's only one top-level node
-        self.setup_topology_node(topo.span.as_raw_slice(), 0)?;
+        Self::setup_topology_node(obj, topo.span.as_raw_slice(), 0)?;
 
         for (node_id, node) in topo.nodes {
-            self.setup_topology_node(node.span.as_raw_slice(), node_id)?;
+            Self::setup_topology_node(obj, node.span.as_raw_slice(), node_id)?;
         }
 
         // LLCs need to use their actual LLC ID for proper indexing in topo_nodes
         for (llc_id, llc) in topo.all_llcs {
-            self.setup_topology_node(
+            Self::setup_topology_node(
+                obj,
                 Arc::<Llc>::into_inner(llc)
                     .expect("missing llc")
                     .span
@@ -235,7 +237,8 @@ impl<'a> ArenaLib<'a> {
         }
 
         for (core_id, core) in topo.all_cores {
-            self.setup_topology_node(
+            Self::setup_topology_node(
+                obj,
                 Arc::<Core>::into_inner(core)
                     .expect("missing core")
                     .span
@@ -246,37 +249,31 @@ impl<'a> ArenaLib<'a> {
         for (_, cpu) in topo.all_cpus {
             let mut mask = [0; Self::MAX_CPU_ARRSZ - 1];
             mask[cpu.id / 64] |= 1 << (cpu.id % 64);
-            self.setup_topology_node(&mask, cpu.id)?;
+            Self::setup_topology_node(obj, &mask, cpu.id)?;
         }
 
         Ok(())
     }
 
-    /// Create an Arenalib object This call only initializes the Rust side of Arenalib.
+    /// Set up the BPF arena library state and, when the object carries the
+    /// scx_urcu doorbell, spawn the reclaim daemon. The returned ArenaLib
+    /// owns the library's background threads.
     /// @task_align: task ctx element alignment, 0 for word alignment.
-    pub fn init(
-        obj: &'a mut Object,
+    pub fn setup(
+        obj: &Object,
         task_size: usize,
         task_align: usize,
         nr_cpus: usize,
-    ) -> Result<Self> {
+    ) -> Result<ArenaLib> {
         if nr_cpus >= MAX_CPU_SUPPORTED {
             bail!("Scheduler specifies too many CPUs");
         }
 
-        Ok(Self {
-            task_size,
-            task_align,
-            obj,
+        Self::setup_arena(obj, task_size, task_align)?;
+        Self::setup_topology(obj)?;
+
+        Ok(ArenaLib {
+            _urcu: crate::urcu_spawn(obj)?,
         })
-    }
-
-    /// Set up the BPF arena library state and, when the object carries the
-    /// scx_urcu doorbell, spawn the detached reclaim daemon.
-    pub fn setup(&self) -> Result<()> {
-        self.setup_arena()?;
-        self.setup_topology()?;
-
-        crate::urcu_spawn(self.obj)
     }
 }

--- a/rust/scx_arena/scx_arena/src/arenalib.rs
+++ b/rust/scx_arena/scx_arena/src/arenalib.rs
@@ -36,6 +36,7 @@ const MAX_CPU_SUPPORTED: usize = 640;
 #[must_use]
 #[derive(Debug)]
 pub struct ArenaLib {
+    _watcher: crate::Daemon,
     _urcu: Option<crate::Daemon>,
 }
 
@@ -273,6 +274,7 @@ impl ArenaLib {
         Self::setup_topology(obj)?;
 
         Ok(ArenaLib {
+            _watcher: crate::stream_watcher_spawn(obj)?,
             _urcu: crate::urcu_spawn(obj)?,
         })
     }

--- a/rust/scx_arena/scx_arena/src/lib.rs
+++ b/rust/scx_arena/scx_arena/src/lib.rs
@@ -260,3 +260,216 @@ pub(crate) fn urcu_spawn(obj: &libbpf_rs::Object) -> Result<Option<Daemon>> {
         thread: Some(thread),
     }))
 }
+
+const BPF_STDOUT: u32 = 1;
+const BPF_STDERR: u32 = 2;
+const BPF_STREAMS: [(u32, &str); 2] = [(BPF_STDOUT, "stdout"), (BPF_STDERR, "stderr")];
+const STREAM_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+fn stream_read(fd: &OwnedFd, stream_id: u32, buf: &mut [u8]) -> i32 {
+    unsafe {
+        libbpf_sys::bpf_prog_stream_read(
+            fd.as_raw_fd(),
+            stream_id,
+            buf.as_mut_ptr() as *mut _,
+            buf.len() as u32,
+            std::ptr::null_mut(),
+        )
+    }
+}
+
+/// The kernel prefixes the errors it reports on a program's BPF stderr
+/// stream with "ERROR: ".
+fn stream_is_fatal(lines: &[String]) -> bool {
+    lines.iter().any(|l| l.starts_with("ERROR: "))
+}
+
+/// Split the complete lines out of @carry, keeping a trailing partial for the
+/// next read. Stream elements are concatenated without separators and reads
+/// split lines arbitrarily, so prefixes may only be matched on complete lines.
+/// @new_data says whether this poll read anything: a partial with no
+/// continuation after a full poll interval is flushed as a line of its own.
+fn stream_extract_lines(carry: &mut String, new_data: bool) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+
+    if let Some(pos) = carry.rfind('\n') {
+        lines = carry[..pos].split('\n').map(str::to_string).collect();
+        carry.drain(..=pos);
+    }
+    if !new_data && !carry.is_empty() {
+        lines.push(std::mem::take(carry));
+    }
+
+    lines
+}
+
+/// Forward the BPF stdout/stderr streams of every program in the object to
+/// the scheduler's stdout and stderr respectively, and abort when the
+/// kernel reports an error on a stderr stream. Nothing reads these streams
+/// otherwise, so messages would be silently dropped. Lines prefixed "IGN: "
+/// are dropped instead of forwarded, for prints with side effects that
+/// nobody needs to see, the arena association print in
+/// scx_arena_subprog_init() for example. Called from ArenaLib::setup(), the
+/// watcher is owned by the returned ArenaLib.
+pub(crate) fn stream_watcher_spawn(obj: &libbpf_rs::Object) -> Result<Daemon> {
+    let mut progs = Vec::new();
+
+    for prog in obj.progs() {
+        let Some(name) = prog.name().to_str() else {
+            continue;
+        };
+        /* feature-gated programs may not be loaded and then have no fd */
+        let Some(fd) = prog_fd_clone(&prog)? else {
+            continue;
+        };
+        progs.push((name.to_string(), fd));
+    }
+
+    let stop = stop_eventfd()?;
+    let daemon_stop = stop
+        .try_clone()
+        .context("cloning stream watcher stop eventfd")?;
+    let thread = std::thread::Builder::new()
+        .name("scx-bpf-stream".into())
+        .spawn(move || {
+            let mut buf = vec![0u8; 65536];
+            let mut carries: Vec<[String; 2]> = (0..progs.len())
+                .map(|_| [String::new(), String::new()])
+                .collect();
+
+            loop {
+                let mut fds = [libc::pollfd {
+                    fd: daemon_stop.as_raw_fd(),
+                    events: libc::POLLIN,
+                    revents: 0,
+                }];
+                let ret = unsafe {
+                    libc::poll(fds.as_mut_ptr(), 1, STREAM_POLL_INTERVAL.as_millis() as i32)
+                };
+                /* run one final scan below before honoring a stop request */
+                let stopping = if ret < 0 {
+                    std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR)
+                } else {
+                    ret > 0
+                };
+
+                for (pidx, (name, fd)) in progs.iter().enumerate() {
+                    for (sidx, (stream_id, label)) in BPF_STREAMS.iter().enumerate() {
+                        let carry = &mut carries[pidx][sidx];
+                        let mut new_data = false;
+
+                        /* drain fully, a backlog can exceed the buffer */
+                        loop {
+                            let n = stream_read(fd, *stream_id, &mut buf);
+                            if n <= 0 {
+                                break;
+                            }
+                            carry.push_str(&String::from_utf8_lossy(&buf[..n as usize]));
+                            new_data = true;
+                            if (n as usize) < buf.len() {
+                                break;
+                            }
+                        }
+
+                        let lines = stream_extract_lines(carry, new_data);
+                        if lines.is_empty() {
+                            continue;
+                        }
+
+                        let kept: Vec<&str> = lines
+                            .iter()
+                            .map(String::as_str)
+                            .filter(|l| !l.starts_with("IGN: "))
+                            .collect();
+                        if !kept.is_empty() {
+                            let msg = kept.join("\n");
+                            let out = format!("BPF {} of prog {}:\n{}\n", label, name, msg);
+                            if *stream_id == BPF_STDOUT {
+                                print!("{}", out);
+                                let _ = std::io::Write::flush(&mut std::io::stdout());
+                            } else {
+                                eprint!("{}", out);
+                            }
+                        }
+                        if *stream_id == BPF_STDERR && stream_is_fatal(&lines) {
+                            eprintln!("FATAL: aborting on BPF error report");
+                            std::process::exit(1);
+                        }
+                    }
+                }
+
+                if stopping {
+                    break;
+                }
+            }
+        })
+        .context("spawning BPF stream watcher")?;
+
+    Ok(Daemon {
+        stop,
+        thread: Some(thread),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stream_extract_lines;
+    use super::stream_is_fatal;
+
+    #[test]
+    fn test_stream_extract_lines() {
+        let mut carry = String::new();
+
+        /* empty carry, quiet tick */
+        assert!(stream_extract_lines(&mut carry, false).is_empty());
+
+        /* one complete line plus a partial */
+        carry.push_str("ERROR: whole line\npartial");
+        assert_eq!(
+            stream_extract_lines(&mut carry, true),
+            ["ERROR: whole line"]
+        );
+        assert_eq!(carry, "partial");
+
+        /* the partial is not flushed while data keeps arriving */
+        assert!(stream_extract_lines(&mut carry, true).is_empty());
+        assert_eq!(carry, "partial");
+
+        /* a line split across reads is reassembled */
+        carry.push_str(" continued\nnext");
+        assert_eq!(
+            stream_extract_lines(&mut carry, true),
+            ["partial continued"]
+        );
+        assert_eq!(carry, "next");
+
+        /* a stale partial flushes on a quiet tick, exactly once */
+        assert_eq!(stream_extract_lines(&mut carry, false), ["next"]);
+        assert!(carry.is_empty());
+        assert!(stream_extract_lines(&mut carry, false).is_empty());
+
+        /* multiple lines per chunk, blank lines forwarded */
+        carry.push_str("a\n\nb\ntail");
+        assert_eq!(stream_extract_lines(&mut carry, true), ["a", "", "b"]);
+        assert_eq!(carry, "tail");
+        carry.clear();
+
+        /* multi-byte UTF-8 split across reads stays on char boundaries */
+        carry.push_str("caf");
+        assert!(stream_extract_lines(&mut carry, true).is_empty());
+        carry.push_str("\u{e9}\n");
+        assert_eq!(stream_extract_lines(&mut carry, true), ["caf\u{e9}"]);
+        assert!(carry.is_empty());
+    }
+
+    #[test]
+    fn test_stream_is_fatal() {
+        let fatal = ["noise".to_string(), "ERROR: Arena READ access".to_string()];
+        assert!(stream_is_fatal(&fatal));
+
+        /* the prefix only counts at the start of a line */
+        let glued = ["no task dataERROR: Arena READ access".to_string()];
+        assert!(!stream_is_fatal(&glued));
+        assert!(!stream_is_fatal(&[]));
+    }
+}

--- a/rust/scx_arena/scx_arena/src/lib.rs
+++ b/rust/scx_arena/scx_arena/src/lib.rs
@@ -14,6 +14,8 @@ pub use arenalib::ArenaLib;
 
 use std::os::fd::AsFd;
 use std::os::fd::AsRawFd;
+use std::os::fd::BorrowedFd;
+use std::os::fd::FromRawFd;
 use std::os::fd::OwnedFd;
 use std::time::Duration;
 use std::time::Instant;
@@ -22,6 +24,7 @@ use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
 use libbpf_rs::libbpf_sys;
+use libbpf_rs::AsRawLibbpf as _;
 use libbpf_rs::MapCore as _;
 
 /// Cacheline size assumed by the arena allocator's alignment parameter.
@@ -37,11 +40,66 @@ const MEMBARRIER_CMD_GLOBAL: libc::c_long = 1;
 const URCU_DOORBELL: &str = "scx_urcu_doorbell";
 const URCU_MIN_INTERVAL: Duration = Duration::from_millis(1);
 
+/// One background thread and the eventfd that stops it. Dropping writes the
+/// eventfd and joins the thread.
+#[derive(Debug)]
+pub(crate) struct Daemon {
+    stop: OwnedFd,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let one: u64 = 1;
+        let ret = unsafe {
+            libc::write(
+                self.stop.as_raw_fd(),
+                &one as *const u64 as *const libc::c_void,
+                std::mem::size_of::<u64>(),
+            )
+        };
+        /* on a failed wakeup, leak the thread rather than hang the join */
+        if ret != std::mem::size_of::<u64>() as isize {
+            return;
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+/// Create the eventfd a Daemon is stopped through.
+fn stop_eventfd() -> Result<OwnedFd> {
+    let fd = unsafe { libc::eventfd(0, libc::EFD_CLOEXEC) };
+    if fd < 0 {
+        bail!(
+            "creating daemon stop eventfd failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+/// Duplicate @prog's fd, None for programs that were not loaded and thus have
+/// no fd, prog.as_fd() on those would construct a BorrowedFd from an invalid
+/// fd. Errors only when a loaded program's fd cannot be duplicated.
+fn prog_fd_clone(prog: &libbpf_rs::Program<'_>) -> Result<Option<OwnedFd>> {
+    let raw_fd = unsafe { libbpf_sys::bpf_program__fd(prog.as_libbpf_object().as_ptr()) };
+    if raw_fd < 0 {
+        return Ok(None);
+    }
+    let fd = unsafe { BorrowedFd::borrow_raw(raw_fd) }
+        .try_clone_to_owned()
+        .with_context(|| format!("cloning the fd of BPF prog {:?}", prog.name()))?;
+    Ok(Some(fd))
+}
+
 /// Userspace half of the scx_urcu machinery, see the BPF side in
 /// lib/sdt_alloc.bpf.c. ArenaLib::setup() spawns the daemon when the object
-/// carries the scx_urcu doorbell and it runs detached for the rest of the
-/// process, so nothing is visible to the scheduler: its whole surface is
-/// calling the scx_*_free_rcu() variants from its free path hooks.
+/// carries the scx_urcu doorbell. The returned ArenaLib owns it and stops and
+/// joins it on drop, so nothing else is visible to the scheduler: its whole
+/// runtime surface is calling the scx_*_free_rcu() variants from its free
+/// path hooks.
 ///
 /// The daemon sleeps on the doorbell and, when woken, waits an RCU grace
 /// period, membarrier(MEMBARRIER_CMD_GLOBAL) is synchronize_rcu(), and runs
@@ -59,7 +117,11 @@ fn urcu_run_prog(fd: &OwnedFd) -> Result<u32> {
     Ok(opts.retval)
 }
 
-fn urcu_daemon(doorbell: libbpf_rs::MapHandle, pairs: Vec<(OwnedFd, OwnedFd)>) -> Result<()> {
+fn urcu_daemon(
+    stop: OwnedFd,
+    doorbell: libbpf_rs::MapHandle,
+    pairs: Vec<(OwnedFd, OwnedFd)>,
+) -> Result<()> {
     let mut builder = libbpf_rs::RingBufferBuilder::new();
     builder
         .add(&doorbell, |_| 0)
@@ -70,13 +132,20 @@ fn urcu_daemon(doorbell: libbpf_rs::MapHandle, pairs: Vec<(OwnedFd, OwnedFd)>) -
 
     let mut last: Option<Instant> = None;
     loop {
-        let mut fds = [libc::pollfd {
-            fd: doorbell.as_fd().as_raw_fd(),
-            events: libc::POLLIN,
-            revents: 0,
-        }];
+        let mut fds = [
+            libc::pollfd {
+                fd: doorbell.as_fd().as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: stop.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
 
-        let ret = unsafe { libc::poll(fds.as_mut_ptr(), 1, -1) };
+        let ret = unsafe { libc::poll(fds.as_mut_ptr(), 2, -1) };
         if ret < 0 {
             let err = std::io::Error::last_os_error();
             if err.raw_os_error() == Some(libc::EINTR) {
@@ -84,6 +153,9 @@ fn urcu_daemon(doorbell: libbpf_rs::MapHandle, pairs: Vec<(OwnedFd, OwnedFd)>) -
             }
             bail!("urcu doorbell poll failed: {}", err);
         }
+
+        /* run one final drain below before honoring a stop request */
+        let stopping = fds[1].revents != 0;
 
         /* drain until nothing is awaiting reclaim */
         loop {
@@ -125,14 +197,19 @@ fn urcu_daemon(doorbell: libbpf_rs::MapHandle, pairs: Vec<(OwnedFd, OwnedFd)>) -
                 while urcu_run_prog(reclaim)? != 0 {}
             }
         }
+
+        if stopping {
+            return Ok(());
+        }
     }
 }
 
-/// Spawn the detached urcu reclaim daemon if @obj carries the scx_urcu
-/// doorbell and driver programs. Called from ArenaLib::setup().
-pub(crate) fn urcu_spawn(obj: &libbpf_rs::Object) -> Result<()> {
+/// Spawn the urcu reclaim daemon if @obj carries the scx_urcu doorbell and
+/// driver programs. Called from ArenaLib::setup(), the daemon is owned by
+/// the returned ArenaLib.
+pub(crate) fn urcu_spawn(obj: &libbpf_rs::Object) -> Result<Option<Daemon>> {
     let Some(doorbell) = obj.maps().find(|m| m.name() == URCU_DOORBELL) else {
-        return Ok(());
+        return Ok(None);
     };
     let doorbell =
         libbpf_rs::MapHandle::try_from(&doorbell).context("cloning urcu doorbell handle")?;
@@ -155,23 +232,31 @@ pub(crate) fn urcu_spawn(obj: &libbpf_rs::Object) -> Result<()> {
             .find(|p| p.name() == reclaim_name.as_str())
             .with_context(|| format!("urcu driver program {} not found", reclaim_name))?;
 
-        pairs.push((
-            prog.as_fd().try_clone_to_owned()?,
-            reclaim.as_fd().try_clone_to_owned()?,
-        ));
+        let Some(pending_fd) = prog_fd_clone(&prog)? else {
+            bail!("urcu driver program {} is not loaded", name);
+        };
+        let Some(reclaim_fd) = prog_fd_clone(&reclaim)? else {
+            bail!("urcu driver program {} is not loaded", reclaim_name);
+        };
+        pairs.push((pending_fd, reclaim_fd));
     }
     if pairs.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
 
-    std::thread::Builder::new()
+    let stop = stop_eventfd()?;
+    let daemon_stop = stop.try_clone().context("cloning urcu stop eventfd")?;
+    let thread = std::thread::Builder::new()
         .name("scx-urcu".into())
         .spawn(move || {
-            if let Err(e) = urcu_daemon(doorbell, pairs) {
+            if let Err(e) = urcu_daemon(daemon_stop, doorbell, pairs) {
                 eprintln!("scx-urcu daemon exiting on error: {:#}", e);
             }
         })
         .context("spawning urcu daemon thread")?;
 
-    Ok(())
+    Ok(Some(Daemon {
+        stop,
+        thread: Some(thread),
+    }))
 }

--- a/scheds/include/lib/alloc/bpf_helpers_local.h
+++ b/scheds/include/lib/alloc/bpf_helpers_local.h
@@ -33,8 +33,16 @@ extern int bpf_stream_vprintk(int stream_id, const char *fmt__str, const void *a
 	___ret;										\
 })
 
-#define scx_out(fmt, ...) bpf_stream_printk(1, (fmt), ##__VA_ARGS__)
-#define scx_err(fmt, ...) bpf_stream_printk(2, (fmt), ##__VA_ARGS__)
+/*
+ * Stream elements are concatenated without separators and the stream watcher
+ * consumes them line-wise, so an unterminated print glues onto whatever
+ * follows, a kernel error report included. The wrappers below terminate every
+ * print. Use them instead of raw bpf_stream_printk().
+ */
+#define scx_out(fmt, ...) bpf_stream_printk(1, fmt "\n", ##__VA_ARGS__)
+#define scx_err(fmt, ...) bpf_stream_printk(2, fmt "\n", ##__VA_ARGS__)
 
-#define scx_out_loc(fmt, ...) bpf_stream_printk(1, "%s:%d " fmt, __func__, __LINE__, ##__VA_ARGS__)
-#define scx_err_loc(fmt, ...) bpf_stream_printk(2, "%s:%d " fmt, __func__, __LINE__, ##__VA_ARGS__)
+#define scx_out_loc(fmt, ...) \
+	bpf_stream_printk(1, "%s:%d " fmt "\n", __func__, __LINE__, ##__VA_ARGS__)
+#define scx_err_loc(fmt, ...) \
+	bpf_stream_printk(2, "%s:%d " fmt "\n", __func__, __LINE__, ##__VA_ARGS__)

--- a/scheds/include/lib/alloc/bpf_helpers_local.h
+++ b/scheds/include/lib/alloc/bpf_helpers_local.h
@@ -6,8 +6,8 @@
  * It assumes the standard <bpf/bpf_helpers.h> has already been included.
  */
 
-extern int bpf_stream_vprintk_impl(int stream_id, const char *fmt__str, const void *args,
-				   __u32 len__sz, void *aux__prog) __weak __ksym;
+extern int bpf_stream_vprintk(int stream_id, const char *fmt__str, const void *args,
+			      __u32 len__sz) __weak __ksym;
 
 #ifdef bpf_stream_printk
 #undef bpf_stream_printk
@@ -17,7 +17,7 @@ extern int bpf_stream_vprintk_impl(int stream_id, const char *fmt__str, const vo
 ({											\
 	int ___ret = 0;									\
 											\
-	if (bpf_ksym_exists(bpf_stream_vprintk_impl)) {				\
+	if (bpf_ksym_exists(bpf_stream_vprintk)) {				\
 		static const char ___fmt[] = fmt;					\
 		unsigned long long ___param[___bpf_narg(args)];				\
 											\
@@ -26,8 +26,8 @@ extern int bpf_stream_vprintk_impl(int stream_id, const char *fmt__str, const vo
 		___bpf_fill(___param, args);						\
 		_Pragma("GCC diagnostic pop")						\
 											\
-		___ret = bpf_stream_vprintk_impl(stream_id, ___fmt, ___param,		\
-						 sizeof(___param), NULL);		\
+		___ret = bpf_stream_vprintk(stream_id, ___fmt, ___param,		\
+					    sizeof(___param));				\
 	}										\
 											\
 	___ret;										\

--- a/scheds/include/lib/alloc/common.h
+++ b/scheds/include/lib/alloc/common.h
@@ -15,10 +15,11 @@
 #error "Arena allocators only require bpf_addr_space_cast feature"
 #endif
 
-#define arena_stdout(fmt, ...) bpf_stream_printk(1, (fmt), ##__VA_ARGS__)
-#define arena_stderr(fmt, ...) bpf_stream_printk(2, (fmt), ##__VA_ARGS__)
+/* newline-terminated, see the comment in bpf_helpers_local.h */
+#define arena_stdout(fmt, ...) bpf_stream_printk(1, fmt "\n", ##__VA_ARGS__)
+#define arena_stderr(fmt, ...) bpf_stream_printk(2, fmt "\n", ##__VA_ARGS__)
 
-#define DIAG() (arena_stderr("%s:%d\n", __func__, __LINE__))
+#define DIAG() (arena_stderr("%s:%d", __func__, __LINE__))
 
 static inline void
 arena_bug_trigger(const char *func, const int line)

--- a/scheds/rust/scx_chaos/src/lib.rs
+++ b/scheds/rust/scx_chaos/src/lib.rs
@@ -167,6 +167,7 @@ pub struct Scheduler {
     _arena: HeapAllocator<ArenaAllocator>,
     _struct_ops: libbpf_rs::Link,
     _links: Vec<Link>,
+    _arenalib: ArenaLib,
     stats_server: StatsServer<(), Metrics>,
 
     // Fields are dropped in declaration order, this must be last as arena holds a reference to the
@@ -276,7 +277,7 @@ impl Builder<'_> {
         Ok(links)
     }
 
-    fn load_skel(&self) -> Result<Pin<Rc<SkelWithObject>>> {
+    fn load_skel(&self) -> Result<(Pin<Rc<SkelWithObject>>, ArenaLib)> {
         let mut out: Rc<MaybeUninit<SkelWithObject>> = Rc::new_uninit();
         let uninit_skel = Rc::get_mut(&mut out).expect("brand new rc should be unique");
 
@@ -448,8 +449,7 @@ impl Builder<'_> {
         scx_p2dq::init_skel!(&mut skel, topo);
 
         let task_size = std::mem::size_of::<types::task_p2dq>();
-        let arenalib = ArenaLib::init(skel.object_mut(), task_size, 0, *NR_CPU_IDS)?;
-        arenalib.setup()?;
+        let arenalib = ArenaLib::setup(skel.object_mut(), task_size, 0, *NR_CPU_IDS)?;
 
         let out = unsafe {
             // SAFETY: initialising field by field. open_object is already "initialised" (it's
@@ -462,7 +462,7 @@ impl Builder<'_> {
             Pin::new_unchecked(out.assume_init())
         };
 
-        Ok(out)
+        Ok((out, arenalib))
     }
 }
 
@@ -470,7 +470,7 @@ impl<'a> TryFrom<Builder<'a>> for Scheduler {
     type Error = anyhow::Error;
 
     fn try_from(b: Builder<'a>) -> Result<Scheduler> {
-        let skel = b.load_skel()?;
+        let (skel, arenalib) = b.load_skel()?;
 
         let arena = HeapAllocator::new(ArenaAllocator(skel.clone()));
         let stats_server = StatsServer::new(stats::server_data()).launch()?;
@@ -486,6 +486,7 @@ impl<'a> TryFrom<Builder<'a>> for Scheduler {
             _arena: arena,
             _struct_ops: struct_ops,
             _links: links,
+            _arenalib: arenalib,
             stats_server,
             skel,
         })

--- a/scheds/rust/scx_lavd/src/main.rs
+++ b/scheds/rust/scx_lavd/src/main.rs
@@ -453,6 +453,7 @@ impl introspec {
 }
 
 struct Scheduler<'a> {
+    _arenalib: ArenaLib,
     skel: BpfSkel<'a>,
     struct_ops: Option<libbpf_rs::Link>,
     intrspc: introspec,
@@ -519,14 +520,14 @@ impl<'a> Scheduler<'a> {
         // Initialize arena
         let mut skel = scx_ops_load!(skel, lavd_ops, uei)?;
         let task_size = std::mem::size_of::<types::task_ctx>();
-        let arenalib = ArenaLib::init(skel.object_mut(), task_size, 0, *NR_CPU_IDS)?;
-        arenalib.setup()?;
+        let arenalib = ArenaLib::setup(skel.object_mut(), task_size, 0, *NR_CPU_IDS)?;
 
         // Attach.
         let struct_ops = Some(scx_ops_attach!(skel, lavd_ops)?);
         let stats_server = StatsServer::new(stats::server_data(*NR_CPU_IDS as u64)).launch()?;
 
         Ok(Self {
+            _arenalib: arenalib,
             skel,
             struct_ops,
             intrspc: introspec::new(),

--- a/scheds/rust/scx_p2dq/src/main.rs
+++ b/scheds/rust/scx_p2dq/src/main.rs
@@ -533,11 +533,12 @@ fn main(opts: CliOpts) -> Result<()> {
 
     let mut open_object = MaybeUninit::uninit();
     loop {
+        /* declared before sched to drop, and join, after sched detaches */
+        let _arenalib;
         let mut sched =
             Scheduler::init(&opts.sched, &opts.libbpf, &mut open_object, &opts.log_level)?;
         let task_size = std::mem::size_of::<types::task_p2dq>();
-        let arenalib = ArenaLib::init(sched.skel.object_mut(), task_size, 0, *NR_CPU_IDS)?;
-        arenalib.setup()?;
+        _arenalib = ArenaLib::setup(sched.skel.object_mut(), task_size, 0, *NR_CPU_IDS)?;
 
         sched.start()?;
 


### PR DESCRIPTION
Make stray NULL arena dereferences detected and fatal instead of silent
corruption. Three patches.

- bpf_stream_printk() gated on and called bpf_stream_vprintk_impl(), the
  kfunc spelling that v7.0 retired for the implicit-prog-aux
  bpf_stream_vprintk(), so on v7.0+ every stream print in the lib (scx_err()
  and friends included) has been a silent no-op. Point it at the current
  kfunc; prints on v6.18/v6.19 revert to the designed no-op fallback.

- ArenaLib::init() is folded into setup(), which now returns an owned
  ArenaLib that the scheduler keeps alive for the scheduler instance's
  lifetime (p2dq per restart iteration, lavd and chaos as a scheduler
  struct field). It owns the lib's background threads, the urcu reclaim
  daemon and the stream watcher below, each paired with a stop eventfd,
  and dropping it signals them, lets them run a final drain and joins
  them. In-process scheduler restarts no longer accumulate detached
  threads whose cloned fds pin the retired object's maps and arena
  pages (@arighi's watcher lifetime comment). Program fds are cloned
  via a raw fd probe so that programs that did not load (feature-gated)
  are skipped instead of constructing a BorrowedFd from an invalid fd
  (@arighi's autoload comment).

- A NULL arena pointer aliases the arena's first page: once an allocation
  claims that page, a stray NULL dereference in BPF reads or corrupts live
  data with no fault and no report (verified by experiment). Keep the front
  32MB of the arena unallocated with bpf_arena_reserve_pages() so NULL
  dereferences stay in the faulting class: the access faults, is recovered
  (loads read zero, stores are dropped) and is reported with a stack trace
  on the program's BPF stderr stream. The guard is skipped on kernels
  without the kfunc, and on kernels without full-range LDIMM64 offset
  support where libbpf places the __arena globals at the bottom of the
  arena, occupying the guard region (v6.17 and earlier, including the CI
  runner kernels).

  Nothing read those streams in production, so ArenaLib::setup() now spawns
  a watcher thread that polls every program's stdout/stderr streams,
  forwards them to the scheduler's stdout/stderr, and aborts the scheduler
  on the kernel's "ERROR: " reports (recovered arena faults, rqspinlock
  deadlocks, may_goto timeouts). Lines prefixed "IGN: " are dropped, for
  prints with side effects that nobody needs to see. Stream content is
  handled line-wise: the lib print wrappers newline-terminate every print
  and the watcher reassembles complete lines across reads (unit-tested
  splitter), so a report cannot be missed by gluing onto an unterminated
  print or splitting at a read boundary.

Testing on sched_ext/for-7.3 in a VM with scx_p2dq: clean runs load with the
guard reserved and the watcher silent, clean exit. An injected NULL arena
read produced the kernel's "ERROR: Arena READ access at unmapped address
..." report on the BPF stderr stream, forwarded intact right next to an
adjacent same-tick debug print, and the scheduler aborted with exit 1. Debug
dumping verified: BPF stdout prints land on stdout and stderr prints on
stderr, an injected >64KB stderr backlog (850 lines) forwarded with every
line intact across the read-size boundary, an unterminated raw print flushed
as its own line, IGN lines dropped. Lib selftest suites (atq, btree,
lvqueue, minheap, rbtree) pass in the VM (with the pre-existing broken
topology selftest bypassed); cargo build (scx_lavd, scx_p2dq, scx_chaos,
scx_arena), cargo test and fmt clean. Also verified on v6.17 (arena
globals at the bottom): the guard is skipped and both scx_p2dq and
scx_lavd load and run cleanly, with programs that fail to load on older
kernels skipped by the stream watcher instead of failing setup.
