### PR TITLE
scx_pandemoniumv5.20.0:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "scx_pandemonium"
-version = "5.19.0"
+version = "5.20.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/scheds/rust/scx_pandemonium/Cargo.toml
+++ b/scheds/rust/scx_pandemonium/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "scx_pandemonium"
-version = "5.19.0"
+version = "5.20.0"
 edition = "2021"
-description = "A behavioral, adaptive sched_ext scheduler with three-tier classification, L2 affinity, and process learning"
+description = "An adaptive sched_ext scheduler: CoDel sojourn ordering, effective-resistance distance pricing and knobs derived each second from measured per-CPU queue behaviour"
 license = "GPL-2.0-only"
 
 [dependencies]

--- a/scheds/rust/scx_pandemonium/README.md
+++ b/scheds/rust/scx_pandemonium/README.md
@@ -10,139 +10,143 @@ PANDEMONIUM is included in the [sched-ext/scx](https://github.com/sched-ext/scx)
 
 ## Performance
 
-12 AMD Zen CPUs (Ryzen 5 3600), kernel 7.1.5-arch1-2, clang 22. EEVDF baseline vs PANDEMONIUM (BPF and ADAPTIVE); external schedulers are omitted from this comparison.
-
-All figures below are v5.18.0, measured 2026-08-17 at **3 iterations** per scheduler.
+12 AMD Zen CPUs (Ryzen 5 3600), kernel 7.2.2-arch1-1, clang 22. EEVDF baseline vs PANDEMONIUM (BPF and ADAPTIVE); external schedulers are omitted from this comparison. **All figures below are the median of N=3 iterations taken in one interleaved session**, so the ratio between arms is the comparable quantity and the absolutes are not comparable to another day's run.
 
 ### P99 Wakeup Latency (interactive probe under CPU saturation)
 
 | Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
 |-------|---------|-------------------|------------------------|
-| 2     | 2,154us | **262us**         | 268us                  |
-| 4     | 3,048us | 73us              | **64us**               |
-| 8     | 1,007us | **65us**          | 149us                  |
-| 12    | 1,740us | **67us**          | **67us**               |
+| 2     | 2,110us | 406us             | **369us**              |
+| 4     | 2,990us | **64us**          | 75us                   |
+| 8     | 920us   | 68us              | **66us**               |
+| 12    | 533us   | 69us              | **67us**               |
 
 ### Burst P99 (fork/exec storm under CPU saturation)
 
 | Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
 |-------|---------|-------------------|------------------------|
-| 2     | 2,074us | **131us**         | 494us                  |
-| 4     | 1,869us | 404us             | **111us**              |
-| 8     | 2,427us | 64us              | **63us**               |
-| 12    | 2,430us | 72us              | **70us**               |
+| 2     | 2,270us | **647us**         | 907us                  |
+| 4     | 1,851us | 943us             | **731us**              |
+| 8     | 2,473us | 1,026us           | **906us**              |
+| 12    | 2,755us | **355us**         | 477us                  |
 
 ### Longrun P99 (interactive latency with sustained CPU-bound long-runners)
 
-| Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|---------|-------------------|------------------------|
-| 2     | 2,605us | **1,115us**       | 1,319us                |
-| 4     | 2,587us | **104us**         | 385us                  |
-| 8     | 1,541us | **65us**          | 190us                  |
-| 12    | 626us   | 69us              | **68us**               |
+| Cores | EEVDF     | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|-----------|-------------------|------------------------|
+| 2     | 2,339us   | 2,075us           | **1,426us**            |
+| 4     | 3,476us   | 1,427us           | **1,257us**            |
+| 8     | 2,230us   | 986us             | **419us**              |
+| 12    | 147us     | 184us             | **130us**              |
 
 ### Mixed Latency P99 (interactive + batch concurrent)
 
-| Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|---------|-------------------|------------------------|
-| 2     | 2,315us | **1,081us**       | 1,712us                |
-| 4     | 2,746us | **65us**          | 989us                  |
-| 8     | 2,243us | **155us**         | 257us                  |
-| 12    | 1,792us | 383us             | **94us**               |
+| Cores | EEVDF     | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|-----------|-------------------|------------------------|
+| 2     | 2,576us   | 2,984us           | **2,101us**            |
+| 4     | 1,998us   | 1,410us           | **1,259us**            |
+| 8     | 1,266us   | **289us**         | 855us                  |
+| 12    | **194us** | 673us             | 982us                  |
 
 ### Deadline Miss Ratio (16.6ms frame target)
 
 | Cores | EEVDF | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
 |-------|-------|-------------------|------------------------|
-| 2     | 23.4% | 1.1%              | **0.7%**               |
-| 4     | 12.9% | **0.4%**          | **0.4%**               |
-| 8     | 12.3% | **0.2%**          | 0.3%                   |
-| 12    | 10.8% | **0.1%**          | 0.2%                   |
+| 2     | 19.5% | **1.0%**          | 1.5%                   |
+| 4     | 12.2% | **0.2%**          | 0.3%                   |
+| 8     | 10.8% | **0.1%**          | 0.3%                   |
+| 12    | 12.9% | **0.0%**          | 0.1%                   |
 
 ### App Launch (`fork()`+`exec()` under load, p99 us)
 
-| Cores | EEVDF   | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-------|---------|-------------------|------------------------|
-| 2     | 2,484us | 2,629us           | **1,629us**            |
-| 4     | 2,195us | 3,331us           | **1,393us**            |
-| 8     | 3,564us | 2,900us           | **2,418us**            |
-| 12    | 3,638us | 3,505us           | **3,503us**            |
-
-ADAPTIVE beats EEVDF at every width and BPF at three of four. Read this one with its sample count in mind: the launch probe runs 100 launches per cell, so a p99 is the second-worst single draw rather than a settled statistic, and individual cells move several-fold between runs of identical code. The v5.18.0 quantum bound removed a reproducible ~16ms outlier that had been the worst cell at every width. IPC is PANDEMONIUM's weak workload — broken out by primitive below.
+| Cores | EEVDF       | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-------|-------------|-------------------|------------------------|
+| 2     | 2,147us     | 1,821us           | **1,669us**            |
+| 4     | 2,138us     | **1,421us**       | 2,325us                |
+| 8     | 3,434us     | 2,537us           | **1,475us**            |
+| 12    | 3,472us     | 2,427us           | **1,623us**            |
 
 ### IPC Round-Trip by Primitive (12C, p50 / p99 us)
 
-| Primitive | EEVDF      | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
-|-----------|------------|-------------------|------------------------|
-| pipe      | 8 / 15      | 11 / 1,383        | 11 / 1,371             |
-| socket    | 16 / 26     | 13 / 1,400        | 13 / 1,445             |
-| eventfd   | 9 / 13      | 12 / 573          | 18 / **32**            |
-| sem       | 12 / 17     | 22 / **35**       | 17 / **30**            |
-| fanout    | 98 / 2,911  | 145 / **2,007**   | 148 / 2,611            |
-
-IPC is PANDEMONIUM's weakest workload and EEVDF leads it at the tail on the paired primitives. The *median* round-trip is at parity or better on socket and within a few microseconds on pipe. `sem` and `eventfd` are at or near EEVDF's tail (30–35us against 13–17us on sem), and 1:N fanout p99 now beats it outright (2.01ms against 2.91ms). The gap is concentrated in pipe and socket p99: ~1.4ms against EEVDF's 15–26us.
-
-The mechanism is not dispatch latency. The wall is **seat topology**. A pair whose two halves settle on the *same* CPU sends every reply's preempt kick to the CPU its partner is running on, so the partner is preempted mid-stint on every exchange and its resume waits out a conveyor-stint remainder — about 1ms per round trip, spent *running*, which is why it never appears in wake latency. Pairs that settle on different CPUs read 3.3us. At 12 cores, seated tasks (98–99% single-anchor) read p99 136–291us, under the tick floor at full saturation; wanderers and same-seat colliders carry the tail. The steal-side pair-warming hold that keeps a won seat is in place; the two remaining fixes — breaking the same-seat attractor at task birth, and queueing rather than preempting a same-CPU partner wake — are not built yet.
-
-This is specific to the paired-IPC shape, not to dispatch generally. On the cold-wake starvation probe at the same width, PANDEMONIUM floors a single wake against EEVDF's 70, with p99 7.4us against 45.3us and p999 57.6us against 670us.
+| Primitive | EEVDF          | PANDEMONIUM (BPF) | PANDEMONIUM (ADAPTIVE) |
+|-----------|----------------|-------------------|------------------------|
+| pipe      | **9 / 15**     | 11 / 1,372        | 14 / 908               |
+| socket    | **16 / 23**    | 22 / 743          | 27 / 1,016             |
+| eventfd   | **9 / 13**     | 18 / 28           | 18 / 26                |
+| sem       | **9 / 13**     | 23 / 42           | 18 / 34                |
+| fanout    | **51** / 2,840 | 74 / 1,638        | 83 / **1,588**         |
 
 ### Fork/Thread IPC (`perf bench sched messaging -t -g 24 -l 6000`, 12C)
 
 | Scheduler                | Time        | vs EEVDF | Cache Misses | Cache Refs | IPC       |
 |--------------------------|-------------|----------|--------------|------------|-----------|
-| EEVDF                    | **16.053s** | baseline | **3.50G**    | 25.81G     | **0.481** |
-| PANDEMONIUM (BPF)        | 21.127s     | +31.6%   | 5.77G        | 35.66G     | 0.426     |
-| PANDEMONIUM (ADAPTIVE)   | 21.514s     | +34.0%   | 6.12G        | 37.11G     | 0.421     |
+| EEVDF                    | **17.198s** | baseline | **3.67G**    | **26.08G** | **0.493** |
+| PANDEMONIUM (BPF)        | 23.346s     | +35.7%   | 6.36G        | 37.17G     | 0.410     |
+| PANDEMONIUM (ADAPTIVE)   | 23.199s     | +34.9%   | 6.42G        | 37.17G     | 0.412     |
 
-The fork/exec storm is PANDEMONIUM's hardest case and its clearest trade. It issues **15.7× the cpu-migrations** (2.97M vs 190K), which costs 1.65× the cache misses (16.18% vs 13.57% miss rate), drops IPC to 0.426, and lands as 32% more wall time. What it buys on the same run is a **4.5× better wake2run p99** — 16,640us against EEVDF's 74,248us. Across three runs on 2026-08-18 the wall cost ranged +23.3% to +33.6% and the wake2run win held at 4.3–4.8×; the table above is the middle run.
+Wake-to-run p99 is the other half of that trade: EEVDF 75,541us against PANDEMONIUM's
+8,734us (BPF) and 8,767us (ADAPTIVE) — **8.6x better** on the arm that costs 35.7% more
+wall time.
 
-The migrations are mostly not a placement error. Traced by cache-tier distance, **74.7% stay inside L3 against EEVDF's 79.6%** — Φ keeps three moves in four local, but the ~5-point gap is real and did not appear in earlier captures, so a share of the count is now landing further out than EEVDF's. The dominant term is still count: aggregate cost is count × distance and Φ prices only the second factor. Cutting the count without giving the tail back is standing work; deepening the per-CPU queues was measured on 2026-08-17 and made it worse (migrations +44%, wall +16 points), so the depth gate is holding the count down, not driving it up.
+| Scheduler                | Mig/s       | same-L2   | same-L3 | same-socket | Decay          |
+|--------------------------|-------------|-----------|---------|-------------|----------------|
+| EEVDF                    | **5,380**   | 36.3%     | 45.3%   | 18.5%       | 1.25/0.41/0.00 |
+| PANDEMONIUM (BPF)        | 38,125      | **62.4%** | 34.6%   | **2.9%**    | **0.56/0.09**  |
+| PANDEMONIUM (ADAPTIVE)   | 37,575      | 62.1%     | 35.1%   | 2.8%        | 0.56/0.08      |
+
+Migrations are reported as a RATE, not a count: The arms do not run for the same number of
+seconds, so a count rewards the slower arm for the extra time alone. Decay is each tier's
+share over the previous one — below 1.00 throughout means migration density FALLS with
+distance, and EEVDF's 1.25 means it RISES. montauk classes the two arms differently on this
+capture, EEVDF `SCATTERED` against PANDEMONIUM `CACHE-LOCAL`. Every arm captured at 100%
+completeness, so the rates are comparable rather than sampled.
 
 ### Energy Efficiency (`prism --dev power`, 12C)
 
-3 runs per (scheduler, workload), 30s cooldown between runs (2026-08-17). Package energy via `perf stat -a -e power/energy-pkg/`. Zen 2 (Ryzen 5 3600) exposes only `J_pkg` (no per-core or per-DRAM RAPL).
+3 runs per (scheduler, workload), 30s cooldown between runs. Package energy via `perf stat -a -e power/energy-pkg/`. Zen 2 (Ryzen 5 3600) exposes only `J_pkg` (no per-core or per-DRAM RAPL).
 
 **Idle floor** (30s `sleep`, scheduler restlessness):
 
-| Scheduler                | J_pkg   | Avg W    | vs EEVDF |
-|--------------------------|---------|----------|----------|
-| EEVDF                    | 706.35J | 23.53W   | baseline |
-| PANDEMONIUM (BPF)        | 702.32J | 23.39W   | -0.6%    |
-| PANDEMONIUM (ADAPTIVE)   | **697.96J** | **23.25W** | **-1.2%** |
-
-At rest both arms idle fractionally below EEVDF. The idle floor is sensitive to background work, so treat all three as at-parity rather than as a win.
+| Scheduler                | J_pkg       | Avg W      | vs EEVDF |
+|--------------------------|-------------|------------|----------|
+| EEVDF                    | 693.82J     | 23.11W     | baseline |
+| PANDEMONIUM (BPF)        | **692.72J** | **23.07W** | **-0.2%** |
+| PANDEMONIUM (ADAPTIVE)   | 694.21J     | 23.12W     | +0.1%    |
 
 **Messaging** (`perf bench sched messaging`, fork-storm + IPC):
 
-| Scheduler                | Wall_s  | J_pkg       | J/op         | vs EEVDF  |
-|--------------------------|---------|-------------|--------------|-----------|
-| EEVDF                    | 15.53s  | **977.52J** | **169.71uJ** | baseline  |
-| PANDEMONIUM (BPF)        | 17.18s  | 1,065.92J   | 185.05uJ     | +9.0%     |
-| PANDEMONIUM (ADAPTIVE)   | 17.69s  | 1,092.45J   | 189.66uJ     | +11.8%    |
+| Scheduler                | Wall_s     | J_pkg       | J/op         | vs EEVDF  |
+|--------------------------|------------|-------------|--------------|-----------|
+| EEVDF                    | **15.81s** | **992.84J** | **172.37uJ** | baseline  |
+| PANDEMONIUM (BPF)        | 20.10s     | 1,230.36J   | 213.60uJ     | +23.9%    |
+| PANDEMONIUM (ADAPTIVE)   | 20.09s     | 1,229.00J   | 213.37uJ     | +23.8%    |
 
-On the fork-storm messaging mix PANDEMONIUM costs 9.0–11.8% more energy per operation than EEVDF, and the cause is wall time rather than power draw: average package wattage is fractionally *lower* than EEVDF's (61.75–62.04W vs 62.96W), but the run takes 10.7–14.0% longer, so the same work integrates more joules. This is the fork/exec storm's cache-locality cost showing up on the energy axis — the same trade that buys the latency, burst and deadline results above, priced in watt-seconds.
+Average power is LOWER on both PANDEMONIUM arms (61.2W against 62.8W); the energy cost is
+wall time, not draw. This is the same trade the fork-thread table shows, priced in joules.
 
 ## Key Features
 
 ### Dispatch Waterfall
 
-Layered dispatch with per-CPU DSQ dominance and one age-driven safety mechanism. CPU-tied placement is bounded at the enqueue site and overflow spills to a sibling per-CPU DSQ in R_eff order, each candidate gated by a per-peer depth threshold folded from R_eff at topology detect — near peers accept at higher depth, distant peers only when near-empty, flat on a monolithic L3. Idle-CPU placement inserts directly into the per-domain overflow DSQ and is picked up within one dispatch cycle; an eager R_eff search at that site is a wire-speed regression on fork storms with no measurable placement benefit. The steal is **one Φ-priced walk** with no near/far tier boundary — the penalty alone prices the move, so nearer relief is always preferred without a structural same-domain/different-domain gate (THE FLAG). Bounding a CPU nobody is calling `dispatch()` on at all is `sweep_bound_preempt`'s off-tick job, not a step here. The sojourn gate at STEP 0/1 is load-bearing for workqueue-worker fairness: without it the watchdog worker strands in the overflow DSQ long enough to trigger a 30s kill.
+Layered dispatch with per-CPU DSQ dominance and one age-driven safety mechanism. CPU-tied placement is bounded at the enqueue site and overflow spills to a sibling per-CPU DSQ in R_eff order, each candidate gated by a per-peer depth threshold folded from R_eff at topology detect — near peers accept at higher depth, distant peers only when near-empty, flat on a monolithic L3. Idle-CPU placement inserts directly into the per-domain overflow DSQ and is picked up within one dispatch cycle; an eager R_eff search at that site is a wire-speed regression on fork storms with no measurable placement benefit. The steal is **one Φ-priced walk** with no near/far tier boundary — the penalty alone prices the move, so nearer relief is always preferred without a structural same-domain/different-domain gate (THE FLAG). Bounding a CPU nobody is calling `dispatch()` on at all is `sweep_bound_preempt`'s off-tick job, not a step here. The sojourn gate at STEP 0/1 is load-bearing for workqueue-worker fairness: Without it the watchdog worker strands in the overflow DSQ long enough to trigger a 30s kill.
 
-0. **Own per-CPU DSQ** — cache-hot, zero contention. Sojourn-gated: if either overflow side has aged past the CoDel target, fall through to STEP 2 so this dispatch serves overflow too.
-1. **R_eff steal** — one loop over the per-CPU R_eff-ascending peer list, cross-domain peers included, on a tau-derived budget. A peer is relieved only when it has more than one task queued and its head has aged past the CoDel target plus that peer's distance penalty, so an SMT sibling is freely relievable while a cross-domain pull must show real backlog. A confirmed tight pair adds a hold so a near steal does not split it, and a per-CPU rate limit gates the walk to once per CoDel target.
-2. **Service older overflow side** — the same pick-the-older comparison at the live CoDel target. Feeds the oscillator.
-3. **Per-cache domain interactive overflow (local)** — cache-coherent drain of this cache domain's interactive overflow DSQ (`node_dsq`; LAT_CRITICAL + INTERACTIVE, sojourn-ordered).
-4. **Per-cache-domain batch overflow (local)** — this cache domain's batch overflow DSQ.
-5. **Cross-domain work conservation** — scan other domains once; drain any non-empty overflow (interactive first per domain, then batch). Runs only when the local domain is empty, so cross-domain migration here is pure idle-time work conservation.
-6. **KEEP_RUNNING** — if prev still wants CPU and nothing queued.
+| Step | Source | Rule |
+|---|---|---|
+| **0** | Own per-CPU DSQ | Cache-hot, zero contention. **Sojourn-gated**: If either overflow side has aged past the CoDel target, fall through to STEP 2 so this dispatch serves overflow too. |
+| **1** | R_eff steal | One loop over the per-CPU R_eff-ascending peer list, cross-domain peers included, on a tau-derived budget. A peer is relieved only when it has more than one task queued *and* its head has aged past the CoDel target plus that peer's distance penalty — so an SMT sibling is freely relievable while a cross-domain pull must show real backlog. A confirmed tight pair adds a hold so a near steal does not split it, and a per-CPU rate limit gates the walk to once per CoDel target. |
+| **2** | Older overflow side | The same pick-the-older comparison at the live CoDel target. Feeds the oscillator. |
+| **3** | Local interactive overflow | Cache-coherent drain of this cache domain's interactive overflow DSQ (`node_dsq`, sojourn-ordered). |
+| **4** | Local batch overflow | This cache domain's batch overflow DSQ. |
+| **5** | Cross-domain work conservation | Scan other domains once; drain any non-empty overflow, interactive first per domain, then batch. Runs only when the local domain is empty, so cross-domain migration here is pure idle-time work conservation. |
+| **6** | KEEP_RUNNING | `prev` still wants CPU and nothing is queued. |
 
 ### Three-Tier Enqueue
 
-- **select_cpu**: idle CPU -> per-CPU DSQ (depth-gated: 1 slot at <4C, 2 at 4C+) -> R_eff sibling spill if full -> last-resort node DSQ, with KICK_IDLE on the placement target. WAKE_SYNC path: partner-CPU fast path (claim the wakee's `last_cpu` directly if idle and allowed, skipping the R_eff scan on a stable pair) -> R_eff idle search -> waker fallback, WITH a kick — arm A (found-idle) KICK_IDLE, arm B (no-idle) KICK_PREEMPT — so the wakee runs next instead of aging until the target's tick (the dominant IPC round-trip tail)
-- **enqueue Tier 1** (idle CPU): direct `node_dsq` insert + KICK_PREEMPT for non-BATCH / KICK_IDLE for BATCH. Drained by STEP 3 (unconditional `node_dsq`) within one dispatch cycle. The wire-speed path: eager R_eff search at this site is a fork-storm regression with no placement benefit, so Tier 1 stays a direct insert
-- **enqueue Tier 2** (wakeup preemption): uses `pick_pcpu_dsq_with_spill` for symmetric placement with `select_cpu`. CPU-tied; benefits from eager per-CPU placement
-- **enqueue Tier 3** (fallback): batch overflow DSQ for BATCH only; LAT_CRITICAL and INTERACTIVE all stay in `node_dsq` — the batch DSQ is for BATCH-tier work only, so a burst of fresh INTERACTIVE threads cannot flood it and starve. The sojourn deadline (`now − warp`) is computed at the insert
-- **tick**: longrun detection (batch non-empty >2s), sojourn enforcement, per-CPU preempt of the resident for an aged waiter (`sojourn_stamp_pcpu[this_cpu]` age vs a tau-scaled threshold; BATCH yields at base, INTERACTIVE at 2×, LAT_CRITICAL never)
+- **select_cpu**: idle CPU -> per-CPU DSQ (depth-gated: 1 slot at <4C, 2 at 4C+) -> R_eff sibling spill if full -> last-resort node DSQ, with KICK_IDLE on the placement target. WAKE_SYNC path: Partner-CPU fast path (claim the wakee's `last_cpu` directly if idle and allowed, skipping the R_eff scan on a stable pair) -> R_eff idle search -> waker fallback, WITH a kick — arm A (found-idle) KICK_IDLE, arm B (no-idle) KICK_PREEMPT — so the wakee runs next instead of aging until the target's tick (the dominant IPC round-trip tail)
+- **enqueue Tier 1** (idle CPU): Direct `node_dsq` insert + KICK_PREEMPT for non-BATCH / KICK_IDLE for BATCH. Drained by STEP 3 (unconditional `node_dsq`) within one dispatch cycle. The wire-speed path: Eager R_eff search at this site is a fork-storm regression with no placement benefit, so Tier 1 stays a direct insert
+- **enqueue Tier 2** (wakeup preemption): Uses `pick_pcpu_dsq_with_spill` for symmetric placement with `select_cpu`. CPU-tied; benefits from eager per-CPU placement
+- **enqueue Tier 3** (fallback): Batch overflow DSQ for BATCH only; INTERACTIVE stays in `node_dsq` — the batch DSQ is for BATCH-tier work only, so a burst of fresh INTERACTIVE threads cannot flood it and starve. The sojourn deadline (`now − warp`) is computed at the insert
+- **tick**: Longrun detection (batch non-empty >2s), sojourn enforcement, per-CPU preempt of the resident for an aged waiter (`sojourn_stamp_pcpu[this_cpu]` age vs a tau-scaled threshold; BATCH yields at base, INTERACTIVE at 2×)
 
 ### Damped Harmonic Oscillator Stall Detection
 
@@ -152,23 +156,23 @@ CoDel-inspired per-CPU DSQ stall detection where the target follows the full dam
 ẍ + 2γẋ + ω₀²(x − c_eq) = F(t)
 ```
 
-Damping is Butterworth-optimal (ζ ≈ 0.707): the flattest response available, at the cost of one bounded ~4.3% overshoot per adaptation. The overshoot is deliberate — it probes the response boundary on each impulse instead of parking inside it.
+Damping is Butterworth-optimal (ζ ≈ 0.707): The flattest response available, at the cost of one bounded ~4.3% overshoot per adaptation. The overshoot is deliberate — it probes the response boundary on each impulse instead of parking inside it.
 
 **Per-task sojourn** (RFC 8289): `task_ctx.enqueue_at` is stamped at every DSQ insert and consumed in `pandemonium_running` to compute `sojourn = now − enqueue_at` — the literal CoDel metric, wait between enqueue and run start. A per-task timestamp stays accurate through an entire drain, where a per-CPU proxy weakens past the first task.
 
-**Stall decision**: per-CPU minimum sojourn against `codel_target_ns`. Below is flowing; above for `sojourn_interval_ns` is stalled and forces rescue. The decision is binary CoDel; the target is what oscillates.
+**Stall decision**: Per-CPU minimum sojourn against `codel_target_ns`. Below is flowing; above for `sojourn_interval_ns` is stalled and forces rescue. The decision is binary CoDel; the target is what oscillates.
 
 **Equilibrium**: `c_eq = ⟨R_eff⟩ × 2m × τ`, built from spectral properties already computed at topology detect — the natural latency tolerance of the machine's own topology rather than a hand-tuned constant. Clamped to `[200µs, 8ms]`.
 
-**Feedback**: the overflow rescue count drives the impulse. Each tick on CPU 0 the oscillator applies impulse, spring and damping, caps velocity and integrates. `x` rests at `c_eq` when quiet, descends on rescue events, returns damped. Every timing constant scales from τ, so a topology change preserves the damping ratio automatically — the live values are derived at runtime, never tabulated.
+**Feedback**: The overflow rescue count drives the impulse. Each tick on CPU 0 the oscillator applies impulse, spring and damping, caps velocity and integrates. `x` rests at `c_eq` when quiet, descends on rescue events, returns damped. Every timing constant scales from τ, so a topology change preserves the damping ratio automatically — the live values are derived at runtime, never tabulated.
 
-**Idle quiescence envelope**: the control effort obeys the same damping law as the system it controls, so the oscillator goes quiet when the system does. An energy reservoir built from values the recompute already maintains drives the recompute cadence down as the oscillator contracts: below a release threshold it recomputes every fourth tick, and below a park threshold it pins the target at its closed-form fixed point, freezes the velocity integrator so it cannot accumulate and slingshot at wake, and stops the arithmetic entirely. The two thresholds sit a factor of two apart, giving multiplicative hysteresis on energy. While parked, three compares per tick arm the detector — a rescue event, the equilibrium moving under the parked value, or a 1024-tick heartbeat — and any of them triggers a full recompute in the same tick, before any dispatch prices against the target, re-priming above release so a bursty wake cannot immediately re-park. Every burst therefore begins from an identical controller state. `nr_osc_park` counts parks; zero parks after an idle-heavy run is the attention-collapse failure this counter exists to detect.
+**Idle quiescence envelope**: The control effort obeys the same damping law as the system it controls, so the oscillator goes quiet when the system does. An energy reservoir built from values the recompute already maintains drives the recompute cadence down as the oscillator contracts: Below a release threshold it recomputes every fourth tick, and below a park threshold it pins the target at its closed-form fixed point, freezes the velocity integrator so it cannot accumulate and slingshot at wake, and stops the arithmetic entirely. The two thresholds sit a factor of two apart, giving multiplicative hysteresis on energy. While parked, three compares per tick arm the detector — a rescue event, the equilibrium moving under the parked value, or a 1024-tick heartbeat — and any of them triggers a full recompute in the same tick, before any dispatch prices against the target, re-priming above release so a bursty wake cannot immediately re-park. Every burst therefore begins from an identical controller state. `nr_osc_park` counts parks; zero parks after an idle-heavy run is the attention-collapse failure this counter exists to detect.
 
 ### Overflow Sojourn Rescue
 
 Per-CPU DSQ dominance under sustained load makes downstream anti-starvation unreachable — 90%+ of dispatches serve per-CPU DSQ while overflow tasks age indefinitely. Dispatch STEP 0 / STEP 1 fall through to STEP 2 when either overflow DSQ has aged past `codel_target_ns` — the live CoDel target the oscillator drives around its R_eff-derived equilibrium `codel_seed_ns` (`⟨R_eff⟩ × 2m × τ`, clamped into the oscillator's `[floor, max]` window, so ≤~2ms at 12C — not a hand-tuned ~10ms). The spectral scalar opens the gate; sojourn (enqueue-age) fills it and selects the older side. `try_service_older_overflow` then drains that side past the threshold. CAS-based timestamp management prevents races across CPUs.
 
-**Drain both when both aged**: under sustained mixed load both overflow DSQs can stay continuously non-empty for tens of seconds, freezing both timestamps at their first-non-empty values. A strict "older wins" would then pick the same side every rescue call until external pressure dropped, locking out batch-demoted long-runners (at 2C, a 19-29s starvation tail; 4C+ closes the window through higher dispatch density). So when BOTH sides are aged, both drain — older-first ordering preserved (latency-budget bias for interactive on ties), at the cost of one extra `scx_bpf_dsq_move_to_local`.
+**Drain both when both aged**: Under sustained mixed load both overflow DSQs can stay continuously non-empty for tens of seconds, freezing both timestamps at their first-non-empty values. A strict "older wins" would then pick the same side every rescue call until external pressure dropped, locking out batch-demoted long-runners (at 2C, a 19-29s starvation tail; 4C+ closes the window through higher dispatch density). So when BOTH sides are aged, both drain — older-first ordering preserved (latency-budget bias for interactive on ties), at the cost of one extra `scx_bpf_dsq_move_to_local`.
 
 ### Longrun Detection
 
@@ -176,13 +180,13 @@ When batch DSQ stays non-empty past `longrun_thresh_ns` (tau-scaled, ~2s at 12C 
 
 ### Wake Sensitivity & Preemption
 
-There is no burst detector, and nothing needs one: a burst is already answered by the oscillator-adapted CoDel target, the placement-side depth gate with its L2/R_eff spill, the starvation rescue, and the tier information present at the enqueue site. Tick preemption is derived per-CPU, with no global signal:
+There is no burst detector, and nothing needs one: A burst is already answered by the oscillator-adapted CoDel target, the placement-side depth gate with its L2/R_eff spill, the starvation rescue, and the tier information present at the enqueue site. Tick preemption is derived per-CPU, with no global signal:
 
-- **Per-CPU preempt**: `pandemonium_tick` reads its own `sojourn_stamp_pcpu[this_cpu]` — the age of the oldest task waiting on this CPU — against a tau-scaled threshold (`preempt_thresh_ns`): a BATCH resident yields once a waiter ages past the base threshold, an INTERACTIVE resident at 2× (batch-throughput protection), a LAT_CRITICAL resident never. Per-CPU by construction — no token to race over. A single global flag instead (armed at enqueue, cleared by the first tick to preempt on *any* CPU) gets token-stolen across cores under a fork storm, so the CPU actually burying a latency waker rarely wins the race — the audio-under-load pathology (intermittent, single-thread, bursty-only). The per-CPU read reuses the bounded-array scan already running for the coarse per-CPU sojourn check, so no new global state.
-- **RT-policy floor**: `SCHED_FIFO`/`SCHED_RR` threads are pinned `TIER_LAT_CRITICAL` by declaration, after the high-prio-kthread→BATCH override. Pinning by policy rather than by a measured score keeps a periodic audio RT thread from flipping out of LAT_CRITICAL mid-burst and stops threaded USB IRQ kthreads being force-demoted to BATCH. The floor keeps both latency-critical under load.
-- **Core-scaled longrun protection**: during sustained `longrun_mode`, the preempt threshold scales up on thin topologies (τ < 4ms) only, extending the protected BATCH window so they don't thrash; wider topologies keep the baseline, where capacity already absorbs LAT_CRIT contention.
+- **Per-CPU preempt**: `pandemonium_tick` reads its own `sojourn_stamp_pcpu[this_cpu]` — the age of the oldest task waiting on this CPU — against a tau-scaled threshold (`preempt_thresh_ns`): A BATCH resident yields once a waiter ages past the base threshold, an INTERACTIVE resident at 2× (batch-throughput protection). Per-CPU by construction — no token to race over. A single global flag instead (armed at enqueue, cleared by the first tick to preempt on *any* CPU) gets token-stolen across cores under a fork storm, so the CPU actually burying a latency waker rarely wins the race — the audio-under-load pathology (intermittent, single-thread, bursty-only). The per-CPU read reuses the bounded-array scan already running for the coarse per-CPU sojourn check, so no new global state.
+- **RT never arrives, and that is a property of the kernel rather than of this scheduler**: sched_ext sits BELOW RT and deadline in the scheduling-class hierarchy and is handed only `SCHED_NORMAL`, `SCHED_BATCH` and `SCHED_IDLE`. A `SCHED_FIFO` or `SCHED_RR` thread is served by the RT class and never reaches these ops at all, so there is no RT tier to declare and no RT floor to hold. Measured rather than assumed: Two `SCHED_FIFO` threads at rtprio 5 held against a live scheduler for 48 seconds produced zero arrivals across all 49 samples.
+- **Core-scaled longrun protection**: During sustained `longrun_mode`, the preempt threshold scales up on thin topologies (τ < 4ms) only, extending the protected BATCH window so they don't thrash; wider topologies keep the baseline, where capacity already absorbs LAT_CRIT contention.
 
-### Sojourn Selector: the CoDel-bounded warp
+### Sojourn Selector: The CoDel-bounded warp
 
 There is no weighted virtual-time engine. `task_deadline()` returns `now − warp` — the enqueue timestamp back-dated by a bounded per-tier warp — so every DSQ is ordered oldest-first (largest sojourn served first). Sojourn IS the selector; no second fairness clock runs parallel to the sojourn + R_eff/CoDel layer.
 
@@ -190,21 +194,21 @@ There is no weighted virtual-time engine. `task_deadline()` returns `now − war
 
 `lag_cap_ns = K_LAG_CAP × τ` clamped `[8ms, 80ms]` is the **starvation** bound and nothing else — the age at which `sweep_bound_preempt` forces a head off its CPU. It was previously also the warp ceiling, which let a single back-date consume the entire starvation budget; the two are no longer one number.
 
-Starvation-freedom is therefore structural rather than clamped: a task older than one target out-sorts any freshly-warped waker, no new-task penalty is needed, and a new task enters at `now` like any other arrival. (A wakeup-frequency-weighted warp and a queue-depth backlog term each reorder by something other than wait — they cluster ping-pong wakers or rubberband interactivity — so the warp stays bounded by the target; deep-queue drainage is left to the overflow sojourn rescue, which forces aged work forward by wait, not depth.)
+Starvation-freedom is therefore structural rather than clamped: A task older than one target out-sorts any freshly-warped waker, no new-task penalty is needed, and a new task enters at `now` like any other arrival. (A wakeup-frequency-weighted warp and a queue-depth backlog term each reorder by something other than wait — they cluster ping-pong wakers or rubberband interactivity — so the warp stays bounded by the target; deep-queue drainage is left to the overflow sojourn rescue, which forces aged work forward by wait, not depth.)
 
 ### Hard Starvation Rescue
 
-Two bounds sit under the dispatch waterfall, the tighter one first. `sweep_bound_preempt` runs off-tick and NO_HZ_FULL-immune: it rotates through CPUs and forces one back into `dispatch()` whenever an overflow head ages past `lag_cap_ns` (see Warp above, ~13ms at 12C). Beneath it, `codel_starve_ns` — `clamp(K_STARVATION_RESCUE × τ, 20ms, 500ms)`, ~167ms at the 12C reference — is the last-resort threshold in dispatch: past it, the older overflow side is serviced unconditionally. The off-tick bound catches the common case; the starve threshold is the floor under everything, including a CPU the sweep has not yet rotated to. A pinned single-CPU task (per-CPU kworker, IRQ thread, cpuset) is a separate hazard: it can only run on its one CPU, and if that CPU is idle it never ticks, so the in-tick rescue scan never fires and the task strands until the 30s scx watchdog disables the scheduler. A tick-independent guard on the enqueue path seats a pinned task on its own CPU and `SCX_KICK_PREEMPT`s it at enqueue (an event scx guarantees runs), closing the watchdog-disable the tick-driven rescue cannot reach.
+Two bounds sit under the dispatch waterfall, the tighter one first. `sweep_bound_preempt` runs off-tick and NO_HZ_FULL-immune: It rotates through CPUs and forces one back into `dispatch()` whenever an overflow head ages past `lag_cap_ns` (see Warp above, ~13ms at 12C). Beneath it, `codel_starve_ns` — `clamp(K_STARVATION_RESCUE × τ, 20ms, 500ms)`, ~167ms at the 12C reference — is the last-resort threshold in dispatch: Past it, the older overflow side is serviced unconditionally. The off-tick bound catches the common case; the starve threshold is the floor under everything, including a CPU the sweep has not yet rotated to. A pinned single-CPU task (per-CPU kworker, IRQ thread, cpuset) is a separate hazard: It can only run on its one CPU, and if that CPU is idle it never ticks, so the in-tick rescue scan never fires and the task strands until the 30s scx watchdog disables the scheduler. A tick-independent guard on the enqueue path seats a pinned task on its own CPU and `SCX_KICK_PREEMPT`s it at enqueue (an event scx guarantees runs), closing the watchdog-disable the tick-driven rescue cannot reach.
 
 ### Topology-Aware Placement
 
-**Resistance affinity**: the CPU topology is modeled as a weighted electrical network — SMT and L2 siblings conduct strongly, cross-socket links weakly. The Laplacian pseudoinverse gives all-pairs migration costs accounting for every path through the graph rather than direct connections alone, and `R_eff(i,j)` is a true metric satisfying the triangle inequality. Per-CPU ranked peer lists are folded into a BPF map at detect; the runtime walks them with sentinels marking unused slots so loops early-exit on small machines.
+**Resistance affinity**: The CPU topology is modeled as a weighted electrical network — SMT and L2 siblings conduct strongly, cross-socket links weakly. The Laplacian pseudoinverse gives all-pairs migration costs accounting for every path through the graph rather than direct connections alone, and `R_eff(i,j)` is a true metric satisfying the triangle inequality. Per-CPU ranked peer lists are folded into a BPF map at detect; the runtime walks them with sentinels marking unused slots so loops early-exit on small machines.
 
-**Online-budget search**: the idle search spends its budget on *online candidates*, not slots. The rank map is built once from the full topology, so after hotplug some top ranks reference offline CPUs; those are skipped without charging budget. Search cost on a fully-online machine is unchanged while remaining correct under arbitrary hotplug asymmetry.
+**Online-budget search**: The idle search spends its budget on *online candidates*, not slots. The rank map is built once from the full topology, so after hotplug some top ranks reference offline CPUs; those are skipped without charging budget. Search cost on a fully-online machine is unchanged while remaining correct under arbitrary hotplug asymmetry.
 
-**Tight-pair gate**: each task's distinct wakers are recorded in a persisted bitmap. A low popcount marks a 1:1-ish handoff pair, where warm co-location pays; a high popcount marks a 1:N server, where it does not and clients must not pile onto the server's CPU. The same discrimination the kernel's `wake_wide()` makes, but persisted and frozen at classification rather than re-derived per wake.
+**Tight-pair gate**: Each task's distinct wakers are recorded in a persisted bitmap. A low popcount marks a 1:1-ish handoff pair, where warm co-location pays; a high popcount marks a 1:N server, where it does not and clients must not pile onto the server's CPU. The same discrimination the kernel's `wake_wide()` makes, but persisted and frozen at classification rather than re-derived per wake.
 
-**L2 cache affinity**: an in-enqueue search for an idle CPU in the same L2 domain, gated by a three-position knob holding its base value. Per-dispatch hit/miss counters are kept per tier.
+**L2 cache affinity**: An in-enqueue search for an idle CPU in the same L2 domain, gated by a three-position knob holding its base value. Per-dispatch hit/miss counters are kept per tier.
 
 R_eff is proportional to expected round-trip time for work between CPUs [2], so minimizing it between pipe partners minimizes cache-line transfer cost [1][3][4].
 
@@ -213,36 +217,58 @@ R_eff is proportional to expected round-trip time for work between CPUs [2], so 
 R_eff alone is a placement *ranking* — it orders candidate CPUs by distance but doesn't price a migration against the queueing relief it buys, so a cross-domain steal would be as cheap as an SMT-sibling steal once a head aged. The migration potential prices it: **Φ = R_eff − β·sojourn**, the graph resistance of a move set against the wait it relieves. The dispatch STEP 1 work steal pays Φ, so it crosses a cache boundary only when the backlog justifies the cache cost.
 
 - **The price is precomputed, never multiplied at runtime.** Rust folds `b·R_eff` into a per-peer table at topology detect, so the dispatch steal reads a ns penalty with one indexed lookup. A companion table carries `domain_phi`, the min-conductance cut price between a CPU and each ranked peer, read by the tight-pair steal hold. Both are all-zero on a monolithic part or under `--phi-scale 0`, which collapses every threshold below to a flat `codel_target` — prior behavior, no special case.
-- **Distance-scaled steal resist**: a peer is relieved only once its head has waited past `codel_target_ns` plus that peer's penalty. An SMT sibling (R_eff ≈ 0) stays freely relievable at the flat target; a cross-domain pull must show roughly τ of sustained backlog first. The scale is always computed — on a single-domain part it calibrates to the L2 boundary rather than vanishing, so distance is priced on every processor with no binary topology gate.
-- **Warm placement and warm-stay**: a wakee is anchored on its own last core and searched R_eff-near before any topology-blind idle pick, which would otherwise seat it on a cross-domain core with a cold L3. A wakee whose stable home is uncongested is held there rather than fanned to a cold idle sibling — the placement dual of the steal threshold, releasing at the same point, so a near home releases quickly and a far one holds hard. The hold lives in `enqueue`, not the idle fast path: placing on a busy core there is a no-op that strands the wakee until the resident yields. LAT_CRITICAL and kthreads are exempt; they flee for immediacy.
+- **Distance-scaled steal resist**: A peer is relieved only once its head has waited past `codel_target_ns` plus that peer's penalty. An SMT sibling (R_eff ≈ 0) stays freely relievable at the flat target; a cross-domain pull must show roughly τ of sustained backlog first. The scale is always computed — on a single-domain part it calibrates to the L2 boundary rather than vanishing, so distance is priced on every processor with no binary topology gate.
+- **Warm placement and warm-stay**: A wakee is anchored on its own last core and searched R_eff-near before any topology-blind idle pick, which would otherwise seat it on a cross-domain core with a cold L3. A wakee whose stable home is uncongested is held there rather than fanned to a cold idle sibling — the placement dual of the steal threshold, releasing at the same point, so a near home releases quickly and a far one holds hard. The hold lives in `enqueue`, not the idle fast path: Placing on a busy core there is a no-op that strands the wakee until the resident yields. Kthreads are exempt; they flee for immediacy.
 
 Φ prices each migration by its graph resistance [1][2] and pays only when queueing relief justifies the cache cost. Cross-domain work conservation is preserved — an idle cross-domain core is still taken freely; what Φ removes is the *cheap* cross-domain steal that thrashed L3 for marginal queueing gain.
 
 ### Tier Classification
 
-- **Declared tier**: three sources set a task's tier, and all three are properties the kernel states outright rather than inferences — the `SCHED_FIFO`/`SCHED_RR` policy floor, the high-priority kthread override and the `PF_WQ_WORKER` floor, in that precedence. A behavioural score (`classify_tier()` over `lat_cri`) also runs and is documented in the source; it is not what separates the workloads on any machine measured so far, and the declared floors are what the tier boundary actually rests on. **The dispatch key takes no tier input at all** — see Sojourn Selector.
-- **Three Tiers**: LAT_CRITICAL and INTERACTIVE take a slice derived from the task's own measured runtime, capped at the knob base slice; BATCH takes the adaptive-layer ceiling, itself capped at `SLICE_STANDING_TARGETS × codel_target_ns` so a resident can hold a CPU for a bounded number of CoDel targets and no longer.
-- **Kworker Floor**: PF_WQ_WORKER floors at INTERACTIVE
-- **High-Priority Kthread Override**: `PF_KTHREAD` at `static_prio <= 110` (`task_nice <= -10`) forced to BATCH regardless of its measured tier, so ZFS workers (`z_rd_int_*`, `arc_*`), kopia helpers and similar storage kthreads do not compete with userspace LAT_CRITICAL. The kworker floor wins for `PF_WQ_WORKER` (a `PF_KTHREAD` subset), so workqueue workers continue to be treated as latency-adjacent.
-- **Flow Signature**: each wakeup sets the waker CPU's bit in a per-task bitmap; the popcount is the task's distinct-partner cardinality — a topology-free read of the live communication graph's conductance. Once the partner set is stable the task is classified once and frozen: `≤ SHAPE_TIGHT_MAX` (2) distinct partners is a **TIGHT** pair/loop; a partner set spanning at least half of `nr_cpu_ids` is a **STORM** mesh; everything between defaults to TIGHT (latency-safe — its steal stays freely relievable). Portable — the STORM threshold scales with the machine, no hardcoded core geometry. The shape drives *placement* (TIGHT consolidates on its warm core, STORM spreads), never the steal: gating the steal on shape strands a STORM-classed latency thread on a busy core, so the steal stays shape-blind.
+`tier` is a **declaration, not a judgement.** It is two values, set from one flag the
+kernel already states, and **the dispatch key takes no tier input at all** — see Sojourn
+Selector.
+
+| Value | Set by | Effect |
+|---|---|---|
+| **INTERACTIVE** | `PF_WQ_WORKER` | Slice derived from the task's own measured runtime, capped at the knob base slice. Userspace blocks on workqueue workers, so they are latency-adjacent by construction rather than by observation. |
+| **BATCH** | everything else | The adaptive layer's ceiling, itself capped at `SLICE_STANDING_TARGETS × codel_target_ns`, so a resident holds a CPU for a bounded number of CoDel targets and no longer. |
+
+There is no third tier and no behavioural scorer. A score over wakeup and context-switch
+rates was built, measured and removed: `last_woke_at` did two jobs that destroyed each
+other, so every task read BATCH after its first wake, and repairing it saturated the other
+way at 92% latency-critical. Mass on a ceiling cannot be cut by moving a threshold. The
+high-priority kthread override went with it — `PF_KTHREAD` at `static_prio <= 110` was
+forced to BATCH by a branch that could only ever see BATCH, and BATCH is now the default.
+
+- **Flow Signature**: Each wakeup sets the waker CPU's bit in a per-task bitmap; the popcount is the task's distinct-partner cardinality — a topology-free read of the live communication graph's conductance. Once the partner set is stable the task is classified once and frozen: `≤ SHAPE_TIGHT_MAX` (2) distinct partners is a **TIGHT** pair/loop; a partner set spanning at least half of `nr_cpu_ids` is a **STORM** mesh; everything between defaults to TIGHT (latency-safe — its steal stays freely relievable). Portable — the STORM threshold scales with the machine, no hardcoded core geometry. The shape drives *placement* (TIGHT consolidates on its warm core, STORM spreads), never the steal: Gating the steal on shape strands a STORM-classed latency thread on a busy core, so the steal stays shape-blind.
 
 ### Adaptive Control Loop
 
 The Rust control plane is chaos-theory-driven, and **every knob is a function of a measurement rather than the output of a search.** A derived knob is correct on the tick it is computed; a learned one is correct several convergence windows later and only if the regime holds still that long.
 
-- **One Thread, Zero Mutexes**: 1-second control loop on the main thread reads the per-CPU BPF stats array — depth, wake latency, dispatch counts, per-tier P99 — and writes knobs BPF picks up on the next scheduling decision. The array survives the read: relating CPU *i* to CPU *j* is the half of the boundary BPF structurally cannot cross, so the spatial dimension is the reason the loop exists.
+Every knob derives from one sensor, and the mapping is the design:
+
+| Sensor | Primitive | Drives | Because |
+|---|---|---|---|
+| **depth** | mean per-CPU queue depth | the per-CPU slice | A deep queue slices shorter so it drains; a shallow one longer so it stops paying context-switch cost for contention that is not there |
+| **critical slowing** | lag-1 autocorrelation | the preempt window | Tightens *ahead* of the burst — the only actuation in the loop acting on a prediction rather than a completed loss |
+| **traffic shape** | Kim-Jo burstiness | batch and burst ceilings | Bursty traffic wants a longer batch ceiling, paced traffic a shorter one |
+| **persistence** | Veitch-Abry Hurst | the rescue threshold | A queue deep on a persistent CPU will still be deep, so rescue sooner |
+| **coupling** | Pecora-Carroll, pairwise | nothing, deliberately | See below — measured, and not actuated |
+
+- **One Thread, Zero Mutexes**: 1-second control loop on the main thread reads the per-CPU BPF stats array — depth, wake latency, dispatch counts, per-tier P99 — and writes knobs BPF picks up on the next scheduling decision. The array survives the read: Relating CPU *i* to CPU *j* is the half of the boundary BPF structurally cannot cross, so the spatial dimension is the reason the loop exists.
 - **Chaos primitives** (`chaos.rs`, pure Rust, recomputed each tick over a 16-sample raw window): HVG mean degree λ (Luque–Lacasa horizontal visibility graph — ~2 periodic, →4 IID-random), Bandt–Pompe D=3 permutation entropy (ordinal disorder, normalized to [0,1]) and RQA determinism (fraction of recurrence points on diagonals — →1 steady, →0 IID).
-- **One base profile, not three**: an audit of what actually varied across the old LIGHT / MIXED / HEAVY profiles found slice, preempt and batch (now all derived from measured depth, critical slowing and traffic shape) and `affinity_mode`. Everything else was identical in all three — defaults wearing a selector. What remains is a starting point the derivations move from: the value a knob holds on a machine that has not been measured yet.
-- **The live load graph**: nodes are CPUs weighted by mean depth, traffic shape, critical slowing and persistence; edges are CPU pairs weighted by coupling. The chip's electrical graph is a constant and R_eff already prices against it — this is the graph the *workload* forms, which moves every second. Depth sets the per-CPU slice, a deep queue slicing shorter so it drains and a shallow one longer so it stops paying context-switch cost for contention that is not there. Critical slowing tightens the preempt window ahead of the burst, the only actuation here acting on a prediction rather than a completed loss. Traffic shape sets the batch and burst ceilings; persistence sets the rescue threshold, since a queue deep on a persistent CPU will still be deep.
-- **Coupling is measured and deliberately not actuated**: deriving affinity strength from pairwise coupling regressed every IPC primitive on every arm, worst pipe p50 20 → 336us at 1.04x drift. IPC is a two-task ping-pong with tightly coupled queue depths, so the derivation fired hardest exactly where the damage landed. Affinity holds its base value until something measures the direction; the coupling reading stays as telemetry, because the reading was never the problem.
-- **One controller on the rescue signal**: the oscillator owns `global_rescue_count` and nothing else adapts on it, so the double-correction hazard the old orchestrator had to be gated against no longer exists. The graph derives from depth, shape and persistence instead.
-- **Quiescence freeze**: when the chaos signals sit in their steady band the loop latches frozen and skips the retune and knob write, still ticking at 1 Hz with the sensors as the thaw condition. Short of that, a sub-threshold retune stretches the interval; any disturbance snaps it back. **Known limit, measured:** both terms of the freeze gate read the same `idle_pct` window, and a fully saturated box pins that window flat — `rqa_det` returns 1.0 through its flat-window path and HVG λ sits inside the periodic band — so saturation can read as quiescence. Whether that is correct is deliberately open; that it can happen is not.
+- **One base profile, not three**: An audit of what actually varied across the old LIGHT / MIXED / HEAVY profiles found slice, preempt and batch (now all derived from measured depth, critical slowing and traffic shape) and `affinity_mode`. Everything else was identical in all three — defaults wearing a selector. What remains is a starting point the derivations move from: The value a knob holds on a machine that has not been measured yet.
+- **The live load graph**: Nodes are CPUs weighted by mean depth, traffic shape, critical slowing and persistence; edges are CPU pairs weighted by coupling. The chip's electrical graph is a constant and R_eff already prices against it — this is the graph the *workload* forms, which moves every second. Depth sets the per-CPU slice, a deep queue slicing shorter so it drains and a shallow one longer so it stops paying context-switch cost for contention that is not there. Critical slowing tightens the preempt window ahead of the burst, the only actuation here acting on a prediction rather than a completed loss. Traffic shape sets the batch and burst ceilings; persistence sets the rescue threshold, since a queue deep on a persistent CPU will still be deep.
+- **Coupling is measured and deliberately not actuated**: Deriving affinity strength from pairwise coupling regressed every IPC primitive on every arm, worst pipe p50 20 → 336us at 1.04x drift. IPC is a two-task ping-pong with tightly coupled queue depths, so the derivation fired hardest exactly where the damage landed. Affinity holds its base value until something measures the direction; the coupling reading stays as telemetry, because the reading was never the problem.
+- **One controller on the rescue signal**: The oscillator owns `global_rescue_count` and nothing else adapts on it, so the double-correction hazard the old orchestrator had to be gated against no longer exists. The graph derives from depth, shape and persistence instead.
+- **Quiescence freeze**: When the chaos signals sit in their steady band the loop latches frozen and skips the retune and knob write, still ticking at 1 Hz with the sensors as the thaw condition. Short of that, a sub-threshold retune stretches the interval; any disturbance snaps it back. **Known limit, measured:** both terms of the freeze gate read the same `idle_pct` window, and a fully saturated box pins that window flat — `rqa_det` returns 1.0 through its flat-window path and HVG λ sits inside the periodic band — so saturation can read as quiescence. Whether that is correct is deliberately open; that it can happen is not.
 
 ### Core-Count Scaling
 
 All timing constants scale from `tau_ns = TAU_SCALE_NS / √(λ₂ · N)` — capacity-aware (the geometric mean of connectivity `1/λ₂` and capacity `1/√N`, so a well-connected but core-starved topology loosens instead of tightening), with safety-rail clamps. 12C reference: τ≈13.3ms (λ₂=12, N=12). Cardinality decisions (per-CPU DSQ depth, wake_wide threshold, tick scan budget) use `nr_cpus` directly — counts are not tau-derived. **The per-column τ values and derived cells below are an approximate reference; the live values are derived at runtime from the capacity-aware τ law.**
 
-Every constant in that law is derived at runtime and none is tabulated here: the sojourn interval, the starvation rescue, the CoDel floor/ceiling/equilibrium, the warp bound, the spill and idle-search budgets, the per-CPU DSQ depth and the longrun preempt shift all fall out of τ with safety-rail clamps. A machine with a different topology gets different numbers by construction, which is the point.
+Every constant in that law is derived at runtime and none is tabulated here: The sojourn interval, the starvation rescue, the CoDel floor/ceiling/equilibrium, the warp bound, the spill and idle-search budgets, the per-CPU DSQ depth and the longrun preempt shift all fall out of τ with safety-rail clamps. A machine with a different topology gets different numbers by construction, which is the point.
 
 - **Low-core slice discipline**: τ is largest at low core count (λ₂ shrinks as cores drop), so the tau slice cap runs loosest exactly where a wide batch slice hurts most — a 4ms slice on 2–4 cores denies a latency-sensitive probe across many consecutive slices, the low-core tail. The slice is capped to 1ms at `nr_cpus ≤ 4`, where a wide slice buys no throughput; 8C/12C keep the tau-scaled width, where it earns it.
 - **CPU Hotplug**: `cpu_online`/`cpu_offline` callbacks clear per-CPU timestamps and oscillator state (velocity, rescue count) to prevent stale oscillation after suspend/resume
@@ -380,16 +406,20 @@ sudo scx_pandemonium --no-adaptive    # BPF-only (no Rust control loop)
 sudo scx_pandemonium -v               # Verbose telemetry on stdout
 ```
 
-There is no compositor allowlist and no learned name database. A compositor
-earns its tier from measured behavior like any other task, every session, from
-cold.
+There is no compositor allowlist and no learned name database, and there is no
+behavioural tier to earn: A task is INTERACTIVE because the kernel flags it a workqueue
+worker, and BATCH otherwise. Every session, from cold, with nothing remembered.
 
 ### Monitoring
 
 Per-second telemetry:
 
 ```
-d/s: 251000 idle: 5% shared: 230000 preempt: 12 keep: 0 kick: H=8000 S=22000 enq: W=8000 R=22000 wake: 4us p99: 10us [B:8 I:9 L:7] lat_idle: 3us lat_kick: 6us sleep: io=87% slice: 1000us batch: 20000us reenq: 4 sjrn: 3ms/5ms rescue: 0 l2: B=67% I=72% L=85% chaos: lam=2.10 H=0.40 det=0.95 x=0 frozen: 0 (n=12) retune_iv: 2 [MIXED]
+BPF-only (--no-adaptive):
+d/s: 4537 idle: 49% shared: 34 preempt: 0 keep: 0 kick: H=34 S=0 enq: W=26 R=8 wake: 8us lat_idle: 8us lat_kick: 9us reenq: 0 sjrn: 0ms l2: B=98% I=28% [BPF]
+
+Adaptive (default) adds the control loop's own readings:
+... p99: 10us [B:8 I:9 L:0] ... sleep: io=87% slice: 1000us batch: 20000us sjrn: 3ms/5ms rescue: 0 chaos: lam=2.10 H=0.40 det=0.95 x=0 frozen: 0 (n=12) retune_iv: 2 [MIXED] graph: n=12 e=31 cpl=0.41/0.02/0.88 osc: 1.04/1300us
 ```
 
 | Counter | Meaning |
@@ -402,7 +432,7 @@ d/s: 251000 idle: 5% shared: 230000 preempt: 12 keep: 0 kick: H=8000 S=22000 enq
 | kick H/S | Hard (PREEMPT) / Soft kicks |
 | enq W/R | Wakeup / Re-enqueue counts |
 | wake / p99 | Average / aggregate P99 wakeup latency |
-| [B/I/L] | Per-tier P99 (BATCH / INTERACTIVE / LAT_CRITICAL) |
+| [B/I/L] | Per-tier P99. `L` is a retired third lane and reads 0 always — `tier` is two values |
 | lat_idle / lat_kick | Wakeup latency split: idle-placement vs kick path |
 | sleep: io | I/O-wait sleep pattern (%) |
 | slice / batch | Current interactive / batch slice knob (us) |
@@ -468,14 +498,14 @@ captures self-elevates, so invoke it without `sudo`.
 fixed profile — the cachyos application workloads, a fork/exec storm, an IPC
 round-trip and capped (20s) burst-starvation and contention captures — under
 your scheduler and EEVDF as a neutral reference, traces each with montauk, and
-assembles one small, redacted file: your system specs, the misbehaving items
+assembles one small, redacted file: Your system specs, the misbehaving items
 ranked by name (hot CPUs, livelocking tasks, unsignaled waiters, idle strands),
 a thermal/power block, then the key wake-to-run metrics. Process names are
 hashed and the raw traces stay local — you share only the report. montauk is the
 only data source; the script orchestrates and assembles, nothing more.
 
 If montauk isn't installed, prism clones it from its repo and drives
-montauk's own installer: two prompts up front decide whether it installs montauk
+montauk's own installer: Two prompts up front decide whether it installs montauk
 permanently (capped so `--trace` needs no sudo) or builds it just for the run and
 removes it after. It self-elevates for the trace, ejects any scheduler it loaded
 if you Ctrl+C, and when a build dependency is missing it prints the exact install
@@ -498,7 +528,7 @@ sudo CARGO_TARGET_DIR=$HOME/.cache/pandemonium-build \
      --test-threads=1 full_gate                                 # Integration gate (requires root)
 ```
 
-5 tests in 1 file: the integration gate at `tests/gate.rs` — `full_gate` plus the
+5 tests in 1 file: The integration gate at `tests/gate.rs` — `full_gate` plus the
 load/classify, latency, responsiveness and contention layers (all `#[ignore]`,
 root-only). The `src/*.rs` modules carry no inline unit tests; the pure-Rust logic
 (chaos, tuning, topology) is validated offline through the bench harnesses.

--- a/scheds/rust/scx_pandemonium/src/adaptive.rs
+++ b/scheds/rust/scx_pandemonium/src/adaptive.rs
@@ -260,22 +260,6 @@ impl LoadGraph {
             .collect()
     }
 
-    // TELEMETRY ONLY since the affinity derivation was withdrawn. This is the
-    // number that says whether the coupling graph carries structure at all, and
-    // it is still wanted -- the reading was never the problem.
-    #[allow(dead_code)]
-    // Mean coupling over the edges that computed. None when the machine is too
-    // quiet or too new to have any -- affinity then keeps whatever the caller
-    // set rather than defaulting to a guess.
-    pub fn mean_coupling(&self) -> Option<f64> {
-        let (n, mean, _, _) = self.edge_summary();
-        if n == 0 {
-            None
-        } else {
-            Some(mean)
-        }
-    }
-
     // Is there structure worth pricing against? Returns (available_edges,
     // mean, min, max) over the edges that computed. A spread near zero means
     // the coupling matrix is flat and the live graph adds nothing over the
@@ -456,6 +440,7 @@ pub fn monitor_loop(
         let delta_wake_samples = stats.wake_lat_samples.wrapping_sub(prev.wake_lat_samples);
         let delta_hard = stats.nr_hard_kicks.wrapping_sub(prev.nr_hard_kicks);
         let delta_soft = stats.nr_soft_kicks.wrapping_sub(prev.nr_soft_kicks);
+        let delta_steal = stats.nr_steal.wrapping_sub(prev.nr_steal);
         let delta_enq_wake = stats.nr_enq_wakeup.wrapping_sub(prev.nr_enq_wakeup);
         let delta_enq_requeue = stats.nr_enq_requeue.wrapping_sub(prev.nr_enq_requeue);
         let delta_rescue = stats
@@ -466,16 +451,6 @@ pub fn monitor_loop(
         // CONSERVATION PATHS XDOM_STEAL (6) AND XDOM_STEP5 (7) ARE EXCLUDED --
         // PENALIZING THEM WOULD MAKE MWU FIGHT THE BPF'S DELIBERATE REBALANCING.
         // saturating_sub ABSORBS A COUNTER RESET (BPF RELOAD) AS 0, NO GARBAGE.
-        let scatter_now: u64 = stats.nr_cross_domain[0..6].iter().sum();
-        let scatter_prev: u64 = prev.nr_cross_domain[0..6].iter().sum();
-        let delta_scatter = scatter_now.saturating_sub(scatter_prev);
-        // Cross-domain scatter: measured and reported. Its consumer was MWU's
-        // scatter loss pathway; placement now prices against the graph instead.
-        let _scatter_pct = if delta_d > 0 {
-            delta_scatter * 100 / delta_d
-        } else {
-            0
-        };
         let wake_avg_us = if delta_wake_samples > 0 {
             delta_wake_sum / delta_wake_samples / 1000
         } else {
@@ -508,12 +483,6 @@ pub fn monitor_loop(
         let dl2_mi = stats
             .nr_l2_miss_interactive
             .wrapping_sub(prev.nr_l2_miss_interactive);
-        let dl2_hl = stats
-            .nr_l2_hit_lat_crit
-            .wrapping_sub(prev.nr_l2_hit_lat_crit);
-        let dl2_ml = stats
-            .nr_l2_miss_lat_crit
-            .wrapping_sub(prev.nr_l2_miss_lat_crit);
         let l2_pct_b = if dl2_hb + dl2_mb > 0 {
             dl2_hb * 100 / (dl2_hb + dl2_mb)
         } else {
@@ -521,11 +490,6 @@ pub fn monitor_loop(
         };
         let l2_pct_i = if dl2_hi + dl2_mi > 0 {
             dl2_hi * 100 / (dl2_hi + dl2_mi)
-        } else {
-            0
-        };
-        let l2_pct_l = if dl2_hl + dl2_ml > 0 {
-            dl2_hl * 100 / (dl2_hl + dl2_ml)
         } else {
             0
         };
@@ -613,6 +577,19 @@ pub fn monitor_loop(
         // tick is the falsification, not the feature.
         let graph = LoadGraph::build(&depth_win);
         let (g_edges, g_mean, g_min, g_max) = graph.edge_summary();
+        // OSCILLATOR POSITION, READ NOT RE-DERIVED. The BPF damped oscillator owns
+        // codel_target_ns; this reads where it currently sits (0.0 floor/tightened,
+        // 1.0 max/relaxed) so the layer can SEE the target it must not fight. The
+        // reader existed with no consumer, which meant the one piece of state that
+        // says whether the BPF has already responded was unobservable from up here.
+        // Reporting only -- the defer gate that would ACT on it is still open.
+        let osc = sched.read_oscillator_state();
+        let osc_pos = osc.position();
+        // The Phi release point the warm-stay and STEP-1 steal actually let a task
+        // leave home at: codel_target plus the nearest-peer hold. Reported beside
+        // the raw position because position() alone cannot say whether the BPF has
+        // genuinely responded -- that comparison is the defer gate, still open.
+        let osc_rel_us = osc.effective_release_ns() / 1000;
         g_tick += 1;
         if g_edges > 0 {
             g_edge_ticks += 1;
@@ -627,7 +604,6 @@ pub fn monitor_loop(
         // SPILL-Phi CHAOS->TEMPERATURE BRIDGE: OVERLAID ONTO EVERY KNOB
         // WRITE BELOW LIKE topology_tau_ns; INERT IN BPF UNTIL THE SPILL
         // PRICE CONSUMES IT.
-        let spill_temp_q16 = tuning::spill_temp_q16(wake_bp_h);
         let bp_delta = wake_bp_h - prev_bp_h;
         let mean_idle = chaos::mean(&idle_win);
         let rqa = chaos::rqa_det(&idle_win);
@@ -664,7 +640,6 @@ pub fn monitor_loop(
                 let mut rk = scaled_regime_knobs(regime, nr_cpus, tau_ns);
                 rk.topology_tau_ns = tau_ns;
                 rk.codel_eq_ns = live.codel_eq_ns;
-                rk.spill_temp_q16 = spill_temp_q16;
                 // Regime baseline, spread per CPU by the graph on the same
                 // terms as the retune path below.
                 sched.write_tuning_knobs_percpu(&graph.derive_percpu_knobs(&rk))?;
@@ -713,7 +688,6 @@ pub fn monitor_loop(
                 let mut knobs = scaled_regime_knobs(regime, nr_cpus, tau_ns);
                 knobs.topology_tau_ns = live.topology_tau_ns;
                 knobs.codel_eq_ns = live.codel_eq_ns;
-                knobs.spill_temp_q16 = spill_temp_q16;
                 // COMMIT-ON-CHANGE: only push when a field actually moved. The
                 // BPF side reads the map unsynchronized, so skipping redundant
                 // writes strictly reduces torn-read exposure.
@@ -756,7 +730,7 @@ pub fn monitor_loop(
             let rqa_disp = rqa.unwrap_or(-1.0);
             let frozen_disp = if frozen { 1 } else { 0 };
             println!(
-                "d/s: {:<8} idle: {}% shared: {:<6} preempt: {:<4} keep: {:<4} kick: H={:<4} S={:<4} enq: W={:<4} R={:<4} wake: {}us p99: {}us [B:{} I:{} L:{}] lat_idle: {}us lat_kick: {}us sleep: io={}% slice: {}us batch: {}us reenq: {} sjrn: {}ms/{}ms rescue: {} l2: B={}% I={}% L={}% chaos: lam={:.2} H={:.2} det={:.2} x={} frozen: {} (n={}) retune_iv: {} [{}{}] graph: n={} e={} cpl={:.2}/{:.2}/{:.2}",
+                "d/s: {:<8} idle: {}% shared: {:<6} preempt: {:<4} keep: {:<4} kick: H={:<4} S={:<4} enq: W={:<4} R={:<4} wake: {}us p99: {}us [B:{} I:{} L:{}] lat_idle: {}us lat_kick: {}us sleep: io={}% slice: {}us batch: {}us reenq: {} sjrn: {}ms/{}ms rescue: {} l2: B={}% I={}% chaos: lam={:.2} H={:.2} det={:.2} x={} frozen: {} (n={}) retune_iv: {} [{}{}] graph: n={} e={} cpl={:.2}/{:.2}/{:.2} osc: {:.2}/{}us",
                 delta_d, idle_pct, delta_shared, delta_preempt, delta_keep,
                 delta_hard, delta_soft, delta_enq_wake, delta_enq_requeue,
                 wake_avg_us, p99_us, tp99_b, tp99_i, tp99_l,
@@ -764,10 +738,11 @@ pub fn monitor_loop(
                 io_pct, knobs.slice_ns / 1000, knobs.batch_slice_ns / 1000,
                 delta_reenq, sojourn_ms, sojourn_thresh_ms,
                 delta_rescue,
-                l2_pct_b, l2_pct_i, l2_pct_l,
+                l2_pct_b, l2_pct_i,
                 idle_lambda, wake_bp_h, rqa_disp, chaos_count.load(),
                 frozen_disp, frozen_ticks, retune_interval,
                 graph.n, g_edges, g_mean, g_min, g_max,
+                osc_pos, osc_rel_us,
                 regime.label(), longrun_label,
             );
         }
@@ -784,6 +759,7 @@ pub fn monitor_loop(
             delta_soft,
             lat_idle_us,
             lat_kick_us,
+            delta_steal,
         );
 
         match regime {
@@ -804,7 +780,6 @@ pub fn monitor_loop(
     let final_stats = sched.read_stats();
     let l2_total_b = final_stats.nr_l2_hit_batch + final_stats.nr_l2_miss_batch;
     let l2_total_i = final_stats.nr_l2_hit_interactive + final_stats.nr_l2_miss_interactive;
-    let l2_total_l = final_stats.nr_l2_hit_lat_crit + final_stats.nr_l2_miss_lat_crit;
     let l2_cum_b = if l2_total_b > 0 {
         final_stats.nr_l2_hit_batch * 100 / l2_total_b
     } else {
@@ -812,11 +787,6 @@ pub fn monitor_loop(
     };
     let l2_cum_i = if l2_total_i > 0 {
         final_stats.nr_l2_hit_interactive * 100 / l2_total_i
-    } else {
-        0
-    };
-    let l2_cum_l = if l2_total_l > 0 {
-        final_stats.nr_l2_hit_lat_crit * 100 / l2_total_l
     } else {
         0
     };
@@ -868,12 +838,12 @@ pub fn monitor_loop(
     }
 
     println!(
-        "[KNOBS] regime={} slice_ns={} batch_ns={} preempt_ns={} mwu={:.3} ticks=L:{}/M:{}/H:{} frozen={} l2_hit=B:{}%/I:{}%/L:{}% cross_domain_scatter_pct={} cross_domain_sel_tight={} cross_domain_sel_sync={} cross_domain_sel_normal={} cross_domain_sel_dfl={} cross_domain_enq_t1={} cross_domain_enq_t2={} cross_domain_steal={} cross_domain_step5={} osc_park={}",
+        "[KNOBS] regime={} slice_ns={} batch_ns={} preempt_ns={} mwu={:.3} ticks=L:{}/M:{}/H:{} frozen={} l2_hit=B:{}%/I:{}% cross_domain_scatter_pct={} cross_domain_sel_tight={} cross_domain_sel_sync={} cross_domain_sel_normal={} cross_domain_sel_dfl={} cross_domain_enq_t1={} cross_domain_enq_t2={} cross_domain_steal={} cross_domain_step5={} osc_park={}",
         regime.label(), final_knobs.slice_ns, final_knobs.batch_slice_ns,
         final_knobs.preempt_thresh_ns,
         0.0f64,
         light_ticks, mixed_ticks, heavy_ticks, frozen_ticks,
-        l2_cum_b, l2_cum_i, l2_cum_l,
+        l2_cum_b, l2_cum_i,
         x_scatter_pct, x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7],
         final_stats.nr_osc_park,
     );
@@ -1306,7 +1276,7 @@ mod derivation_tests {
 #[cfg(test)]
 mod affinity_tests {
     use super::*;
-    use crate::tuning::{TuningKnobs, AFFINITY_STRONG};
+    use crate::tuning::{TuningKnobs, AFFINITY_WEAK};
 
     fn win(vals: &[f64]) -> RawWindow<CHAOS_WIN> {
         let mut w = RawWindow::new();
@@ -1331,14 +1301,14 @@ mod affinity_tests {
         let b: Vec<f64> = a.iter().map(|v| 2.0 * v + 1.0).collect();
         let g = LoadGraph::build(&[win(&a), win(&b)]);
         assert!(
-            g.mean_coupling().unwrap() > 0.9,
+            g.edge_summary().1 > 0.9,
             "the pair must still READ as coupled"
         );
         let mut base = TuningKnobs::default();
-        base.affinity_mode = AFFINITY_STRONG;
+        base.affinity_mode = AFFINITY_WEAK;
         for k in g.derive_percpu_knobs(&base) {
             assert_eq!(
-                k.affinity_mode, AFFINITY_STRONG,
+                k.affinity_mode, AFFINITY_WEAK,
                 "affinity must carry the base through, not be derived"
             );
         }

--- a/scheds/rust/scx_pandemonium/src/bpf/intf.h
+++ b/scheds/rust/scx_pandemonium/src/bpf/intf.h
@@ -39,8 +39,6 @@ struct tuning_knobs {
 	u64 slice_ns;           // BASE TIME SLICE (DEFAULT 1MS)
 	u64 preempt_thresh_ns;  // TICK PREEMPTION THRESHOLD (DEFAULT 1MS)
 	u64 batch_slice_ns;     // BATCH TASK SLICE CEILING (DEFAULT 20MS)
-	u64 lat_cri_thresh_high; // CLASSIFIER: LAT_CRITICAL THRESHOLD (DEFAULT 32)
-	u64 lat_cri_thresh_low;  // CLASSIFIER: INTERACTIVE THRESHOLD (DEFAULT 8)
 	u64 affinity_mode;      // L2 PLACEMENT: 0=OFF, 1=WEAK, 2=STRONG
 	u64 codel_thresh_ns;    // BATCH DSQ RESCUE THRESHOLD (SET BY RUST)
 	u64 burst_slice_ns;     // SLICE CEILING DURING BURST/LONGRUN (SET BY RUST, DEFAULT 1MS)
@@ -53,10 +51,6 @@ struct tuning_knobs {
 	                        // <R_eff> * 2m * tau, CLAMPED [200us, 8ms].
 	                        // 0 MEANS NOT YET WRITTEN. WRITTEN AT TOPOLOGY
 	                        // DETECT AND ON HOTPLUG (CO-LOCATED WITH tau).
-	u64 spill_temp_q16;     // SPILL-Phi: T_base*(1+kappa*H) Q16, FROM THE
-	                        // BANDT-POMPE PERMUTATION ENTROPY. COMPUTED AND
-	                        // SHIPPED EACH ADAPTIVE TICK; INERT UNTIL THE
-	                        // SPILL PRICE CONSUMES IT.
 	// PHI DISTANCE PENALTY IS PRE-FOLDED INTO THE reff_value MAP (IN NS) BY
 	// RUST AT TOPOLOGY DETECT -- NO KNOB FIELD: BPF READS THE MAP DIRECTLY.
 };
@@ -85,8 +79,6 @@ struct pandemonium_stats {
 	u64 nr_l2_miss_batch;
 	u64 nr_l2_hit_interactive;
 	u64 nr_l2_miss_interactive;
-	u64 nr_l2_hit_lat_crit;
-	u64 nr_l2_miss_lat_crit;
 	// CPU RELEASE: TASKS RESCUED FROM LOCAL DSQ BY scx_bpf_reenqueue_local()
 	u64 nr_reenqueue;
 	// CODEL SOJOURN: CURRENT BATCH WAIT AGE (NS), WRITTEN BY tick()
@@ -114,6 +106,14 @@ struct pandemonium_stats {
 	// strand fix -- it should track the formerly tick-floored burst wakes while
 	// the >=900us wake2run bucket collapses.
 	u64 nr_spill_kick_preempt;
+	// TOTAL STEAL COUNT: every successful STEP 1 peer move_to_local, regardless
+	// of domain. nr_cross_domain[XDOM_STEAL] counts only CROSS-domain steals, and
+	// on a two-domain box most steals are same-domain and were counted nowhere --
+	// so "what fraction of the migration count is the dispatch-side steal" had no
+	// answer from anything in the tree. Every successful steal IS a migration by
+	// definition: the task comes off a peer's queue and runs here. One bump, no
+	// per-cause breakdown, operator-useful on any workload.
+	u64 nr_steal;
 	// PER-CPU RUNNABLE DEPTH, ACCUMULATED. THE ADAPTIVE LAYER HAD NO QUEUE
 	// SERIES AT ALL: IT INFERRED LOAD FROM idle_pct, ONE SYSTEM-WIDE INTEGER
 	// PERCENTAGE, WHICH IS WHY THE WHOLE CHAOS LAYER RAN OVER 16 SAMPLES OF

--- a/scheds/rust/scx_pandemonium/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_pandemonium/src/bpf/main.bpf.c
@@ -40,9 +40,8 @@ const volatile u64 nr_cpu_ids = 1;
 
 #define TIER_BATCH        0
 #define TIER_INTERACTIVE  1
-#define TIER_LAT_CRITICAL 2
 
-// FLOW SIGNATURE (PERSISTED SHAPE, FROZEN AT EWMA_AGE_MATURE). COUNTS THE
+// FLOW SIGNATURE (PERSISTED SHAPE, MONOTONE -- NO FREEZE). COUNTS THE
 // DISTINCT WAKER CPUs OF A TASK IN A BITMAP; THE POPCOUNT IS ITS PARTNER
 // CARDINALITY -- A TOPOLOGY-FREE READ OF THE LIVE COMMUNICATION GRAPH'S
 // CONDUCTANCE. A FEW PARTNERS = A TIGHT LOOP; MANY (SPANNING HALF+ THE MACHINE)
@@ -55,9 +54,6 @@ const volatile u64 nr_cpu_ids = 1;
 // THRESHOLD SCALES WITH THE MACHINE, NO HARDCODED CORE GEOMETRY.
 #define SHAPE_TIGHT_MAX    2u
 
-#define LAT_CRI_THRESH_HIGH  32
-#define LAT_CRI_THRESH_LOW   8
-#define LAT_CRI_CAP          255
 
 // HIGH-PRIORITY KTHREAD THRESHOLD: NICE <= -10 EQUIVALENT.
 // static_prio = nice + 120, SO nice <= -10 IS static_prio <= 110.
@@ -73,18 +69,17 @@ const volatile u64 nr_cpu_ids = 1;
 #define SCHED_RR   2
 #endif
 
-#define WEIGHT_LAT_CRITICAL  256   // 2X
 #define WEIGHT_INTERACTIVE   192   // 1.5X
 #define WEIGHT_BATCH         128   // 1X
 
-#define EWMA_AGE_MATURE      8
-#define EWMA_AGE_CAP         16
-#define MAX_WAKEUP_FREQ      64
-#define MAX_CSW_RATE         512
+#define RUNNABLE_COUNT_MATURE  8
+#define RUNNABLE_COUNT_CAP     16
+
 // STARVATION BOUND: TAU-DERIVED IN apply_tau_scaling() VIA K_LAG_CAP. THE AGE AT
-// WHICH sweep_bound_preempt FORCES A HEAD OFF ITS CPU, AND THE OUTER GUARD ON THE
-// warp IN task_deadline() (WHICH IS BOUNDED BY codel_target_ns FIRST, SO THE GUARD
-// IS NEVER THE BINDING CONSTRAINT). NO LONGER THE ORDERING BOUND -- THE TWO WERE
+// WHICH sweep_bound_preempt FORCES A HEAD OFF ITS CPU. IT DOES NOT APPEAR IN
+// task_deadline() AT ALL -- IT NEVER BOUND THE warp IN PRACTICE, BECAUSE THE warp IS
+// BOUNDED BY codel_target_ns BY CONSTRUCTION AND THAT IS THE SMALLER OF THE TWO, SO
+// THE CLAMP THAT USED TO SIT THERE COULD NOT FIRE. NO LONGER THE ORDERING BOUND -- THE TWO WERE
 // ONE NUMBER, WHICH LET A WARP CONSUME THE WHOLE STARVATION BUDGET. AT THE 12C
 // REFERENCE (tau=40MS) THIS IS 40MS. CLAMPED [8MS, 80MS]. INIT FALLBACK MATCHES.
 static u64 lag_cap_ns = 40000000ULL;
@@ -312,11 +307,10 @@ struct {
 	// GLOBALLY -- EVERY LOCAL FINDING IS AVERAGED AWAY AT THE MOMENT OF ACTION.
 	// stats_map IS ALREADY PER-CPU; THIS MAKES THE BOUNDARY SYMMETRIC.
 	//
-	// NOT EVERY FIELD IS PER-CPU. topology_tau_ns, codel_eq_ns, spill_temp_q16,
-	// affinity_mode AND THE TWO lat_cri THRESHOLDS MUST HOLD THE SAME VALUE ON
-	// EVERY CPU OR TAU-SCALING AND TASK CLASSIFICATION DIVERGE BY WHICHEVER CPU
-	// HAPPENED TO OBSERVE. THE RUST WRITER ENFORCES THAT BY CONSTRUCTION --
-	// SEE Scheduler::write_tuning_knobs_percpu.
+	// NOT EVERY FIELD IS PER-CPU. topology_tau_ns, codel_eq_ns AND affinity_mode
+	// MUST HOLD THE SAME VALUE ON EVERY CPU OR TAU-SCALING AND PLACEMENT DIVERGE
+	// BY WHICHEVER CPU HAPPENED TO OBSERVE. THE RUST WRITER ENFORCES THAT BY
+	// CONSTRUCTION -- SEE Scheduler::write_tuning_knobs_percpu.
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
 	__type(key, u32);
@@ -463,14 +457,8 @@ struct {
 
 struct task_ctx {
 	u64 last_run_at;
-	u64 wakeup_freq;
 	u64 last_woke_at;
-	u64 avg_runtime;
-	u64 runtime_dev;     // EWMA OF |RUNTIME - AVG_RUNTIME| (VARIANCE SIGNAL)
 	u64 cached_weight;
-	u64 prev_nvcsw;
-	u64 csw_rate;
-	u64 lat_cri;
 	u64 sleep_start_ns;  // SET IN quiescent(), USED IN running()
 	u64 wait_since;      // WHEN THIS QUEUE WAIT BEGAN; 0 = NOT WAITING. STAMPED ON
 	                     // THE FIRST INSERT AFTER A RUN, PRESERVED ACROSS REQUEUES,
@@ -487,11 +475,12 @@ struct task_ctx {
 	                     // RENDERED, NEVER GUESSES WHAT THE TASK IS. MAINTAINED IN
 	                     // stopping() BESIDE last_run_ns; RESET BY ANY SHORT RUN.
 	u32 tier;
-	u32 ewma_age;
+	u32 runnable_count;
 	s32 last_cpu;        // LAST CPU THIS TASK RAN ON (FOR CACHE AFFINITY)
 	s32 home_cpu;        // STABLE PLACEMENT HOME: PINNED TO THE FIRST CPU THE
 	                     // TASK RAN ON; NEVER CHASES last_cpu. WARM-STAY ANCHOR
-	                     // SO THE TASK RETURNS HOME INSTEAD OF DRIFTING.
+	                     // SO THE TASK RETURNS HOME INSTEAD OF DRIFTING. THE
+	                     // RESTORING FORCE -- SEE THE ANCHOR IN warm_stay_anchor.
 	u8  dispatch_path;   // 0=IDLE, 1=HARD_KICK, 2=SOFT_KICK
 	u8  ran_since_wake;  // is_wakeup = !ran_since_wake; SET 1 IN running(), 0 ON WAKE
 	u8  shape;           // FLOW SIGNATURE: SHAPE_* (FROZEN AT MATURITY)
@@ -606,15 +595,16 @@ static __always_inline void count_l2_affinity(struct pandemonium_stats *s,
 	u32 *nd = bpf_map_lookup_elem(&cache_domain, &ncpu);
 	bool hit = ld && nd && *ld == *nd;
 
-	if (tctx->tier == TIER_BATCH) {
-		if (hit) s->nr_l2_hit_batch += 1;
-		else     s->nr_l2_miss_batch += 1;
-	} else if (tctx->tier == TIER_INTERACTIVE) {
+	// TWO LANES. The latcrit pair was a structurally empty bucket -- it read 0 in
+	// 1598 of 1599 samples in the field capture, because nothing can reach the tier
+	// that fed it. Two counters and a branch per placement for a lane that cannot
+	// fill. This is RELEASE GATE item 1.
+	if (tctx->tier == TIER_INTERACTIVE) {
 		if (hit) s->nr_l2_hit_interactive += 1;
 		else     s->nr_l2_miss_interactive += 1;
 	} else {
-		if (hit) s->nr_l2_hit_lat_crit += 1;
-		else     s->nr_l2_miss_lat_crit += 1;
+		if (hit) s->nr_l2_hit_batch += 1;
+		else     s->nr_l2_miss_batch += 1;
 	}
 }
 
@@ -640,6 +630,25 @@ static __always_inline s32 find_idle_by_affinity(s32 src_cpu,
 {
 	if (src_cpu < 0 || (u32)src_cpu >= nr_cpu_ids)
 		return -1;
+
+	// THE ANCHOR IS A CANDIDATE, AND IT IS THE FIRST ONE. affinity_rank IS BUILT
+	// WITH `c != cpu` (topology.rs build_affinity_rank), SO src_cpu IS NOT IN ITS
+	// OWN RANK AND THIS WALK COULD NEVER RETURN IT. THE COMMENT ABOVE
+	// phi_warm_target ASSERTED THE OPPOSITE -- "RANK SLOT 0 = SELF" -- AND USED
+	// THAT CLAIM TO JUSTIFY NOT WRITING THIS TEST, WHICH IS WHY IT WENT UNREAD.
+	// SLOT 0 IS THE SMT SIBLING AT R_eff 0.001 AGAINST 0.042 FOR EVERYTHING ELSE,
+	// SO THE STANDING OUTCOME WAS: MOVE THE WAKEE TO THE OTHER THREAD OF ITS OWN
+	// CORE, ON EVERY WAKE, INCLUDING WHEN ITS OWN CORE WAS IDLE AND WARM.
+	//
+	// THIS IS EXPRESSED AS *WHICH* IDLE, NEVER AS REFUSING TO MOVE, SO IT IS NOT A
+	// GATE IN FRONT OF PLACEMENT: WHEN THE ANCHOR IS BUSY THE WALK PROCEEDS
+	// EXACTLY AS BEFORE AND EVERY PEER STAYS REACHABLE. IT SELF-LIMITS UNDER LOAD
+	// FOR THE SAME REASON. A MOVE TO AN IDLE PEER WHEN THE ANCHOR IS ALSO IDLE
+	// CANNOT START THE TASK SOONER -- BOTH ARE IDLE -- AND COSTS AN L2 RELOAD
+	// MEASURED AT ~4,500 LLC REFERENCES, SO IT IS PRICE WITHOUT PURCHASE.
+	if ((!allowed || bpf_cpumask_test_cpu(src_cpu, allowed)) &&
+	    scx_bpf_test_and_clear_cpu_idle(src_cpu))
+		return src_cpu;
 
 	u32 base = (u32)src_cpu * MAX_AFFINITY_CANDIDATES;
 	u32 checked = 0;
@@ -679,8 +688,10 @@ static __always_inline s32 find_idle_by_affinity(s32 src_cpu,
 //     BIAS, EXPRESSED BY *WHICH* IDLE, NEVER BY REFUSING TO USE ONE.
 //   - NOTHING IDLE -> RETURN -1, AND select_cpu FALLS THROUGH TO dfl -> enqueue, THE
 //     PROVEN PATH THAT PLACES BUSY-CORE WAKEUPS WITH A REAL PREEMPT (KICK_PREEMPT).
-// find_idle_by_affinity ALREADY RETURNS THE ANCHOR ITSELF WHEN IT IS IDLE (RANK SLOT
-// 0 = SELF), SO A CORRECT SUBORDINATE PLACEMENT BIAS COLLAPSES TO EXACTLY THAT WALK.
+// THE ANCHOR-IDLE CASE IS THE FIRST TEST INSIDE find_idle_by_affinity AND IS WRITTEN
+// THERE EXPLICITLY. THIS COMMENT USED TO CLAIM THE WALK COVERED IT ALREADY ("RANK SLOT
+// 0 = SELF"); IT DID NOT, BECAUSE build_affinity_rank FILTERS `c != cpu`, AND THE CLAIM
+// IS WHY NOBODY READ THE WALK. SLOT 0 IS THE SMT SIBLING, NOT SELF.
 // A PLACE-ON-BUSY WARM-STAY, IF EVER PURSUED, BELONGS IN THE enqueue PATH THAT KICKS
 // PREEMPT -- NEVER THE IDLE FAST PATH.
 static __always_inline s32 phi_warm_target(s32 anchor,
@@ -724,15 +735,23 @@ static __always_inline s32 phi_warm_target(s32 anchor,
 // exact baseline behavior. WAKES are unchanged (is_wakeup still fires); this only
 // ADDS the requeue case for genuine handoff partners. LAT_CRITICAL always
 // qualifies (the latency floor); BATCH and unclassified tasks never do.
+// IPC HANDOFF DISCRIMINATOR -- THE NARROW GATE BRANCH. A SELF-CHECK for a true tight
+// synchronous handoff partner: a matured, non-BATCH task woken by only a handful of
+// distinct partners (popcount of the waker bitmap <= SHAPE_TIGHT_MAX).
+//
+// IT IS KWORKER-ONLY IN PRACTICE AND THAT IS MEASURED, NOT ASSUMED. tier resolves to
+// three declarations and SCHED_FIFO/RR never reaches sched_ext, so every SCHED_OTHER
+// task returns false at the BATCH line and the popcount below is reachable only by a
+// matured PF_WQ_WORKER. Swapping the test onto `shape` to make it reachable was tried on
+// 2026-09-01 and had to be interrupted -- see DO-NOT-RE-ATTEMPT on the board. Do not
+// re-land that swap without the investigation it owes.
 static __always_inline bool is_handoff_partner(const struct task_ctx *tctx)
 {
 	if (!tctx)
 		return false;
-	if (tctx->tier == TIER_LAT_CRITICAL)
-		return true;
 	if (tctx->tier == TIER_BATCH)
 		return false;
-	if (tctx->ewma_age < EWMA_AGE_MATURE)
+	if (tctx->runnable_count < RUNNABLE_COUNT_MATURE)
 		return false;            // not yet classified -- stay on baseline
 	return __builtin_popcountll(tctx->waker_bitmap) <= SHAPE_TIGHT_MAX;
 }
@@ -748,21 +767,36 @@ static __always_inline s32 warm_stay_anchor(struct task_struct *p,
 		return -1;
 	if (!knobs)
 		return -1;
-	if (tctx->tier == TIER_LAT_CRITICAL || (p->flags & PF_KTHREAD))
+	// The LAT_CRITICAL half of this test is deleted with the tier value nothing can
+	// hold; the kthread exclusion is what actually fired.
+	if (p->flags & PF_KTHREAD)
 		return -1;
 	// STABLE HOME ANCHOR: PREFER THE PINNED HOME OVER last_cpu, WHICH IS REWRITTEN
 	// EVERY stopping() AND SO CHASES THE TASK ACROSS CPUs -- THE MIGRATION-STORM
 	// ROOT. AN UNCONGESTED HOME PULLS THE TASK BACK INSTEAD OF DRIFTING. FALLS
 	// BACK TO last_cpu UNTIL HOME IS PINNED (FIRST RUN).
+	//
+	// ANCHORING ON last_cpu INSTEAD WAS TRIED AND IS A LARGE REGRESSION, MEASURED
+	// 2026-09-01 AT N=3 ON BOTH ARMS: Migrations 2.83M -> 4.74M on thread and 2.93M
+	// -> 4.59M on process, wall ratio 1.372 -> 1.641 and 1.427 -> 1.666, cache-miss
+	// ratio 1.729 -> 1.848 and 1.756 -> 2.243. The argument for it was that
+	// returning a displaced task "home" is itself a migration, which is true and is
+	// not the whole account: A pull toward a FIXED point is self-limiting, because
+	// once the task is home no further pull fires. Endorsing wherever the task last
+	// landed has NO restoring force at all, so the spill and the steal move it and
+	// warm-stay ratifies each move in turn. home_cpu is crude -- it is whichever CPU
+	// the task first ran on -- but it is STABLE, and stability is the property doing
+	// the work. A better attractor would be a ledger (the CPU a task has actually
+	// run on most), not the absence of one.
 	s32 lc = (tctx->home_cpu >= 0) ? tctx->home_cpu : tctx->last_cpu;
 	if (lc < 0 || (u32)lc >= nr_cpu_ids)
 		return -1;
 	if (!bpf_cpumask_test_cpu(lc, p->cpus_ptr))
 		return -1;
-	// OCCUPANCY GATE (fan-out 1:N): if the home per-CPU DSQ already holds a
-	// queued waiter, release the NEXT same-home wakee to idle-seek instead of
-	// stacking it. A 1:N parent wakes K children whose home_cpu collides onto a
-	// few cores; warm-stay seats with NO spill, so without this they pile on one
+	// OCCUPANCY GATE (fan-out 1:N): if the anchor's per-CPU DSQ already holds a
+	// queued waiter, release the NEXT same-anchor wakee to idle-seek instead of
+	// stacking it. A 1:N parent wakes K children whose anchors collide onto a few
+	// cores; warm-stay seats with NO spill, so without this they pile on one
 	// per-CPU DSQ and the per-round straggler waits a CoDel-aged steal/tick (the
 	// fan-out ms p50). The FIRST wakee (nq==0) still takes the warm seat, so the
 	// 1:1 IPC handoff -- where the waker is on-CPU, not queued -- is unaffected.
@@ -774,8 +808,14 @@ static __always_inline s32 warm_stay_anchor(struct task_struct *p,
 	// WAKEES TO THE WARM SEAT AND SO FIRES FAR MORE HOME-PULLS: MEASURED AT 12C
 	// UNDER --dev ipc AS intra_wake 2161 -> 57485, TOTAL MIGRATIONS 3037 -> 59150
 	// AGAINST A FLAT WAKEUP COUNT (233147 -> 246540), 1.3% -> 24.0% PER WAKEUP.
-	// DO NOT REPLACE THIS WITH A PRICE UNTIL THE home_cpu / last_cpu DIVERGENCE
-	// BELOW IT IS SETTLED -- THE GATE IS SUPPRESSING A DEFECT, NOT EXPRESSING ONE.
+	//
+	// REMOVING THE home_cpu / last_cpu DIVERGENCE DOES NOT DISCHARGE THIS. Anchoring
+	// on last_cpu was tried on 2026-09-01 and regressed migrations ~60% on both
+	// arms (see the anchor above), so the divergence is load-bearing rather than a
+	// defect to settle first, and this gate keeps its second job. It remains a
+	// boolean where the constraint wants a price, and the Phi comparison below asks
+	// the same question in the right form -- but replacing it now would be measured
+	// against a restoring force we have just confirmed we need.
 	if (scx_bpf_dsq_nr_queued((u64)lc) > 0)
 		return -1;
 	u64 stamp = sojourn_stamp_pcpu[(u32)lc & (MAX_CPUS - 1)].ns;
@@ -819,6 +859,10 @@ static __always_inline s32 warm_stay_anchor(struct task_struct *p,
 // LAMBDA_2 = 12 (USER'S 12C): 6. AT LAMBDA_2 = 32 (ROLAND'S 32C): 16.
 // CLAMPED TO [6, MAX_AFFINITY_CANDIDATES]. SET IN apply_tau_scaling().
 static u32 pcpu_spill_search_budget = 6;
+
+// CEILING ON THE keep_own DEPTH BYPASS. Set in apply_tau_scaling beside the depth
+// gate it extends; see there for why it is twice pcpu_depth_base.
+static u32 keep_own_depth_max = 4;
 
 // STATIC SCAN CEILING FOR THE SPILL HELPER ONLY. THE RUNTIME BUDGET ABOVE IS
 // SMALL (6 AT 12C, 16 AT 32C); MAX_AFFINITY_CANDIDATES (= 128) AS THE LOOP'S
@@ -909,17 +953,25 @@ static __always_inline u64 pick_pcpu_dsq_with_spill(s32 src_cpu,
 	u64 now = bpf_ktime_get_ns();
 	bool src_ok = (u64)src_cpu < nr_cpu_ids &&
 		      (!allowed || bpf_cpumask_test_cpu(src_cpu, allowed));
+	// HOISTED ONCE. Both the depth gate and the keep_own ceiling ask about the same
+	// queue, and the verifier note on this function is about CONTROL FLOW rather
+	// than size -- a conditional added upstream of the CAS sites cost src_cpu's
+	// range 350 insns later once before. One read, one local, no second kfunc call
+	// and no second branch.
+	u32 src_depth = src_ok ? scx_bpf_dsq_nr_queued((u64)src_cpu) : 0;
 
-	// PAIR-WARM MARKER: a handoff partner (keep_own) always seats on its own
-	// warm core (src_cpu) -- the sibling spill is forced off below, and the
-	// only non-src_cpu outcome is the affinity-stranded escape (!src_ok).
-	// Stamp the seat so the STEP-1 steal can price splitting this warm pair
-	// without a remote task_ctx deref.
-	if (keep_own && src_ok && (u32)src_cpu < MAX_CPUS)
+	// PAIR-WARM MARKER: a handoff partner seats on its own warm core (src_cpu)
+	// while the queue is under the keep_own ceiling -- the sibling spill is forced
+	// off below, and the other non-src_cpu outcome is the affinity-stranded escape
+	// (!src_ok). Stamp the seat so the STEP-1 steal can price splitting this warm
+	// pair without a remote task_ctx deref. The stamp follows the BOUNDED decision:
+	// past the ceiling the partner spills like anything else, so claiming a warm
+	// pair on src_cpu would price a pair that is not seated there.
+	if (keep_own && src_ok && src_depth < keep_own_depth_max &&
+	    (u32)src_cpu < MAX_CPUS)
 		pair_warm_ns[(u32)src_cpu & (MAX_CPUS - 1)] = now;
 
-	if (src_ok &&
-	    scx_bpf_dsq_nr_queued((u64)src_cpu) < pcpu_depth_base) {
+	if (src_ok && src_depth < pcpu_depth_base) {
 		if ((u32)src_cpu < MAX_CPUS)
 			__sync_val_compare_and_swap(
 				&sojourn_stamp_pcpu[(u32)src_cpu].ns,
@@ -948,7 +1000,15 @@ static __always_inline u64 pick_pcpu_dsq_with_spill(s32 src_cpu,
 	// or the tick (the ~1% / 1.3ms IPC tail). Fall through to the over-depth-own
 	// seat on src_cpu below (bounded by the CoDel sojourn steal). NO kick change
 	// -- pure placement, the zero-IPI half of the fix.
-	s32 spill = keep_own ? -1 : find_pcpu_with_room(src_cpu, allowed);
+	// BOUNDED. keep_own holds the own seat only while STEP 0 can still plausibly
+	// reach the partner; past keep_own_depth_max the partner spills like anything
+	// else and the sibling search is allowed to relieve the core. Without the
+	// ceiling this is an uncapped depth bypass, and step 4 -- which makes the
+	// predicate reachable for every SCHED_OTHER task instead of kworkers alone --
+	// would arm it on the whole population at once. Bounding first is what makes
+	// that step measurable rather than a cliff.
+	bool hold_own = keep_own && src_depth < keep_own_depth_max;
+	s32 spill = hold_own ? -1 : find_pcpu_with_room(src_cpu, allowed);
 	if (spill >= 0) {
 		if ((u32)spill < MAX_CPUS)
 			__sync_val_compare_and_swap(
@@ -1250,6 +1310,21 @@ static __always_inline void apply_tau_scaling(u64 tau_ns, u64 codel_eq_ns)
 	// SATURATION.
 	pcpu_depth_base = (tau_ns >= 6000000ULL) ? 2 : 1;
 
+	// KEEP-OWN CEILING. keep_own suppresses the sibling spill so a handoff partner
+	// lands on the waker's own core, on the argument that the waker blocks within
+	// microseconds and STEP 0 then drains the partner next. That argument holds only
+	// while the queue is SHALLOW: with tasks already ahead, STEP 0 reaches them
+	// first and the partner waits behind a line it was never meant to join, on a
+	// core the spill search was forbidden from relieving. Unbounded, it is a depth
+	// bypass with no ceiling at all.
+	//
+	// TWICE THE DEPTH GATE, in the same unit and derived from the same tau, so it
+	// scales with topology exactly as the gate it extends does. It has to bind
+	// tighter on narrow machines and does: declining the spill peer costs half the
+	// machine at 2C and a twelfth at 12C, which is why arming the predicate against
+	// an unbounded consumer measured 2C jitter p99 73 -> 953us while 12C improved.
+	keep_own_depth_max = pcpu_depth_base * 2;
+
 	// LONGRUN PREEMPT BOOST SHIFT. STEP-FUNCTION ON tau. AT tau < 4MS (2C
 	// RANGE) BOOST PREEMPT THRESHOLD 4X UNDER longrun_mode SO BATCH GETS
 	// MORE ROPE ON THIN TOPOLOGIES; AT HIGHER tau (4C+) NO BOOST.
@@ -1356,51 +1431,7 @@ static __always_inline u32 sleep_bucket(u64 sleep_ns)
 	return 3;
 }
 
-// EWMA
-
-static __always_inline u64 calc_avg(u64 old_val, u64 new_val, u32 age)
-{
-	if (age < EWMA_AGE_MATURE)
-		return (old_val >> 1) + (new_val >> 1);
-	return old_val - (old_val >> 3) + (new_val >> 3);
-}
-
-static __always_inline u64 update_freq(u64 freq, u64 interval_ns, u32 age)
-{
-	if (interval_ns == 0)
-		interval_ns = 1;
-	u64 new_freq = (100ULL * 1000000ULL) / interval_ns;
-	return calc_avg(freq, new_freq, age);
-}
-
 // BEHAVIORAL CLASSIFICATION
-
-// LAT_CRI SCORE: HIGH WAKEUP FREQ + HIGH CSW RATE + SHORT RUNTIME = CRITICAL
-static __always_inline u64 compute_lat_cri(u64 wakeup_freq, u64 csw_rate,
-					    u64 avg_runtime_ns,
-					    u64 runtime_dev_ns)
-{
-	u64 effective_runtime_ns = avg_runtime_ns + (runtime_dev_ns >> 1);
-	u64 avg_runtime_ms = effective_runtime_ns >> 20;
-	if (avg_runtime_ms == 0)
-		avg_runtime_ms = 1;
-	u64 score = (wakeup_freq * csw_rate) / avg_runtime_ms;
-	if (score > LAT_CRI_CAP)
-		score = LAT_CRI_CAP;
-	return score;
-}
-
-static __always_inline u32 classify_tier(u64 lat_cri,
-					  const struct tuning_knobs *knobs)
-{
-	u64 thresh_high = knobs ? knobs->lat_cri_thresh_high : LAT_CRI_THRESH_HIGH;
-	u64 thresh_low  = knobs ? knobs->lat_cri_thresh_low  : LAT_CRI_THRESH_LOW;
-	if (lat_cri >= thresh_high)
-		return TIER_LAT_CRITICAL;
-	if (lat_cri >= thresh_low)
-		return TIER_INTERACTIVE;
-	return TIER_BATCH;
-}
 
 // TRACE: FAST 4-BYTE COMM CHECK FOR SCHEDULER PROCESS TRACING
 // CATCHES "pandemonium" WITH ZERO MAP OVERHEAD. GATED BY TRACE_SCHED BECAUSE
@@ -1421,12 +1452,10 @@ static __always_inline u64 effective_weight(const struct task_struct *p,
 	u64 weight = p->scx.weight;
 	u64 behavioral;
 
-	if (tctx->tier == TIER_LAT_CRITICAL)
-		behavioral = WEIGHT_LAT_CRITICAL;
-	else if (tctx->tier == TIER_INTERACTIVE)
-		behavioral = WEIGHT_INTERACTIVE;
-	else
-		behavioral = WEIGHT_BATCH;
+	// TWO LEVELS, NOT THREE. The LAT_CRITICAL level was reachable only through a tier
+	// value nothing can hold, so dropping it is arithmetic-identical.
+	behavioral = (tctx->tier == TIER_INTERACTIVE) ? WEIGHT_INTERACTIVE
+						      : WEIGHT_BATCH;
 
 	return weight * behavioral >> 7;
 }
@@ -1446,7 +1475,7 @@ static __always_inline u64 effective_weight(const struct task_struct *p,
 // BETWEEN DEFAULTS TO TIGHT (LATENCY-SAFE -- ITS STEAL STAYS FREELY RELIEVABLE).
 // THEN FREEZE -- DETERMINISTIC PER TASK, SO ROUTING CAN'T COIN-FLIP.
 // THE FREEZE WAS PREMATURE AND THE GATE ON IT WAS EWMA STATE. shape WAS DECIDED AT
-// ewma_age == EWMA_AGE_MATURE -- THE FIRST ~8 WAKEUPS -- AND KEPT FOR THE TASK'S
+// runnable_count == RUNNABLE_COUNT_MATURE -- THE FIRST ~8 WAKEUPS -- AND KEPT FOR THE TASK'S
 // LIFE, SO A THREAD THAT WILL EVENTUALLY TALK TO THE WHOLE MACHINE WAS STAMPED
 // TIGHT FROM ITS FIRST FEW PARTNERS. THAT STAMP ADMITS select_cpu's WAKER-ANCHORED
 // CO-LOCATION, WHICH IS THE LARGEST SCATTER SOURCE IN THE SCHEDULER: 498,471
@@ -1508,11 +1537,11 @@ static __always_inline u64 task_deadline(struct task_ctx *tctx,
 	// FOR A TARGET OR LONGER EARNS NOTHING; EVERYTHING BETWEEN IS CONTINUOUS. THE
 	// SIGNAL IS THE TASK'S OWN MEASURED RUN, PRICED IN THE ONLY UNIT THE GATE
 	// USES -- NO CLASSIFIER, NO EWMA, NO TIER, NO MATURITY GATE, NO Q16 SCALING.
-	// BOUNDED BY codel_target_ns BY CONSTRUCTION, SO THE ORDERING BOUND IS NOW
-	// THE CoDel TARGET AND NO LONGER THE STARVATION BOUND: A TASK THAT HAS WAITED
-	// PAST ONE TARGET OUTRANKS ANY FRESH CLAIM, WHICH IS THE SOJOURN GUARANTEE
-	// STATED IN THE UNIT THE OSCILLATOR MAINTAINS. lag_cap_ns REMAINS THE OUTER
-	// GUARD ONLY (STARVATION), ENFORCED BY sweep_bound_preempt, NOT BY THIS KEY.
+	// BOUNDED BY codel_target_ns BY CONSTRUCTION, SO THE ORDERING BOUND IS THE
+	// CoDel TARGET: A TASK THAT HAS WAITED PAST ONE TARGET OUTRANKS ANY FRESH
+	// CLAIM, WHICH IS THE SOJOURN GUARANTEE STATED IN THE UNIT THE OSCILLATOR
+	// MAINTAINS. lag_cap_ns IS THE STARVATION BOUND, ENFORCED BY
+	// sweep_bound_preempt, AND IT DOES NOT APPEAR IN THIS KEY.
 	// A TASK THAT HAS NEVER RUN HAS LEFT NO SHARE OF A TARGET UNCONSUMED -- IT HAS
 	// NO SERVICE HISTORY TO PRICE. last_run_ns IS WRITTEN ONLY IN stopping(), SO A
 	// FRESH FORK CARRIES 0 AND target - 0 HANDS IT THE FULL TARGET: THE MAXIMUM
@@ -1523,8 +1552,30 @@ static __always_inline u64 task_deadline(struct task_ctx *tctx,
 	u64 target = codel_target_ns;
 	u64 ran = tctx->last_run_ns;
 	u64 warp = ran ? (target > ran ? target - ran : 0) : 0;
-	if (warp > lag_cap_ns)
-		warp = lag_cap_ns;
+
+	// DO NOT BOUND THIS BY sojourn_stamp_pcpu. Tried 2026-09-01 and reverted the
+	// same night: `warp = min(warp, now - sojourn_stamp_pcpu[cpu])`, on the
+	// argument that a ceiling should scale with the queue the task is entering
+	// rather than sit at a constant. Post-reboot at N=3 with an EEVDF arm, 12C
+	// pipe p99 pinned at 1370us across all three iterations on both arms -- the
+	// archive's dominant mode, where the same cell had read 153-472us hours
+	// earlier -- and 4C went 674-915 -> 1299us. p50 did not move, which is what
+	// the change was for.
+	//
+	// THE REASON IS WHAT THAT STAMP MEANS. pcpu_drain_clear() zeroes it every time
+	// the per-CPU DSQ empties and placement re-arms it, so it is a QUEUE-OCCUPANCY
+	// stamp, not the head's age. The two coincide only on a queue that never
+	// empties. Under a ping-pong the DSQ empties constantly, the derived "head
+	// age" is near zero, and min() crushes the back-date to nothing in exactly the
+	// workload the warp exists for. A bound wants a quantity that is small when
+	// the queue is SHALLOW, and this one is small when the queue is HEALTHY.
+	//
+	// The lag_cap_ns clamp that stood here was dead. warp is bounded by target by
+	// construction (target - ran <= target), lag_cap_ns is K_LAG_CAP * tau = one
+	// tau (13ms live) and codel_target is clamped below codel_target_max_ns, so
+	// the test could not fire. lag_cap_ns is the STARVATION bound and it is
+	// enforced by sweep_bound_preempt, which is what the comment above already
+	// said and what the code did not do.
 
 	// SOJOURN BACK-PRESSURE: ORDERING IS base - warp, OLDEST-FIRST -- A STARVING
 	// TASK RISES AS IT AGES, AND BOUNDED WARP MAKES IT STARVATION-FREE. DEEP-QUEUE
@@ -1542,7 +1593,7 @@ static __always_inline u64 task_deadline(struct task_ctx *tctx,
 // THRESHOLD -- THE BOUNDARY IS ONE TARGET BY CONSTRUCTION. THE CONFIRM DEPTH IS THE
 // MEMORY last_run_ns ALONE LACKS: A HOG THAT BLOCKS ONCE READS AS DRAINED ON A SINGLE
 // SAMPLE, AND AN EWMA IS THE ANSWER THIS PROJECT HAS RULED OUT. A FRESH FORK CARRIES
-// 0 AND IS NOT STANDING, WHICH IS WHAT THE ewma_age < 2 BURST-SPAWN HACK EXISTED FOR.
+// 0 AND IS NOT STANDING, WHICH IS WHAT THE runnable_count < 2 BURST-SPAWN HACK EXISTED FOR.
 #define STANDING_CONFIRM 2u
 #define STANDING_CAP     8u
 
@@ -2104,8 +2155,7 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 	// DRAINS THE WARM PER-CPU DSQ WHEN last_cpu NEXT DISPATCHES; STEP 1
 	// (NEAREST-SURPLUS STEAL) COVERS A SIBLING LANDING.
 	if (tctx &&
-	    (tctx->tier == TIER_LAT_CRITICAL || is_wakeup ||
-	     is_handoff_partner(tctx))) {
+	    (is_wakeup || is_handoff_partner(tctx))) {
 		// WARM-ANCHOR: PREFER THE WAKEE'S OWN LAST CORE. pick_pcpu_dsq_with_spill
 		// THEN SEATS IT ON THAT cpu'S PER-CPU DSQ (WARM), A NEAR R_eff SIBLING,
 		// OR domain_inter_dsq AS LAST RESORT.
@@ -2156,7 +2206,7 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 	// ROUTED BY SERVICE RENDERED. A TASK THAT HAS STOOD ON A CPU FOR A FULL CoDel
 	// TARGET ON EACH OF ITS LAST STANDING_CONFIRM RUNS TAKES THE BATCH OVERFLOW;
 	// EVERYTHING ELSE TAKES THE INTERACTIVE ONE. THE BURST-SPAWN CARVE-OUT THAT
-	// USED TO LIVE HERE (ewma_age < 2 STAYS INTERACTIVE, SO A FORK STORM DOES NOT
+	// USED TO LIVE HERE (runnable_count < 2 STAYS INTERACTIVE, SO A FORK STORM DOES NOT
 	// FLOOD THE BATCH DSQ AND STARVE 30-40s BEHIND A SOJOURN RESCUE THAT NEVER
 	// REACHES THE TAIL) IS NOW STRUCTURAL RATHER THAN A SPECIAL CASE: A FRESH FORK
 	// HAS RENDERED NO SERVICE, SO standing_runs IS 0 AND IT IS INTERACTIVE BY
@@ -2179,7 +2229,6 @@ void BPF_STRUCT_OPS(pandemonium_enqueue, struct task_struct *p,
 	else
 		__sync_val_compare_and_swap(&sojourn_stamp_overflow[src_dom_t3 & (MAX_OVERFLOW_DOMAINS - 1)].inter, 0, bpf_ktime_get_ns());
 
-	// WARP IS BOUNDED BY lag_cap_ns INSIDE task_deadline() (NO CEILING CLAMP).
 	dl = tctx ? task_deadline(tctx, knobs) : bpf_ktime_get_ns();
 
 	scx_bpf_dsq_insert_vtime(p, target_dsq, sl, dl, enq_flags);
@@ -2451,6 +2500,7 @@ void BPF_STRUCT_OPS(pandemonium_dispatch, s32 cpu, struct task_struct *prev)
 			s = get_stats();
 			if (s) {
 				s->nr_dispatches += 1;
+				s->nr_steal += 1;
 				// STEAL: task's home is best_peer, now consumed by `cpu`.
 				cross_domain_bump(s, XDOM_STEAL, best_peer, cpu);
 			}
@@ -2565,74 +2615,43 @@ void BPF_STRUCT_OPS(pandemonium_runnable, struct task_struct *p,
 	u64 now = bpf_ktime_get_ns();
 	tctx->ran_since_wake = false;
 
-	// FAST PATH: BRAND-NEW TASKS (< 2 WAKEUPS)
-	if (tctx->ewma_age < 2) {
-		tctx->last_woke_at = now;
-		tctx->prev_nvcsw = p->nvcsw;
-		tctx->ewma_age += 1;
-		return;
-	}
+	// A SATURATING COUNT OF runnable() ENTRIES. NOT AN AVERAGE AND NOT AN
+	// AVERAGE'S AGE -- IT WAS calc_avg's WARM-UP SCHEDULE, AND calc_avg IS GONE.
+	if (tctx->runnable_count < RUNNABLE_COUNT_CAP)
+		tctx->runnable_count += 1;
 
-	// WAKEUP FREQUENCY
-	u64 delta_t = now > tctx->last_woke_at ? now - tctx->last_woke_at : 1;
-	tctx->wakeup_freq = update_freq(tctx->wakeup_freq, delta_t,
-					 tctx->ewma_age);
-	if (tctx->wakeup_freq > MAX_WAKEUP_FREQ)
-		tctx->wakeup_freq = MAX_WAKEUP_FREQ;
+	// last_woke_at HAS ONE JOB AGAIN. It used to carry two that destroyed each
+	// other: runnable() read it as the inter-wake interval and stamped it, while
+	// running() read it as the start of this wake and cleared it to 0. After a
+	// task's first run the interval read was therefore `now - 0`, nanoseconds
+	// since boot, which drove update_freq to 0, csw_freq to 0 and the score to 0
+	// -- BATCH for every task, forever. Removing the interval reader resolves the
+	// collision by deletion rather than repair: stamped here, read and cleared in
+	// running(), wake latency only.
 	tctx->last_woke_at = now;
 
-	if (tctx->ewma_age < EWMA_AGE_CAP)
-		tctx->ewma_age += 1;
-
-	// VOLUNTARY CONTEXT SWITCH RATE
-	u64 nvcsw = p->nvcsw;
-	u64 csw_delta = nvcsw > tctx->prev_nvcsw ? nvcsw - tctx->prev_nvcsw : 0;
-	tctx->prev_nvcsw = nvcsw;
-
-	if (csw_delta > 0 && delta_t > 0) {
-		u64 csw_freq = csw_delta * (100ULL * 1000000ULL) / delta_t;
-		tctx->csw_rate = calc_avg(tctx->csw_rate, csw_freq,
-					   tctx->ewma_age);
-	} else {
-		tctx->csw_rate = calc_avg(tctx->csw_rate, 0, tctx->ewma_age);
-	}
-	if (tctx->csw_rate > MAX_CSW_RATE)
-		tctx->csw_rate = MAX_CSW_RATE;
-
-	// BEHAVIORAL CLASSIFICATION
-	tctx->lat_cri = compute_lat_cri(tctx->wakeup_freq, tctx->csw_rate,
-					 tctx->avg_runtime, tctx->runtime_dev);
-	struct tuning_knobs *knobs = get_knobs();
-	u32 new_tier = classify_tier(tctx->lat_cri, knobs);
-
-	// HIGH-PRIORITY KTHREAD OVERRIDE: PF_KTHREAD AT NICE <= -10 LOOK
-	// LATENCY-SENSITIVE TO THE BEHAVIORAL SCORER (SHORT RUNTIMES, HIGH
-	// WAKEUP FREQUENCY) BUT ARE COMPUTE CLASS. LEFT IN LAT_CRITICAL THEY
-	// DOMINATE DISPATCH OVER LEGITIMATE USERSPACE INTERACTIVE WORK UNDER
-	// HEAVY KERNEL LOAD. FORCED TO BATCH SO THEY STILL GET WEIGHTED
-	// PREFERENCE WITHIN BATCH BUT DO NOT MIX WITH USER LAT_CRITICAL.
-	// PF_WQ_WORKER IS A PF_KTHREAD SUBSET HANDLED BY THE FLOOR BELOW
-	// (WORKQUEUE WORKERS STAY INTERACTIVE).
-	if (p->flags & PF_KTHREAD &&
-	    p->static_prio <= KTHREAD_HIPRI_STATIC_PRIO_MAX)
-		new_tier = TIER_BATCH;
-
-	// KWORKER FLOOR: WORKQUEUE WORKERS HANDLE I/O COMPLETIONS, TIMER
-	// CALLBACKS, AND DEFERRED INTERRUPT WORK. USERSPACE BLOCKS ON THESE.
-	// THEIR LOW EWMA SCORES (INFREQUENT WAKEUPS, LONG RUNTIMES) PUSH
-	// THEM TO BATCH, BUT THEY ARE LATENCY-CRITICAL KERNEL INFRASTRUCTURE.
-	// ALSO RE-PROMOTES ANY PF_WQ_WORKER DEMOTED BY THE KTHREAD OVERRIDE
-	// ABOVE -- WORKQUEUE WORKERS ARE PF_KTHREAD BUT THE FLOOR WINS.
-	if (new_tier == TIER_BATCH && (p->flags & PF_WQ_WORKER))
-		new_tier = TIER_INTERACTIVE;
-
-	// RT-POLICY FLOOR: SCHED_FIFO/SCHED_RR (PipeWire/JACK RT THREADS, THREADED
-	// IRQ kthreads) ARE LATENCY-CRITICAL BY POLICY. PIN LAT_CRITICAL REGARDLESS
-	// OF THE BEHAVIORAL SCORE AND THE kthread->BATCH OVERRIDE ABOVE.
-	if (p->policy == SCHED_FIFO || p->policy == SCHED_RR)
-		new_tier = TIER_LAT_CRITICAL;
-
-	tctx->tier = new_tier;
+	// TIER IS THREE DECLARATIONS, WHICH IS ALL IT HAS EVER RESOLVED TO. The score
+	// fed classify_tier, classify_tier returned BATCH for every task, and the
+	// overrides below then rewrote it unconditionally: the kthread floor was a
+	// no-op against an already-BATCH value, the PF_WQ_WORKER floor always fired,
+	// and the RT floor always won. Four EWMAs, a score and two thresholds
+	// computing an input that could not change the output. Stating the
+	// declarations directly is bit-identical and costs a wakeup nothing.
+	//
+	//   SCHED_FIFO / SCHED_RR   -> LAT_CRITICAL   (a policy userspace declared)
+	//   PF_WQ_WORKER            -> INTERACTIVE    (userspace blocks on these)
+	//   everything else         -> BATCH
+	//
+	// PF_KTHREAD at nice <= -10 was forced to BATCH by an override that could
+	// only ever see BATCH; it is the default now and needs no statement.
+	// THE RT BRANCH IS DELETED BECAUSE IT CANNOT BE TAKEN, and that is a property of
+	// the kernel rather than of this machine or this workload: sched_ext sits BELOW
+	// RT and deadline in the scheduling-class hierarchy and is handed only
+	// SCHED_NORMAL, SCHED_BATCH and SCHED_IDLE. An RT task is served by the RT class
+	// and never reaches these ops at all. Measured to be sure -- two SCHED_FIFO
+	// threads at rtprio 5 held against a live scheduler for 48 seconds, and the
+	// LAT_CRITICAL bucket read 0 in all 49 samples. tier is two values.
+	tctx->tier = (p->flags & PF_WQ_WORKER) ? TIER_INTERACTIVE : TIER_BATCH;
 }
 
 // RUNNING: TASK STARTS EXECUTING -- RECORD WAKE LATENCY, SET RAN-SINCE-WAKE
@@ -2734,37 +2753,6 @@ void BPF_STRUCT_OPS(pandemonium_stopping, struct task_struct *p,
 	} else {
 		tctx->standing_runs = 0;
 	}
-	{
-		u64 avg = tctx->avg_runtime;
-		u64 diff = slice > avg ? slice - avg : avg - slice;
-		tctx->avg_runtime = calc_avg(avg, slice, tctx->ewma_age);
-		tctx->runtime_dev = calc_avg(tctx->runtime_dev, diff,
-					      tctx->ewma_age);
-	}
-
-	// CPU-BOUND DEMOTION. LONG-RUNNERS THAT NEVER SLEEP KEEP ewma_age
-	// PINNED AT 1 (INCREMENTED ONLY ON SLEEP->RUNNABLE IN runnable()),
-	// SO classify_tier NEVER RERUNS. THE CLASSIFIER-BASED PATH LEAVES
-	// SUCH TASKS AT TIER_INTERACTIVE INDEFINITELY, WHICH MAKES THEM
-	// UNPREEMPTIBLE BY tick() (ONLY TIER_BATCH RECEIVES THE TICK RESCUE
-	// AT LINE ~2031). THRESHOLD SCALES WITH slice_ns: AN INTERACTIVE
-	// LONG-RUNNER'S avg_runtime ASYMPTOTES TO THE SLICE CAP, SO A
-	// FIXED-NS THRESHOLD ABOVE slice_ns CAN NEVER FIRE FOR THE EXACT
-	// TASKS THE DEMOTION IS MEANT TO CATCH. 75% OF slice_cap CATCHES
-	// PURE CPU-BOUND WITHIN ~6 STOP CYCLES (~6ms WALL). THE ewma_age
-	// GUARD SPARES LEGIT INTERACTIVE TASKS THAT USE FULL SLICE BUT
-	// SLEEP FREQUENTLY -- THEIR ewma_age GROWS ON EVERY SLEEP->WAKE.
-	{
-		struct tuning_knobs *kk = get_knobs();
-		u64 slice_cap = kk ? kk->slice_ns : 1000000;
-		if (tctx->tier == TIER_INTERACTIVE &&
-		    tctx->avg_runtime * 4 >= slice_cap * 3 &&
-		    tctx->ewma_age <= 4) {
-			tctx->tier = TIER_BATCH;
-			tctx->cached_weight = effective_weight(p, tctx);
-		}
-	}
-
 }
 
 // TICK: SOJOURN ENFORCEMENT + EVENT-DRIVEN BATCH PREEMPTION
@@ -3164,15 +3152,9 @@ void BPF_STRUCT_OPS(pandemonium_enable, struct task_struct *p)
 	if (tctx) {
 		tctx->ran_since_wake = false;
 		tctx->last_run_at = 0;
-		tctx->wakeup_freq = 20;
 		tctx->last_woke_at = bpf_ktime_get_ns();
-		tctx->avg_runtime = 100000;
 		tctx->cached_weight = WEIGHT_INTERACTIVE;
-		tctx->prev_nvcsw = p->nvcsw;
-		tctx->csw_rate = 0;
-		tctx->lat_cri = 0;
 		tctx->tier = TIER_INTERACTIVE;
-		tctx->ewma_age = 0;
 		tctx->standing_runs = 0;   // NO SERVICE RENDERED YET
 		tctx->wake_obs = 0;        // NOTHING OBSERVED YET
 		tctx->dispatch_path = 0;
@@ -3180,6 +3162,7 @@ void BPF_STRUCT_OPS(pandemonium_enable, struct task_struct *p)
 		// prev_cpu (the parent's CPU at fork) so it warm-routes per-domain instead
 		// of aliasing CPU 0 or scattering via the node-wide dfl pick.
 		tctx->last_cpu = -1;
+		tctx->runnable_count = 0;
 		tctx->home_cpu = -1;   // pinned on first run (stopping)
 	}
 }
@@ -3251,14 +3234,11 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(pandemonium_init)
 		knobs->slice_ns = 1000000;
 		knobs->preempt_thresh_ns = 1000000;
 		knobs->batch_slice_ns = 20000000;        // 20MS FLAT DEFAULT
-		knobs->lat_cri_thresh_high = LAT_CRI_THRESH_HIGH; // 32
-		knobs->lat_cri_thresh_low  = LAT_CRI_THRESH_LOW;  // 8
 		knobs->affinity_mode = 0;                // OFF BY DEFAULT (RUST SETS PER REGIME)
 		knobs->codel_thresh_ns = 5000000;        // 5MS DEFAULT (RUST OVERRIDES)
 		knobs->burst_slice_ns = 1000000;         // 1MS DEFAULT (BURST/LONGRUN CEILING)
 		knobs->topology_tau_ns = 0;              // RUST WRITES AT TOPOLOGY DETECT
 		knobs->codel_eq_ns = 0;                  // RUST WRITES AT TOPOLOGY DETECT
-		knobs->spill_temp_q16 = 65536;           // T_base (Q16 1.0); ADAPTIVE OVERLAYS
 	}
 
 	// BELT-AND-SUSPENDERS: DERIVE tau-SCALED STATICS IMMEDIATELY IF RUST

--- a/scheds/rust/scx_pandemonium/src/event.rs
+++ b/scheds/rust/scx_pandemonium/src/event.rs
@@ -19,6 +19,10 @@ pub struct Snapshot {
     pub soft_kicks: u64,
     pub lat_idle_us: u64,
     pub lat_kick_us: u64,
+    // Every successful STEP 1 peer move_to_local. Each one IS a migration, so
+    // this against dispatches is the dispatch side's share of the migration
+    // count -- the half no counter in the tree could report before.
+    pub steal: u64,
 }
 
 pub struct EventLog {
@@ -43,7 +47,8 @@ impl EventLog {
                     hard_kicks: 0,
                     soft_kicks: 0,
                     lat_idle_us: 0,
-                    lat_kick_us: 0
+                    lat_kick_us: 0,
+                    steal: 0
                 };
                 MAX_SNAPSHOTS
             ],
@@ -67,6 +72,7 @@ impl EventLog {
         soft_kicks: u64,
         lat_idle_us: u64,
         lat_kick_us: u64,
+        steal: u64,
     ) {
         self.snapshots[self.head] = Snapshot {
             ts_ns: now_ns(),
@@ -81,6 +87,7 @@ impl EventLog {
             soft_kicks,
             lat_idle_us,
             lat_kick_us,
+            steal,
         };
         self.head = (self.head + 1) % MAX_SNAPSHOTS;
         if self.len < MAX_SNAPSHOTS {
@@ -190,6 +197,7 @@ impl EventLog {
         let total_preempt: u64 = snapshots.iter().map(|s| s.preempt).sum();
         let total_keep: u64 = snapshots.iter().map(|s| s.keep_run).sum();
         let total_parks: u64 = snapshots.iter().map(|s| s.osc_parks).sum();
+        let total_steal: u64 = snapshots.iter().map(|s| s.steal).sum();
 
         let peak_d = snapshots.iter().map(|s| s.dispatches).max().unwrap_or(0);
 
@@ -203,6 +211,7 @@ impl EventLog {
         println!("  TOTAL PREEMPT:     {}", total_preempt);
         println!("  TOTAL KEEP_RUN:    {}", total_keep);
         println!("  TOTAL OSC PARKS:   {}", total_parks);
+        println!("  TOTAL STEALS:      {}", total_steal);
         println!("  PEAK DISPATCH/S:   {}", peak_d);
         if elapsed_s > 0.0 {
             println!("  AVG DISPATCH/S:    {:.0}", total_d as f64 / elapsed_s);

--- a/scheds/rust/scx_pandemonium/src/main.rs
+++ b/scheds/rust/scx_pandemonium/src/main.rs
@@ -7,7 +7,6 @@
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
-#[allow(dead_code)]
 mod bpf_skel;
 
 mod bpf_intf;
@@ -220,6 +219,7 @@ fn run_scheduler(
                 let delta_wake_samples = stats.wake_lat_samples.wrapping_sub(prev.wake_lat_samples);
                 let delta_hard = stats.nr_hard_kicks.wrapping_sub(prev.nr_hard_kicks);
                 let delta_soft = stats.nr_soft_kicks.wrapping_sub(prev.nr_soft_kicks);
+                let delta_steal = stats.nr_steal.wrapping_sub(prev.nr_steal);
                 let delta_enq_wake = stats.nr_enq_wakeup.wrapping_sub(prev.nr_enq_wakeup);
                 let delta_enq_requeue = stats.nr_enq_requeue.wrapping_sub(prev.nr_enq_requeue);
                 let wake_avg_us = if delta_wake_samples > 0 {
@@ -253,12 +253,6 @@ fn run_scheduler(
                 let dl2_mi = stats
                     .nr_l2_miss_interactive
                     .wrapping_sub(prev.nr_l2_miss_interactive);
-                let dl2_hl = stats
-                    .nr_l2_hit_lat_crit
-                    .wrapping_sub(prev.nr_l2_hit_lat_crit);
-                let dl2_ml = stats
-                    .nr_l2_miss_lat_crit
-                    .wrapping_sub(prev.nr_l2_miss_lat_crit);
                 let l2_pct_b = if dl2_hb + dl2_mb > 0 {
                     dl2_hb * 100 / (dl2_hb + dl2_mb)
                 } else {
@@ -266,11 +260,6 @@ fn run_scheduler(
                 };
                 let l2_pct_i = if dl2_hi + dl2_mi > 0 {
                     dl2_hi * 100 / (dl2_hi + dl2_mi)
-                } else {
-                    0
-                };
-                let l2_pct_l = if dl2_hl + dl2_ml > 0 {
-                    dl2_hl * 100 / (dl2_hl + dl2_ml)
                 } else {
                     0
                 };
@@ -290,11 +279,11 @@ fn run_scheduler(
 
                 if verbose {
                     println!(
-                        "d/s: {:<8} idle: {}% shared: {:<6} preempt: {:<4} keep: {:<4} kick: H={:<4} S={:<4} enq: W={:<4} R={:<4} wake: {}us lat_idle: {}us lat_kick: {}us reenq: {} sjrn: {}ms l2: B={}% I={}% L={}% [BPF{}]",
+                        "d/s: {:<8} idle: {}% shared: {:<6} preempt: {:<4} keep: {:<4} kick: H={:<4} S={:<4} enq: W={:<4} R={:<4} wake: {}us lat_idle: {}us lat_kick: {}us reenq: {} sjrn: {}ms l2: B={}% I={}% [BPF{}]",
                         delta_d, idle_pct, delta_shared, delta_preempt, delta_keep,
                         delta_hard, delta_soft, delta_enq_wake, delta_enq_requeue,
                         wake_avg_us, lat_idle_us, lat_kick_us,
-                        delta_reenq, sojourn_ms, l2_pct_b, l2_pct_i, l2_pct_l,
+                        delta_reenq, sojourn_ms, l2_pct_b, l2_pct_i,
                         longrun_label,
                     );
                 }
@@ -311,6 +300,7 @@ fn run_scheduler(
                     delta_soft,
                     lat_idle_us,
                     lat_kick_us,
+                    delta_steal,
                 );
 
                 prev = stats;
@@ -321,7 +311,6 @@ fn run_scheduler(
             let final_stats = sched.read_stats();
             let l2_total_b = final_stats.nr_l2_hit_batch + final_stats.nr_l2_miss_batch;
             let l2_total_i = final_stats.nr_l2_hit_interactive + final_stats.nr_l2_miss_interactive;
-            let l2_total_l = final_stats.nr_l2_hit_lat_crit + final_stats.nr_l2_miss_lat_crit;
             let l2_cum_b = if l2_total_b > 0 {
                 final_stats.nr_l2_hit_batch * 100 / l2_total_b
             } else {
@@ -329,11 +318,6 @@ fn run_scheduler(
             };
             let l2_cum_i = if l2_total_i > 0 {
                 final_stats.nr_l2_hit_interactive * 100 / l2_total_i
-            } else {
-                0
-            };
-            let l2_cum_l = if l2_total_l > 0 {
-                final_stats.nr_l2_hit_lat_crit * 100 / l2_total_l
             } else {
                 0
             };
@@ -349,10 +333,10 @@ fn run_scheduler(
                 0
             };
             println!(
-                "[KNOBS] regime=BPF slice_ns={} batch_ns={} preempt_ns={} l2_hit=B:{}%/I:{}%/L:{}% cross_domain_scatter_pct={} cross_domain_sel_tight={} cross_domain_sel_sync={} cross_domain_sel_normal={} cross_domain_sel_dfl={} cross_domain_enq_t1={} cross_domain_enq_t2={} cross_domain_steal={} cross_domain_step5={}",
+                "[KNOBS] regime=BPF slice_ns={} batch_ns={} preempt_ns={} l2_hit=B:{}%/I:{}% cross_domain_scatter_pct={} cross_domain_sel_tight={} cross_domain_sel_sync={} cross_domain_sel_normal={} cross_domain_sel_dfl={} cross_domain_enq_t1={} cross_domain_enq_t2={} cross_domain_steal={} cross_domain_step5={}",
                 knobs.slice_ns, knobs.batch_slice_ns,
                 knobs.preempt_thresh_ns,
-                l2_cum_b, l2_cum_i, l2_cum_l,
+                l2_cum_b, l2_cum_i,
                 x_scatter_pct, x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7],
             );
 

--- a/scheds/rust/scx_pandemonium/src/scheduler.rs
+++ b/scheds/rust/scx_pandemonium/src/scheduler.rs
@@ -43,8 +43,6 @@ pub struct PandemoniumStats {
     pub nr_l2_miss_batch: u64,
     pub nr_l2_hit_interactive: u64,
     pub nr_l2_miss_interactive: u64,
-    pub nr_l2_hit_lat_crit: u64,
-    pub nr_l2_miss_lat_crit: u64,
     pub nr_reenqueue: u64,
     pub batch_sojourn_ns: u64,
     pub longrun_mode_active: u64,
@@ -57,6 +55,11 @@ pub struct PandemoniumStats {
     // SPILL-KICK PREEMPTS (select_cpu seat redirected off the idle pick onto a
     // busy spill CPU; intf.h nr_spill_kick_preempt). Confirms the tick-floor fix.
     pub nr_spill_kick_preempt: u64,
+    // TOTAL STEALS (intf.h nr_steal). Every successful STEP 1 peer move_to_local,
+    // same-domain included -- nr_cross_domain[XDOM_STEAL] counts only the cross-
+    // domain half, which on a two-domain box is the minority. Every steal is a
+    // migration by definition, so this is the dispatch side's share of the count.
+    pub nr_steal: u64,
     // PER-CPU RUNNABLE DEPTH (intf.h rq_depth_sum / rq_depth_samples).
     // Monotonic accumulators sampled at tick rate; difference BOTH across an
     // interval and divide for the mean depth on that CPU, exactly as
@@ -68,10 +71,13 @@ pub struct PandemoniumStats {
 }
 
 // COMPILE-TIME ABI SAFETY: MUST MATCH STRUCT LAYOUTS IN intf.h
-// 200 (base) + 8*8 (nr_cross_domain) + 8 (nr_osc_park) + 8 (nr_spill_kick_preempt)
-// + 8 (rq_depth_sum) + 8 (rq_depth_samples) = 296.
-const _: () = assert!(std::mem::size_of::<PandemoniumStats>() == 296);
-const _: () = assert!(std::mem::size_of::<TuningKnobs>() == 88);
+// 184 (base, after the structurally empty latcrit l2 pair) + 8*8 (nr_cross_domain)
+// + 8 (nr_osc_park) + 8 (nr_spill_kick_preempt) + 8 (nr_steal) + 8 (rq_depth_sum)
+// + 8 (rq_depth_samples) = 288.
+const _: () = assert!(std::mem::size_of::<PandemoniumStats>() == 288);
+// 88 - 16 (lat_cri_thresh_high/_low, removed with the classifier that read them)
+// - 8 (spill_temp_q16, computed every tick and consumed by nothing).
+const _: () = assert!(std::mem::size_of::<TuningKnobs>() == 64);
 
 // MAX_AFFINITY_CANDIDATES IS DEFINED IN intf.h. THE RUST MIRROR IN
 // bpf_intf.rs MUST KEEP THE SAME VALUE; IF THE TWO SIDES DRIFT, THE
@@ -235,8 +241,6 @@ impl<'a> Scheduler<'a> {
                 total.nr_l2_miss_batch += stats.nr_l2_miss_batch;
                 total.nr_l2_hit_interactive += stats.nr_l2_hit_interactive;
                 total.nr_l2_miss_interactive += stats.nr_l2_miss_interactive;
-                total.nr_l2_hit_lat_crit += stats.nr_l2_hit_lat_crit;
-                total.nr_l2_miss_lat_crit += stats.nr_l2_miss_lat_crit;
                 total.nr_reenqueue += stats.nr_reenqueue;
                 if stats.batch_sojourn_ns > total.batch_sojourn_ns {
                     total.batch_sojourn_ns = stats.batch_sojourn_ns;
@@ -250,6 +254,7 @@ impl<'a> Scheduler<'a> {
                 }
                 total.nr_osc_park += stats.nr_osc_park;
                 total.nr_spill_kick_preempt += stats.nr_spill_kick_preempt;
+                total.nr_steal += stats.nr_steal;
                 // Folded so the aggregate stays complete, but the SUMMED value
                 // is close to meaningless -- it is the total depth seen across
                 // every CPU. The per-CPU pair is the point; read it from
@@ -272,12 +277,11 @@ impl<'a> Scheduler<'a> {
     // FIELDS THAT MUST BE IDENTICAL ON EVERY CPU.
     //
     // tuning_knobs_map is per-CPU, which makes divergence expressible -- and
-    // for these six it would be a defect rather than a feature. tau and
+    // for these three it would be a defect rather than a feature. tau and
     // codel_eq are topology-owned and drive tau-scaling, which every CPU
-    // re-derives from the same constant; the two lat_cri thresholds and
-    // affinity_mode decide how a TASK is classified and placed, so a task would
-    // change class depending on which CPU last looked at it; spill_temp is
-    // computed from system-wide permutation entropy and has no per-CPU meaning.
+    // re-derives from the same constant; affinity_mode decides how a TASK is
+    // placed, so a task would change placement depending on which CPU last
+    // looked at it.
     //
     // Broadcast rather than trusted: the writer overwrites these in every slot
     // from slot 0, so a caller cannot diverge them by omission.
@@ -289,10 +293,7 @@ impl<'a> Scheduler<'a> {
         for k in rest.iter_mut() {
             k.topology_tau_ns = first.topology_tau_ns;
             k.codel_eq_ns = first.codel_eq_ns;
-            k.spill_temp_q16 = first.spill_temp_q16;
             k.affinity_mode = first.affinity_mode;
-            k.lat_cri_thresh_high = first.lat_cri_thresh_high;
-            k.lat_cri_thresh_low = first.lat_cri_thresh_low;
         }
     }
 
@@ -349,7 +350,6 @@ impl<'a> Scheduler<'a> {
     // oscillator is now the only thing adapting on rescue count, and the graph
     // derives from depth, shape and persistence instead. The accessor stays
     // because the live-R_eff work reads the same maps.
-    #[allow(dead_code)]
     // MWU GATES ITS RESCUE-DRIVEN PATHWAYS ON THIS SO IT DOESN'T
     // DOUBLE-CORRECT WHEN THE BPF DAMPED OSCILLATOR HAS ALREADY MOVED.
     pub fn read_oscillator_state(&self) -> OscillatorState {
@@ -561,7 +561,6 @@ impl<'a> Scheduler<'a> {
     // READ ONE reff_value SLOT (ns PHI HOLD TO THAT RANKED PEER). RETURNS 0 ON
     // MISS OR THE (u32)-1 UNUSED-SLOT SENTINEL. USED BY THE ADAPTIVE LOOP TO
     // LEARN THE NEAREST-PEER HOLD WARM-STAY PRICES IN (SLOT 0 = CHEAPEST PEER).
-    #[allow(dead_code)]
     pub fn read_reff_value(&self, cpu: u32, slot: u32) -> u32 {
         let stride = crate::bpf_intf::MAX_AFFINITY_CANDIDATES;
         let key = (cpu * stride + slot).to_ne_bytes();
@@ -726,25 +725,19 @@ mod fold_tests {
 mod knob_broadcast_tests {
     use super::*;
 
-    fn knobs(slice: u64, tau: u64, lat_hi: u64) -> TuningKnobs {
+    fn knobs(slice: u64, tau: u64) -> TuningKnobs {
         let mut k = TuningKnobs::default();
         k.slice_ns = slice;
         k.topology_tau_ns = tau;
-        k.lat_cri_thresh_high = lat_hi;
         k
     }
 
     #[test]
     fn global_fields_are_broadcast_from_slot_zero() {
-        let mut v = vec![
-            knobs(100, 7_000, 32),
-            knobs(200, 9_999, 64),
-            knobs(300, 1, 8),
-        ];
+        let mut v = vec![knobs(100, 7_000), knobs(200, 9_999), knobs(300, 1)];
         Scheduler::broadcast_global_fields(&mut v);
         for (i, k) in v.iter().enumerate() {
             assert_eq!(k.topology_tau_ns, 7_000, "slot {i} diverged on tau");
-            assert_eq!(k.lat_cri_thresh_high, 32, "slot {i} diverged on classifier");
         }
     }
 
@@ -753,7 +746,7 @@ mod knob_broadcast_tests {
         // The whole point: slices may differ per CPU. A broadcast that
         // flattened them would silently restore the global-only behavior this
         // change exists to remove.
-        let mut v = vec![knobs(100, 7_000, 32), knobs(200, 0, 0), knobs(300, 0, 0)];
+        let mut v = vec![knobs(100, 7_000), knobs(200, 0), knobs(300, 0)];
         Scheduler::broadcast_global_fields(&mut v);
         assert_eq!(v[0].slice_ns, 100);
         assert_eq!(v[1].slice_ns, 200);
@@ -764,7 +757,7 @@ mod knob_broadcast_tests {
     fn uniform_input_stays_uniform() {
         // The acceptance criterion for the whole change: identical values in
         // every slot must be indistinguishable from the pre-per-CPU map.
-        let mut v = vec![knobs(100, 7_000, 32); 8];
+        let mut v = vec![knobs(100, 7_000); 8];
         let before = v.clone();
         Scheduler::broadcast_global_fields(&mut v);
         for (a, b) in before.iter().zip(v.iter()) {
@@ -777,7 +770,7 @@ mod knob_broadcast_tests {
     fn empty_and_single_slot_are_no_ops() {
         let mut none: Vec<TuningKnobs> = Vec::new();
         Scheduler::broadcast_global_fields(&mut none);
-        let mut one = vec![knobs(100, 7_000, 32)];
+        let mut one = vec![knobs(100, 7_000)];
         Scheduler::broadcast_global_fields(&mut one);
         assert_eq!(one[0].slice_ns, 100);
     }

--- a/scheds/rust/scx_pandemonium/src/topology.rs
+++ b/scheds/rust/scx_pandemonium/src/topology.rs
@@ -72,7 +72,6 @@ pub enum DomainNode {
     },
 }
 
-#[allow(dead_code)]
 impl DomainNode {
     // Flatten to the leaf CPU sets -- each an emergent atomic domain.
     pub fn leaves(&self) -> Vec<Vec<usize>> {
@@ -160,7 +159,6 @@ fn compute_codel_eq_ns(eigenvalues: &[f64], n: usize, tau_ns: u64) -> u64 {
     (raw_ns as u64).clamp(C_EQ_FLOOR_NS, C_EQ_CEIL_NS)
 }
 
-#[allow(dead_code)]
 pub struct CpuTopology {
     pub nr_cpus: usize,
     pub l2_domain: Vec<u32>,      // l2_domain[cpu] = group_id
@@ -543,7 +541,6 @@ impl CpuTopology {
     // Conductance phi of a bipartition of `members` (in_side[c] = c is on side A).
     // O(|members|^2); boot-time only. The random-walk variant (next) avoids the
     // full scan for large N -- this exact form is the ground-truth + the price.
-    #[allow(dead_code)]
     fn cut_conductance(&self, members: &[usize], in_side: &[bool]) -> f64 {
         let mut cut = 0.0f64;
         let (mut vol_a, mut vol_b) = (0.0f64, 0.0f64);
@@ -575,7 +572,6 @@ impl CpuTopology {
     // Fiedler vector (eigenvector of lambda_2) of the full graph -- the ground
     // truth the scalable random-walk cut is cross-checked against. eigenvectors
     // are column-major: component i of eigenvector k is eigenvectors[i*n + k].
-    #[allow(dead_code)]
     fn fiedler_vector(eigenvalues: &[f64], eigenvectors: &[f64], n: usize) -> Vec<f64> {
         let mut idx: Vec<usize> = (0..n).collect();
         idx.sort_by(|&a, &b| {
@@ -587,45 +583,8 @@ impl CpuTopology {
         (0..n).map(|i| eigenvectors[i * n + k]).collect()
     }
 
-    // Single-level min-conductance cut of `members` via the Fiedler sweep: order
-    // the members by their Fiedler component, sweep every prefix as side A, keep
-    // the split with the lowest phi. Balance-free. Returns (side_a, side_b, phi),
-    // or None for a singleton. fvec is indexed by global CPU id.
-    #[allow(dead_code)]
-    fn fiedler_sweep_cut(
-        &self,
-        members: &[usize],
-        fvec: &[f64],
-    ) -> Option<(Vec<usize>, Vec<usize>, f64)> {
-        if members.len() < 2 {
-            return None;
-        }
-        let mut ordered = members.to_vec();
-        ordered.sort_by(|&a, &b| {
-            fvec[a]
-                .partial_cmp(&fvec[b])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        let mut in_side = vec![false; self.nr_cpus];
-        let (mut best_phi, mut best_k) = (f64::INFINITY, 1usize);
-        for k in 1..ordered.len() {
-            in_side[ordered[k - 1]] = true; // grow the prefix one vertex
-            let phi = self.cut_conductance(members, &in_side);
-            if phi < best_phi {
-                best_phi = phi;
-                best_k = k;
-            }
-        }
-        Some((
-            ordered[..best_k].to_vec(),
-            ordered[best_k..].to_vec(),
-            best_phi,
-        ))
-    }
-
     // True when every member shares one L2 group -- the atomic leaf. L2 siblings
     // are maximally coupled; there is no meaningful seam to find below them.
-    #[allow(dead_code)]
     fn all_same_l2(&self, members: &[usize]) -> bool {
         members
             .windows(2)
@@ -638,7 +597,6 @@ impl CpuTopology {
     // replaces these internals with a local random walk -- no eigensolve, so it
     // scales; the tree-builder is agnostic to which produces the cut.) Returns
     // global CPU ids.
-    #[allow(dead_code)]
     fn domain_cut(&self, members: &[usize]) -> Option<(Vec<usize>, Vec<usize>, f64)> {
         let k = members.len();
         if k < 2 {
@@ -695,7 +653,6 @@ impl CpuTopology {
     // walk eigenvector). Deterministic hash start (not a ramp -- ramps can align
     // with a non-Fiedler mode) so a topology yields the same domains every boot.
     // Cross-checked against domain_cut as ground truth (the T2 gate).
-    #[allow(dead_code)]
     fn walk_cut(&self, members: &[usize]) -> Option<(Vec<usize>, Vec<usize>, f64)> {
         let k = members.len();
         if k < 2 {
@@ -789,7 +746,6 @@ impl CpuTopology {
 
     // Dispatch: exact eigen cut below the threshold, scalable random-walk cut
     // above. Both produce the same boundary on real cache graphs (gate-tested).
-    #[allow(dead_code)]
     fn best_cut(&self, members: &[usize]) -> Option<(Vec<usize>, Vec<usize>, f64)> {
         if members.len() <= Self::WALK_CUT_THRESHOLD {
             self.domain_cut(members)
@@ -802,7 +758,6 @@ impl CpuTopology {
     // single L2 group (or one CPU) -- maximally coupled, no seam. Each Cut carries
     // its phi (the crossing price). This IS de-facto NUMA: the boundary is drawn
     // by the conductance landscape, not a hardcoded topology table.
-    #[allow(dead_code)]
     pub fn build_domain_tree(&self, members: &[usize]) -> DomainNode {
         if members.len() <= 1 || self.all_same_l2(members) {
             return DomainNode::Leaf(members.to_vec());
@@ -1390,11 +1345,8 @@ mod t2_cut_tests {
     #[test]
     fn min_conductance_cut_splits_on_llc() {
         let t = synth_2domain();
-        let lap = t.build_laplacian();
-        let (ev, evec) = CpuTopology::symmetric_eigen(&lap, 8);
-        let fvec = CpuTopology::fiedler_vector(&ev, &evec, 8);
         let members: Vec<usize> = (0..8).collect();
-        let (a, b, phi) = t.fiedler_sweep_cut(&members, &fvec).expect("cut");
+        let (a, b, phi) = t.best_cut(&members).expect("cut");
         let (mut sa, mut sb) = (a.clone(), b.clone());
         sa.sort();
         sb.sort();
@@ -1412,7 +1364,7 @@ mod t2_cut_tests {
     fn cut_conductance_zero_weight_guard() {
         // A singleton member set has no valid bipartition -> None, not a panic.
         let t = synth_2domain();
-        assert!(t.fiedler_sweep_cut(&[3usize], &vec![0.0; 8]).is_none());
+        assert!(t.best_cut(&[3usize]).is_none());
     }
 
     // 8 CPUs WITH SMT: 4 L2 pairs {0,1}{2,3}{4,5}{6,7}, two L3 groups {0..3},

--- a/scheds/rust/scx_pandemonium/src/tuning.rs
+++ b/scheds/rust/scx_pandemonium/src/tuning.rs
@@ -30,9 +30,6 @@ const HEAVY_P99_CEIL_NS: u64 = 10_000_000; // 10MS: HEAVY LOAD, REALISTIC
 // LAT_CRI SCORE BOUNDARIES FOR TIER CLASSIFICATION
 // EXPOSED AS TUNING KNOBS FOR RUNTIME ADJUSTMENT
 
-pub const DEFAULT_LAT_CRI_THRESH_HIGH: u64 = 32; // >= THIS: LAT_CRITICAL
-pub const DEFAULT_LAT_CRI_THRESH_LOW: u64 = 8; // >= THIS: INTERACTIVE, BELOW: BATCH
-
 // TUNING KNOBS
 // MATCHES struct tuning_knobs IN BPF (intf.h)
 
@@ -42,20 +39,11 @@ pub const AFFINITY_WEAK: u64 = 1;
 // Unused since the coupling->affinity derivation was withdrawn 2026-08-05.
 // Kept: it is half of a two-value ABI the BPF side still reads, and a knob that
 // can only ever hold one of its values is a defect waiting to be re-found.
-#[allow(dead_code)]
-pub const AFFINITY_STRONG: u64 = 2;
 
 // SPILL TEMPERATURE (SPILL-Phi). T = T_base*(1 + kappa*H), H THE Bandt-Pompe
 // PERMUTATION ENTROPY IN [0,1]; Q16 FIXED-POINT (65536 = T_base = 1.0).
 // COMPUTED EACH ADAPTIVE TICK FROM THE CHAOS LAYER, SHIPPED AS A NON-MWU KNOB
 // OVERLAID LIKE topology_tau_ns. INERT UNTIL THE SPILL PRICE CONSUMES IT.
-pub const SPILL_TEMP_BASE_Q16: u64 = 65536;
-pub const SPILL_TEMP_KAPPA: f64 = 1.0;
-
-pub fn spill_temp_q16(h: f64) -> u64 {
-    let h = h.clamp(0.0, 1.0);
-    ((SPILL_TEMP_BASE_Q16 as f64) * (1.0 + SPILL_TEMP_KAPPA * h)) as u64
-}
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -63,8 +51,6 @@ pub struct TuningKnobs {
     pub slice_ns: u64,
     pub preempt_thresh_ns: u64,
     pub batch_slice_ns: u64,
-    pub lat_cri_thresh_high: u64,
-    pub lat_cri_thresh_low: u64,
     pub affinity_mode: u64,
     pub codel_thresh_ns: u64,
     pub burst_slice_ns: u64,
@@ -76,7 +62,6 @@ pub struct TuningKnobs {
     // R_eff-DERIVED CODEL EQUILIBRIUM TARGET (<R_eff> * 2m * tau).
     // CO-LOCATED WITH topology_tau_ns; SAME ZERO/WRITE/CLAMP SEMANTICS.
     pub codel_eq_ns: u64,
-    pub spill_temp_q16: u64,
 }
 
 impl Default for TuningKnobs {
@@ -85,14 +70,11 @@ impl Default for TuningKnobs {
             slice_ns: 1_000_000,
             preempt_thresh_ns: 1_000_000,
             batch_slice_ns: 20_000_000,
-            lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
-            lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
             affinity_mode: AFFINITY_OFF,
             codel_thresh_ns: 5_000_000,
             burst_slice_ns: 1_000_000,
             topology_tau_ns: 0,
             codel_eq_ns: 0,
-            spill_temp_q16: SPILL_TEMP_BASE_Q16,
         }
     }
 }
@@ -132,14 +114,11 @@ pub fn base_knobs() -> TuningKnobs {
         slice_ns: MIXED_SLICE_NS,
         preempt_thresh_ns: MIXED_PREEMPT_NS,
         batch_slice_ns: MIXED_BATCH_NS,
-        lat_cri_thresh_high: DEFAULT_LAT_CRI_THRESH_HIGH,
-        lat_cri_thresh_low: DEFAULT_LAT_CRI_THRESH_LOW,
         affinity_mode: AFFINITY_WEAK,
         codel_thresh_ns: 5_000_000,
         burst_slice_ns: 1_000_000,
         topology_tau_ns: 0,
         codel_eq_ns: 0,
-        spill_temp_q16: SPILL_TEMP_BASE_Q16,
     }
 }
 
@@ -293,7 +272,6 @@ pub fn compute_p99_from_histogram(counts: &[u64; HIST_BUCKETS]) -> u64 {
 // The BPF damped-harmonic oscillator owns codel_target_ns. The adaptive layer
 // reads its position so nothing upstream re-derives a target the oscillator is
 // already moving.
-#[allow(dead_code)]
 #[derive(Default, Clone, Copy, Debug)]
 pub struct OscillatorState {
     pub codel_target_ns: u64,
@@ -311,7 +289,6 @@ pub struct OscillatorState {
 impl OscillatorState {
     // 0.0 = AT FLOOR (TIGHTENED), 1.0 = AT MAX (RELAXED).
     // SENTINEL OR DEGENERATE RANGE -> 0.5 (CENTER, NEUTRAL).
-    #[allow(dead_code)]
     pub fn position(&self) -> f64 {
         if self.codel_target_max_ns == 0 || self.codel_target_floor_ns >= self.codel_target_max_ns {
             return 0.5;
@@ -327,7 +304,6 @@ impl OscillatorState {
     // A TASK LEAVE HOME (codel_target + NEAREST-PEER HOLD). THE DEFER GATE
     // COMPARES THIS AGAINST codel_eq TO DECIDE WHETHER THE BPF HAS GENUINELY
     // RESPONDED, RATHER THAN TRUSTING THE BARE-WINDOW position() ALONE.
-    #[allow(dead_code)]
     pub fn effective_release_ns(&self) -> u64 {
         self.codel_target_ns.saturating_add(self.home_dist_extra_ns)
     }
@@ -416,8 +392,6 @@ pub fn knobs_differ(a: &TuningKnobs, b: &TuningKnobs) -> bool {
     a.slice_ns != b.slice_ns
         || a.preempt_thresh_ns != b.preempt_thresh_ns
         || a.batch_slice_ns != b.batch_slice_ns
-        || a.lat_cri_thresh_high != b.lat_cri_thresh_high
-        || a.lat_cri_thresh_low != b.lat_cri_thresh_low
         || a.affinity_mode != b.affinity_mode
         || a.codel_thresh_ns != b.codel_thresh_ns
         || a.burst_slice_ns != b.burst_slice_ns


### PR DESCRIPTION
The behavioural score is deleted. v5.19.0 removed the sites that read it; this release removes the thing itself, and with it the arithmetic every wakeup had been paying for a value that could not change an outcome. What survived the audit is smaller than what went in: Tier resolves to three declarations, and those three are what the classifier had always produced. The last running average followed them out, and the audit priced what it had been buying: One kworker, one shorter slice, four times in its life. IPC p99 is the best in the archive now. The deletions are not the only measurement, though. Placement prices distance -- migration density decays across cache tiers at 0.656 where it grew at 2.157, and where EEVDF decays at 1.090. The thesis the R_eff and Phi machinery was built on had never once been confirmed before now.

SCHEDULER, THE SCORE IS GONE AND SO IS THE WORK IT COST: src/bpf/main.bpf.c src/bpf/intf.h src/tuning.rs src/scheduler.rs
- compute_lat_cri, classify_tier and update_freq are deleted, with three of the four EWMAs behind them: wakeup_freq, csw_rate and runtime_dev. lat_cri and prev_nvcsw go with them, as do LAT_CRI_THRESH_HIGH/LOW, LAT_CRI_CAP, MAX_WAKEUP_FREQ and MAX_CSW_RATE. runnable() had been running a divide, two clamps and a calc_avg on every wakeup; stopping() a second calc_avg.
- tier is three declarations now, which is all it ever resolved to. The score fed classify_tier, classify_tier returned BATCH for every task, and the overrides then rewrote it unconditionally: The kthread floor was a no-op against an already-BATCH value, the PF_WQ_WORKER floor always fired, the RT floor always won. SCHED_FIFO/RR is LAT_CRITICAL, PF_WQ_WORKER is INTERACTIVE, everything else is BATCH -- read from what the task declared, not from what it did.
- last_woke_at has one job again. It carried two that destroyed each other: runnable() read it as the inter-wake interval and stamped it, running() read it as the start of this wake and cleared it to zero. After a task's first run the interval was therefore nanoseconds since boot, which drove the frequency to zero, the switch rate to zero and the score to zero. Deleting the interval reader resolves the collision rather than repairing it.
- ONE BEHAVIOUR CHANGE, and it is not in the arithmetic. The old runnable() took an early return for a task's first two wakeups and never assigned tier at all, so a fresh task kept enable()'s TIER_INTERACTIVE. Removing that carve-out makes a fresh task BATCH, and its cached_weight 128 rather than 192 -- a shorter standing slice for the first two wakes of every task the machine forks.
- lat_cri_thresh_high and lat_cri_thresh_low are removed from the knob page on both sides of the ABI. TuningKnobs is 88 bytes to 72; the compile-time size assertion caught the change, which is what it is for.

THE LAST EWMA FOLLOWS THE SCORE OUT, AND IT BOUGHT ONE SLICE: src/bpf/main.bpf.c
- The CPU-bound demotion in stopping() is deleted, and avg_runtime, calc_avg and the machinery behind them go with it. The demotion required TIER_INTERACTIVE, which after a task's first runnable() means PF_WQ_WORKER and nothing else. It required ewma_age <= 4, so the first four wakes only. And the next runnable() rewrote tier back to INTERACTIVE unconditionally, because the PF_WQ_WORKER floor always fires. Its entire surviving effect was a cached_weight of 128 instead of 192, recomputed back to 192 at the top of the next stopping(). One kworker, one shorter slice, at most four times in its life -- that is what a running average fed on every stop, a calc_avg call in every stopping() and two constants were being paid for.
- ewma_age is renamed runnable_count, and EWMA_AGE_MATURE and EWMA_AGE_CAP follow it. The name outlived the thing and cost a release for it: The field read as EWMA machinery while the EWMA was leaving, so its last consumer went unnoticed and the plan to remove it as a side effect of the demotion was wrong. What it is, and all it has been since calc_avg went, is a saturating count of runnable() entries -- calc_avg's warm-up schedule outliving the average it warmed. It is named for its increment site on purpose, because wake_obs counts the same event from update_shape and the two do not advance in lockstep. src/ now holds no exponentially weighted moving average and no identifier claiming one.
- avg_runtime had one reader and calc_avg had one caller, so both fall out mechanically rather than by argument, and EWMA_AGE_MATURE loses one of its two readers. Thirty-nine lines, and no behaviour change: What the demotion did was already being erased before anything could read it.
- prism --dev ipc, BPF arm, median p99 across all twenty cells: 336us. The cache holds ninety-one archived IPC runs reaching back to v5.15.0. Three sit under 570us and all three come from this line of work, with a 70% gap to fourth place; the v5.18.0 era ran 700-2000us and v5.15.0 ran 1400-4000us. The classifier ran on the wakeup path, on every wakeup, and p99 is the percentile that path dominates.
- WHAT DID NOT MOVE, and the archive is unambiguous: P99.9 at 1,708us against a best of 1,086us, WORST at 2,947us against 2,000us. Both sit inside the strong band and neither tops it. The tail past p99 is a migration-count story, and count is the axis nothing in this release touches.

ADAPTIVE LAYER, DEAD WEIGHT OUT AND ONE READER FINALLY GIVEN A CONSUMER: src/adaptive.rs src/topology.rs src/tuning.rs
- OscillatorState existed with no consumer. The BPF damped oscillator owns codel_target_ns, and the reader that says where it currently sits was written and never called -- so the one piece of state that reports whether the BPF has already responded was invisible to the layer that must not fight it. Its position and its effective Phi release point now report on the graph line as `osc: pos/release`. Reporting only; the gate that would ACT on it is open work.
- mean_coupling is deleted: edge_summary() is already wired to the same line and mean_coupling only wrapped it.
- fiedler_sweep_cut is deleted, superseded by domain_cut and walk_cut, which are what best_cut actually dispatches to.
- AFFINITY_STRONG is deleted, orphaned when the coupling derivation was withdrawn.

A KNOB DELETED RATHER THAN WIRED, AND THE REASON IS THE FINDING: src/bpf/intf.h src/tuning.rs src/adaptive.rs src/scheduler.rs src/bpf/main.bpf.c
- spill_temp_q16 was computed every adaptive tick from a Bandt-Pompe permutation entropy, broadcast to every CPU's knob page, and read by nothing. The board offered two ways to close that: Wire the consumer or delete the knob. It is deleted, because its design has the wrong sign. The form is T_base*(1+kappa*H): High entropy RAISES the per-peer spill depth caps, so the scheduler spreads MORE when queue behaviour is disordered. This release is what proves that backwards -- same-L2 residency doubled past EEVDF's while cache-misses ROSE, because a migration costs L1 wherever it lands. Count is the price, not distance, and a knob that buys more spilling under churn buys more of the one thing measured to hurt. The inverted sign is a candidate for the deferred SPILL-Phi work, with its own run; it is not a restoration of this.
- _scatter_pct and its three feeders are deleted: A sum, a difference and a division computed every second into a variable the compiler already warned was unused. Its consumer was the removed learner. The nr_cross_domain counters stay -- they still carry the per-path attribution the bench surfaces each run.
- TuningKnobs is 64 bytes now, from 88 at the start of the release. Both reductions were caught by the compile-time size assertion rather than by a runtime surprise, which is the whole reason it is there.
- Cargo.toml's description no longer advertises three-tier classification or process learning. Neither has existed for two releases; it shipped in package metadata regardless.

PLACEMENT PRICES DISTANCE, MEASURED:
- prism --dev fork-thread, thread and proc arms, traced. Migration density decay across cache tiers reads 0.656 against EEVDF's 1.090; it read 2.157 before, which is density GROWING with distance -- the scheduler preferring the farther seat. Same-L2 residency 22.8% to 46.9% on the thread arm and 59.9% on the proc arm, against EEVDF's 36.2% and 42.1%. Cross-socket traffic 23.4% to 11.5%.
- Migration avalanches 3,739 to 295 against EEVDF's 76 -- a cascade ratio of 23.5x down to 3.9x. The CCDF slope shallows from -1.84 to -1.28, so the avalanches that remain are relatively larger; rarer and lumpier, not gone.
- Migrations per dispatch 63.7% to 39.8% against a flat EEVDF at 7.5%. Inter-migration interval p50 3,531us to 5,064us.
- wake2run p99 16,002us to 10,580us on the thread arm and 7,869us on the proc arm, against EEVDF's 79,684us and 76,636us.
- prism --dev scale: Deadline miss 1.6/0.4/0.1/0.2% to 0.3/0.1/0.0/0.0% on the BPF arm and 2.2/0.6/0.0/0.0% to 0.1/0.2/0.1/0.0% adaptive. The 0.0-0.4% band holds at every width including 2C, which it has not done on any prior release. Deadline jitter p99 at 2C 947us to 84us and 1,052us to 71us, against EEVDF's 2,690us; the distribution flattens across widths to 63-84us everywhere.
- WHAT IT DID NOT BUY, stated because the numbers are unambiguous: Cache-misses 5.97G against EEVDF's 3.34G, unmoved while same-L2 residency doubled past EEVDF's. Migration COUNT is 2.80M against 164K, and count is what costs -- a migration loses L1 whether it lands on a sibling or across the socket. Wall time is +44.1% against EEVDF. Distance is now priced correctly; how often a task moves at all is untouched, and that is the open axis.

THE WAKE PATH NEVER ASKED WHETHER THE TASK COULD JUST STAY: src/bpf/main.bpf.c
- find_idle_by_affinity WALKS affinity_rank, AND build_affinity_rank IS WRITTEN `.filter(|&c| c != cpu)`. The anchor is not in its own rank, so the walk could never return it. There is exactly ONE scx_bpf_test_and_clear_cpu_idle in the tree and it sits inside that walk, which means nothing in this scheduler had ever asked whether the wakee's own CPU was idle. Three placement sites consume it -- select_cpu's WAKE_SYNC path, its normal warm path, enqueue TIER 1 -- and each asks "is a CPU near my anchor idle" and takes the first hit.
- SLOT 0 IS THE SMT SIBLING, at R_eff 0.001 against 0.042 for everything else. So the standing outcome was to move the wakee to the other thread of its own core, on every wake, including when its own core was idle and warm. A move to an idle peer when the anchor is also idle cannot start the task sooner -- both are idle -- and costs an L2 reload measured at ~4,500 LLC references. Price without purchase, several million times per run.
- THE COMMENT ABOVE phi_warm_target ASSERTED THE OPPOSITE and is why the walk went unread: "find_idle_by_affinity ALREADY RETURNS THE ANCHOR ITSELF WHEN IT IS IDLE (RANK SLOT 0 = SELF), SO A CORRECT SUBORDINATE PLACEMENT BIAS COLLAPSES TO EXACTLY THAT WALK." It does not, it never did, and the claim was load-bearing for the decision not to write the test. Corrected in place.
- The fix is one comparison at the head of the walk, expressed as WHICH idle and never as refusing to move: When the anchor is busy the walk proceeds exactly as before and every peer stays reachable. It self-limits under load for the same reason, and it satisfies the standing rule against a binary gate in front of placement.
- MEASURED, thread arm, two independent runs against five pre-change ones. Cache miss ratio (BPF over EEVDF) 1.730 and 1.729 against a prior range of 1.751 to 2.000. Wall ratio 1.382 and 1.372 against 1.390 to 1.535. Both below the prior range, both reproduced. wake2run p99 8,919us, the best thread-arm figure on record, against 12,910us before -- the latency axis paid nothing.
- THE PROCESS ARM DID NOT MOVE, and that is the mechanism agreeing with itself. Miss ratio 1.700 and 1.756 sit inside a prior range of 1.689 to 2.003. Separate address spaces mean no shared working set, so scatter is free and staying put buys nothing. Migration COUNT is the noisier reading and overlaps the prior range on both arms; the cache-miss ratio is the instrument that separates here.
- This closes the "Return-to-home wake placement" re-add, which had been carried as not-confirmed-live and was in fact never restored.

THE DISPATCH SIDE'S SHARE OF THE MIGRATION COUNT HAD NO ANSWER: src/bpf/intf.h src/bpf/main.bpf.c src/scheduler.rs src/event.rs src/main.rs src/adaptive.rs
- nr_steal counts every successful STEP 1 peer move_to_local. Each one IS a migration by definition -- the task comes off a peer's queue and runs here -- and nr_cross_domain[XDOM_STEAL] counted only the CROSS-domain half, which on a two-domain box is the minority. So "what fraction of the migration count is the dispatch-side steal" could not be answered from anything in the tree, while every placement-side fix was being staged against the assumption that it is small. One bump, no per-cause breakdown, operator-useful on any workload.
- Surfaced as TOTAL STEALS in the shutdown summary rather than collected and discarded. The compile-time size assertion moved 296 to 304 and caught the ABI in the same commit, which is what it is for.

THE keep_own DEPTH BYPASS HAD NO CEILING: src/bpf/main.bpf.c
- keep_own suppresses the sibling spill so a handoff partner lands on the waker's own core, on the argument that the waker blocks within microseconds and STEP 0 drains the partner next. That argument holds only while the queue is SHALLOW. With tasks already ahead, STEP 0 reaches them first and the partner waits behind a line it was never meant to join, on a core the spill search was forbidden from relieving. Unbounded, it is a depth bypass with no ceiling.
- keep_own_depth_max is twice pcpu_depth_base, derived in apply_tau_scaling beside the gate it extends so it scales with topology the same way and binds tighter on narrow machines -- which is where the cliff was measured. Arming the predicate against an unbounded consumer once cost 2C jitter p99 73 -> 953us and deadline miss 0.40 -> 1.70% while 12C improved, a gradient monotone in core count because one declined spill peer is half the machine at 2C and a twelfth at 12C.
- The queue read is hoisted once into src_depth and shared by the depth gate and the ceiling. The verifier note on this function is about CONTROL FLOW rather than size -- a conditional upstream of the CAS sites cost src_cpu's range 350 insns later once before -- so the bound costs one comparison, not a second kfunc call and a second branch.
- The pair_warm stamp follows the BOUNDED decision. Past the ceiling the partner spills like anything else, and stamping src_cpu would price a warm pair that is not seated there.
- LATENT, NOT LIVE. is_handoff_partner short-circuits on tier, so keep_own is false for every SCHED_OTHER task and this ceiling can only fire for kworkers today. It goes in first precisely so the step that makes the predicate reachable is measured against a bounded consumer rather than a cliff.

THE WARP'S OUTER GUARD WAS DEAD CODE AND THREE COMMENTS SAID OTHERWISE: src/bpf/main.bpf.c
- task_deadline() clamped the warp to lag_cap_ns after computing it. The clamp could not fire. warp is `codel_target_ns - last_run_ns` floored at 0, so it is bounded by codel_target_ns BY CONSTRUCTION; lag_cap_ns is K_LAG_CAP * tau, one whole tau, which reads 13ms live against a target seeded at 8000us and clamped below codel_target_max_ns. The smaller bound always won and the test was never reached.
- THE COMMENTS WERE THE REAL COST. Three of them described lag_cap_ns as the outer guard on the ordering key -- the declaration at :78, the derivation note in task_deadline, and the TIER 3 site that stated "WARP IS BOUNDED BY lag_cap_ns INSIDE task_deadline()". A reader auditing the ordering bound found two constants named as bounds and one of them inert, which is exactly the reading that makes a key look safer than it is. lag_cap_ns is the STARVATION bound, it is enforced by sweep_bound_preempt, and it now appears nowhere in task_deadline().
- No behaviour change, and none owed. Deleting a comparison that could not be taken leaves one bound on the warp where the source previously claimed two.

PLACEMENT: THE ANCHOR COULD NEVER WIN ITS OWN WALK: src/bpf/main.bpf.c
- find_idle_by_affinity walked the R_eff rank for an idle seat and the rank it walked CANNOT CONTAIN THE ANCHOR: build_affinity_rank filters `c != cpu` when it builds the table. So a task whose own last CPU was idle was never offered it; the walk began at rank slot 0, which on this topology is the SMT sibling at R_eff 0.001 against the anchor's 0.042. Every warm wake onto an idle anchor was a migration to the seat next door, priced as if it were free because the price never saw the alternative.
- The anchor is tested for idle BEFORE the walk, and the test is expressed as WHICH idle seat rather than as a refusal to move: When the anchor is busy the walk proceeds exactly as it does today. That satisfies the standing no-gate constraint and self-limits under load, which a bail would not.

PLACEMENT: keep_own HELD AN UNBOUNDED DEPTH BYPASS BEHIND A CONSTANT-FALSE BOOLEAN: src/bpf/main.bpf.c
- keep_own had no depth ceiling at all. It was latent rather than live only because is_handoff_partner short-circuits on tier, and with LAT_CRITICAL unreachable the predicate was a kworker-only test -- constant-false for every SCHED_OTHER task. A boolean that has been effectively false for months is not a disabled feature, it is an untested one, and the moment anything made it true the bypass had no bound.
- The ceiling is derived, not tuned: keep_own_depth_max = pcpu_depth_base * 2, taken from the same tau scaling everything else on this path reads, and src_depth is hoisted once at entry rather than re-read per site.
- MEASURED COST OF ARMING THE PREDICATE AGAINST AN UNBOUNDED CONSUMER, which is why the bound landed first: 2C jitter p99 73 -> 953us, deadline miss 0.40 -> 1.70%, wall +12.7%, while 12C IMPROVED (latency p99 1078 -> 70us). The gradient is monotone in core count because keep_own declines the spill peer, and one declined peer is the whole machine at 2C and a twelfth of it at 12C.

SCHEDULER: THE LAST TIER READS ARE GONE: src/bpf/main.bpf.c, src/bpf/intf.h, src/scheduler.rs, src/event.rs, src/main.rs, src/adaptive.rs
- effective_weight lost tier. Three levels resolved to one for every userspace task, and its only consumer was cached_weight, whose only consumer is the standing slice, which is_standing already gates. Base weight, no multiplier.
- TIER_LAT_CRITICAL is deleted along with WEIGHT_LAT_CRITICAL and all seven live reads: the TIER 2 entry term, warm_stay_anchor's exclusion, the bpf_printk, enable()'s init and the l2/histogram buckets, which become standing and not-standing lanes. runnable() reduces to a declaration -- PF_WQ_WORKER or BATCH -- and count_l2_affinity drops from three lanes to two. nr_l2_hit_lat_crit and nr_l2_miss_lat_crit go with them.
- A DEAD CLAMP WENT TOO. task_deadline's lag_cap_ns clamp could never fire: The warp is bounded by codel_target (~2ms) by construction and lag_cap is one tau (13ms live), so the smaller bound was always the one that applied. It was removed rather than documented, and the comment that asserted the opposite went with it.