### PR TITLE
common.bpf.h: probe the BPF prolog on the cid-form attach path too

### DIFF
--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -675,10 +675,20 @@ macro_rules! scx_ops_open {
 /// Open a cid-form (struct sched_ext_ops_cid) skeleton. Pair with
 /// scx_ops_cid_load!(), which skips the fix-ups for the cpu-form-only cgroup
 /// callbacks that don't exist in the cid form.
+///
+/// A cid-form scheduler enters the kernel through bpf_scx_reg_cid() rather
+/// than bpf_scx_reg(), so it needs the matching prolog probe from
+/// common.bpf.h. The cid form only exists from v7.2, and so does
+/// bpf_scx_reg_cid(), so the probe can be enabled unconditionally here.
 #[macro_export]
 macro_rules! scx_ops_cid_open {
     ($builder: expr, $obj_ref: expr, $ops: ident, $open_opts: expr) => {
-        $crate::__scx_ops_open!($builder, $obj_ref, $ops, "sched_ext_ops_cid", $open_opts)
+        $crate::__scx_ops_open!($builder, $obj_ref, $ops, "sched_ext_ops_cid", $open_opts).map(
+            |mut skel| {
+                skel.progs.scx_lib_init_probe_cid.set_autoload(true);
+                skel
+            },
+        )
     };
 }
 

--- a/rust/scx_utils/src/compat.rs
+++ b/rust/scx_utils/src/compat.rs
@@ -676,17 +676,19 @@ macro_rules! scx_ops_open {
 /// scx_ops_cid_load!(), which skips the fix-ups for the cpu-form-only cgroup
 /// callbacks that don't exist in the cid form.
 ///
-/// A cid-form scheduler enters the kernel through bpf_scx_reg_cid() rather
-/// than bpf_scx_reg(), so it needs the matching prolog probe from
-/// common.bpf.h. The cid form only exists from v7.2, and so does
-/// bpf_scx_reg_cid(), so the probe can be enabled unconditionally here.
+/// A cid-form scheduler registers through bpf_scx_reg_cid() rather than
+/// bpf_scx_reg(), so common.bpf.h's prolog probe gets repointed at it. Both
+/// the cid form and bpf_scx_reg_cid() appeared in v7.2, so a kernel that
+/// accepts this skeleton always has the symbol.
 #[macro_export]
 macro_rules! scx_ops_cid_open {
     ($builder: expr, $obj_ref: expr, $ops: ident, $open_opts: expr) => {
-        $crate::__scx_ops_open!($builder, $obj_ref, $ops, "sched_ext_ops_cid", $open_opts).map(
+        $crate::__scx_ops_open!($builder, $obj_ref, $ops, "sched_ext_ops_cid", $open_opts).and_then(
             |mut skel| {
-                skel.progs.scx_lib_init_probe_cid.set_autoload(true);
-                skel
+                skel.progs
+                    .scx_lib_init_probe
+                    .set_attach_target(0, Some("bpf_scx_reg_cid".to_string()))?;
+                ::anyhow::Result::Ok(skel)
             },
         )
     };

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -532,9 +532,9 @@ static __always_inline const struct cpumask *cast_mask(struct bpf_cpumask *mask)
 
 /*
  * True if the non-sleepable BPF trampoline prolog (__bpf_prog_enter) calls
- * migrate_disable() for the current task. Recorded once by the prolog probes
- * below, which fire during the natural scheduler-attach call chain
- * (auto-attached by scx_ops_attach!).
+ * migrate_disable() for the current task. Recorded once by
+ * scx_lib_init_probe, an fentry program that fires during the natural
+ * scheduler-attach call chain (auto-attached by scx_ops_attach!).
  *
  * Defaults to false (conservative). Over-reporting in is_migration_disabled()
  * causes local-only dispatch, which is safe. Under-reporting can crash the
@@ -542,40 +542,25 @@ static __always_inline const struct cpumask *cast_mask(struct bpf_cpumask *mask)
  */
 bool __scx_prolog_disables_migration __weak = false;
 
-static __always_inline void __scx_record_prolog_migration(void)
-{
-	if (bpf_core_field_exists(((struct task_struct *)0)->migration_disabled)) {
-		const struct task_struct *p = bpf_get_current_task_btf();
-		unsigned int md = p->migration_disabled;
-
-		if (md > 1)
-			bpf_printk("scx prolog probe: unexpected migration_disabled=%u "
-				   "upstream of BPF prolog; probe result unreliable",
-				   md);
-
-		__scx_prolog_disables_migration = md > 0;
-	}
-}
-
 /*
- * Non-sleepable prolog probes.
+ * scx_lib_init_probe - non-sleepable prolog probe.
  *
- * Attached to the .reg callbacks of the sched_ext struct_ops types
- * (kernel/sched/ext/ext.c): bpf_scx_reg() serves bpf_sched_ext_ops and
- * bpf_scx_reg_cid() serves bpf_sched_ext_ops_cid. They are separate
- * functions, so a cid-form scheduler never enters through bpf_scx_reg() and
- * needs a probe of its own. The kernel's struct_ops machinery invokes them
- * when userspace creates the scheduler link, before ops.init() fires. Their
- * addresses are taken in the vtables, so the symbols are non-inlinable and
- * have been stable since introduction.
+ * Attached to bpf_scx_reg(), the .reg callback in bpf_sched_ext_ops
+ * (kernel/sched/ext.c). The kernel's struct_ops machinery invokes
+ * bpf_scx_reg when userspace creates the scheduler link, before
+ * ops.init() fires. Its address is taken in the vtable, so the symbol
+ * is non-inlinable and has been stable since introduction.
+ *
+ * A cid-form scheduler registers through bpf_scx_reg_cid(), the .reg
+ * callback of bpf_sched_ext_ops_cid, and so never enters bpf_scx_reg().
+ * The cid-form open paths (SCX_OPS_CID_OPEN(), scx_ops_cid_open!())
+ * therefore repoint this program at bpf_scx_reg_cid(). Repointing rather
+ * than adding a second program keeps the object loadable on kernels
+ * predating the cid form, where bpf_scx_reg_cid() has no BTF entry.
  *
  * Entering via fentry runs us through __bpf_prog_enter -- the
  * non-sleepable prolog that consumers of is_migration_disabled() live
  * under.
- *
- * bpf_scx_reg_cid() only exists from v7.2 while this header still builds
- * schedulers for older kernels, so that probe is "?" and the cid-form open
- * paths (SCX_OPS_CID_OPEN(), scx_ops_cid_open!()) switch it on.
  *
  * Loud warning: the prolog adds at most 1 to migration_disabled.
  * Reading > 1 means something upstream in the
@@ -585,14 +570,17 @@ static __always_inline void __scx_record_prolog_migration(void)
 SEC("fentry/bpf_scx_reg") __weak
 int scx_lib_init_probe(void *ctx)
 {
-	__scx_record_prolog_migration();
-	return 0;
-}
+	if (bpf_core_field_exists(((struct task_struct *)0)->migration_disabled)) {
+		const struct task_struct *p = bpf_get_current_task_btf();
+		unsigned int md = p->migration_disabled;
 
-SEC("?fentry/bpf_scx_reg_cid") __weak
-int scx_lib_init_probe_cid(void *ctx)
-{
-	__scx_record_prolog_migration();
+		if (md > 1)
+			bpf_printk("scx_lib_init_probe: unexpected migration_disabled=%u "
+				   "upstream of BPF prolog; probe result unreliable",
+				   md);
+
+		__scx_prolog_disables_migration = md > 0;
+	}
 	return 0;
 }
 
@@ -630,7 +618,7 @@ static inline bool is_migration_disabled(const struct task_struct *p)
 	 * A slow path handles pre-v6.18 kernels without CONFIG_PREEMPT_RCU,
 	 * where the prolog historically called migrate_disable() unconditionally
 	 * but a cherry-picked downstream kernel may not. The runtime-probed flag
-	 * __scx_prolog_disables_migration (set by the prolog probes) distinguishes
+	 * __scx_prolog_disables_migration (set by scx_lib_init_probe) distinguishes
 	 * the two cases without relying on the kernel version alone.
 	 */
 	if (bpf_core_field_exists(p->migration_disabled)) {

--- a/scheds/include/scx/common.bpf.h
+++ b/scheds/include/scx/common.bpf.h
@@ -532,9 +532,9 @@ static __always_inline const struct cpumask *cast_mask(struct bpf_cpumask *mask)
 
 /*
  * True if the non-sleepable BPF trampoline prolog (__bpf_prog_enter) calls
- * migrate_disable() for the current task. Recorded once by
- * scx_lib_init_probe, an fentry program on bpf_scx_reg() that fires during
- * the natural scheduler-attach call chain (auto-attached by scx_ops_attach!).
+ * migrate_disable() for the current task. Recorded once by the prolog probes
+ * below, which fire during the natural scheduler-attach call chain
+ * (auto-attached by scx_ops_attach!).
  *
  * Defaults to false (conservative). Over-reporting in is_migration_disabled()
  * causes local-only dispatch, which is safe. Under-reporting can crash the
@@ -542,38 +542,57 @@ static __always_inline const struct cpumask *cast_mask(struct bpf_cpumask *mask)
  */
 bool __scx_prolog_disables_migration __weak = false;
 
-/*
- * scx_lib_init_probe - non-sleepable prolog probe.
- *
- * Attached to bpf_scx_reg(), the .reg callback in bpf_sched_ext_ops
- * (kernel/sched/ext.c). The kernel's struct_ops machinery invokes
- * bpf_scx_reg when userspace creates the scheduler link, before
- * ops.init() fires. Its address is taken in the vtable, so the symbol
- * is non-inlinable and has been stable since introduction.
- *
- * Entering via fentry runs us through __bpf_prog_enter -- the
- * non-sleepable prolog that consumers of is_migration_disabled() live
- * under.
- *
- * Loud warning: the prolog adds at most 1 to migration_disabled.
- * Reading > 1 means something upstream in the
- * bpf_struct_ops_link_create -> bpf_scx_reg path disabled migration
- * before the prolog ran, invalidating the probe; audit and adjust.
- */
-SEC("fentry/bpf_scx_reg") __weak
-int scx_lib_init_probe(void *ctx)
+static __always_inline void __scx_record_prolog_migration(void)
 {
 	if (bpf_core_field_exists(((struct task_struct *)0)->migration_disabled)) {
 		const struct task_struct *p = bpf_get_current_task_btf();
 		unsigned int md = p->migration_disabled;
 
 		if (md > 1)
-			bpf_printk("scx_lib_init_probe: unexpected migration_disabled=%u "
+			bpf_printk("scx prolog probe: unexpected migration_disabled=%u "
 				   "upstream of BPF prolog; probe result unreliable",
 				   md);
 
 		__scx_prolog_disables_migration = md > 0;
 	}
+}
+
+/*
+ * Non-sleepable prolog probes.
+ *
+ * Attached to the .reg callbacks of the sched_ext struct_ops types
+ * (kernel/sched/ext/ext.c): bpf_scx_reg() serves bpf_sched_ext_ops and
+ * bpf_scx_reg_cid() serves bpf_sched_ext_ops_cid. They are separate
+ * functions, so a cid-form scheduler never enters through bpf_scx_reg() and
+ * needs a probe of its own. The kernel's struct_ops machinery invokes them
+ * when userspace creates the scheduler link, before ops.init() fires. Their
+ * addresses are taken in the vtables, so the symbols are non-inlinable and
+ * have been stable since introduction.
+ *
+ * Entering via fentry runs us through __bpf_prog_enter -- the
+ * non-sleepable prolog that consumers of is_migration_disabled() live
+ * under.
+ *
+ * bpf_scx_reg_cid() only exists from v7.2 while this header still builds
+ * schedulers for older kernels, so that probe is "?" and the cid-form open
+ * paths (SCX_OPS_CID_OPEN(), scx_ops_cid_open!()) switch it on.
+ *
+ * Loud warning: the prolog adds at most 1 to migration_disabled.
+ * Reading > 1 means something upstream in the
+ * bpf_struct_ops_link_create -> .reg path disabled migration
+ * before the prolog ran, invalidating the probe; audit and adjust.
+ */
+SEC("fentry/bpf_scx_reg") __weak
+int scx_lib_init_probe(void *ctx)
+{
+	__scx_record_prolog_migration();
+	return 0;
+}
+
+SEC("?fentry/bpf_scx_reg_cid") __weak
+int scx_lib_init_probe_cid(void *ctx)
+{
+	__scx_record_prolog_migration();
 	return 0;
 }
 
@@ -611,7 +630,7 @@ static inline bool is_migration_disabled(const struct task_struct *p)
 	 * A slow path handles pre-v6.18 kernels without CONFIG_PREEMPT_RCU,
 	 * where the prolog historically called migrate_disable() unconditionally
 	 * but a cherry-picked downstream kernel may not. The runtime-probed flag
-	 * __scx_prolog_disables_migration (set by scx_lib_init_probe) distinguishes
+	 * __scx_prolog_disables_migration (set by the prolog probes) distinguishes
 	 * the two cases without relying on the kernel version alone.
 	 */
 	if (bpf_core_field_exists(p->migration_disabled)) {

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -332,9 +332,17 @@ static inline long scx_hotplug_seq(void)
 /*
  * Open a cid-form (struct sched_ext_ops_cid) skeleton. The cid form postdates
  * every op the load-time fix-ups above handle, so none of them apply.
+ *
+ * The cid form only exists from v7.2, and so does bpf_scx_reg_cid(), so the
+ * prolog probe attached to it can be enabled unconditionally here.
  */
-#define SCX_OPS_CID_OPEN(__ops_name, __scx_name)				\
-	__SCX_OPS_OPEN(__ops_name, __scx_name, "sched_ext_ops_cid")
+#define SCX_OPS_CID_OPEN(__ops_name, __scx_name) ({				\
+	struct __scx_name *__cskel;						\
+										\
+	__cskel = __SCX_OPS_OPEN(__ops_name, __scx_name, "sched_ext_ops_cid");	\
+	bpf_program__set_autoload(__cskel->progs.scx_lib_init_probe_cid, true);	\
+	__cskel;								\
+})
 
 /*
  * Associate non-struct_ops BPF programs with the scheduler's struct_ops map so

--- a/scheds/include/scx/compat.h
+++ b/scheds/include/scx/compat.h
@@ -333,14 +333,17 @@ static inline long scx_hotplug_seq(void)
  * Open a cid-form (struct sched_ext_ops_cid) skeleton. The cid form postdates
  * every op the load-time fix-ups above handle, so none of them apply.
  *
- * The cid form only exists from v7.2, and so does bpf_scx_reg_cid(), so the
- * prolog probe attached to it can be enabled unconditionally here.
+ * A cid-form scheduler registers through bpf_scx_reg_cid() rather than
+ * bpf_scx_reg(), so repoint common.bpf.h's prolog probe at it. Both the cid
+ * form and bpf_scx_reg_cid() appeared in v7.2, so a kernel that accepts this
+ * skeleton always has the symbol.
  */
 #define SCX_OPS_CID_OPEN(__ops_name, __scx_name) ({				\
 	struct __scx_name *__cskel;						\
 										\
 	__cskel = __SCX_OPS_OPEN(__ops_name, __scx_name, "sched_ext_ops_cid");	\
-	bpf_program__set_autoload(__cskel->progs.scx_lib_init_probe_cid, true);	\
+	bpf_program__set_attach_target(__cskel->progs.scx_lib_init_probe, 0,	\
+				       "bpf_scx_reg_cid");			\
 	__cskel;								\
 })
 


### PR DESCRIPTION
scx_lib_init_probe hooks bpf_scx_reg(), but a cid-form scheduler enters through bpf_scx_reg_cid(), so the probe never fires and __scx_prolog_disables_migration keeps its default, leaving is_migration_disabled() to over-report on its slow path. Give that path its own probe. bpf_scx_reg_cid() only exists from v7.2, so the new program is "?" and the cid-form open paths switch it on.