### PR TITLE
lib/sdt_task: free task data without deleting task_storage

### DIFF
--- a/lib/sdt_task.bpf.c
+++ b/lib/sdt_task.bpf.c
@@ -85,21 +85,29 @@ void __arena *scx_task_data(struct task_struct *p)
 	return data;
 }
 
+/*
+ * Repeated and concurrent frees are no-ops: whoever claims the pointer frees
+ * the allocation. The task_storage entry is left for the kernel to reclaim
+ * when the task itself is freed, which takes the immediate free path and keeps
+ * task exit off RCU-tasks-trace deferral.
+ */
 __hidden
 void scx_task_free(struct task_struct *p)
 {
 	struct scx_task_map_val *mval;
+	void __arena *data;
 
 	scx_arena_subprog_init();
 
 	mval = bpf_task_storage_get(&scx_task_map, p, 0, 0);
-	if (!mval) {
-		scx_err_loc("bpf_task_storage_get failed");
+	if (unlikely(!mval))
 		return;
-	}
 
-	scx_alloc_free_idx(&scx_task_allocator, mval->tid.idx);
-	bpf_task_storage_delete(&scx_task_map, p);
+	data = (void __arena *)__sync_lock_test_and_set((__u64 *)&mval->data, 0);
+	if (unlikely(!data))
+		return;
+
+	scx_free(&scx_task_allocator, data);
 }
 
 static struct scx_urcu scx_task_urcu;


### PR DESCRIPTION
scx_task_free() called bpf_task_storage_delete() on every task exit. The explicit delete defers the storage-element free through call_rcu_tasks_trace() (kernel/bpf/bpf_local_storage.c). Under mass task exit this produces a burst of RCU-tasks-trace callbacks, driving the RCU-tasks-trace callback-queuing autoscaler to oscillate between single-CPU and per-CPU queuing. That is what emits the recurring dmesg pair:

    Switching RCU Tasks Trace to per-CPU callback queuing.
    Starting switch RCU Tasks Trace to CPU-0 callback queuing.

The explicit delete is unnecessary. When a task is freed the kernel tears down its task_storage via bpf_local_storage_destroy(), which frees the element immediately without call_rcu_tasks_trace(). Not deleting lets that path reclaim the element and keeps task exit off RCU-tasks-trace deferral.

Drop bpf_task_storage_delete() and free only the arena allocation, mirroring scx_cgrp_free(): atomically claim mval->data so repeated and concurrent frees are no-ops, then scx_free() the payload. This restores the non-deleting behavior from before the delete was added as a cleanup.

Fixes: 5c16eb5ad5f9 ("sdt_task: Avoid use-after-free after deleting task_storage")