### PR TITLE
scx_mitosis: Three small cleanups

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -1202,12 +1202,10 @@ s32 BPF_STRUCT_OPS(mitosis_cgroup_init, struct cgroup *cgrp, struct scx_cgroup_i
 	return init_cgrp_ctx(cgrp);
 }
 
-s32 BPF_STRUCT_OPS(mitosis_cgroup_exit, struct cgroup *cgrp)
+void BPF_STRUCT_OPS(mitosis_cgroup_exit, struct cgroup *cgrp)
 {
 	if (cpu_controller_disabled)
-		return 0;
-
-	return 0;
+		return;
 }
 
 void BPF_STRUCT_OPS(mitosis_cgroup_move, struct task_struct *p, struct cgroup *from,

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -996,6 +996,20 @@ void BPF_STRUCT_OPS(mitosis_running, struct task_struct *p)
 	}
 }
 
+/*
+ * Smoothed average of a task's per-wake runtime (EWMA, alpha=1/8). Updated in
+ * stopping() after each run. Starts at 0 and converges over ~8 runs. Used by
+ * features like slice shrinking to estimate how long a task typically runs.
+ */
+static inline void update_task_runtime_ewma(struct task_ctx *tctx, u64 used)
+{
+	if (unlikely(!tctx->avg_runtime_ns))
+		/* Init */
+		tctx->avg_runtime_ns = used;
+	else
+		tctx->avg_runtime_ns = (tctx->avg_runtime_ns * 7 + used) / 8;
+}
+
 void BPF_STRUCT_OPS(mitosis_stopping, struct task_struct *p, bool runnable)
 {
 	struct cpu_ctx *cctx;

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -64,7 +64,6 @@ u32 applied_cpuset_seq;
 /* Configuration struct for apply_cell_config, populated by userspace */
 struct cell_config cell_config;
 
-private(all_cpumask) struct bpf_cpumask __kptr *all_cpumask;
 private(root_cgrp) struct cgroup __kptr *root_cgrp;
 
 UEI_DEFINE(uei);
@@ -1261,11 +1260,6 @@ void BPF_STRUCT_OPS(mitosis_set_cpumask, struct task_struct *p, const struct cpu
 	if (!(tctx = lookup_task_ctx(p)))
 		return;
 
-	if (!all_cpumask) {
-		scx_bpf_error("NULL all_cpumask");
-		return;
-	}
-
 	update_task_cpumask(p, tctx);
 }
 
@@ -1312,11 +1306,6 @@ static int init_task_impl(struct task_struct *p, struct cgroup *cgrp)
 		/* Should never happen as we just inserted it above. */
 		bpf_cpumask_release(cpumask);
 		scx_bpf_error("tctx cpumask is unexpectedly populated on init");
-		return -EINVAL;
-	}
-
-	if (!all_cpumask) {
-		scx_bpf_error("missing all_cpumask");
 		return -EINVAL;
 	}
 
@@ -1540,7 +1529,6 @@ void BPF_STRUCT_OPS(mitosis_dump_task, struct scx_dump_ctx *dctx, struct task_st
 
 s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 {
-	struct bpf_cpumask *cpumask;
 	u32 i;
 	s32 ret;
 
@@ -1564,28 +1552,20 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 
 	struct cgroup *old __free(cgroup) = bpf_kptr_xchg(&root_cgrp, no_free_ptr(rootcg));
 
-	/* setup all_cpumask - must be done before cgroup iteration */
-	cpumask = bpf_cpumask_create();
-	if (!cpumask)
-		return -ENOMEM;
-
 	bpf_for(i, 0, nr_possible_cpus)
 	{
 		const volatile u8 *u8_ptr;
 
 		if ((u8_ptr = MEMBER_VPTR(all_cpus, [i / 8]))) {
 			if (*u8_ptr & (1 << (i % 8))) {
-				bpf_cpumask_set_cpu(i, cpumask);
 				dsq_id_t dsq_id = get_cpu_dsq_id(i);
 				if (dsq_is_invalid(dsq_id)) {
-					bpf_cpumask_release(cpumask);
 					scx_bpf_error("Invalid dsq_id for cpu %d, dsq_id: %llx", i,
 						      dsq_id.raw);
 					return -EINVAL;
 				}
 				ret = scx_bpf_create_dsq(dsq_id.raw, ANY_NUMA);
 				if (ret < 0) {
-					bpf_cpumask_release(cpumask);
 					scx_bpf_error(
 						"Failed to create dsq for cpu %d, dsq_id: %llx, ret: %d",
 						i, dsq_id.raw, ret);
@@ -1598,10 +1578,8 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 
 		/* Store the LLC that each cpu belongs to. Used in Dispatch. */
 		struct cpu_ctx *cpu_ctx = lookup_cpu_ctx(i);
-		if (!cpu_ctx) {
-			bpf_cpumask_release(cpumask);
+		if (!cpu_ctx)
 			return -EINVAL;
-		}
 
 		if (enable_llc_awareness) {
 			if (i < MAX_CPUS) // explicit bounds check for verifier
@@ -1611,10 +1589,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(mitosis_init)
 		}
 		cpu_ctx->subcell = 0;
 	}
-
-	cpumask = bpf_kptr_xchg(&all_cpumask, cpumask);
-	if (cpumask)
-		bpf_cpumask_release(cpumask);
 
 	/*
 	 * When CPU controller is disabled, initialize cgrp_ctx for all existing

--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.h
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.h
@@ -141,21 +141,6 @@ struct task_ctx {
 static inline struct task_ctx *lookup_task_ctx(struct task_struct *p);
 static inline struct cpu_ctx *lookup_cpu_ctx(int cpu);
 
-/*
- * Smoothed average of a task's per-wake runtime (EWMA, alpha=1/8).
- * Updated in stopping() after each run. Starts at 0 and converges
- * over ~8 runs. Used by features like slice shrinking to estimate
- * how long a task typically runs.
- */
-static inline void update_task_runtime_ewma(struct task_ctx *tctx, u64 used)
-{
-	if (unlikely(!tctx->avg_runtime_ns))
-		/* Init */
-		tctx->avg_runtime_ns = used;
-	else
-		tctx->avg_runtime_ns = (tctx->avg_runtime_ns * 7 + used) / 8;
-}
-
 extern const volatile bool use_lockless_peek;
 
 /*


### PR DESCRIPTION
Three small scx_mitosis cleanups:

- Move `update_task_runtime_ewma()` out of the header: it has a single
  caller, the stopping path in mitosis.bpf.c.
- Drop the orphaned `all_cpumask`: nothing has consumed it since
  46240f63e544 ("scx_mitosis: Avoid overuse of LO_FALLBACK") replaced the
  whole-system affinity classification with the per-cell
  `all_cell_cpus_allowed`. The `all_cpus` rodata stays, it also gates which
  per-CPU DSQs are created.
- Make `mitosis_cgroup_exit()` return void, matching the `ops.cgroup_exit`
  prototype that the `(void *)` cast in the ops table was hiding.

No functional change intended by any of the three.
