### PR TITLE
scx_cidland: Rework virtual deadline accounting toward EEVDF

### DIFF
--- a/scheds/experimental/scx_cidland/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_cidland/src/bpf/main.bpf.c
@@ -85,12 +85,6 @@ UEI_DEFINE(uei);
 #define STATIC_ALLOC_PAGES	8
 
 /*
- * Maximum measured task wakeup rate. Used to avoid spikes when prioritizing
- * wakeup-intensive tasks.
- */
-#define MAX_WAKEUP_FREQ	1024
-
-/*
  * The verifier only associates a program with an arena if the program emits an
  * LD_IMM64 loading the map. Reaching the arena through a pointer kept in a
  * global doesn't do that, so a program that has no other reason to load the
@@ -165,19 +159,25 @@ static u32 nr_cmask_words;
 static u32 nr_cpu_ids;
 
 /*
- * Current system virtual time: the largest vruntime seen so far, used to give
- * waking tasks a sane starting point.
+ * Current system virtual time: the reference every task is placed against.
  */
 static u64 vtime_now;
+
+/*
+ * Total weight of the runnable tasks, EEVDF's \Sum w_i (cfs_rq->sum_weight).
+ *
+ * Maintained across the ops.runnable() / ops.quiescent() pair, which the core
+ * scheduler guarantees to be symmetric, so it converges even when a task is
+ * dequeued without ever being consumed by the BPF side.
+ */
+static u64 sum_weight;
 
 /*
  * Per-task context.
  */
 struct task_ctx {
 	u64 last_run_at;		/* when the task last started running */
-	u64 last_woke_at;		/* when the task last woke up */
 	u64 burst_runtime;		/* runtime accumulated since the last sleep */
-	u64 wakeup_freq;		/* average wakeup frequency */
 	struct scx_cmask allowed;	/* cids the task is allowed to run on */
 };
 
@@ -217,6 +217,7 @@ struct cid_ctx {
 	u32 core_nr;		/* number of cids (SMT siblings) in the core */
 	u32 llc_base;		/* first cid of the LLC this cid belongs to */
 	u32 llc_nr;		/* number of cids in the LLC */
+	u64 vtime_rem;		/* service not yet folded into @vtime_now */
 };
 
 /*
@@ -518,27 +519,6 @@ static s32 pick_idle_cid(const struct task_struct *p, s32 prev_cid,
 }
 
 /*
- * Exponentially weighted moving average:
- *
- * new_avg := (old_avg * .75) + (new_val * .25)
- */
-static u64 calc_avg(u64 old_val, u64 new_val)
-{
-	return (old_val - (old_val >> 2)) + (new_val >> 2);
-}
-
-/*
- * Update the average frequency of an event, given the @interval since the
- * previous one.
- */
-static u64 update_freq(u64 freq, u64 interval)
-{
-	u64 new_freq = (100 * NSEC_PER_MSEC) / interval;
-
-	return calc_avg(freq, new_freq);
-}
-
-/*
  * Return the virtual deadline of @p.
  *
  * The deadline is defined as:
@@ -553,19 +533,35 @@ static u64 update_freq(u64 freq, u64 interval)
  * sleep frequently and use the CPU in short bursts (hence with a small
  * @burst_vruntime), which are typically the latency critical ones.
  *
- * To avoid over-prioritizing tasks that sleep for a long time, the vruntime
- * credit they can build up while sleeping is capped at @slice_lag, scaled by
- * the task's weight and by its wakeup frequency: tasks that sleep often get a
- * bigger lag than tasks with infrequent, long sleeps.
+ * The distance from @vtime_now is bounded on both sides by @slice_lag, which
+ * caps both the credit a sleeper builds up and how far a task that has been
+ * running can drift behind.
  */
 static u64 task_dl(struct task_struct *p, const struct task_ctx __arena *tctx)
 {
-	u64 lag_scale = MAX(tctx->wakeup_freq, 1);
-	u64 vsleep_max = scale_by_task_weight(p, slice_lag * lag_scale);
-	u64 vtime_min = vtime_now - vsleep_max;
+	u64 limit = scale_by_task_weight_inverse(p, slice_lag);
+	u64 vtime_min = vtime_now - limit;
+	u64 vtime_max = vtime_now + limit;
 
+	/*
+	 * Bound the lag on both sides, like EEVDF's entity_lag():
+	 *
+	 *	return clamp(vlag, -limit, limit);
+	 *
+	 * The lower bound caps the credit a sleeper builds up. The upper bound
+	 * is what keeps a task that has been running from drifting arbitrarily
+	 * far behind: without it the gap only ever grows, and a task that is
+	 * never picked never advances the clock either, so nothing brings it
+	 * back.
+	 *
+	 * The limit is scaled by the inverse of the task's weight, matching
+	 * calc_delta_fair(): the same amount of real time is a smaller step in
+	 * virtual time for a heavier task.
+	 */
 	if (time_before(p->scx.dsq_vtime, vtime_min))
 		scx_bpf_task_set_dsq_vtime(p, vtime_min);
+	else if (time_after(p->scx.dsq_vtime, vtime_max))
+		scx_bpf_task_set_dsq_vtime(p, vtime_max);
 
 	return p->scx.dsq_vtime + scale_by_task_weight_inverse(p, tctx->burst_runtime);
 }
@@ -745,22 +741,21 @@ void BPF_STRUCT_OPS(cidland_dispatch, s32 cid, struct task_struct *prev)
 	cid_set_idle(cid, true);
 }
 
+void BPF_STRUCT_OPS(cidland_quiescent, struct task_struct *p, u64 deq_flags)
+{
+	__sync_fetch_and_sub(&sum_weight, p->scx.weight);
+}
+
 void BPF_STRUCT_OPS(cidland_runnable, struct task_struct *p, u64 enq_flags)
 {
-	u64 now = bpf_ktime_get_ns(), delta_t;
 	struct task_ctx __arena *tctx;
+
+	__sync_fetch_and_add(&sum_weight, p->scx.weight);
 
 	tctx = lookup_task_ctx(p);
 
 	/* The task just woke up: restart accounting its burst runtime. */
 	tctx->burst_runtime = 0;
-
-	/*
-	 * Refresh the wakeup frequency, capped to avoid large spikes.
-	 */
-	delta_t = now - tctx->last_woke_at;
-	tctx->wakeup_freq = MIN(update_freq(tctx->wakeup_freq, delta_t), MAX_WAKEUP_FREQ);
-	tctx->last_woke_at = now;
 }
 
 void BPF_STRUCT_OPS(cidland_running, struct task_struct *p)
@@ -770,16 +765,13 @@ void BPF_STRUCT_OPS(cidland_running, struct task_struct *p)
 	tctx = lookup_task_ctx(p);
 
 	tctx->last_run_at = bpf_ktime_get_ns();
-
-	/* Keep the system virtual time in sync with the running task. */
-	if (time_before(vtime_now, p->scx.dsq_vtime))
-		vtime_now = p->scx.dsq_vtime;
 }
 
 void BPF_STRUCT_OPS(cidland_stopping, struct task_struct *p, bool runnable)
 {
+	s32 cid = scx_bpf_task_cid(p);
 	struct task_ctx __arena *tctx;
-	u64 slice;
+	u64 slice, weight;
 
 	tctx = lookup_task_ctx(p);
 
@@ -793,6 +785,42 @@ void BPF_STRUCT_OPS(cidland_stopping, struct task_struct *p, bool runnable)
 	scx_bpf_task_set_dsq_vtime(p, p->scx.dsq_vtime +
 				   scale_by_task_weight_inverse(p, slice));
 	tctx->burst_runtime = MIN(tctx->burst_runtime + slice, slice_lag);
+
+	/*
+	 * Advance the system virtual time by the service just delivered.
+	 *
+	 * EEVDF's reference is the weighted average of the runnable set,
+	 *
+	 *	V = \Sum (w_i * v_i) / \Sum w_i
+	 *
+	 * so serving @p for @slice moves it by
+	 *
+	 *	dV = w_p * dv_p / \Sum w_i = slice * NICE_0 / \Sum w_i
+	 *
+	 * since dv_p is the slice scaled by the inverse of @p's weight. That
+	 * is an identity, not an approximation: what matters is that V rises
+	 * with the service handed out no matter who receives it. Deriving it
+	 * from the running task's own vruntime instead (the previous
+	 * max-of-running rule) stalls the clock exactly when it is needed,
+	 * because the tasks that are behind never run and the tasks that do
+	 * run barely advance their own vruntime.
+	 *
+	 * The division truncates, and once the total weight exceeds a
+	 * hundred times the length of a burst every burst contributes
+	 * nothing: with a few thousand runnable tasks V would stop entirely
+	 * and everything queued behind it would starve. Carry the remainder
+	 * per cid so that the service is accounted in full.
+	 */
+	weight = sum_weight;
+	if (weight && cid_valid(cid)) {
+		struct cid_ctx __arena *cctx = cid_ctx(cid);
+		u64 acc = slice * 100 + cctx->vtime_rem;
+		u64 delta = acc / weight;
+
+		cctx->vtime_rem = acc - delta * weight;
+		if (delta)
+			__sync_fetch_and_add(&vtime_now, delta);
+	}
 }
 
 /*
@@ -1083,6 +1111,7 @@ SCX_OPS_CID_DEFINE(cidland_ops,
 		   .enqueue		= (void *)cidland_enqueue,
 		   .dispatch		= (void *)cidland_dispatch,
 		   .runnable		= (void *)cidland_runnable,
+		   .quiescent		= (void *)cidland_quiescent,
 		   .running		= (void *)cidland_running,
 		   .stopping		= (void *)cidland_stopping,
 		   .set_cmask		= (void *)cidland_set_cmask,

--- a/scheds/experimental/scx_cidland/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_cidland/src/bpf/main.bpf.c
@@ -21,8 +21,7 @@
  * idle cid when one can be found, preferring (in order) a fully idle core, the
  * previous LLC, and finally anything idle in the system. Tasks that don't get
  * an idle cid are queued to a single shared DSQ, ordered by the virtual
- * deadline computed by task_dl(), which prioritizes tasks that sleep often and
- * run in short bursts.
+ * deadline computed by task_dl().
  */
 #include <scx/common.bpf.h>
 #include <lib/arena_map.h>
@@ -116,8 +115,7 @@ const volatile bool primary_all = true;
 static u64 __arena *primary_cpus;
 
 /*
- * Bound on the lag a task carries across a sleep, before being scaled by the
- * inverse of its weight (see ops.quiescent()).
+ * Maximum lag, in virtual time, that a task can carry across a sleep.
  */
 const volatile u64 slice_lag;
 
@@ -177,7 +175,6 @@ static u64 sum_weight;
  */
 struct task_ctx {
 	u64 last_run_at;		/* when the task last started running */
-	u64 burst_runtime;		/* runtime accumulated since the last sleep */
 	u64 vruntime;			/* total runtime, scaled by the weight */
 	s64 vlag;			/* lag carried across a sleep */
 	struct scx_cmask allowed;	/* cids the task is allowed to run on */
@@ -523,26 +520,41 @@ static s32 pick_idle_cid(const struct task_struct *p, s32 prev_cid,
 /*
  * Return the virtual deadline of @p.
  *
- * The deadline is defined as:
+ * This is EEVDF's virtual deadline, see update_deadline():
  *
- *   deadline = vruntime + burst_vruntime
+ *	vd_i = ve_i + r_i / w_i
  *
- * Here @vruntime is the task's total accumulated runtime, inversely scaled by
- * its weight, while @burst_vruntime accounts only for the runtime accumulated
- * since the task last went to sleep, also inversely scaled by its weight.
- *
- * Fairness is driven by @vruntime, while @burst_vruntime prioritizes tasks that
- * sleep frequently and use the CPU in short bursts (hence with a small
- * @burst_vruntime), which are typically the latency critical ones.
+ * The request size r_i is the same @slice_ns for everybody, exactly like
+ * sysctl_sched_base_slice: the weight does not buy a task a longer time
+ * slice, it buys it an earlier deadline, so it runs more often instead of
+ * running longer.
  *
  * The deadline is the DSQ key and nothing else. The kernel stores what is
  * passed to scx_bpf_dsq_insert_vtime() in p->scx.dsq_vtime, so the
  * vruntime has to live somewhere the key cannot overwrite it, see
  * task_ctx.vruntime.
+ *
+ * pick_eevdf() considers only the eligible tasks, v_i <= V, and picks the
+ * earliest deadline among them. A DSQ cannot skip a task and its key is
+ * fixed at insertion, so the filter is not applied here. It is mostly not
+ * needed: a task that is over-served carries the excess in its key and
+ * sorts after the under-served tasks of the same weight, and stays there
+ * until V has moved past it, which is the wait pick_eevdf() would impose
+ * anyway. What is lost is the case of a heavier over-served task, whose
+ * r_i / w_i is smaller, sorting ahead of a lighter under-served one: it
+ * wins by at most the difference between the two requests, a bounded
+ * latency skew, not a fairness leak, since the vruntime is charged all
+ * the same.
+ *
+ * Pushing the ineligible tasks further back with an offset, to apply the
+ * filter exactly, would starve them instead. V advances by the service
+ * delivered divided by the total weight, so under load it barely moves,
+ * and a task waiting for V to cover a fixed offset waits for seconds
+ * while every newly woken task keeps being queued ahead of it.
  */
 static u64 task_dl(const struct task_struct *p, const struct task_ctx __arena *tctx)
 {
-	return tctx->vruntime + scale_by_task_weight_inverse(p, tctx->burst_runtime);
+	return tctx->vruntime + scale_by_task_weight_inverse(p, slice_ns);
 }
 
 s32 BPF_STRUCT_OPS(cidland_select_cid, struct task_struct *p, s32 prev_cid,
@@ -758,9 +770,6 @@ void BPF_STRUCT_OPS(cidland_runnable, struct task_struct *p, u64 enq_flags)
 
 	tctx = lookup_task_ctx(p);
 
-	/* The task just woke up: restart accounting its burst runtime. */
-	tctx->burst_runtime = 0;
-
 	/*
 	 * Place the task back at the lag it had when it went to sleep, the
 	 * way place_entity() does:
@@ -793,12 +802,12 @@ void BPF_STRUCT_OPS(cidland_stopping, struct task_struct *p, bool runnable)
 	slice = bpf_ktime_get_ns() - tctx->last_run_at;
 
 	/*
-	 * Charge the used time slice to the task's vruntime and to the runtime
-	 * accumulated since its last sleep, capping the latter at @slice_lag so
-	 * that CPU intensive tasks don't get starved.
+	 * Charge the service just consumed to the task's vruntime, the way
+	 * update_curr() does:
+	 *
+	 *	se->vruntime += calc_delta_fair(delta_exec, se);
 	 */
 	tctx->vruntime += scale_by_task_weight_inverse(p, slice);
-	tctx->burst_runtime = MIN(tctx->burst_runtime + slice, slice_lag);
 
 	/*
 	 * Advance the system virtual time by the service just delivered.

--- a/scheds/experimental/scx_cidland/src/bpf/main.bpf.c
+++ b/scheds/experimental/scx_cidland/src/bpf/main.bpf.c
@@ -116,8 +116,8 @@ const volatile bool primary_all = true;
 static u64 __arena *primary_cpus;
 
 /*
- * Maximum time slice credit a task can accumulate while sleeping, before being
- * scaled by its weight and its wakeup frequency (see task_dl()).
+ * Bound on the lag a task carries across a sleep, before being scaled by the
+ * inverse of its weight (see ops.quiescent()).
  */
 const volatile u64 slice_lag;
 
@@ -178,6 +178,8 @@ static u64 sum_weight;
 struct task_ctx {
 	u64 last_run_at;		/* when the task last started running */
 	u64 burst_runtime;		/* runtime accumulated since the last sleep */
+	u64 vruntime;			/* total runtime, scaled by the weight */
+	s64 vlag;			/* lag carried across a sleep */
 	struct scx_cmask allowed;	/* cids the task is allowed to run on */
 };
 
@@ -533,37 +535,14 @@ static s32 pick_idle_cid(const struct task_struct *p, s32 prev_cid,
  * sleep frequently and use the CPU in short bursts (hence with a small
  * @burst_vruntime), which are typically the latency critical ones.
  *
- * The distance from @vtime_now is bounded on both sides by @slice_lag, which
- * caps both the credit a sleeper builds up and how far a task that has been
- * running can drift behind.
+ * The deadline is the DSQ key and nothing else. The kernel stores what is
+ * passed to scx_bpf_dsq_insert_vtime() in p->scx.dsq_vtime, so the
+ * vruntime has to live somewhere the key cannot overwrite it, see
+ * task_ctx.vruntime.
  */
-static u64 task_dl(struct task_struct *p, const struct task_ctx __arena *tctx)
+static u64 task_dl(const struct task_struct *p, const struct task_ctx __arena *tctx)
 {
-	u64 limit = scale_by_task_weight_inverse(p, slice_lag);
-	u64 vtime_min = vtime_now - limit;
-	u64 vtime_max = vtime_now + limit;
-
-	/*
-	 * Bound the lag on both sides, like EEVDF's entity_lag():
-	 *
-	 *	return clamp(vlag, -limit, limit);
-	 *
-	 * The lower bound caps the credit a sleeper builds up. The upper bound
-	 * is what keeps a task that has been running from drifting arbitrarily
-	 * far behind: without it the gap only ever grows, and a task that is
-	 * never picked never advances the clock either, so nothing brings it
-	 * back.
-	 *
-	 * The limit is scaled by the inverse of the task's weight, matching
-	 * calc_delta_fair(): the same amount of real time is a smaller step in
-	 * virtual time for a heavier task.
-	 */
-	if (time_before(p->scx.dsq_vtime, vtime_min))
-		scx_bpf_task_set_dsq_vtime(p, vtime_min);
-	else if (time_after(p->scx.dsq_vtime, vtime_max))
-		scx_bpf_task_set_dsq_vtime(p, vtime_max);
-
-	return p->scx.dsq_vtime + scale_by_task_weight_inverse(p, tctx->burst_runtime);
+	return tctx->vruntime + scale_by_task_weight_inverse(p, tctx->burst_runtime);
 }
 
 s32 BPF_STRUCT_OPS(cidland_select_cid, struct task_struct *p, s32 prev_cid,
@@ -743,7 +722,32 @@ void BPF_STRUCT_OPS(cidland_dispatch, s32 cid, struct task_struct *prev)
 
 void BPF_STRUCT_OPS(cidland_quiescent, struct task_struct *p, u64 deq_flags)
 {
+	struct task_ctx __arena *tctx;
+	s64 limit, lag;
+
 	__sync_fetch_and_sub(&sum_weight, p->scx.weight);
+
+	tctx = lookup_task_ctx(p);
+
+	/*
+	 * Remember how far the task is from the reference as it stops being
+	 * runnable, clamped both ways, like update_entity_lag():
+	 *
+	 *	vlag = avg_vruntime(cfs_rq) - se->vruntime;
+	 *	se->vlag = clamp(vlag, -limit, limit);
+	 *
+	 * What is preserved across a sleep is the position relative to the
+	 * reference, not the absolute vruntime. Restoring the vruntime
+	 * against the reference alone would hand every task that sleeps long
+	 * enough the full credit, no matter whether it had earned it.
+	 */
+	limit = scale_by_task_weight_inverse(p, slice_lag);
+	lag = (s64)(vtime_now - tctx->vruntime);
+	if (lag > limit)
+		lag = limit;
+	else if (lag < -limit)
+		lag = -limit;
+	tctx->vlag = lag;
 }
 
 void BPF_STRUCT_OPS(cidland_runnable, struct task_struct *p, u64 enq_flags)
@@ -756,6 +760,17 @@ void BPF_STRUCT_OPS(cidland_runnable, struct task_struct *p, u64 enq_flags)
 
 	/* The task just woke up: restart accounting its burst runtime. */
 	tctx->burst_runtime = 0;
+
+	/*
+	 * Place the task back at the lag it had when it went to sleep, the
+	 * way place_entity() does:
+	 *
+	 *	se->vruntime = vruntime - lag;
+	 *
+	 * A task that had consumed its share before sleeping comes back with
+	 * no credit, while one that was still owed service keeps it.
+	 */
+	tctx->vruntime = vtime_now - tctx->vlag;
 }
 
 void BPF_STRUCT_OPS(cidland_running, struct task_struct *p)
@@ -782,8 +797,7 @@ void BPF_STRUCT_OPS(cidland_stopping, struct task_struct *p, bool runnable)
 	 * accumulated since its last sleep, capping the latter at @slice_lag so
 	 * that CPU intensive tasks don't get starved.
 	 */
-	scx_bpf_task_set_dsq_vtime(p, p->scx.dsq_vtime +
-				   scale_by_task_weight_inverse(p, slice));
+	tctx->vruntime += scale_by_task_weight_inverse(p, slice);
 	tctx->burst_runtime = MIN(tctx->burst_runtime + slice, slice_lag);
 
 	/*
@@ -897,7 +911,9 @@ void BPF_STRUCT_OPS(cidland_exit_task, struct task_struct *p,
  */
 void BPF_STRUCT_OPS(cidland_enable, struct task_struct *p)
 {
-	scx_bpf_task_set_dsq_vtime(p, vtime_now);
+	struct task_ctx __arena *tctx = lookup_task_ctx(p);
+
+	tctx->vruntime = vtime_now;
 }
 
 /*

--- a/scheds/experimental/scx_cidland/src/main.rs
+++ b/scheds/experimental/scx_cidland/src/main.rs
@@ -95,11 +95,7 @@ struct Opts {
     #[clap(short = 's', long, default_value = "1000")]
     slice_us: u64,
 
-    /// Maximum time slice credit, in microseconds, that a task can accumulate
-    /// while sleeping.
-    ///
-    /// Larger values give a bigger priority boost to tasks that sleep a lot,
-    /// at the cost of fairness towards CPU intensive tasks.
+    /// Maximum lag, in microseconds of virtual time, that a task can carry across a sleep.
     #[clap(short = 'l', long, default_value = "20000")]
     slice_lag_us: u64,
 


### PR DESCRIPTION
## Summary

Start moving scx_cidland's shared-DSQ scheduling policy closer to EEVDF.

The current virtual-time logic can stop advancing when tasks with a larger vruntime do not run. Sleeping tasks can also receive fresh credit on every wakeup, regardless of the lag they had before sleeping, while deadlines are based on a burst-runtime heuristic (derived from scx_cosmos), rather than an EEVDF-style request.

This series reworks that accounting by:
  - advancing the system virtual time from the service delivered, divided by the total runnable weight;
  - carrying division remainders so virtual time continues to advance with large runnable populations;
  - tracking runnable weight through `ops.runnable()` and `ops.quiescent()`;
  - preserving each task's bounded lag across sleep instead of assigning new wakeup credit;
  - keeping task vruntime separate from `p->scx.dsq_vtime`, which is overwritten by the DSQ deadline key;
  - computing deadlines from a fixed request size: `deadline = vruntime + slice_ns / weight`, rather than from runtime accumulated since the last sleep;
  - removing the wakeup-frequency and burst-runtime latency heuristics that are no longer needed.

This gives scx_cidland EEVDF-like virtual-time, lag, and deadline accounting while retaining its existing topology-aware idle placement and shared deadline-ordered DSQ.

## Limitations

This is not a complete EEVDF implementation. In particular, EEVDF selects the earliest-deadline task only among eligible entities (`v_i <= V`), while a sched_ext DSQ cannot skip an ineligible task during consumption.

The deadline ordering still accounts for excess service in task vruntime, but it cannot reproduce the eligibility filter exactly. This series is intended as the accounting foundation for further work toward an EEVDF-like scheduling policy.
