### PR TITLE
scx_cosmos: Avoid redundant shared DSQ kicks

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -1034,6 +1034,20 @@ static bool task_should_migrate(struct task_struct *p, u64 enq_flags)
 }
 
 /*
+ * Return true if a shared DSQ insertion needs an explicit CPU kick.
+ *
+ * ops.select_cpu() normally provides the wakeup side effect for unbound
+ * tasks. Affinity-constrained and migration-disabled tasks can otherwise end
+ * up waiting in a shared DSQ with no eligible CPU checking it, so always kick
+ * their previous CPU.
+ */
+static bool task_needs_shared_dsq_kick(struct task_struct *p, u64 enq_flags)
+{
+	return p->nr_cpus_allowed != nr_cpu_ids || is_migration_disabled(p) ||
+	       task_should_migrate(p, enq_flags);
+}
+
+/*
  * Return true if a task is waking up another task that share the same
  * address space, false otherwise.
  */
@@ -1222,7 +1236,9 @@ void BPF_STRUCT_OPS(cosmos_enqueue, struct task_struct *p, u64 enq_flags)
 	 */
 	scx_bpf_dsq_insert_vtime(p, shared_dsq(prev_cpu),
 				 task_slice(p), task_dl(p, tctx), enq_flags);
-	scx_bpf_kick_cpu(prev_cpu, SCX_KICK_IDLE);
+
+	if (task_needs_shared_dsq_kick(p, enq_flags))
+		scx_bpf_kick_cpu(prev_cpu, SCX_KICK_IDLE);
 }
 
 /*


### PR DESCRIPTION
Commit 59bb398f7af9 made every shared DSQ insertion kick the previous CPU. While this prevents constrained tasks from waiting indefinitely for an eligible CPU to inspect the shared queue, it also adds a kick to the hot enqueue path when ops.select_cpu() already supplied the wakeup side effect. This regresses 7-Zip (and other CPU-intensive benchmarks) on the DGX Spark.

Kick after shared DSQ insertion only for affinity-constrained or migration-disabled tasks, and when ops.select_cpu() was skipped. This retains the wakeup needed by constrained tasks without penalizing regular unbound wakeups.

Fixes: 59bb398f7af9 ("scx_cosmos: Avoid redundant kicks after local dispatch")