### PR TITLE
scx_cosmos: Replace polled CPU utilization with in-BPF accounting

### DIFF
--- a/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_cosmos/src/bpf/main.bpf.c
@@ -159,7 +159,14 @@ const volatile u64 slice_ns = 1000000ULL;
 const volatile u64 slice_lag = 20000000ULL;
 
 /*
- * User CPU utilization threshold to determine when the system is busy.
+ * Per-CPU contention threshold, in the range [0 .. 1024], to determine
+ * when a CPU is busy: a CPU is considered busy when it has had tasks
+ * waiting to run for more than this fraction of time.
+ *
+ * 0 = contention tracking disabled: every CPU is always considered busy
+ * (pure deadline mode) and no contention state is ever updated (the
+ * branches are resolved at load time, since this is read-only data frozen
+ * at that point).
  */
 const volatile u64 busy_threshold;
 
@@ -170,17 +177,6 @@ const volatile u64 busy_threshold;
  * domain).
  */
 const volatile u64 overload_thresh_ns;
-
-/*
- * Per-CPU user utilization in the range [0 .. 1024], updated periodically
- * from userspace. Indexed by CPU id.
- */
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__uint(max_entries, MAX_CPUS);
-	__type(key, u32);
-	__type(value, u64);
-} cpu_util_map SEC(".maps");
 
 /*
  * Scheduler statistics.
@@ -219,6 +215,7 @@ struct task_ctx {
 	u64 exec_runtime;
 	u64 wakeup_freq;
 	u64 last_woke_at;
+	u64 last_utime;
 	u64 perf_events;
 	u64 perf_sticky_events;
 };
@@ -332,6 +329,10 @@ struct cpu_ctx {
 	u64 last_update;
 	u64 perf_lvl;
 	u64 perf_events;
+	u64 busy_avg;
+	u64 busy_eval_at;
+	u64 acc_utime;
+	bool busy;
 	struct bpf_cpumask __kptr *smt;
 };
 
@@ -653,27 +654,98 @@ static inline bool is_pcpu_task(const struct task_struct *p)
 }
 
 /*
- * Return true if the given CPU is busy, false otherwise.
+ * Per-CPU user utilization tracking.
+ *
+ * This determines, per CPU, when the scheduler needs to switch to
+ * deadline-mode (using a shared DSQ) vs round-robin mode (using per-CPU
+ * local DSQs).
+ *
+ * The signal is the fraction of wall time the CPU spends executing user
+ * code, deliberately excluding system time: sleep-intensive workloads
+ * (frequent short sleeps and wakeups) burn most of their CPU time in the
+ * kernel, and for them tasks should stay on their CPU / local DSQ to
+ * reduce the scheduling overhead and the balancing pressure in
+ * ops.dispatch(). Only CPUs running sustained user work are worth the
+ * extra migrations that deadline mode brings.
+ *
+ * The user time of the running task (p->utime deltas, charged in
+ * ops.tick() and ops.stopping()) is accumulated per CPU and periodically
+ * folded into an EWMA (@busy_avg) of the user utilization, normalized in
+ * the range [0 .. 1024] of wall time. The busy state is derived from the
+ * EWMA with hysteresis (enter at @busy_threshold, exit at 3/4 of it) to
+ * avoid flapping between the two modes around the threshold. Idle CPUs
+ * don't tick, so a CPU with no recent evaluations is considered not
+ * busy.
+ */
+#define BUSY_EVAL_NS	(10ULL * NSEC_PER_MSEC)
+#define BUSY_STALE_NS	(50ULL * NSEC_PER_MSEC)
+
+/*
+ * Charge the user time accumulated by @p (running on @cpu) since the
+ * last update and periodically refresh the CPU's busy state.
+ */
+static void update_cpu_busy(struct task_struct *p, s32 cpu)
+{
+	struct cpu_ctx *cctx;
+	struct task_ctx *tctx;
+	u64 now, delta_t, util;
+
+	if (!busy_threshold)
+		return;
+
+	cctx = try_lookup_cpu_ctx(cpu);
+	tctx = try_lookup_task_ctx(p);
+	if (!cctx || !tctx)
+		return;
+
+	cctx->acc_utime += p->utime - tctx->last_utime;
+	tctx->last_utime = p->utime;
+
+	now = bpf_ktime_get_ns();
+	delta_t = time_delta(now, cctx->busy_eval_at);
+	if (delta_t < BUSY_EVAL_NS)
+		return;
+
+	util = MIN(cctx->acc_utime * 1024 / delta_t, 1024);
+	cctx->busy_avg = calc_avg(cctx->busy_avg, util);
+	cctx->acc_utime = 0;
+	cctx->busy_eval_at = now;
+
+	if (!cctx->busy && cctx->busy_avg >= busy_threshold)
+		cctx->busy = true;
+	else if (cctx->busy && cctx->busy_avg < busy_threshold - busy_threshold / 4)
+		cctx->busy = false;
+}
+
+/*
+ * Return true if the given CPU is busy (running sustained user work),
+ * false otherwise.
  *
  * @cpu should be the CPU of interest: prev_cpu in select_cpu/enqueue, or
  * scx_bpf_task_cpu(p) in tick.
- *
- * This determines when the scheduler needs to switch to deadline-mode
- * (using a shared DSQ) vs round-robin mode (using per-CPU local DSQs).
  */
 static inline bool is_cpu_busy(s32 cpu)
 {
-	u64 *util;
-	u64 max_cpu = MIN(nr_cpu_ids, MAX_CPUS);
+	struct cpu_ctx *cctx;
 
-	if (cpu < 0 || cpu >= max_cpu)
+	/*
+	 * Utilization tracking disabled: always use deadline mode.
+	 */
+	if (!busy_threshold)
+		return true;
+
+	cctx = try_lookup_cpu_ctx(cpu);
+	if (!cctx)
+		return true;
+
+	/*
+	 * No recent evaluations: the CPU has been (mostly) idle, hence
+	 * not busy.
+	 */
+	if (time_delta(bpf_ktime_get_ns(), cctx->busy_eval_at) > BUSY_STALE_NS)
 		return false;
 
-	util = bpf_map_lookup_elem(&cpu_util_map, &cpu);
-	if (!util)
-		return false;
-
-	return *util >= busy_threshold;
+	return cctx->busy;
 }
 
 /*
@@ -1303,6 +1375,13 @@ void BPF_STRUCT_OPS(cosmos_tick, struct task_struct *p)
 {
 	struct task_ctx *tctx;
 
+	/*
+	 * Refresh the CPU user utilization state (resolved to a no-op at
+	 * load time when utilization tracking is disabled).
+	 */
+	if (busy_threshold)
+		update_cpu_busy(p, scx_bpf_task_cpu(p));
+
 	if (!time_preemption)
 		return;
 
@@ -1535,6 +1614,13 @@ void BPF_STRUCT_OPS(cosmos_running, struct task_struct *p)
 	tctx->last_run_at = bpf_ktime_get_ns();
 
 	/*
+	 * Snapshot the task's user time, so that only the user time
+	 * accumulated on this CPU is charged to it.
+	 */
+	if (busy_threshold)
+		tctx->last_utime = p->utime;
+
+	/*
 	 * Update current system's vruntime.
 	 */
 	if (time_before(vtime_now, p->scx.dsq_vtime))
@@ -1577,6 +1663,19 @@ void BPF_STRUCT_OPS(cosmos_stopping, struct task_struct *p, bool runnable)
 	if (perf_config || perf_sticky) {
 		scx_pmu_event_stop(p);
 		update_counters(p, tctx, cpu);
+	}
+
+	/*
+	 * Charge the user time accumulated on this CPU before the task
+	 * releases it.
+	 */
+	if (busy_threshold) {
+		struct cpu_ctx *cctx = try_lookup_cpu_ctx(cpu);
+
+		if (cctx) {
+			cctx->acc_utime += p->utime - tctx->last_utime;
+			tctx->last_utime = p->utime;
+		}
 	}
 
 	/*

--- a/scheds/rust/scx_cosmos/src/main.rs
+++ b/scheds/rust/scx_cosmos/src/main.rs
@@ -17,8 +17,6 @@ use cgroup::CgroupReader;
 
 use std::collections::{HashMap, HashSet};
 use std::ffi::{c_int, c_ulong};
-use std::fs::File;
-use std::io::{BufRead, BufReader};
 use std::mem::MaybeUninit;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -82,12 +80,15 @@ struct Opts {
 
     /// CPU busy threshold.
     ///
-    /// Specifies the CPU utilization percentage (0-100%) at which the scheduler considers the
-    /// system to be busy.
+    /// Specifies the user CPU utilization percentage (0-100%) at which the scheduler considers a
+    /// CPU to be busy. Only user time counts: sleep-intensive workloads burn most of their CPU
+    /// time in the kernel and their CPUs are deliberately not considered busy, so that tasks stay
+    /// on their CPU / local dispatch queue, reducing the scheduling overhead and the balancing
+    /// pressure in dispatch.
     ///
-    /// When the average CPU utilization reaches this threshold, the scheduler switches from using
-    /// multiple per-CPU round-robin dispatch queues (which favor locality and reduced locking
-    /// contention) to a global deadline-based dispatch queue (which improves load balancing).
+    /// When a CPU crosses this threshold, the scheduler switches it from using its per-CPU
+    /// round-robin dispatch queue (which favors locality and reduced locking contention) to the
+    /// global deadline-based dispatch queue (which improves load balancing).
     ///
     /// The global dispatch queue can increase task migrations and improve responsiveness for
     /// interactive tasks under heavy load. Lower values make the scheduler switch to deadline
@@ -97,15 +98,14 @@ struct Opts {
     ///
     /// A higher value is recommended for server-type workloads, while a lower value is recommended
     /// for interactive-type workloads.
+    ///
+    /// 0 = utilization tracking disabled: every CPU is always considered busy (pure deadline
+    /// mode) with no tracking overhead.
     #[clap(short = 'c', long, default_value = "0")]
     cpu_busy_thresh: u64,
 
-    /// Polling time (ms) to refresh the CPU utilization.
-    ///
-    /// This interval determines how often the scheduler refreshes the CPU utilization that is
-    /// compared with the CPU busy threshold (option -c) to decide if the system is busy or not
-    /// and trigger the switch between using multiple per-CPU dispatch queues or a single global
-    /// deadline-based dispatch queue.
+    /// Polling time (ms) to refresh the dynamic perf event thresholds (options -E / -Y in
+    /// dynamic mode).
     ///
     /// Value is clamped to the range [10 .. 1000].
     ///
@@ -528,13 +528,6 @@ impl DynamicThresholdState {
             DYNAMIC_THRESHOLD_SCALE_MIN + DYNAMIC_THRESHOLD_SLOPE_LOW * t
         }
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-struct CpuTimes {
-    user: u64,
-    nice: u64,
-    total: u64,
 }
 
 struct Scheduler<'a> {
@@ -1120,104 +1113,16 @@ impl<'a> Scheduler<'a> {
         uei_exited!(&self.skel, uei)
     }
 
-    fn compute_user_cpu_pct(prev: &CpuTimes, curr: &CpuTimes) -> Option<u64> {
-        // Evaluate total user CPU time as user + nice.
-        let user_diff = (curr.user + curr.nice).saturating_sub(prev.user + prev.nice);
-        let total_diff = curr.total.saturating_sub(prev.total);
-
-        if total_diff > 0 {
-            let user_ratio = user_diff as f64 / total_diff as f64;
-            Some((user_ratio * 1024.0).round() as u64)
-        } else {
-            None
-        }
-    }
-
-    /// Parse per-CPU times from /proc/stat (lines "cpu0", "cpu1", ...).
-    /// Returns entries indexed by CPU id. Offline CPUs may be absent.
-    fn parse_per_cpu_cpu_times<R: BufRead>(
-        reader: R,
-        nr_cpus: usize,
-    ) -> Option<Vec<Option<CpuTimes>>> {
-        let mut result = vec![None; nr_cpus];
-
-        for line in reader.lines() {
-            let line = line.ok()?;
-            let line = line.trim();
-            if !line.starts_with("cpu") {
-                continue;
-            }
-            let rest = line.strip_prefix("cpu")?;
-            if rest.starts_with(' ') {
-                // Aggregate line "cpu " - skip.
-                continue;
-            }
-            let cpu_id: usize = rest.split_whitespace().next()?.parse().ok()?;
-            if cpu_id >= nr_cpus {
-                continue;
-            }
-            let fields: Vec<&str> = line.split_whitespace().collect();
-            if fields.len() < 5 {
-                return None;
-            }
-            let user: u64 = fields[1].parse().ok()?;
-            let nice: u64 = fields[2].parse().ok()?;
-            let total: u64 = fields
-                .iter()
-                .skip(1)
-                .take(8)
-                .filter_map(|v| v.parse::<u64>().ok())
-                .sum();
-            result[cpu_id] = Some(CpuTimes { user, nice, total });
-        }
-
-        result.iter().any(Option::is_some).then_some(result)
-    }
-
-    /// Read per-CPU times from /proc/stat.
-    fn read_per_cpu_cpu_times(nr_cpus: usize) -> Option<Vec<Option<CpuTimes>>> {
-        let file = File::open("/proc/stat").ok()?;
-        Self::parse_per_cpu_cpu_times(BufReader::new(file), nr_cpus)
-    }
-
     fn run(&mut self, shutdown: Arc<AtomicBool>) -> Result<UserExitInfo> {
         let (res_ch, req_ch) = self.stats_server.channels();
 
-        // Periodically evaluate per-CPU user utilization from userspace and update the
-        // cpu_util_map in BPF. The scheduler uses is_cpu_busy(cpu) with prev_cpu or
-        // scx_bpf_task_cpu(p) to decide per-CPU whether to use local DSQs (round-robin)
-        // or deadline-based shared DSQ.
+        // Periodic (option -p) updates of the dynamic perf thresholds.
         let polling_time = Duration::from_millis(self.opts.polling_ms).min(Duration::from_secs(1));
-        let nr_cpus = *NR_CPU_IDS as usize;
-        let mut prev_cputime = Self::read_per_cpu_cpu_times(nr_cpus).unwrap_or_else(|| {
-            warn!("Failed to read initial per-CPU stats; starting with zero CPU utilization");
-            vec![None; nr_cpus]
-        });
         let mut last_update = Instant::now();
         let mut last_gpu_sync = Instant::now();
 
         while !shutdown.load(Ordering::Relaxed) && !self.exited() {
-            // Update per-CPU utilization.
             if !polling_time.is_zero() && last_update.elapsed() >= polling_time {
-                if let Some(curr_cputime) = Self::read_per_cpu_cpu_times(nr_cpus) {
-                    let map = &self.skel.maps.cpu_util_map;
-                    for cpu in 0..nr_cpus {
-                        let util = match (&prev_cputime[cpu], &curr_cputime[cpu]) {
-                            (Some(prev), Some(curr)) => Self::compute_user_cpu_pct(prev, curr),
-                            _ => Some(0),
-                        };
-
-                        if let Some(util) = util {
-                            let _ = map.update(
-                                &(cpu as u32).to_ne_bytes(),
-                                &util.to_ne_bytes(),
-                                MapFlags::ANY,
-                            );
-                        }
-                    }
-                    prev_cputime = curr_cputime;
-                }
-
                 // Update dynamic perf thresholds using EMA + hysteresis.
                 let elapsed_secs = last_update.elapsed().as_secs_f64();
 


### PR DESCRIPTION
is_cpu_busy() decides, per CPU, when the scheduler switches from round-robin mode (per-CPU local DSQs, favoring locality) to deadline mode (shared DSQ, favoring fairness and load balancing). The decision is based on per-CPU user utilization, polled from /proc/stat by userspace (option -p) and pushed to BPF via cpu_util_map.

The user-time basis of the signal is deliberate and is preserved: sleep-intensive workloads burn most of their CPU time in the kernel, and for them tasks should stay on their CPU / local DSQ to reduce the scheduling overhead and the balancing pressure in ops.dispatch(). Only CPUs running sustained user work are worth the extra migrations that deadline mode brings.

The polled implementation however has a few problems:

 - it reacts in O(polling interval), up to a second,

 - it silently depends on the coupling of two options: -c without -p leaves the utilization stuck at zero, so no CPU is ever considered busy,

 - it needs a userspace thread waking up periodically and one map update per CPU per interval.

Move the accounting into the BPF code: the user time of the running task (p->utime deltas) is charged to its CPU from ops.tick() and ops.stopping(), periodically folded into a per-CPU EWMA of the user utilization (normalized to [0 .. 1024] of wall time), and turned into the busy state with hysteresis (enter at the -c threshold, exit at 3/4 of it) to avoid flapping between the two modes. Idle CPUs don't tick, so a CPU with no recent evaluations is considered not busy.

The -c option keeps its range and meaning, but now works on its own, with no polling dependency. The -p option remains for the dynamic perf event thresholds, which are still updated from userspace.

The default (-c 0) remains pure deadline mode: is_cpu_busy() always returns true and no utilization state is ever touched.