### PR TITLE
scx_cosmos: Expand GPU locality hints to cgroup workloads

### DIFF
--- a/scheds/rust/scx_cosmos/README.md
+++ b/scheds/rust/scx_cosmos/README.md
@@ -23,6 +23,31 @@ the use of very short time slices (10 us by default).
 The scheduler tries to keep tasks running on the same CPU as much as
 possible when the system is not saturated.
 
+## NVIDIA GPU Workloads
+
+With `--gpu`, scx_cosmos uses NVML to identify NVIDIA GPU processes and
+prefers CPUs on the GPU-local NUMA node. It also discovers other processes in
+the same exact cgroup so multi-process services receive a consistent locality
+hint without requiring users to provide process IDs or cgroup paths.
+
+The cgroup is treated as the workload boundary. GPU services should run in a
+dedicated cgroup, as every process in the group inherits the GPU locality hint.
+Systemd services and container runtimes normally provide such a boundary;
+processes launched directly from a login shell may instead share a broader
+session cgroup.
+
+scx_cosmos must run in the host PID and cgroup namespaces so userspace TGIDs
+match the TGIDs used by BPF. Workloads may still run in containers.
+
+Discovery never expands the root cgroup, child cgroups, or threaded cgroups.
+If cgroup membership cannot be determined safely, scx_cosmos retains the
+NVML process-only behavior.
+
+Cgroup discovery is used only with `--gpu-util-threshold=0` (the default).
+When utilization filtering is enabled, scx_cosmos retains the existing
+process-only behavior so filtered NVML processes are not reintroduced as
+cgroup peers.
+
 ## Typical Use Case
 
 General-purpose scheduler: the scheduler should adapt itself both for

--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -268,8 +268,9 @@ struct {
 } gpu_node_map SEC(".maps");
 
 /*
- * Process TGID -> NUMA node mapping for GPU tasks (updated from userspace via
- * NVML). Entries are removed when the process is no longer using a GPU.
+ * Process TGID -> NUMA node mapping for GPU workload tasks. NVML identifies
+ * GPU processes, and userspace may include peer processes from the same
+ * workload cgroup.
  */
 #define MAX_GPU_PIDS	8192
 
@@ -281,8 +282,8 @@ struct {
 } gpu_pid_map SEC(".maps");
 
 /*
- * Look up the preferred NUMA node for a process TGID from the
- * userspace-provided NVML GPU process list. Returns a node id or a negative
+ * Look up the preferred NUMA node for a process TGID from the userspace-
+ * provided GPU workload list. Returns a node id or a negative
  * error.
  */
 static int gpu_node_by_tgid(u32 tgid)
@@ -1152,7 +1153,7 @@ void BPF_STRUCT_OPS(cosmos_enqueue, struct task_struct *p, u64 enq_flags)
 		return;
 
 	/*
-	 * If the task's TGID is in gpu_pid_map (NVML GPU process), prefer the
+	 * If the task's TGID is in gpu_pid_map (GPU workload process), prefer the
 	 * GPU NUMA node. If we're on a different node, migrate to the GPU
 	 * node.
 	 */

--- a/scheds/rust/scx_cosmos/src/cgroup.rs
+++ b/scheds/rust/scx_cosmos/src/cgroup.rs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-2.0
+
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+
+/// Read process membership from the host's unified cgroup hierarchy.
+pub(crate) struct CgroupReader {
+    mount_point: PathBuf,
+}
+
+impl CgroupReader {
+    /// Locate the host cgroup v2 mount from mountinfo.
+    pub(crate) fn discover() -> Result<Self> {
+        let file = File::open("/proc/self/mountinfo").context("open /proc/self/mountinfo")?;
+        let mount_point =
+            parse_cgroup2_mount(BufReader::new(file))?.context("root cgroup v2 mount not found")?;
+        Ok(Self { mount_point })
+    }
+
+    /// Return the exact, non-root cgroup directory for a process.
+    pub(crate) fn process_cgroup(&self, tgid: u32) -> Result<Option<PathBuf>> {
+        let path = format!("/proc/{tgid}/cgroup");
+        let file = File::open(&path).with_context(|| format!("open {path}"))?;
+        let cgroup_path = parse_process_cgroup(BufReader::new(file))?;
+        let Some(relative) = relative_cgroup_path(&cgroup_path)? else {
+            return Ok(None);
+        };
+        Ok(Some(self.mount_point.join(relative)))
+    }
+
+    /// Return all process IDs in an exact cgroup (not its descendants).
+    pub(crate) fn processes(&self, cgroup: &Path) -> Result<HashSet<u32>> {
+        let type_path = cgroup.join("cgroup.type");
+        let cgroup_type = std::fs::read_to_string(&type_path)
+            .with_context(|| format!("read {}", type_path.display()))?;
+        if cgroup_type.trim_end() != "domain" {
+            bail!(
+                "cgroup {} is not an exact domain: unsupported cgroup type {:?}",
+                cgroup.display(),
+                cgroup_type.trim_end()
+            );
+        }
+
+        let path = cgroup.join("cgroup.procs");
+        let file = File::open(&path).with_context(|| format!("open {}", path.display()))?;
+        parse_cgroup_procs(BufReader::new(file))
+    }
+}
+
+fn parse_process_cgroup(reader: impl BufRead) -> Result<PathBuf> {
+    let mut unified = None;
+
+    for line in reader.lines() {
+        let line = line.context("read process cgroup entry")?;
+        let Some(path) = line.strip_prefix("0::") else {
+            continue;
+        };
+        if unified.is_some() {
+            bail!("multiple cgroup v2 entries");
+        }
+        if path.ends_with(" (deleted)") {
+            bail!("cgroup was deleted");
+        }
+        unified = Some(PathBuf::from(path));
+    }
+
+    unified.context("cgroup v2 entry not found")
+}
+
+fn relative_cgroup_path(path: &Path) -> Result<Option<PathBuf>> {
+    if !path.is_absolute() {
+        bail!("cgroup path is not absolute: {}", path.display());
+    }
+    let relative = path
+        .strip_prefix(Path::new("/"))
+        .context("strip cgroup root")?;
+    if relative.as_os_str().is_empty() {
+        return Ok(None);
+    }
+    if relative
+        .components()
+        .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        bail!("invalid cgroup path: {}", path.display());
+    }
+    Ok(Some(relative.to_path_buf()))
+}
+
+fn parse_cgroup_procs(reader: impl BufRead) -> Result<HashSet<u32>> {
+    let mut processes = HashSet::new();
+
+    for line in reader.lines() {
+        let line = line.context("read cgroup.procs entry")?;
+        let value = line.trim();
+        if value.is_empty() {
+            continue;
+        }
+        let tgid = value
+            .parse::<u32>()
+            .with_context(|| format!("invalid process ID in cgroup.procs: {value}"))?;
+        if tgid == 0 {
+            bail!("invalid process ID in cgroup.procs: 0");
+        }
+        processes.insert(tgid);
+    }
+
+    Ok(processes)
+}
+
+fn parse_cgroup2_mount(reader: impl BufRead) -> Result<Option<PathBuf>> {
+    for line in reader.lines() {
+        let line = line.context("read mountinfo entry")?;
+        let Some((mount_fields, fs_fields)) = line.split_once(" - ") else {
+            continue;
+        };
+        let mount_fields: Vec<_> = mount_fields.split_whitespace().collect();
+        let mut fs_fields = fs_fields.split_whitespace();
+        if mount_fields.len() < 5 || fs_fields.next() != Some("cgroup2") {
+            continue;
+        }
+        // Require the hierarchy root so process cgroup paths resolve beneath
+        // this mount without namespace-specific path translation.
+        if mount_fields[3] != "/" {
+            continue;
+        }
+        return Ok(Some(decode_mount_path(mount_fields[4])?));
+    }
+
+    Ok(None)
+}
+
+fn decode_mount_path(value: &str) -> Result<PathBuf> {
+    let mut input = value.chars();
+    let mut output = String::with_capacity(value.len());
+
+    while let Some(character) = input.next() {
+        if character != '\\' {
+            output.push(character);
+            continue;
+        }
+
+        let mut digits = [0u16; 3];
+        for digit in &mut digits {
+            let Some(character @ '0'..='7') = input.next() else {
+                bail!("invalid mountinfo path escape: {value}");
+            };
+            *digit = u16::from(character as u8 - b'0');
+        }
+        let decoded = (digits[0] << 6) | (digits[1] << 3) | digits[2];
+        if decoded > u16::from(u8::MAX) {
+            bail!("mountinfo path escape is out of range: {value}");
+        }
+        let decoded = decoded as u8;
+        if !decoded.is_ascii() {
+            bail!("non-ASCII mountinfo path escape is unsupported: {value}");
+        }
+        output.push(char::from(decoded));
+    }
+
+    Ok(PathBuf::from(output))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn parses_unified_cgroup_entry() {
+        let input = b"7:cpu:/legacy\n0::/services/inference\n";
+        assert_eq!(
+            parse_process_cgroup(Cursor::new(input)).unwrap(),
+            PathBuf::from("/services/inference")
+        );
+    }
+
+    #[test]
+    fn rejects_deleted_or_missing_cgroup() {
+        assert!(parse_process_cgroup(Cursor::new(b"0::/gone (deleted)\n")).is_err());
+        assert!(parse_process_cgroup(Cursor::new(b"7:cpu:/legacy\n")).is_err());
+        assert!(parse_process_cgroup(Cursor::new(b"0::/one\n0::/two\n")).is_err());
+    }
+
+    #[test]
+    fn rejects_root_and_unsafe_paths() {
+        assert_eq!(relative_cgroup_path(Path::new("/")).unwrap(), None);
+        assert!(relative_cgroup_path(Path::new("relative")).is_err());
+        assert!(relative_cgroup_path(Path::new("/safe/../unsafe")).is_err());
+    }
+
+    #[test]
+    fn parses_cgroup2_mount_and_escapes() {
+        let input = b"10 1 0:1 / /old rw - cgroup cgroup rw\n\
+                      39 30 0:33 / /sys/fs/cgroup\\040root rw - cgroup2 cgroup2 rw\n";
+        assert_eq!(
+            parse_cgroup2_mount(Cursor::new(input)).unwrap(),
+            Some(PathBuf::from("/sys/fs/cgroup root"))
+        );
+    }
+
+    #[test]
+    fn decodes_utf8_mount_path() {
+        assert_eq!(
+            decode_mount_path("/sys/fs/cgroup-é\\040root").unwrap(),
+            PathBuf::from("/sys/fs/cgroup-é root")
+        );
+        assert!(decode_mount_path("/sys/fs/cgroup\\377root").is_err());
+    }
+
+    #[test]
+    fn ignores_non_root_cgroup2_mount() {
+        let input = b"39 30 0:33 /slice /sys/fs/cgroup rw - cgroup2 cgroup2 rw\n";
+        assert_eq!(parse_cgroup2_mount(Cursor::new(input)).unwrap(), None);
+    }
+
+    #[test]
+    fn parses_and_deduplicates_cgroup_procs() {
+        let input = b"10\n20\n10\n";
+        assert_eq!(
+            parse_cgroup_procs(Cursor::new(input)).unwrap(),
+            HashSet::from([10, 20])
+        );
+        assert!(parse_cgroup_procs(Cursor::new(b"not-a-pid\n")).is_err());
+    }
+}

--- a/scheds/rust/scx_cosmos/src/gpu.rs
+++ b/scheds/rust/scx_cosmos/src/gpu.rs
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: GPL-2.0
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use log::debug;
+
+use crate::cgroup::CgroupReader;
+
+/// Keep only NVML processes whose GPUs resolve to one NUMA node.
+pub(crate) fn direct_gpu_processes(
+    process_nodes: &HashMap<u32, HashSet<u32>>,
+) -> HashMap<u32, u32> {
+    process_nodes
+        .iter()
+        .filter_map(|(&tgid, nodes)| {
+            (nodes.len() == 1).then(|| (tgid, *nodes.iter().next().unwrap()))
+        })
+        .collect()
+}
+
+/// Expand NVML processes to peer processes in the same exact cgroup.
+///
+/// NVML remains the source of GPU usage and NUMA locality. Cgroups are used
+/// only to discover the other processes that belong to the same workload.
+pub(crate) fn expand_gpu_processes(
+    process_nodes: &HashMap<u32, HashSet<u32>>,
+    cgroups: &CgroupReader,
+) -> HashMap<u32, u32> {
+    expand_gpu_processes_with(
+        process_nodes,
+        |tgid| cgroups.process_cgroup(tgid),
+        |cgroup| cgroups.processes(cgroup),
+    )
+}
+
+/// Fit workload hints into the BPF map without partially expanding a cgroup.
+pub(crate) fn fit_gpu_processes(
+    expanded: HashMap<u32, u32>,
+    direct: &HashMap<u32, u32>,
+    max_entries: usize,
+) -> HashMap<u32, u32> {
+    if expanded.len() <= max_entries {
+        expanded
+    } else if direct.len() <= max_entries {
+        direct.clone()
+    } else {
+        HashMap::new()
+    }
+}
+
+fn expand_gpu_processes_with<C, P>(
+    process_nodes: &HashMap<u32, HashSet<u32>>,
+    mut process_cgroup: C,
+    mut cgroup_processes: P,
+) -> HashMap<u32, u32>
+where
+    C: FnMut(u32) -> Result<Option<PathBuf>>,
+    P: FnMut(&Path) -> Result<HashSet<u32>>,
+{
+    #[derive(Default)]
+    struct Observation {
+        nodes: HashSet<u32>,
+        seeds: HashSet<u32>,
+    }
+
+    // Every NVML observation is authoritative, including processes whose
+    // GPUs span multiple nodes and therefore intentionally have no hint.
+    // Peer discovery must not override them when membership changes.
+    let direct = direct_gpu_processes(process_nodes);
+    let mut peer_nodes: HashMap<u32, HashSet<u32>> = HashMap::new();
+    let mut cgroups: HashMap<PathBuf, Observation> = HashMap::new();
+
+    for (&tgid, nodes) in process_nodes {
+        match process_cgroup(tgid) {
+            Ok(Some(cgroup)) => {
+                let observation = cgroups.entry(cgroup).or_default();
+                observation.nodes.extend(nodes.iter().copied());
+                observation.seeds.insert(tgid);
+            }
+            Ok(None) => debug!("GPU process {tgid} is in the root cgroup; not expanding"),
+            Err(error) => debug!("GPU process {tgid} cgroup discovery failed: {error:#}"),
+        }
+    }
+
+    for (cgroup, observation) in cgroups {
+        if observation.nodes.len() != 1 {
+            debug!(
+                "GPU cgroup {} spans multiple NUMA nodes; not expanding",
+                cgroup.display()
+            );
+            continue;
+        }
+        let node = *observation.nodes.iter().next().unwrap();
+        match cgroup_processes(&cgroup) {
+            Ok(processes) => {
+                // Membership is mutable. Do not expand an old path after all
+                // of the NVML seed processes have moved away or exited.
+                if observation.seeds.is_disjoint(&processes) {
+                    debug!(
+                        "GPU cgroup {} no longer contains an observed GPU process; not expanding",
+                        cgroup.display()
+                    );
+                    continue;
+                }
+                debug!(
+                    "GPU cgroup {} expands {} NVML processes to {} workload processes",
+                    cgroup.display(),
+                    observation.seeds.len(),
+                    processes.len()
+                );
+                for tgid in processes {
+                    if !process_nodes.contains_key(&tgid) {
+                        peer_nodes.entry(tgid).or_default().insert(node);
+                    }
+                }
+            }
+            Err(error) => debug!(
+                "GPU cgroup {} process discovery failed: {error:#}",
+                cgroup.display()
+            ),
+        }
+    }
+
+    let mut expanded = direct;
+    for (tgid, nodes) in peer_nodes {
+        // A peer discovered in conflicting workloads is safer without a hint
+        // than with a node chosen according to iteration order.
+        if nodes.len() == 1 {
+            expanded.insert(tgid, *nodes.iter().next().unwrap());
+        }
+    }
+    expanded
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::bail;
+
+    use super::*;
+
+    fn nodes(values: &[u32]) -> HashSet<u32> {
+        values.iter().copied().collect()
+    }
+
+    #[test]
+    fn expands_exact_cgroup_processes() {
+        let observed = HashMap::from([(100, nodes(&[0]))]);
+        let expanded = expand_gpu_processes_with(
+            &observed,
+            |tgid| {
+                assert_eq!(tgid, 100);
+                Ok(Some(PathBuf::from("/cgroup/a")))
+            },
+            |path| {
+                assert_eq!(path, Path::new("/cgroup/a"));
+                Ok(nodes(&[100, 200, 300]))
+            },
+        );
+
+        assert_eq!(expanded, HashMap::from([(100, 0), (200, 0), (300, 0)]));
+    }
+
+    #[test]
+    fn falls_back_to_direct_process_on_discovery_failure() {
+        let observed = HashMap::from([(100, nodes(&[0]))]);
+        let expanded = expand_gpu_processes_with(
+            &observed,
+            |_| bail!("unavailable"),
+            |_| bail!("must not read cgroup.procs"),
+        );
+        assert_eq!(expanded, HashMap::from([(100, 0)]));
+    }
+
+    #[test]
+    fn does_not_expand_after_seed_leaves_cgroup() {
+        let observed = HashMap::from([(100, nodes(&[0]))]);
+        let expanded = expand_gpu_processes_with(
+            &observed,
+            |_| Ok(Some(PathBuf::from("/cgroup/a"))),
+            |_| Ok(nodes(&[200, 300])),
+        );
+        assert_eq!(expanded, HashMap::from([(100, 0)]));
+    }
+
+    #[test]
+    fn does_not_expand_cgroup_across_nodes() {
+        let observed = HashMap::from([(100, nodes(&[0])), (101, nodes(&[1]))]);
+        let expanded = expand_gpu_processes_with(
+            &observed,
+            |_| Ok(Some(PathBuf::from("/cgroup/a"))),
+            |_| Ok(nodes(&[100, 101, 200])),
+        );
+
+        assert_eq!(expanded, HashMap::from([(100, 0), (101, 1)]));
+    }
+
+    #[test]
+    fn removes_ambiguous_process_hint() {
+        let observed = HashMap::from([(100, nodes(&[0, 1]))]);
+        let expanded = expand_gpu_processes_with(
+            &observed,
+            |_| Ok(Some(PathBuf::from("/cgroup/a"))),
+            |_| Ok(nodes(&[100, 200])),
+        );
+        assert!(expanded.is_empty());
+    }
+
+    #[test]
+    fn removes_peer_seen_in_conflicting_cgroups() {
+        let observed = HashMap::from([(100, nodes(&[0])), (101, nodes(&[1]))]);
+        let expanded = expand_gpu_processes_with(
+            &observed,
+            |tgid| Ok(Some(PathBuf::from(format!("/cgroup/{tgid}")))),
+            |_| Ok(nodes(&[200])),
+        );
+
+        assert_eq!(expanded, HashMap::from([(100, 0), (101, 1)]));
+        assert!(!expanded.contains_key(&200));
+    }
+
+    #[test]
+    fn direct_nvml_mapping_wins_membership_race() {
+        let observed = HashMap::from([(100, nodes(&[0])), (101, nodes(&[1]))]);
+        let expanded = expand_gpu_processes_with(
+            &observed,
+            |tgid| Ok(Some(PathBuf::from(format!("/cgroup/{tgid}")))),
+            |path| {
+                if path == Path::new("/cgroup/100") {
+                    Ok(nodes(&[100]))
+                } else {
+                    Ok(nodes(&[100, 101]))
+                }
+            },
+        );
+
+        assert_eq!(expanded, HashMap::from([(100, 0), (101, 1)]));
+    }
+
+    #[test]
+    fn ambiguous_nvml_observation_wins_membership_race() {
+        let observed = HashMap::from([(100, nodes(&[0])), (101, nodes(&[0, 1]))]);
+        let expanded = expand_gpu_processes_with(
+            &observed,
+            |tgid| {
+                if tgid == 100 {
+                    Ok(Some(PathBuf::from("/cgroup/a")))
+                } else {
+                    bail!("cgroup lookup raced")
+                }
+            },
+            |_| Ok(nodes(&[100, 101])),
+        );
+
+        assert_eq!(expanded, HashMap::from([(100, 0)]));
+    }
+
+    #[test]
+    fn capacity_falls_back_without_partial_expansion() {
+        let direct = HashMap::from([(100, 0)]);
+        let expanded = HashMap::from([(100, 0), (200, 0), (300, 0)]);
+
+        assert_eq!(fit_gpu_processes(expanded.clone(), &direct, 3), expanded);
+        assert_eq!(fit_gpu_processes(expanded, &direct, 2), direct);
+        assert!(fit_gpu_processes(HashMap::from([(100, 0)]), &direct, 0).is_empty());
+    }
+}

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -10,7 +10,11 @@ pub use bpf_skel::*;
 pub mod bpf_intf;
 pub use bpf_intf::*;
 
+mod cgroup;
+mod gpu;
 mod stats;
+use cgroup::CgroupReader;
+
 use std::collections::{HashMap, HashSet};
 use std::ffi::{c_int, c_ulong};
 use std::fs::File;
@@ -527,10 +531,12 @@ struct Scheduler<'a> {
     stats_server: StatsServer<(), Metrics>,
     /// GPU device index -> NUMA node (for NVML PID sync). Only set when --gpu and NUMA enabled.
     gpu_index_to_node: Option<HashMap<u32, u32>>,
-    /// Previous (pid, node) set so we can remove PIDs that stopped using the GPU.
+    /// Previous (TGID, node) set so we can remove processes that stopped using the GPU.
     previous_gpu_pids: Option<HashMap<u32, u32>>,
     /// Reused NVML handle to avoid re-initializing on every sync (expensive).
     nvml: Option<Nvml>,
+    /// Host cgroup v2 reader used to discover peer processes of NVML GPU processes.
+    gpu_cgroup_reader: Option<CgroupReader>,
     /// Dynamic threshold state for perf event migrations (when --perf-threshold is 0/dynamic).
     perf_threshold_state: Option<DynamicThresholdState>,
     /// Dynamic threshold state for sticky perf events (when --perf-sticky-threshold is 0/dynamic).
@@ -661,6 +667,28 @@ impl<'a> Scheduler<'a> {
         } else {
             rodata.gpu_enabled = false;
             (None, None, None)
+        };
+
+        let gpu_cgroup_reader = if nvml.is_some() && opts.gpu_util_threshold == 0 {
+            match CgroupReader::discover() {
+                Ok(reader) => {
+                    info!("NVIDIA GPU workload discovery enabled (cgroup v2)");
+                    Some(reader)
+                }
+                Err(error) => {
+                    warn!(
+                        "GPU workload discovery unavailable, using NVML process scope: {error:#}"
+                    );
+                    None
+                }
+            }
+        } else if nvml.is_some() {
+            info!(
+                "NVIDIA GPU workload discovery requires --gpu-util-threshold=0; using NVML process scope"
+            );
+            None
+        } else {
+            None
         };
 
         // Set scheduler flags.
@@ -818,14 +846,16 @@ impl<'a> Scheduler<'a> {
             gpu_index_to_node,
             previous_gpu_pids,
             nvml,
+            gpu_cgroup_reader,
             perf_threshold_state,
             perf_sticky_threshold_state,
         })
     }
 
-    /// Sync process TGID -> GPU (node) map from NVML. When gpu_util_threshold > 0, only
-    /// processes with GPU utilization (SM or memory) >= threshold are added. Only processes
-    /// whose GPUs resolve to a single NUMA node are included.
+    /// Sync process TGID -> GPU (node) hints from NVML. Peer processes in the same exact,
+    /// non-root cgroup inherit the hint when all observed GPUs resolve to one NUMA node.
+    /// gpu_util_threshold > 0 retains process-only behavior because its NVML snapshot is
+    /// intentionally filtered.
     fn sync_gpu_pids(&mut self) -> Result<()> {
         let gpu_index_to_node = match &self.gpu_index_to_node {
             Some(m) => m,
@@ -836,17 +866,28 @@ impl<'a> Scheduler<'a> {
             None => return Ok(()),
         };
         let threshold = self.opts.gpu_util_threshold;
-        let previous = self.previous_gpu_pids.as_ref().unwrap();
-        // First collect pid -> set of nodes (GPUs) per process.
+        // First collect TGID -> set of nodes (GPUs) per process.
         let mut pid_to_nodes: HashMap<u32, HashSet<u32>> = HashMap::new();
+        let mut snapshot_complete = true;
 
+        // A failed NVML query is not an empty snapshot. Keep the last applied
+        // hints instead of deleting processes we simply failed to observe.
         let count = nvml.device_count().context("NVML device count")?;
         for i in 0..count {
             let node = match gpu_index_to_node.get(&i) {
                 Some(&n) => n,
-                None => continue,
+                None => {
+                    snapshot_complete = false;
+                    continue;
+                }
             };
-            let device = nvml.device_by_index(i).context("NVML device_by_index")?;
+            let device = match nvml.device_by_index(i) {
+                Ok(device) => device,
+                Err(error) => {
+                    debug!("NVML device {i} lookup failed: {error:#}");
+                    return Err(error).context(format!("NVML device {i} lookup failed"));
+                }
+            };
 
             if threshold > 0 {
                 // Use process utilization; only add PIDs above threshold.
@@ -861,34 +902,99 @@ impl<'a> Scheduler<'a> {
                     }
                     Err(_) => {
                         // NotSupported or other: fall back to all running processes.
-                        Self::add_running_gpu_processes_to_set(&device, node, &mut pid_to_nodes);
+                        Self::add_running_gpu_processes_to_set(&device, node, &mut pid_to_nodes)
+                            .with_context(|| {
+                                format!("NVML device {i} process snapshot is incomplete")
+                            })?;
                     }
                 }
             } else {
-                Self::add_running_gpu_processes_to_set(&device, node, &mut pid_to_nodes);
+                Self::add_running_gpu_processes_to_set(&device, node, &mut pid_to_nodes)
+                    .with_context(|| format!("NVML device {i} process snapshot is incomplete"))?;
             }
         }
 
-        // Only add process TGIDs whose GPUs resolve to exactly one NUMA node.
-        let mut current: HashMap<u32, u32> = HashMap::new();
-        for (tgid, nodes) in pid_to_nodes {
-            if nodes.len() == 1 {
-                let node = nodes.into_iter().next().unwrap();
-                current.insert(tgid, node);
-            }
-        }
+        let mut direct = gpu::direct_gpu_processes(&pid_to_nodes);
+        direct.remove(&std::process::id());
+        let mut current = if snapshot_complete {
+            self.gpu_cgroup_reader
+                .as_ref()
+                .map(|reader| gpu::expand_gpu_processes(&pid_to_nodes, reader))
+                .unwrap_or_else(|| direct.clone())
+        } else {
+            direct.clone()
+        };
+        current.remove(&std::process::id());
+        let max_entries = self.skel.maps.gpu_pid_map.max_entries() as usize;
 
+        // Workload discovery can include many peer processes. Fall back to
+        // direct NVML processes rather than partially populating the map.
+        if current.len() > max_entries {
+            warn!(
+                "GPU workload has {} processes, exceeding gpu_pid_map capacity {}; using {} direct NVML processes",
+                current.len(),
+                max_entries,
+                direct.len()
+            );
+        }
+        if direct.len() > max_entries {
+            warn!(
+                "{} direct NVML processes exceed gpu_pid_map capacity {}; clearing GPU process hints",
+                direct.len(),
+                max_entries
+            );
+        }
+        current = gpu::fit_gpu_processes(current, &direct, max_entries);
+
+        self.reconcile_gpu_pid_hints(&current)
+    }
+
+    /// Reconcile the desired GPU workload hints with the BPF map.
+    fn reconcile_gpu_pid_hints(&mut self, desired: &HashMap<u32, u32>) -> Result<()> {
+        let previous = self.previous_gpu_pids.as_ref().unwrap().clone();
         let map = &self.skel.maps.gpu_pid_map;
-        for (pid, node) in &current {
-            map.update(&pid.to_ne_bytes(), &node.to_ne_bytes(), MapFlags::ANY)
-                .context("gpu_pid_map update")?;
-        }
+
+        // Track the state actually applied to BPF so a partial map operation
+        // is retried and cleaned up on the next synchronization.
+        let mut applied = previous.clone();
+        let mut first_error = None;
+
+        // Delete stale entries first so replacements cannot temporarily run
+        // out of map capacity.
         for pid in previous.keys() {
-            if !current.contains_key(pid) {
-                let _ = map.delete(&pid.to_ne_bytes());
+            if desired.contains_key(pid) {
+                continue;
+            }
+            match map.delete(&pid.to_ne_bytes()).context("gpu_pid_map delete") {
+                Ok(()) => {
+                    applied.remove(pid);
+                }
+                Err(error) => {
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                }
             }
         }
-        *self.previous_gpu_pids.as_mut().unwrap() = current;
+        for (pid, node) in desired {
+            match map
+                .update(&pid.to_ne_bytes(), &node.to_ne_bytes(), MapFlags::ANY)
+                .context("gpu_pid_map update")
+            {
+                Ok(()) => {
+                    applied.insert(*pid, *node);
+                }
+                Err(error) => {
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                }
+            }
+        }
+        *self.previous_gpu_pids.as_mut().unwrap() = applied;
+        if let Some(error) = first_error {
+            return Err(error);
+        }
         Ok(())
     }
 
@@ -897,14 +1003,30 @@ impl<'a> Scheduler<'a> {
         device: &nvml_wrapper::Device<'_>,
         node: u32,
         pid_to_nodes: &mut HashMap<u32, HashSet<u32>>,
-    ) {
-        for proc in device
-            .running_compute_processes()
-            .unwrap_or_default()
-            .into_iter()
-            .chain(device.running_graphics_processes().unwrap_or_default())
-        {
-            pid_to_nodes.entry(proc.pid).or_default().insert(node);
+    ) -> Result<()> {
+        let mut errors = Vec::new();
+
+        match device.running_compute_processes() {
+            Ok(processes) => {
+                for process in processes {
+                    pid_to_nodes.entry(process.pid).or_default().insert(node);
+                }
+            }
+            Err(error) => errors.push(format!("compute process query failed: {error}")),
+        }
+        match device.running_graphics_processes() {
+            Ok(processes) => {
+                for process in processes {
+                    pid_to_nodes.entry(process.pid).or_default().insert(node);
+                }
+            }
+            Err(error) => errors.push(format!("graphics process query failed: {error}")),
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            bail!(errors.join("; "))
         }
     }
 


### PR DESCRIPTION
## Summary

\NVML reports processes that own GPU contexts, but it does not describe the complete workload. For multiprocess services such as vLLM, NVML reports EngineCore while the API server and helper process remain invisible. Moving only EngineCore toward the GPU can therefore split the request path across NUMA nodes and regress latency.

Use an NVML-reported process as the seed for discovering its exact cgroup workload. Read cgroup.procs and extend the GPU-local NUMA hint to peer process in the same domain cgroup.

A six-pair AB/BA Qwen3-8B vLLM test used fresh services for every arm, 512 requests per arm, 512 input and 128 output tokens, 10 requests/s, and concurrency 32. All 6144 requests completed without failure.

Compared with the same scheduler without GPU awareness:

mean TTFT:  27.704 -> 22.708 ms  (-18.0%)
p95 TTFT:   32.723 -> 26.285 ms  (-19.7%)
p99 TTFT:   35.245 -> 27.920 ms  (-20.8%)
mean TPOT:   8.020 ->  7.332 ms  (-8.6%)
mean E2E:  1046.191 -> 953.897 ms (-8.8%)
throughput:  9.7968 -> 9.8156 req/s (+0.19%)

All six pairs improved. Every GPU-aware map snapshot contained the API, helper, and EngineCore TGIDs on node 0, while NVML directly reported only EngineCore. Earlier process-only testing regressed mean and p99 TTFT by 3.6% and 34.1%, respectively.

### Conservative choices
The initial implementation deliberately avoids guessing:
* Expand only exact cgroup-v2 membership. Child cgroups are not included.
* A direct NVML TGID receives a hint only when all its observed GPUs resolve to exactly one NUMA node.
* If a peer is observed in cgroups associated with conflicting nodes, omit its hint instead of selecting a node based on iteration order.
* Perform cgroup expansion only when the NVML snapshot completed successfully
* Keep --gpu-util-threshold > 0 process-only. Expanding a filtered process set could reintroduce peers intentionally excluded by the threshold.

### capacity policy
gpu_pid_map has 8,192 entries. The implementation does not partially fill the remaining capacity from HashMap iteration:

1. If the complete expanded set fits, use it.
2. If expansion does not fit but the complete direct-NVML set fits, use only the direct set.
3. If even the direct set does not fit, use an empty set.

## Testing
Comparing before/after the change , with `--gpu` enabled


| Metric | before | after | before v.s. after |
|---|---:|---:|---:|
| Mean TTFT | 29.197 ms | 22.708 ms | -22.2% |
| Average per-run p95 TTFT | 44.171 ms | 26.285 ms | -40.5% |
| Average per-run p99 TTFT | 50.329 ms | 27.920 ms | -44.5% |
| Mean TPOT | 7.511 ms | 7.332 ms | -2.4% |
| Mean E2E | 983.047 ms | 953.897 ms | -3.0% |
| Average per-run p99 E2E | 1047.374 ms | 988.946 ms | -5.6% |
| Throughput | 9.8140 req/s | 9.8156 req/s | +0.02% |


