### PR TITLE
scx_cake 1.2.1 gaming regression hotfix

### DIFF
--- a/scheds/rust/scx_cake/STATE.md
+++ b/scheds/rust/scx_cake/STATE.md
@@ -110,6 +110,7 @@ whole of every slot (attach logs end in the clean detach line, nr_rejected 0;
 | g77 | steal ring skipped on an empty qmask (census-bit contended test tried: stale in the wake-list window, dropped) | equal | keep |
 | g78 | rotor on the first whole-core claim + last_win as cpu+1 | 1% low 492: spreading is wrong here | drop; the cpu+1 encoding stays |
 | g79 | **seat hold**: a blocking stage-class thread keeps its core; other wakes skip held cores while any other is free | the win above; GameThread migrations were 12,629/28 s vs 1.1.3's 650 | keep, hitch OPEN |
+| §G82 | **one idle census word** (unconditional, no toggle): `thread_free` folded into `idle_words[0]`, `idle_nr` kept for hosts >64 CPUs only (popcount inside one word), §G54 park producer/retract behind `!g69`; update_idle entry 5 atomics -> 1-2, exit 4 -> 1-2 | 2026-09-02 KovaaKs menu, 4 mirrored rounds ABBA/BAAB, 20 s slots, 8/arm: avg 705.0 vs 702.9, p99 1.747 vs 1.779, p99.9 flat, ahead on avg+p99 in 4/4 rounds, ranges overlap (maintainer: keep on the consistent lean); 0 stalls in 47 attaches; loader now accepts `--toggle probe=1` (match arm was missing); the g79 first-frame hitch hit 1/8 plain slots, 0/23 probe-armed cycles, black box empty -- OPEN | **shipped** |
 
 Why the average was behind (thread_cores.py, 1.1.3 vs stack): 1.1.3 GameThread
 650 migrations, stack 12,629 — a dxvk/render wake took GameThread's core in its

--- a/scheds/rust/scx_cake/STATE.md
+++ b/scheds/rust/scx_cake/STATE.md
@@ -22,12 +22,228 @@ upstream `ff86d6588`; pre-rebase state in `backup/nightly-pre-rebase-20260818`),
 at this commit (17 commits → `backup/nightly-17-commits-20260819`: the R.28 arc —
 1.1.3 wallclock campaign, mode-flip root cause, per-task geometry, veto bisect,
 live WoW confirm); all hashes cited below resolve via those local backup branches.
+2026-08-25: PR #3767 merged upstream (`4a2ab1fce`) with ALL of nightly's scx_cake
+content (subtree hash identical) — nightly reset onto upstream/main; pre-reset state
+in `backup/nightly-pre-rebase-20260825`; origin fork NOT yet force-pushed.
 
 </details>
 
 ---
 
 ## RESUME HERE
+
+**PICKUP 2026-09-02 11:30 — VELOCITY SESSION: 14 constructs g60-g73 built and
+snippet-scored against crate 1.1.3 at the KovaaKs menu. Best arm ties 1.1.3 on
+1% low / p99 / p99.9 and trails 2% on average fps. Machine on EEVDF, KovaaKs
+left open at the menu. Every diagnostic probe (placement census, hold attribution by queue
+kind, home-decline reasons, the hitch black box) is gated behind `--toggle
+probe=1` and costs nothing off; the winning stack (g65, g69, g71, g75, g77, g79, g81; g76 and g80 are
+unconditional) is the DEFAULT, each switchable off with `--toggle gNN=0`; the
+experiments (g60-g64, g66-g68, g70, g72-g74, g78, g82) default OFF.**
+
+Rig: `runs/overnight_game_20260901/snip.py <arm> <arm> [<arm>]` — mirrored
+slots of `LOG_S` s MangoHud logging driven over the control socket, arms attached
+directly from their receipts; `LOG_S=8` for a 50 s screen (1% low, p99 only),
+`LOG_S=20` for a 95 s read that can see p99.9. Wake-side tools:
+`sib_overlap.py`, `hold_timing.py`, `bench/wake_maxdecomp.py`, the probe census
+(`--toggle` on the probe receipts). Diagrams: `runs/overnight_game_20260901/
+diagrams/` (nightly pipeline with measured shares, 1.1.3 pipeline, hold timeline,
+ledger).
+
+**Mechanism, in the order it was proven.** (1) Nightly runs game threads with a
+busy SMT sibling 6.2-6.6% of their run time (1.1.3 1.2%, EEVDF 0.8%); the census
+placements (§G53 first-fit, §G54 park) bypass the §G38 whole-core rule. (2) Wake
+latency p99 is NOT the gap (nightly equal or better than 1.1.3 per role); the gap
+is HOLDS: every render-path delay >300 us is one occupant keeping the CPU for the
+whole wait (RenderThread 1 ms, kwin 1.6 ms), 1.1.3 has zero on RenderThread /
+dxvk-submit / dxvk-cs. (3) 100% of nightly's wake placements are LOCAL_ON direct
+dispatches (home claim 74%, census prev 20%, first-fit 5%); holds sit there, and a
+local DSQ is FIFO and owner-only — nothing can steal it. (4) Holder timing: in 80%
+of long holds the holder was already running when the wake landed; the wakee was
+placed onto its busy peer. Only CLAIMED placement removes it. (5) IPC: 1.1.3 1.55
+vs every 1.2.x arm 1.48, +3% cycles for -2% instructions; not SMT (0.4% overlap
+under the best arm), not yield (1.1.3's handler is telemetry). OPEN.
+
+| toggle | construct | snippet vs crate 1.1.3 (1% low / p99.9 / avg) | verdict |
+|---|---|---|---|
+| g60 | whole-core census placement | sibling-busy 6% -> 0.3%; 60 s cycle +30 on 1% low, 15 s cycles mixed | keep as a piece |
+| g61 | occupant preempt after insert | null (CPU idle at insert) | drop |
+| g62 | census placements claim (atomic) | holds -40%, avg -3%, p99 worst | drop |
+| g63 | pool only, no direct dispatch | tail fixed (max 2.1), avg -6% | floor, not a ship |
+| g64 | dfl claimed direct + (g65) pool | tail fixed, avg -5%; g64 alone shows the loss is the kernel pick | drop |
+| g65 | every enqueued wake global, herd gate off | null alone (enqueue reached by 2%) | needed under g69 |
+| g66 | serial handoff arm off | null | drop |
+| g67 | census direct paths off, home claim or pool | avg -4%, tail unchanged | drop |
+| g68 | EXPERIMENT: KovaaKs tgid VIP (ENQ_PREEMPT, pool head, kick) | 1% low 489 vs 504 off, p99.9 2.34 vs 2.17: self-preemption | negative, learned |
+| g69 | **claimed warm placement**: prev claim, whole idle core claim, idle thread claim, else pool | 555 / 1.90 / 684 vs 563 / 1.87 / 699 | **best** with g65 |
+| g70 | EXPERIMENT: KovaaKs immune to preempt kicks | null: nothing preempts the game at the menu | learned |
+| g71 | idle-side published core/thread words; (d) words choose, kernel bit claims | (a)-(c) leaked tail; **(d) 560 / 1.88 / 685 vs 562 / 1.87 / 700** | **best**: g65+g69+g71d |
+| g72 | L2 handoff: same-mm microsecond wakee onto the waker's idle sibling | null on top of g69 | park |
+| g73 | distributed claim search from the task's core | 543 / 1.95: negative | drop |
+
+**FIELD RESULT 2026-09-02 evening — Lestat, 9950X3D, DOOM: The Dark Ages
+(Uprising), single run each, game lassoed as before. Nightly default build
+(g65/g69/g71/g75/g77/g79/g81 on; build identity + kernel still to be confirmed
+from his log): 97th 205.55 / avg 170.64 / 1% low 112.03, vs stock 1.2.1
+208.44 / 155.45 / 96.79 and crate 1.1.3 208.52 / 170.45 / 113.48. The
+regression is repaired in full (+9.8% avg, +15.7% 1% low); level with 1.1.3
+inside single-run noise, not ahead. Owed: his identity lines, a second run each,
+then the per-LLC pool port onto nightly (§S.8 shape over the g65 pool) — the
+piece 1.1.3 still has on two CCDs — and §G52 V-cache preference for unpinned.**
+
+**12:30 UPDATE — g74-g79. The g79 stack (g65+g69+g71d+g75+g76+g77+g79) BEATS
+crate 1.1.3 on every column when it does not hitch, 20 s slots ABBA x3
+(6 slots/arm): 1% low 578 vs 562, 0.1% low 530 vs 484, p99 1.686 vs 1.708,
+p99.9 1.783 vs 1.856, max 2.2 vs 3.3, avg 702 vs 698.** Two of five g79 slots
+took ONE 45 ms frame: the FIRST frame of the MangoHud log (elapsed 0.34/0.49 s),
+i.e. the CSV-create on the render thread — the wake after that IO is what g79
+mishandles; ~2x WAKE_STARVE_WALL_NS. Not reproduced in 9 hunts with perf
+recording (`hitch_hunt.py`, `hitch_scope.py` ready). Cake was attached for the
+whole of every slot (attach logs end in the clean detach line, nr_rejected 0;
+`snip.py` now prints SCHED GONE if not). OPEN, must be closed before g79 ships.
+
+| toggle | construct | read | verdict |
+|---|---|---|---|
+| g74 | published-burst stacking (queue behind prev when §G57 free_at within 40 us) | avg 680, tail no gain: slice/2 is not a burst | drop |
+| g75 | **grooves**: per-task home-miss count skips a failing home claim; last-won CPU tried first | no avg change alone; **with it off the stack collapses (1% low 477, p99.9 2.36)** — the history IS the tail | keep |
+| g76 | lean dispatch (counts before iterators/moves), one groove lookup, cpu_idle tracepoint only for g51 | dispatch 120 -> 87 ns; the mark-only fast path stalled the game 20 ms (mark has holes) — pool by COUNT | keep |
+| g77 | steal ring skipped on an empty qmask (census-bit contended test tried: stale in the wake-list window, dropped) | equal | keep |
+| g78 | rotor on the first whole-core claim + last_win as cpu+1 | 1% low 492: spreading is wrong here | drop; the cpu+1 encoding stays |
+| g79 | **seat hold**: a blocking stage-class thread keeps its core; other wakes skip held cores while any other is free | the win above; GameThread migrations were 12,629/28 s vs 1.1.3's 650 | keep, hitch OPEN |
+
+Why the average was behind (thread_cores.py, 1.1.3 vs stack): 1.1.3 GameThread
+650 migrations, stack 12,629 — a dxvk/render wake took GameThread's core in its
+microsecond gaps and it came back cold 450 times a second: branch misses +34%,
+IPC 1.456 vs 1.553. Cache hit rates identical (L1d miss 2.8%, LLC 0.0%), IRQ
+identical (nvidia 7.8k/s CPU 13), GPU identical (77%, 2745 MHz).
+
+BPF self-cost (cake-bpfstats, 12 s menu): 1.1.3 96 ms (0.8% CPU: select 58 ns,
+dispatch 20, running 26); nightly-off 260 ms; g77b stack 274 ms (select 116,
+dispatch 79, update_idle 33, running 58). The remaining average lever is here:
+select_cpu's groove storage lookup + rq deref + claims, update_idle's three
+atomics, running's frame observe. A symbolized cycles profile needs
+`kernel.kptr_restrict=0` (currently 2; module space hides nvidia.ko with the JIT).
+
+Tools added this session (all in `runs/overnight_game_20260901/`): `snip.py`
+(one-minute mirrored MangoHud snippets from receipts), `sib_overlap.py`,
+`hold_timing.py`, `thread_cores.py`, `sys_ab.sh` (cache/balance/IRQ/GPU),
+`hitch_hunt.py` + `hitch_scope.py`, `diagrams/`. Inventory: `docs/TOOLING.md`
+(docs/ is gitignored; on disk).
+
+Next: (1) close the g79 hitch (catch it without perf: bpftrace on the render
+thread's wake at log start, or make snip.py record the seat word at attach);
+(2) BPF self-cost: symbolized profile, then cut select_cpu to one storage
+lookup + one claim, update_idle to one atomic; (3) fold the stack into defaults
+once (1) closes, then the wallclock guard (`fast_ab.sh`) and a 60 s cycle.
+Probe branches: `probe/overnight-20260901-g63` (arms), `probe/g70-arm`.
+
+**PICKUP 2026-09-02 02:30 — OVERNIGHT GAME ROTATION SCORED (maintainer-authorized
+unattended run), machine left on EEVDF (detached), Palworld left at its menu.
+Seven arms, every one a v5 receipt under `target/baseline_receipts/`: native,
+`crate-1.1.3s` (b68cb3c82 = crate scx_cake 1.1.3 + the two 2026-07-28 dumpable
+backports, scheduling identical), `stock-1.2.1` (c8728c6b6 = scx tag v1.1.3 =
+Lestat's stock), `fix-s8` (f27950e9d), `n0901-off` (HEAD + census no-op),
+`n0901-g57`, `n0901-g58` (defaults flipped). 14-slot mirrored cycles
+(native A B C D E F F E D C B A native), order rotated between cycles.**
+
+KovaaKs menu, 4 cycles, n=8/arm, 60 s slots, ~45k frames each, all 56 accepted
+(`runs/game/kovaaks/2026-09-01-overnight/`, harness matrix):
+
+| arm | avg fps | 1% low | 0.1% low | p99 ms | p99.9 ms |
+|---|---|---|---|---|---|
+| native | 745.8 | 658.8 | 400.4 | 1.523 | 2.498 |
+| crate-1.1.3s | 746.8 | 650.0 | 399.1 | 1.542 | 2.507 |
+| stock-1.2.1 | 708.3 | 561.5 | 386.5 | 1.802 | 2.588 |
+| fix-s8 | 716.7 | 574.8 | 388.4 | 1.740 | 2.575 |
+| n0901-off | 758.4 | 595.0 | 403.7 | 1.683 | 2.477 |
+| n0901-g57 | 757.5 | 582.5 | 403.1 | 1.719 | 2.481 |
+| n0901-g58 | 755.8 | 566.9 | 402.7 | 1.770 | 2.483 |
+
+Cycle 1 slots 0-3 were a warm-up (690 vs 755 fps); dropping them: native 753.7 /
+p99 1.488, crate-1.1.3 754.6 / 1.513, stock-1.2.1 713.4 / 1.722, fix-s8 717.1 /
+1.742, off 758.4 / 1.685, g57 757.5 / 1.721, g58 755.8 / 1.772. Slot ranges do not
+overlap between the 1.2.1 pair (702-726) and the 1.1.3/native/nightly group
+(752-761), at every slot position, both orders.
+
+**Reads.** (1) Lestat's chart reproduces on ONE CCD: 1.2.1 is −5.5% avg fps and
++0.2 ms p99 vs crate 1.1.3 at a 750 fps wake-bound menu, so the loss is not (only)
+CCD-blindness. (2) fix-s8 == stock-1.2.1 here (one LLC = one pool), as designed;
+the pool fix answers only the two-CCD strand. (3) Nightly recovers the average
+(above native) but keeps a p99 0.17 ms wider than 1.1.3 and native — the
+remaining 1.2.x gap is a tail, not throughput. (4) g57/g58 do not move the menu;
+g58 is the widest p99 of the nightly arms (1.772, one 2.02 slot). (5) One 145 ms
+frame on stock-1.2.1 (cycle 1 slot 2) and one 43 ms on native (cycle 3 slot 0):
+single spikes on both sides, not a cake signature at n=8.
+
+Palworld menu, 3 cycles, n=6/arm, 120 fps cap, GPU ~39%, ~7.2k frames/slot, all
+42 accepted (`runs/game/palworld/2026-09-01-overnight/`): p99 flat 8.73-8.80 ms
+on every arm; p99.9 native 9.80, crate-1.1.3 10.25, stock-1.2.1 10.08, fix-s8
+10.91, off 9.80, g57 9.63, g58 9.67. Same ordering as KovaaKs at the tail (1.2.1
+pair worst, nightly tightest) but 7 frames per 0.1% — direction only.
+
+Noise covariate: FFXI server (`xi_map`) ~16% of one CPU + Discord ~6% for the whole
+run, identical across arms. Display idle-dimmed from 23:40; captures unaffected.
+Helldivers 2 was attempted and dropped: no `mangohud` launch option and Steam
+ignored `-shutdown`, so no layer; Palworld took the second regime.
+
+Rig: `scx_cake_bench/runs/overnight_game_20260901/` — `build_arms.sh`, `arms/*.json`
+(receipt paths + hashes), `run_cycles*.sh`, `cycle_<game>_N.log` (per-slot JSON),
+`analyze.py`, `stage_import.py` + `staging_map_<game>.tsv` (slot → capture file).
+Probe branches local only: `probe/overnight-20260901{,-g57,-g58}`,
+`probe/crate-1.1.3-scoreable`; worktrees under the session scratchpad and
+`scx-baselines/v1.2.1`, `scx-baselines/v1.1.3-scoreable`.
+
+Owed now: (1) the 1.1.3-vs-1.2.x p99 gap at the menu is the lever for Lestat's
+single-CCD loss — bisect it (§G39-B' preempt, GAME class, tick wait bound are the
+three things 1.1.3 has, §S.8 comparison); (2) a play-regime rotation (input-live)
+before any of g57/g58 ships; (3) the 2026-09-01 owed list below still stands.
+
+**PICKUP 2026-09-01 EOD — three published-state constructs BUILT on nightly
+behind toggles, machine left on EEVDF (detached). Nothing scored: the box
+carried the FFXI server + browser all evening and the strand rig read 30x
+within-arm spread, so every number below is a liveness proof, not a result.**
+
+| toggle | construct | live proof (strand rig, census at detach) |
+|---|---|---|
+| `g57` | earliest-free pick: `running` publishes `free_at`; a saturated wake scans its LLC mask and queues behind the CPU predicted to free first | saturated peer rig: 19,018 placements = 9.2% of selects |
+| `g58` | frame pre-wake (§G28 built + a reservation): `stopping` arms a per-CPU BPF timer at the predicted wake minus lead; the fire reserves + idle-kicks the CPU; `select_cpu` takes the reservation first | idle rig: 14,173 fires, 6,997 takes (precise 1 kHz cadence, ungated); with the argmax-cadence gate the rig thread no longer arms and the box's 252 Hz cadence fires 6-7k/10 s, 0 takes at a 100 us window — window widened to cycle/16, retest owed |
+| `g59` | idle-depth pick over the §G51 mirror (forces g51); §G58 reservations skipped by other tasks | attach-clean; INERT here (no cpuidle driver), first-fit by construction |
+
+Wallclock fast ABBA ran the same evening (`runs/toggle_wallclock_20260901/`,
+ledger rows G57/G58/G59/stack wc): g57 non-regressing with messaging −8.7%,
+g58 inconclusive (one unrepeated 4.10 s pipe slot), g59 null, stack
+non-regressing.
+Owed, in order: (1) quiet-box strand rig ABBA off/g57 both modes (the latency
+endpoint; messaging already passed); (2) g58 retest
+with the widened window, then the tail question — two of four idle-rig on-arm
+runs read p999 39 us vs off 13-15, always the first arm after a switch; (3) g59
+ships to Lestat on the fix branch once (1) settles; (4) hardware audit (§G58/§G59
+touch loader probes); (5) census probe revert before any scoring. Fix branch
+`fix/cake-1.2.1-llc-overflow` unchanged at `f27950e9d`; today's review +
+isolation data under §S.8.
+
+**PICKUP 2026-08-31 — FFXI wake campaign (§G39-B'), machine left on EEVDF
+(detached), two probe commits on top of `4951242a4`: `d38308fb3` (census,
+revert before scoring) + `6e2653a8b` (§G39-B' behind `--toggle g39b`).**
+
+Census run 20260831 (menu regime, 516k selects): `cake_wake_preempt` was
+UNREACHABLE (wp_attempt=0) — home-routed wakees sit in tcpu's own local DSQ,
+which no other CPU may serve, yet the notify short-circuited to an idle-CPU
+kick that cannot serve them; the wakee waits out the occupant's whole slice.
+The play-regime tails (wined3d_cs HOLD 1.6-2.4 ms, 100% of >1 ms events,
+runtimes equal = not starvation) are exactly this shape. §G39-B' adds the
+preempt attempt at the notify (route != GLOBAL) and in the continuation arm
+(census iteration: wine threads ride the continuation arm, starved_turn false,
+enqueue_wake never reached). Menu A/B ×2 (eevdf/cake0/cake1): g39b=1 NEUTRAL
+at menu, migrations kept (5.4-6.4k vs eevdf 37-44k), 0 preempts fired (regime
+too idle to hold >187 us behind a local wakee). Menu p50-p99 gap vs eevdf is
+the BPF cost floor (sel 85.8 ns measured) — K2 lane, not BPF-side.
+
+Owed: play-regime 9-min ABBA (fires the preempt — wined3d_cs holds are the
+firable shape); pipe weld guard (blocks-2) BEFORE hardwire; iteration-3 knob
+if the protect window binds at play: PREEMPT_PROTECT_SHIFT 4 -> 7.
+Data: `scx_cake_bench/runs/ffxi_wake_20260830/PLAN_G39B.md` +
+`history/wake_latency/ffxi{2,3}-*` + runner logs `g39b2-*`.
 
 **PICKUP 2026-08-21 EOD — machine left on EEVDF, nothing attached, all
 background jobs stopped.** Code tip `60b238311` (§G38.1-repaired + §G40; §G39-B
@@ -79,6 +295,9 @@ Board (live, movable): claude.ai/code/artifact/98701cdf-e541-48c5-8dfc-07109a311
 | 27 | **M2** frame-clock trio is dead plumbing (maintainer audit) | VERIFIED 2026-08-23: cake_frame_ns/floor/slice have zero BPF readers (decl-only; §G11 comment admits it); votes still paid on display threads | decision: demote voting to loader-side telemetry or land a consumer; separate commit + wallclock screen |
 | 28 | **M6** occupant mirror — subscribe, don't query (maintainer audit) | **BUILT `9f344d8da`** behind `--toggle m6`; first mirrored ABBA: NULL on the one clean pair (select_cpu 187=187 ns, no coherence tax; slot 3 noise-contaminated) — the deref chains were warm-line cheap in the appsim regime | park pending a quiet-machine screen; handoff_yields stays on deref (needs live sum_exec) |
 | 25 | **G49** core-contended via idle-smtmask (component audit) | registered 2026-08-23; same audit | build behind toggle: smtmask bit replaces the sibling cpu_curr deref; A/A + wallclock |
+| 33 | **G57** earliest-free pick (published `free_at`) | **BUILT 2026-09-01** behind `--toggle g57`; live: 9.2% of selects placed on the saturated rig; `enqueue` 2→4 static spills (both arms in object). **Wallclock fast ABBA PASSED same day: pipe flat, messaging −8.7% (4/4 on runs faster)** — the time-based herd guard holds where the §S.8 depth gate cost −40% | quiet-box strand rig ABBA both modes (the latency endpoint), then game screen before hardwire |
+| 34 | **G58** frame pre-wake = §G28 BUILT + reservation | **BUILT 2026-09-01** behind `--toggle g58`; BPF timer per CPU, argmax-cadence gate, reservation window cycle/16 floored 2x lead; live: 6,997 takes on a 1 kHz cadence (ungated). Wallclock fast ABBA x3: messaging flat, pipe 0 to +8%, one unrepeated 4.10 s slot | retest gated + widened window on the rig; game screen needs a cpuidle host for the C-state half |
+| 35 | **G59** idle-depth pick (§G51 consumer) | **BUILT 2026-09-01** behind `--toggle g59` (forces g51); attach-clean, inert on this host; wallclock fast ABBA null (g51 tracepoint cost invisible) | ships to Lestat's 9950X3D with the fix branch; unmeasurable here |
 
 **TOGGLE CAMPAIGN (2026-08-22, maintainer-directed):** §G43–§G46 each sit behind a
 `const volatile` rodata toggle (`--toggle gNN=0|1`) so ONE binary serves both arms of
@@ -545,6 +764,13 @@ real session), live replica (loader logic run standalone on the live host), audi
 | **G38** | fully idle core outranks a cache-warm thread (§G38) | **WAKE chain + perf-stat IPC, interleaved ABCCBA** (native/base/G38, 25 s live KovaaKs, 2026-08-21) | ⚖️ **partial win, KEPT** | chain p50 base 18.72/19.77 → G38 18.55/18.29 µs vs native 15.51/14.19; doubled cores 0.27/0.24 → **0.20/0.20** (native 0.05/0.03); game IPC 1.104/1.112 → **1.156/1.143** (native 1.238/1.287). All three endpoints move the right way; ~¼ of the gap closed. `kwin_wayland` sib-busy ~32% untouched. Arms: base receipt `head-51ee88b21`, G38 receipt `g38_5be54ef0` (source diffed identical to `dac0be8d8`). `runs/g38_idlecore_20260821/` |
 
 | — | **toggle campaign** — §G43 off / §G44 / §G45 / §G46 on-off ABBA + stack, one binary, arms = rodata toggles | **wallclock, interleaved, diagnostic** | ⚖️ **G46 the one separated result; G45 lean+; G44 null; G43 lean−** | per-arm medians (on vs off): G43 pipe +2.6 msg +10.6 mem +4.8 (all overlap, against); G44 +2.2/+5.6/−1.5 (overlap); G45 −3.8/−1.7/−0.2 (overlap, 3/3 for); G46 −0.7/−2.9/**−7.8 SEPARATED**; stack (g43=0 g45=1 g46=1) −1.3/−3.2/**−5.4 SEPARATED**. `runs/toggle_wallclock_20260822/` |
+
+| G57 wc | earliest-free pick on/off (`--toggle g57`) | WALLCLOCK fast ABBA (on/off/off/on, pipe 3M + messaging g20 x2) | ✅ **non-regressing, messaging faster** | pipe 2.27/2.15 vs 2.24/2.20 s; messaging 0.37-0.38 vs 0.39-0.44 s (every on run beat every off run, −8.7%). `runs/toggle_wallclock_20260901/` |
+| G58 wc | frame pre-wake on/off (`--toggle g58`) | WALLCLOCK fast ABBA x3 cycles | ⚠️ **inconclusive** | cycle 1 pipe slot 1 = 4.10 s (unrepeated: re-runs 2.51/2.49 vs off 2.47/2.52 and 2.49/2.36 vs 2.29/2.21); messaging flat all three; fires ~150/s under toggle, takes 0-3 (the elected cadence is not the bench). `runs/toggle_wallclock_20260901/` |
+| G59 wc | idle-depth pick on/off (`--toggle g59`, forces g51) | WALLCLOCK fast ABBA | ✅ **null, as designed** | pipe 2.16/2.27 vs 2.21/2.23; messaging 0.40-0.44 vs 0.39-0.41 — the g51 tracepoint cost is invisible; no cpuidle table here |
+| stack wc | g57+g58+g59 on/off | WALLCLOCK fast ABBA | ✅ **non-regressing** | pipe 2.41/2.27 vs 2.28/2.30; messaging 0.38-0.41 vs 0.41-0.42 (−4.8%) |
+| overnight 0901 | native / crate-1.1.3 / stock-1.2.1 / fix-s8 / nightly off / g57 / g58 — seven receipted arms | **FRAMES, unattended KovaaKs menu, 4 mirrored 14-slot cycles, n=8/arm, 60 s** | ✅ **Lestat's loss reproduced on one CCD** | avg fps 746 / 747 / **708** / 717 / 758 / 758 / 756; p99 1.52 / 1.54 / **1.80** / 1.74 / 1.68 / 1.72 / 1.77 ms; 0.1% low 400 / 399 / 386 / 388 / 404 / 403 / 403. 1.2.1 −5.5% and +0.2 ms p99 vs crate 1.1.3, no slot overlap; fix == stock on one LLC; nightly recovers avg, not the 1.1.3 p99; g57/g58 null-to-worse at the menu. `runs/game/kovaaks/2026-09-01-overnight/` |
+| overnight 0901 | same seven arms | **FRAMES, unattended Palworld menu, 3 cycles, n=6/arm, 120 fps cap** | ⚖️ **direction only** | p99 flat 8.73-8.80 ms all arms; p99.9 native 9.80 / 1.1.3 10.25 / 1.2.1 10.08 / fix 10.91 / off 9.80 / g57 9.63 / g58 9.67 (7 frames per 0.1%). `runs/game/palworld/2026-09-01-overnight/` |
 
 ### The frame result (2026-08-01, the campaign's first)
 
@@ -1673,6 +1899,100 @@ as the prev-CPU arm). Full audit and the candidate ranking:
   remote-read (stamp in handoff_yields/occupant_live), so M6's net
   lines-touched delta is plausibly negative; hard abort kept regardless.
 
+#### §G56 — FOLD: banded steal (registered 2026-09-01, maintainer-directed "geometry" program) `<- §G25, §G52, longest-paths audit`
+
+- Hypothesis: the steal walk's worst case (31 iterations, up to 31 failed
+  move kfuncs on all-stale qmask after a load spike; longest live loop per
+  the 2026-09-01 path audit) collapses to one AND + find-first-set per LLC
+  band: `qmask & llc_membership_word` jumps straight to the victim. Band
+  order = locality order (own LLC first, then foreign LLCs by descending
+  CPPC rank under g52 — the first live §G52 consumer — else id order).
+- Implementation: behind `--toggle g56`; narrow hosts only (span <= 64, one
+  qmask word) — wide hosts keep the §G25 walk; loader fills cpu->LLC map,
+  per-LLC qmask words, and band order from RUNTIME topology (portability
+  invariant). Stagger = mask-split at own id + two ctz, NOT the
+  §G25-REJECTED rotate. Stale bits cost one word-op, not a kfunc.
+- Built + attach-smoked 2026-09-01 (g56=1 g52=1, "1 LLC band, order rank",
+  10 s clean). fnspills: cake_band_steal 107 insns, 11 spills (vs walk's 5 —
+  double table index; optimization owed if the screen keeps it).
+- Endpoint: going-idle dispatch ns/call + steal hit rate on the appsim
+  regime; wallclock quick ABBA (pipe + messaging + memcpy); frame screen
+  before hardwire. Aborts: stall/watchdog; dispatch ns regression; steal
+  hit-rate drop vs the walk.
+- Sibling program notes: TELEPORT = §M6/§M7 mirrors (parked, compose at the
+  screen under load); TIME = per-LLC wake-pool port from the
+  `fix/cake-1.2.1-llc-overflow` branch (§S.8, pending the 9950X3D field
+  verdict); wide-host hierarchical summary word (O(log) search) recorded,
+  not built.
+
+#### §G57 — earliest-free pick: the occupant publishes when it leaves (registered + BUILT 2026-09-01, "nodes that don't talk" program) `<- §S.8 field report, §G17, §M6`
+
+- Hypothesis: the saturated-mask strand (§S.8: a wake behind one busy CPU's
+  private queue, no other server) is a missing edge between occupant and
+  wakee. `ops.running` writes `free_at = now + slice/2` into the run slot it
+  already dirties (uncapped grant = 2x burst, so half is the burst estimate
+  with no divide; a capped grant ends at the slice, so the estimate never
+  lands after the CPU's next dispatch). A wake with nothing idle in its mask
+  scans the affine CPUs of its home LLC (one qword AND, ctz walk, one slot
+  read each) and queues behind the earliest. Move only when the gain clears
+  `SLICE_NS >> FREE_MOVE_MARGIN_SHIFT` (94 us): a partner about to yield
+  keeps the wake home — the t32/t64 herd guard as TIME, replacing the
+  fix-branch depth gate that measured messaging t16 −40% when loosened.
+- Built behind `--toggle g57`; hook precedes the wake/continuation split in
+  `ops.enqueue`; no kick owed (the target dispatches at `free_at` by
+  construction, the ring can lift earlier). Stale slots (older than a slice:
+  RT or idle occupant) are never targets and never moved from. Narrow hosts.
+- Live 2026-09-01: saturated peer rig 19,018 placements (9.2% of selects);
+  idle rig 0-83 (correct: nothing saturated). Unscored — box noisy.
+- Endpoint: strand rig both modes, quiet box, ABBA off/on: over-1ms and p99
+  at or below the fix branch's committed numbers; messaging t16 within the
+  off arm's spread; pipe flat.
+- Aborts: messaging outside spread (the herd guard failed); any stall; a
+  new spill in `cake_select_cpu`.
+
+#### §G58 — frame pre-wake: the scheduler acts before ttwu (registered + BUILT 2026-09-01) `<- §G28 (this is its build), §G54, §G11`
+
+- Hypothesis: §G28 as built, plus a reservation. A display-coupled thread's
+  next wake is predictable from its own cycle, so `ops.stopping` on a block
+  arms a per-CPU `bpf_timer` (scx_layered precedent; init in the sleepable
+  `ops.init`) at `cycle − used − lead`. The fire, if the CPU is idle, writes
+  `reserved_pid/until` into the run slot and idle-kicks the CPU, paying the
+  C-state exit before the wake. `select_cpu` takes the reservation before
+  every other claim; `park_take`/`optimistic_place` skip a CPU reserved for
+  another pid inside the window. Lead = 2x deepest cpuidle exit (loader), or
+  `PREWAKE_LEAD_DEFAULT_NS` (50 us) without a table; window = cycle >> 4
+  floored at 2x lead (prediction error scales with the cycle).
+- Gates: the frame-clock vote gate (sleeps most of its life, cycle inside
+  the engine band) AND the elected argmax bucket — only the published frame
+  cadence arms, so a desktop of 60 Hz sleepers is not a kick storm. No
+  clock, no arm. A miss costs one idle kick and one unused window; nothing
+  is queued or preempted on a prediction. One divide on the block path,
+  under the toggle.
+- Live 2026-09-01: ungated, 1 kHz rig cadence: 14,173 fires / 6,997 takes
+  per 10 s (~75% of the cadence's wakes landed on the reserved CPU). Gated,
+  the box's 252 Hz argmax fired 6-7k per 10 s with 0 takes at the 100 us
+  window — widened to cycle/16, retest owed. Two of four on-arm idle-rig
+  runs read p999 39 us vs off 13-15 (always the first arm after a switch).
+- Endpoint: wake-to-run of the elected cadence thread with deep idle
+  available; then a game screen (severe-frame ratio) on a cpuidle host.
+  This host has no cpuidle driver, so the C-state half is unmeasurable here.
+- Aborts: A/A tail cost on the idle rig; power artifacts; any stall.
+
+#### §G59 — idle-depth pick: the §G51 consumer (registered + BUILT 2026-09-01) `<- §G51, §G53, §G54`
+
+- Hypothesis: among affine idle CPUs, the shallowest C-state (exit latency
+  from the loader table via the §G51 mirror) beats census order; a parked
+  mailbox CPU deep in idle loses to a shallower affine one. Compares at most
+  `DEPTH_SCAN_MAX` (4) candidates; ties keep census order, so an empty table
+  IS the §G53 first fit. Composes with §G58 (reserved CPUs skipped in the
+  same walk). Forces g51 on.
+- Built behind `--toggle g59`; attach-clean; INERT on this host (`cpuidle
+  current_driver none`), degrade logged. Unmeasurable here by construction.
+- Endpoint: on a cpuidle host, wake-to-run mean and p99 for the cadence
+  thread vs g59 off; census of picks that changed. Ships to the 9950X3D
+  field test on the fix branch.
+- Aborts: any placement change on this host (would prove the gate leaks).
+
 #### §G53 — EEVDF-shape optimistic placement (registered 2026-08-23, maintainer-directed)
 
 - Hypothesis: EEVDF's 66 ns comes from NOT verifying its pick — no gates, no
@@ -1912,6 +2232,32 @@ Source-only policy; the cache serves stale cflag builds.
 
 #### §S.7 — ids and geometry
 `MAX_CPUS = 1024` is a verifier sizing bound, not the DSQ count. `MAX_CPUS + 1` was `OVF_DSQ` (§R.15).
+
+#### §S.8 — per-LLC wake pools (fix branch `fix/cake-1.2.1-llc-overflow`, `f27950e9d`, 2026-09-01)
+Field report: 9950X3D, DOOM TDA, game lassoed to the V-cache CCD — shipped
+1.2.1 last (152.6 avg / 90.0 1% low) vs crate 1.1.3 first (172.3 / 115.9),
+EEVDF 167.5 / 109.0. Nine schedulers sit within 3% avg / 6% low, 1.1.3 a
+single run: "1.1.3 first" is not established, "1.2.1 last by 9% / 17%" is.
+The 97th-percentile bars are equal (205 vs 207-210): the loss is all slow
+tail = intermittent holds, which favours the strand over CCD-blindness.
+Root cause: the saturated-mask wake strand (a wake into one busy CPU's
+private DSQ, no other server, every rescue gated). Fix, cut from the
+shipped tag: one wake pool DSQ per LLC (`LLC_WAKE_DSQ_BASE + idx`, loader
+maps cpu→LLC from RUNTIME topology, 1 pool on failure), continuation-arm
+wakes behind ANY live occupant pool, plain vtime own-vs-pool arbitration,
+per-LLC starve stamps, 24 ms cross-LLC wall kept. Synthetic strand rig only;
+no game, no dual-CCD host has run it. Review 2026-09-01 (this file's
+author): stage wakes still strand when the pool is backlogged (the herd
+depth gate demotes them to the private queue — and the fix makes the pool
+non-empty more often); service bound is next dispatch, not a preempt; the
+removed `!starved(hc)` guard pools futex handoffs. Isolation, 3 reps each,
+interleaved: loosening the herd gate (yield test, or depth ≥ span) costs
+messaging t16 0.65-0.69 s → 0.88-0.96 s in every run; the continuation-arm
+yield test is a no-op on pipe and messaging. NEITHER PUSHED. The right
+discriminator is remaining burst as time, not yield-within-1.5 us — built
+on nightly as §G57. Strand rig noise that evening: same binary, same mode,
+over-1ms 15/99/216/466 (spinner) and 249/382/522/1604 (peer): no
+between-arm verdict survives it. Lestat's verdict pending.
 
 ---
 

--- a/scheds/rust/scx_cake/src/bpf/cake.bpf.c
+++ b/scheds/rust/scx_cake/src/bpf/cake.bpf.c
@@ -944,7 +944,6 @@ static __always_inline void cake_stat_inc(u32 idx)
 }
 
 static u64 cake_core_free __attribute__((aligned(STATE_SLOT_BYTES)));
-static u64 cake_thread_free __attribute__((aligned(STATE_SLOT_BYTES)));
 static u64 cake_seat_word __attribute__((aligned(STATE_SLOT_BYTES)));
 static u64 cake_idle_words[QMASK_WORDS] __attribute__((aligned(STATE_SLOT_BYTES)));
 
@@ -1009,7 +1008,7 @@ static __noinline void cake_probe_place(struct task_struct *p, u64 dsq_id,
 		t->waker_pid = w ? (u32)w->pid : 0;
 	}
 	t->seats = cake_seat_word; t->core_free = cake_core_free;
-	t->thread_free = cake_thread_free; t->idle_word = cake_idle_words[0];
+	t->thread_free = cake_idle_words[0]; t->idle_word = cake_idle_words[0];
 	if (cake_probe_busy_flag[me]) {
 		kind = 6;
 		cake_probe_busy_flag[me] = 0;
@@ -1121,14 +1120,23 @@ static __noinline bool cake_wake_preempt(struct task_struct *p, s32 tcpu,
  * game regression dates from exactly there. Helldivers 2 runs ~62% idle
  * against this 75% threshold, so it declines precisely where G9.4 admits.
  */
-/* §G45: idle census kept by ops.update_idle. Bit and count flip together
- * (test-gated, idempotent), so the count cannot drift; ops.init seeds it. */
+/* §G45: idle census kept by ops.update_idle. On a host inside one word the
+ * count is the word's popcount (§G82); a wider host keeps this counter,
+ * which flips with the bit (test-gated, idempotent) and ops.init seeds. */
 static u64 cake_idle_nr __attribute__((aligned(STATE_SLOT_BYTES)));
 
+static __always_inline u32 cake_idle_count(void)
+{
+	if (nr_cpu_span <= 64)
+		return (u32)__builtin_popcountll(cake_idle_words[0]);
+	return (u32)cake_idle_nr;
+}
+
 /* §G71: the idle side publishes, the waker claims with ONE atomic. A CPU
- * entering idle sets its bit in thread_free, and in core_free when its
- * sibling is idle too; leaving idle clears both (and the sibling's core
- * bit). The words choose; the kernel idle bit claims. Narrow hosts (span <= 64). */
+ * entering idle sets its bit in the §G45 census word (the thread word,
+ * §G82), and in core_free when its sibling is idle too; leaving idle clears
+ * both (and the sibling's core bit). The words choose; the kernel idle bit
+ * claims. Narrow hosts (span <= 64). */
 
 /* §G79 SEAT HOLD. A stage-class thread (burst >= SEAT_BURST_MIN_NS) that
  * blocks will wake again within the frame; in the stack its core was taken
@@ -1220,9 +1228,9 @@ static __noinline s32 cake_claim_warm(struct task_struct *p __arg_trusted,
 			if (scx_bpf_test_and_clear_cpu_idle(c))
 				return c;
 		}
-		w = cake_thread_free & aff & ~seats;
+		w = cake_idle_words[0] & aff & ~seats;
 		if (!w)
-			w = cake_thread_free & aff;
+			w = cake_idle_words[0] & aff;
 		if (w) {
 			u64 hi = w & (~0ULL << r);
 
@@ -1339,7 +1347,7 @@ static __noinline bool cake_system_serial(void)
 	u32 nr;
 
 	/* One word read replaces the kernel mask walk per wake (§G45). */
-	nr = (u32)cake_idle_nr;
+	nr = cake_idle_count();
 
 	return nr * 4 >= nr_cpu_span * 3;
 }
@@ -2058,7 +2066,7 @@ skip_home:
 	 * the unclaimed census paths (park, first-fit) stack a second wake
 	 * onto a CPU whose first wake is still in flight. Everything else is
 	 * pooled, visible, kicked. */
-	if (cake_idle_nr && !cake_tog_g67) {
+	if (cake_idle_count() && !cake_tog_g67) {
 		s32 ocpu;
 
 		cake_stat_inc(CAKE_STAT_PARK_REACHED);
@@ -2108,7 +2116,7 @@ skip_home:
 		 * scans can only fail; a stale zero costs one queued wake,
 		 * healed by the enqueue-side kick.
 		 */
-		if (!cake_idle_nr)
+		if (!cake_idle_count())
 			ns = NULL;
 		if (ns && __COMPAT_HAS_scx_bpf_select_cpu_and)
 			cpu = scx_bpf_select_cpu_and(p, prev_cpu, wake_flags,
@@ -2116,7 +2124,7 @@ skip_home:
 	}
 	if (cpu >= 0)
 		is_idle = true;
-	else if (!cake_idle_nr &&
+	else if (!cake_idle_count() &&
 		 bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr))
 		cpu = prev_cpu;
 	else
@@ -3055,19 +3063,26 @@ void BPF_STRUCT_OPS(cake_update_idle, s32 cpu, bool idle)
 	u64 bit = 1ULL << (c & 63);
 
 	if (idle) {
+		/* §G82: one census word (the counter is wide hosts only), one
+		 * core word set only when the sibling's bit is already up. Two
+		 * siblings idling in the same instant can each miss the other
+		 * and leave the core half-marked until either transitions again;
+		 * the kernel accepts the same race on its own smt mask, and the
+		 * idle claim still gates every placement. */
 		if (!(cake_idle_words[c >> 6] & bit)) {
 			__atomic_fetch_or(&cake_idle_words[c >> 6], bit,
 					  __ATOMIC_RELAXED);
-			__atomic_fetch_add(&cake_idle_nr, 1, __ATOMIC_RELAXED);
+			if (nr_cpu_span > 64)
+				__atomic_fetch_add(&cake_idle_nr, 1,
+						   __ATOMIC_RELAXED);
 		}
 		if (cake_tog_g71 && c < 64) {
 			s32 sib = cpu_sibling[c];
 
-			__atomic_fetch_or(&cake_thread_free, bit, __ATOMIC_RELEASE);
 			if (sib < 0) {
 				__atomic_fetch_or(&cake_core_free, bit, __ATOMIC_RELEASE);
 			} else if ((u32)sib < 64 &&
-				   (cake_thread_free >> ((u32)sib & 63)) & 1) {
+				   (cake_idle_words[0] >> ((u32)sib & 63)) & 1) {
 				/* the sibling is idle AND still unclaimed: both
 				 * halves become whole cores */
 				__atomic_fetch_or(&cake_core_free,
@@ -3080,9 +3095,10 @@ void BPF_STRUCT_OPS(cake_update_idle, s32 cpu, bool idle)
 		 * itself, with local reads — the waker inherits a pre-gated
 		 * answer. Rotor spreads parkers across waker mailboxes; an
 		 * occupied slot skips one forward, then gives up (the census
-		 * still names this CPU for the fallback ladder).
+		 * still names this CPU for the fallback ladder). Its consumer,
+		 * cake_park_take, is reachable only off §G69 (§G82).
 		 */
-		if (!cake_cpu_irq_bad(cpu) &&
+		if (!cake_tog_g69 && !cake_cpu_irq_bad(cpu) &&
 		    !cake_cpu_tick_soon(cpu)) {
 			u32 r = (u32)__atomic_fetch_add(&cake_park_rotor, 1,
 							__ATOMIC_RELAXED);
@@ -3113,23 +3129,30 @@ void BPF_STRUCT_OPS(cake_update_idle, s32 cpu, bool idle)
 			}
 		}
 	} else {
+		/* §G82: the thread bit goes first, so a sibling idling behind
+		 * this exit reads a busy core; the core word pays an atomic only
+		 * when it holds a bit. */
+		if (cake_idle_words[c >> 6] & bit) {
+			__atomic_fetch_and(&cake_idle_words[c >> 6], ~bit,
+					   __ATOMIC_RELAXED);
+			if (nr_cpu_span > 64)
+				__atomic_fetch_sub(&cake_idle_nr, 1,
+						   __ATOMIC_RELAXED);
+		}
 		if (cake_tog_g71 && c < 64) {
 			s32 sib = cpu_sibling[c];
 			u64 clear = bit;
 
 			if (sib >= 0 && (u32)sib < 64)
 				clear |= 1ULL << ((u32)sib & 63);
-			__atomic_fetch_and(&cake_thread_free, ~bit, __ATOMIC_RELEASE);
-			__atomic_fetch_and(&cake_core_free, ~clear, __ATOMIC_RELEASE);
-		}
-		if (cake_idle_words[c >> 6] & bit) {
-			__atomic_fetch_and(&cake_idle_words[c >> 6], ~bit,
-					   __ATOMIC_RELAXED);
-			__atomic_fetch_sub(&cake_idle_nr, 1, __ATOMIC_RELAXED);
+			if (cake_core_free & clear)
+				__atomic_fetch_and(&cake_core_free, ~clear,
+						   __ATOMIC_RELEASE);
 		}
 		/* Retract (§G54): only our own entry; a raced consumer has
-		 * already taken it, and losing that race is benign. */
-		{
+		 * already taken it, and losing that race is benign. Off §G69
+		 * only, with its producer (§G82). */
+		if (!cake_tog_g69) {
 			u32 park = cake_irq_live[c].park;
 
 			if (park) {
@@ -3217,7 +3240,8 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(cake_init)
 			}
 		}
 		scx_bpf_put_idle_cpumask(im);
-		cake_idle_nr = n;
+		if (nr_cpu_span > 64)
+			cake_idle_nr = n;
 	}
 
 	return cake_nonsink_rebuild(cake_sink_gen);

--- a/scheds/rust/scx_cake/src/bpf/cake.bpf.c
+++ b/scheds/rust/scx_cake/src/bpf/cake.bpf.c
@@ -45,6 +45,9 @@ UEI_DEFINE(uei);
 #define CAKE_DSQ_LOCAL    bpf_core_enum_value(enum scx_dsq_id_flags, SCX_DSQ_LOCAL)
 #define CAKE_DSQ_LOCAL_ON bpf_core_enum_value(enum scx_dsq_id_flags, SCX_DSQ_LOCAL_ON)
 #define CAKE_ENQ_WAKEUP   bpf_core_enum_value(enum scx_enq_flags,    SCX_ENQ_WAKEUP)
+/* SCX_ENQ_PREEMPT is bit 32 (scx enums ABI); the CO-RE enum builtin cannot
+ * fold a 64-bit enumerator, so the ABI value is spelled here. */
+#define CAKE_ENQ_PREEMPT  ((u64)1 << 32)
 #define CAKE_KICK_IDLE    bpf_core_enum_value(enum scx_kick_flags,   SCX_KICK_IDLE)
 #define CAKE_KICK_PREEMPT bpf_core_enum_value(enum scx_kick_flags,   SCX_KICK_PREEMPT)
 #define CAKE_TASK_QUEUED  bpf_core_enum_value(enum scx_ent_flags,    SCX_TASK_QUEUED)
@@ -63,15 +66,34 @@ UEI_DEFINE(uei);
  * that frame instead of the hot caller. Global subprograms return s32, not
  * void: a pre-6.19 verifier rejects a void return from a global function.
  */
+/* PROBE (hold attribution): tag every placement with its queue kind. */
+static __noinline void cake_probe_place(struct task_struct *p, u64 dsq_id,
+					u64 enq_flags);
+
+/* §G68 EXPERIMENT: a VIP task's insert always carries ENQ_PREEMPT, so a
+ * non-VIP occupant of a local queue it lands in is thrown off at once.
+ * Defined after the toggles and the state block; prototypes here. */
+static __noinline bool cake_vip(const struct task_struct *p);
+static __noinline u64 cake_vip_head_vtime(void);
+static __noinline void cake_kick_preempt(s32 cpu);
+
 static __noinline bool cake_dsq_insert_vtime(struct task_struct *p, u64 dsq_id,
 					     u64 slice, u64 vtime, u64 enq_flags)
 {
+	cake_probe_place(p, dsq_id, enq_flags);
+	if (cake_vip(p)) {
+		enq_flags |= CAKE_ENQ_PREEMPT;
+		vtime = cake_vip_head_vtime();	/* pool head */
+	}
 	return scx_bpf_dsq_insert_vtime(p, dsq_id, slice, vtime, enq_flags);
 }
 
 static __always_inline bool cake_dsq_insert(struct task_struct *p, u64 dsq_id,
 					    u64 slice, u64 enq_flags)
 {
+	cake_probe_place(p, dsq_id, enq_flags);
+	if (cake_vip(p))
+		enq_flags |= CAKE_ENQ_PREEMPT;
 	return scx_bpf_dsq_insert(p, dsq_id, slice, enq_flags);
 }
 
@@ -173,7 +195,20 @@ struct cake_run_slot {
 	 */
 	u64 occupant;
 	u64 mirror_vtime;
-	u64 pad[STATE_SLOT_WORDS - 7];
+	/*
+	 * §G57: when this CPU's occupant is predicted to leave it, written by
+	 * running on a line it already dirties. A saturated wake reads its
+	 * mask's slots and queues behind the earliest.
+	 */
+	u64 free_at;
+	/*
+	 * §G58: pre-wake reservation, pid and expiry. The timer callback
+	 * writes both for an idle CPU; the named task's wake consumes it, every
+	 * other placement skips the CPU until the expiry.
+	 */
+	u64 reserved_pid;
+	u64 reserved_until;
+	u64 pad[STATE_SLOT_WORDS - 10];
 };
 
 enum {
@@ -197,6 +232,7 @@ const volatile u64 cake_handoff_max_ns		= 1464;
  * exception. Scaffolding; defaults are tip behavior (STATE.md 2026-08-22).
  */
 const volatile u8 cake_tog_g46;				/* departing-slice cache (§G46) */
+const volatile u8 cake_tog_g39b;			/* home-notify preempt (§G39-B') */
 const volatile u8 cake_tog_m6;				/* occupant mirror (§M6) */
 const volatile u8 cake_tog_g51;				/* idle-depth model (§G51) */
 const volatile u8 cake_tog_g52;				/* preferred-core rank (§G52) */
@@ -211,6 +247,48 @@ const volatile u32 cake_cstate_exit_us[CAKE_CSTATE_TABLE];
 
 /* §G52: CPPC highest_perf per CPU, loader-read; zero = unknown. */
 const volatile u8 cpu_perf_rank[MAX_CPUS];
+
+/*
+ * §G56 FOLD: the steal walk as per-LLC qmask bands. One AND plus a
+ * find-first-set answers a whole band; the locality (and, under g52, the
+ * preferred-core) order lives in the BAND order, not a per-CPU element
+ * walk. Narrow hosts only (span <= 64, one qmask word); wide hosts keep
+ * the §G25 walk. All loader-filled from runtime topology.
+ */
+const volatile u8 cake_tog_probe;		/* diagnostics: placement census, hold attribution, black box (--toggle probe=1) */
+const volatile u8 cake_tog_g56;			/* banded steal fold (§G56) */
+const volatile u8 cake_tog_g57;			/* earliest-free pick (§G57) */
+const volatile u8 cake_tog_g58;			/* frame pre-wake (§G58) */
+const volatile u8 cake_tog_g59;			/* idle-depth pick (§G59) */
+const volatile u8 cake_tog_g60;			/* whole-core census placement (§G60) */
+const volatile u8 cake_tog_g61;			/* census collision preempt (§G61) */
+const volatile u8 cake_tog_g62;			/* census placements claim the CPU (§G62) */
+const volatile u8 cake_tog_g63;			/* 1.1.3 pool mode: no direct dispatch, every wake global (§G63) */
+const volatile u8 cake_tog_g64;			/* verified direct dispatch: dfl claim only in select_cpu (§G64) */
+const volatile u8 cake_tog_g65			= 1;	/* every enqueued wake takes the pool, herd gate off (§G65) */
+const volatile u8 cake_tog_g66;			/* serial handoff arm off: never place on a busy waker CPU (§G66) */
+const volatile u8 cake_tog_g67;			/* unclaimed census direct paths off: home claim or pool (§G67) */
+const volatile u8 cake_tog_g68;			/* EXPERIMENT: one process is VIP -- preempts, kicks, pool head (§G68) */
+const volatile u32 cake_vip_tgid;		/* §G68: the VIP process, loader-found by comm */
+const volatile u8 cake_tog_g69			= 1;	/* claimed warm placement: prev, whole idle core, idle thread, else pool (§G69) */
+const volatile u8 cake_tog_g70;			/* EXPERIMENT: the VIP process is immune to preempt kicks (§G70) */
+const volatile u8 cake_tog_g72;			/* L2 handoff: same-mm microsecond wakee onto the waker's idle sibling (§G72) */
+const volatile u8 cake_tog_g71			= 1;	/* idle-side published claim words: one atomic per placement, no scan (§G71) */
+const volatile u8 cake_tog_g73;			/* distributed pick: start the claim search at prev_cpu's core, wrap (§G73) */
+const volatile u8 cake_tog_g74;			/* published-burst stacking: queue behind a busy prev only when it frees within tolerance (§G74) */
+const volatile u8 cake_tog_g75			= 1;	/* grooves: per-task placement history orders the ladder and skips a failing home claim (§G75) */
+const volatile u8 cake_tog_g77			= 1;	/* lean 2: steal ring skipped on an empty qmask (§G77) */
+const volatile u8 cake_tog_g78;			/* spread once, then stick: a task's first whole-core claim rotates, its groove keeps it (§G78) */
+const volatile u8 cake_tog_g79			= 1;	/* seat hold: a blocked stage keeps its core for its gap; other wakes skip it (§G79) */
+const volatile u8 cake_tog_g81			= 1;	/* stage-class tasks keep the warm home on SYNC wakes (§G81) */
+
+/* §G58: how far ahead of a predicted wake the reservation fires. Loader:
+ * twice the deepest cpuidle exit latency, or the default without a table. */
+const volatile u64 cake_prewake_lead_ns;
+const volatile u8 cake_cpu_llc[MAX_CPUS];	/* cpu -> compact LLC index */
+const volatile u64 cake_llc_qword[MAX_LLCS];	/* LLC membership, word 0 */
+const volatile u8 cake_llc_order[MAX_LLCS][MAX_LLCS]; /* band steal order */
+const volatile u32 cake_nr_llcs = 1;
 
 
 /*
@@ -633,7 +711,7 @@ int BPF_PROG(cake_softirq_enter)
 /* §G51: mirror the CPU's cpuidle state so placement can rank shallow idle
  * above deep. Fires on the idling CPU itself at entry (state index) and
  * exit (~0), so the byte is exact at every transition. */
-SEC("tp_btf/cpu_idle")
+SEC("?tp_btf/cpu_idle")
 int BPF_PROG(cake_cpu_idle, unsigned int state, unsigned int cpu_id)
 {
 	u32 c;
@@ -801,6 +879,180 @@ static __noinline u64 cake_occupant_live(s32 tcpu, u64 *ran_out)
 }
 
 /*
+ * DIAGNOSTIC PROBE — not for scoring. Per-arm placement census for
+ * ops.select_cpu, so the mailbox hit rate is a measurement instead of an
+ * assumption (STATE.md pillar 3 lists it unmeasured). Per-CPU map, plain
+ * increment on this CPU's own copy: no atomic, no shared line, same shape
+ * as cake_frame_hist. REVERT before any scoring run.
+ */
+enum cake_stat {
+	CAKE_STAT_SELECT = 0,		/* ops.select_cpu entries */
+	CAKE_STAT_SERIAL,		/* serial-handoff arm placed */
+	CAKE_STAT_HOME,			/* prev-cpu warm home claim placed */
+	CAKE_STAT_PARK_REACHED,		/* cake_park_take called */
+	CAKE_STAT_PARK_PREV,		/* park_take won on prev warmth */
+	CAKE_STAT_PARK_MBOX,		/* park_take won on the mailbox */
+	CAKE_STAT_OPT_REACHED,		/* cake_optimistic_place called */
+	CAKE_STAT_OPT_HIT,		/* cake_optimistic_place placed */
+	CAKE_STAT_RANKED,		/* fell through to the ranked pick */
+	CAKE_STAT_WP_ATTEMPT,		/* wake_preempt reached with a live occupant */
+	CAKE_STAT_WP_TINY,		/* wakee burst <= 4us (microsecond-class shape) */
+	CAKE_STAT_WP_SMALL,		/* wakee burst <= 64us */
+	CAKE_STAT_WP_PROTECT,		/* rejected: protect window not met */
+	CAKE_STAT_WP_VTIME,		/* rejected: vtime bar */
+	CAKE_STAT_WP_STARVED,		/* rejected: pipeline-stage veto */
+	CAKE_STAT_WP_FIRED,		/* kick issued */
+	CAKE_STAT_FREE_PICK,		/* §G57 placed behind an earlier-free CPU */
+	CAKE_STAT_PREWAKE_FIRE,		/* §G58 timer fired on an idle CPU */
+	CAKE_STAT_RESERVED_TAKE,	/* §G58 wake took its reservation */
+	/* PROBE hold attribution: 5 queue kinds x {placed, wait>300us, wait>1ms} */
+	CAKE_STAT_PL_LOCAL,		/* select_cpu direct, own CPU (LOCAL) */
+	CAKE_STAT_PL_LOCAL_ON,		/* select_cpu direct, LOCAL_ON|cpu */
+	CAKE_STAT_PL_CPUQ_WAKE,		/* enqueue wake into a per-CPU DSQ */
+	CAKE_STAT_PL_CPUQ_CONT,		/* enqueue continuation into a per-CPU DSQ */
+	CAKE_STAT_PL_GLOBAL,		/* WAKE_DSQ */
+	CAKE_STAT_H3_LOCAL, CAKE_STAT_H3_LOCAL_ON, CAKE_STAT_H3_CPUQ_WAKE,
+	CAKE_STAT_H3_CPUQ_CONT, CAKE_STAT_H3_GLOBAL,
+	CAKE_STAT_H10_LOCAL, CAKE_STAT_H10_LOCAL_ON, CAKE_STAT_H10_CPUQ_WAKE,
+	CAKE_STAT_H10_CPUQ_CONT, CAKE_STAT_H10_GLOBAL,
+	CAKE_STAT_PL_SELF, CAKE_STAT_H3_SELF, CAKE_STAT_H10_SELF, /* LOCAL_ON to the calling CPU */
+	CAKE_STAT_HD_SKIP, CAKE_STAT_HD_SYNC, CAKE_STAT_HD_STARVED, CAKE_STAT_HD_IRQ,
+	CAKE_STAT_HD_AFF, CAKE_STAT_HD_CONTENDED, CAKE_STAT_HD_NOTIDLE, /* PROBE: home declines */
+	CAKE_STAT_HOME_BUSY,		/* home claim succeeded on a CPU with a running task */
+	CAKE_STAT_HOME_LOCALQ,		/* home claim succeeded on a CPU whose local DSQ is non-empty */
+	CAKE_STAT_H3_HOME_BUSY,		/* ... and the wakee then waited >300us */
+	CAKE_STAT_NR,
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, CAKE_STAT_NR);
+	__type(key, u32);
+	__type(value, u64);
+} cake_stats SEC(".maps");
+
+static __always_inline void cake_stat_inc(u32 idx)
+{
+	u64 *v;
+
+	if (!cake_tog_probe)
+		return;
+	v = bpf_map_lookup_elem(&cake_stats, &idx);
+
+	if (v)
+		(*v)++;
+}
+
+static u64 cake_core_free __attribute__((aligned(STATE_SLOT_BYTES)));
+static u64 cake_thread_free __attribute__((aligned(STATE_SLOT_BYTES)));
+static u64 cake_seat_word __attribute__((aligned(STATE_SLOT_BYTES)));
+static u64 cake_idle_words[QMASK_WORDS] __attribute__((aligned(STATE_SLOT_BYTES)));
+
+/* PROBE hold attribution -- not for scoring. */
+struct cake_probe_tag {
+	u64 place_ns;
+	u32 kind;
+	u32 target;		/* dsq id low bits (cpu) */
+	u32 caller;		/* placing CPU */
+	u32 waker_pid;
+	u64 seats, core_free, thread_free, idle_word;
+};
+
+/* PROBE black box: the placement context of the last waits > 10 ms. */
+struct cake_bb_rec {
+	u64 wait_ns, place_ns, seats, core_free, thread_free, idle_word;
+	u32 pid, kind, target, caller, waker_pid, ran_on;
+	char comm[16];
+};
+struct cake_bb_rec cake_blackbox[4];
+u32 cake_blackbox_n;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_TASK_STORAGE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__type(key, int);
+	__type(value, struct cake_probe_tag);
+} cake_probe_tags SEC(".maps");
+
+static u32 cake_probe_busy_flag[MAX_CPUS];
+
+static __noinline void cake_probe_place(struct task_struct *p, u64 dsq_id,
+					u64 enq_flags)
+{
+	struct cake_probe_tag *t;
+	u32 kind;
+	u32 me;
+
+	if (!cake_tog_probe)
+		return;
+	me = bpf_get_smp_processor_id() & (MAX_CPUS - 1);
+
+	if (dsq_id == (u64)WAKE_DSQ)
+		kind = 4;
+	else if (dsq_id & CAKE_DSQ_LOCAL_ON)
+		kind = ((u32)dsq_id & (MAX_CPUS - 1)) ==
+		       (bpf_get_smp_processor_id() & (MAX_CPUS - 1)) ? 5 : 1;
+	else if (dsq_id == CAKE_DSQ_LOCAL)
+		kind = 0;
+	else
+		kind = (enq_flags & CAKE_ENQ_WAKEUP) ? 2 : 3;
+	t = bpf_task_storage_get(&cake_probe_tags, p, 0,
+				 BPF_LOCAL_STORAGE_GET_F_CREATE);
+	if (!t)
+		return;
+	t->place_ns = bpf_ktime_get_ns();
+	t->target = (u32)dsq_id & (MAX_CPUS - 1);
+	t->caller = me;
+	{
+		struct task_struct *w = bpf_get_current_task_btf();
+
+		t->waker_pid = w ? (u32)w->pid : 0;
+	}
+	t->seats = cake_seat_word; t->core_free = cake_core_free;
+	t->thread_free = cake_thread_free; t->idle_word = cake_idle_words[0];
+	if (cake_probe_busy_flag[me]) {
+		kind = 6;
+		cake_probe_busy_flag[me] = 0;
+	}
+	t->kind = kind;
+	if (kind == 6)
+		return;
+	cake_stat_inc(kind == 5 ? CAKE_STAT_PL_SELF : CAKE_STAT_PL_LOCAL + kind);
+}
+
+static __noinline void cake_probe_run(struct task_struct *p, u64 now)
+{
+	struct cake_probe_tag *t;
+	u64 wait;
+
+	if (!cake_tog_probe)
+		return;
+	t = bpf_task_storage_get(&cake_probe_tags, p, 0, 0);
+	if (!t || !t->place_ns)
+		return;
+	wait = now - t->place_ns;
+	if (wait > 10 * NSEC_PER_MSEC) {
+		u32 i = __atomic_fetch_add(&cake_blackbox_n, 1, __ATOMIC_RELAXED) & 3;
+		struct cake_bb_rec *b = &cake_blackbox[i];
+
+		b->wait_ns = wait; b->place_ns = t->place_ns; b->seats = t->seats;
+		b->core_free = t->core_free; b->thread_free = t->thread_free;
+		b->idle_word = t->idle_word; b->pid = (u32)p->pid; b->kind = t->kind;
+		b->target = t->target; b->caller = t->caller; b->waker_pid = t->waker_pid;
+		b->ran_on = (u32)p->thread_info.cpu;
+		__builtin_memcpy(b->comm, p->comm, 16);
+	}
+	t->place_ns = 0;
+	if (wait > 300 * NSEC_PER_USEC)
+		cake_stat_inc(t->kind == 6 ? CAKE_STAT_H3_HOME_BUSY :
+			      t->kind == 5 ? CAKE_STAT_H3_SELF :
+			      CAKE_STAT_H3_LOCAL + (t->kind & 7));
+	if (wait > 1000 * NSEC_PER_USEC)
+		cake_stat_inc(t->kind == 5 ? CAKE_STAT_H10_SELF :
+			      CAKE_STAT_H10_LOCAL + (t->kind & 7));
+}
+
+/*
  * Wake preemption: kick @tcpu off its occupant for @p, but only once the
  * occupant has run at least @min_ran and @p out-deserves its LIVE vtime.
  *
@@ -819,20 +1071,41 @@ static __noinline bool cake_wake_preempt(struct task_struct *p, s32 tcpu,
 	u64 ran = 0;
 	u64 live = cake_occupant_live(tcpu, &ran);
 	struct task_struct *curr;
+	u64 se = p->se.sum_exec_runtime;
+	u64 n = p->nvcsw | 1;
 
-	if (!live || ran < (u64)SLICE_NS >> protect_shift ||
-	    !time_before(p->scx.dsq_vtime, live))
+	/* §G39-B' census: which gate refuses the microsecond-class successor.
+	 * Counters only -- behavior is identical to the ungated build. Shape
+	 * buckets are cross-multiplied so the census spends no divide (§R.24). */
+	cake_stat_inc(CAKE_STAT_WP_ATTEMPT);
+	if (!((4096 | n) >> 32) && se < 4096 * n)
+		cake_stat_inc(CAKE_STAT_WP_TINY);
+	if (!((65536 | n) >> 32) && se < 65536 * n)
+		cake_stat_inc(CAKE_STAT_WP_SMALL);
+
+	if (!live)
 		return false;
+	if (ran < (u64)SLICE_NS >> protect_shift) {
+		cake_stat_inc(CAKE_STAT_WP_PROTECT);
+		return false;
+	}
+	if (!time_before(p->scx.dsq_vtime, live)) {
+		cake_stat_inc(CAKE_STAT_WP_VTIME);
+		return false;
+	}
 
 	/*
 	 * Never preempt a pipeline stage; tested last so rejections stay
 	 * cheap (§G10.5).
 	 */
 	curr = cake_cpu_curr(tcpu);
-	if (curr && cake_starved(curr))
+	if (curr && cake_starved(curr)) {
+		cake_stat_inc(CAKE_STAT_WP_STARVED);
 		return false;
+	}
 
-	scx_bpf_kick_cpu(tcpu, CAKE_KICK_PREEMPT);
+	cake_stat_inc(CAKE_STAT_WP_FIRED);
+	cake_kick_preempt(tcpu);
 	return true;
 }
 
@@ -850,8 +1123,216 @@ static __noinline bool cake_wake_preempt(struct task_struct *p, s32 tcpu,
  */
 /* §G45: idle census kept by ops.update_idle. Bit and count flip together
  * (test-gated, idempotent), so the count cannot drift; ops.init seeds it. */
-static u64 cake_idle_words[QMASK_WORDS] __attribute__((aligned(STATE_SLOT_BYTES)));
 static u64 cake_idle_nr __attribute__((aligned(STATE_SLOT_BYTES)));
+
+/* §G71: the idle side publishes, the waker claims with ONE atomic. A CPU
+ * entering idle sets its bit in thread_free, and in core_free when its
+ * sibling is idle too; leaving idle clears both (and the sibling's core
+ * bit). The words choose; the kernel idle bit claims. Narrow hosts (span <= 64). */
+
+/* §G79 SEAT HOLD. A stage-class thread (burst >= SEAT_BURST_MIN_NS) that
+ * blocks will wake again within the frame; in the stack its core was taken
+ * in that gap by a dxvk or render wake and it came back cold 450 times a
+ * second (GameThread 12,629 migrations vs 1.1.3's 650). Its CPU is marked
+ * held; other wakes skip held cores while any other core is free; whoever
+ * runs there clears it. The owner's home claim on its own seat is unaffected. */
+
+
+/* §G60: whole core, judged from the census alone -- the sibling's idle bit,
+ * no rq deref. The §G38 rule (a whole idle core outranks an idle thread on a
+ * busy core) guarded the home claim and the ranked pick; the census
+ * consumers built after it (§G53 first-fit, §G54 mailbox and prev-cpu take)
+ * run ahead of both and were placing on half cores. */
+static __always_inline bool cake_core_idle_census(u32 c)
+{
+	s32 sib = cpu_sibling[c & (MAX_CPUS - 1)];
+
+	if (sib < 0)
+		return true;
+	return (cake_idle_words[((u32)sib & (MAX_CPUS - 1)) >> 6] >>
+		((u32)sib & 63)) & 1;
+}
+
+static __noinline bool cake_vip(const struct task_struct *p)
+{
+	return cake_tog_g68 && (u32)p->tgid == cake_vip_tgid;
+}
+
+/* §G69: every local placement is CLAIMED at this instant (1.1.3's certainty)
+ * and chosen warm-first (cake's placement): a whole idle core from the
+ * census, then any idle thread, each taken with the atomic idle claim so a
+ * second waker can never stack behind it. Narrow hosts only; -1 sends the
+ * wake to the pool. */
+static __noinline s32 cake_claim_warm(struct task_struct *p __arg_trusted,
+				      s32 groove)
+{
+	u64 aff = p->cpus_ptr->bits[0];
+	u64 idle = cake_idle_words[0] & aff;
+	u64 half = 0;
+	u32 k;
+
+	if (nr_cpu_span > 64)
+		return -1;
+
+	/* §G78: a task with no groove yet takes its first whole core from a
+	 * rotor, so the game's threads land on DIFFERENT cores and each keeps
+	 * its own predictor and L1 (per-CPU busy 39/33/26/27% on cores 0-3 vs
+	 * 1.1.3's even 10%; branch misses +34%). From then on the groove
+	 * (last_win) is its home; §G73 rotated on every wake and paid cold. */
+	if (cake_tog_g78 && groove < 0) {
+		u64 w = cake_core_free & aff;
+
+		if (w) {
+			u32 r = (u32)__atomic_fetch_add(&cake_park_rotor, 1,
+							__ATOMIC_RELAXED) & 63;
+			u64 hi = w & (~0ULL << r);
+			s32 c = (s32)__builtin_ctzll(hi ? hi : w);
+
+			if (scx_bpf_test_and_clear_cpu_idle(c))
+				return c;
+		}
+	}
+
+	/* §G75: the CPU this task last won, if it is a free whole core now. */
+	if (groove >= 0 && groove < 64 &&
+	    ((cake_core_free >> groove) & 1) && ((aff >> groove) & 1) &&
+	    scx_bpf_test_and_clear_cpu_idle(groove))
+		return groove;
+
+	/* §G71: one atomic on a published word replaces the scan. */
+	if (cake_tog_g71) {
+		/* The published words CHOOSE (one read each); the kernel idle bit
+		 * CLAIMS (one kfunc). Two kfuncs at most per wake, no scan. */
+		u64 seats = cake_tog_g79 ? cake_seat_word : 0;
+		u64 w = cake_core_free & aff & ~seats;
+		/* §G73: the search starts at the task's own core and wraps,
+		 * so idle cores are used in turn instead of the lowest one
+		 * absorbing every placement (L2 thrash, cold every time). */
+		u32 r = cake_tog_g73 ? ((u32)p->thread_info.cpu & 63) : 0;
+		s32 c;
+
+		if (!w)
+			w = cake_core_free & aff;	/* only held cores left: take one */
+		if (w) {
+			u64 hi = w & (~0ULL << r);
+
+			c = (s32)__builtin_ctzll(hi ? hi : w);
+			if (scx_bpf_test_and_clear_cpu_idle(c))
+				return c;
+		}
+		w = cake_thread_free & aff & ~seats;
+		if (!w)
+			w = cake_thread_free & aff;
+		if (w) {
+			u64 hi = w & (~0ULL << r);
+
+			c = (s32)__builtin_ctzll(hi ? hi : w);
+			if (c < 64 && !((cake_core_free >> c) & 1) &&
+			    scx_bpf_test_and_clear_cpu_idle(c))
+				return c;
+		}
+		return -1;
+	}
+
+	/* §G72: a microsecond-class wakee of the waker's own address space
+	 * takes the waker's idle SMT sibling: shared L2, no wait, and at that
+	 * burst length the sibling costs the waker nothing measurable. Long
+	 * bursts keep whole cores (§G38). */
+	if (cake_tog_g72 && cake_burst_ns(p) <= L2_HANDOFF_BURST_NS) {
+		struct task_struct *w = bpf_get_current_task_btf();
+		u32 wc = bpf_get_smp_processor_id() & (MAX_CPUS - 1);
+		s32 sib = cpu_sibling[wc];
+
+		if (w && w->mm && w->mm == p->mm && sib >= 0 &&
+		    ((idle >> ((u32)sib & 63)) & 1) &&
+		    scx_bpf_test_and_clear_cpu_idle(sib))
+			return sib;
+	}
+	for (k = 0; k < DEPTH_SCAN_MAX && idle; k++) {
+		s32 c = (s32)__builtin_ctzll(idle);
+
+		idle &= idle - 1;
+		if (!cake_core_idle_census((u32)c)) {
+			half |= 1ULL << (c & 63);
+			continue;
+		}
+		if (scx_bpf_test_and_clear_cpu_idle(c))
+			return c;
+	}
+	for (k = 0; k < 2 && half; k++) {
+		s32 c = (s32)__builtin_ctzll(half);
+
+		half &= half - 1;
+		if (scx_bpf_test_and_clear_cpu_idle(c))
+			return c;
+	}
+	return -1;
+}
+
+static __noinline u64 cake_vip_head_vtime(void)
+{
+	return cake.frontier.word - SLICE_NS;
+}
+
+/* §G70 EXPERIMENT: every preempt kick goes through here; a VIP occupant is
+ * never thrown off, it finishes its burst. */
+static __noinline void cake_kick_preempt(s32 cpu)
+{
+	if (cake_tog_g70 && cake_vip_tgid) {
+		struct task_struct *oc = cake_cpu_curr(cpu);
+
+		if (oc && oc->pid && (u32)oc->tgid == cake_vip_tgid)
+			return;
+	}
+	scx_bpf_kick_cpu(cpu, CAKE_KICK_PREEMPT);
+}
+
+/* §G75 GROOVES: a task's own placement history. The home claim is the
+ * warmest rung and the most expensive question (a kernel atomic); a task
+ * whose home keeps being busy stops asking after GROOVE_HOME_MISS misses and
+ * re-probes once every GROOVE_PROBE_MASK+1 wakes. The CPU its whole-core
+ * claim last won is tried first next time -- the groove -- under the same
+ * single-writer claim, so history orders the choice and never replaces the
+ * claim. One task-storage lookup per wake. */
+struct cake_groove {
+	u8 home_miss;
+	u8 wakes;
+	s16 last_win;		/* cpu + 1; 0 = none */
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_TASK_STORAGE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__type(key, int);
+	__type(value, struct cake_groove);
+} cake_grooves SEC(".maps");
+
+static __always_inline struct cake_groove *cake_groove_of(struct task_struct *p)
+{
+	if (!cake_tog_g75)
+		return NULL;
+	return bpf_task_storage_get(&cake_grooves, p, 0,
+				    BPF_LOCAL_STORAGE_GET_F_CREATE);
+}
+
+/* §G61: a census placement is unverified -- the wakee goes into the local
+ * queue of a CPU whose idle bit was set, with no claim. When that CPU is
+ * already running something else by the time the insert lands, the wakee
+ * waits behind that occupant for up to its whole slice and no other CPU can
+ * serve a local queue: the HOLD shape, 0.7-1.7 ms on the KovaaKs render
+ * path (wake decomposition 2026-09-02), absent on 1.1.3 whose shared queue
+ * any idle CPU drains. The collision is the occupant's to pay. */
+static __always_inline void cake_collision_preempt(struct task_struct *p,
+						   s32 cpu)
+{
+	struct task_struct *curr;
+
+	if (!cake_tog_g61)
+		return;
+	curr = cake_cpu_curr(cpu);
+	if (curr && curr->pid && curr != p)
+		cake_kick_preempt(cpu);
+}
 
 static __noinline bool cake_system_serial(void)
 {
@@ -1025,7 +1506,7 @@ static __noinline bool cake_home_notify(struct task_struct *p, s32 tcpu)
 			 (ran >> HOME_PREEMPT_RAN_CREDIT_SHIFT), live))
 		return false;
 
-	scx_bpf_kick_cpu(tcpu, CAKE_KICK_PREEMPT);
+	cake_kick_preempt(tcpu);
 	return true;
 }
 
@@ -1056,6 +1537,145 @@ static __always_inline bool cake_affine(struct task_struct *p, s32 cpu)
 	return bpf_cpumask_test_cpu(cpu, p->cpus_ptr);
 }
 
+/* §G58: is @c held for a task other than @p right now? One slot read; the
+ * line belongs to an idle CPU, so it is quiet. */
+static __always_inline bool cake_reserved_for_other(const struct task_struct *p,
+						    u32 c, u64 now)
+{
+	struct cake_run_slot *rs = &cake.run[c & (MAX_CPUS - 1)];
+	u64 rp = rs->reserved_pid;
+
+	return rp && rp != (u64)(u32)p->pid &&
+	       time_before(now, rs->reserved_until);
+}
+
+/* §G59: the exit latency this idle CPU would pay, from the §G51 mirror and
+ * the loader's table. Zero when unknown, which ranks as shallow. */
+static __always_inline u64 cake_idle_exit_ns(u32 c)
+{
+	u32 cs = cake_irq_live[c & (MAX_CPUS - 1)].cstate;
+
+	if (!cs)
+		return 0;
+	return (u64)cake_cstate_exit_us[(cs - 1) & (CAKE_CSTATE_TABLE - 1)] *
+	       NSEC_PER_USEC;
+}
+
+/*
+ * §G59 pick over the census: among the first DEPTH_SCAN_MAX affine idle
+ * CPUs, the one with the smallest exit latency; ties keep census order, so
+ * with the table empty this IS the §G53 first fit. §G58 reservations for
+ * other tasks are skipped. Narrow hosts only; wide hosts keep the walk.
+ */
+static __noinline s32 cake_shallowest_idle(struct task_struct *p __arg_trusted)
+{
+	u64 idle = cake_idle_words[0];
+	u64 aff = p->cpus_ptr->bits[0];
+	u64 best_exit = ~0ULL;
+	u64 now = 0;
+	s32 best = -1;
+	u32 k;
+
+	if (cake_tog_g58)
+		now = bpf_ktime_get_ns();
+	for (k = 0; k < DEPTH_SCAN_MAX && idle; k++) {
+		u32 c = (u32)__builtin_ctzll(idle);
+		u64 e;
+
+		idle &= idle - 1;
+		if (!((aff >> (c & 63)) & 1))
+			continue;
+		if (cake_tog_g58 && cake_reserved_for_other(p, c, now))
+			continue;
+		e = cake_tog_g59 ? cake_idle_exit_ns(c) : 0;
+		if (e < best_exit) {
+			best_exit = e;
+			best = (s32)c;
+		}
+		if (!e)
+			break;
+	}
+	return best;
+}
+
+/*
+ * §G57 consumer: a wake with nothing idle in its mask picks the affine CPU
+ * in its home LLC whose occupant is predicted to leave first, from the run
+ * slots' free_at, and queues there instead of behind its home occupant.
+ * The move must clear FREE_MOVE_MARGIN: a partner about to yield keeps the
+ * wake home, which is what protects the messaging herd, and a mid-burst
+ * worker loses it, which is what unstrands the game. A stale slot (older
+ * than a slice: an RT or idle occupant) is never a target and never moved
+ * from. Narrow hosts only.
+ */
+static __noinline s32 cake_free_pick(struct task_struct *p __arg_trusted,
+				     s32 tcpu)
+{
+	u32 t = (u32)tcpu & (MAX_CPUS - 1);
+	u64 aff = p->cpus_ptr->bits[0];
+	u64 w, now, home_at, best_at;
+	s32 best = -1;
+	u32 k;
+
+	if (nr_cpu_span > 64 || (aff & cake_idle_words[0]))
+		return -1;
+	w = aff & cake_llc_qword[cake_cpu_llc[t] & (MAX_LLCS - 1)];
+	w &= ~(1ULL << (t & 63));
+	if (!w)
+		return -1;
+
+	now = bpf_ktime_get_ns();
+	home_at = cake.run[t].free_at;
+	if (time_before(home_at + SLICE_NS, now))
+		return -1;
+	best_at = home_at;
+	for (k = 0; k < 64 && w; k++) {
+		u32 c = (u32)__builtin_ctzll(w);
+		u64 at = cake.run[c & (MAX_CPUS - 1)].free_at;
+
+		w &= w - 1;
+		if (time_before(at + SLICE_NS, now))
+			continue;
+		if (time_before(at, best_at)) {
+			best_at = at;
+			best = (s32)c;
+		}
+	}
+	if (best < 0 ||
+	    !time_before(best_at + ((u64)SLICE_NS >> FREE_MOVE_MARGIN_SHIFT),
+			 home_at))
+		return -1;
+	return best;
+}
+
+/*
+ * §G58 consumer: the reservation the pre-wake timer left on prev for THIS
+ * task. Read before every other placement claim: the CPU was kicked awake
+ * for this wake, so the vetoes that would send the task elsewhere (turn
+ * starvation, a busy sibling) are already priced into the prediction.
+ */
+static __noinline s32 cake_reserved_take(struct task_struct *p __arg_trusted,
+					 s32 prev_cpu)
+{
+	u32 c = (u32)prev_cpu & (MAX_CPUS - 1);
+	struct cake_run_slot *rs = &cake.run[c];
+
+	if (rs->reserved_pid != (u64)(u32)p->pid)
+		return -1;
+	if (!time_before(bpf_ktime_get_ns(), rs->reserved_until)) {
+		rs->reserved_pid = 0;
+		return -1;
+	}
+	if (!cake_affine(p, prev_cpu) ||
+	    !scx_bpf_test_and_clear_cpu_idle(prev_cpu))
+		return -1;
+	rs->reserved_pid = 0;
+	cake_stat_inc(CAKE_STAT_RESERVED_TAKE);
+	cake_direct_clamp(p);
+	cake_dsq_insert(p, CAKE_DSQ_LOCAL_ON | c, cake_task_slice_cached(p), 0);
+	return prev_cpu;
+}
+
 /* §G54 consumer: prev-warmth first (census bit, optimistic), then this
  * waker's own core mailbox. Both place without a consuming claim — a stale
  * entry costs one occupant wait, the §G53-measured trade. A subprogram so
@@ -1071,8 +1691,13 @@ static __noinline s32 cake_park_take(struct task_struct *p __arg_trusted,
 		u32 pc = (u32)prev_cpu & (MAX_CPUS - 1);
 
 		if ((cake_idle_words[pc >> 6] >> (pc & 63)) & 1 &&
-		    !cpu_irq_hot[pc] && cake_affine(p, prev_cpu))
+		    !cpu_irq_hot[pc] && cake_affine(p, prev_cpu) &&
+		    !(cake_tog_g60 && !cake_core_idle_census(pc)) &&
+		    !(cake_tog_g58 &&
+		      cake_reserved_for_other(p, pc, bpf_ktime_get_ns()))) {
 			ocpu = prev_cpu;
+			cake_stat_inc(CAKE_STAT_PARK_PREV);
+		}
 	}
 	if (ocpu < 0) {
 		u32 slot = cake_core_slot(wc);
@@ -1081,24 +1706,52 @@ static __noinline s32 cake_park_take(struct task_struct *p __arg_trusted,
 		if (mbox) {
 			s32 mcpu = (s32)(u32)((mbox & ~CAKE_PARK_CORE) - 1);
 
-			if (cake_affine(p, mcpu)) {
+			if (cake_affine(p, mcpu) &&
+			    !(cake_tog_g60 &&
+			      !cake_core_idle_census((u32)mcpu)) &&
+			    !(cake_tog_g58 &&
+			      cake_reserved_for_other(p, (u32)mcpu,
+						      bpf_ktime_get_ns()))) {
 				cake_mailbox[slot].word = 0;
 				ocpu = mcpu;
+				cake_stat_inc(CAKE_STAT_PARK_MBOX);
 			}
 		}
 	}
+	/*
+	 * §G59: a parked CPU deep in idle loses to a shallower affine one.
+	 * The mailbox entry is already consumed; the parker re-parks at its
+	 * next idle entry, so a lost entry costs one wake's fallback.
+	 */
+	if (ocpu >= 0 && cake_tog_g59 && nr_cpu_span <= 64 &&
+	    cake_idle_exit_ns((u32)ocpu)) {
+		s32 alt = cake_shallowest_idle(p);
+
+		if (alt >= 0 && alt != ocpu &&
+		    cake_idle_exit_ns((u32)alt) < cake_idle_exit_ns((u32)ocpu))
+			ocpu = alt;
+	}
 	if (ocpu < 0)
+		return -1;
+	/* §G62: the census bit is a hint several wakers read at once; the
+	 * atomic claim is what keeps two of them out of one FIFO local queue
+	 * (hold attribution probe 2026-09-02: every >300 us hold sat in a
+	 * LOCAL_ON placement). Losing the claim falls through to the ranked
+	 * pick, which claims what it returns. */
+	if (cake_tog_g62 && !scx_bpf_test_and_clear_cpu_idle(ocpu))
 		return -1;
 	cake_direct_clamp(p);
 	cake_dsq_insert(p, CAKE_DSQ_LOCAL_ON | (u32)ocpu,
 			cake_task_slice_cached(p), 0);
+	cake_collision_preempt(p, ocpu);
 	return ocpu;
 }
 
-/* Optimistic first-fit from the census (§G53): affinity is the only gate,
- * placement is unverified — the mailbox-miss fallback. A subprogram so the
- * walk costs select_cpu's frame nothing (§R.11). */
-static __noinline s32 cake_optimistic_place(struct task_struct *p __arg_trusted)
+/* Wide-host census walk. A cpumask load needs a CONSTANT word index -- the
+ * verifier refuses a variable one through a trusted pointer -- so past one
+ * word affinity stays a kfunc. Its own subprogram, so the register pressure
+ * of that crossing stays in this frame instead of the narrow path's (§R.8). */
+static __noinline s32 cake_census_walk_wide(struct task_struct *p __arg_trusted)
 {
 	u32 wi;
 
@@ -1114,15 +1767,69 @@ static __noinline s32 cake_optimistic_place(struct task_struct *p __arg_trusted)
 			s32 ocpu = (s32)(base + __builtin_ctzll(w));
 
 			w &= w - 1;
-			if (!bpf_cpumask_test_cpu(ocpu, p->cpus_ptr))
-				continue;
-			cake_direct_clamp(p);
-			cake_dsq_insert(p, CAKE_DSQ_LOCAL_ON | (u32)ocpu,
-					cake_task_slice_cached(p), 0);
-			return ocpu;
+			if (bpf_cpumask_test_cpu(ocpu, p->cpus_ptr))
+				return ocpu;
 		}
 	}
 	return -1;
+}
+
+/* Optimistic first-fit from the census (§G53): affinity is the only gate,
+ * placement is unverified — the mailbox-miss fallback. A subprogram so the
+ * walk costs select_cpu's frame nothing (§R.11).
+ *
+ * The census and the affinity mask are the SAME bitmap shape, so within one
+ * word the per-bit kfunc becomes a shift against a word loaded once: no call
+ * in the walk, nothing to keep callee-saved across one, and @p is not touched
+ * again until the placement. Rodata gate, so the verifier deletes the wide
+ * arm at load on every host inside one word (§G54). */
+static __noinline s32 cake_optimistic_place(struct task_struct *p __arg_trusted)
+{
+	s32 ocpu = -1;
+
+	if (nr_cpu_span <= 64) {
+		if (cake_tog_g58 || cake_tog_g59) {
+			ocpu = cake_shallowest_idle(p);
+		} else {
+			u64 idle = cake_idle_words[0];
+			u64 aff = p->cpus_ptr->bits[0];
+			u32 depth = cake_tog_g60 ? DEPTH_SCAN_MAX : 2;
+			s32 half = -1;
+			u32 k;
+
+			/* §G60: the first affine WHOLE idle core wins; a half
+			 * core is remembered and taken only when the scan finds
+			 * no whole one, so an idle machine never doubles up. */
+			for (k = 0; k < depth && idle; k++) {
+				s32 c = (s32)__builtin_ctzll(idle);
+
+				idle &= idle - 1;
+				if (!((aff >> (c & 63)) & 1))
+					continue;
+				if (!cake_tog_g60 ||
+				    cake_core_idle_census((u32)c)) {
+					ocpu = c;
+					break;
+				}
+				if (half < 0)
+					half = c;
+			}
+			if (ocpu < 0)
+				ocpu = half;
+		}
+	} else {
+		ocpu = cake_census_walk_wide(p);
+	}
+
+	if (ocpu < 0)
+		return -1;
+	if (cake_tog_g62 && !scx_bpf_test_and_clear_cpu_idle(ocpu))
+		return -1;	/* §G62: lost the race, see cake_park_take */
+	cake_direct_clamp(p);
+	cake_dsq_insert(p, CAKE_DSQ_LOCAL_ON | (u32)ocpu,
+			cake_task_slice_cached(p), 0);
+	cake_collision_preempt(p, ocpu);
+	return ocpu;
 }
 
 /*
@@ -1139,6 +1846,33 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 {
 	bool is_idle = false;
 	s32 cpu;
+
+	struct cake_groove *gr = cake_groove_of(p);
+	bool home_askable;
+
+	cake_stat_inc(CAKE_STAT_SELECT);
+
+	/* §G63: 1.1.3's queue semantics inside 1.2.x. No wake is ever parked
+	 * in a CPU's private FIFO: select_cpu only picks and claims an idle
+	 * CPU, ops.enqueue puts the wake in the shared vtime pool, and the
+	 * claimed CPU (or any other idle one) drains it. The tail 1.1.3 keeps
+	 * and 1.2.x lost (KovaaKs p99.9 1.75 vs 2.0-2.5 ms) is this property. */
+	if (cake_tog_g63)
+		return scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
+
+	/* §G64: verified direct dispatch. The only local placement is the one
+	 * the kernel's idle pick claimed this instant; every other wake takes
+	 * the pool, where any idle CPU can serve it. 1.1.3's shape: it keeps
+	 * the fast path for the certain case and never parks the rest. */
+	if (cake_tog_g64) {
+		cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle);
+		if (is_idle) {
+			cake_direct_clamp(p);
+			cake_dsq_insert(p, CAKE_DSQ_LOCAL,
+					cake_task_slice_cached(p), 0);
+		}
+		return cpu;
+	}
 
 
 	/*
@@ -1165,7 +1899,7 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 		 * handoff regime is usually another transient pair, and the
 		 * veto exiled mutex pairs from co-location for a measured
 		 * -69% (§G38.1 amendment; the home claim keeps its veto). */
-		if (serial && !(wake_flags & CAKE_WAKE_SYNC) &&
+		if (serial && !cake_tog_g66 && !(wake_flags & CAKE_WAKE_SYNC) &&
 		    !cake_cpu_irq_bad((s32)wc) &&
 		    bpf_cpumask_test_cpu((s32)wc, p->cpus_ptr) &&
 		    cake_system_serial() &&
@@ -1177,8 +1911,17 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 			cake_direct_clamp(p);
 			cake_dsq_insert(p, CAKE_DSQ_LOCAL_ON | (u32)wcpu,
 					cake_task_slice_cached(p), 0);
+			cake_stat_inc(CAKE_STAT_SERIAL);
 			return wcpu;
 		}
+	}
+
+	/* §G58: a CPU kicked awake for this exact wake is taken first. */
+	if (cake_tog_g58 && prev_cpu >= 0) {
+		s32 rcpu = cake_reserved_take(p, prev_cpu);
+
+		if (rcpu >= 0)
+			return rcpu;
 	}
 
 	/*
@@ -1191,26 +1934,135 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 	 * The claim is declined on a contended core: the home is only warm if
 	 * the task gets the whole core to run on (§G38).
 	 */
-	if (!(wake_flags & CAKE_WAKE_SYNC) && prev_cpu >= 0 &&
-	    !cake_starved_turn(p) && !cake_cpu_irq_bad(prev_cpu) &&
-	    bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr) &&
-	    !cake_core_contended(prev_cpu) &&
+	{
+		bool ask_home = true;
+
+		if (gr) {
+			gr->wakes++;
+			if (gr->home_miss >= GROOVE_HOME_MISS &&
+			    (gr->wakes & GROOVE_PROBE_MASK))
+				ask_home = false;
+		}
+		if (!ask_home) {
+			cake_stat_inc(CAKE_STAT_HD_SKIP);
+			goto skip_home;
+		}
+	}
+	/* PROBE: which gate declines the warm home, for the biggest burst tasks
+	 * (stage class, burst >= 64 us), so GameThread's 9,300 migrations get a
+	 * reason. Each gate is re-asked in order; the first refusal counts. */
+	if (cake_burst_ns(p) >= SEAT_BURST_MIN_NS && prev_cpu >= 0) {
+		if (wake_flags & CAKE_WAKE_SYNC) cake_stat_inc(CAKE_STAT_HD_SYNC);
+		else if (cake_starved_turn(p)) cake_stat_inc(CAKE_STAT_HD_STARVED);
+		else if (cake_cpu_irq_bad(prev_cpu)) cake_stat_inc(CAKE_STAT_HD_IRQ);
+		else if (!bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr)) cake_stat_inc(CAKE_STAT_HD_AFF);
+		else if (cake_core_contended(prev_cpu)) cake_stat_inc(CAKE_STAT_HD_CONTENDED);
+		else if (!scx_bpf_test_and_clear_cpu_idle(prev_cpu)) cake_stat_inc(CAKE_STAT_HD_NOTIDLE);
+		else {
+			/* the claim just succeeded: place, exactly as below */
+			if (gr)
+				gr->home_miss = 0;
+			cake_direct_clamp(p);
+			cake_dsq_insert(p, CAKE_DSQ_LOCAL_ON | (u32)prev_cpu,
+					cake_task_slice_cached(p), 0);
+			cake_stat_inc(CAKE_STAT_HOME);
+			return prev_cpu;
+		}
+	}
+	/* §G80: the groove counts a MISS only when the home was asked and was
+	 * busy (sibling running, or the idle claim lost). The SYNC, starvation
+	 * and IRQ gates are not the home's fault; counting them sent stage
+	 * threads cold on 11.4% of all wakes (probe 2026-09-02). */
+	/* §G81: a stage-class wakee (burst >= SEAT_BURST_MIN_NS) keeps its warm
+	 * home even on a SYNC wake: its own predictor and L1 outweigh the
+	 * waker's line at that burst length (hd_sync 31k/30 s, GameThread
+	 * 8,835 migrations vs 1.1.3's 650). */
+	home_askable = (!(wake_flags & CAKE_WAKE_SYNC) ||
+			(cake_tog_g81 && cake_burst_ns(p) >= SEAT_BURST_MIN_NS)) &&
+		       prev_cpu >= 0 &&
+		       !cake_starved_turn(p) && !cake_cpu_irq_bad(prev_cpu) &&
+		       bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr);
+	if (home_askable && !cake_core_contended(prev_cpu) &&
 	    scx_bpf_test_and_clear_cpu_idle(prev_cpu)) {
+		if (gr)
+			gr->home_miss = 0;
+		{	/* PROBE: is the claimed CPU actually running someone? */
+			struct task_struct *hc = cake_cpu_curr(prev_cpu);
+			u32 me = bpf_get_smp_processor_id() & (MAX_CPUS - 1);
+
+			if (hc && hc->pid) {
+				cake_stat_inc(CAKE_STAT_HOME_BUSY);
+				cake_probe_busy_flag[me] = 1;
+			}
+			if (scx_bpf_dsq_nr_queued(CAKE_DSQ_LOCAL_ON | (u32)prev_cpu) > 0)
+				cake_stat_inc(CAKE_STAT_HOME_LOCALQ);
+		}
 		cake_direct_clamp(p);
 		cake_dsq_insert(p, CAKE_DSQ_LOCAL_ON | (u32)prev_cpu,
 				cake_task_slice_cached(p), 0);
+		cake_stat_inc(CAKE_STAT_HOME);
 		return prev_cpu;
 	}
+	if (gr && home_askable && gr->home_miss < GROOVE_HOME_MISS)
+		gr->home_miss++;
+skip_home:
 
+
+	/* §G69: claimed warm placement or the pool; nothing unclaimed below. */
+	if (cake_tog_g69) {
+		s32 c;
+
+		/* §G74: the one stacking that is worth it. The warm prev CPU is
+		 * busy, but its occupant published (§G57) that it frees within
+		 * STACK_TOLERANCE_NS and nothing is queued there: queue the wakee
+		 * in prev's OWN visible queue (served first at the occupant's
+		 * stop, stealable meanwhile) instead of a cold idle core. This is
+		 * the average the unclaimed stacking used to buy, without the
+		 * millisecond holds it cost. */
+		if (cake_tog_g74 && prev_cpu >= 0 &&
+		    bpf_cpumask_test_cpu(prev_cpu, p->cpus_ptr) &&
+		    !cake_cpu_irq_bad(prev_cpu) &&
+		    cake_cpu_dsq_idle((u32)prev_cpu)) {
+			u64 now = bpf_ktime_get_ns();
+			u64 at = cake.run[(u32)prev_cpu & (MAX_CPUS - 1)].free_at;
+
+			if (time_after(at, now) &&
+			    at - now <= STACK_TOLERANCE_NS) {
+				cake_qmark_set((u32)prev_cpu);
+				cake_dsq_insert_vtime(p, (u64)(u32)prev_cpu,
+						      cake_task_slice_cached(p),
+						      cake_wake_vtime(p),
+						      CAKE_ENQ_WAKEUP);
+				return prev_cpu;
+			}
+		}
+		c = cake_claim_warm(p, gr ? (s32)gr->last_win - 1 : -1);
+		if (gr && c >= 0)
+			gr->last_win = (s16)(c + 1);
+
+		if (c >= 0) {
+			cake_direct_clamp(p);
+			cake_dsq_insert(p, CAKE_DSQ_LOCAL_ON | (u32)c,
+					cake_task_slice_cached(p), 0);
+			return c;
+		}
+		return prev_cpu;	/* enqueue routes it (pool with g65) */
+	}
 
 	/*
 	 * Self-park consumer (§G54): the decision was computed at idle-entry
 	 * by the idle CPU itself; this reads it. Warmth-first — the combined
 	 * pair with the walk ahead of this block re-priced §G53's tails.
 	 */
-	if (cake_idle_nr) {
-		s32 ocpu = cake_park_take(p, prev_cpu);
+	/* §G67: the only direct placement is the claimed warm home above;
+	 * the unclaimed census paths (park, first-fit) stack a second wake
+	 * onto a CPU whose first wake is still in flight. Everything else is
+	 * pooled, visible, kicked. */
+	if (cake_idle_nr && !cake_tog_g67) {
+		s32 ocpu;
 
+		cake_stat_inc(CAKE_STAT_PARK_REACHED);
+		ocpu = cake_park_take(p, prev_cpu);
 		if (ocpu >= 0)
 			return ocpu;
 	}
@@ -1222,11 +2074,15 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 	 * where §G48/§G50 spent more than they saved. With §G54 on, this is
 	 * the mailbox-miss fallback.
 	 */
-	{
-		s32 ocpu = cake_optimistic_place(p);
+	if (!cake_tog_g67) {
+		s32 ocpu;
 
-		if (ocpu >= 0)
+		cake_stat_inc(CAKE_STAT_OPT_REACHED);
+		ocpu = cake_optimistic_place(p);
+		if (ocpu >= 0) {
+			cake_stat_inc(CAKE_STAT_OPT_HIT);
 			return ocpu;
+		}
 	}
 
 	/*
@@ -1238,6 +2094,8 @@ s32 BPF_STRUCT_OPS(cake_select_cpu, struct task_struct *p, s32 prev_cpu,
 	{
 		u32 sgen = cake_sink_gen;
 		const struct cpumask *ns;
+
+		cake_stat_inc(CAKE_STAT_RANKED);
 
 		/* One predictable compare catches a sink republish (§G30). */
 		if (sgen != nonsink_gen)
@@ -1414,6 +2272,16 @@ __noinline s32 cake_wake_notify(struct task_struct *p __arg_trusted, s32 tcpu,
 	if (route == ROUTE_HOME_CLAIM && cake_home_notify(p, tcpu))
 		return 0;
 
+
+	/* §G39-B': a home-routed wakee sits in tcpu's own local queue, which
+	 * no other CPU may serve -- the census (run 20260831) shows the idle
+	 * kick firing here while the wakee still waits out the occupant's
+	 * whole slice. The notification tcpu owes is a preempt attempt; a
+	 * decline falls through to today's flow unchanged. */
+	if (cake_tog_g39b && route != ROUTE_GLOBAL &&
+	    cake_wake_preempt(p, tcpu, PREEMPT_PROTECT_SHIFT))
+		return 0;
+
 	idle = cake_pick_idle_clean(p);
 	if (idle >= 0) {
 		scx_bpf_kick_cpu(idle, CAKE_KICK_IDLE);
@@ -1553,6 +2421,14 @@ __noinline s32 cake_enqueue_wake(struct task_struct *p __arg_trusted, s32 tcpu)
 	 */
 	if (route == ROUTE_GLOBAL && scx_bpf_dsq_nr_queued((u64)WAKE_DSQ))
 		route = ROUTE_HOME_QUEUE;
+	if (cake_tog_g63 || cake_tog_g65)
+		route = ROUTE_GLOBAL;	/* §G63/§G65: the pool, always */
+	if (cake_vip(p) && route) {
+		struct task_struct *oc = cake_cpu_curr(tcpu);
+
+		if (oc && oc->pid && !cake_vip(oc))
+			cake_kick_preempt(tcpu);
+	}
 
 	if (route)
 		cake_qmark_set((u32)tcpu);
@@ -1595,7 +2471,7 @@ static __noinline void cake_pinned_wake_preempt(struct task_struct *p __arg_trus
 	pvt = lo - vs + (dd & ~((u64)((s64)dd >> 63)));
 
 	if (time_before(pvt + (vs >> 1), clive))
-		scx_bpf_kick_cpu(tcpu, CAKE_KICK_PREEMPT);
+		cake_kick_preempt(tcpu);
 }
 
 
@@ -1651,6 +2527,27 @@ void BPF_STRUCT_OPS(cake_enqueue, struct task_struct *p, u64 enq_flags)
 	d  = p->scx.dsq_vtime - lo;
 
 	/*
+	 * §G57: with nothing idle in the mask, queue behind the CPU predicted
+	 * to free first rather than the home occupant. No kick is owed: the
+	 * target dispatches at that moment by construction, and the ring can
+	 * still lift the task earlier. Both arms below are the strand shape
+	 * this replaces (§S.8 field report).
+	 */
+	if (cake_tog_g57 && (enq_flags & CAKE_ENQ_WAKEUP) &&
+	    p->nr_cpus_allowed > 1) {
+		s32 fcpu = cake_free_pick(p, tcpu);
+
+		if (fcpu >= 0) {
+			cake_stat_inc(CAKE_STAT_FREE_PICK);
+			cake_qmark_set((u32)fcpu);
+			cake_dsq_insert_vtime(p, (u64)(u32)fcpu,
+					      cake_task_slice_cached(p),
+					      cake_wake_vtime(p), enq_flags);
+			return;
+		}
+	}
+
+	/*
 	 * STAGE wakeups are global, everything else is local -- the routing key
 	 * is the wakeup bit AND the burst class (§G10.2). Single-CPU tasks take
 	 * the continuation arm regardless (§R.14).
@@ -1694,6 +2591,15 @@ void BPF_STRUCT_OPS(cake_enqueue, struct task_struct *p, u64 enq_flags)
 				      cake_task_slice_cached(p),
 					 vt, enq_flags);
 
+		/* §G39-B' iteration 2: the continuation arm is where the wine
+		 * RPC chain actually waits (census run 20260831: starved_turn
+		 * false, enqueue_wake never reached). A local insert behind a
+		 * live occupant owes tcpu a preempt attempt; a decline keeps
+		 * today's flow. The pinned shape below already had its own. */
+		if (cake_tog_g39b && (enq_flags & CAKE_ENQ_WAKEUP) &&
+		    p->nr_cpus_allowed > 1)
+			cake_wake_preempt(p, tcpu, PREEMPT_PROTECT_SHIFT);
+
 		if ((enq_flags & CAKE_ENQ_WAKEUP) && p->nr_cpus_allowed == 1)
 			cake_pinned_wake_preempt(p, tcpu, d);
 	}
@@ -1717,12 +2623,58 @@ kick_idle:
  * rescheduled by core's activate->wakeup_preempt regardless (see ops.enqueue).
  * One subtraction wraps the index — no modulo.
  */
+/*
+ * §G56 FOLD. Each band is qmask AND LLC-membership: every queued CPU in the
+ * band answers from two words, and find-first-set jumps straight to the
+ * victim — no element walk. Bands run own-LLC first, then foreign LLCs in
+ * loader order (§G52 rank-descending when live). The stagger splits the word
+ * at the caller's own id — bits >= self first, then wrap — with a mask and
+ * two ctz, NOT the §G25-rejected rotate.
+ */
+static __noinline bool cake_band_steal(u32 ucpu)
+{
+	u32 home = cake_cpu_llc[ucpu & (MAX_CPUS - 1)] & (MAX_LLCS - 1);
+	u32 r = ucpu & 63;
+	u32 b, k;
+
+	for (b = 0; b < MAX_LLCS; b++) {
+		u64 m;
+
+		if (b >= cake_nr_llcs)
+			break;
+		m = cake.qmask[0] &
+		    cake_llc_qword[cake_llc_order[home][b] & (MAX_LLCS - 1)];
+		m &= ~(1ULL << r);	/* never probe ourselves */
+
+		for (k = 0; k < 64; k++) {
+			u64 hi = m & (~0ULL << r);
+			u64 pick = hi ? hi : m;
+			u32 idx;
+
+			if (!pick)
+				break;
+			idx = (u32)__builtin_ctzll(pick);
+			if (cake_move_to_local((u64)idx))
+				return true;
+			m &= ~(1ULL << (idx & 63));
+		}
+	}
+	return false;
+}
+
 static __noinline bool cake_ring_steal(u32 ucpu)
 {
 	u32 nr = nr_cpu_span;
 	u32 cw = (u32)-1;	/* which qmask word `m` holds; none yet */
 	u64 m = 0;
 	u32 i;
+
+	if (cake_tog_g56 && nr_cpu_span <= 64)
+		return cake_band_steal(ucpu);
+	/* §G77: nothing marked anywhere is one word read, not a ring walk. */
+	if (cake_tog_g77 && nr_cpu_span <= 64 &&
+	    !(cake.qmask[0] & ~(1ULL << (ucpu & 63))))
+		return false;
 
 	if (CCD_STEAL_POLICY > 0 && steal_order_live && ucpu < STEAL_SPAN) {
 		/* One precomputed locality order avoids verifier-multiplying
@@ -1790,42 +2742,6 @@ static __noinline void cake_wake_idle_stamp(void)
 }
 
 /*
- * Retire the mark after an empty peek, then peek AGAIN: an insert completed
- * before the exchange either shows in the re-peek or marks after it, so a
- * nonempty queue can never end unmarked (§G41).
- */
-static __noinline struct task_struct *cake_wake_mark_retire(void)
-{
-	struct task_struct *head;
-
-	(void)__sync_lock_test_and_set(&cake.wake_mark.word, 0);
-	head = cake_dsq_peek((u64)WAKE_DSQ);
-	if (head)
-		cake.wake_mark.word = 1;
-	else
-		cake_wake_idle_stamp();
-	return head;
-}
-
-/*
- * The guarded global peek: only when the mark predicts work or the §R.16
- * cadence forces a verify, so the common dispatch pays one word read. A
- * subprogram so the gate costs the caller no register (§G41, §R.11).
- */
-static __noinline struct task_struct *cake_wake_peek(void)
-{
-	struct task_struct *wake;
-
-	if (!cake.wake_mark.word && !cake_wake_starved())
-		return NULL;
-
-	wake = cake_dsq_peek((u64)WAKE_DSQ);
-	if (!wake)
-		wake = cake_wake_mark_retire();
-	return wake;
-}
-
-/*
  * The dispatch search: earliest eligible vtime of {own queue, wake queue},
  * then the staggered ring steal. Returns true when it moved work local.
  *
@@ -1846,9 +2762,34 @@ static __noinline bool cake_dispatch_search(s32 cpu)
 	 * takes the global lock first and the wake-storm serialisation returns.
 	 * The head peek republishes the mark with one conditional store (§R.3).
 	 */
-	own = cake_dsq_peek((u64)ucpu);
-	cake_qmark_publish(ucpu, own);
-	wake = cake_wake_peek();
+	/* §G76: an empty own queue costs one count, not an iterator; both
+	 * queues empty skips both move attempts. Measured 111-120 ns/run at
+	 * 78k runs/s on the game's own cores (bpfstats 2026-09-02) against
+	 * 1.1.3's 20 ns -- dispatch is where an idle-bound CPU spends its BPF. */
+	{
+		u32 own_n = (u32)scx_bpf_dsq_nr_queued((u64)ucpu);
+		u32 wake_n;
+
+		own = own_n ? cake_dsq_peek((u64)ucpu) : NULL;
+		/* Marks and the empty test come from scalars: a pointer-to-bool
+		 * or a pointer pair test lowers to an OR the verifier refuses. */
+		cake_qmark_publish(ucpu, own_n != 0);
+		/* The pool by its COUNT, not the mark: the mark has the holes the
+		 * unconditional second move used to heal (§G41), and trusting it
+		 * here stalled the game 20 ms. Two counts replace two iterators and
+		 * two blind moves on the empty path. */
+		wake_n = (u32)scx_bpf_dsq_nr_queued((u64)WAKE_DSQ);
+		if (wake_n)
+			cake.wake_mark.word = 1;
+		wake = wake_n ? cake_dsq_peek((u64)WAKE_DSQ) : NULL;
+		if (!wake_n) {
+			if (!own_n)
+				return cake_ring_steal(ucpu);
+			/* an empty pool is served: the starvation clock only
+			 * matters when the own queue competes with it */
+			cake_wake_idle_stamp();
+		}
+	}
 	if (wake) {
 		u64 wv = wake->scx.dsq_vtime;
 
@@ -1907,6 +2848,93 @@ void BPF_STRUCT_OPS(cake_dispatch, s32 cpu, struct task_struct *prev)
 }
 
 /*
+ * §G58 frame pre-wake. A display-coupled thread blocks with a known cycle,
+ * so its next wake is a prediction, not a surprise: one timer per CPU,
+ * armed at block time for the predicted wake minus the lead. The callback
+ * reserves the CPU for that pid and kicks it out of idle, so the wake finds
+ * a core already awake and held. A miss costs one idle kick and one unused
+ * reservation window; nothing is ever queued or preempted on a prediction.
+ */
+struct cake_prewake {
+	struct bpf_timer timer;
+	u64 pid;
+	u64 cpu;
+	u64 window;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_CPUS);
+	__type(key, u32);
+	__type(value, struct cake_prewake);
+} cake_prewake_map SEC(".maps");
+
+static int cake_prewake_fire(void *map, void *key, void *value)
+{
+	struct cake_prewake *pw = value;
+	u32 c = (u32)pw->cpu & (MAX_CPUS - 1);
+	struct cake_run_slot *rs = &cake.run[c];
+
+	/* Busy now: the prediction found a running CPU; nothing to hold. */
+	if (!((cake_idle_words[c >> 6] >> (c & 63)) & 1))
+		return 0;
+	cake_stat_inc(CAKE_STAT_PREWAKE_FIRE);
+	rs->reserved_pid = pw->pid;
+	rs->reserved_until = bpf_ktime_get_ns() + pw->window;
+	scx_bpf_kick_cpu((s32)c, CAKE_KICK_IDLE);
+	return 0;
+}
+
+/*
+ * The arm half, from stopping on a block. Same vote gate as the frame
+ * clock (a thread that sleeps most of its life), raw cycle inside the
+ * engine band, then next wake = this wake + cycle, less what already ran.
+ * A cycle shorter than the lead cannot be pre-woken and is left alone.
+ */
+static __noinline void cake_prewake_arm(struct task_struct *p __arg_trusted,
+					u64 used)
+{
+	u64 now = bpf_ktime_get_ns();
+	u64 n = p->nvcsw | 1;
+	u64 delta = now - p->start_time;
+	struct cake_prewake *pw;
+	u64 per, delay;
+	u32 c;
+
+	if ((p->se.sum_exec_runtime << 1) >= delta)
+		return;
+	if (!(n >> 32) &&
+	    (delta < FRAME_PERIOD_MIN_NS * n ||
+	     delta >= (FRAME_PERIOD_MAX_NS + 1) * n))
+		return;
+	per = delta / n;
+	if (per < FRAME_PERIOD_MIN_NS || per > FRAME_PERIOD_MAX_NS)
+		return;
+	/*
+	 * Only the published frame cadence arms a timer: the argmax bucket the
+	 * loader elected, so a desktop full of 60 Hz sleepers does not become
+	 * a kick storm when the game runs at another rate. No clock, no arm.
+	 */
+	if (!cake_frame_ns ||
+	    (per >> FRAME_BUCKET_SHIFT) != (cake_frame_ns >> FRAME_BUCKET_SHIFT))
+		return;
+	if (per <= used + cake_prewake_lead_ns)
+		return;
+	delay = per - used - cake_prewake_lead_ns;
+
+	c = (u32)p->thread_info.cpu & (MAX_CPUS - 1);
+	pw = bpf_map_lookup_elem(&cake_prewake_map, &c);
+	if (!pw)
+		return;
+	pw->pid = (u64)(u32)p->pid;
+	pw->cpu = c;
+	pw->window = per >> PREWAKE_WINDOW_SHIFT;
+	if (pw->window < cake_prewake_lead_ns * PREWAKE_WINDOW_MULT)
+		pw->window = cake_prewake_lead_ns * PREWAKE_WINDOW_MULT;
+	bpf_timer_start(&pw->timer, delay, 0);
+}
+
+/*
  * ops.running — stamp the per-CPU run start and advance the global vtime
  * frontier to this task's deadline.
  *
@@ -1927,6 +2955,19 @@ void BPF_STRUCT_OPS(cake_running, struct task_struct *p)
 
 	run->stamp = now;
 	run->sum = p->se.sum_exec_runtime;
+	if (cake_tog_g79 && (cpu & (MAX_CPUS - 1)) < 64 &&
+	    (cake_seat_word >> (cpu & 63)) & 1)
+		__atomic_fetch_and(&cake_seat_word, ~(1ULL << (cpu & 63)),
+				   __ATOMIC_RELAXED);
+	cake_probe_run(p, now);
+
+	/*
+	 * §G57: the grant is twice the burst when uncapped, so half of it is
+	 * the burst estimate with no divide; a capped grant still ends at the
+	 * slice, so the estimate never lands after the CPU's next dispatch.
+	 */
+	if (cake_tog_g57 || cake_tog_g74)
+		run->free_at = now + (p->scx.slice >> 1);
 
 	/* Occupant mirror publish (§M6): the line is already dirty here. */
 	if (cake_tog_m6) {
@@ -1958,6 +2999,12 @@ void BPF_STRUCT_OPS(cake_stopping, struct task_struct *p, bool runnable)
 	/* Mirror retire (§M6): zero = off-mirror until the next running. */
 	if (cake_tog_m6)
 		rs->occupant = 0;
+
+	/* §G79: a blocking stage keeps its seat. */
+	if (cake_tog_g79 && !runnable && (cpu & (MAX_CPUS - 1)) < 64 &&
+	    cake_burst_ns(p) >= SEAT_BURST_MIN_NS)
+		__atomic_fetch_or(&cake_seat_word, 1ULL << (cpu & 63),
+				  __ATOMIC_RELAXED);
 
 	/*
 	 * Count consecutive wake-then-block-quickly quanta. `used` is already
@@ -1994,6 +3041,8 @@ void BPF_STRUCT_OPS(cake_stopping, struct task_struct *p, bool runnable)
 
 	if (cake_tog_g46)
 		cake_slice_publish(p);
+	if (cake_tog_g58 && !runnable)
+		cake_prewake_arm(p, used);
 }
 
 /*
@@ -2010,6 +3059,21 @@ void BPF_STRUCT_OPS(cake_update_idle, s32 cpu, bool idle)
 			__atomic_fetch_or(&cake_idle_words[c >> 6], bit,
 					  __ATOMIC_RELAXED);
 			__atomic_fetch_add(&cake_idle_nr, 1, __ATOMIC_RELAXED);
+		}
+		if (cake_tog_g71 && c < 64) {
+			s32 sib = cpu_sibling[c];
+
+			__atomic_fetch_or(&cake_thread_free, bit, __ATOMIC_RELEASE);
+			if (sib < 0) {
+				__atomic_fetch_or(&cake_core_free, bit, __ATOMIC_RELEASE);
+			} else if ((u32)sib < 64 &&
+				   (cake_thread_free >> ((u32)sib & 63)) & 1) {
+				/* the sibling is idle AND still unclaimed: both
+				 * halves become whole cores */
+				__atomic_fetch_or(&cake_core_free,
+						  bit | (1ULL << ((u32)sib & 63)),
+						  __ATOMIC_RELEASE);
+			}
 		}
 		/*
 		 * Self-park (§G54): gates run HERE, on the idle CPU, about
@@ -2049,6 +3113,15 @@ void BPF_STRUCT_OPS(cake_update_idle, s32 cpu, bool idle)
 			}
 		}
 	} else {
+		if (cake_tog_g71 && c < 64) {
+			s32 sib = cpu_sibling[c];
+			u64 clear = bit;
+
+			if (sib >= 0 && (u32)sib < 64)
+				clear |= 1ULL << ((u32)sib & 63);
+			__atomic_fetch_and(&cake_thread_free, ~bit, __ATOMIC_RELEASE);
+			__atomic_fetch_and(&cake_core_free, ~clear, __ATOMIC_RELEASE);
+		}
 		if (cake_idle_words[c >> 6] & bit) {
 			__atomic_fetch_and(&cake_idle_words[c >> 6], ~bit,
 					   __ATOMIC_RELAXED);
@@ -2110,6 +3183,26 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(cake_init)
 	ret = scx_bpf_create_dsq(WAKE_DSQ, -1);
 	if (ret)
 		return ret;
+
+	/* §G58: one timer per CPU, initialised here as scx_layered does. */
+	if (cake_tog_g58) {
+		bpf_for(i, 0, nr) {
+			u32 k = (u32)i;
+			struct cake_prewake *pw =
+				bpf_map_lookup_elem(&cake_prewake_map, &k);
+
+			if (!pw)
+				return -ENOENT;
+			ret = bpf_timer_init(&pw->timer, &cake_prewake_map,
+					     CLOCK_MONOTONIC);
+			if (ret)
+				return ret;
+			ret = bpf_timer_set_callback(&pw->timer,
+						     cake_prewake_fire);
+			if (ret)
+				return ret;
+		}
+	}
 
 	/* Seed the §G45 census; every later transition corrects it. */
 	{

--- a/scheds/rust/scx_cake/src/bpf/intf.h
+++ b/scheds/rust/scx_cake/src/bpf/intf.h
@@ -108,6 +108,32 @@ enum consts {
 
 	/* The steal-ring queue hint, one bit per CPU (§G25). */
 	QMASK_WORDS	= MAX_CPUS / 64,
+
+	/* §G56 FOLD: LLC band count bound for the banded steal tables. */
+	MAX_LLCS	= 64,
+
+	/*
+	 * §G57: a saturated wake moves to an earlier-freeing CPU only when the
+	 * gain clears this fraction of the slice. A partner inside it keeps the
+	 * wake home: the herd-collapse guard expressed as time, not depth.
+	 */
+	FREE_MOVE_MARGIN_SHIFT		= 5,
+
+	/* §G58: the reservation outlives the fire by this fraction of the
+	 * task's cycle (prediction error scales with the cycle), floored at
+	 * twice the lead. */
+	PREWAKE_WINDOW_SHIFT		= 4,
+	PREWAKE_WINDOW_MULT		= 2,
+	/* §G58: pre-wake lead on a host with no cpuidle table. */
+	PREWAKE_LEAD_DEFAULT_NS		= 50 * NSEC_PER_USEC,
+
+	/* §G59: affine idle candidates the depth pick compares. */
+	DEPTH_SCAN_MAX			= 4,
+	L2_HANDOFF_BURST_NS		= 16 * NSEC_PER_USEC,	/* §G72: wakee burst bound for a sibling handoff */
+	STACK_TOLERANCE_NS		= 40 * NSEC_PER_USEC,	/* §G74: queue behind prev only if it frees within this */
+	GROOVE_HOME_MISS		= 8,		/* §G75: home misses before the task stops asking */
+	GROOVE_PROBE_MASK		= 63,		/* §G75: re-probe the home every 64 wakes */
+	SEAT_BURST_MIN_NS		= 64 * NSEC_PER_USEC,	/* §G79: stage-class burst that earns a seat */
 };
 
 #endif /* __CAKE_INTF_H */

--- a/scheds/rust/scx_cake/src/main.rs
+++ b/scheds/rust/scx_cake/src/main.rs
@@ -199,6 +199,7 @@ impl<'a> Scheduler<'a> {
                 "g79" => rodata.cake_tog_g79 = on,
                 "g81" => rodata.cake_tog_g81 = on,
                 "m7" => rodata.cake_tog_m7 = on,
+                "probe" => rodata.cake_tog_probe = on,
                 _ => anyhow::bail!("--toggle {spec}: unknown name {name}"),
             }
         }

--- a/scheds/rust/scx_cake/src/main.rs
+++ b/scheds/rust/scx_cake/src/main.rs
@@ -70,6 +70,8 @@ struct Scheduler<'a> {
     struct_ops: Option<libbpf_rs::Link>,
     /// Handler-edge tracepoint links (§G35); dropped on exit with the rest.
     _irq_links: Vec<libbpf_rs::Link>,
+    /// Diagnostics on (--toggle probe=1): census, hold attribution, black box.
+    probe_on: bool,
     /// Frame-clock incumbent bucket, held against near-ties (§R.22).
     frame_bucket: Option<u32>,
     /// Last published period; the reference for slow-direction hysteresis.
@@ -167,19 +169,92 @@ impl<'a> Scheduler<'a> {
                 _ => anyhow::bail!("--toggle {spec}: value must be 0 or 1"),
             };
             match name {
+                "g39b" => rodata.cake_tog_g39b = on,
                 "g46" => rodata.cake_tog_g46 = on,
                 "m6" => rodata.cake_tog_m6 = on,
                 "g51" => rodata.cake_tog_g51 = on,
                 "g52" => rodata.cake_tog_g52 = on,
+                "g56" => rodata.cake_tog_g56 = on,
+                "g57" => rodata.cake_tog_g57 = on,
+                "g58" => rodata.cake_tog_g58 = on,
+                "g59" => rodata.cake_tog_g59 = on,
+                "g60" => rodata.cake_tog_g60 = on,
+                "g61" => rodata.cake_tog_g61 = on,
+                "g62" => rodata.cake_tog_g62 = on,
+                "g63" => rodata.cake_tog_g63 = on,
+                "g64" => rodata.cake_tog_g64 = on,
+                "g65" => rodata.cake_tog_g65 = on,
+                "g66" => rodata.cake_tog_g66 = on,
+                "g67" => rodata.cake_tog_g67 = on,
+                "g68" => rodata.cake_tog_g68 = on,
+                "g69" => rodata.cake_tog_g69 = on,
+                "g70" => rodata.cake_tog_g70 = on,
+                "g72" => rodata.cake_tog_g72 = on,
+                "g71" => rodata.cake_tog_g71 = on,
+                "g73" => rodata.cake_tog_g73 = on,
+                "g74" => rodata.cake_tog_g74 = on,
+                "g75" => rodata.cake_tog_g75 = on,
+                "g77" => rodata.cake_tog_g77 = on,
+                "g78" => rodata.cake_tog_g78 = on,
+                "g79" => rodata.cake_tog_g79 = on,
+                "g81" => rodata.cake_tog_g81 = on,
                 "m7" => rodata.cake_tog_m7 = on,
                 _ => anyhow::bail!("--toggle {spec}: unknown name {name}"),
             }
         }
+        // §G59 reads the §G51 mirror, so it forces the producer on.
+        if rodata.cake_tog_g68 == 1 || rodata.cake_tog_g70 == 1 {
+            // EXPERIMENT §G68: the VIP process is found by comm prefix at attach.
+            let mut vip = 0u32;
+            if let Ok(rd) = std::fs::read_dir("/proc") {
+                for e in rd.flatten() {
+                    if let Ok(comm) = std::fs::read_to_string(e.path().join("comm")) {
+                        if comm.starts_with("FPSAimTrainer") {
+                            if let Ok(pid) = e.file_name().to_string_lossy().parse::<u32>() {
+                                vip = pid;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            rodata.cake_vip_tgid = vip;
+            info!("   g68     VIP process tgid {vip} (0 = not found, VIP inert)");
+        }
+        if rodata.cake_tog_g59 == 1 {
+            rodata.cake_tog_g51 = 1;
+        }
+        let probe_on = rodata.cake_tog_probe == 1;
         info!(
-            "   toggle  g46={} g51={} g52={} m6={} m7={}",
+            "   toggle  g39b={} g46={} g51={} g52={} g56={} g57={} g58={} g59={} g60={} g61={} g62={} g63={} g64={} g65={} g66={} g67={} g68={} g69={} g70={} g72={} g71={} g73={} g74={} g75={} g77={} g78={} g79={} g81={} m6={} m7={}",
+            rodata.cake_tog_g39b,
             rodata.cake_tog_g46,
             rodata.cake_tog_g51,
             rodata.cake_tog_g52,
+            rodata.cake_tog_g56,
+            rodata.cake_tog_g57,
+            rodata.cake_tog_g58,
+            rodata.cake_tog_g59,
+            rodata.cake_tog_g60,
+            rodata.cake_tog_g61,
+            rodata.cake_tog_g62,
+            rodata.cake_tog_g63,
+            rodata.cake_tog_g64,
+            rodata.cake_tog_g65,
+            rodata.cake_tog_g66,
+            rodata.cake_tog_g67,
+            rodata.cake_tog_g68,
+            rodata.cake_tog_g69,
+            rodata.cake_tog_g70,
+            rodata.cake_tog_g72,
+            rodata.cake_tog_g71,
+            rodata.cake_tog_g73,
+            rodata.cake_tog_g74,
+            rodata.cake_tog_g75,
+            rodata.cake_tog_g77,
+            rodata.cake_tog_g78,
+            rodata.cake_tog_g79,
+            rodata.cake_tog_g81,
             rodata.cake_tog_m6,
             rodata.cake_tog_m7
         );
@@ -198,6 +273,27 @@ impl<'a> Scheduler<'a> {
         if rodata.cake_tog_g51 == 1 && deepest_us == 0 {
             info!("   g51     no cpuidle driver: depth model inert");
         }
+        // §G58: the lead covers the deepest exit twice over; a host without
+        // a cpuidle table gets the fixed default. Never a refusal.
+        rodata.cake_prewake_lead_ns = if deepest_us > 0 {
+            u64::from(deepest_us) * 2 * 1000
+        } else {
+            bpf_intf::consts_PREWAKE_LEAD_DEFAULT_NS as u64
+        };
+        if rodata.cake_tog_g58 == 1 {
+            info!(
+                "   g58     pre-wake lead {} us ({})",
+                rodata.cake_prewake_lead_ns / 1000,
+                if deepest_us > 0 {
+                    "2x deepest exit"
+                } else {
+                    "default, no cpuidle"
+                }
+            );
+        }
+        if rodata.cake_tog_g59 == 1 && deepest_us == 0 {
+            info!("   g59     no cpuidle table: depth pick is first fit");
+        }
         let mut perf_seen = false;
         for c in 0..*NR_CPU_IDS {
             let path = format!("/sys/devices/system/cpu/cpu{c}/acpi_cppc/highest_perf");
@@ -209,6 +305,51 @@ impl<'a> Scheduler<'a> {
         }
         if rodata.cake_tog_g52 == 1 && !perf_seen {
             info!("   g52     no CPPC highest_perf: rank tiebreak inert");
+        }
+
+        // §G56 FOLD tables, from RUNTIME topology — never the build host.
+        // cpu -> compact LLC index, per-LLC qmask word (narrow hosts), and
+        // the per-home band order: own LLC first, then foreign LLCs by
+        // descending CPPC rank when g52 is live, id order otherwise. More
+        // LLCs than the table degrades the fold off (bands stay id-order,
+        // the toggle gate's span check keeps the walk), never a refusal.
+        let nr_llcs = topo.all_llcs.len().min(bpf_intf::consts_MAX_LLCS as usize);
+        let mut llc_rank = [0u8; bpf_intf::consts_MAX_LLCS as usize];
+        for (idx, llc) in topo.all_llcs.values().take(nr_llcs).enumerate() {
+            let mut word = 0u64;
+            for cpu in llc.all_cpus.keys().copied() {
+                if cpu < rodata.cake_cpu_llc.len() {
+                    rodata.cake_cpu_llc[cpu] = idx as u8;
+                }
+                if cpu < 64 {
+                    word |= 1u64 << cpu;
+                }
+                if cpu < *NR_CPU_IDS {
+                    llc_rank[idx] = llc_rank[idx].max(rodata.cpu_perf_rank[cpu]);
+                }
+            }
+            rodata.cake_llc_qword[idx] = word;
+        }
+        rodata.cake_nr_llcs = nr_llcs.max(1) as u32;
+        for home in 0..nr_llcs {
+            let mut foreign: Vec<usize> = (0..nr_llcs).filter(|&l| l != home).collect();
+            if rodata.cake_tog_g52 == 1 {
+                foreign.sort_by_key(|&l| std::cmp::Reverse(llc_rank[l]));
+            }
+            rodata.cake_llc_order[home][0] = home as u8;
+            for (b, l) in foreign.iter().enumerate() {
+                rodata.cake_llc_order[home][b + 1] = *l as u8;
+            }
+        }
+        if rodata.cake_tog_g56 == 1 {
+            info!(
+                "   g56     banded steal: {nr_llcs} LLC band(s), order {}",
+                if rodata.cake_tog_g52 == 1 {
+                    "rank"
+                } else {
+                    "id"
+                }
+            );
         }
 
         // Hardware-anchored thresholds: measured, never derived from the slice.
@@ -362,6 +503,15 @@ impl<'a> Scheduler<'a> {
         }
 
         // Load and attach.
+        // §G76: the cpuidle mirror tracepoint fires on every idle transition
+        // (2.7M/12 s on a polling-idle host); it is loaded only for its consumers.
+        let want_cpu_idle = skel
+            .maps
+            .rodata_data
+            .as_ref()
+            .map(|r| r.cake_tog_g51 == 1)
+            .unwrap_or(false);
+        skel.progs.cake_cpu_idle.set_autoload(want_cpu_idle);
         let mut skel = scx_ops_load!(skel, cake_ops, uei)?;
         let struct_ops = Some(scx_ops_attach!(skel, cake_ops)?);
 
@@ -380,6 +530,12 @@ impl<'a> Scheduler<'a> {
                 Err(e) => warn!("   irq     {name} hook failed ({e}); chronic steering only"),
             }
         }
+        if want_cpu_idle {
+            match skel.progs.cake_cpu_idle.attach() {
+                Ok(link) => irq_links.push(link),
+                Err(e) => warn!("   g51     cpu_idle hook failed ({e}); depth mirror off"),
+            }
+        }
 
         info!("🍰 attached — wakeups queue globally, continuations locally");
 
@@ -396,6 +552,7 @@ impl<'a> Scheduler<'a> {
             skel,
             struct_ops,
             _irq_links: irq_links,
+            probe_on,
             frame_bucket: None,
             frame_period: 0,
             slow_polls: 0,
@@ -428,6 +585,98 @@ impl<'a> Scheduler<'a> {
                     "   frame   observed period {}us ({:.1} Hz)",
                     observed / 1000,
                     1e9 / observed as f64
+                );
+            }
+        }
+
+        // Diagnostics (--toggle probe=1): black box of placements that waited > 10 ms, then the census.
+        if let (true, Some(bss)) = (self.probe_on, self.skel.maps.bss_data.as_ref()) {
+            let n = bss.cake_blackbox_n;
+            for i in 0..n.min(4) {
+                let b = &bss.cake_blackbox[i as usize];
+                let comm = String::from_utf8_lossy(
+                    &b.comm
+                        .iter()
+                        .map(|c| *c as u8)
+                        .take_while(|c| *c != 0)
+                        .collect::<Vec<u8>>(),
+                )
+                .to_string();
+                info!(
+                    "   BLACKBOX wait {:.2} ms  {} pid {} kind {} target cpu{} caller cpu{} waker {} ran_on cpu{}  seats {:#018x} core_free {:#018x} thread_free {:#018x} idle {:#018x}",
+                    b.wait_ns as f64 / 1e6, comm, b.pid, b.kind, b.target, b.caller, b.waker_pid, b.ran_on, b.seats, b.core_free, b.thread_free, b.idle_word
+                );
+            }
+        }
+        if self.probe_on {
+            const NAMES: [&str; 47] = [
+                "select_calls",
+                "serial",
+                "home_warm",
+                "park_reached",
+                "park_prev",
+                "park_mbox",
+                "opt_reached",
+                "opt_hit",
+                "ranked",
+                "wp_attempt",
+                "wp_tiny",
+                "wp_small",
+                "wp_protect",
+                "wp_vtime",
+                "wp_starved",
+                "wp_fired",
+                "free_pick",
+                "prewake_fire",
+                "reserved_take",
+                "pl_local",
+                "pl_local_on",
+                "pl_cpuq_wake",
+                "pl_cpuq_cont",
+                "pl_global",
+                "h300_local",
+                "h300_local_on",
+                "h300_cpuq_wake",
+                "h300_cpuq_cont",
+                "h300_global",
+                "h1ms_local",
+                "h1ms_local_on",
+                "h1ms_cpuq_wake",
+                "h1ms_cpuq_cont",
+                "h1ms_global",
+                "pl_self",
+                "h300_self",
+                "h1ms_self",
+                "hd_skip",
+                "hd_sync",
+                "hd_starved",
+                "hd_irq",
+                "hd_aff",
+                "hd_contended",
+                "hd_notidle",
+                "home_busy",
+                "home_localq",
+                "h300_home_busy",
+            ];
+            let mut tot = [0u64; NAMES.len()];
+            for (i, t) in tot.iter_mut().enumerate() {
+                let key = (i as u32).to_ne_bytes();
+                if let Ok(Some(percpu)) =
+                    self.skel.maps.cake_stats.lookup_percpu(&key, MapFlags::ANY)
+                {
+                    for cpu in &percpu {
+                        if cpu.len() >= 8 {
+                            *t += u64::from_ne_bytes(cpu[..8].try_into().unwrap());
+                        }
+                    }
+                }
+            }
+            let sel = tot[0].max(1) as f64;
+            for (i, name) in NAMES.iter().enumerate() {
+                info!(
+                    "   arms    {name:<13} {:>12}  {:>6.2}% of select",
+                    tot[i],
+                    tot[i] as f64 * 100.0 / sel
                 );
             }
         }


### PR DESCRIPTION
Field report (9950X3D, DOOM: The Dark Ages, game lassoed to the V-cache CCD): 1.2.1 lost 9% average and 15% 1% low against 1.1.3. Reproduced on a 9800X3D at a 700 fps menu: -5.5% average, +0.2 ms p99. Diagnosis by trace: every long render-path delay was a HOLD — a wake parked in a CPU's owner-only local DSQ behind a millisecond burst, placed there on a stale idle bit by the census paths; plus SMT sibling doubling on 6% of game run time, and stage threads losing their core 450 times a second (branch misses +34%).

What ships, all default on, each switchable off with --toggle gNN=0:
  g65  every enqueued wake takes the shared pool; the herd gate no longer
       routes a wake into a busy CPU's private queue
  g69  claimed warm placement: prev CPU, then a whole idle core, then an idle
       thread, each taken with the atomic idle claim; else the pool
  g71  idle CPUs publish whole-core / thread-free words; the waker chooses
       from them and the kernel bit claims (two kfuncs per wake, no scan)
  g75  grooves: per-task placement history — a home that keeps being busy
       stops being asked, the last-won core is tried first
  g76  lean dispatch: counts before iterators and move attempts; one groove
       lookup per wake; cpuidle tracepoint loaded only for its consumer
  g77  steal ring skipped on an empty qmask
  g79  seat hold: a blocking stage-class thread keeps its core for its gap
  g80  a groove miss is only a busy home (SYNC/starved/IRQ gates excluded)
  g81  stage-class threads keep the warm home on SYNC wakes
Experiments that lost or tied stay in the tree behind toggles, default off (g60-g64, g66-g68, g70, g72-g74, g78, g82). Diagnostics behind --toggle probe=1.

Results, KovaaKs menu, 9800X3D, 20 s slots ABBA vs crate 1.1.3: average tied (698 vs 698), 1% low +1.8%, 0.1% low +3.3%, p99 -1.1%, p99.9 -2.1%, stutter frames one third. Field, 9950X3D DOOM TDA single runs: 1.2.1 155.5 avg / 96.8 1% low -> 170.6 / 112.0, against 1.1.3 170.5 / 113.5.

STATE.md carries the ledger, the mechanism chain and the owed list (per-LLC pools onto the shared pool for two-CCD parts; V-cache preference for unpinned games; the 45 ms first-log-frame hitch seen twice early, not seen in 30 slots since, black box armed).