### PR TITLE
scx_cosmos: Re-introduce direct dispatch in ops.enqueue()

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -1076,6 +1076,20 @@ static void direct_dispatch_local(struct task_struct *p, s32 cpu)
 }
 
 /*
+ * Return true if a shared DSQ insertion needs an explicit CPU kick.
+ *
+ * ops.select_cpu() normally provides the wakeup side effect for unbound
+ * tasks. Affinity-constrained and migration-disabled tasks can otherwise end
+ * up waiting in a shared DSQ with no eligible CPU checking it, so always kick
+ * their previous CPU.
+ */
+static bool task_needs_shared_dsq_kick(struct task_struct *p, u64 enq_flags)
+{
+	return p->nr_cpus_allowed != nr_cpu_ids || is_migration_disabled(p) ||
+	       task_should_migrate(p, enq_flags);
+}
+
+/*
  * Return true if a task is waking up another task that share the same
  * address space, false otherwise.
  */
@@ -1211,38 +1225,63 @@ void BPF_STRUCT_OPS(cosmos_enqueue, struct task_struct *p, u64 enq_flags)
 	}
 
 	/*
+	 * Attempt to immediately dispatch sticky event-heavy tasks to the
+	 * same CPU.
+	 */
+	if (is_sticky_event_heavy(tctx) &&
+	    (is_primary_cpu(prev_cpu) || is_pcpu_task(p)) &&
+	    !is_smt_contended(prev_cpu)) {
+		const struct task_struct *q = __COMPAT_scx_bpf_dsq_peek(shared_dsq(prev_cpu));
+
+		/*
+		 * If a per-CPU task is waiting to acquire the CPU, skip
+		 * direct dispatch to prevent starvation.
+		 */
+		if (!q || q->nr_cpus_allowed > 1) {
+			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p), enq_flags);
+			__sync_fetch_and_add(&nr_ev_sticky_dispatches, 1);
+			return;
+		}
+	}
+
+	/*
+	 * Attempt to dispatch directly to an idle CPU if the task can
+	 * migrate.
+	 */
+	if (task_should_migrate(p, enq_flags) ||
+	    !is_cpu_idle(prev_cpu) ||
+	    (!is_pcpu_task(p) && is_smt_contended(prev_cpu)) ||
+	    (!is_pcpu_task(p) && (is_event_heavy(tctx) || !is_primary_cpu(prev_cpu)))) {
+		if (is_pcpu_task(p))
+			cpu = test_cpu_idle(prev_cpu) ? prev_cpu : -EBUSY;
+		else
+			cpu = pick_idle_cpu(p, prev_cpu, -1, 0, true);
+		if (cpu >= 0) {
+			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | cpu,
+					   task_slice(p), enq_flags | SCX_ENQ_IMMED);
+			if (is_event_heavy(tctx) && cpu != prev_cpu)
+				__sync_fetch_and_add(&nr_event_dispatches, 1);
+			return;
+		}
+	}
+
+	/*
+	 * Keep using the same CPU if that CPU is not busy.
+	 */
+	if (!is_cpu_busy(prev_cpu) &&
+	    (is_primary_cpu(prev_cpu) || is_pcpu_task(p))) {
+		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL_ON | prev_cpu, task_slice(p), enq_flags);
+		return;
+	}
+
+	/*
 	 * Dispatch the task to the shared DSQ.
 	 */
 	scx_bpf_dsq_insert_vtime(p, shared_dsq(prev_cpu),
 				 task_slice(p), task_dl(p, tctx), enq_flags);
 
-	if (is_pcpu_task(p) ||
-	    (is_sticky_event_heavy(tctx) && is_primary_cpu(prev_cpu))) {
+	if (task_needs_shared_dsq_kick(p, enq_flags))
 		scx_bpf_kick_cpu(prev_cpu, SCX_KICK_IDLE);
-		return;
-	}
-
-	if (!task_should_migrate(p, enq_flags) && !is_event_heavy(tctx))
-		return;
-
-	scx_bpf_kick_cpu(prev_cpu, SCX_KICK_IDLE);
-
-	cpu = pick_idle_cpu(p, prev_cpu, -1, 0, true);
-	if (cpu >= 0 && cpu != prev_cpu)
-		scx_bpf_kick_cpu(cpu, SCX_KICK_IDLE);
-}
-
-/*
- * Return true if @p is running in its primary domain, false otherwise.
- */
-static bool is_task_in_primary(const struct task_struct *p, s32 cpu)
-{
-	const struct cpumask *mask = cast_mask(primary_cpumask);
-
-	if (!mask)
-		return true;
-
-	return is_primary_cpu(cpu) || !bpf_cpumask_intersects(p->cpus_ptr, mask);
 }
 
 /*
@@ -1251,6 +1290,8 @@ static bool is_task_in_primary(const struct task_struct *p, s32 cpu)
  */
 static bool keep_running(const struct task_struct *p, s32 cpu)
 {
+	const struct cpumask *mask = cast_mask(primary_cpumask);
+
 	/*
 	 * Do not keep running if the task doesn't need to run.
 	 */
@@ -1258,10 +1299,28 @@ static bool keep_running(const struct task_struct *p, s32 cpu)
 		return false;
 
 	/*
+	* If the task can only run on this CPU, keep it running.
+	*/
+	if (is_pcpu_task(p))
+		return true;
+
+	/*
+	 * If the task is not running in a full-idle SMT core and there are
+	 * full-idle SMT cores available in the system, give it a chance to
+	 * migrate elsewhere.
+	 */
+	if (is_smt_contended(cpu))
+		return false;
+
+	/*
 	 * If the task is not in the primary domain, give it a chance to
 	 * migrate.
 	 */
-	return is_pcpu_task(p) || is_task_in_primary(p, cpu);
+	if (!is_primary_cpu(cpu) &&
+	    mask && bpf_cpumask_intersects(p->cpus_ptr, mask))
+		return false;
+
+	return true;
 }
 
 void BPF_STRUCT_OPS(cosmos_dispatch, s32 cpu, struct task_struct *prev)


### PR DESCRIPTION
Commit 8258404d4 ("scx_cosmos: replace direct dispatch in ops.enqueue() with CPU kicks") moved task placement to ops.dispatch(), with ops.enqueue() only queuing tasks to the shared DSQs and kicking idle CPUs.

The extra enqueue -> kick -> dispatch round-trip proved to introduce measurable overhead, regressing CPU-intensive workloads: GEMM on a 352 CPU machine dropped from ~9.8 TFLOPS to ~9.1 TFLOPS.

Re-introduce direct dispatch in ops.enqueue(), inserting tasks straight into the local DSQ of the target CPU via SCX_DSQ_LOCAL_ON whenever possible:

 - sticky event-heavy tasks are dispatched to their previous CPU, unless a per-CPU task is already waiting on its shared DSQ (to prevent starving it),

 - tasks that should migrate, or whose previous CPU is busy or SMT-contended, are dispatched to an idle CPU, if one can be found,

 - tasks whose previous CPU is not busy keep running on it,

 - everything else falls back to the shared DSQ, kicking the previous CPU only for tasks that ops.select_cpu() may never wake up (affinity-constrained or migration-disabled tasks).

Also update keep_running() to let tasks running on an SMT-contended or non-primary CPU go through the regular enqueue path, so they get a chance to migrate to a better CPU.

Results on a 352 CPU arm64 machine (2 NUMA nodes, SMT on), running scx_cosmos -m 0-175, "kicks" = previous behavior, "direct" = this commit:

 - SGEMM (nvpl benchblas, 88 threads bound to NUMA node 0, avg GFLOPS of 2 runs over 10 trials):
```
  +----------------------------------+-------+--------+-------+
  | config (more is better)          | kicks | direct | delta |
  +----------------------------------+-------+--------+-------+
  | default OMP placement            |  8998 |   9728 | +8.1% |
  | OMP_PLACES=cores/PROC_BIND=spread|  9750 |   9727 | -0.2% |
  +----------------------------------+-------+--------+-------+
```
 - schbench -m 4 -t 88 -r 30 (saturated, 352 workers):
```
  +---------------------------+-------+--------+--------+
  | metric (less is better)   | kicks | direct | delta  |
  +---------------------------+-------+--------+--------+
  | wakeup lat p50 (usec)     |    25 |     24 |  -4.0% |
  | wakeup lat p90 (usec)     |   120 |     32 | -73.3% |
  | wakeup lat p99 (usec)     |  1054 |     88 | -91.7% |
  | wakeup lat p99.9 (usec)   |  1118 |    207 | -81.5% |
  | request lat p99 (msec)    | 114.6 |  106.4 |  -7.2% |
  | average RPS               |  9491 |  10284 |  +8.4% |
  +---------------------------+-------+--------+--------+
```
 - schbench -m 2 -t 16 -r 30 (light, 32 workers):
```
  +---------------------------+-------+--------+--------+
  | metric (less is better)   | kicks | direct | delta  |
  +---------------------------+-------+--------+--------+
  | wakeup lat p50 (usec)     |    21 |      5 | -76.2% |
  | wakeup lat p99 (usec)     |   149 |    131 | -12.1% |
  +---------------------------+-------+--------+--------+
```