### PR TITLE
scx_mitosis: Fix solo-task placement staleness and test script robustness

### DIFF
--- a/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
+++ b/scheds/rust/scx_mitosis/src/bpf/mitosis.bpf.c
@@ -421,10 +421,11 @@ static s32 pick_idle_cpu_from(struct task_struct *p, const struct cpumask *cand_
 }
 
 /* Check if we need to update the cell/cpumask mapping */
-static __always_inline int maybe_refresh_cell(struct task_struct *p, struct task_ctx *tctx)
+/* True when the task's cell/cpumask mapping is stale, read-only */
+static __always_inline bool task_needs_refresh(struct task_struct *p, struct task_ctx *tctx)
 {
 	if (tctx->configuration_seq != READ_ONCE(applied_configuration_seq))
-		return refresh_task_cell(p, tctx);
+		return true;
 
 	/*
 	 * When not using CPU controller, check if task's cgroup changed.
@@ -440,9 +441,17 @@ static __always_inline int maybe_refresh_cell(struct task_struct *p, struct task
 		}
 
 		if (current_cgid != tctx->cgid)
-			return refresh_task_cell(p, tctx);
+			return true;
 	}
 
+	return false;
+}
+
+/* Check if we need to update the cell/cpumask mapping */
+static __always_inline int maybe_refresh_cell(struct task_struct *p, struct task_ctx *tctx)
+{
+	if (task_needs_refresh(p, tctx))
+		return refresh_task_cell(p, tctx);
 	return 0;
 }
 
@@ -746,10 +755,13 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 		if (cpu < 0)
 			return;
 
-	} else if (!__COMPAT_is_enq_cpu_selected(enq_flags)) {
+	} else if (!__COMPAT_is_enq_cpu_selected(enq_flags) || (enq_flags & SCX_ENQ_LAST)) {
 		/*
 		 * If we haven't selected a cpu, then we haven't looked for and kicked an
-		 * idle CPU. Let's do the lookup now.
+		 * idle CPU. Let's do the lookup now. SCX_ENQ_LAST enqueues skip
+		 * select_cpu() and this cpu is going idle, tested explicitly as
+		 * they must end in a kick to guarantee a follow-up scheduling
+		 * event.
 		 */
 		if (!(cctx = lookup_cpu_ctx(-1)))
 			return;
@@ -852,7 +864,7 @@ void BPF_STRUCT_OPS(mitosis_enqueue, struct task_struct *p, u64 enq_flags)
 	}
 
 	/* Kick the CPU if needed */
-	if (!__COMPAT_is_enq_cpu_selected(enq_flags) && cpu >= 0)
+	if ((!__COMPAT_is_enq_cpu_selected(enq_flags) || (enq_flags & SCX_ENQ_LAST)) && cpu >= 0)
 		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
 }
 
@@ -914,14 +926,37 @@ void BPF_STRUCT_OPS(mitosis_dispatch, s32 cpu, struct task_struct *prev)
 		found = true;
 	}
 
-	/*
-	 * If we failed to find an eligible task, try the sibling LLC DSQs.
-	 * Otherwise, scx will keep running prev if prev->scx.flags &
-	 * SCX_TASK_QUEUED (we don't set SCX_OPS_ENQ_LAST), and otherwise go idle.
-	 */
+	/* If we failed to find an eligible task, try the sibling LLC DSQs. */
 	if (!found) {
-		if (enable_llc_awareness && !try_stealing_work(cell, subcell_id, llc))
+		if (enable_llc_awareness && !try_stealing_work(cell, subcell_id, llc)) {
 			cstat_inc(CSTAT_STEAL, cell, cctx);
+			return;
+		}
+
+		/*
+		 * Nothing to run. Extend the slice of a still-runnable prev
+		 * whose placement is current and still names this cpu.
+		 * Otherwise let the SCX_ENQ_LAST enqueue re-place the task, its
+		 * kicks provide the follow-up scheduling event while this cpu
+		 * goes idle.
+		 */
+		if (prev && (prev->scx.flags & SCX_TASK_QUEUED)) {
+			struct task_ctx *tctx;
+			bool stay = false;
+
+			if (!(tctx = lookup_task_ctx(prev)))
+				return;
+
+			if (!task_needs_refresh(prev, tctx)) {
+				if (tctx->all_cell_cpus_allowed)
+					stay = tctx->cell == cell && tctx->subcell == subcell_id;
+				else
+					stay = tctx->dsq.raw == cpu_dsq.raw;
+			}
+
+			if (stay)
+				scx_bpf_task_set_slice(prev, slice_ns);
+		}
 		return;
 	}
 
@@ -2128,6 +2163,14 @@ int apply_cell_config(void *ctx)
 
 // clang-format off
 SCX_OPS_DEFINE(mitosis,
+	       /*
+		* Placement refresh is enqueue-driven: without ENQ_LAST the core
+		* keeps a solo task running with no enqueue, so it never notices
+		* a configuration change. dispatch() extends the slice of a solo
+		* task whose placement remains valid, so the enqueue only fires
+		* when the task must leave the cpu.
+		*/
+	       .flags			= SCX_OPS_ENQ_LAST,
 	       .select_cpu		= (void *)mitosis_select_cpu,
 	       .enqueue			= (void *)mitosis_enqueue,
 	       .dispatch		= (void *)mitosis_dispatch,

--- a/scheds/rust/scx_mitosis/test/test_affinity_load_balance.sh
+++ b/scheds/rust/scx_mitosis/test/test_affinity_load_balance.sh
@@ -108,6 +108,9 @@ trap cleanup EXIT INT TERM
 
 start_scheduler() {
     mkdir -p "$CGROUP_BASE"
+    if ! grep -qw "cpu" "$CGROUP_BASE/cgroup.controllers" 2>/dev/null; then
+        echo "+cpu" > /sys/fs/cgroup/cgroup.subtree_control
+    fi
     if ! grep -q "cpu" "$CGROUP_BASE/cgroup.subtree_control" 2>/dev/null; then
         echo "+cpu" > "$CGROUP_BASE/cgroup.subtree_control"
     fi
@@ -121,7 +124,13 @@ start_scheduler() {
 
     "$SCHEDULER_BIN" "${scheduler_args[@]}" > /tmp/scx_mitosis_affinity.log 2>&1 &
     SCHED_PID=$!
-    sleep 3
+    # Wait for scheduler to attach: scheduler startup can take a while
+    # on large machines.
+    for _ in $(seq 1 120); do
+        [[ "$(cat /sys/kernel/sched_ext/state 2>/dev/null)" == "enabled" ]] && break
+        ps -p "$SCHED_PID" > /dev/null 2>&1 || break
+        sleep 0.5
+    done
 
     if ! ps -p "$SCHED_PID" > /dev/null 2>&1; then
         echo -e "${RED}Failed to start scx_mitosis${NC}"

--- a/scheds/rust/scx_mitosis/test/test_cell_churn.sh
+++ b/scheds/rust/scx_mitosis/test/test_cell_churn.sh
@@ -68,6 +68,9 @@ echo -e "${YELLOW}MANAGED CELL EXHAUSTION / REUSE TEST${NC}"
 echo -e "${YELLOW}========================================${NC}\n"
 
 mkdir -p "$CGROUP_BASE"
+if ! grep -qw "cpu" "$CGROUP_BASE/cgroup.controllers" 2>/dev/null; then
+    echo "+cpu" > /sys/fs/cgroup/cgroup.subtree_control
+fi
 if ! grep -q "cpu" "$CGROUP_BASE/cgroup.subtree_control" 2>/dev/null; then
     echo "+cpu" > "$CGROUP_BASE/cgroup.subtree_control"
 fi
@@ -75,7 +78,13 @@ fi
 echo -e "${YELLOW}Starting scx_mitosis with managed parent /test.slice${NC}"
 "$SCHEDULER_BIN" --cell-parent-cgroup /test.slice > "$LOG_FILE" 2>&1 &
 SCHED_PID=$!
-sleep 3
+# Wait for scheduler to attach: scheduler startup can take a while
+# on large machines.
+for _ in $(seq 1 120); do
+    [[ "$(cat /sys/kernel/sched_ext/state 2>/dev/null)" == "enabled" ]] && break
+    ps -p "$SCHED_PID" > /dev/null 2>&1 || break
+    sleep 0.5
+done
 
 if ! ps -p "$SCHED_PID" > /dev/null 2>&1; then
     echo -e "${RED}scx_mitosis failed to start${NC}"

--- a/scheds/rust/scx_mitosis/test/test_cell_exclude.sh
+++ b/scheds/rust/scx_mitosis/test/test_cell_exclude.sh
@@ -66,6 +66,9 @@ fi
 
 log_info "Preparing cgroup hierarchy under $CGROUP_BASE"
 sudo mkdir -p "$CGROUP_BASE"
+if ! grep -qw "cpu" "$CGROUP_BASE/cgroup.controllers" 2>/dev/null; then
+    echo "+cpu" | sudo tee /sys/fs/cgroup/cgroup.subtree_control > /dev/null
+fi
 if ! grep -q "cpu" "$CGROUP_BASE/cgroup.subtree_control" 2>/dev/null; then
     echo "+cpu" | sudo tee "$CGROUP_BASE/cgroup.subtree_control" > /dev/null
 fi
@@ -77,7 +80,13 @@ sudo "$SCHEDULER_BIN" \
     --cell-exclude "$EXCLUDED_NAME" \
     > "$LOG_FILE" 2>&1 &
 SCHED_PID=$!
-sleep 3
+# Wait for scheduler to attach: scheduler startup can take a while
+# on large machines.
+for _ in $(seq 1 120); do
+    [[ "$(cat /sys/kernel/sched_ext/state 2>/dev/null)" == "enabled" ]] && break
+    ps -p "$SCHED_PID" > /dev/null 2>&1 || break
+    sleep 0.5
+done
 
 if ! ps -p "$SCHED_PID" > /dev/null 2>&1; then
     log_error "Scheduler failed to start"

--- a/scheds/rust/scx_mitosis/test/test_cell_isolation.sh
+++ b/scheds/rust/scx_mitosis/test/test_cell_isolation.sh
@@ -205,7 +205,11 @@ create_cgroups() {
         sudo mkdir -p "$CGROUP_BASE"
     fi
 
-    # Enable CPU controller for children (required for sched_ext cgroup callbacks)
+    # Enable CPU controller for children (required for sched_ext cgroup callbacks).
+    # The root may not delegate cpu on minimal systems, enable it there first.
+    if ! grep -qw "cpu" "$CGROUP_BASE/cgroup.controllers" 2>/dev/null; then
+        echo "+cpu" | sudo tee /sys/fs/cgroup/cgroup.subtree_control > /dev/null
+    fi
     if ! grep -q "cpu" "$CGROUP_BASE/cgroup.subtree_control" 2>/dev/null; then
         log_info "Enabling CPU controller for $CGROUP_BASE children"
         echo "+cpu" | sudo tee "$CGROUP_BASE/cgroup.subtree_control" > /dev/null
@@ -237,8 +241,13 @@ start_scheduler() {
 
     log_info "Scheduler PID: $SCHED_PID"
 
-    # Wait for scheduler to attach
-    sleep 3
+    # Wait for scheduler to attach: scheduler startup can take a while
+    # on large machines.
+    for _ in $(seq 1 120); do
+        [[ "$(cat /sys/kernel/sched_ext/state 2>/dev/null)" == "enabled" ]] && break
+        ps -p "$SCHED_PID" > /dev/null 2>&1 || break
+        sleep 0.5
+    done
 
     # Verify scheduler is running
     if ! ps -p "$SCHED_PID" > /dev/null 2>&1; then
@@ -456,12 +465,20 @@ test_dynamic_cell_lifecycle() {
 
     log_info "Found $procs processes in dynamic cell"
 
-    # Stop the workload
+    # Stop the workload and remove the cell. Retry the rmdir: the cgroup
+    # stays busy until the killed workers are fully reaped, which can take
+    # a while, and exiting tasks pin it even after cgroup.procs reads
+    # empty.
     sudo pkill -f "stress-ng.*cpu" 2>/dev/null || true
-    sleep 2
-
-    # Remove the cell
-    sudo rmdir "$cell_path"
+    for _ in $(seq 1 60); do
+        sudo rmdir "$cell_path" 2>/dev/null && break
+        sleep 0.5
+    done
+    if [[ -d "$cell_path" ]]; then
+        log_error "Failed to remove dynamic cell cgroup"
+        record_result "dynamic_cell_lifecycle" "FAILED"
+        return 1
+    fi
     sleep 3
 
     # Verify destruction logged
@@ -750,7 +767,13 @@ test_cpu_rebalancing_demand() {
         > "$LOG_FILE" 2>&1 &
     SCHED_PID=$!
 
-    sleep 3
+    # Wait for scheduler to attach: scheduler startup can take a while
+    # on large machines.
+    for _ in $(seq 1 120); do
+        [[ "$(cat /sys/kernel/sched_ext/state 2>/dev/null)" == "enabled" ]] && break
+        ps -p "$SCHED_PID" > /dev/null 2>&1 || break
+        sleep 0.5
+    done
 
     # Verify scheduler is running
     if ! ps -p "$SCHED_PID" > /dev/null 2>&1; then
@@ -948,10 +971,23 @@ test_cpuset_change() {
         fi
     done
 
+    # a previous test's cleanup may have removed the base cgroup
+    sudo mkdir -p "$CGROUP_BASE"
+    if ! grep -qw "cpu" "$CGROUP_BASE/cgroup.controllers" 2>/dev/null; then
+        echo "+cpu" | sudo tee /sys/fs/cgroup/cgroup.subtree_control > /dev/null
+    fi
+    if ! grep -q "cpu" "$CGROUP_BASE/cgroup.subtree_control" 2>/dev/null; then
+        echo "+cpu" | sudo tee "$CGROUP_BASE/cgroup.subtree_control" > /dev/null
+    fi
     sudo mkdir -p "$cell_a"
     sudo mkdir -p "$cell_b"
 
-    # Enable cpuset controller for children of test.slice
+    # Enable cpuset controller for children of test.slice. The root may not
+    # delegate cpuset (systemd enables only cpu/memory/pids by default), so
+    # enable it there first.
+    if ! grep -q "cpuset" "$CGROUP_BASE/cgroup.controllers" 2>/dev/null; then
+        echo "+cpuset" | sudo tee /sys/fs/cgroup/cgroup.subtree_control > /dev/null
+    fi
     if ! grep -q "cpuset" "$CGROUP_BASE/cgroup.subtree_control" 2>/dev/null; then
         echo "+cpuset" | sudo tee "$CGROUP_BASE/cgroup.subtree_control" > /dev/null
     fi
@@ -1120,7 +1156,13 @@ test_new_cell_gets_fair_share() {
         > "$LOG_FILE" 2>&1 &
     SCHED_PID=$!
 
-    sleep 3
+    # Wait for scheduler to attach: scheduler startup can take a while
+    # on large machines.
+    for _ in $(seq 1 120); do
+        [[ "$(cat /sys/kernel/sched_ext/state 2>/dev/null)" == "enabled" ]] && break
+        ps -p "$SCHED_PID" > /dev/null 2>&1 || break
+        sleep 0.5
+    done
 
     # Verify scheduler is running
     if ! ps -p "$SCHED_PID" > /dev/null 2>&1; then

--- a/scheds/rust/scx_mitosis/test/test_llc_drain_affinity_rebalance.sh
+++ b/scheds/rust/scx_mitosis/test/test_llc_drain_affinity_rebalance.sh
@@ -367,6 +367,9 @@ build_helper
 rm -f "$LOG_FILE" "$MONITOR_LOG_FILE"
 
 mkdir -p "$CGROUP_BASE/$VICTIM_NAME"
+if ! grep -qw cpu "$CGROUP_BASE/cgroup.controllers" 2>/dev/null; then
+    echo "+cpu" > /sys/fs/cgroup/cgroup.subtree_control
+fi
 if ! grep -qw cpu "$CGROUP_BASE/cgroup.subtree_control" 2>/dev/null; then
     echo "+cpu" > "$CGROUP_BASE/cgroup.subtree_control"
 fi
@@ -386,7 +389,13 @@ info "Starting scx_mitosis"
     > "$LOG_FILE" 2>&1 &
 SCHED_PID="$!"
 
-sleep 2
+# Wait for scheduler to attach: scheduler startup can take a while
+# on large machines.
+for _ in $(seq 1 120); do
+    [[ "$(cat /sys/kernel/sched_ext/state 2>/dev/null)" == "enabled" ]] && break
+    ps -p "$SCHED_PID" >/dev/null 2>&1 || break
+    sleep 0.5
+done
 if ! ps -p "$SCHED_PID" >/dev/null 2>&1; then
     error "scx_mitosis failed to start"
     cat "$LOG_FILE"


### PR DESCRIPTION
A task that is alone on its cpu is kept running by the sched_ext core without ever re-enqueueing, so it never notices cell reconfigurations and can camp on another cell's cpu indefinitely, violating isolation. Set SCX_OPS_ENQ_LAST, with dispatch extending the slice of a solo task whose placement is still valid, so the flag costs one seq check per slice in steady state; a task that must leave goes through the ENQ_LAST enqueue and the cpu goes idle.

The keep/evict behavior was verified with trace instrumentation on an 8-cpu VM: a solo hog is kept via slice extension with no idle bounces and zero ENQ_LAST enqueues, and a cpuset reconfiguration evicts it with exactly one ENQ_LAST enqueue, migrating it into the new cpu range within a slice. The isolation test suite passes identically to the unpatched scheduler on the same VM, and the test script fixes were exercised on a 192-cpu dual-socket machine where the timing assumptions were originally caught.
