### PR TITLE
scx_lavd: fix and rate-limit the CPU performance target for schedutil governor

### DIFF
--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -104,6 +104,8 @@ enum consts_internal {
 
 	LAVD_CPU_UTIL_MAX_FOR_CPUPERF	= p2s(85), /* 85.0% */
 	LAVD_CPU_UTIL_THR_FOR_MAX_FREQ	= p2s(80), /* cpu utilization threshold to update max freq */
+	LAVD_CPUPERF_UP_SHIFT		= 6, /* raise in steps of capacity / 64 */
+	LAVD_CPUPERF_DOWN_SHIFT		= 5, /* lower only past a capacity / 32 deadband */
 
 	LAVD_CC_REQ_CAPACITY_HEADROOM	= p2s(25), /* 25%: inflate required capacity by 25% to handle sudden spikes */
 	LAVD_CC_PER_CPU_UTIL		= p2s(50), /* 50%: maximum per-CPU utilization */

--- a/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/lavd.bpf.h
@@ -385,7 +385,6 @@ struct cpu_ctx {
 	u8		cpdom_alt_id;	/* compute domain id of alternative type */
 	u8		is_online;	/* is this CPU online? */
 	u8		__pad0[2];
-	u32		cpuperf_cur;	/* CPU's current performance target */
 	volatile s32	futex_op;	/* futex op in futex V1 */
 
 	/* --- cacheline 1 boundary (64 bytes): write accumulators --- */
@@ -460,6 +459,9 @@ struct cpu_ctx {
 	volatile u32	avg_util_invr;	/* average of the scaled CPU utilization, which is capacity and frequency invariant. */
 	volatile u32	cur_util_invr;	/* the scaled CPU utilization of the current interval, which is capacity and frequency invariant. */
 	volatile u32	lat_headroom;	/* latency headroom available to this CPU (inversely related to irq/steal time) */
+	volatile u32	cpuperf_target;	/* performance target computed at the last sys_stat
+					   interval, committed at ops.running() */
+	u32		cpuperf_cur;	/* CPU's current performance target */
 	/*
 	 * Steal utilization: steal_time as a fraction of duration_wall,
 	 * in LAVD_SHIFT fixed-point. cur_* is the current interval value;

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -1718,10 +1718,7 @@ void BPF_STRUCT_OPS(lavd_running, struct task_struct *p)
 	update_stat_for_running(p, taskc, cpuc, now);
 
 	/*
-	 * Calculate the task's CPU performance target and update if the new
-	 * target is higher than the current one. The CPU's performance target
-	 * urgently increases according to task's target but it decreases
-	 * gradually according to EWMA of past performance targets.
+	 * Update this CPU's performance target from its utilization.
 	 */
 	update_cpuperf_target(cpuc);
 

--- a/scheds/rust/scx_lavd/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/main.bpf.c
@@ -2517,6 +2517,7 @@ static s32 init_per_cpu_ctx(u64 now)
 		cpuc->prev_task_clk = scx_clock_task(cpu);
 		cpuc->prev_pelt_clk = scx_clock_pelt(cpu);
 		cpuc->avg_perf_factor = LAVD_SCALE;
+		cpuc->cpuperf_cur = SCX_CPUPERF_ONE;
 
 		sum_capacity += cpuc->max_capacity;
 

--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -803,6 +803,16 @@ unlock_out:
 	return err;
 }
 
+/*
+ * The utilization counts all non-idle time, including what RT/DL and IRQ
+ * stole from SCX. schedutil adds those on its own, so the target must carry
+ * the SCX part only.
+ */
+static __always_inline u32 scx_only_util(u32 total, u32 steal)
+{
+	return (total > steal) ? (total - steal) : 0;
+}
+
 __hidden
 int update_cpuperf_target(struct cpu_ctx *cpuc)
 {
@@ -822,17 +832,26 @@ int update_cpuperf_target(struct cpu_ctx *cpuc)
 	 *
 	 * Note that we should use scx_bpf_cpuperf_cap() because that is
 	 * what actually schedutil takes care of.
+	 *
+	 * Both utilizations are taken net of the stolen time, since schedutil
+	 * accounts for RT/DL and IRQ separately; passing the total would count
+	 * them twice.
 	 */
 	cap = scx_bpf_cpuperf_cap(cpuc->cpu_id);
 	if (no_freq_scaling) {
 		cpuperf_target = cap;
 	} else {
-		max_util_wall = max(cpuc->avg_util_wall, cpuc->cur_util_wall);
+		max_util_wall = max(scx_only_util(cpuc->avg_util_wall,
+						  cpuc->avg_steal_util_wall),
+				    scx_only_util(cpuc->cur_util_wall,
+						  cpuc->cur_steal_util_wall));
 		if (max_util_wall >= LAVD_CPU_UTIL_MAX_FOR_CPUPERF) {
 			cpuperf_target = cap;
 		} else {
-			max_util_invr = max(cpuc->avg_util_invr,
-					    cpuc->cur_util_invr);
+			max_util_invr = max(scx_only_util(cpuc->avg_util_invr,
+							  cpuc->avg_steal_util_invr),
+					    scx_only_util(cpuc->cur_util_invr,
+							  cpuc->cur_steal_util_invr));
 			cpuperf_target = min(max_util_invr, cap);
 		}
 	}

--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -814,7 +814,7 @@ static __always_inline u32 scx_only_util(u32 total, u32 steal)
 }
 
 __hidden
-int update_cpuperf_target(struct cpu_ctx *cpuc)
+int calc_cpuperf_target(struct cpu_ctx *cpuc)
 {
 	u32 max_util_wall, max_util_invr, cpuperf_target, cap;
 
@@ -856,8 +856,21 @@ int update_cpuperf_target(struct cpu_ctx *cpuc)
 		}
 	}
 
+	cpuc->cpuperf_target = cpuperf_target;
+
+	return 0;
+}
+
+__hidden
+int update_cpuperf_target(struct cpu_ctx *cpuc)
+{
+	u32 cpuperf_target = cpuc->cpuperf_target;
+
 	/*
-	 * Update the performance target once it changes.
+	 * Commit the target computed at the last sys_stat interval. This must
+	 * run on the target CPU itself, since schedutil ignores an update made
+	 * from a CPU outside the policy unless the cpufreq driver allows DVFS
+	 * from any CPU.
 	 */
 	if (cpuc->cpuperf_cur != cpuperf_target) {
 		scx_bpf_cpuperf_set(cpuc->cpu_id, cpuperf_target);

--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -806,21 +806,36 @@ unlock_out:
 __hidden
 int update_cpuperf_target(struct cpu_ctx *cpuc)
 {
-	u32 util_wall, max_util_wall, cpuperf_target;
+	u32 max_util_wall, max_util_invr, cpuperf_target, cap;
 
 	/*
 	 * The CPU utilization decides the frequency. The bigger one between
 	 * the running average and the recent utilization is used to respond
 	 * quickly upon load spikes. When the utilization is greater than
 	 * LAVD_CPU_UTIL_MAX_FOR_CPUPERF (85%), ceil to 100%.
+	 *
+	 * The performance target is on the system-wide capacity scale, where
+	 * SCX_CPUPERF_ONE is the most capable CPU, not a ratio of this CPU's
+	 * own busy time. Scale it by the CPU's capacity. The proportional part
+	 * uses the capacity- and frequency-invariant utilization, which does
+	 * not depend on the frequency we end up picking.
+	 *
+	 * Note that we should use scx_bpf_cpuperf_cap() because that is
+	 * what actually schedutil takes care of.
 	 */
-	if (!no_freq_scaling) {
+	cap = scx_bpf_cpuperf_cap(cpuc->cpu_id);
+	if (no_freq_scaling) {
+		cpuperf_target = cap;
+	} else {
 		max_util_wall = max(cpuc->avg_util_wall, cpuc->cur_util_wall);
-		util_wall = (max_util_wall < LAVD_CPU_UTIL_MAX_FOR_CPUPERF) ?
-				max_util_wall : LAVD_SCALE;
-		cpuperf_target = (util_wall * SCX_CPUPERF_ONE) >> LAVD_SHIFT;
-	} else
-		cpuperf_target = SCX_CPUPERF_ONE;
+		if (max_util_wall >= LAVD_CPU_UTIL_MAX_FOR_CPUPERF) {
+			cpuperf_target = cap;
+		} else {
+			max_util_invr = max(cpuc->avg_util_invr,
+					    cpuc->cur_util_invr);
+			cpuperf_target = min(max_util_invr, cap);
+		}
+	}
 
 	/*
 	 * Update the performance target once it changes.

--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.c
@@ -817,6 +817,7 @@ __hidden
 int calc_cpuperf_target(struct cpu_ctx *cpuc)
 {
 	u32 max_util_wall, max_util_invr, cpuperf_target, cap;
+	u32 step, cur;
 
 	/*
 	 * The CPU utilization decides the frequency. The bigger one between
@@ -854,6 +855,24 @@ int calc_cpuperf_target(struct cpu_ctx *cpuc)
 							  cpuc->cur_steal_util_invr));
 			cpuperf_target = min(max_util_invr, cap);
 		}
+	}
+
+	/*
+	 * Committing a target is not free, so utilization jitter around a
+	 * steady load should not reach cpufreq. Round the target up to a step
+	 * boundary, and apply a deadband on the way down: a lower target is
+	 * accepted only once it has fallen by cap/32.
+	 */
+	step = cap >> LAVD_CPUPERF_UP_SHIFT;
+	if (step < 1) {
+		step = 1;
+	}
+	cpuperf_target = min(round_up(cpuperf_target, step), cap);
+
+	cur = cpuc->cpuperf_target;
+	if (cpuperf_target < cur &&
+	    (cur - cpuperf_target) < (cap >> LAVD_CPUPERF_DOWN_SHIFT)) {
+		return 0;
 	}
 
 	cpuc->cpuperf_target = cpuperf_target;

--- a/scheds/rust/scx_lavd/src/bpf/power.bpf.h
+++ b/scheds/rust/scx_lavd/src/bpf/power.bpf.h
@@ -22,6 +22,7 @@ extern u32			default_big_core_scale;
 int init_autopilot_caps(void);
 int update_autopilot_high_cap(void);
 
+int calc_cpuperf_target(struct cpu_ctx *cpuc);
 int update_cpuperf_target(struct cpu_ctx *cpuc);
 u16 get_cpuperf_cap(s32 cpu);
 

--- a/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
+++ b/scheds/rust/scx_lavd/src/bpf/sys_stat.bpf.c
@@ -403,6 +403,12 @@ static void collect_sys_stat(void)
 		cpuc->avg_util_invr = calc_asym_avg(cpuc->avg_util_invr, cpuc->cur_util_invr);
 
 		/*
+		 * Both utilization signals are now up to date, so recompute
+		 * the performance target. ops.running() only commits it.
+		 */
+		calc_cpuperf_target(cpuc);
+
+		/*
 		 * Calculate domain-pinned task utilization. Clamp both
 		 * snapshots to compute_wall. For wall time, this guards against
 		 * cross-interval contamination (last_measured_*_clk is sampled


### PR DESCRIPTION
lavd drives cpufreq through scx_bpf_cpuperf_set(). The value it passed was
recomputed redundantly, and sent unfiltered. What started this was
schedutil's per-policy kthread (sugov:N) consuming a noticeable amount of
CPU time (3-5% of a single CPU) on an asymmetric arm64 chipset. This affects
only systems running the schedutil governor.

1/4 fixes the scale. scx_bpf_cpuperf_set() takes a target on the
system-wide capacity scale, where SCX_CPUPERF_ONE is the most capable CPU,
but lavd passed the CPU's own wall-clock utilization ratio -- the same
thing only when that CPU's capacity is SCX_CPUPERF_ONE. A little core
therefore over-asks and pins at its top frequency well below full
utilization.

2/4 stops double-counting. schedutil treats the value as fair-class
utilization and adds RT, DL and IRQ on top, but lavd's utilization is all
non-idle time and already included them, so the request was inflated by
their share.

3/4 removes redundant work. The target was recomputed on every
ops.running() from inputs the sys_stat timer only refreshes once per
interval. Computation moves to that timer; ops.running() just commits,
which it must, since schedutil ignores an update made from outside the
policy.

4/4 filters. Any change of the computed target, down to a single unit,
reached the governor, so utilization jitter around a steady load did too --
and on a slow-switching driver every update wakes a SCHED_DEADLINE kthread
with an IPI.

Measured on a Snapdragon chipset, at the same load on the little cluster:
requested frequency 2089 -> 1250 MHz, and scx_bpf_cpuperf_set() calls
551.7/s -> 225.1/s.
