### PR TITLE
scx_bpfland: Remove experimental TIMELY mode

### DIFF
--- a/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_bpfland/src/bpf/main.bpf.c
@@ -28,12 +28,6 @@
  */
 #define MAX_WAKEUP_FREQ		64ULL
 
-/*
- * Enable TIMELY mode: when true, the scheduler uses TIMELY's delay-driven
- * feedback for adaptive time slices.
- */
-const volatile bool timely_enabled;
-
 char _license[] SEC("license") = "GPL";
 
 /* Allow to use bpf_printk() only when @debug is set */
@@ -121,12 +115,6 @@ const volatile u64 cpu_capacity[MAX_CPUS];
  * Scheduling statistics.
  */
 volatile u64 nr_kthread_dispatches, nr_direct_dispatches, nr_shared_dispatches,
-	nr_delay_recovery_dispatches, nr_delay_middle_add_dispatches,
-	nr_delay_fast_recovery_dispatches, nr_delay_rate_limited_dispatches,
-	nr_gain_floor_dispatches, nr_gain_ceiling_dispatches,
-	nr_delay_low_region_samples, nr_delay_mid_region_samples,
-	nr_delay_high_region_samples, nr_gain_floor_resident_samples,
-	nr_gain_mid_resident_samples, nr_gain_ceiling_resident_samples,
 	nr_idle_select_path_picks, nr_idle_enqueue_path_picks,
 	nr_idle_prev_cpu_picks, nr_idle_primary_picks, nr_idle_spill_picks,
 	nr_idle_pick_failures, nr_idle_primary_domain_misses,
@@ -149,22 +137,6 @@ volatile u64 nr_online_cpus;
  * Maximum possible CPU number.
  */
 static u64 nr_cpu_ids;
-
-/*
- * TIMELY tunables.
- */
-const volatile u64 timely_tlow_ns = 5000ULL * NSEC_PER_USEC;
-const volatile u64 timely_thigh_ns = 50000ULL * NSEC_PER_USEC;
-const volatile u32 timely_gain_min_fp = 128U;
-const volatile u32 timely_gain_max_fp = 1024U;
-const volatile u32 timely_gain_step_fp = 32U;
-const volatile u32 timely_hai_thresh_fp = 768U;
-const volatile u32 timely_hai_multiplier = 2U;
-const volatile u32 timely_backoff_low_fp = 768U;
-const volatile u32 timely_backoff_high_fp = 960U;
-const volatile u32 timely_backoff_gradient_fp = 992U;
-const volatile u64 timely_gradient_margin_ns = 125ULL * NSEC_PER_USEC;
-const volatile u64 timely_control_interval_ns = 500ULL * NSEC_PER_USEC;
 
 /*
  * Runtime throttling.
@@ -267,14 +239,6 @@ struct task_ctx {
 	u64 wakeup_freq;
 	u64 last_woke_at;
 	u64 avg_runtime;
-	/* TIMELY-specific fields (valid when timely_enabled=true) */
-	u64 timely_last_enqueued_at;
-	u32 timely_gain_fp;
-	u64 timely_last_gain_update_at;
-	u64 timely_last_delay_sample_at;
-	u64 timely_avg_queue_delay;
-	s64 timely_avg_queue_gradient;
-	u32 timely_hai_streak;
 };
 
 /* Map that contains task-local storage. */
@@ -802,8 +766,6 @@ s32 BPF_STRUCT_OPS(bpfland_select_cpu, struct task_struct *p, s32 prev_cpu, u64 
 
 		tctx = try_lookup_task_ctx(p);
 		if (tctx) {
-			if (timely_enabled)
-				tctx->timely_last_enqueued_at = bpf_ktime_get_ns();
 			scx_bpf_dsq_insert_vtime(p, cpu_dsq(cpu),
 						 task_slice(p, cpu), task_dl(p, cpu, tctx), 0);
 			__sync_fetch_and_add(&nr_direct_dispatches, 1);
@@ -869,8 +831,6 @@ static bool task_should_migrate(struct task_struct *p, u64 enq_flags)
  * Dispatch all the other tasks that were not dispatched directly in
  * select_cpu().
  */
-
-/* Forward declarations for functions used by TIMELY helpers */
 static bool keep_running(const struct task_struct *p, s32 cpu);
 static bool consume_first_task(u64 dsq_id, struct task_struct *p);
 
@@ -883,9 +843,6 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	if (!tctx)
 		return;
 
-	if (timely_enabled)
-		tctx->timely_last_enqueued_at = bpf_ktime_get_ns();
-
 	/*
 	 * If the task is marked as sticky due to excessive rescheduling
 	 * activity, dispatch it directly to the same CPU to reduce the
@@ -893,7 +850,7 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	 */
 	if (is_task_sticky(tctx)) {
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p, prev_cpu),
-				   enq_flags | (timely_enabled ? SCX_ENQ_IMMED : 0));
+				   enq_flags);
 		__sync_fetch_and_add(&nr_direct_dispatches, 1);
 		return;
 	}
@@ -905,7 +862,7 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	 */
 	if (local_kthreads && is_kthread(p) && p->nr_cpus_allowed == 1) {
 		scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p, prev_cpu),
-				   enq_flags | (timely_enabled ? SCX_ENQ_IMMED : 0));
+				   enq_flags);
 		__sync_fetch_and_add(&nr_kthread_dispatches, 1);
 		return;
 	}
@@ -926,7 +883,7 @@ void BPF_STRUCT_OPS(bpfland_enqueue, struct task_struct *p, u64 enq_flags)
 	if (is_pcpu_task(p)) {
 		if (local_pcpu)
 			scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, task_slice(p, prev_cpu),
-					   enq_flags | (timely_enabled ? SCX_ENQ_IMMED : 0));
+					   enq_flags);
 		else
 			scx_bpf_dsq_insert_vtime(p, cpu_dsq(prev_cpu),
 						 task_slice(p, prev_cpu), task_dl(p, prev_cpu, tctx), enq_flags);
@@ -1106,30 +1063,9 @@ void BPF_STRUCT_OPS(bpfland_running, struct task_struct *p)
 	tctx->last_run_at = bpf_ktime_get_ns();
 
 	/*
-	 * TIMELY: Track queue delay if task was enqueued with TIMELY enabled.
+	 * Adjust target CPU frequency before the task starts to run.
 	 */
-	if (timely_enabled && tctx->timely_last_enqueued_at) {
-		u64 delay = tctx->last_run_at > tctx->timely_last_enqueued_at
-				    ? tctx->last_run_at - tctx->timely_last_enqueued_at
-				    : 1;
-		u64 prev_avg = tctx->timely_avg_queue_delay;
-		s64 gradient;
-
-		tctx->timely_avg_queue_delay =
-			(tctx->timely_avg_queue_delay * 3 + delay) >> 2;
-		gradient = (s64)tctx->timely_avg_queue_delay - (s64)prev_avg;
-		tctx->timely_avg_queue_gradient =
-			(tctx->timely_avg_queue_gradient * 3 + gradient) >> 2;
-		tctx->timely_last_delay_sample_at = tctx->last_run_at;
-		tctx->timely_last_enqueued_at = 0;
-	}
-
-	if (!timely_enabled) {
-		/*
-		 * Adjust target CPU frequency before the task starts to run.
-		 */
-		update_cpu_load(p, tctx);
-	}
+	update_cpu_load(p, tctx);
 
 	/*
 	 * Update current system's vruntime.

--- a/scheds/rust/scx_bpfland/src/main.rs
+++ b/scheds/rust/scx_bpfland/src/main.rs
@@ -195,54 +195,6 @@ struct Opts {
     #[clap(short = 'f', long, action = clap::ArgAction::SetTrue)]
     cpufreq: bool,
 
-    /// Enable TIMELY mode: use TIMELY's delay-driven feedback for adaptive time slices.
-    #[clap(short = 'T', long, action = clap::ArgAction::SetTrue)]
-    timely: bool,
-
-    /// TIMELY lower delay threshold in microseconds.
-    #[clap(long, default_value = "5000")]
-    timely_tlow_us: u64,
-
-    /// TIMELY higher delay threshold in microseconds.
-    #[clap(long, default_value = "50000")]
-    timely_thigh_us: u64,
-
-    /// TIMELY minimum gain value (fixed-point).
-    #[clap(long, default_value = "128")]
-    timely_gain_min: u32,
-
-    /// TIMELY gain step (fixed-point).
-    #[clap(long, default_value = "32")]
-    timely_gain_step: u32,
-
-    /// TIMELY HAI threshold (fixed-point).
-    #[clap(long, default_value = "768")]
-    timely_hai_thresh: u32,
-
-    /// TIMELY HAI multiplier.
-    #[clap(long, default_value = "2")]
-    timely_hai_multiplier: u32,
-
-    /// TIMELY backoff low (fixed-point).
-    #[clap(long, default_value = "768")]
-    timely_backoff_low: u32,
-
-    /// TIMELY backoff high (fixed-point).
-    #[clap(long, default_value = "960")]
-    timely_backoff_high: u32,
-
-    /// TIMELY backoff gradient (fixed-point).
-    #[clap(long, default_value = "992")]
-    timely_backoff_gradient: u32,
-
-    /// TIMELY gradient margin in microseconds.
-    #[clap(long, default_value = "125")]
-    timely_gradient_margin_us: u64,
-
-    /// TIMELY control interval in microseconds.
-    #[clap(long, default_value = "500")]
-    timely_control_interval_us: u64,
-
     /// Enable stats monitoring with the specified interval.
     #[clap(long)]
     stats: Option<f64>,
@@ -365,21 +317,6 @@ impl<'a> Scheduler<'a> {
         rodata.slice_lag = opts.slice_us_lag * 1000;
         rodata.throttle_ns = opts.throttle_us * 1000;
         rodata.primary_all = domain.weight() == *NR_CPU_IDS;
-
-        // TIMELY settings (only effective when timely_enabled=true)
-        rodata.timely_enabled = opts.timely;
-        rodata.timely_tlow_ns = opts.timely_tlow_us * 1000;
-        rodata.timely_thigh_ns = opts.timely_thigh_us * 1000;
-        rodata.timely_gain_min_fp = opts.timely_gain_min;
-        rodata.timely_gain_max_fp = 1024;
-        rodata.timely_gain_step_fp = opts.timely_gain_step;
-        rodata.timely_hai_thresh_fp = opts.timely_hai_thresh;
-        rodata.timely_hai_multiplier = opts.timely_hai_multiplier;
-        rodata.timely_backoff_low_fp = opts.timely_backoff_low;
-        rodata.timely_backoff_high_fp = opts.timely_backoff_high;
-        rodata.timely_backoff_gradient_fp = opts.timely_backoff_gradient;
-        rodata.timely_gradient_margin_ns = opts.timely_gradient_margin_us * 1000;
-        rodata.timely_control_interval_ns = opts.timely_control_interval_us * 1000;
 
         // Generate the list of available CPUs sorted by capacity in descending order.
         let mut cpus: Vec<_> = topo.all_cpus.values().collect();
@@ -627,18 +564,6 @@ impl<'a> Scheduler<'a> {
             nr_kthread_dispatches: bss_data.nr_kthread_dispatches,
             nr_direct_dispatches: bss_data.nr_direct_dispatches,
             nr_shared_dispatches: bss_data.nr_shared_dispatches,
-            nr_delay_recovery_dispatches: bss_data.nr_delay_recovery_dispatches,
-            nr_delay_middle_add_dispatches: bss_data.nr_delay_middle_add_dispatches,
-            nr_delay_fast_recovery_dispatches: bss_data.nr_delay_fast_recovery_dispatches,
-            nr_delay_rate_limited_dispatches: bss_data.nr_delay_rate_limited_dispatches,
-            nr_gain_floor_dispatches: bss_data.nr_gain_floor_dispatches,
-            nr_gain_ceiling_dispatches: bss_data.nr_gain_ceiling_dispatches,
-            nr_delay_low_region_samples: bss_data.nr_delay_low_region_samples,
-            nr_delay_mid_region_samples: bss_data.nr_delay_mid_region_samples,
-            nr_delay_high_region_samples: bss_data.nr_delay_high_region_samples,
-            nr_gain_floor_resident_samples: bss_data.nr_gain_floor_resident_samples,
-            nr_gain_mid_resident_samples: bss_data.nr_gain_mid_resident_samples,
-            nr_gain_ceiling_resident_samples: bss_data.nr_gain_ceiling_resident_samples,
             nr_idle_select_path_picks: bss_data.nr_idle_select_path_picks,
             nr_idle_enqueue_path_picks: bss_data.nr_idle_enqueue_path_picks,
             nr_idle_prev_cpu_picks: bss_data.nr_idle_prev_cpu_picks,

--- a/scheds/rust/scx_bpfland/src/stats.rs
+++ b/scheds/rust/scx_bpfland/src/stats.rs
@@ -25,31 +25,6 @@ pub struct Metrics {
     pub nr_direct_dispatches: u64,
     #[stat(desc = "Number of regular task dispatches")]
     pub nr_shared_dispatches: u64,
-    // TIMELY stats (zero when timely mode is disabled)
-    #[stat(desc = "Number of delay recovery dispatches")]
-    pub nr_delay_recovery_dispatches: u64,
-    #[stat(desc = "Number of delay middle add dispatches")]
-    pub nr_delay_middle_add_dispatches: u64,
-    #[stat(desc = "Number of delay fast recovery dispatches")]
-    pub nr_delay_fast_recovery_dispatches: u64,
-    #[stat(desc = "Number of delay rate-limited dispatches")]
-    pub nr_delay_rate_limited_dispatches: u64,
-    #[stat(desc = "Number of gain floor dispatches")]
-    pub nr_gain_floor_dispatches: u64,
-    #[stat(desc = "Number of gain ceiling dispatches")]
-    pub nr_gain_ceiling_dispatches: u64,
-    #[stat(desc = "Number of delay low region samples")]
-    pub nr_delay_low_region_samples: u64,
-    #[stat(desc = "Number of delay mid region samples")]
-    pub nr_delay_mid_region_samples: u64,
-    #[stat(desc = "Number of delay high region samples")]
-    pub nr_delay_high_region_samples: u64,
-    #[stat(desc = "Number of gain floor resident samples")]
-    pub nr_gain_floor_resident_samples: u64,
-    #[stat(desc = "Number of gain mid resident samples")]
-    pub nr_gain_mid_resident_samples: u64,
-    #[stat(desc = "Number of gain ceiling resident samples")]
-    pub nr_gain_ceiling_resident_samples: u64,
     #[stat(desc = "Number of idle select path picks")]
     pub nr_idle_select_path_picks: u64,
     #[stat(desc = "Number of idle enqueue path picks")]
@@ -86,18 +61,13 @@ impl Metrics {
     fn format<W: Write>(&self, w: &mut W) -> Result<()> {
         writeln!(
             w,
-            "[{}] tasks -> r: {:>2}/{:<2} | dispatch -> k: {:<5} d: {:<5} s: {:<5} | timely -> rec: {:<5} mid: {:<5} rl: {:<5} min: {:<5} max: {:<5}",
+            "[{}] tasks -> r: {:>2}/{:<2} | dispatch -> k: {:<5} d: {:<5} s: {:<5}",
             crate::SCHEDULER_NAME,
             self.nr_running,
             self.nr_cpus,
             self.nr_kthread_dispatches,
             self.nr_direct_dispatches,
-            self.nr_shared_dispatches,
-            self.nr_delay_recovery_dispatches,
-            self.nr_delay_middle_add_dispatches,
-            self.nr_delay_rate_limited_dispatches,
-            self.nr_gain_floor_dispatches,
-            self.nr_gain_ceiling_dispatches
+            self.nr_shared_dispatches
         )?;
         Ok(())
     }
@@ -107,29 +77,6 @@ impl Metrics {
             nr_kthread_dispatches: self.nr_kthread_dispatches - rhs.nr_kthread_dispatches,
             nr_direct_dispatches: self.nr_direct_dispatches - rhs.nr_direct_dispatches,
             nr_shared_dispatches: self.nr_shared_dispatches - rhs.nr_shared_dispatches,
-            nr_delay_recovery_dispatches: self.nr_delay_recovery_dispatches
-                - rhs.nr_delay_recovery_dispatches,
-            nr_delay_middle_add_dispatches: self.nr_delay_middle_add_dispatches
-                - rhs.nr_delay_middle_add_dispatches,
-            nr_delay_fast_recovery_dispatches: self.nr_delay_fast_recovery_dispatches
-                - rhs.nr_delay_fast_recovery_dispatches,
-            nr_delay_rate_limited_dispatches: self.nr_delay_rate_limited_dispatches
-                - rhs.nr_delay_rate_limited_dispatches,
-            nr_gain_floor_dispatches: self.nr_gain_floor_dispatches - rhs.nr_gain_floor_dispatches,
-            nr_gain_ceiling_dispatches: self.nr_gain_ceiling_dispatches
-                - rhs.nr_gain_ceiling_dispatches,
-            nr_delay_low_region_samples: self.nr_delay_low_region_samples
-                - rhs.nr_delay_low_region_samples,
-            nr_delay_mid_region_samples: self.nr_delay_mid_region_samples
-                - rhs.nr_delay_mid_region_samples,
-            nr_delay_high_region_samples: self.nr_delay_high_region_samples
-                - rhs.nr_delay_high_region_samples,
-            nr_gain_floor_resident_samples: self.nr_gain_floor_resident_samples
-                - rhs.nr_gain_floor_resident_samples,
-            nr_gain_mid_resident_samples: self.nr_gain_mid_resident_samples
-                - rhs.nr_gain_mid_resident_samples,
-            nr_gain_ceiling_resident_samples: self.nr_gain_ceiling_resident_samples
-                - rhs.nr_gain_ceiling_resident_samples,
             nr_idle_select_path_picks: self.nr_idle_select_path_picks
                 - rhs.nr_idle_select_path_picks,
             nr_idle_enqueue_path_picks: self.nr_idle_enqueue_path_picks


### PR DESCRIPTION
## About

This removes the experimental TIMELY mode from scx_bpfland.

Fixes #3799.

1.  The TIMELY code was added by me months ago as an experiment, and I
    already have enough data from it.
2.  TIMELY mode combined with one of (-k -p -P -S) crashes the scheduler
    at enable time, as reported in #3799.
3.  The proper way forward is to simply remove TIMELY from bpfland to
    avoid any issues from it in the future.
4.  The default path is unchanged. Every gated call site now uses the
    exact form it had when TIMELY was disabled.
5.  This is aware of #3757, which set `SCX_ENQ_IMMED` on the
    TIMELY-mode local inserts as the drain-on-preempt guarantee.
    That guarantee only ever applied to TIMELY-mode inserts, so it
    goes away with TIMELY. The default path never had it.

## Summary

The commit removes the `--timely` flag and all 12 `--timely-*`
tunables from the CLI, all `timely_*` rodata and `task_ctx` fields from
BPF, the `SCX_ENQ_IMMED` fast path that caused the crash in #3799, the
EWMA queue-delay tracker, and the 12 `nr_delay_*/nr_gain_*` stats
counters. The `update_cpu_load()` call in the running path is now
unconditional, matching the previous non-TIMELY behavior.

## Changes

- [`c57f12ed`](https://github.com/galpt/scx/commit/c57f12ede7211e2619d4702cf9b4a8b9c98a5bc6) **scx_bpfland: Remove experimental TIMELY mode**